### PR TITLE
clean up logging level change

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -130,10 +130,15 @@ class test_ui(SherpaTestCase):
 class test_more_ui(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
+        self._old_logger_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
         self.img = self.datadir + '/img.fits'
         self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
         self.rmf = self.datadir + '/threads/simultaneous/rmf2286.fits'
         logger.setLevel(logging.ERROR)
+
+    def tearDown(self):
+        logger.setLevel(self._old_logger_level)
 
     #bug #12732
     @unittest.skipIf(not has_fits_support(),


### PR DESCRIPTION
This PR simply makes sure that one test case I stumbled upon while investigating issue #38 cleans up the logging level after changing it to start the tests. Might this be the origin of some logging weirdness @DougBurke experienced, e.g. issue #30?