### PR TITLE
add astropy build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ python:
   - "2.7"
 
 env:
-#  - PYFITS=false INSTALL_TYPE=develop TEST=submodule
-  - PYFITS=true INSTALL_TYPE=develop TEST=submodule
-#  - PYFITS=false INSTALL_TYPE=install TEST=package
-#  - PYFITS=true INSTALL_TYPE=install TEST=package
-#  - PYFITS=true INSTALL_TYPE=install TEST=smoke
+  - FITS="astropy" INSTALL_TYPE=develop TEST=submodule
+  - FITS="pyfits" INSTALL_TYPE=develop TEST=submodule
+#  - INSTALL_TYPE=install TEST=package
+#  - FITS="astropy" INSTALL_TYPE=install TEST=package
+#  - FITS="astropy" INSTALL_TYPE=install TEST=smoke
 
 before_install:
   - sudo apt-get update -qq
@@ -33,7 +33,7 @@ install:
   - python setup.py $INSTALL_TYPE
 
 script:
-  - if [ ${PYFITS} == true ]; then conda install --yes pyfits; fi
+  - if [ -n ${FITS} ]; then conda install --yes ${FITS}; fi
   - if [ ${TEST} == submodule ];
      then python setup.py test;
     else


### PR DESCRIPTION
This PR changes the automatic build settings to include two builds: one with `pyfits` and one with `astropy`. After Travis CI successfully completed the tests on the push build, I visually inspected the build log to double-check that the correct dependencies were being installed, and that the tests involving FITS files were correctly run and not skipped.