### PR TITLE
Fix for -Werror=format-security build error

### DIFF
--- a/sherpa/optmethods/tests/_tstoptfct.cc
+++ b/sherpa/optmethods/tests/_tstoptfct.cc
@@ -1474,12 +1474,12 @@ static PyObject *init_optfcn( PyObject *self, PyObject *args ) {
 
   if ( xpar.get_size() != lo.get_size() ||
        xpar.get_size() != hi.get_size() ) {
-    char errmsg[128];
-    sprintf( errmsg, "init_optfcn: Incompatible array sizes "
-	     "xpar=%d, lo=%d, hi=%d\n",
-	     (int) xpar.get_size(), (int) lo.get_size(), (int) hi.get_size());
     PyErr_Format( PyExc_ValueError,
-		  static_cast<const char*>( errmsg ) );
+		  "init_optfcn: Incompatible array sizes "
+		  "xpar=%d, lo=%d, hi=%d\n",
+		  (int) xpar.get_size(), 
+		  (int) lo.get_size(), 
+		  (int) hi.get_size() );
     return NULL;
   }
 


### PR DESCRIPTION
On some systems, building Sherpa can end in the following error:

```
c++: sherpa/optmethods/tests/_tstoptfct.cc
sherpa/optmethods/tests/_tstoptfct.cc: In function ‘PyObject*
init_optfcn(PyObject*, PyObject*)’:
sherpa/optmethods/tests/_tstoptfct.cc:1482:40: error: format not a
string literal and no format arguments [-Werror=format-security]
     static_cast<const char*>( errmsg ) );
```

This patch provides one fix. It is also possible to override the compile-time flags, as shown below,
to avoid needing to apply a patch. Run `python-config` to figure out the `CFLAGS` that are going to be used to build C/C++ extensions:

```
$ python-config --cflags
    -I/usr/include/python2.7 -I/usr/include/x86_64-linux-gnu/python2.7  -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security  -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes
```

Then call `python setup.py install` with the CFLAGS output from the above command, but *without* `-Werror=format-security`. For example (using bash):

```
$ OPT="" BASECFLAGS="" CFLAGS="-I/usr/include/python2.7 -I/usr/include/x86_64-linux-gnu/python2.7  -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat  -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes" python setup.py install
```