### PR TITLE
make python setup.py develop transparent to user

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -17,21 +17,16 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import shutil
+import os
+from numpy.distutils.command.develop import develop as _develop
 
-from build import build
-from clean import clean
-from develop import develop
-from install import install
-from sdist import sdist
-from sherpa_config import sherpa_config
-from xspec_config import xspec_config
 
-commands = {
-             'build': build,
-             'clean' : clean,
-             'develop' : develop,
-             'install' : install,
-             'sdist' : sdist,
-             'sherpa_config' : sherpa_config,
-             'xspec_config' : xspec_config,
-            }
+class develop(_develop):
+
+    def run(self):
+        _develop.run(self)
+        sherpa_config = self.get_finalized_command('sherpa_config', True)
+        print("install stk and group extensions locally")
+        shutil.copyfile(sherpa_config.stk_location, os.path.join(os.getcwd(), 'stk.so'))
+        shutil.copyfile(sherpa_config.group_location, os.path.join(os.getcwd(), 'group.so'))

--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -27,6 +27,6 @@ class develop(_develop):
     def run(self):
         _develop.run(self)
         sherpa_config = self.get_finalized_command('sherpa_config', True)
-        print("install stk and group extensions locally")
+        self.announce("install stk and group extensions locally")
         shutil.copyfile(sherpa_config.stk_location, os.path.join(os.getcwd(), 'stk.so'))
         shutil.copyfile(sherpa_config.group_location, os.path.join(os.getcwd(), 'group.so'))

--- a/helpers/install.py
+++ b/helpers/install.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -25,8 +25,7 @@ from deps import build_deps
 
 class install(_install):
     def run(self):
-        if not os.path.exists('extern/built'):
-            configure = self.get_finalized_command('sherpa_config', True).build_configure()
-            self.get_finalized_command('xspec_config', True).run()
-            build_deps(configure)
+        self.get_finalized_command('sherpa_config', True).build_configure()
+        self.get_finalized_command('xspec_config', True).run()
+        self.get_finalized_command('sherpa_config', True).run()
         _install.run(self)

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -136,7 +136,6 @@ class sherpa_config(Command):
             return configure
 
         def run(self):
-            configure = self.build_configure()
-            build_deps(configure)
-
-
+            if not os.path.exists('extern/built'):
+                configure = self.build_configure()
+                build_deps(configure)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[aliases]
+test = sherpa_config xspec_config test
+build_ext = sherpa_config xspec_config build_ext
+develop = sherpa_config xspec_config develop
+
 [sherpa_config]
 
 # Directory where the external dependencies must be installed.


### PR DESCRIPTION
This PR enables transparent `python setup.py {build_ext, test, develop}` commands, by making sure that Sherpa-specific commands are run before the standard ones.

It introduces several aliases in `setup.cfg` to ensure that `sherpa_config` and `xspec_config` commands are always run when `build_ext`, `develop`, and `test` commands are given to `setup.py`, while still allowing the user to have control over which commands are run.

Moreover, it introduces a custom `develop` command that makes sure `stk` and `group` extensions are installed as well.

To test the PR, run `python setup.py develop` and check that `sherpa_test` runs and without failures. Also, test that `python -c "import group"` and `python -c "import stk"` don't fail.

Moreover, `python setup.py build_ext --inplace` should build the `_psf.so` and `_wcs.so` should be built (see #14).

To test this PR one also needs PR #21 and both `pyfits` and `matplotlib` to be installed (see issue #22).

This PR fixes #14 and supports the new testing infrastructure that is under development.