### PR TITLE
workaround new crates API: crates now returns var-length arrays

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -236,7 +236,7 @@ def _try_col(crate, colname, make_copy=False, fix_type=False, dtype=SherpaFloat)
     if col is None:
         return None
 
-    if col.is_varlen():
+    if hasattr(col, 'is_varlen') and col.is_varlen():
         values = col.get_fixed_length_array()
     else:
         values = col.values
@@ -309,7 +309,7 @@ def _try_col_list(crate, colname, num, make_copy=False, fix_type=False,
 
     col = crate.get_column(colname)
 
-    if col.is_varlen():
+    if hasattr(col, 'is_varlen') and col.is_varlen():
         values = col.get_fixed_length_array()
     else:
         values = col.values

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -236,13 +236,18 @@ def _try_col(crate, colname, make_copy=False, fix_type=False, dtype=SherpaFloat)
     if col is None:
         return None
 
+    if col.is_varlen():
+        values = col.get_fixed_length_array()
+    else:
+        values = col.values
+
     if make_copy:
         # Make a copy if a filename passed in
-        data = numpy.array(col.values).ravel()
+        data = numpy.array(values).ravel()
 
     else:
         # Use a reference if a crate passed in
-        data = numpy.asarray(col.values).ravel()
+        data = numpy.asarray(values).ravel()
 
     if fix_type:
         data = data.astype(dtype)
@@ -304,12 +309,17 @@ def _try_col_list(crate, colname, num, make_copy=False, fix_type=False,
 
     col = crate.get_column(colname)
 
+    if col.is_varlen():
+        values = col.get_fixed_length_array()
+    else:
+        values = col.values
+
     if make_copy:
         # Make a copy if a filename passed in
-        col = numpy.array(col.values)
+        col = numpy.array(values)
     else:
         # Use a reference if a crate passed in
-        col = numpy.asarray(col.values)
+        col = numpy.asarray(values)
 
     if fix_type:
         col = col.astype(dtype)


### PR DESCRIPTION
#### Release Note
Fix segfault from CRATES update in 4.8b1

In 4.8b1 CRATES returns variable length arrays by default, rather than the zero-padded fixed length ones it used to return. Sherpa manipulated the arrays so to remove the zero-padding and obtaining variable length arrays. The change in the CRATES API resulted in Sherpa segfaulting when trying to manipulate the data coming from CRATES.

In the patch, we use a new API offered by CRATES to get the old-style fixed-length arrays instead of the new default ones.

In the future, we may want to update the Sherpa code to deal with the new arrays directly. Also, this patch uncovered some code duplication.

#### Tests
The patch was tested in the CIAO 4.8b1 builds where the segmentation fault occurred, and new CIAO builds have been produced with this change.

Additional tests (after commit 683f2d4) have been performed on CIAOD from June 25, 2015.