### PR TITLE
fix #38 - grouping twice gives an IndexError exception

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -828,7 +828,6 @@ class DataPHA(Data1DInt):
         # self.quality_filter used for pre-grouping filter
         self.quality_filter = qual_flags
 
-
     def _dynamic_group(self, group_func, *args, **kwargs):
 
         keys = kwargs.keys()[:]

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -127,12 +127,14 @@ class test_ui(SherpaTestCase):
         ui.load_filter(self.filter_single_log_table)
         ui.load_filter(self.filter_single_log_table, ignore=True)
 
+
 class test_more_ui(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.img = self.datadir + '/img.fits'
         self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
         self.rmf = self.datadir + '/threads/simultaneous/rmf2286.fits'
+        self.pha3c273 = self.datadir + '/ciao4.3/pha_intro/3c273.pi'
         logger.setLevel(logging.ERROR)
 
     #bug #12732
@@ -153,6 +155,15 @@ class test_more_ui(SherpaTestCase):
         from sherpa.astro.instrument import RMFModelPHA
         self.assertTrue(isinstance(m, RMFModelPHA))
 
+    #bug #38
+    @unittest.skipIf(not has_fits_support(),
+                     'need pycrates, pyfits or astropy.io.fits')
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    def test_bug38(self):
+        ui.load_pha('3c273', self.pha3c273)
+        ui.notice_id('3c273', 0.3, 2)
+        ui.group_counts('3c273', 30)
+        ui.group_counts('3c273', 15)
 
 
 class test_image_12578(SherpaTestCase):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -571,7 +571,7 @@ def create_expr(vals, mask=None, format='%s', delim='-'):
                 expr.append(',')
             expr.append(format % vals[ii])
             expr.append(',')
-    if expr[-1] in (',',delim):
+    if len(expr) and expr[-1] in (',',delim):
         expr.append(format % vals[-1])
 
     return ''.join(expr)


### PR DESCRIPTION
### Release Note
Fix bug #38 (grouping twice gives an IndexError exception). An un-handled corner case in one of the Sherpa internal methods (`utils.create_expr`) was triggering an `IndexError` when two `group_counts` operations were performed back to back. The fix handles the case so that applying `group_counts` twice does not result in an Exception

### Tests
The test exercises a simple case where the grouping is applied more than once in contiguous calls. The test does not check that the grouping is done correctly, and it looks like no tests are actually checking that grouping operations provide meaningful results. We need to decide whether we want to add meaningful tests at this iteration (before merging this PR) or not.