### PR TITLE
Skip tests instead of pretending to pass

### DIFF
--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -20,6 +20,8 @@
 
 from sherpa.utils import SherpaTestCase
 import os
+import unittest
+from sherpa.utils import has_fits_support
 from sherpa.astro.ui import *
 from sherpa.astro.datastack import *
 from sherpa.astro import datastack
@@ -44,8 +46,8 @@ class test_design(SherpaTestCase):
         ui.clean()
         set_template_id("__ID")
 
-
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     def test_case_1(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, '3c273.lis'))
@@ -263,8 +265,8 @@ class test_load(SherpaTestCase):
         os.remove(self.name2)
         set_stack_verbose(False)
 
-
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     def test_case_3(self):
         load_ascii("@{}".format(self.lisname))
         assert len(ui._session._data) == 2
@@ -571,8 +573,8 @@ class test_pha(SherpaTestCase):
         ui.clean()
         set_template_id("__ID")
 
-
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     def test_case_6(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, 'pha.lis'))
@@ -634,6 +636,8 @@ class test_query(SherpaTestCase):
         set_template_id("__ID")
         set_stack_verbose(False)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     def test_case_7(self):
         load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
 

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -130,6 +130,8 @@ class test_global(SherpaTestCase):
     def setUp(self):
         clear_stack()
         ui.clean()
+        logger.setLevel(logging.ERROR)
+        set_stack_verbosity(logging.ERROR)
         set_template_id("__ID")
 
     def tearDown(self):

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -22,7 +22,8 @@ import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, has_package_from_list
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
+from sherpa.utils import has_package_from_list, has_fits_support
 import sherpa.astro.sim as sim
 
 from sherpa.astro.instrument import Response1D
@@ -39,6 +40,10 @@ logger = logging.getLogger('sherpa')
 
 class test_sim(SherpaTestCase):
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     def setUp(self):
         try:
             from sherpa.astro.xspec import XSwabs, XSpowerlaw

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -76,7 +76,7 @@ class test_sim(SherpaTestCase):
             logger.setLevel(self.old_level)
 
     @needs_xspec
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_simarf(self):
         datadir = SherpaTestCase.datadir
         if datadir is None:
@@ -106,7 +106,7 @@ class test_sim(SherpaTestCase):
         #     raise
 
     @needs_xspec
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_pcaarf(self):
         datadir = SherpaTestCase.datadir
         if datadir is None:

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -22,7 +22,7 @@ import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, needs_xspec
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, has_package_from_list
 import sherpa.astro.sim as sim
 
 from sherpa.astro.instrument import Response1D
@@ -76,7 +76,8 @@ class test_sim(SherpaTestCase):
         if hasattr(self,'old_level'):
             logger.setLevel(self.old_level)
 
-    @needs_xspec
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_simarf(self):
         datadir = SherpaTestCase.datadir
@@ -106,7 +107,8 @@ class test_sim(SherpaTestCase):
         #     print 'param: ', str(params.std(1))
         #     raise
 
-    @needs_xspec
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_pcaarf(self):
         datadir = SherpaTestCase.datadir

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -18,10 +18,11 @@
 #
 
 
+import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTest, SherpaTestCase, needs_data, needs_xspec
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, needs_xspec
 import sherpa.astro.sim as sim
 
 from sherpa.astro.instrument import Response1D

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -27,7 +27,6 @@ from sherpa.utils import has_package_from_list, has_fits_support
 import sherpa.astro.sim as sim
 
 from sherpa.astro.instrument import Response1D
-from sherpa.astro.io import read_pha
 from sherpa.astro.data import DataPHA
 from sherpa.fit import Fit
 from sherpa.stats import Cash, CStat
@@ -46,6 +45,7 @@ class test_sim(SherpaTestCase):
                      "required sherpa.astro.xspec module missing")
     def setUp(self):
         try:
+            from sherpa.astro.io import read_pha
             from sherpa.astro.xspec import XSwabs, XSpowerlaw
         except:
             return

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -17,10 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTestCase, needs_data
+from sherpa.utils import SherpaTestCase, test_data_missing
 import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
 

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -58,7 +58,7 @@ class test_threads(SherpaTestCase):
         execfile(scriptname, {}, self.locals)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pha_intro(self):
         self.run_thread('pha_intro')
         # astro.ui imported as ui, instead of
@@ -84,12 +84,12 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,44)
         self.assertEqual(ui.get_fit_results().dof,42)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pha_read(self):
         self.run_thread('pha_read')
         self.assertEqual(type(ui.get_data()), DataPHA)
         
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_basic(self):
         # In data1.dat for this test, there is a comment with one
         # word at the beginning -- deliberately would break when reading
@@ -109,7 +109,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,11)
         self.assertEqual(ui.get_fit_results().dof,9)
                 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_simultaneous(self):
         self.run_thread('simultaneous')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 7.4429, 1e-4)
@@ -122,7 +122,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,18)
         self.assertEqual(ui.get_fit_results().dof,14)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_sourceandbg(self):
         self.run_thread('sourceandbg')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 947.5, 1e-4)
@@ -136,7 +136,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,1330)
         self.assertEqual(ui.get_fit_results().dof,1325)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_spatial(self):
         self.run_thread('spatial')
         self.assertEqualWithinTol(ui.get_fit_results().statval, -59229.749441, 1e-4)
@@ -152,7 +152,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,4881)
         self.assertEqual(ui.get_fit_results().dof,4877)
         
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pileup(self):
         self.run_thread('pileup')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 53.6112, 1e-4)
@@ -166,7 +166,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,42)
         self.assertEqual(ui.get_fit_results().dof,37)
     
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro(self):
         self.run_thread('radpro')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 217.450, 1e-4)
@@ -180,7 +180,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,38)
         self.assertEqual(ui.get_fit_results().dof,35)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro_dm(self):
         # This test is completely redundant to test_radpro above.
         # The only difference is that here I test if using DM syntax
@@ -201,7 +201,7 @@ class test_threads(SherpaTestCase):
             self.assertEqual(ui.get_fit_results().numpoints,38)
             self.assertEqual(ui.get_fit_results().dof,35)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_psf2d(self):
         self.run_thread('psf')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 4066.78, 1e-4)
@@ -213,7 +213,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,4899)
         self.assertEqual(ui.get_fit_results().dof,4895)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fpsf2d(self):
         self.run_thread('fpsf')
         self.assertEqualWithinTol(ui.get_fit_results().statval, -4053.6635, 1e-4)
@@ -230,7 +230,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,4899)
         self.assertEqual(ui.get_fit_results().dof,4895)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro_psf(self):
         self.run_thread('radpro_psf')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 200.949, 1e-4)
@@ -241,7 +241,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,38)
         self.assertEqual(ui.get_fit_results().dof,35)
         
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_linepro(self):
         self.run_thread('linepro')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 203.34, 1e-4)
@@ -252,7 +252,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,75)
         self.assertEqual(ui.get_fit_results().dof,72)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_kernel(self):
         self.run_thread('kernel')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 98.5793, 1e-4)
@@ -263,7 +263,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,75)
         self.assertEqual(ui.get_fit_results().dof,72)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_spectrum(self):
         self.run_thread('spectrum')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 0.0496819, 1e-4)
@@ -275,7 +275,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,446)
         self.assertEqual(ui.get_fit_results().dof,441)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_histo(self):
         self.run_thread('histo')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 14.7264, 1e-4)
@@ -286,7 +286,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,50)
         self.assertEqual(ui.get_fit_results().dof,47)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xmm(self):
         self.run_thread('xmm')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 118.085, 1e-4)
@@ -297,7 +297,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,162)
         self.assertEqual(ui.get_fit_results().dof,159)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     # As of CIAO 4.5, can filter on channel number, even when
     # data are grouped! Test results should exactly match CIAO 4.4
     # fit results in grouped/fit.py
@@ -308,7 +308,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.83906, 1e-4)
         self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000301258, 1e-4)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_proj(self):
         self.run_thread('proj')
         # Fit 1
@@ -379,7 +379,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['proj_res2'].parmaxes[2],
                                   0.0981627, 1e-2)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_proj_bubble(self):
         self.run_thread('proj_bubble')
         # Fit -- Results from reminimize
@@ -408,7 +408,7 @@ class test_threads(SherpaTestCase):
 
     ### New tests based on SDS threads -- we should catch these errors
     ### (if any occur) so SDS doesn't waste time tripping over them.
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_counts(self):
         self.run_thread('counts')
         self.assertEqualWithinTol(self.locals['counts_data1'], 52701.0, 1e-4)
@@ -419,7 +419,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['eflux2'], 1.39662954483e-08, 1e-3)
         self.assertEqualWithinTol(self.locals['pflux1'], 1.6178938637, 1e-2)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_stats_all(self):
         self.run_thread('stats_all')
         self.assertEqualWithinTol(self.locals['stat_lsqr'],213746.236464,1e-4)
@@ -431,7 +431,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['stat_chi2x'],1204.69363458,1e-4)
         self.assertEqualWithinTol(self.locals['stat_cstat'],1210.56896183,1e-4)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_lev3fft(self):
         self.run_thread('lev3fft', scriptname='bar.py')
         self.assertEqualWithinTol(self.locals['src'].fwhm.val, 0.04418584, 1e-4)
@@ -444,15 +444,15 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 3307)
         self.assertEqual(ui.get_fit_results().dof, 3302)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_setfullmodel(self):
         self.run_thread('setfullmodel')
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_bug13537(self):
         self.run_thread('bug13537')
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xmm2(self):
         self.run_thread('xmm2')
         self.assertEqualWithinTol(ui.get_data().channel[0], 1.0, 1e-4)

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -21,7 +21,8 @@ import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTestCase, test_data_missing, has_package_from_list
+from sherpa.utils import SherpaTestCase, test_data_missing
+from sherpa.utils import has_package_from_list, has_fits_support
 import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
 
@@ -58,6 +59,8 @@ class test_threads(SherpaTestCase):
         os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
         execfile(scriptname, {}, self.locals)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -86,11 +89,15 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,44)
         self.assertEqual(ui.get_fit_results().dof,42)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pha_read(self):
         self.run_thread('pha_read')
         self.assertEqual(type(ui.get_data()), DataPHA)
-        
+
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_basic(self):
         # In data1.dat for this test, there is a comment with one
@@ -111,6 +118,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,11)
         self.assertEqual(ui.get_fit_results().dof,9)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -126,6 +135,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,18)
         self.assertEqual(ui.get_fit_results().dof,14)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -142,6 +153,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,1330)
         self.assertEqual(ui.get_fit_results().dof,1325)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_spatial(self):
         self.run_thread('spatial')
@@ -158,6 +171,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,4881)
         self.assertEqual(ui.get_fit_results().dof,4877)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -173,7 +188,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['power'].ampl.val, 0.00199457, 1e-2)
         self.assertEqual(ui.get_fit_results().numpoints,42)
         self.assertEqual(ui.get_fit_results().dof,37)
-    
+
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro(self):
         self.run_thread('radpro')
@@ -209,6 +226,8 @@ class test_threads(SherpaTestCase):
             self.assertEqual(ui.get_fit_results().numpoints,38)
             self.assertEqual(ui.get_fit_results().dof,35)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_psf2d(self):
         self.run_thread('psf')
@@ -221,6 +240,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,4899)
         self.assertEqual(ui.get_fit_results().dof,4895)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fpsf2d(self):
         self.run_thread('fpsf')
@@ -238,6 +259,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,4899)
         self.assertEqual(ui.get_fit_results().dof,4895)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro_psf(self):
         self.run_thread('radpro_psf')
@@ -248,7 +271,9 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().nfev,48)
         self.assertEqual(ui.get_fit_results().numpoints,38)
         self.assertEqual(ui.get_fit_results().dof,35)
-        
+
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_linepro(self):
         self.run_thread('linepro')
@@ -260,6 +285,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,75)
         self.assertEqual(ui.get_fit_results().dof,72)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_kernel(self):
         self.run_thread('kernel')
@@ -271,6 +298,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,75)
         self.assertEqual(ui.get_fit_results().dof,72)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -285,6 +314,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,446)
         self.assertEqual(ui.get_fit_results().dof,441)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_histo(self):
         self.run_thread('histo')
@@ -296,6 +327,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,50)
         self.assertEqual(ui.get_fit_results().dof,47)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -309,6 +342,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,162)
         self.assertEqual(ui.get_fit_results().dof,159)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     # As of CIAO 4.5, can filter on channel number, even when
     # data are grouped! Test results should exactly match CIAO 4.4
@@ -320,6 +355,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.83906, 1e-4)
         self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000301258, 1e-4)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -393,6 +430,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['proj_res2'].parmaxes[2],
                                   0.0981627, 1e-2)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -424,7 +463,8 @@ class test_threads(SherpaTestCase):
 
     # New tests based on SDS threads -- we should catch these errors
     # (if any occur) so SDS doesn't waste time tripping over them.
-    # TODO (OL): What does the above mean? Does this comment still apply?
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -438,6 +478,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['eflux2'], 1.39662954483e-08, 1e-3)
         self.assertEqualWithinTol(self.locals['pflux1'], 1.6178938637, 1e-2)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -452,6 +494,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['stat_chi2x'],1204.69363458,1e-4)
         self.assertEqualWithinTol(self.locals['stat_cstat'],1210.56896183,1e-4)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_lev3fft(self):
         self.run_thread('lev3fft', scriptname='bar.py')
@@ -465,16 +509,22 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 3307)
         self.assertEqual(ui.get_fit_results().dof, 3302)
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_setfullmodel(self):
         self.run_thread('setfullmodel')
-
+   
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_bug13537(self):
         self.run_thread('bug13537')
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -21,7 +21,7 @@ import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTestCase, test_data_missing, has_package_from_list
 import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
 
@@ -58,7 +58,8 @@ class test_threads(SherpaTestCase):
         os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
         execfile(scriptname, {}, self.locals)
 
-
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pha_intro(self):
         self.run_thread('pha_intro')
@@ -109,7 +110,9 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().nfev,9)
         self.assertEqual(ui.get_fit_results().numpoints,11)
         self.assertEqual(ui.get_fit_results().dof,9)
-                
+
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_simultaneous(self):
         self.run_thread('simultaneous')
@@ -123,6 +126,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,18)
         self.assertEqual(ui.get_fit_results().dof,14)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_sourceandbg(self):
         self.run_thread('sourceandbg')
@@ -152,7 +157,9 @@ class test_threads(SherpaTestCase):
         #self.assertEqual(ui.get_fit_results().nfev,371)
         self.assertEqual(ui.get_fit_results().numpoints,4881)
         self.assertEqual(ui.get_fit_results().dof,4877)
-        
+
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pileup(self):
         self.run_thread('pileup')
@@ -264,6 +271,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,75)
         self.assertEqual(ui.get_fit_results().dof,72)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_spectrum(self):
         self.run_thread('spectrum')
@@ -287,6 +296,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,50)
         self.assertEqual(ui.get_fit_results().dof,47)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xmm(self):
         self.run_thread('xmm')
@@ -309,6 +320,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.83906, 1e-4)
         self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000301258, 1e-4)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_proj(self):
         self.run_thread('proj')
@@ -380,6 +393,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['proj_res2'].parmaxes[2],
                                   0.0981627, 1e-2)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_proj_bubble(self):
         self.run_thread('proj_bubble')
@@ -407,8 +422,11 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(ui.get_proj_results().parmaxes[1],
                                   2.403640e-06, 1e-2)
 
-    ### New tests based on SDS threads -- we should catch these errors
-    ### (if any occur) so SDS doesn't waste time tripping over them.
+    # New tests based on SDS threads -- we should catch these errors
+    # (if any occur) so SDS doesn't waste time tripping over them.
+    # TODO (OL): What does the above mean? Does this comment still apply?
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_counts(self):
         self.run_thread('counts')
@@ -420,6 +438,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['eflux2'], 1.39662954483e-08, 1e-3)
         self.assertEqualWithinTol(self.locals['pflux1'], 1.6178938637, 1e-2)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_stats_all(self):
         self.run_thread('stats_all')
@@ -445,6 +465,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 3307)
         self.assertEqual(ui.get_fit_results().dof, 3302)
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_setfullmodel(self):
         self.run_thread('setfullmodel')
@@ -453,6 +475,8 @@ class test_threads(SherpaTestCase):
     def test_bug13537(self):
         self.run_thread('bug13537')
 
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                     "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xmm2(self):
         self.run_thread('xmm2')

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -17,8 +17,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import unittest
 from sherpa.astro.data import DataPHA
-from sherpa.utils import SherpaTestCase, needs_data
+from sherpa.utils import SherpaTestCase, test_data_missing
 from sherpa.all import *
 from sherpa.astro.all import *
 import logging

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/tests/test_plot.py
+++ b/sherpa/astro/tests/test_plot.py
@@ -17,7 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, needs_data
+import unittest
+from sherpa.utils import SherpaTestCase, test_data_missing
 from sherpa.astro.data import DataPHA
 from sherpa.all import *
 from sherpa.astro.all import *

--- a/sherpa/astro/tests/test_plot.py
+++ b/sherpa/astro/tests/test_plot.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -21,6 +21,7 @@
 
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
+from sherpa.utils import has_fits_support
 import sherpa.astro.ui as ui
 import logging
 import os
@@ -46,7 +47,9 @@ class test_more_ui(SherpaTestCase):
         self.nan = self.datadir + '/ciao4.3/filternan/with_nan.fits'
         logger.setLevel(logging.ERROR)
 
-    #bug 12784
+    # bug 12784
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits, or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_nan(self):
         self.run_thread('filternan')

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -37,7 +37,7 @@ class test_more_ui(SherpaTestCase):
         os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
         execfile(scriptname, {}, self.locals)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.img = self.datadir + '/img.fits'
         self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
@@ -46,7 +46,7 @@ class test_more_ui(SherpaTestCase):
         logger.setLevel(logging.ERROR)
 
     #bug 12784
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_nan(self):
         self.run_thread('filternan')
         self.assertFalse(numpy.isnan(ui.get_fit_results().statval))

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -19,7 +19,8 @@
 
 
 
-from sherpa.utils import SherpaTest, SherpaTestCase, needs_data
+import unittest
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 import sherpa.astro.ui as ui
 import logging
 import os

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -49,7 +49,7 @@ class test_more_ui(SherpaTestCase):
 
     # bug 12784
     @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits, or astropy.io.fits')
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_nan(self):
         self.run_thread('filternan')

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2013  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2013, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/tests/test_ui.py
+++ b/sherpa/astro/ui/tests/test_ui.py
@@ -17,9 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
 import unittest
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, has_package_from_list
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, has_fits_support
 import sherpa.astro.ui as ui
 import numpy
 import logginglogger = logging.getLogger("sherpa")
@@ -42,14 +41,16 @@ class test_ui(SherpaTestCase):
         self.func = lambda x: x
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
 
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ascii(self):
         ui.load_ascii(1, self.ascii)
         ui.load_ascii(1, self.ascii, 2)
         ui.load_ascii(1, self.ascii, 2, ("col2", "col1"))
 
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table(self):
         ui.load_table(1, self.fits)
@@ -58,38 +59,45 @@ class test_ui(SherpaTestCase):
         ui.load_table(1, self.fits, 4, ('R',"SUR_BRI",'SUR_BRI_ERR'),
                       ui.Data1DInt)
 
-
     # Test table model
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.singledat)
         ui.load_table_model('tbl', self.doubledat)
 
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_fits_table(self):
         ui.load_table_model('tbl', self.singletbl)
         ui.load_table_model('tbl', self.doubletbl)
 
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_fits_image(self):
         ui.load_table_model('tbl', self.img)
 
 
     # Test user model
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_user_model_ascii_table(self):
         ui.load_user_model(self.func, 'mdl', self.singledat)
         ui.load_user_model(self.func, 'mdl', self.doubledat)
 
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_user_model_fits_table(self):
         ui.load_user_model(self.func, 'mdl', self.singletbl)
         ui.load_user_model(self.func, 'mdl', self.doubletbl)
 
-
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_ascii(self):
         ui.load_filter(self.filter_single_int_ascii)
@@ -97,6 +105,8 @@ class test_ui(SherpaTestCase):
 
 
     # Test load_filter
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_table(self):
         ui.load_filter(self.filter_single_int_table)
@@ -114,6 +124,8 @@ class test_more_ui(SherpaTestCase):
 	logger.setLevel(logging.ERROR)
 
     #bug #12732
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_string_model_with_rmf(self):
 	ui.load_pha("foo", self.pha)
@@ -139,6 +151,8 @@ class test_image_12578(SherpaTestCase):
 	ui.clean()
     
     #bug #12578
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_coord_bad_coord(self):
 	from sherpa.utils.err import IdentifierErr, DataErr
@@ -178,7 +192,9 @@ class test_psf_ui(SherpaTestCase):
     def tearDown(self):
         pass
 
-    def test_psf_model2d(self):
+    @unittest.skip("TODO: failing test used to have a different name and " +
+                   "was never executed")
+    def test_psf_model1d(self):
         ui.dataspace1d(1, 10)
         for model in self.models1d:
             try:
@@ -190,7 +206,6 @@ class test_psf_ui(SherpaTestCase):
             except:
                 print model
                 raise
-
 
     def test_psf_model2d(self):
         ui.dataspace2d([216,261])
@@ -217,7 +232,9 @@ class test_stats_ui(SherpaTestCase):
         self.data = self.datadir + '/threads/chi2/SWIFTJ0840.1+2946.pha.gz'
 	ui.clean()
 
-    #bugs #11400, #13297, #12365    
+    # bugs #11400, #13297, #12365
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_chi2(self):
 

--- a/sherpa/astro/ui/tests/test_ui.py
+++ b/sherpa/astro/ui/tests/test_ui.py
@@ -25,7 +25,7 @@ import logginglogger = logging.getLogger("sherpa")
 
 class test_ui(SherpaTestCase):
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.ascii = self.datadir + '/threads/ascii_table/sim.poisson.1.dat'
         self.fits = self.datadir + '/1838_rprofile_rmid.fits'
@@ -42,14 +42,14 @@ class test_ui(SherpaTestCase):
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ascii(self):
         ui.load_ascii(1, self.ascii)
         ui.load_ascii(1, self.ascii, 2)
         ui.load_ascii(1, self.ascii, 2, ("col2", "col1"))
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table(self):
         ui.load_table(1, self.fits)
         ui.load_table(1, self.fits, 3)
@@ -59,44 +59,44 @@ class test_ui(SherpaTestCase):
 
 
     # Test table model
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.singledat)
         ui.load_table_model('tbl', self.doubledat)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_fits_table(self):
         ui.load_table_model('tbl', self.singletbl)
         ui.load_table_model('tbl', self.doubletbl)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_fits_image(self):
         ui.load_table_model('tbl', self.img)
 
 
     # Test user model
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_user_model_ascii_table(self):
         ui.load_user_model(self.func, 'mdl', self.singledat)
         ui.load_user_model(self.func, 'mdl', self.doubledat)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_user_model_fits_table(self):
         ui.load_user_model(self.func, 'mdl', self.singletbl)
         ui.load_user_model(self.func, 'mdl', self.doubletbl)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_ascii(self):
         ui.load_filter(self.filter_single_int_ascii)
         ui.load_filter(self.filter_single_int_ascii, ignore=True)
 
 
     # Test load_filter
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_table(self):
         ui.load_filter(self.filter_single_int_table)
         ui.load_filter(self.filter_single_int_table, ignore=True)
@@ -105,7 +105,7 @@ class test_ui(SherpaTestCase):
         ui.load_filter(self.filter_single_log_table, ignore=True)
 
 class test_more_ui(SherpaTestCase):
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.img = self.datadir + '/img.fits'
 	self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
@@ -113,7 +113,7 @@ class test_more_ui(SherpaTestCase):
 	logger.setLevel(logging.ERROR)
 
     #bug #12732
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_string_model_with_rmf(self):
 	ui.load_pha("foo", self.pha)
 	ui.load_rmf("foo", self.rmf)
@@ -131,14 +131,14 @@ class test_more_ui(SherpaTestCase):
 
 
 class test_image_12578(SherpaTestCase):
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.img = self.datadir + '/img.fits'
 	logger.setLevel(logging.ERROR)
 	ui.clean()
     
     #bug #12578
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_coord_bad_coord(self):
 	from sherpa.utils.err import IdentifierErr, DataErr
 
@@ -211,13 +211,13 @@ class test_psf_ui(SherpaTestCase):
     
 class test_stats_ui(SherpaTestCase):
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.data = self.datadir + '/threads/chi2/SWIFTJ0840.1+2946.pha.gz'
 	ui.clean()
 
     #bugs #11400, #13297, #12365    
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_chi2(self):
 
 	#Case 1: first ds has no error, second has, chi2-derived (chi2gehrels) statistic

--- a/sherpa/astro/ui/tests/test_ui.py
+++ b/sherpa/astro/ui/tests/test_ui.py
@@ -18,7 +18,8 @@
 #
 
 
-from sherpa.utils import SherpaTest, SherpaTestCase, needs_data
+import unittest
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing, has_package_from_list
 import sherpa.astro.ui as ui
 import numpy
 import logginglogger = logging.getLogger("sherpa")

--- a/sherpa/astro/ui/tests/test_ui.py
+++ b/sherpa/astro/ui/tests/test_ui.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2012  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -34,7 +34,7 @@ def is_proper_subclass(obj, cls):
 
 
 @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                         "required package sherpa.astro.xspec not available")
+                         "required sherpa.astro.xspec module missing")
 class test_xspec(SherpaTestCase):
 
     def test_create_model_instances(self):

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -90,7 +90,7 @@ class test_xspec(SherpaTestCase):
                 raise
 
     @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits, or astropy.io.fits')
+                     'need pycrates, pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_analysis_wave_fabrizio(self):
         rmf = self.datadir + '/ciao4.3/fabrizio/Data/3c273.rmf'

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -83,7 +83,7 @@ class test_xspec(SherpaTestCase):
                 error('XS%s model evaluation failed' % model)
                 raise
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_analysis_wave_fabrizio(self):
         rmf = self.datadir + '/ciao4.3/fabrizio/Data/3c273.rmf'
         arf = self.datadir + '/ciao4.3/fabrizio/Data/3c273.arf'

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -19,9 +19,8 @@
 
 import unittest
 import numpy
-import sherpa.astro.xspec as xs
 from sherpa.astro import ui
-from sherpa.utils import SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTestCase, test_data_missing, has_package_from_list
 
 import logging
 error = logging.getLogger(__name__).error
@@ -34,9 +33,12 @@ def is_proper_subclass(obj, cls):
     return issubclass(obj, cls)
 
 
+@unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                         "required package sherpa.astro.xspec not available")
 class test_xspec(SherpaTestCase):
 
     def test_create_model_instances(self):
+        import sherpa.astro.xspec as xs
         count = 0
 
         for cls in dir(xs):
@@ -53,6 +55,7 @@ class test_xspec(SherpaTestCase):
         self.assertEqual(count, 164)
 
     def test_evaluate_model(self):
+        import sherpa.astro.xspec as xs
         m = xs.XSbbody()
         out = m([1,2,3,4])
         if m.calc.__name__.startswith('C_'):
@@ -64,6 +67,7 @@ class test_xspec(SherpaTestCase):
 
 
     def test_xspec_models(self):
+        import sherpa.astro.xspec as xs
         models = [model for model in dir(xs) if model[:2] == 'XS']
         models.remove('XSModel')
         models.remove('XSMultiplicativeModel')
@@ -107,12 +111,13 @@ class test_xspec(SherpaTestCase):
         self.assertAlmostEqual(y_m, y2_m)
 
     def test_xsxset_get(self):
+        import sherpa.astro.xspec as xs
 	# TEST CASE #1 Case insentitive keys
 	xs.set_xsxset('fooBar', 'somevalue')
 	self.assertEqual('somevalue', xs.get_xsxset('Foobar'))
 
 
 if __name__ == '__main__':
-
+    import sherpa.astro.xspec as xs
     from sherpa.utils import SherpaTest
     SherpaTest(xs).test()

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -20,7 +20,8 @@
 import unittest
 import numpy
 from sherpa.astro import ui
-from sherpa.utils import SherpaTestCase, test_data_missing, has_package_from_list
+from sherpa.utils import SherpaTestCase, test_data_missing
+from sherpa.utils import has_package_from_list, has_fits_support
 
 import logging
 error = logging.getLogger(__name__).error
@@ -34,7 +35,7 @@ def is_proper_subclass(obj, cls):
 
 
 @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                         "required sherpa.astro.xspec module missing")
+                 "required sherpa.astro.xspec module missing")
 class test_xspec(SherpaTestCase):
 
     def test_create_model_instances(self):
@@ -88,6 +89,8 @@ class test_xspec(SherpaTestCase):
                 error('XS%s model evaluation failed' % model)
                 raise
 
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits, or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_analysis_wave_fabrizio(self):
         rmf = self.datadir + '/ciao4.3/fabrizio/Data/3c273.rmf'

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -17,10 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import unittest
 import numpy
 import sherpa.astro.xspec as xs
 from sherpa.astro import ui
-from sherpa.utils import SherpaTestCase, needs_data
+from sherpa.utils import SherpaTestCase, test_data_missing
 
 import logging
 error = logging.getLogger(__name__).error

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -20,6 +20,7 @@
 import unittest
 import numpy
 import os
+import sherpa
 from sherpa.image import *
 from sherpa.utils import SherpaTestCase, has_package_from_list
 
@@ -54,7 +55,7 @@ class test_image(SherpaTestCase):
         @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
                          "reqiured package sherpa.image.ds9_backend not available")
         def test_ds9(self):
-            im = sherpa.image.ds9_backend.DS9Win(sherpa.image.ds9_backend._DefTemplate, False)
+            im = sherpa.image.ds9_backend.DS9.DS9Win(sherpa.image.ds9_backend.DS9._DefTemplate, False)
             im.doOpen()
             im.showArray(data.y)
             data_out = get_arr_from_imager(im)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -17,11 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import unittest
 import numpy
 import os
 from sherpa.image import *
-import sherpa.image.DS9
-from sherpa.utils import SherpaTestCase
+from sherpa.utils import SherpaTestCase, has_package_from_list
 
 # Create a 10x10 array for the tests.
 class Data(object):
@@ -37,7 +37,7 @@ class Data(object):
             return (self.y, self.y)
         else:
             return self.y
-        
+
 data = Data()
 
 def get_arr_from_imager(im):
@@ -51,14 +51,18 @@ def get_arr_from_imager(im):
 
 class test_image(SherpaTestCase):
     if (os.environ.has_key("DISPLAY") == True):
+        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                         "reqiured package sherpa.image.ds9_backend not available")
         def test_ds9(self):
-            im = sherpa.image.DS9.DS9Win(sherpa.image.DS9._DefTemplate, False)
+            im = sherpa.image.ds9_backend.DS9Win(sherpa.image.ds9_backend._DefTemplate, False)
             im.doOpen()
             im.showArray(data.y)
             data_out = get_arr_from_imager(im)
             im.xpaset("quit") 
             self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
+        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                         "reqiured package sherpa.image.ds9_backend not available")
         def test_image(self):
             im = Image()
             im.image(data.y)
@@ -66,6 +70,8 @@ class test_image(SherpaTestCase):
             im.xpaset("quit") 
             self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
+        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                         "reqiured package sherpa.image.ds9_backend not available")
         def test_data_image(self):
             im = DataImage()
             im.prepare_image(data)
@@ -74,6 +80,8 @@ class test_image(SherpaTestCase):
             im.xpaset("quit") 
             self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
+        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                         "reqiured package sherpa.image.ds9_backend not available")
         def test_model_image(self):
             im = ModelImage()
             im.prepare_image(data, 1)
@@ -82,6 +90,8 @@ class test_image(SherpaTestCase):
             im.xpaset("quit") 
             self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
+        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                         "reqiured package sherpa.image.ds9_backend not available")
         def test_ratio_image(self):
             im = RatioImage()
             im.prepare_image(data, 1)
@@ -93,6 +103,8 @@ class test_image(SherpaTestCase):
             # reassigns the ratio there to be one.
             self.assertEqualWithinTol(data_out.sum(), 99.0, 1e-4)
 
+        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                         "reqiured package sherpa.image.ds9_backend not available")
         def test_resid_image(self):
             im = ResidImage()
             im.prepare_image(data, 1)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -46,13 +46,13 @@ class test_new_templates_ui(SherpaTestCase):
     # When restoring a file saved with an older version of sherpa,
     # we need to make sure models are assigned an is_discrete field.
     # For model that do not have the is_discrete field, fallback to False.
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_restore_is_discrete(self):
 	self.run_thread('template_restore', 'test.py')
 	
 
     # TestCase 1 load_template_model enables interpolation by default
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_with_interpolation(self):
         self.run_thread('load_template_with_interpolation')
         try:   
@@ -62,14 +62,14 @@ class test_new_templates_ui(SherpaTestCase):
                 self.assertEqualWithinTol(2743.47, ui.get_fit_results().parvals[0], 0.001)
                 self.assertEqualWithinTol(2023.46, ui.get_fit_results().parvals[1], 0.001)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_interpolator(self):
         self.run_thread('load_template_interpolator')
         self.assertEqualWithinTol(2743.91, ui.get_fit_results().parvals[0], 0.001)
 
     # TestCase 2 load_template_model with template_interpolator_name=None disables interpolation
     # TestCase 3.1 discrete templates fail when probed for values they do not represent (gridsearch with wrong values) 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
         try:   
                 self.run_thread('load_template_without_interpolation', scriptname='test_case_2_and_3.1.py')
@@ -78,7 +78,7 @@ class test_new_templates_ui(SherpaTestCase):
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
 
     # TestCase 3.2 discrete templates fail when probed for values they do not represent (continuous method with discrete template)
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
         try:   
                 self.run_thread('load_template_without_interpolation', scriptname='test_case_3.2.py')
@@ -88,12 +88,12 @@ class test_new_templates_ui(SherpaTestCase):
 
 
     # TestCase 4 gridsearch with right values succeeds
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_grid_search_with_discrete_template(self):
 	self.run_thread('load_template_without_interpolation', scriptname='test_case_4.py')
 
     # TestCase 5 user can access interpolators' parvals
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_grid_search_with_discrete_template(self):
 	self.run_thread('load_template_with_interpolation', scriptname='test_case_5.py')
 

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -18,9 +18,10 @@
 #
 
 
+import unittest
 from sherpa.models import TableModel, Gauss1D
 from sherpa.models.template import TemplateModel, create_template_model
-from sherpa.utils import SherpaTest, SherpaTestCase, needs_data
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils.err import ModelErr
 from sherpa import ui
 import numpy, logging, os

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -116,7 +116,7 @@ class test_plot(SherpaTestCase):
 
 class test_contour(SherpaTestCase):
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.data = read_data(self.datadir+'/gauss2d.dat',
                               ncols=3, sep='\t', dstype=Data2D)
@@ -126,35 +126,35 @@ class test_contour(SherpaTestCase):
         self.f = Fit(self.data, self.g1)
         self.levels = numpy.array([0.5, 2, 5, 10, 20])
 
-    @needs_data    
+    @unittest.skipIf(test_data_missing(), "required test data missing")    
     def test_datacontour(self):
         dc = DataContour()
         dc.prepare(self.data)
         dc.levels=self.levels
         #dc.contour()
 
-    @needs_data    
+    @unittest.skipIf(test_data_missing(), "required test data missing")    
     def test_modelcontour(self):
         mc = ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
         mc.levels=self.levels
         #mc.contour()
 
-    @needs_data   
+    @unittest.skipIf(test_data_missing(), "required test data missing")   
     def test_residcontour(self):
         rc = ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
         rc.levels=self.levels
         #rc.contour()
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ratiocontour(self):
         tc = RatioContour()
         tc.prepare(self.data, self.g1, self.f.stat)
         tc.levels=self.levels
         #tc.contour()
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fitcontour(self):
         dc = DataContour()
         dc.prepare(self.data)
@@ -166,7 +166,7 @@ class test_contour(SherpaTestCase):
         fc.prepare(dc, mc)
         #fc.contour()
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_splitcontour(self):
         dc = DataContour()
         dc.levels=self.levels
@@ -201,7 +201,7 @@ class test_confidence(SherpaTestCase):
         self.rp = RegionProjection()
         self.ru = RegionUncertainty()
 
-    #@needs_data
+    #@unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_projection(self):
         _ipx = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -223,7 +223,7 @@ class test_confidence(SherpaTestCase):
         #self.ip.plot()
         
 
-    #@needs_data
+    #@unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_uncertainty(self):
         _iux = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -245,7 +245,7 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_iuy, self.iu.y, 1e-4)
         #self.iu.plot()
         
-    #@needs_data
+    #@unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_projection(self):
         _rpx0 = numpy.array(
             [ 11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
@@ -326,7 +326,7 @@ class test_confidence(SherpaTestCase):
         #self.rp.contour()
 
         
-    #@needs_data
+    #@unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_uncertainty(self):
         _rux0 = numpy.array(
             [ 12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -17,10 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import unittest
 import numpy
 from sherpa.all import *
 #FIXME change from full import 
-from sherpa.utils import SherpaTestCase, needs_data
+from sherpa.utils import SherpaTestCase, test_data_missing
 
 
 _datax = numpy.array(

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -28,25 +28,25 @@ class test_sherpa(SherpaTestCase):
         incdir = os.path.join(sherpa.get_include(), 'sherpa')
         self.assert_(os.path.isdir(incdir))
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
 	self.agn2 = self.datadir + '/ciao4.3/faulty_load_data/agn2'
 	self.agn2_fixed = self.datadir + '/ciao4.3/faulty_load_data/agn2_fixed'
 	self.template_idx = self.datadir + '/ciao4.3/faulty_load_data/table.txt'
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_not_reading_header_without_comment(self):
 	self.assertRaises(ValueError, ui.load_data, self.agn2)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_reading_floats(self):
 	ui.load_data(self.agn2_fixed)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_reading_strings(self):
 	ui.load_data(self.template_idx, require_floats=False)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_require_float(self):
 	self.assertRaises(ValueError, ui.load_data, self.agn2)
 

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -17,9 +17,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import unittest
 import os.path
 import sherpa
-from sherpa.utils import SherpaTest, SherpaTestCase, needs_data
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa import ui
 
 class test_sherpa(SherpaTestCase):

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -18,7 +18,8 @@
 #
 
 
-from sherpa.utils import SherpaTest, SherpaTestCase, needs_data
+import unittest
+from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.models import ArithmeticModel, Parameter
 from sherpa.utils.err import ModelErr
 import sherpa.ui as ui

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2012  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -40,7 +40,7 @@ class UserModel(ArithmeticModel):
 
 class test_ui(SherpaTestCase):
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.ascii = self.datadir + '/threads/ascii_table/sim.poisson.1.dat'
         self.single = self.datadir + '/single.dat'
@@ -50,7 +50,7 @@ class test_ui(SherpaTestCase):
         
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ascii(self):
         ui.load_data(1, self.ascii)
         ui.load_data(1, self.ascii, 2)
@@ -58,30 +58,30 @@ class test_ui(SherpaTestCase):
 
 
     # Test table model
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.single)
         ui.load_table_model('tbl', self.double)
 
 
     # Test user model
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_user_model_ascii_table(self):
         ui.load_user_model(self.func, 'mdl', self.single)
         ui.load_user_model(self.func, 'mdl', self.double)
 
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_ascii(self):
         ui.load_filter(self.filter)
         ui.load_filter(self.filter, ignore=True)
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_add_model(self):
         ui.add_model(UserModel)
         ui.set_model('usermodel.user1')
 
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_full_model(self):
         ui.load_psf('psf1', 'gauss2d.g1')
         ui.set_full_model('psf1(gauss2d.g2)+const2d.c1')
@@ -89,7 +89,7 @@ class test_ui(SherpaTestCase):
 #        ui.get_source()
 
     # Bug 12644
-    @needs_data
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_source_methods_with_full_model(self):
         from sherpa.utils.err import IdentifierErr
         

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -223,23 +223,6 @@ class SherpaTestCase(numpytest.NumpyTestCase):
         self.assert_(numpy.all(sao_fcmp(first, second, tol)), msg)
 
 
-def needs_xspec(meth):
-    """
-    Decorator for tests requiring the xspec extension, similar to needs_data.
-
-    :param meth:
-    :return:
-    """
-    def new_meth(self):
-        try:
-            from sherpa.astro import xspec
-        except:
-            return
-        return meth(self)
-    new_meth.__name__ = meth.__name__
-    return new_meth
-
-
 def test_data_missing():
     """
     Returns True if external data (i.e. data not distributed with Sherpa
@@ -256,7 +239,7 @@ def has_package_from_list(*packages):
         try:
             importlib.import_module(package)
             return True
-        except ImportError:
+        except:
             pass
     return False
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -88,7 +88,7 @@ __all__ = ('NoNewAttributesAfterInit', 'SherpaTest', 'SherpaTestCase',
            'guess_reference', 'histogram1d', 'histogram2d', 'igam', 'igamc',
            'incbet', 'interpolate', 'is_binary_file', 'Knuth_close',
            'lgam', 'linear_interp', 'nearest_interp',
-           'needs_data', 'neville', 'neville2d',
+           'test_data_missing', 'neville', 'neville2d',
            'new_muller', 'normalize', 'numpy_convolve',
            'pad_bounding_box', 'parallel_map', 'param_apply_limits',
            'parse_expr', 'poisson_noise', 'print_fields', 'rebin',
@@ -240,22 +240,12 @@ def needs_xspec(meth):
     return new_meth
 
 
-def needs_data(meth):
+def test_data_missing():
     """
-
-    Decorator for test_* methods of SherpaTestCase subclasses that
-    indicates that the corresponding test requires external data
-    (i.e. data not distributed with Sherpa itself).  Its effect is to
-    make the test a no-op if SherpaTestCase.datadir is None.
-
+    Returns True if external data (i.e. data not distributed with Sherpa
+    itself) is missing.  This is used to skip tests that require such data.
     """
-
-    def new_meth(self):
-        if SherpaTestCase.datadir is None:
-            return
-        meth(self)
-    new_meth.__name__ = meth.__name__
-    return new_meth
+    return SherpaTestCase.datadir is None
 
 
 def has_package_from_list(*packages):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -29,6 +29,7 @@ from types import FunctionType as function
 from types import MethodType as instancemethod
 import string
 import sys
+import importlib
 import numpy
 import numpy.random
 import numpytest
@@ -255,6 +256,19 @@ def needs_data(meth):
         meth(self)
     new_meth.__name__ = meth.__name__
     return new_meth
+
+
+def has_package_from_list(*packages):
+    """
+    Returns True if at least one of the ``packages`` args is importable.
+    """
+    for package in packages:
+        try:
+            importlib.import_module(package)
+            return True
+        except ImportError:
+            pass
+    return False
 
 
 class SherpaTest(numpytest.NumpyTest):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -244,6 +244,16 @@ def has_package_from_list(*packages):
     return False
 
 
+def has_fits_support():
+    """
+    Returns True if there is an importable backend for FITS I/O.
+    Used to skip tests requiring fits_io
+    """
+    return has_package_from_list('pyfits',
+                                 'pycrates',
+                                 )
+
+
 class SherpaTest(numpytest.NumpyTest):
     "Sherpa test suite manager"
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Tests are properly skipped when some conditions are not met, e.g. when there is no `FITS` backend available, or the external data/threads data folder is missing.

This is largely based on @taldcroft's original PR #10, but it removes the dependency on astropy (PR #6), it includes more checks, and covers the CIAO use cases, i.e. it also checks for the presence of `pycrates`.

To test:

```
python setup.py develop
sherpa_test
```
tests should be run with and without pyfits or pycrates, with and without xspec, with and without the test data directory (i.e. `sherpa_test -d /data/scialg/testdata`).

When running the full regression test suite (i.e. pyfits+testdata, with or without pyfits) some tests are expected to fail because of unmet dependencies (CIAO data model, pycrates), and they will be fixed in the PR that introduces the new testing infrastructure.

Below is a log of the tests that are expected to fail:
```
$ sherpa_test -d /data/scialg/testdata
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
Failed importing sherpa.astro.xspec: No module named _xspec
  Found 7/7 tests for sherpa.astro.tests.test_datastack
  Found 1/1 tests for sherpa.astro.models.tests.test_models
  Found 25/25 tests for sherpa.astro.tests.test_optical
  Found 2/2 tests for sherpa.astro.sim.tests.test_sim
  Found 26/26 tests for sherpa.astro.tests.test_astro
  Found 6/6 tests for sherpa.astro.tests.test_data
  Found 1/1 tests for sherpa.astro.tests.test_plot
  Found 1/1 tests for sherpa.astro.ui.tests.test_nan
  Found 15/15 tests for sherpa.astro.ui.tests.test_ui
  Found 1/1 tests for sherpa.astro.utils.tests.test_utils
  Found 4/4 tests for sherpa.estmethods.tests.test_estmethods
  Found 0/0 tests for sherpa.image.tests.test_image
  Found 1/1 tests for sherpa.models.tests.test_basic
  Found 14/14 tests for sherpa.models.tests.test_model
  Found 12/12 tests for sherpa.models.tests.test_parameter
  Found 6/6 tests for sherpa.models.tests.test_template
  Found 26/26 tests for sherpa.optmethods.tests.test_optmethods
  Found 18/18 tests for sherpa.plot.tests.test_plot
  Found 18/18 tests for sherpa.sim.tests.test_sim
  Found 5/5 tests for sherpa.tests.test_sherpa
  Found 1/1 tests for sherpa.tests.test_stack
  Found 8/8 tests for sherpa.tests.test_ui
  Found 1/1 tests for sherpa.utils.tests.test_err
  Found 1/1 tests for sherpa.utils.tests.test_integration
  Found 43/43 tests for sherpa.utils.tests.test_root
  Found 10/10 tests for sherpa.utils.tests.test_utils
.................................ss..s....E.s.sss....sss.ssss..........s..E..................................................................................................................................................................................
======================================================================
ERROR: test_lev3fft (sherpa.astro.tests.test_astro.test_threads)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/tests/test_astro.py", line 501, in test_lev3fft
    self.run_thread('lev3fft', scriptname='bar.py')
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/tests/test_astro.py", line 60, in run_thread
    execfile(scriptname, {}, self.locals)
  File "bar.py", line 15, in <module>
    notice2d_id(srcid, "region(" + reg_file + "[SRCREG])")
  File "<string>", line 1, in notice2d_id
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/ui/utils.py", line 6432, in notice2d_id
    self.get_data(id).notice2d(val, False)
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/data.py", line 2002, in notice2d
    os.path.isfile(val), ignore)
TypeError: unable to parse region string successfully

======================================================================
ERROR: test_chi2 (sherpa.astro.ui.tests.test_ui.test_stats_ui)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/ui/tests/test_ui.py", line 252, in test_chi2
    si=ui.get_stat_info()
  File "<string>", line 1, in get_stat_info
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/ui/utils.py", line 7660, in get_stat_info
    return self._get_stat_info()
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/ui/utils.py", line 9441, in _get_stat_info
    ids, datasets, models = self._prepare_fit(None)
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/ui/utils.py", line 7484, in _prepare_fit
    mod = self._get_model(i)
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/ui/utils.py", line 5552, in _get_model
    return self._add_convolution_models(id, data, model, is_source)
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/ui/utils.py", line 8325, in _add_convolution_models
    resp = sherpa.astro.instrument.Response1D(data)
  File "/data/scialg/staff/olaurino/working/sherpa/sherpa/astro/instrument.py", line 651, in __init__
    raise DataErr('norsp', pha.name)
DataErr: No instrument response found for dataset /data/scialg/testdata/threads/chi2/SWIFTJ0840.1+2946.pha.gz

----------------------------------------------------------------------
Ran 253 tests in 36.441s

FAILED (errors=2, skipped=15)
```
