### PR TITLE
improvements to plot labels

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -58,6 +58,7 @@ except:
     warning('failed to import sherpa.plot.%s;' % plot_opt +
             ' plotting routines will not be available')
     import dummy_backend as backend
+    plot_opt = 'dummy_backend'
 
 backend.init()
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1202,6 +1202,14 @@ class ResidPlot(ModelPlot):
         else:
             self.yerr = data.get_yerr(True,stat.calc_staterror)
 
+        # Some data sets (e.g. DataPHA, which shows the units) have a y
+        # label that could (should?) be displayed (or added to the label).
+        # To avoid a change in behavior, the label is only changed if
+        # the "generic" Y axis label is used. To be reviewed.
+        #
+        if self.ylabel == 'y':
+            self.ylabel = 'Data - Model'
+
         self.title = _make_title('Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -78,6 +78,7 @@ _stats_noerr = ('cash', 'cstat', 'leastsq')
 begin = backend.begin
 end = backend.end
 exceptions = backend.exceptions
+get_latex_for_string = backend.get_latex_for_string
 
 def _make_title(title, name=''):
     """Return the plot title to use.
@@ -101,34 +102,6 @@ def _make_title(title, name=''):
         return title
     else:
         return "{} for {}".format(title, name)
-
-def _l(txt):
-    """Convert to LaTeX form for the current back end.
-
-    Parameters
-    ----------
-    txt : str
-        The text component in LaTeX form (e.g. r'\alpha^2'). It
-        should not contain any non-LaTeX content.
-
-    Returns
-    -------
-    latex : str
-        The input text with any text adornment needed by
-        the chosen plot back end to display it as LaTeX.
-
-    Notes
-    -----
-    No change is made when the dummy backend is in use.
-
-    """
-
-    if plot_opt == 'chips_backend':
-        return txt
-    elif plot_opt == 'pylab_backend':
-        return "${}$".format(txt)
-    else:
-        return txt
 
 class Plot(NoNewAttributesAfterInit):
     "Base class for line plots"
@@ -1183,8 +1156,8 @@ class ChisqrPlot(ModelPlot):
         staterr = data.get_yerr(True,stat.calc_staterror)
 
         self.y = self._calc_chisqr(y, staterr)
-        self.ylabel = _l('\chi^2')
-        self.title = _make_title(_l('\chi^2'), data.name)
+        self.ylabel = get_latex_for_string('\chi^2')
+        self.title = _make_title(get_latex_for_string('\chi^2'), data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -102,6 +102,34 @@ def _make_title(title, name=''):
     else:
         return "{} for {}".format(title, name)
 
+def _l(txt):
+    """Convert to LaTeX form for the current back end.
+
+    Parameters
+    ----------
+    txt : str
+        The text component in LaTeX form (e.g. r'\alpha^2'). It
+        should not contain any non-LaTeX content.
+
+    Returns
+    -------
+    latex : str
+        The input text with any text adornment needed by
+        the chosen plot back end to display it as LaTeX.
+
+    Notes
+    -----
+    No change is made when the dummy backend is in use.
+
+    """
+
+    if plot_opt == 'chips_backend':
+        return txt
+    elif plot_opt == 'pylab_backend':
+        return "${}$".format(txt)
+    else:
+        return txt
+
 class Plot(NoNewAttributesAfterInit):
     "Base class for line plots"
     plot_prefs = backend.get_plot_defaults()
@@ -1155,9 +1183,8 @@ class ChisqrPlot(ModelPlot):
         staterr = data.get_yerr(True,stat.calc_staterror)
 
         self.y = self._calc_chisqr(y, staterr)
-        # NOTE: these are not displayed as LaTeX by the matplotlib backend
-        self.ylabel = '\chi^2'
-        self.title = _make_title('\chi^2', data.name)
+        self.ylabel = _l('\chi^2')
+        self.title = _make_title(_l('\chi^2'), data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -78,6 +78,28 @@ begin = backend.begin
 end = backend.end
 exceptions = backend.exceptions
 
+def _make_title(title, name=''):
+    """Return the plot title to use.
+
+    Parameters
+    ----------
+    title : str
+        The main title to use
+    name : str or None
+        The identifier for the dataset.
+
+    Returns
+    -------
+    title : str
+        If the name is empty or None then use title,
+        otherwise use title + ' for ' + name.
+
+    """
+
+    if name in [None, '']:
+        return title
+    else:
+        return "{} for {}".format(title, name)
 
 class Plot(NoNewAttributesAfterInit):
     "Base class for line plots"
@@ -1090,7 +1112,7 @@ class DelchiPlot(ModelPlot):
         self.y = self._calc_delchi(y, staterr)
         self.yerr = staterr/staterr
         self.ylabel = 'Sigma'
-        self.title = 'Sigma Residuals of %s' % data.name
+        self.title = _make_title('Sigma Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
@@ -1132,8 +1154,9 @@ class ChisqrPlot(ModelPlot):
         staterr = data.get_yerr(True,stat.calc_staterror)
 
         self.y = self._calc_chisqr(y, staterr)
+        # NOTE: these are not displayed as LaTeX by the matplotlib backend
         self.ylabel = '\chi^2'
-        self.title = '\chi^2 of %s' % data.name
+        self.title = _make_title('\chi^2', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,
@@ -1179,7 +1202,7 @@ class ResidPlot(ModelPlot):
         else:
             self.yerr = data.get_yerr(True,stat.calc_staterror)
 
-        self.title = 'Residuals of %s - Model' % data.name
+        self.title = _make_title('Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
@@ -1198,7 +1221,7 @@ class ResidContour(ModelContour):
          self.ylabel) = data.to_contour(yfunc=model)
         
         self.y = self._calc_resid(self.y)
-        self.title = 'Residuals of %s - Model' % data.name
+        self.title = _make_title('Residuals', data.name)
 
     def contour(self, overcontour=False, clearwindow=True):
         Contour.contour(self, self.x0, self.x1, self.y, levels=self.levels,
@@ -1253,7 +1276,7 @@ class RatioPlot(ModelPlot):
             self.yerr = staterr/y[1]
 
         self.ylabel = 'Data / Model'
-        self.title = 'Ratio of %s : Model' % data.name
+        self.title = _make_title('Ratio of Data to Model', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
@@ -1277,7 +1300,7 @@ class RatioContour(ModelContour):
          self.ylabel) = data.to_contour(yfunc=model)
 
         self.y = self._calc_ratio(self.y)
-        self.title = 'Ratio of %s : Model' % data.name
+        self.title = _make_title('Ratio of Data to Model', data.name)
 
     def contour(self, overcontour=False, clearwindow=True):
         Contour.contour(self, self.x0, self.x1, self.y, levels=self.levels,

--- a/sherpa/plot/chips_backend.py
+++ b/sherpa/plot/chips_backend.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -39,7 +39,8 @@ __all__ = ('clear_window', 'plot', 'histo', 'contour', 'point', 'set_subplot',
            'get_confid_contour_defaults', 'set_window_redraw', 'set_jointplot',
            'get_histo_defaults', 'get_model_histo_defaults',
            'get_component_plot_defaults', 'get_component_histo_defaults',
-           'vline', 'hline', 'get_cdf_plot_defaults', 'get_scatter_plot_defaults')
+           'vline', 'hline', 'get_cdf_plot_defaults', 'get_scatter_plot_defaults',
+           'get_latex_for_string')
 
 _initialized = False # Set this True first time begin() is called
 
@@ -565,3 +566,21 @@ def get_scatter_plot_defaults():
     d['symbolfill'] = True
     d['yerrorbars'] = False
     return d
+
+def get_latex_for_string(txt):
+    """Convert to LaTeX form for the ChIPS back end.
+
+    Parameters
+    ----------
+    txt : str
+        The text component in LaTeX form (e.g. r'\alpha^2'). It
+        should not contain any non-LaTeX content.
+
+    Returns
+    -------
+    latex : str
+        The input text (i.e. no change).
+
+    """
+
+    return txt

--- a/sherpa/plot/dummy_backend.py
+++ b/sherpa/plot/dummy_backend.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -31,7 +31,8 @@ __all__ = ('clear_window', 'plot', 'contour', 'point', 'set_subplot',
            'get_confid_contour_defaults', 'set_window_redraw', 'set_jointplot',
            'get_histo_defaults', 'get_model_histo_defaults',
            'get_component_plot_defaults', 'get_component_histo_defaults',
-           'vline', 'hline', 'get_scatter_plot_defaults', 'get_cdf_plot_defaults')
+           'vline', 'hline', 'get_scatter_plot_defaults', 'get_cdf_plot_defaults',
+           'get_latex_for_string')
 
 def point(*args, **kwargs):
     pass
@@ -92,3 +93,21 @@ get_component_plot_defaults = get_dummy_defaults
 get_component_histo_defaults = get_dummy_defaults
 get_scatter_plot_defaults = get_dummy_defaults
 get_cdf_plot_defaults = get_dummy_defaults
+
+def get_latex_for_string(txt):
+    """Convert to LaTeX form for the dummy back end.
+
+    Parameters
+    ----------
+    txt : str
+        The text component in LaTeX form (e.g. r'\alpha^2'). It
+        should not contain any non-LaTeX content.
+
+    Returns
+    -------
+    latex : str
+        The input text (i.e. no change).
+
+    """
+
+    return txt

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,7 +36,8 @@ __all__ = ('clear_window','point','plot','histo','contour','set_subplot','init',
            'get_confid_contour_defaults', 'set_window_redraw', 'set_jointplot',
            'get_model_histo_defaults', 'get_histo_defaults',
            'get_component_plot_defaults','get_component_histo_defaults', 
-           'vline', 'hline', 'get_scatter_plot_defaults', 'get_cdf_plot_defaults')
+           'vline', 'hline', 'get_scatter_plot_defaults', 'get_cdf_plot_defaults',
+           'get_latex_for_string')
 
 def init():
     pass
@@ -438,3 +439,22 @@ def get_cdf_plot_defaults():
 def get_scatter_plot_defaults():
     d = get_data_plot_defaults()
     return d
+
+def get_latex_for_string(txt):
+    """Convert to LaTeX form for the matplotlib back end.
+
+    Parameters
+    ----------
+    txt : str
+        The text component in LaTeX form (e.g. r'\alpha^2'). It
+        should not contain any non-LaTeX content.
+
+    Returns
+    -------
+    latex : str
+        The input text surrounded by $. Note that there's no
+        attempt to protect any $ characters in txt.
+
+    """
+
+    return "${}$".format(txt)


### PR DESCRIPTION
# Release Note

Fix up several issues seen in plot labels - titles and Y-axis labels - for commands such as `sherpa.ui.plot_data`, `sherpa.ui.plot_fit_resid`, and `sherpa.ui.plot_chisqr`:

1. Plot titles when the `name` attribute of the data set is empty
2. Y axis label for residual plots (non PHA data sets)
3. `plot_chisqr` title and Y axis label takes advantage of LaTeX support using the matplotlib backend.

# Details

There are three changes:

1. Plot titles when the `name` attribute of the data set is empty
2. Y axis label for residual plots (non PHA data sets)
3. `plot_chisqr` title and Y axis label takes advantage of LaTeX support using the matplotlib backend.

##  1. Plot titles when the `name` attribute of the data set is empty

For a dataset created with `sherpa.ui.load_arrays`, it is likely that the `name` attribute of the data structure will be empty. This led to plot titles like 'Residuals of - Model', since the code expected the `name` to not be empty. I have changed the title code so that:

  - the logic is in the `_make_title` routine, and use the `.format` method of strings rather than
    the old-style string interpolation (although there's a lot of that left in the rest of the code)
  - the `name` attribute is only added to the title if it is not empty
  - the titles are more consistent in appearance, so that it's now "\<title> for \<name>" rather than some 
    saying "\<title> of \<name>" or having the name in the middle of the string.

This code is independent of the plotting back end.

## 2. Y axis label for residual plots (non PHA data sets)

The old behaviour for the Y axis label of residual plots (those created by `sherpa.ui.plot_resid`) was to use `y` as the label. I find this confusing, particularly when using `sherpa.ui.plot_fit_resid()`, so switched it to `Data - Model`. This better matches the existing behaviour of `sherpa.ui.plot_ratio()`, which uses the label 'Data / Model'.

This code is independent of the plotting back end.

**Note:** for PHA datasets (i.e. `DataPHA` objects), the y label is changed to be the units displayed for that axis (e.g. `photon/cm^2/s/keV`). I have left this in, rather than change it to `Data - Model`. This should be reviewed.

## 3. `plot_chisqr` title and Y axis label takes advantage of LaTeX support using the matplotlib backend.

ChIPS and matplotlib use different approaches to displaying LaTeX: ChIPS does it automatically whereas matplotlib requires the LaTeX be surrounded by '$'. The only plot where this matters is `sherpa.ui.plot_chisqr()`, which uses a title and Y axis label of `'\chi^2'`. I have a simple wrapper which
converts this to matplotlib format if this backend is in use.

**Note:** there are other places where this could be relevant or important (e.g. the `photom/cm^2/s/keV` label mentioned in point 2 above), but it's not clear how to handle this given the current design of the plots. I would consider this a later RFE for potential improvements to the plotting (along with fixes to simplify the note from point 2), and not be a part of this PR.

# Example

The following code can be used to compare the behaviour before and after the PR (run from the top-level of the sherpa distribution). The comments, when talking about comparing plots, refers to the plots with the pre- and post-PR changes in them.

```
from sherpa.astro import ui

ui.load_arrays(1, [11,22,33], [4,6,5])
ui.set_source(ui.const1d.m1)

# compare the title and the Y axis label
ui.plot_resid()

# compare the Y axis labels
ui.plot_fit_resid()

# compare the titles
ui.plot_delchi()
ui.plot_ratio()

# with the matplotlib back end, the title and Y axis now use the LaTeX support
ui.plot_chisqr()


ui.load_pha(1, 'sherpa/astro/datastack/tests/data/3c273.pi')
ui.set_source(ui.powlaw1d.m1)

# compare y axes (they should be the same)
ui.plot_resid()
ui.plot_fit_resid()
ui.plot_delchi()
```
