### PR TITLE
Setuptools not required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ python:
 env:
   - FITS="astropy" INSTALL_TYPE=develop TEST=submodule
   - FITS="pyfits" INSTALL_TYPE=develop TEST=submodule
-#  - INSTALL_TYPE=install TEST=package
-#  - FITS="astropy" INSTALL_TYPE=install TEST=package
-#  - FITS="astropy" INSTALL_TYPE=install TEST=smoke
+  - INSTALL_TYPE=install TEST=package
+  - FITS="astropy" INSTALL_TYPE=install TEST=package
+  - FITS="astropy" INSTALL_TYPE=install TEST=smoke
+  - INSTALL_TYPE=install TEST=smoke NOSETUPTOOLS="true"
 
 before_install:
   - sudo apt-get update -qq
@@ -19,7 +20,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy matplotlib
-  - conda config --add channels https://conda.binstar.org/cxc
+  - conda config --add channels https://conda.binstar.org/sherpa
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;
@@ -28,17 +29,21 @@ before_install:
   - if [ ${TEST} == smoke ];
      then git submodule deinit -f .;
     fi
+  - if [ -n "${NOSETUPTOOLS}" ]; then conda remove --yes setuptools; fi
 
 install:
   - python setup.py $INSTALL_TYPE
 
 script:
-  - if [ -n ${FITS} ]; then conda install --yes ${FITS}; fi
-  - if [ ${TEST} == submodule ];
-     then python setup.py test;
-    else
-     cd /home;
-     sherpa_test;
+  - if [ -n "${FITS}" ]; then conda install --yes ${FITS}; fi
+  - if [ ${TEST} == submodule ]; then python setup.py test; fi
+  - if [ ${TEST} == smoke ];
+        then cd /home;
+        python -c "import sherpa; sherpa.test()";
+    fi
+  - if [ ${TEST} == package ];
+        then cd /home;
+        sherpa_test;
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ python:
   - "2.7"
 
 env:
-#  - PYFITS=false INSTALL_TYPE=develop TEST=submodule
-  - PYFITS=true INSTALL_TYPE=develop TEST=submodule
-#  - PYFITS=false INSTALL_TYPE=install TEST=package
-#  - PYFITS=true INSTALL_TYPE=install TEST=package
-#  - PYFITS=true INSTALL_TYPE=install TEST=smoke
+  - FITS="astropy" INSTALL_TYPE=develop TEST=submodule
+  - FITS="pyfits" INSTALL_TYPE=develop TEST=submodule
+#  - INSTALL_TYPE=install TEST=package
+#  - FITS="astropy" INSTALL_TYPE=install TEST=package
+#  - FITS="astropy" INSTALL_TYPE=install TEST=smoke
 
 before_install:
   - sudo apt-get update -qq
@@ -33,7 +33,7 @@ install:
   - python setup.py $INSTALL_TYPE
 
 script:
-  - if [ ${PYFITS} == true ]; then conda install --yes pyfits; fi
+  - if [ -n ${FITS} ]; then conda install --yes ${FITS}; fi
   - if [ ${TEST} == submodule ];
      then python setup.py test;
     else

--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -19,14 +19,31 @@
 
 import shutil
 import os
-from numpy.distutils.command.develop import develop as _develop
 
+try:
+    from numpy.distutils.command.develop import develop as _develop
 
-class develop(_develop):
+    class develop(_develop):
 
-    def run(self):
-        _develop.run(self)
-        sherpa_config = self.get_finalized_command('sherpa_config', True)
-        self.announce("install stk and group extensions locally")
-        shutil.copyfile(sherpa_config.stk_location, os.path.join(os.getcwd(), 'stk.so'))
-        shutil.copyfile(sherpa_config.group_location, os.path.join(os.getcwd(), 'group.so'))
+        def run(self):
+            _develop.run(self)
+            sherpa_config = self.get_finalized_command('sherpa_config', True)
+            self.announce("install stk and group extensions locally")
+            shutil.copyfile(sherpa_config.stk_location, os.path.join(os.getcwd(), 'stk.so'))
+            shutil.copyfile(sherpa_config.group_location, os.path.join(os.getcwd(), 'group.so'))
+
+except ImportError:
+    from distutils.core import Command
+
+    class develop(Command):
+
+        user_options = []
+
+        def run(self):
+            print("develop command is not available without setuptools")
+
+        def initialize_options(self):
+            pass
+
+        def finalize_options(self):
+            pass

--- a/helpers/test.py
+++ b/helpers/test.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -17,26 +17,43 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from setuptools.command.test import test
-import sys
+try:
+    from setuptools.command.test import test
+
+    import sys
 
 
-class PyTest(test):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+    class PyTest(test):
+        user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
-    def initialize_options(self):
-        test.initialize_options(self)
-        self.pytest_args = []
+        def initialize_options(self):
+            test.initialize_options(self)
+            self.pytest_args = []
 
-    def finalize_options(self):
-        test.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
+        def finalize_options(self):
+            test.finalize_options(self)
+            self.test_args = []
+            self.test_suite = True
 
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        if not self.pytest_args:
-            self.pytest_args = 'sherpa'
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
+        def run_tests(self):
+            # import here, cause outside the eggs aren't loaded
+            import pytest
+            if not self.pytest_args:
+                self.pytest_args = 'sherpa'
+            errno = pytest.main(self.pytest_args)
+            sys.exit(errno)
+
+except ImportError:
+    from distutils.core import Command
+
+    class PyTest(Command):
+        user_options = []
+
+        def initialize_options(self):
+            pass
+
+        def finalize_options(self):
+            pass
+
+        def run(self):
+            print("test command is not available without setuptools")


### PR DESCRIPTION
This PR ensures that `setuptools` is not required for building Sherpa. Sherpa already provides a warning when `setuptools` is not available, but some commands like `develop` and `test`, while not directly imported by Sherpa, rely on the presence of `setuptools`. With this PR, when the package is not available, Sherpa will just prints a warning on the standard output. While this is mostly required to support CIAO builds, we do claim that `setuptools` is not required, and this PR ensures this is true.

The PR also adds a Travis build for testing the ability to build and test Sherpa without setuptools. As Travis builds have become rather cheap and quick (even though we haven't migrated to the new system ourselves), I have also reinstated the other builds, and fixed a couple of issues in the Travis build configuration.

The changes were tested locally on Linux64 by manually removing `setuptools` and by running `python setup.py {develop,test,install}`, testing that the commands did not choke. Plus, a new build has been added to the Travis builds, exercising an `install` without setuptools, which is what CIAO does.