### PR TITLE
Fix for -Werror=format-security build error (redo of PR #2)

### DIFF
--- a/sherpa/optmethods/tests/_tstoptfct.cc
+++ b/sherpa/optmethods/tests/_tstoptfct.cc
@@ -1474,12 +1474,11 @@ static PyObject *init_optfcn( PyObject *self, PyObject *args ) {
 
   if ( xpar.get_size() != lo.get_size() ||
        xpar.get_size() != hi.get_size() ) {
-    char errmsg[128];
-    sprintf( errmsg, "init_optfcn: Incompatible array sizes "
-	     "xpar=%d, lo=%d, hi=%d\n",
-	     (int) xpar.get_size(), (int) lo.get_size(), (int) hi.get_size());
     PyErr_Format( PyExc_ValueError,
-		  static_cast<const char*>( errmsg ) );
+                  "init_optfcn: Incompatible array sizes "
+	          "xpar=%d, lo=%d, hi=%d\n",
+	          (int) xpar.get_size(), (int) lo.get_size(),
+                  (int) hi.get_size() );
     return NULL;
   }
 


### PR DESCRIPTION
On some systems, building Sherpa can end in the following error:

```
c++: sherpa/optmethods/tests/_tstoptfct.cc
sherpa/optmethods/tests/_tstoptfct.cc: In function ‘PyObject*
init_optfcn(PyObject*, PyObject*)’:
sherpa/optmethods/tests/_tstoptfct.cc:1482:40: error: format not a
string literal and no format arguments [-Werror=format-security]
     static_cast<const char*>( errmsg ) );
```

This patch fixes this issue. This is a re-post of sherpa#2 which was to a different branch; please see that PR for further commentary.