### PR TITLE
Bugfix: Improving the X-Spec build

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,32 +327,58 @@ Sherpa does not support
 default. However, it is possible to instruct Sherpa to build its
 `XSPEC` extension module by changing the build configuration options.
 
-There are three ways to build the extension:
-
- 1. build the full XSpec system;
-
- 2. use the model-only build of XSpec, which will also require
-    building the cfitsio, CCfits, and WCS libraries;
- 
- 3. or point to the X-Spec libraries provided by
-    [CIAO](http://cxc.harvard.edu/ciao/).
-
-In all cases, the same version of `gfortran` should be used to
-build Sherpa and X-Spec, to avoid possible incompatabilities.
-
 The `xspec_config` section of the `setup.cfg` file will need
 changing to point to the libraries, and to turn on the extension.
-An example, for the case when a full XSpec build was made, is:
+In all cases, set
 
     with-xspec=True
-    xspec_lib_dirs=$HEADAS/lib
-    xspec_libraries=XSFunctions XSModel XSUtil XS wcs-4.20
-    cfitsio_libraries=cfitsio_3.37
-    ccfits_libraries=CCfits_2.4
 
-The environment variable `$HEADAS` should be expanded out, and the
-version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
-may need to be changed.
+The remaining settings depend on how the XSPEC libraries have
+been built (in the examples below, environment variables are
+used, but the full path should be in your own copy of the file):
+
+ 1. If the full XSPEC system has been built, then use
+
+        xspec_lib_dirs=$HEADAS/lib
+        xspec_libraries=XSFunctions XSModel XSUtil XS wcs-4.20
+        cfitsio_libraries=cfitsio_3.37
+        ccfits_libraries=CCfits_2.4
+
+    The environment variable `$HEADAS` should be expanded out, and the
+    version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
+    may need to be changed.
+
+ 2. Use the model-only build of XSPEC, which will also require
+    building the
+    [cfitsio](http://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html),
+    [CCfits](http://heasarc.gsfc.nasa.gov/docs/software/fitsio/ccfits/),
+    and
+    [WCSLIB](http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/)
+    libraries (it is not clear if version 5 is supported, since
+    XSPEC 12.8.2 uses version 4.20). If all the libraries are installed
+    into the same location ($HEADAS/lib), then a similar set up to the
+    full XSPEC build is used
+
+        xspec_lib_dirs=$HEADAS/lib
+        xspec_libraries=XSFunctions XSModel XSUtil XS wcs
+
+    except that the library names (`cfitiso`, `CCfits`, and
+    `wcs`) do not need version numbers. If placed in different
+    directories then the `cfitsio_lib_dirs`, `ccfits_lib_dirs`,
+    and (possibly) `gfortran_lib_dirs` values should be set
+    appropriately.
+
+ 3. or point to the XSPEC libraries provided by
+    [CIAO](http://cxc.harvard.edu/ciao/). In this case the
+    `wcs` library does not need to be specified because of
+    the way the XSPEC models-only version was built with
+    CIAO 4.7.
+
+        xspec_lib_dirs=$ASCDS_INSTALL/ots/lib
+        xspec_libraries=XSFunctions XSModel XSUtil XS
+
+In all cases, the same version of `gfortran` should be used to
+build Sherpa and XSPEC, to avoid possible incompatabilities.
 
 If there are problems building, or using, the module, then the other
 options may need to be set - in particular the `gfortran_lib_dirs` and
@@ -361,6 +387,21 @@ options may need to be set - in particular the `gfortran_lib_dirs` and
 The XSpec module is designed for use with XSpec version 12.8.2e. It
 can be used with other versions - either patches to 12.8.2 or
 different versions - but there may be build or user issues.
+
+In order for the module to work, the `HEADAS` environment variable has
+to be set in the shell from which the Python session is started.  For
+the CIAO-XSPEC build, `HEADAS` should be set to
+`$ASCDS_INSTALL/ots/spectral`, otherwise it is the parent directory of
+the `xspec_lib_dirs` directory.
+
+In order to check that the module is working, importing the
+`sherpa.astro.ui` module will no-longer warn you that the
+`sherpa.astro.xspec` module is not available and you can use routines
+such as:
+
+    >>> from sherpa.astro import xspec
+    >>> xspec.get_xsversion()
+    '12.8.2e'
 
 Other customization options
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -327,34 +327,40 @@ Sherpa does not support
 default. However, it is possible to instruct Sherpa to build its
 `XSPEC` extension module by changing the build configuration options.
 
-You may need to build `XSPEC` yourself, and in any case to  point Sherpa to existing
-binary libraries for `XSPEC`, `cfitsio`, and `CCfits`.
-Additionaly, you will need to point Sherpa to the `libgfortran` shared library.
-These dependencies are required to build `XSPEC` itself, so they are assumed to
-be present on the system where you want to build Sherpa with `XSPEC` support.
+There are three ways to build the extension:
 
-First, download the Sherpa source tarball or get the source code from GitHub:
+ 1. build the full XSpec system;
 
-    $ git clone https://github.com/sherpa/sherpa.git
-    $ cd sherpa
+ 2. use the model-only build of XSpec, which will also require
+    building the cfitsio, CCfits, and WCS libraries;
+ 
+ 3. or point to the X-Spec libraries provided by
+    [CIAO](http://cxc.harvard.edu/ciao/).
 
-Now, edit the `setup.cfg` file. Find the XSPEC configuration section in the
-file, uncomment the relative options and make sure they point to the location
-of the `XSPEC`, `cfitsio`, `CCfits`, and `gfortran` libraries. For instance:
+In all cases, the same version of `gfortran` should be used to
+build Sherpa and X-Spec, to avoid possible incompatabilities.
+
+The `xspec_config` section of the `setup.cfg` file will need
+changing to point to the libraries, and to turn on the extension.
+An example, for the case when a full XSpec build was made, is:
 
     with-xspec=True
-    xspec_lib_dirs=/opt/xspec/lib
-    cfitsio_lib_dirs=/usr/local/lib
-    ccfits_lib_dirs=/usr/local/lib
-    gfortran_lib_dirs=/usr/local/lib
+    xspec_lib_dirs=$HEADAS/lib
+    xspec_libraries=XSFunctions XSModel XSUtil XS wcs-4.20
+    cfitsio_libraries=cfitsio_3.37
+    ccfits_libraries=CCfits_2.4
 
-You may need to change the values in the above example to reflect the actual
-directories where the libraries are to be found on your system.
+The environment variable `$HEADAS` should be expanded out, and the
+version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
+may need to be changed.
 
-Then, build Sherpa in the standard way:
+If there are problems building, or using, the module, then the other
+options may need to be set - in particular the `gfortran_lib_dirs` and
+`gfortran_libraries` settings.
 
-    $ python setup.py install
-
+The XSpec module is designed for use with XSpec version 12.8.2e. It
+can be used with other versions - either patches to 12.8.2 or
+different versions - but there may be build or user issues.
 
 Other customization options
 ---------------------------

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -35,6 +35,8 @@ class xspec_config(Command):
                     ('cfitsio-libraries', None, "Name of the libraries that should be linked for cfitsio"),
                     ('ccfits-lib-dirs', None, "Where the CCfits libraries are located, if with-xspec is True"),
                     ('ccfits-libraries', None, "Name of the libraries that should be linked for CCfits"),
+                    ('wcslib-lib-dirs', None, "Where the WCSLIB libraries are located, if with-xspec is True"),
+                    ('wcslib-libraries', None, "Name of the libraries that should be linked for WCSLIB"),
                     ('gfortran-lib-dirs', None, "Where the gfortran libraries are located, if with-xspec is True"),
                     ('gfortran-libraries', None, "Name of the libraries that should be linked for gfortran"),
                     ]
@@ -50,6 +52,9 @@ class xspec_config(Command):
         self.ccfits_include_dirs = ''
         self.ccfits_lib_dirs = ''
         self.ccfits_libraries = 'CCfits'
+        self.wcslib_include_dirs = ''
+        self.wcslib_lib_dirs = ''
+        self.wcslib_libraries = 'wcs'
         self.gfortran_include_dirs = ''
         self.gfortran_lib_dirs = ''
         self.gfortran_libraries = 'gfortran'
@@ -72,11 +77,12 @@ class xspec_config(Command):
             ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
             ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
             ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
-            ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
+            ld4, inc4, l4 = build_lib_arrays(self, 'wcslib')
+            ld5, inc5, l5 = build_lib_arrays(self, 'gfortran')
 
-            ld = clean(ld1 + ld2 + ld3 + ld4)
-            inc = clean(inc1 + inc2 + inc3 + inc4)
-            l = clean(l1 + l2 + l3 + l4)
+            ld = clean(ld1 + ld2 + ld3 + ld4 + ld5)
+            inc = clean(inc1 + inc2 + inc3 + inc4 + inc5)
+            l = clean(l1 + l2 + l3 + l4 + l5)
 
             self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))
 

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -22,63 +22,63 @@ from numpy.distutils.core import Command
 from extensions import build_ext, build_lib_arrays
 
 class xspec_config(Command):
-        description = "Configure XSPEC Models external module (optional) "
-        user_options = [
-                        ('with-xspec', None, "Whether sherpa must build the XSPEC module (default False)"),
-                        ('xspec-lib-dirs', None, "Where the xspec libraries are located, if with-xspec is True"),
-                        ('xspec-libraries', None, "Name of the libraries that should be linked for xspec"),
-                        ('cfitsio-lib-dirs', None, "Where the cfitsio libraries are located, if with-xspec is True"),
-                        ('cfitsio-libraries', None, "Name of the libraries that should be linked for cfitsio"),
-                        ('ccfits-lib-dirs', None, "Where the CCfits libraries are located, if with-xspec is True"),
-                        ('ccfits-libraries', None, "Name of the libraries that should be linked for CCfits"),
-                        ('gfortran-lib-dirs', None, "Where the gfortran libraries are located, if with-xspec is True"),
-                        ('gfortran-libraries', None, "Name of the libraries that should be linked for gfortran"),
-                        ]
+    description = "Configure XSPEC Models external module (optional) "
+    user_options = [
+                    ('with-xspec', None, "Whether sherpa must build the XSPEC module (default False)"),
+                    ('xspec-lib-dirs', None, "Where the xspec libraries are located, if with-xspec is True"),
+                    ('xspec-libraries', None, "Name of the libraries that should be linked for xspec"),
+                    ('cfitsio-lib-dirs', None, "Where the cfitsio libraries are located, if with-xspec is True"),
+                    ('cfitsio-libraries', None, "Name of the libraries that should be linked for cfitsio"),
+                    ('ccfits-lib-dirs', None, "Where the CCfits libraries are located, if with-xspec is True"),
+                    ('ccfits-libraries', None, "Name of the libraries that should be linked for CCfits"),
+                    ('gfortran-lib-dirs', None, "Where the gfortran libraries are located, if with-xspec is True"),
+                    ('gfortran-libraries', None, "Name of the libraries that should be linked for gfortran"),
+                    ]
 
-        def initialize_options(self):
-            self.with_xspec = False
-            self.xspec_include_dirs = ''
-            self.xspec_lib_dirs = ''
-            self.xspec_libraries = 'XSFunctions XSModel XSUtil XS'
-            self.cfitsio_include_dirs = ''
-            self.cfitsio_lib_dirs = ''
-            self.cfitsio_libraries = 'cfitsio'
-            self.ccfits_include_dirs = ''
-            self.ccfits_lib_dirs = ''
-            self.ccfits_libraries = 'CCfits'
-            self.gfortran_include_dirs = ''
-            self.gfortran_lib_dirs = ''
-            self.gfortran_libraries = 'gfortran'
+    def initialize_options(self):
+        self.with_xspec = False
+        self.xspec_include_dirs = ''
+        self.xspec_lib_dirs = ''
+        self.xspec_libraries = 'XSFunctions XSModel XSUtil XS'
+        self.cfitsio_include_dirs = ''
+        self.cfitsio_lib_dirs = ''
+        self.cfitsio_libraries = 'cfitsio'
+        self.ccfits_include_dirs = ''
+        self.ccfits_lib_dirs = ''
+        self.ccfits_libraries = 'CCfits'
+        self.gfortran_include_dirs = ''
+        self.gfortran_lib_dirs = ''
+        self.gfortran_libraries = 'gfortran'
 
-        def finalize_options(self):
-            pass
+    def finalize_options(self):
+        pass
 
-        def run(self):
-            package = 'sherpa.astro.xspec'
-            dist_packages = self.distribution.packages
-            dist_data = self.distribution.package_data
+    def run(self):
+        package = 'sherpa.astro.xspec'
+        dist_packages = self.distribution.packages
+        dist_data = self.distribution.package_data
 
-            if self.with_xspec:
-                if package not in dist_packages:
-                    dist_packages.append(package)
+        if self.with_xspec:
+            if package not in dist_packages:
+                dist_packages.append(package)
 
-                if not dist_data.has_key(package):
-                    dist_data[package] = ['tests/test_*.py']
+            if not dist_data.has_key(package):
+                dist_data[package] = ['tests/test_*.py']
 
-                ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
-                ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
-                ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
-                ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
+            ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
+            ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
+            ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
+            ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
 
-                ld = ld1 + ld2 + ld3 + ld4
-                inc = inc1 + inc2 + inc3 + inc4
-                l = l1 + l2 + l3 + l4
-                ld = [p for p in ld if p != '']
-                
-                self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))
+            ld = ld1 + ld2 + ld3 + ld4
+            inc = inc1 + inc2 + inc3 + inc4
+            l = l1 + l2 + l3 + l4
+            ld = [p for p in ld if p != '']
 
-            else:
-                if package in dist_packages:
-                    dist_packages.remove(package)
-                if dist_data.has_key(package):
-                    del dist_data[package]
+            self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))
+
+        else:
+            if package in dist_packages:
+                dist_packages.remove(package)
+            if dist_data.has_key(package):
+                del dist_data[package]

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -21,6 +21,10 @@
 from numpy.distutils.core import Command
 from extensions import build_ext, build_lib_arrays
 
+def clean(xs):
+    "Remove all '' entries from xs, returning the new list."
+    return [x for x in xs if x != '']
+
 class xspec_config(Command):
     description = "Configure XSPEC Models external module (optional) "
     user_options = [
@@ -70,10 +74,9 @@ class xspec_config(Command):
             ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
             ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
 
-            ld = ld1 + ld2 + ld3 + ld4
-            inc = inc1 + inc2 + inc3 + inc4
-            l = l1 + l2 + l3 + l4
-            ld = [p for p in ld if p != '']
+            ld = clean(ld1 + ld2 + ld3 + ld4)
+            inc = clean(inc1 + inc2 + inc3 + inc4)
+            l = clean(l1 + l2 + l3 + l4)
 
             self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))
 

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -71,7 +71,8 @@ class xspec_config(Command):
                 ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
 
                 ld, inc, l = (ld1 + ld2 + ld3 + ld4, inc1 + inc2 + inc3 + inc4, l1 + l2 + l3 + l4)
-
+                ld = [p for p in ld if p != '']
+                
                 self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))
 
             else:

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -70,7 +70,9 @@ class xspec_config(Command):
                 ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
                 ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
 
-                ld, inc, l = (ld1 + ld2 + ld3 + ld4, inc1 + inc2 + inc3 + inc4, l1 + l2 + l3 + l4)
+                ld = ld1 + ld2 + ld3 + ld4
+                inc = inc1 + inc2 + inc3 + inc4
+                l = l1 + l2 + l3 + l4
                 ld = [p for p in ld if p != '']
                 
                 self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -70,7 +70,7 @@ class xspec_config(Command):
                 ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
                 ld4, inc4, l4 = build_lib_arrays(self, 'gfortran')
 
-                ld, inc, l = (ld1 + ld2 + l3 + ld4, inc1 + inc2 + inc3 + inc4, l1 + l2 + l3 + l4)
+                ld, inc, l = (ld1 + ld2 + ld3 + ld4, inc1 + inc2 + inc3 + inc4, l1 + l2 + l3 + l4)
 
                 self.distribution.ext_modules.append(build_ext('xspec', ld, inc, l))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,13 +68,33 @@ test = develop test
 
 # If with-xspec is True, make sure to point Sherpa to right
 # XSPEC-related libraries.
-# Library names may most likely be left to their default values,
-# unless you have a different setup
+#
+# If you are using a full XSPEC build, then set xspec_lib_dirs
+# to $HEADAS/lib and add the correct version numbers to
+# the cfitsio, CCfits, and wcs libraries used in the build
+# (an example is cfitsio_3.37, CCfits_2.4, and wcs-4.20).
+#
+# If you are using the models-only XSPEC build, then set
+# xspec_lib_dirs to $HEADAS/lib (that is, the prefix setting
+# used to configure the build, with <os name>/lib appended to
+# it, where <os name> looks something like
+# 'x86_64-unknown-linux-gnu-libc2.21-0'). The cfitsio_lib_dirs,
+# ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if
+# these libraries are installed in a different location.
+#
+# If you are building against the XSPEC libraries provided as
+# part of CIAO then set xspec_lib_dirs to $ASCDS_INSTALL_LIB/ots
+# and set wcslib_libraries to None.
+#
+# The gfortran_lib_dirs should be set if needed.
+#
 #xspec_lib_dirs = None
 #xspec_libraries = XSFunctions XSModel XSUtil XS
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio
 #ccfits_lib_dirs = None
 #ccfits_libraries = CCfits
+#wcslib_lib_dirs = None
+#wcslib_libraries = wcs
 #gfortran_lib_dirs = None
 #gfortran_libraries = gfortran


### PR DESCRIPTION
# Aim

Improve the build for the X-Spec module

# Issue

I have build X-Spec 12.8.2 and then used this as the libraries against which to build the X-Spec module.
Building `master` with the `xspec_config` section of `setup.cfg` set to (expanding out the HEADAS environment variable, but I'm keeping it in here to make things a bit more obvious what's going on):

```
with-xspec=True
xspec_lib_dirs=$HEADAS/lib
xspec_libraries = XSFunctions XSModel XSUtil XS wcs-4.20
cfitsio_libraries=cfitsio_3.37
ccfits_libraries=CCfits_2.4
```

results in the following failure when trying to import `sherpa.astro.xspec`:

```
ImportError: sherpa/astro/xspec/_xspec.so: undefined symbol: C_superExpCutoff
```

As a "work around", I can get the build to work if I also set the following values in `setup.cfg` (i.e. explicltly list all the directories):

```
cfitsio_lib_dirs=$HEADAS/lib
ccfits_lib_dirs=$HEADAS/lib
gfortran_lib_dirs=$HEADAS/lib
```

# Details

There are four main changes:

1. The use of `ld3` rather than `l3` when constructing `ld`. This is obviously a typo. Fixing this is only needed for those set ups where the CCfits library (which is what the `*3` settings refer to) is in a different location to any of the other libraries.

2. The removal of empty strings from the `ld`, `l`, and `inc` variables before sending to `self.distribution.ext_modules.append()`.  I believe this is what causes the problems for me above, since I did not set `cfitsio_lib_dirs`, `ccfits_lib_dirs, and `gfortran_lib_dirs`, so they were set to `''`, which resulted in a link line which included `-L -L -L`. Somewhere this lead to link problems. To fix this, either remove the empty elements (as the patch does) or require all the `*_lib_dirs` settings to be set (which I don't like). It's not clear to me whether this also needs to be done to the `l` and `inc` variables (library name and include paths), but it looks like a sensible thing to do (and I think I've seen `-I -I ...` in the build line, which this removes, but could be mistaken)

3. The addition of `wcslib_lib_dirs` and `wcslib_libraries` options. The library is now needed to build the XSPEC module, so it makes sense to follow the cfitsio and CCfits settings here. Note that in CIAO 4.7, the XSPEC code was built in such a way that a static WCSLIB library was used, so this setting is not needed when building against CIAO's version of the library.

4. pep8 fixes.

# Example

Without these changes, using the `setup.cfg` setting given above, the link line on a Linux (Ubuntu) machine was (I've replaced paths by env var names for simplicity, $anaconda is my conda installation path):

```
g++ -pthread -shared -L$anaconda/lib -Wl,-rpath$anaconda/lib,--no-as-needed \
  build/temp.linux-x86_64-2.7/sherpa/astro/xspec/src/_xspec.o \
  -L$HEADAS/lib -L -LCCfits_2.4 -L \
  -L$anaconda/lib -Wl,-R$HEADAS/lib \
  -Wl,-R -Wl,-RCCfits_2.4 -Wl,-R \
  -lXSFunctions -lXSModel -lXSUtil -lXS \
  -lwcs-4.20 -lcfitsio_3.37 -lCCfits_2.4 -lgfortran \
  -lpython2.7 -o sherpa/astro/xspec/_xspec.so
```

You can see that there is `-L$HEADAS_/lib -L -LCCfits_2.4 -L ...`, which comes out because empty elements are not removed from the link line (the `-L ` entries) and `-LCCfits_2.4` because of the type (`l3` instead of `ld3`). You can see that this is repeated in the `-Wl,-R` sections. Something in this setup causes the resulting library (_xspec.so) to not find the `C_superExpCutoff` symbol which is defined (in `libXSFunctions.so`).

With the changes (this was written before I added the `wcslib_lib_dirs/wcslib_libraries` option, so I had just added `wcs-4.20` to the end of the `xspec_lib_dirs` options), the link line becomes

```
g++ -pthread -shared -L$anaconda/lib -Wl,-rpath=$anaconda/lib,--no-as-needed \
  build/temp.linux-x86_64-2.7/sherpa/astro/xspec/src/_xspec.o \
  -L$HEADAS/lib -L$anaconda/lib \
  -Wl,-R$HEADAS/lib \
  -lXSFunctions -lXSModel -lXSUtil -lXS \
  -lwcs-4.20 -lcfitsio_3.37 -lCCfits_2.4 -lgfortran \
  -lpython2.7 -o sherpa/astro/xspec/_xspec.so
```

# Notes

If merged into  `master` and `python setup.py test` run after `git submodule init ; git submodule update`, then one test will fail due to a missing file. This is a known issue with the test suite and not to do with this patch.
