### PR TITLE
Set up travis-ci

### DIFF
--- a/.continuous-integration/README.md
+++ b/.continuous-integration/README.md
@@ -1,0 +1,15 @@
+About
+=====
+
+This directory contains a set of scripts that are used by the 
+``.travis.yml`` and ``appveyor.yml`` files for the 
+[Travis](http://travis-ci.org) and [AppVeyor](http://www.appveyor.com/) 
+services respectively.
+
+The scripts include:
+
+* ``appveyor/install-miniconda.ps1`` - set up conda on Windows
+* ``appveyor/windows_sdk.cmd`` - set up the compiler environment on Windows
+* ``travis/setup_dependencies_common.sh`` - set up conda packages on Linux and MacOS X
+* ``travis/setup_environment_linux.sh`` - set up conda and non-Python dependencies on Linux
+* ``travis/setup_environment_osx.sh`` - set up conda and non-Python dependencies on MacOS X

--- a/.continuous-integration/appveyor/install-miniconda.ps1
+++ b/.continuous-integration/appveyor/install-miniconda.ps1
@@ -1,0 +1,71 @@
+﻿# Sample script to install anaconda under windows
+# Authors: Stuart Mumford
+# Borrwed from: Olivier Grisel and Kyle Kastner
+# License: BSD 3 clause
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+
+function DownloadMiniconda ($version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "Miniconda-" + $version + "-Windows-" + $platform_suffix + ".exe"
+
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing miniconda" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "x86") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $args = "/InstallationType=AllUsers /S /AddToPath=1 /RegisterPython=1 /D=" + $python_home
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    #Start-Sleep -s 15
+    if (Test-Path C:\conda) {
+        Write-Host "Miniconda $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Exit 1
+    }
+}
+
+function main () {
+    InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON
+}
+
+main

--- a/.continuous-integration/appveyor/windows_sdk.cmd
+++ b/.continuous-integration/appveyor/windows_sdk.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -x
+
+# CONDA
+conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
+source activate test
+
+# EGG_INFO
+if [[ $SETUP_CMD == egg_info ]]
+then
+  exit  # no more dependencies needed
+fi
+
+# PEP8
+if [[ $MAIN_CMD == pep8* ]]
+then
+  pip install pep8
+  exit  # no more dependencies needed
+fi
+
+# CORE DEPENDENCIES
+conda install --yes pytest Cython jinja2 psutil
+
+# NUMPY
+if [[ $NUMPY_VERSION == dev ]]
+then
+  pip install git+http://github.com/numpy/numpy.git
+  export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION"
+else
+  conda install --yes numpy=$NUMPY_VERSION
+  export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+fi
+
+# Now set up shortcut to conda install command to make sure the Python and Numpy
+# versions are always explicitly specified.
+
+# OPTIONAL DEPENDENCIES
+if $OPTIONAL_DEPS
+then
+  $CONDA_INSTALL scipy h5py matplotlib pyyaml scikit-image pandas
+  pip install beautifulsoup4
+fi
+
+# DOCUMENTATION DEPENDENCIES
+# build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
+# this matplotlib will *not* work with py 3.x, but our sphinx build is
+# currently 2.7, so that's fine
+if [[ $SETUP_CMD == build_sphinx* ]]
+then
+  $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib
+fi
+
+# COVERAGE DEPENDENCIES
+if [[ $SETUP_CMD == 'test --coverage' ]]
+then
+  pip install coverage coveralls
+fi
+
+

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -20,6 +20,11 @@ fi
 # CORE DEPENDENCIES
 conda install --yes pytest Cython jinja2 psutil
 
+# Install Sherpa
+# TODO: really we only want to install all the dependencies. Is there a conda command for this?
+conda config --add channels https://conda.binstar.org/cxc
+conda install sherpa
+
 # NUMPY
 if [[ $NUMPY_VERSION == dev ]]
 then
@@ -54,5 +59,3 @@ if [[ $SETUP_CMD == 'test --coverage' ]]
 then
   pip install coverage coveralls
 fi
-
-

--- a/.continuous-integration/travis/setup_environment_linux.sh
+++ b/.continuous-integration/travis/setup_environment_linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install conda
+wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b
+export PATH=/home/travis/miniconda/bin:$PATH
+conda update --yes conda
+
+# Install non-Python dependencies for documentation
+if [[ $SETUP_CMD == build_sphinx* ]]
+then
+  sudo apt-get update
+  sudo apt-get install graphviz texlive-latex-extra dvipng
+fi
+
+# Install Python dependencies
+source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/.continuous-integration/travis/setup_environment_osx.sh
+++ b/.continuous-integration/travis/setup_environment_osx.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install conda
+wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-MacOSX-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b
+export PATH=/Users/travis/miniconda/bin:$PATH
+conda update --yes conda
+
+# Install Python dependencies
+source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,82 @@
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
+
+os:
+    - linux
+
+env:
+    global:
+        # Set defaults to avoid repeating in most cases
+        - NUMPY_VERSION=1.9
+        - OPTIONAL_DEPS=false
+        - MAIN_CMD='python setup.py'
+    matrix:
+        - PYTHON_VERSION=2.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+
+matrix:
+
+    # Don't wait for allowed failures
+    fast_finish: true
+
+    include:
+
+        # Try MacOS X
+        - os: osx
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test' OPTIONAL_DEPS=true
+
+        # Check for sphinx doc build warnings - we do this first because it
+        # runs for a long time
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'  OPTIONAL_DEPS=true
+          # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
+
+        # Try all python versions with the latest numpy
+        - os: linux
+          env: PYTHON_VERSION=2.6 SETUP_CMD='test --open-files'
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test --open-files'
+        - os: linux
+          env: PYTHON_VERSION=3.3 SETUP_CMD='test --open-files'
+        - os: linux
+          env: PYTHON_VERSION=3.4 SETUP_CMD='test --open-files'
+
+        # Now try with all optional dependencies on 2.7 and an appropriate 3.x
+        # build (with latest numpy). We also note the code coverage on Python
+        # 2.7.
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
+        - os: linux
+          env: PYTHON_VERSION=3.4 SETUP_CMD='test' OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
+
+        # Try older numpy versions
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test'
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test'
+
+        # Try developer version of Numpy
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
+
+        # Do a PEP8 test
+        - os: linux
+          env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
+
+    allow_failures:
+      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
+
+install:
+    - source .continuous-integration/travis/setup_environment_$TRAVIS_OS_NAME.sh
+
+script:
+    - $MAIN_CMD $SETUP_CMD
+
+after_success:
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='astropy/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ env:
         - OPTIONAL_DEPS=false
         - MAIN_CMD='python setup.py'
     matrix:
-        - PYTHON_VERSION=2.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+        # - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
 
 matrix:
 
@@ -31,27 +29,23 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'  OPTIONAL_DEPS=true
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'  OPTIONAL_DEPS=true
           # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
 
         # Try all python versions with the latest numpy
         - os: linux
-          env: PYTHON_VERSION=2.6 SETUP_CMD='test --open-files'
-        - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.3 SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test --open-files'
+        # - os: linux
+        #   env: PYTHON_VERSION=3.4 SETUP_CMD='test --open-files'
 
         # Now try with all optional dependencies on 2.7 and an appropriate 3.x
         # build (with latest numpy). We also note the code coverage on Python
         # 2.7.
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
-        - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test' OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
+        # - os: linux
+        #   env: PYTHON_VERSION=3.4 SETUP_CMD='test' OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
 
         # Try older numpy versions
         - os: linux
@@ -66,8 +60,8 @@ matrix:
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
 
         # Do a PEP8 test
-        - os: linux
-          env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
 
     allow_failures:
       - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
@@ -79,4 +73,4 @@ script:
     - $MAIN_CMD $SETUP_CMD
 
 after_success:
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='astropy/tests/coveragerc'; fi
+    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='astropy/tests/coveragerc'; fi


### PR DESCRIPTION
First of all, it's great that Sherpa is on Github now, thank you!

How about setting up https://travis-ci.org/ for continuous testing of Sherpa?
I've done this for a few Python packages, so I could make a pull request adding the `.travis.yml` file.
But an admin for the Sherpa Github repo has to activate builds on travis-ci as described [here](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in) ... it just takes a minute.

