### PR TITLE
Test cleanup

### DIFF
--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,6 +37,7 @@ class test_design(SherpaTestCase):
         clear_stack()
         ui.clean()
         set_template_id("ID")
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         set_stack_verbosity(logging.ERROR)
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
@@ -45,6 +46,7 @@ class test_design(SherpaTestCase):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -126,10 +128,12 @@ class test_design(SherpaTestCase):
         assert 0 == len(ui._session._data)
         assert 3 == len(ds.datasets)
 
+
 class test_global(SherpaTestCase):
     def setUp(self):
         clear_stack()
         ui.clean()
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         set_stack_verbosity(logging.ERROR)
         set_template_id("__ID")
@@ -138,8 +142,7 @@ class test_global(SherpaTestCase):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
-
-
+        logger.setLevel(self.loggingLevel)
 
     def test_case_2(self):
         x1 = np.arange(50)+100
@@ -201,6 +204,8 @@ class test_global(SherpaTestCase):
         vals = get_par([], 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
+        # QUS: pars is not checked, so is this just
+        # checking that get_par doesn't fail?
         pars = get_par([], 'const.c0')
 
         fit([])
@@ -257,6 +262,8 @@ class test_load(SherpaTestCase):
         set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.create_files()
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         clear_stack()
@@ -266,6 +273,7 @@ class test_load(SherpaTestCase):
         os.remove(self.name1)
         os.remove(self.name2)
         set_stack_verbose(False)
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -281,7 +289,6 @@ class test_load(SherpaTestCase):
         load_data("@"+"/".join((self._this_dir, 'data', 'pha.lis')))
         assert len(ui._session._data) == 6
         assert len(DATASTACK.datasets) == 6
-
 
     def create_files(self):
         fd1, self.name1 = tempfile.mkstemp()
@@ -321,12 +328,15 @@ class test_partial_oo(SherpaTestCase):
         set_template_id("__ID")
         clear_stack()
         ui.clean()
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         self.ds.clear_stack()
         clear_stack()
         set_template_id("__ID")
         ui.clean()
+        logger.setLevel(self.loggingLevel)
 
     def test_case_4(self):
         x1 = np.arange(50)+100
@@ -390,6 +400,8 @@ class test_partial_oo(SherpaTestCase):
         vals = get_par(ds, 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
+        # QUS: pars is not checked, so is this just
+        # checking that get_par doesn't fail?
         pars = get_par(ds, 'const.c0')
 
         fit(ds)
@@ -446,12 +458,15 @@ class test_oo(SherpaTestCase):
         datastack.set_template_id("__ID")
         ui.clean()
         self.ds = datastack.DataStack()
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         self.ds.clear_stack()
         datastack.clear_stack()
         datastack.set_template_id("__ID")
         ui.clean()
+        logger.setLevel(self.loggingLevel)
 
     def test_case_5(self):
         x1 = np.arange(50)+100
@@ -515,6 +530,8 @@ class test_oo(SherpaTestCase):
         vals = ds.get_par('poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
+        # QUS: pars is not checked, so is this just
+        # checking that get_par doesn't fail?
         pars = ds.get_par('const.c0')
 
         ds.fit()
@@ -563,17 +580,21 @@ class test_oo(SherpaTestCase):
 
         assert const3.c0._link is not const2.c0
 
+
 class test_pha(SherpaTestCase):
     def setUp(self):
         clear_stack()
         ui.clean()
         set_template_id("ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -587,7 +608,6 @@ class test_pha(SherpaTestCase):
 
         load_bkg_arf([], '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits")))
         load_bkg_arf([], '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits")))
-
 
         # Define background models
         bkg_arfs = get_bkg_arf([])
@@ -620,10 +640,11 @@ class test_pha(SherpaTestCase):
                       src_model * const1d.ratio_12]
         for i in range(2):
             id_ = i + 1
-            set_full_model(id_, (rsps[i](src_models[i])
-                                 + bkg_scales[i] * bkg_rsps[i](bkg_models[i])))
+            set_full_model(id_, (rsps[i](src_models[i]) +
+                                 bkg_scales[i] * bkg_rsps[i](bkg_models[i])))
 
         fit()
+
 
 class test_query(SherpaTestCase):
     def setUp(self):
@@ -631,12 +652,15 @@ class test_query(SherpaTestCase):
         ui.clean()
         set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
         set_stack_verbose(False)
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -662,3 +686,15 @@ class test_query(SherpaTestCase):
         f = query_by_obsid(ds, '7867')
 
         assert f == [4]
+
+if __name__ == '__main__':
+
+    from sherpa.utils import SherpaTest
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(datastack).test(datadir=datadir)

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -20,32 +20,33 @@
 
 from sherpa.utils import SherpaTestCase
 import os
+import sys
 import unittest
 from sherpa.utils import has_fits_support
-from sherpa.astro.ui import *
-from sherpa.astro.datastack import *
+from sherpa.astro import ui
 from sherpa.astro import datastack
 from acis_bkg_model import acis_bkg_model
 import numpy as np
 import tempfile
+import logging
 
 logger = logging.getLogger('sherpa')
 
 
 class test_design(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("ID")
+        datastack.set_template_id("ID")
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        set_stack_verbosity(logging.ERROR)
+        datastack.set_stack_verbosity(logging.ERROR)
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
@@ -53,48 +54,48 @@ class test_design(SherpaTestCase):
     def test_case_1(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, '3c273.lis'))
-        load_pha(ls, use_errors=True)
+        datastack.load_pha(ls, use_errors=True)
 
-        assert 2 == len(DATASTACK.datasets)
+        assert 2 == len(datastack.DATASTACK.datasets)
         assert 2 == len(ui._session._data)
 
-        load_pha("myid", '/'.join((datadir, "3c273.pi")))
+        datastack.load_pha("myid", '/'.join((datadir, "3c273.pi")))
 
-        assert 2 == len(DATASTACK.datasets)
+        assert 2 == len(datastack.DATASTACK.datasets)
         assert 3 == len(ui._session._data)
 
-        load_pha('/'.join((datadir, "3c273.pi")))
+        datastack.load_pha('/'.join((datadir, "3c273.pi")))
 
-        assert 3 == len(DATASTACK.datasets)
+        assert 3 == len(datastack.DATASTACK.datasets)
         assert 4 == len(ui._session._data)
 
-        load_pha([], '/'.join((datadir, "3c273.pi")))
+        datastack.load_pha([], '/'.join((datadir, "3c273.pi")))
 
-        assert 4 == len(DATASTACK.datasets)
+        assert 4 == len(datastack.DATASTACK.datasets)
         assert 5 == len(ui._session._data)
 
-        ds = DataStack()
+        ds = datastack.DataStack()
 
-        load_pha(ds, ls)
+        datastack.load_pha(ds, ls)
 
-        assert 4 == len(DATASTACK.datasets)
+        assert 4 == len(datastack.DATASTACK.datasets)
         assert 7 == len(ui._session._data)
         assert 2 == len(ds.datasets)
 
-        load_pha(ds, '/'.join((datadir, "3c273.pi")))
+        datastack.load_pha(ds, '/'.join((datadir, "3c273.pi")))
 
-        assert 4 == len(DATASTACK.datasets)
+        assert 4 == len(datastack.DATASTACK.datasets)
         assert 8 == len(ui._session._data)
         assert 3 == len(ds.datasets)
 
-        dids = DATASTACK.get_stack_ids()
+        dids = datastack.DATASTACK.get_stack_ids()
         assert dids == [1,2,3,4]
 
         sids = ui._session._data.keys()
         assert sids == [1,2,3,4,5,6,7, "myid"]
 
-        set_source([1,2], "powlaw1d.pID")
-        set_source([3,4], "brokenpowerlaw.bpID")
+        datastack.set_source([1,2], "powlaw1d.pID")
+        datastack.set_source([3,4], "brokenpowerlaw.bpID")
 
         dsids = ds.get_stack_ids()
         assert dsids == [5,6,7]
@@ -109,8 +110,8 @@ class test_design(SherpaTestCase):
         assert bp3 is not None
         assert bp4 is not None
 
-        set_source(1, "polynom1d.poly1")
-        set_source([2,3,4], "atten.attID")
+        datastack.set_source(1, "polynom1d.poly1")
+        datastack.set_source([2,3,4], "atten.attID")
 
         poly1 = ui._session._model_components['poly1']
         a2 = ui._session._model_components['att2']
@@ -122,26 +123,26 @@ class test_design(SherpaTestCase):
         assert a3 is not None
         assert a4 is not None
 
-        clean()
+        datastack.clean()
 
-        assert 0 == len(DATASTACK.datasets)
+        assert 0 == len(datastack.DATASTACK.datasets)
         assert 0 == len(ui._session._data)
         assert 3 == len(ds.datasets)
 
 
 class test_global(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        set_stack_verbosity(logging.ERROR)
-        set_template_id("__ID")
+        datastack.set_stack_verbosity(logging.ERROR)
+        datastack.set_template_id("__ID")
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
     def test_case_2(self):
@@ -152,20 +153,20 @@ class test_global(SherpaTestCase):
         x3 = np.arange(50)+200
         y3 = 2*(x3**2+3*x3)
 
-        load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        set_source([], 'const1d.const * polynom1d.poly__ID')
+        datastack.set_source([], 'const1d.const * polynom1d.poly__ID')
 
         poly1 = ui._session._get_model_component('poly1')
         poly2 = ui._session._get_model_component('poly2')
         poly3 = ui._session._get_model_component('poly3')
         const = ui._session._get_model_component('const')
 
-        freeze([], 'poly')
-        thaw([], 'poly.c0')
-        thaw([], 'poly.c1')
-        thaw([], 'poly.c2')
-        thaw([], 'const')
+        datastack.freeze([], 'poly')
+        datastack.thaw([], 'poly.c0')
+        datastack.thaw([], 'poly.c1')
+        datastack.thaw([], 'poly.c2')
+        datastack.thaw([], 'const')
 
         assert poly1.c0.frozen is False
         assert poly1.c1.frozen is False
@@ -182,33 +183,33 @@ class test_global(SherpaTestCase):
         assert poly3.c2.frozen is False
         assert poly3.c3.frozen is True
 
-        set_par([], 'poly.c1', 0.45)
+        datastack.set_par([], 'poly.c1', 0.45)
 
         assert poly1.c1.val == 0.45
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par([1], 'poly.c1', 0.1)
+        datastack.set_par([1], 'poly.c1', 0.1)
 
         assert poly1.c1.val == 0.1
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par([], 'const.c0', 2)
+        datastack.set_par([], 'const.c0', 2)
 
         assert const.c0.val == 2
 
-        set_par([], 'const.integrate', False)
-        freeze([], 'const.c0')
+        datastack.set_par([], 'const.integrate', False)
+        datastack.freeze([], 'const.c0')
 
-        vals = get_par([], 'poly.c1.val')
+        vals = datastack.get_par([], 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
         # QUS: pars is not checked, so is this just
         # checking that get_par doesn't fail?
-        pars = get_par([], 'const.c0')
+        pars = datastack.get_par([], 'const.c0')
 
-        fit([])
+        datastack.fit([])
 
         assert round(poly1.c1.val) == 1
         assert round(poly1.c2.val) == 3
@@ -217,7 +218,7 @@ class test_global(SherpaTestCase):
         assert round(poly3.c1.val) == 3
         assert round(poly3.c2.val) == 1
 
-        clear_stack()
+        datastack.clear_stack()
 
         x1 = np.arange(50)+100
         y1 = 7*(3*x1**2 + x1)
@@ -226,69 +227,69 @@ class test_global(SherpaTestCase):
         x3 = np.arange(50)+200
         y3 = 2*(x3**2+3*x3)
 
-        load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        set_template_id("foo")
+        datastack.set_template_id("foo")
 
-        set_source([], 'const1d.constfoo * polynom1d.polyfoo')
+        datastack.set_source([], 'const1d.constfoo * polynom1d.polyfoo')
 
         const1 = ui._session._get_model_component('const1')
         const2 = ui._session._get_model_component('const2')
         const3 = ui._session._get_model_component('const3')
 
-        link([2,3], 'const.c0')
+        datastack.link([2,3], 'const.c0')
 
-        set_par([2], 'const.c0', 3)
-        set_par([1], 'const.c0', 7)
+        datastack.set_par([2], 'const.c0', 3)
+        datastack.set_par([1], 'const.c0', 7)
 
-        freeze([1], 'const.c0')
+        datastack.freeze([1], 'const.c0')
 
         assert const2.c0.frozen is False
 
-        fit([])
+        datastack.fit([])
 
         assert const2.c0.val == const3.c0.val
         assert const3.c0._link is const2.c0
 
-        unlink([], "const.c0")
+        datastack.unlink([], "const.c0")
 
         assert const3.c0._link is not const2.c0
 
 
 class test_load(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.create_files()
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         os.remove(self.lisname)
         os.remove(self.name1)
         os.remove(self.name2)
-        set_stack_verbose(False)
+        datastack.set_stack_verbose(False)
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     def test_case_3(self):
-        load_ascii("@{}".format(self.lisname))
+        datastack.load_ascii("@{}".format(self.lisname))
         assert len(ui._session._data) == 2
-        assert len(DATASTACK.datasets) == 2
+        assert len(datastack.DATASTACK.datasets) == 2
 
-        load_data("@{}".format(self.lisname))
+        datastack.load_data("@{}".format(self.lisname))
         assert len(ui._session._data) == 4
-        assert len(DATASTACK.datasets) == 4
+        assert len(datastack.DATASTACK.datasets) == 4
 
-        load_data("@"+"/".join((self._this_dir, 'data', 'pha.lis')))
+        datastack.load_data("@"+"/".join((self._this_dir, 'data', 'pha.lis')))
         assert len(ui._session._data) == 6
-        assert len(DATASTACK.datasets) == 6
+        assert len(datastack.DATASTACK.datasets) == 6
 
     def create_files(self):
         fd1, self.name1 = tempfile.mkstemp()
@@ -324,17 +325,17 @@ class test_load(SherpaTestCase):
 class test_partial_oo(SherpaTestCase):
 
     def setUp(self):
-        self.ds = DataStack()
-        set_template_id("__ID")
-        clear_stack()
+        self.ds = datastack.DataStack()
+        datastack.set_template_id("__ID")
+        datastack.clear_stack()
         ui.clean()
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         self.ds.clear_stack()
-        clear_stack()
-        set_template_id("__ID")
+        datastack.clear_stack()
+        datastack.set_template_id("__ID")
         ui.clean()
         logger.setLevel(self.loggingLevel)
 
@@ -348,20 +349,20 @@ class test_partial_oo(SherpaTestCase):
 
         ds = self.ds
 
-        load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
 
-        set_source(ds, 'const1d.const * polynom1d.poly__ID')
+        datastack.set_source(ds, 'const1d.const * polynom1d.poly__ID')
 
         poly1 = ui._session._get_model_component('poly1')
         poly2 = ui._session._get_model_component('poly2')
         poly3 = ui._session._get_model_component('poly3')
         const = ui._session._get_model_component('const')
 
-        freeze(ds, 'poly')
-        thaw(ds, 'poly.c0')
-        thaw(ds, 'poly.c1')
-        thaw(ds, 'poly.c2')
-        thaw(ds, 'const')
+        datastack.freeze(ds, 'poly')
+        datastack.thaw(ds, 'poly.c0')
+        datastack.thaw(ds, 'poly.c1')
+        datastack.thaw(ds, 'poly.c2')
+        datastack.thaw(ds, 'const')
 
         assert poly1.c0.frozen is False
         assert poly1.c1.frozen is False
@@ -378,33 +379,33 @@ class test_partial_oo(SherpaTestCase):
         assert poly3.c2.frozen is False
         assert poly3.c3.frozen is True
 
-        set_par(ds, 'poly.c1', 0.45)
+        datastack.set_par(ds, 'poly.c1', 0.45)
 
         assert poly1.c1.val == 0.45
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par(ds[1], 'poly.c1', 0.1)
+        datastack.set_par(ds[1], 'poly.c1', 0.1)
 
         assert poly1.c1.val == 0.1
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par(ds, 'const.c0', 2)
+        datastack.set_par(ds, 'const.c0', 2)
 
         assert const.c0.val == 2
 
-        set_par(ds, 'const.integrate', False)
-        freeze(ds, 'const.c0')
+        datastack.set_par(ds, 'const.integrate', False)
+        datastack.freeze(ds, 'const.c0')
 
-        vals = get_par(ds, 'poly.c1.val')
+        vals = datastack.get_par(ds, 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
         # QUS: pars is not checked, so is this just
         # checking that get_par doesn't fail?
-        pars = get_par(ds, 'const.c0')
+        pars = datastack.get_par(ds, 'const.c0')
 
-        fit(ds)
+        datastack.fit(ds)
 
         assert round(poly1.c1.val) == 1
         assert round(poly1.c2.val) == 3
@@ -422,31 +423,31 @@ class test_partial_oo(SherpaTestCase):
         x3 = np.arange(50)+200
         y3 = 2*(x3**2+3*x3)
 
-        load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
 
-        set_template_id("foo")
+        datastack.set_template_id("foo")
 
-        set_source(ds, 'const1d.constfoo * polynom1d.polyfoo')
+        datastack.set_source(ds, 'const1d.constfoo * polynom1d.polyfoo')
 
         const1 = ui._session._get_model_component('const1')
         const2 = ui._session._get_model_component('const2')
         const3 = ui._session._get_model_component('const3')
 
-        link(ds[2,3], 'const.c0')
+        datastack.link(ds[2,3], 'const.c0')
 
-        set_par(ds[2], 'const.c0', 3)
-        set_par(ds[1], 'const.c0', 7)
+        datastack.set_par(ds[2], 'const.c0', 3)
+        datastack.set_par(ds[1], 'const.c0', 7)
 
-        freeze(ds[1], 'const.c0')
+        datastack.freeze(ds[1], 'const.c0')
 
         assert const2.c0.frozen is False
 
-        fit(ds)
+        datastack.fit(ds)
 
         assert const2.c0.val == const3.c0.val
         assert const3.c0._link is const2.c0
 
-        unlink(ds, "const.c0")
+        datastack.unlink(ds, "const.c0")
 
         assert const3.c0._link is not const2.c0
 
@@ -583,17 +584,17 @@ class test_oo(SherpaTestCase):
 
 class test_pha(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("ID")
+        datastack.set_template_id("ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
@@ -601,81 +602,86 @@ class test_pha(SherpaTestCase):
     def test_case_6(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, 'pha.lis'))
-        load_pha(ls)
+        rmf1 = '/'.join((datadir, "acisf04938_000N002_r0043_rmf3.fits"))
+        rmf2 = '/'.join((datadir, "acisf07867_000N001_r0002_rmf3.fits"))
+        arf1 = '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits"))
+        arf2 = '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits"))
+        datastack.load_pha(ls)
 
-        load_bkg_rmf([], '/'.join((datadir, "acisf04938_000N002_r0043_rmf3.fits")))
-        load_bkg_rmf([], '/'.join((datadir, "acisf07867_000N001_r0002_rmf3.fits")))
+        datastack.load_bkg_rmf([], rmf1)
+        datastack.load_bkg_rmf([], rmf2)
 
-        load_bkg_arf([], '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits")))
-        load_bkg_arf([], '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits")))
+        datastack.load_bkg_arf([], arf1)
+        datastack.load_bkg_arf([], arf2)
 
         # Define background models
-        bkg_arfs = get_bkg_arf([])
-        bkg_scales = get_bkg_scale([])
-        bkg_models = [const1d.c1 * acis_bkg_model('acis7s'),
-                      const1d.c2 * acis_bkg_model('acis7s')]
-        bkg_rsps = get_response([], bkg_id=1)
+        bkg_arfs = datastack.get_bkg_arf([])
+        bkg_scales = datastack.get_bkg_scale([])
+        bkg_models = [ui.const1d.c1 * acis_bkg_model('acis7s'),
+                      ui.const1d.c2 * acis_bkg_model('acis7s')]
+        bkg_rsps = datastack.get_response([], bkg_id=1)
         for i in range(2):
             id_ = i + 1
             # Make the ARF spectral response flat.  This is required for using
             # the acis_bkg_model.
             bkg_arfs[i].specresp = bkg_arfs[i].specresp * 0 + 1.
-            set_bkg_full_model(id_, bkg_rsps[i](bkg_models[i]))
+            datastack.set_bkg_full_model(id_, bkg_rsps[i](bkg_models[i]))
 
         # Fit background
-        notice(0.5, 8.)
-        set_method("neldermead")
-        set_stat("cash")
+        datastack.notice(0.5, 8.)
+        datastack.set_method("neldermead")
+        datastack.set_stat("cash")
 
-        thaw(c1.c0)
-        thaw(c2.c0)
-        fit_bkg()
-        freeze(c1.c0)
-        freeze(c2.c0)
+        datastack.thaw(c1.c0)
+        datastack.thaw(c2.c0)
+        datastack.fit_bkg()
+        datastack.freeze(c1.c0)
+        datastack.freeze(c2.c0)
 
         # Define source models
-        rsps = get_response([])
-        src_model = powlaw1d.pow1
+        rsps = datastack.get_response([])
+        src_model = ui.powlaw1d.pow1
         src_models = [src_model,
-                      src_model * const1d.ratio_12]
+                      src_model * ui.const1d.ratio_12]
         for i in range(2):
             id_ = i + 1
-            set_full_model(id_, (rsps[i](src_models[i]) +
-                                 bkg_scales[i] * bkg_rsps[i](bkg_models[i])))
+            datastack.set_full_model(id_, (rsps[i](src_models[i]) +
+                                           bkg_scales[i] *
+                                           bkg_rsps[i](bkg_models[i])))
 
-        fit()
+        datastack.fit()
 
 
 class test_query(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
-        set_stack_verbose(False)
+        datastack.set_template_id("__ID")
+        datastack.set_stack_verbose(False)
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     def test_case_7(self):
-        load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
+        datastack.load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
 
-        f = query_by_header_keyword('INSTRUME', 'ACIS')
+        f = datastack.query_by_header_keyword('INSTRUME', 'ACIS')
 
         assert f == [1,2]
 
-        f = query_by_obsid('7867')
+        f = datastack.query_by_obsid('7867')
 
         assert f == [2]
 
-        ds = DataStack()
+        ds = datastack.DataStack()
 
         ds.load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
 
@@ -683,7 +689,7 @@ class test_query(SherpaTestCase):
 
         assert f == [3]
 
-        f = query_by_obsid(ds, '7867')
+        f = datastack.query_by_obsid(ds, '7867')
 
         assert f == [4]
 

--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -17,22 +17,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
 import unittest
 import logging
-import os
-import os.path
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils import has_package_from_list, has_fits_support
-import sherpa.astro.sim as sim
+from sherpa.astro import sim
 
 from sherpa.astro.instrument import Response1D
-from sherpa.astro.data import DataPHA
 from sherpa.fit import Fit
-from sherpa.stats import Cash, CStat
+from sherpa.stats import CStat
 from sherpa.optmethods import NelderMead
 from sherpa.estmethods import Covariance
-
 
 logger = logging.getLogger('sherpa')
 
@@ -49,20 +44,16 @@ class test_sim(SherpaTestCase):
             from sherpa.astro.xspec import XSwabs, XSpowerlaw
         except:
             return
-        #self.startdir = os.getcwd()
+        # self.startdir = os.getcwd()
         self.old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.CRITICAL)
 
-        datadir = SherpaTestCase.datadir
-        if datadir is None:
-            return
+        pha = self.make_path("refake_0934_1_21_1e4.fak")
+        # rmf = self.make_path("ccdid7_default.rmf")
+        # arf = self.make_path("quiet_0934.arf")
 
-        pha = os.path.join(datadir, "refake_0934_1_21_1e4.fak")
-        rmf = os.path.join(datadir, "ccdid7_default.rmf")
-        arf = os.path.join(datadir, "quiet_0934.arf")
-
-        self.simarf = os.path.join(datadir, "aref_sample.fits")
-        self.pcaarf = os.path.join(datadir, "aref_Cedge.fits")
+        self.simarf = self.make_path("aref_sample.fits")
+        self.pcaarf = self.make_path("aref_Cedge.fits")
 
         data = read_pha(pha)
         data.ignore(None,0.3)
@@ -75,20 +66,15 @@ class test_sim(SherpaTestCase):
 
         self.fit = Fit(data, model, CStat(), NelderMead(), Covariance())
 
-
     def tearDown(self):
-        #os.chdir(self.startdir)
-        if hasattr(self,'old_level'):
+        # os.chdir(self.startdir)
+        if hasattr(self, 'old_level'):
             logger.setLevel(self.old_level)
 
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_simarf(self):
-        datadir = SherpaTestCase.datadir
-        if datadir is None:
-            return
-
         mcmc = sim.MCMC()
 
         self.abs1.nh = 0.092886
@@ -116,10 +102,6 @@ class test_sim(SherpaTestCase):
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_pcaarf(self):
-        datadir = SherpaTestCase.datadir
-        if datadir is None:
-            return
-
         mcmc = sim.MCMC()
 
         self.abs1.nh = 0.092886
@@ -146,5 +128,10 @@ class test_sim(SherpaTestCase):
 
 if __name__ == '__main__':
 
-    import sherpa.astro.sim as sim
-    SherpaTest(sim).test(datadir="/data/scialg/testdata")
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(sim).test(datadir=datadir)

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -28,6 +28,7 @@ from sherpa.astro.data import DataPHA
 
 logger = logging.getLogger('sherpa')
 
+
 class test_threads(SherpaTestCase):
 
     def setUp(self):
@@ -56,7 +57,7 @@ class test_threads(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
+        os.chdir(self.make_path('ciao4.3', name))
         execfile(scriptname, {}, self.locals)
 
     @unittest.skipIf(not has_fits_support(),
@@ -78,7 +79,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(ui.calc_energy_flux(), 9.614847e-13, 1e-4)
         self.assertEqualWithinTol(ui.calc_data_sum(), 706.85714092, 1e-4)
         self.assertEqualWithinTol(ui.calc_model_sum(), 638.45693377, 1e-4)
-        self.assertEqualWithinTol(ui.calc_source_sum(),0.046996409, 1e-4)
+        self.assertEqualWithinTol(ui.calc_source_sum(), 0.046996409, 1e-4)
         self.assertEqualWithinTol(ui.eqwidth(self.locals['p1'],
                                              ui.get_source()),-0.57731725, 1e-4)
         self.assertEqualWithinTol(ui.calc_kcorr([1,1.2,1.4,1.6,1.8,2], 0.5, 2),
@@ -114,9 +115,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['m1'].c3.val, -0.00277729, 1e-4)
         self.assertEqualWithinTol(self.locals['m2'].c0.val, 1.75548, 1e-4)
         self.assertEqualWithinTol(self.locals['m2'].c1.val, 0.198455, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,9)
-        self.assertEqual(ui.get_fit_results().numpoints,11)
-        self.assertEqual(ui.get_fit_results().dof,9)
+        self.assertEqual(ui.get_fit_results().nfev, 9)
+        self.assertEqual(ui.get_fit_results().numpoints, 11)
+        self.assertEqual(ui.get_fit_results().dof, 9)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -132,8 +133,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['pl1'].gamma.val, 1.645, 1e-4)
         self.assertEqualWithinTol(self.locals['pl1'].ampl.val, 2.28323e-05, 1e-3)
         self.assertEqualWithinTol(self.locals['pl2'].ampl.val, 2.44585e-05, 1e-3)
-        self.assertEqual(ui.get_fit_results().numpoints,18)
-        self.assertEqual(ui.get_fit_results().dof,14)
+        self.assertEqual(ui.get_fit_results().numpoints, 18)
+        self.assertEqual(ui.get_fit_results().dof, 14)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -150,8 +151,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['b1'].norm.val, 0.00953809, 1e-2)
         self.assertEqualWithinTol(self.locals['b2'].kt.val, 0.563109, 1e-2)
         self.assertEqualWithinTol(self.locals['b2'].norm.val, 1.16118e-05, 1e-2)
-        self.assertEqual(ui.get_fit_results().numpoints,1330)
-        self.assertEqual(ui.get_fit_results().dof,1325)
+        self.assertEqual(ui.get_fit_results().numpoints, 1330)
+        self.assertEqual(ui.get_fit_results().dof, 1325)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -167,9 +168,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g2'].xpos.val, 4070.78, 1e-4)
         self.assertEqualWithinTol(self.locals['g2'].ypos.val, 4249.33, 1e-4)
         self.assertEqualWithinTol(self.locals['g2'].ampl.val, 226.563, 1e-4)
-        #self.assertEqual(ui.get_fit_results().nfev,371)
-        self.assertEqual(ui.get_fit_results().numpoints,4881)
-        self.assertEqual(ui.get_fit_results().dof,4877)
+        # self.assertEqual(ui.get_fit_results().nfev,371)
+        self.assertEqual(ui.get_fit_results().numpoints, 4881)
+        self.assertEqual(ui.get_fit_results().dof, 4877)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -186,8 +187,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['abs1'].nh.val, 6.12101, 1e-2)
         self.assertEqualWithinTol(self.locals['power'].gamma.val, 1.41887, 1e-2)
         self.assertEqualWithinTol(self.locals['power'].ampl.val, 0.00199457, 1e-2)
-        self.assertEqual(ui.get_fit_results().numpoints,42)
-        self.assertEqual(ui.get_fit_results().dof,37)
+        self.assertEqual(ui.get_fit_results().numpoints, 42)
+        self.assertEqual(ui.get_fit_results().dof, 37)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -201,9 +202,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['src'].beta.val, 4.1633, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].xpos.val, 0.0, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].ampl.val, 4.42821, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,92)
-        self.assertEqual(ui.get_fit_results().numpoints,38)
-        self.assertEqual(ui.get_fit_results().dof,35)
+        self.assertEqual(ui.get_fit_results().nfev, 92)
+        self.assertEqual(ui.get_fit_results().numpoints, 38)
+        self.assertEqual(ui.get_fit_results().dof, 35)
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro_dm(self):
@@ -222,9 +223,9 @@ class test_threads(SherpaTestCase):
             self.assertEqualWithinTol(self.locals['src'].beta.val, 4.1633, 1e-4)
             self.assertEqualWithinTol(self.locals['src'].xpos.val, 0.0, 1e-4)
             self.assertEqualWithinTol(self.locals['src'].ampl.val, 4.42821, 1e-4)
-            self.assertEqual(ui.get_fit_results().nfev,92)
-            self.assertEqual(ui.get_fit_results().numpoints,38)
-            self.assertEqual(ui.get_fit_results().dof,35)
+            self.assertEqual(ui.get_fit_results().nfev, 92)
+            self.assertEqual(ui.get_fit_results().numpoints, 38)
+            self.assertEqual(ui.get_fit_results().dof, 35)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -236,9 +237,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g1'].ypos.val, 77.2271, 1e-2)
         self.assertEqualWithinTol(self.locals['g1'].xpos.val, 88.661, 1e-2)
         self.assertEqualWithinTol(self.locals['g1'].ampl.val, 166.649, 1e-2)
-        #self.assertEqual(ui.get_fit_results().nfev,342)
-        self.assertEqual(ui.get_fit_results().numpoints,4899)
-        self.assertEqual(ui.get_fit_results().dof,4895)
+        # self.assertEqual(ui.get_fit_results().nfev,342)
+        self.assertEqual(ui.get_fit_results().numpoints, 4899)
+        self.assertEqual(ui.get_fit_results().dof, 4895)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -255,9 +256,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g1'].xpos.val, 88.940712, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].ypos.val, 76.577265, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].ampl.val, 36344.48324, 1e-4)
-        #self.assertEqual(ui.get_fit_results().nfev,978)
-        self.assertEqual(ui.get_fit_results().numpoints,4899)
-        self.assertEqual(ui.get_fit_results().dof,4895)
+        # self.assertEqual(ui.get_fit_results().nfev,978)
+        self.assertEqual(ui.get_fit_results().numpoints, 4899)
+        self.assertEqual(ui.get_fit_results().dof, 4895)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -268,9 +269,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['src'].r0.val, 83.0997, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].beta.val, 2.97737, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].ampl.val, 5.27604, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,48)
-        self.assertEqual(ui.get_fit_results().numpoints,38)
-        self.assertEqual(ui.get_fit_results().dof,35)
+        self.assertEqual(ui.get_fit_results().nfev, 48)
+        self.assertEqual(ui.get_fit_results().numpoints, 38)
+        self.assertEqual(ui.get_fit_results().dof, 35)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -281,9 +282,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['b1'].r0.val, 4.25557, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].beta.val, 0.492232, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].ampl.val, 11.8129, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,17)
-        self.assertEqual(ui.get_fit_results().numpoints,75)
-        self.assertEqual(ui.get_fit_results().dof,72)
+        self.assertEqual(ui.get_fit_results().nfev, 17)
+        self.assertEqual(ui.get_fit_results().numpoints, 75)
+        self.assertEqual(ui.get_fit_results().dof, 72)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -294,9 +295,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['b1'].r0.val, 19.2278, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].beta.val, 0.555464, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].ampl.val, 1.93706, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,21)
-        self.assertEqual(ui.get_fit_results().numpoints,75)
-        self.assertEqual(ui.get_fit_results().dof,72)
+        self.assertEqual(ui.get_fit_results().nfev, 21)
+        self.assertEqual(ui.get_fit_results().numpoints, 75)
+        self.assertEqual(ui.get_fit_results().dof, 72)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -311,8 +312,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['mek1'].norm.val, 0.699761, 1e-4)
         self.assertEqualWithinTol(self.locals['mek2'].kt.val, 2.35845, 1e-4)
         self.assertEqualWithinTol(self.locals['mek2'].norm.val, 1.03724, 1e-4)
-        self.assertEqual(ui.get_fit_results().numpoints,446)
-        self.assertEqual(ui.get_fit_results().dof,441)
+        self.assertEqual(ui.get_fit_results().numpoints, 446)
+        self.assertEqual(ui.get_fit_results().dof, 441)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -323,9 +324,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g1'].fwhm.val, 0.0232473, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].pos.val, 1.26713, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].ampl.val, 40.4503, 1e-4)
-        #self.assertEqual(ui.get_fit_results().nfev,19)
-        self.assertEqual(ui.get_fit_results().numpoints,50)
-        self.assertEqual(ui.get_fit_results().dof,47)
+        # self.assertEqual(ui.get_fit_results().nfev,19)
+        self.assertEqual(ui.get_fit_results().numpoints, 50)
+        self.assertEqual(ui.get_fit_results().dof, 47)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -338,9 +339,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['intrin'].nh.val, 11.0769, 1e-2)
         self.assertEqualWithinTol(self.locals['phard'].phoindex.val, 1.49055, 1e-2)
         self.assertEqualWithinTol(self.locals['phard'].norm.val, 0.00140301, 1e-2)
-        self.assertEqual(ui.get_fit_results().nfev,95)
-        self.assertEqual(ui.get_fit_results().numpoints,162)
-        self.assertEqual(ui.get_fit_results().dof,159)
+        self.assertEqual(ui.get_fit_results().nfev, 95)
+        self.assertEqual(ui.get_fit_results().numpoints, 162)
+        self.assertEqual(ui.get_fit_results().dof, 159)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -548,5 +549,12 @@ class test_threads(SherpaTestCase):
 if __name__ == '__main__':
 
     from sherpa.utils import SherpaTest
-    import sherpa.astro as astro
-    SherpaTest(astro).test(datadir="/data/scialg/testdata")
+    from sherpa import astro
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(astro).test(datadir=datadir)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -136,7 +136,7 @@ class test_more_ui(SherpaTestCase):
         self.img = self.make_path('img.fits')
         self.pha = self.make_path('threads/simultaneous/pi2286.fits')
         self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
-        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi'
+        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi')
 
     def tearDown(self):
         logger.setLevel(self._old_logger_level)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -21,25 +21,26 @@ import os
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase
 from sherpa.utils import test_data_missing, has_fits_support
-import sherpa.astro.ui as ui
+from sherpa.astro import ui
 import numpy
 import logging
 logger = logging.getLogger("sherpa")
+
 
 class test_ui(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.ascii = self.datadir + '/threads/ascii_table/sim.poisson.1.dat'
-        self.fits = self.datadir + '/1838_rprofile_rmid.fits'
-        self.singledat = self.datadir + '/single.dat'
-        self.singletbl = self.datadir + '/single.fits'
-        self.doubledat = self.datadir + '/double.dat'
-        self.doubletbl = self.datadir + '/double.fits'
-        self.img = self.datadir + '/img.fits'
-        self.filter_single_int_ascii = self.datadir + '/filter_single_integer.dat'
-        self.filter_single_int_table = self.datadir + '/filter_single_integer.fits'
-        self.filter_single_log_table = self.datadir + '/filter_single_logical.fits'
+        self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
+        self.fits = self.make_path('1838_rprofile_rmid.fits')
+        self.singledat = self.make_path('single.dat')
+        self.singletbl = self.make_path('single.fits')
+        self.doubledat = self.make_path('double.dat')
+        self.doubletbl = self.make_path('double.fits')
+        self.img = self.make_path('img.fits')
+        self.filter_single_int_ascii = self.make_path('filter_single_integer.dat')
+        self.filter_single_int_table = self.make_path('filter_single_integer.fits')
+        self.filter_single_log_table = self.make_path('filter_single_logical.fits')
 
         self.func = lambda x: x
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
@@ -65,6 +66,7 @@ class test_ui(SherpaTestCase):
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     def test_load_table_fits(self):
+        # QUS: why is this not in the sherpa-test-data repository?
         this_dir = os.path.dirname(os.path.abspath(__file__))
         ui.load_table(1, os.path.join(this_dir, 'data', 'two_column_x_y.fits.gz'))
         data = ui.get_data(1)
@@ -92,7 +94,6 @@ class test_ui(SherpaTestCase):
     def test_table_model_fits_image(self):
         ui.load_table_model('tbl', self.img)
 
-
     # Test user model
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -115,7 +116,6 @@ class test_ui(SherpaTestCase):
         ui.load_filter(self.filter_single_int_ascii)
         ui.load_filter(self.filter_single_int_ascii, ignore=True)
 
-
     # Test load_filter
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -133,16 +133,15 @@ class test_more_ui(SherpaTestCase):
     def setUp(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        self.img = self.datadir + '/img.fits'
-        self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
-        self.rmf = self.datadir + '/threads/simultaneous/rmf2286.fits'
-        self.pha3c273 = self.datadir + '/ciao4.3/pha_intro/3c273.pi'
-        logger.setLevel(logging.ERROR)
+        self.img = self.make_path('img.fits')
+        self.pha = self.make_path('threads/simultaneous/pi2286.fits')
+        self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
+        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi'
 
     def tearDown(self):
         logger.setLevel(self._old_logger_level)
 
-    #bug #12732
+    # bug #12732
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -152,7 +151,7 @@ class test_more_ui(SherpaTestCase):
         # Check that get_rmf(id)('modelexpression') works
         caught = False
         try:
-            m=ui.get_rmf("foo")("powlaw1d.pl1")
+            m = ui.get_rmf("foo")("powlaw1d.pl1")
         except:
             caught = True
         if caught:
@@ -170,22 +169,27 @@ class test_more_ui(SherpaTestCase):
         ui.group_counts('3c273', 30)
         ui.group_counts('3c273', 15)
 
-
 class test_image_12578(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.img = self.datadir + '/img.fits'
+        self.img = self.make_path('img.fits')
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         ui.clean()
 
-    #bug #12578
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
+
+    # bug #12578
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_coord_bad_coord(self):
         from sherpa.utils.err import IdentifierErr, DataErr
 
-        # Test Case #1: if the list of ids is empty, raise a IdentifierErr['nodatasets']
+        # Test Case #1: if the list of ids is empty, raise
+        # IdentifierErr['nodatasets']
         caught = False
         try:
             ui.set_coord('image')
@@ -194,8 +198,9 @@ class test_image_12578(SherpaTestCase):
         if not caught:
             self.fail("Test Case #1: IdentifierErr Exception not caught")
 
-        # Test Case #2: check the user expected behavior. The call set_coord("sky")
-        # will result in the error message DataErr: unknown coordinates: 'sky'\n \
+        # Test Case #2: check the user expected behavior. The call
+        # set_coord("sky") will result in the error message
+        # DataErr: unknown coordinates: 'sky'\n \
         # Valid coordinates: logical, image, physical, world, wcs
         ui.load_image(self.img)
 
@@ -208,6 +213,7 @@ class test_image_12578(SherpaTestCase):
             caught = True
         if not caught:
             self.fail("Test Case #2: DataErr Exception not caught")
+
 
 class test_psf_ui(SherpaTestCase):
 
@@ -229,8 +235,8 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf1d', model+'.mdl')
                 ui.set_psf('psf1d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([4])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([4])).all())
             except:
                 print model
                 raise
@@ -242,22 +248,23 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf2d', model+'.mdl')
                 ui.set_psf('psf2d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([108,130])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([108,130])).all())
             except:
                 print model
                 raise
 
-    #bug #12503
+    # bug #12503
     def test_psf_pars_are_frozen(self):
         ui.load_psf('psf', ui.beta2d.p1)
         self.assertEqual([], p1.thawedpars)
+
 
 class test_stats_ui(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.data = self.datadir + '/threads/chi2/3c273.pi'
+        self.data = self.make_path('threads/chi2/3c273.pi')
         ui.clean()
 
     # bugs #11400, #13297, #12365
@@ -266,8 +273,9 @@ class test_stats_ui(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_chi2(self):
 
-        #Case 1: first ds has no error, second has, chi2-derived (chi2gehrels) statistic
-        #I expect stat.name to be chi2gehrels for ds1, chi2 for ds2, chi2gehrels for ds1,2
+        # Case 1: first ds has no error, second has, chi2-derived (chi2gehrels)
+        # statistic. I expect stat.name to be chi2gehrels for ds1, chi2 for
+        # ds2, chi2gehrels for ds1,2
         ui.load_data(1, self.data)
         ui.load_data(2, self.data, use_errors=True)
 
@@ -276,7 +284,7 @@ class test_stats_ui(SherpaTestCase):
 
         ui.set_stat("chi2gehrels")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
@@ -286,105 +294,106 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat2)
         self.assertEqual('chi2gehrels', stat12)
 
-        #Case 2: first ds has errors, second has not, chi2-derived (chi2gehrels) statistic
-        #I expect stat.name to be chi2 for ds1, chi2gehrels for ds2, chi2gehrels for ds1,2
+        # Case 2: first ds has errors, second has not, chi2-derived
+        # (chi2gehrels) statistic. I expect stat.name to be chi2 for ds1,
+        # chi2gehrels for ds2, chi2gehrels for ds1,2
         ui.load_data(2, self.data)
         ui.load_data(1, self.data, use_errors=True)
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('chi2gehrels', stat2)
         self.assertEqual('chi2', stat1)
         self.assertEqual('chi2gehrels', stat12)
 
-        #Case 3: both datasets have errors, chi2-derived (chi2gehrels) statistic
-        #I expect stat.name to be chi2 for ds1, chi2 for ds2, chi2 for ds1,2
+        # Case 3: both datasets have errors, chi2-derived (chi2gehrels)
+        # statistic. I expect stat.name to be chi2 for all of them.
         ui.load_data(2, self.data, use_errors=True)
         ui.load_data(1, self.data, use_errors=True)
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('chi2', stat2)
         self.assertEqual('chi2', stat1)
         self.assertEqual('chi2', stat12)
 
-        #Case 4: first ds has errors, second has not, LeastSq statistic
-        #I expect stat.name to be leastsq for ds1, leastsq for ds2, leastsq for ds1,2
+        # Case 4: first ds has errors, second has not, LeastSq statistic
+        # I expect stat.name to be leastsq for all of them.
         ui.load_data(2, self.data)
         ui.load_data(1, self.data, use_errors=True)
 
         ui.set_stat("leastsq")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('leastsq', stat2)
         self.assertEqual('leastsq', stat1)
         self.assertEqual('leastsq', stat12)
 
-        #Case 5: both ds have errors, LeastSq statistic
-        #I expect stat.name to be leastsq for ds1, leastsq for ds2, leastsq for ds1,2
+        # Case 5: both ds have errors, LeastSq statistic
+        # I expect stat.name to be leastsq for all of them.
         ui.load_data(2, self.data, use_errors=True)
         ui.load_data(1, self.data, use_errors=True)
 
         ui.set_stat("leastsq")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('leastsq', stat2)
         self.assertEqual('leastsq', stat1)
         self.assertEqual('leastsq', stat12)
 
-        #Case 6: first ds has errors, second has not, CStat statistic
-        #I expect stat.name to be cstat for ds1, cstat for ds2, cstat for ds1,2
+        # Case 6: first ds has errors, second has not, CStat statistic
+        # I expect stat.name to be cstat for all of them.
         ui.load_data(2, self.data)
         ui.load_data(1, self.data, use_errors=True)
 
         ui.set_stat("cstat")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('cstat', stat2)
         self.assertEqual('cstat', stat1)
         self.assertEqual('cstat', stat12)
 
-        #Case7: select chi2 as statistic. One of the ds does not provide errors
-        #I expect sherpa to raise a StatErr exception.
+        # Case7: select chi2 as statistic. One of the ds does not provide
+        # errors. I expect sherpa to raise a StatErr exception.
         ui.set_stat('chi2')
 
-        caught=False
+        caught = False
 
         from sherpa.utils.err import StatErr
         try:
             ui.get_stat_info()
         except StatErr:
-            caught=True
+            caught = True
 
-        self.assertTrue(caught)
+        self.assertTrue(caught, msg='StatErr was not caught')
 
-        #Case8: select chi2 as statistic. Both datasets provide errors
-        #I expect stat to be 'chi2'
+        # Case8: select chi2 as statistic. Both datasets provide errors
+        # I expect stat to be 'chi2'
         ui.load_data(2, self.data, use_errors=True)
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
@@ -395,9 +404,12 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat12)
 
 
-
 if __name__ == '__main__':
 
     import sys
     if len(sys.argv) > 1:
-        SherpaTest(ui).test(datadir=sys.argv[1])
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2013, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -17,16 +17,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
-
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils import has_fits_support
-import sherpa.astro.ui as ui
+from sherpa.astro import ui
 import logging
 import os
 import numpy
 logger = logging.getLogger("sherpa")
+
 
 class test_more_ui(SherpaTestCase):
     def assign_model(self, name, obj):
@@ -36,16 +35,25 @@ class test_more_ui(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
-        execfile(scriptname, {}, self.locals)
+        cwd = os.getcwd()
+        os.chdir(self.make_path('ciao4.3', name))
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.img = self.datadir + '/img.fits'
-        self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
-        self.rmf = self.datadir + '/threads/simultaneous/rmf2286.fits'
-        self.nan = self.datadir + '/ciao4.3/filternan/with_nan.fits'
+        self.img = self.make_path('img.fits')
+        self.pha = self.make_path('threads/simultaneous/pi2286.fits')
+        self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
+        self.nan = self.make_path('ciao4.3/filternan/with_nan.fits')
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
+
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
 
     # bug 12784
     @unittest.skipIf(not has_fits_support(),
@@ -59,4 +67,8 @@ if __name__ == '__main__':
 
     import sys
     if len(sys.argv) > 1:
-        SherpaTest(ui).test(datadir=sys.argv[1])
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -95,9 +95,9 @@ class test_new_templates_ui(SherpaTestCase):
 
     # TestCase 5 user can access interpolators' parvals
     @unittest.skipIf(test_data_missing(), "required test data missing")
-    def test_grid_search_with_discrete_template(self):
-        self.run_thread('load_template_with_interpolation', scriptname='test_case_5.py')
-
+    def test_grid_search_with_discrete_template_parvals(self):
+        self.run_thread('load_template_with_interpolation',
+                        scriptname='test_case_5.py')
 
 
 class test_template(SherpaTestCase):

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -20,13 +20,16 @@
 
 import unittest
 from sherpa.models import TableModel, Gauss1D
-from sherpa.models.template import TemplateModel, create_template_model
+from sherpa.models.template import create_template_model
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils.err import ModelErr
 from sherpa import ui
-import numpy, logging, os
+import numpy
+import logging
+import os
 
 logger = logging.getLogger("sherpa")
+
 
 class test_new_templates_ui(SherpaTestCase):
     def assign_model(self, name, obj):
@@ -36,12 +39,19 @@ class test_new_templates_ui(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
-        execfile(scriptname, {}, self.locals)
+        cwd = os.getcwd()
+        os.chdir(self.make_path('ciao4.3', name))
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
 
     def setUp(self):
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
+    def tearDown(self):
+        logger.setLevel(self.loggingLevel)
 
     # Regression reported by Aneta (original report by Fabrizio Nicastro)
     # When restoring a file saved with an older version of sherpa,
@@ -51,12 +61,11 @@ class test_new_templates_ui(SherpaTestCase):
     def test_restore_is_discrete(self):
         self.run_thread('template_restore', 'test.py')
 
-
     # TestCase 1 load_template_model enables interpolation by default
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_with_interpolation(self):
         self.run_thread('load_template_with_interpolation')
-        try:   
+        try:
             self.assertEqualWithinTol(2023.46, ui.get_fit_results().parvals[0], 0.001)
             self.assertEqualWithinTol(2743.47, ui.get_fit_results().parvals[1], 0.001)
         except:
@@ -69,11 +78,12 @@ class test_new_templates_ui(SherpaTestCase):
         self.assertEqualWithinTol(2743.91, ui.get_fit_results().parvals[0], 0.001)
 
     # TestCase 2 load_template_model with template_interpolator_name=None disables interpolation
-    # TestCase 3.1 discrete templates fail when probed for values they do not represent (gridsearch with wrong values) 
+    # TestCase 3.1 discrete templates fail when probed for values they do not represent (gridsearch with wrong values)
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
-        try:   
-            self.run_thread('load_template_without_interpolation', scriptname='test_case_2_and_3.1.py')
+        try:
+            self.run_thread('load_template_without_interpolation',
+                            scriptname='test_case_2_and_3.1.py')
         except ModelErr:
             return
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
@@ -81,17 +91,18 @@ class test_new_templates_ui(SherpaTestCase):
     # TestCase 3.2 discrete templates fail when probed for values they do not represent (continuous method with discrete template)
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
-        try:   
-            self.run_thread('load_template_without_interpolation', scriptname='test_case_3.2.py')
+        try:
+            self.run_thread('load_template_without_interpolation',
+                            scriptname='test_case_3.2.py')
         except ModelErr:
             return
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
 
-
     # TestCase 4 gridsearch with right values succeeds
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_grid_search_with_discrete_template(self):
-        self.run_thread('load_template_without_interpolation', scriptname='test_case_4.py')
+        self.run_thread('load_template_without_interpolation',
+                        scriptname='test_case_4.py')
 
     # TestCase 5 user can access interpolators' parvals
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -128,10 +139,10 @@ class test_template(SherpaTestCase):
     def tearDown(self):
         self.model = None
 
-
     def test_template_model_evaluation(self):
         self.model.thawedpars = [0,1,0,1]
-        vals = self.model(self.x)
+        # We want to evaluate the model, but do not check the result
+        self.model(self.x)
 
 #    def test_template_query_index(self):
 #        expected = 5
@@ -143,8 +154,14 @@ class test_template(SherpaTestCase):
 #        result = self.model.query([0,1,0,1])
 
 
-
 if __name__ == '__main__':
 
-    import sherpa.models as models
-    SherpaTest(models).test()
+    from sherpa import models
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(models).test(datadir=datadir)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,9 +20,8 @@
 import unittest
 import numpy
 from sherpa.all import *
-#FIXME change from full import 
+# FIXME change from full import
 from sherpa.utils import SherpaTestCase, test_data_missing
-
 
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
@@ -48,6 +47,7 @@ _datay = numpy.array(
        0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,
        0.])
 
+
 class test_plot(SherpaTestCase):
 
     def setUp(self):
@@ -58,32 +58,32 @@ class test_plot(SherpaTestCase):
     def test_dataplot(self):
         dp = DataPlot()
         dp.prepare(self.data, self.f.stat)
-        #dp.plot()
+        # dp.plot()
 
     def test_modelplot(self):
         mp = ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
-        #mp.plot()
+        # mp.plot()
 
     def test_residplot(self):
         rp = ResidPlot()
         rp.prepare(self.data, self.g1, self.f.stat)
-        #rp.plot()
+        # rp.plot()
 
     def test_delchiplot(self):
         dp = DelchiPlot()
         dp.prepare(self.data, self.g1, self.f.stat)
-        #dp.plot()
+        # dp.plot()
 
     def test_chisqrplot(self):
         cs = ChisqrPlot()
         cs.prepare(self.data, self.g1, self.f.stat)
-        #cs.plot()
+        # cs.plot()
 
     def test_ratioplot(self):
         tp = RatioPlot()
         tp.prepare(self.data, self.g1, self.f.stat)
-        #tp.plot()
+        # tp.plot()
 
     def test_fitplot(self):
         dp = DataPlot()
@@ -94,7 +94,7 @@ class test_plot(SherpaTestCase):
 
         fp = FitPlot()
         fp.prepare(dp,mp)
-        #fp.plot()
+        # fp.plot()
 
     def test_splitplot(self):
         dp = DataPlot()
@@ -110,16 +110,17 @@ class test_plot(SherpaTestCase):
         fp.prepare(dp,mp)
 
         sp = SplitPlot(2,2)
-        #sp.addplot(dp)
-        #sp.addplot(mp)
-        #sp.addplot(fp)
-        #sp.addplot(rp)
+        # sp.addplot(dp)
+        # sp.addplot(mp)
+        # sp.addplot(fp)
+        # sp.addplot(rp)
+
 
 class test_contour(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.data = read_data(self.datadir+'/gauss2d.dat',
+        self.data = read_data(self.make_path('gauss2d.dat'),
                               ncols=3, sep='\t', dstype=Data2D)
         self.g1 = Gauss2D('g1')
         self.g1.ellip.freeze()
@@ -127,33 +128,33 @@ class test_contour(SherpaTestCase):
         self.f = Fit(self.data, self.g1)
         self.levels = numpy.array([0.5, 2, 5, 10, 20])
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")    
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_datacontour(self):
         dc = DataContour()
         dc.prepare(self.data)
-        dc.levels=self.levels
-        #dc.contour()
+        dc.levels = self.levels
+        # dc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")    
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_modelcontour(self):
         mc = ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
-        mc.levels=self.levels
-        #mc.contour()
+        mc.levels = self.levels
+        # mc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")   
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_residcontour(self):
         rc = ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
-        rc.levels=self.levels
-        #rc.contour()
+        rc.levels = self.levels
+        # rc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ratiocontour(self):
         tc = RatioContour()
         tc.prepare(self.data, self.g1, self.f.stat)
-        tc.levels=self.levels
-        #tc.contour()
+        tc.levels = self.levels
+        # tc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fitcontour(self):
@@ -163,37 +164,37 @@ class test_contour(SherpaTestCase):
         mc = ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()        
+        fc = FitContour()
         fc.prepare(dc, mc)
-        #fc.contour()
+        # fc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_splitcontour(self):
         dc = DataContour()
-        dc.levels=self.levels
+        dc.levels = self.levels
         dc.prepare(self.data)
 
         mc = ModelContour()
-        mc.levels=self.levels
+        mc.levels = self.levels
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()        
+        fc = FitContour()
         fc.prepare(dc, mc)
 
         rc = ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
-        rc.levels=self.levels
+        rc.levels = self.levels
 
         sp = SplitPlot(2,2)
-        #sp.addcontour(dc)
-        #sp.addcontour(mc)
-        #sp.addcontour(fc)
-        #sp.addcontour(rc)
+        # sp.addcontour(dc)
+        # sp.addcontour(mc)
+        # sp.addcontour(fc)
+        # sp.addcontour(rc)
 
 class test_confidence(SherpaTestCase):
 
     def setUp(self):
-        self.data = Data1D('testdata',_datax,_datay)
+        self.data = Data1D('testdata', _datax, _datay)
         self.g1 = Gauss1D('g1')
         self.f = Fit(self.data, self.g1)
         self.f.fit()
@@ -202,7 +203,7 @@ class test_confidence(SherpaTestCase):
         self.rp = RegionProjection()
         self.ru = RegionUncertainty()
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_projection(self):
         _ipx = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -221,10 +222,10 @@ class test_confidence(SherpaTestCase):
         self.ip.calc(self.f, self.g1.fwhm)
         self.assertEqualWithinTol(_ipx, self.ip.x, 1e-4)
         self.assertEqualWithinTol(_ipy, self.ip.y, 1e-4)
-        #self.ip.plot()
+        # self.ip.plot()
 
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_uncertainty(self):
         _iux = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -244,9 +245,9 @@ class test_confidence(SherpaTestCase):
         self.iu.calc(self.f, self.g1.fwhm)
         self.assertEqualWithinTol(_iux, self.iu.x, 1e-4)
         self.assertEqualWithinTol(_iuy, self.iu.y, 1e-4)
-        #self.iu.plot()
+        # self.iu.plot()
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_projection(self):
         _rpx0 = numpy.array(
             [ 11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
@@ -324,10 +325,10 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_rpx0, self.rp.x0, 1e-4)
         self.assertEqualWithinTol(_rpx1, self.rp.x1, 1e-4)
         self.assertEqualWithinTol(_rpy, self.rp.y, 1e-4)
-        #self.rp.contour()
+        # self.rp.contour()
 
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_uncertainty(self):
         _rux0 = numpy.array(
             [ 12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
@@ -405,9 +406,16 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_rux0, self.ru.x0, 1e-4)
         self.assertEqualWithinTol(_rux1, self.ru.x1, 1e-4)
         self.assertEqualWithinTol(_ruy, self.ru.y, 1e-4)
-        #self.ru.contour()
+        # self.ru.contour()
 
 if __name__ == '__main__':
     from sherpa.utils import SherpaTest
     import sherpa.plot
-    SherpaTest(sherpa.plot).test()
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(sherpa.plot).test(datadir=datadir)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -19,8 +19,7 @@
 
 import unittest
 import numpy
-from sherpa.all import *
-# FIXME change from full import
+import sherpa.all as sherpa
 from sherpa.utils import SherpaTestCase, test_data_missing
 
 _datax = numpy.array(
@@ -51,65 +50,65 @@ _datay = numpy.array(
 class test_plot(SherpaTestCase):
 
     def setUp(self):
-        self.data = Data1D('testdata',_datax,_datay)
-        self.g1 = Gauss1D('g1')
-        self.f = Fit(self.data, self.g1)
+        self.data = sherpa.Data1D('testdata',_datax,_datay)
+        self.g1 = sherpa.Gauss1D('g1')
+        self.f = sherpa.Fit(self.data, self.g1)
 
     def test_dataplot(self):
-        dp = DataPlot()
+        dp = sherpa.DataPlot()
         dp.prepare(self.data, self.f.stat)
         # dp.plot()
 
     def test_modelplot(self):
-        mp = ModelPlot()
+        mp = sherpa.ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
         # mp.plot()
 
     def test_residplot(self):
-        rp = ResidPlot()
+        rp = sherpa.ResidPlot()
         rp.prepare(self.data, self.g1, self.f.stat)
         # rp.plot()
 
     def test_delchiplot(self):
-        dp = DelchiPlot()
+        dp = sherpa.DelchiPlot()
         dp.prepare(self.data, self.g1, self.f.stat)
         # dp.plot()
 
     def test_chisqrplot(self):
-        cs = ChisqrPlot()
+        cs = sherpa.ChisqrPlot()
         cs.prepare(self.data, self.g1, self.f.stat)
         # cs.plot()
 
     def test_ratioplot(self):
-        tp = RatioPlot()
+        tp = sherpa.RatioPlot()
         tp.prepare(self.data, self.g1, self.f.stat)
         # tp.plot()
 
     def test_fitplot(self):
-        dp = DataPlot()
+        dp = sherpa.DataPlot()
         dp.prepare(self.data, self.f.stat)
 
-        mp = ModelPlot()
+        mp = sherpa.ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
 
-        fp = FitPlot()
+        fp = sherpa.FitPlot()
         fp.prepare(dp,mp)
         # fp.plot()
 
     def test_splitplot(self):
-        dp = DataPlot()
+        dp = sherpa.DataPlot()
         dp.prepare(self.data, self.f.stat)
 
-        mp = ModelPlot()
+        mp = sherpa.ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
 
-        rp = ResidPlot()
+        rp = sherpa.ResidPlot()
         rp.prepare(self.data, self.g1, self.f.stat)
 
-        fp = FitPlot()
+        fp = sherpa.FitPlot()
         fp.prepare(dp,mp)
 
-        sp = SplitPlot(2,2)
+        sp = sherpa.SplitPlot(2,2)
         # sp.addplot(dp)
         # sp.addplot(mp)
         # sp.addplot(fp)
@@ -120,72 +119,72 @@ class test_contour(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.data = read_data(self.make_path('gauss2d.dat'),
-                              ncols=3, sep='\t', dstype=Data2D)
-        self.g1 = Gauss2D('g1')
+        self.data = sherpa.read_data(self.make_path('gauss2d.dat'),
+                                     ncols=3, sep='\t', dstype=sherpa.Data2D)
+        self.g1 = sherpa.Gauss2D('g1')
         self.g1.ellip.freeze()
         self.g1.theta.freeze()
-        self.f = Fit(self.data, self.g1)
+        self.f = sherpa.Fit(self.data, self.g1)
         self.levels = numpy.array([0.5, 2, 5, 10, 20])
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_datacontour(self):
-        dc = DataContour()
+        dc = sherpa.DataContour()
         dc.prepare(self.data)
         dc.levels = self.levels
         # dc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_modelcontour(self):
-        mc = ModelContour()
+        mc = sherpa.ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
         mc.levels = self.levels
         # mc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_residcontour(self):
-        rc = ResidContour()
+        rc = sherpa.ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
         rc.levels = self.levels
         # rc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ratiocontour(self):
-        tc = RatioContour()
+        tc = sherpa.RatioContour()
         tc.prepare(self.data, self.g1, self.f.stat)
         tc.levels = self.levels
         # tc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fitcontour(self):
-        dc = DataContour()
+        dc = sherpa.DataContour()
         dc.prepare(self.data)
 
-        mc = ModelContour()
+        mc = sherpa.ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()
+        fc = sherpa.FitContour()
         fc.prepare(dc, mc)
         # fc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_splitcontour(self):
-        dc = DataContour()
+        dc = sherpa.DataContour()
         dc.levels = self.levels
         dc.prepare(self.data)
 
-        mc = ModelContour()
+        mc = sherpa.ModelContour()
         mc.levels = self.levels
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()
+        fc = sherpa.FitContour()
         fc.prepare(dc, mc)
 
-        rc = ResidContour()
+        rc = sherpa.ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
         rc.levels = self.levels
 
-        sp = SplitPlot(2,2)
+        sp = sherpa.SplitPlot(2,2)
         # sp.addcontour(dc)
         # sp.addcontour(mc)
         # sp.addcontour(fc)
@@ -194,14 +193,14 @@ class test_contour(SherpaTestCase):
 class test_confidence(SherpaTestCase):
 
     def setUp(self):
-        self.data = Data1D('testdata', _datax, _datay)
-        self.g1 = Gauss1D('g1')
-        self.f = Fit(self.data, self.g1)
+        self.data = sherpa.Data1D('testdata', _datax, _datay)
+        self.g1 = sherpa.Gauss1D('g1')
+        self.f = sherpa.Fit(self.data, self.g1)
         self.f.fit()
-        self.ip = IntervalProjection()
-        self.iu = IntervalUncertainty()
-        self.rp = RegionProjection()
-        self.ru = RegionUncertainty()
+        self.ip = sherpa.IntervalProjection()
+        self.iu = sherpa.IntervalUncertainty()
+        self.rp = sherpa.RegionProjection()
+        self.ru = sherpa.RegionUncertainty()
 
     # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_projection(self):

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -23,6 +23,7 @@ import sherpa
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa import ui
 
+
 class test_sherpa(SherpaTestCase):
 
     def test_include_dir(self):
@@ -31,9 +32,9 @@ class test_sherpa(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.agn2 = self.datadir + '/ciao4.3/faulty_load_data/agn2'
-        self.agn2_fixed = self.datadir + '/ciao4.3/faulty_load_data/agn2_fixed'
-        self.template_idx = self.datadir + '/ciao4.3/faulty_load_data/table.txt'
+        self.agn2 = self.make_path('ciao4.3/faulty_load_data/agn2')
+        self.agn2_fixed = self.make_path('ciao4.3/faulty_load_data/agn2_fixed')
+        self.template_idx = self.make_path('ciao4.3/faulty_load_data/table.txt')
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_not_reading_header_without_comment(self):
@@ -50,3 +51,15 @@ class test_sherpa(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_require_float(self):
         self.assertRaises(ValueError, ui.load_data, self.agn2)
+
+if __name__ == '__main__':
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    # This is probably not what you want, since it also runs
+    # all the tests in sub-modules
+    SherpaTest(sherpa).test(datadir=datadir)

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -21,11 +21,9 @@
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.models import ArithmeticModel, Parameter
-from sherpa.utils.err import ModelErr
-import sherpa.ui as ui
-import numpy, logging, os
+from sherpa import ui
+import numpy
 
-logger = logging.getLogger("sherpa")
 
 class UserModel(ArithmeticModel):
 
@@ -39,14 +37,15 @@ class UserModel(ArithmeticModel):
     def calc(self, p, x, *args, **kwargs):
         return p[0]*x+p[1]
 
+
 class test_ui(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.ascii = self.datadir + '/threads/ascii_table/sim.poisson.1.dat'
-        self.single = self.datadir + '/single.dat'
-        self.double = self.datadir + '/double.dat'
-        self.filter = self.datadir + '/filter_single_integer.dat'
+        self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
+        self.single = self.make_path('single.dat')
+        self.double = self.make_path('double.dat')
+        self.filter = self.make_path('filter_single_integer.dat')
         self.func = lambda x: x
 
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
@@ -137,8 +136,8 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf1d', model+'.mdl')
                 ui.set_psf('psf1d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([4])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([4])).all())
             except:
                 print model
                 raise
@@ -151,8 +150,8 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf2d', model+'.mdl')
                 ui.set_psf('psf2d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([108,130])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([108,130])).all())
             except:
                 print model
                 raise

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -130,7 +130,7 @@ class test_psf_ui(SherpaTestCase):
     def tearDown(self):
         pass
 
-    def test_psf_model2d(self):
+    def test_psf_model1d(self):
         ui.dataspace1d(1, 10)
         for model in self.models1d:
             try:
@@ -162,4 +162,8 @@ if __name__ == '__main__':
 
     import sys
     if len(sys.argv) > 1:
-        SherpaTest(ui).test(datadir=sys.argv[1])
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -105,13 +105,14 @@ _guess_ampl_scale = 1.e+3
 ###############################################################################
 
 
-
 # Default numeric types (these match the typedefs in extension.hh)
 SherpaInt = numpy.intp
 SherpaUInt = numpy.uintp
 SherpaFloat = numpy.float_
 
-################################################################################
+###############################################################################
+
+
 class TraceCalls(object):
     """ Use as a decorator on functions that should be traced. Several
         functions can be decorated - they will all be indented according
@@ -144,7 +145,9 @@ class TraceCalls(object):
                 self.stream.write('%s--> %s\n' % (indent, ret))
             return ret
         return wrapper
-################################################################################
+
+###############################################################################
+
 
 class NoNewAttributesAfterInit(object):
     """
@@ -283,7 +286,6 @@ class SherpaTest(numpytest.NumpyTest):
             SherpaTestCase.datadir = old_datadir
 
 
-
 ###############################################################################
 #
 # Utilities
@@ -306,15 +308,15 @@ def filter_bins(mins, maxes, axislist):
             continue
 
         if lo is None:
-            #axismask = axis <= hi
+            # axismask = axis <= hi
             axismask = (sao_fcmp(hi,axis,eps) >= 0)
 
         elif hi is None:
-            #axismask = axis >= lo
+            # axismask = axis >= lo
             axismask = (sao_fcmp(lo,axis,eps) <= 0)
 
         else:
-            #axismask = (lo <= axis) & (axis <= hi)
+            # axismask = (lo <= axis) & (axis <= hi)
             axismask = (sao_fcmp(lo,axis,eps) <= 0) & (sao_fcmp(hi,axis,eps) >= 0)
 
         if mask is None:
@@ -385,7 +387,8 @@ def export_method(meth, name=None, modname=None):
         old_name = meth.func_name
 
     # Make an argument list string, removing 'self'
-    if meth.func_name == 'log_decorator': # needed for making loggable decorator work (Omar)
+    if meth.func_name == 'log_decorator':
+        # This is needed for making loggable decorator work (Omar)
         argspec = inspect.getargspec(meth._original)
         defaults = meth._original.func_defaults
         doc = meth._original.func_doc
@@ -746,6 +749,7 @@ def poisson_noise(x):
 
     return x_out
 
+
 def multinormal_pdf(x, mu, sigma):
     """The PDF of a multivariate-normal.
 
@@ -896,8 +900,8 @@ def dataspace1d(start, stop, step=1, numbins=None):
         if step >= (stop-start):
             raise TypeError("input has produced less than 2 bins, found start=%s stop=%s step=%s" % (start, stop, step))
 
-    #xx = numpy.arange(start, stop, step, dtype=float)
-    #xx = sao_arange(start, stop, step)
+    # xx = numpy.arange(start, stop, step, dtype=float)
+    # xx = sao_arange(start, stop, step)
     xx = None
     if numbins is not None:
         if numbins <= 1:
@@ -938,6 +942,7 @@ def dataspace2d(dim):
     y = numpy.zeros(numpy.prod(dim))
 
     return x0, x1, y, shape
+
 
 def histogram1d( x, x_lo, x_hi ):
     """Create a 1D histogram from a binned grid (``x_lo``, ``xhi``)
@@ -991,6 +996,7 @@ def histogram1d( x, x_lo, x_hi ):
     x_hi.sort()
 
     return hist1d( numpy.asarray(x), x_lo, x_hi )
+
 
 def histogram2d( x, y, x_grid, y_grid ):
     """Create 21D histogram from a binned grid (``x_grid``, ``y_grid``)
@@ -1047,16 +1053,17 @@ def interp_util( xout, xin, yin ):
     i1[ i1==0 ] = 1
     i1[ i1==lenxin ] = lenxin-1
 
-##     if 0 == i1:
-##         i1 = 1
-##     if lenxin == i1:
-##         i1 = lenxin - 1
+#     if 0 == i1:
+#         i1 = 1
+#     if lenxin == i1:
+#         i1 = lenxin - 1
 
     x0 = xin[i1-1]
     x1 = xin[i1]
     y0 = yin[i1-1]
     y1 = yin[i1]
     return x0, x1, y0, y1
+
 
 def linear_interp( xout, xin, yin ):
     """Linear interpolation of (xin,yin) onto xout."""
@@ -1067,10 +1074,12 @@ def linear_interp( xout, xin, yin ):
         return nearest_interp( xout, xin, yin )
     return val
 
+
 def nearest_interp( xout, xin, yin ):
     """Nearest-neighbor interpolation of (xin,yin) onto xout."""
     x0, x1, y0, y1 = interp_util( xout, xin, yin )
     return numpy.where((numpy.abs(xout - x0) < numpy.abs(xout - x1)), y0, y1)
+
 
 def interpolate(xout, xin, yin, function=linear_interp):
     """Interpolate the curve defined by (xin, yin) at points xout.
@@ -1125,7 +1134,7 @@ def is_binary_file( filename ):
 
 
 def get_midpoint(a):
-    #return numpy.abs(a.max() - a.min())/2. + a.min()
+    # return numpy.abs(a.max() - a.min())/2. + a.min()
     return numpy.abs(a.max() + a.min())/2.
 
 
@@ -1136,6 +1145,7 @@ def get_peak(y, x, xhi=None):
 def get_valley(y, x, xhi=None):
     return x[y.argmin()]
 
+
 def get_fwhm(y, x, xhi=None):
     half_max_val = y.max() / 2.0
     x_max = x[y.argmax()]
@@ -1143,6 +1153,7 @@ def get_fwhm(y, x, xhi=None):
         if val >= half_max_val:
             return 2.0*numpy.abs(x[ii] - x_max)
     return x_max
+
 
 def guess_fwhm(y, x, xhi=None, scale=1000):
     fwhm = get_fwhm(y, x, xhi)
@@ -1355,7 +1366,7 @@ def guess_position(y, x0lo, x1lo, x0hi=None, x1hi=None):
 
     """
 
-    #pos = int(y.argmax())
+    # pos = int(y.argmax())
     # return the average of location of brightest pixels
     pos = numpy.where(y==y.max())
 
@@ -1479,7 +1490,7 @@ def run_tasks(procs, err_q, out_q, num):
         idx, result = out_q.get()
         results[idx] = result
 
-    #return list(numpy.concatenate(results))
+    # return list(numpy.concatenate(results))
     # Remove extra dimension added by split
     vals = []
     [ vals.extend(result) for result in results ]
@@ -1514,7 +1525,7 @@ def parallel_map(function, sequence, numcores=None):
     if numcores is None:
         numcores = _ncpus
 
-    # Returns a started SyncManager object which can be used for sharing 
+    # Returns a started SyncManager object which can be used for sharing
     # objects between processes. The returned manager object corresponds
     # to a spawned child process and has methods which will create shared
     # objects and return corresponding proxies.
@@ -1527,7 +1538,7 @@ def parallel_map(function, sequence, numcores=None):
     err_q = manager.Queue()
     lock  = manager.Lock()
 
-    # if sequence is less than numcores, only use len sequence number of 
+    # if sequence is less than numcores, only use len sequence number of
     # processes
     if size < numcores:
         numcores = size  
@@ -1555,11 +1566,13 @@ def neville2d( xinterp, yinterp, x, y, fval ):
 
 ################################## Hessian ####################################
 
+
 class NumDeriv:
 
     def __init__( self, func, fval0 ):
         self.nfev, self.func = func_counter( func )
         self.fval_0 = fval0
+
 
 class NumDerivCentralOrdinary( NumDeriv ):
     """
@@ -1719,6 +1732,7 @@ class NumDerivCentralPartial(NumDeriv):
             fval /= ( 4.0 * deltai * deltaj )
             return fval
 
+
 class NoRichardsonExtrapolation:
 
     def __init__( self, sequence, verbose=False ):
@@ -1727,6 +1741,7 @@ class NoRichardsonExtrapolation:
 
     def __call__( self, x, t, tol, maxiter, h, *args ):
         self.sequence( x, h, *args )
+
 
 class RichardsonExtrapolation( NoRichardsonExtrapolation ):
     """From Wikipedia, the free encyclopedia
@@ -1799,6 +1814,7 @@ def print_low_triangle( matrix, num ):
             print matrix[ ii, jj ],
         print
 
+
 def symmetric_to_low_triangle( matrix, num ):
     low_triangle = []
     for ii in xrange( num ):
@@ -1809,9 +1825,8 @@ def symmetric_to_low_triangle( matrix, num ):
     return low_triangle
 
 
-################################## Hessian ####################################
-
 ############################### Root of all evil ##############################
+
 
 def printf(format, *args):
     """Format args with the first argument as format string, and write.
@@ -1819,24 +1834,31 @@ def printf(format, *args):
     sys.stdout.write(str(format) % args)
     return if_(args, args[-1], format)
 
+
 def func_counter( func ):
     '''A function wrapper to count the number of times being called'''
     nfev = [0]
+
     def func_counter_wrapper( x, *args ):
         nfev[0] += 1
         return func( x, *args )
+
     return nfev, func_counter_wrapper
+
 
 def func_counter_history( func, history ):
     '''A function wrapper to count the number of times being called'''
     nfev = [0]
+
     def func_counter_history_wrapper( x, *args ):
         nfev[0] += 1
         y = func( x, *args )
         history[ 0 ].append( x )
         history[ 1 ].append( y )
         return y
+
     return nfev, func_counter_history_wrapper
+
 
 def is_in( arg, seq ):
     for x in seq:
@@ -1848,8 +1870,10 @@ def is_iterable( arg ):
     return isinstance( arg, list ) or isinstance( arg, tuple ) \
            or isinstance( arg, numpy.ndarray ) or numpy.iterable( arg )
 
+
 def is_sequence( start, mid, end ):
     return (start < mid) and (mid < end)
+
 
 def Knuth_close( x, y, tol, myop=operator.__or__ ):
     """Check whether two floating-point numbers are close together.
@@ -1890,6 +1914,7 @@ def Knuth_close( x, y, tol, myop=operator.__or__ ):
         return diff <= tol
     return myop( diff <= tol * abs( x ), diff <= tol * abs( y ) )
 
+
 def safe_div( num, denom ):
     import sys
     dbl_max = sys.float_info.max
@@ -1904,6 +1929,7 @@ def safe_div( num, denom ):
         return 0
 
     return num / denom
+
 
 def Knuth_boost_close( x, y, tol, myop=operator.__or__ ):
     """ The following text was taken verbatim from:
@@ -1941,11 +1967,13 @@ def Knuth_boost_close( x, y, tol, myop=operator.__or__ ):
     diff_y = safe_div( diff, y )
     return myop( diff_x <= tol, diff_y <= tol )
 
+
 def list_to_open_interval( arg ):
     if not numpy.iterable(arg):
         return arg
     str = '(%e, %e)' % (arg[0],arg[1])
     return str
+
 
 def mysgn( arg ):
     if arg == 0.0:
@@ -2077,6 +2105,7 @@ def bisection( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6 ):
     except OutOfBoundErr:
         return [ [None, None], [ [xa, fa], [xb, fb] ], nfev[0] ]
 
+
 def quad_coef( x, f ):
     """
     p( x ) = f( xc ) + A ( x - xc ) + B ( x - xc ) ( x - xb )
@@ -2158,6 +2187,7 @@ def transformed_quad_coef( x, f ):
     B = ( A - fb_fa / xb_xa ) / xc_xa
     C = A + B * xc_xb
     return [ B, C ]
+
 
 def demuller( fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(), 
               maxfev=32, tol=1.0e-6 ):
@@ -2247,7 +2277,7 @@ def demuller( fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(),
             xd = xc - 2.0 * fc / ( C + mysgn( C ) * numpy.sqrt( discriminant ) )
 
             fd = myfcn( xd, *args )
-            #print 'fd(%e)=%e' % (xd, fd)
+            # print 'fd(%e)=%e' % (xd, fd)
             if abs( fd ) <= tol:
                 return [ [xd, fd], [ [None, None], [None, None] ], nfev[0] ]
 
@@ -2258,14 +2288,14 @@ def demuller( fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(),
             xc = xd
             fc = fd
 
-        #print 'demuller(): maxfev exceeded'
+        # print 'demuller(): maxfev exceeded'
         return [ [xd, fd], [ [None, None], [None, None] ], nfev[0] ]
 
     except ZeroDivisionError:
 
-        #print 'demuller(): fixme ZeroDivisionError'
-        #for x, y in izip( history[0], history[1] ):
-        #    print 'f(%e)=%e' % ( x, y )
+        # print 'demuller(): fixme ZeroDivisionError'
+        # for x, y in izip( history[0], history[1] ):
+        #     print 'f(%e)=%e' % ( x, y )
         return [ [xd, fd], [ [None, None], [None, None] ], nfev[0] ]
 
 
@@ -2321,7 +2351,7 @@ def new_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6 ):
             xd = xc - 2.0 * fc / ( C + mysgn( C ) * numpy.sqrt( discriminant ) )
 
             fd = myfcn( xd, *args )
-            #print 'fd(%e)=%e' % (xd, fd)
+            # print 'fd(%e)=%e' % (xd, fd)
             if abs( fd ) <= tol:
                 return [ [xd, fd], [ [xa, fa], [xb, fb] ], nfev[0] ]
 
@@ -2351,14 +2381,14 @@ def new_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6 ):
                 xa = xc; fa = fc
                 continue
 
-        #print 'new_muller(): maxfev exceeded'
+        # print 'new_muller(): maxfev exceeded'
         return [ [xd, fd], [ [xa, fa], [xb, fb] ], nfev[0] ]
 
     except (ZeroDivisionError, OutOfBoundErr):
 
-        #print 'new_muller(): fixme ZeroDivisionError'
-        #for x, y in izip( history[0], history[1] ):
-        #    print 'f(%e)=%e' % ( x, y )
+        # print 'new_muller(): fixme ZeroDivisionError'
+        # for x, y in izip( history[0], history[1] ):
+        #     print 'f(%e)=%e' % ( x, y )
         return [ [xd, fd], [ [xa, fa], [xb, fb] ], nfev[0] ]
 
 #
@@ -2378,7 +2408,7 @@ def new_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6 ):
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 #  */
-# 
+#
 def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
                    tol=1.0e-6 ):
 
@@ -2404,7 +2434,7 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
 
         xc = ( xa + xb ) / 2.0
         fc = myfcn( xc, *args )
-        #print 'MullerBound() fc(%.14e)=%.14e' % (xc,fc)
+        # print 'MullerBound() fc(%.14e)=%.14e' % (xc,fc)
         if abs( fc ) <= tol:
             return [ [ xc, fc ], [ [xc, fc], [xc, fc] ], nfev[0] ]
 
@@ -2433,19 +2463,19 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
             else:
                 x = xminus
 
-            #print 'xa=', xa, '\tx=', x, '\txb=', xb, '\txc=', xc
+            # print 'xa=', xa, '\tx=', x, '\txb=', xb, '\txc=', xc
 
-            #fubar = quad_coef( [xa,xb,xc], [fa,fb,fc] )
-            #quad = QuadEquaRealRoot( )
-            #print quad( fubar[0], fubar[1], fubar[2] )
-            #print
+            # fubar = quad_coef( [xa,xb,xc], [fa,fb,fc] )
+            # quad = QuadEquaRealRoot( )
+            # print quad( fubar[0], fubar[1], fubar[2] )
+            # print
 
-            #sanity check
+            # sanity check
             if not is_sequence(xa, x, xb):
                 x = ( xa + xb ) / 2.0
 
             y = myfcn( x, *args );
-            #print 'MullerBound() y(%.14e)=%.14e' % (x,y)
+            # print 'MullerBound() y(%.14e)=%.14e' % (x,y)
             if abs( y ) < abs( fbest ):
                 xbest = x; fbest = y
             tolerance = min( tol * abs( x ), tol )
@@ -2470,7 +2500,7 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
                 fmid = myfcn( xmid, *args )
                 if abs( fmid ) < abs( fbest ):
                     xbest = xmid; fbest = fmid
-                #print 'MullerBound() fmid(%.14e)=%.14e' % (xmid,fmid)
+                # print 'MullerBound() fmid(%.14e)=%.14e' % (xmid,fmid)
                 if abs( fmid ) <= tol:
                     return [ [xmid, fmid], [ [xa, fa], [xb, fb] ], nfev[0] ]
                 if mysgn( fa ) + mysgn( fmid ) == 0:
@@ -2483,7 +2513,7 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
                 fc = myfcn( xc, *args )
                 if abs( fc ) < abs( fbest ):
                     xbest = xc; fbest = fc                
-                #print 'MullerBound() fc(%.14e)=%.14e' % (xc,fc)
+                # print 'MullerBound() fc(%.14e)=%.14e' % (xc,fc)
                 if abs( fc ) <= tol:
                     return [ [xc, fc], [ [xa, fa], [xb, fb] ], nfev[0] ]
                 oldx = 1.0e128
@@ -2625,7 +2655,7 @@ def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
             fa = fb
             xb += new_step
             fb = myfcn( xb, *args )
-            #print 'fa(%f)=%f\tfb(%f)=%f\tfc(%f)=%f' % (xa,fa,xb,fb,xc,fc)
+            # print 'fa(%f)=%f\tfb(%f)=%f\tfc(%f)=%f' % (xa,fa,xb,fb,xc,fc)
             if fb > 0 and fc > 0 or fb < 0 and fc < 0:
                 xc = xa
                 fc = fa

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -218,31 +218,50 @@ def _get_datadir():
 class SherpaTestCase(numpytest.NumpyTestCase):
     "Base class for Sherpa unit tests"
 
+    # The location of the Sherpa test data (it is optional)
     datadir = _get_datadir()
 
+    # What is the benefit of this over numpy.testing.assert_allclose(),
+    # which was added in version 1.5 of NumPy?
     def assertEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
         """
 
-        Test first and second for floating-point equality to within
-        the given tolerance.  If first and second are arrays, then
-        they will be tested for equality on an element-by-element
-        basis.
-
-        """
-
-        self.assert_(not numpy.any(sao_fcmp(first, second, tol)), msg)
+        self.assertFalse(numpy.any(sao_fcmp(first, second, tol)), msg)
 
     def assertNotEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are not equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
         """
 
-        Test first and second for floating-point inequality to within
-        the given tolerance.  If first and second are arrays, then
-        they will be tested for inequality on an element-by-element
-        basis.
-
-        """
-
-        self.assert_(numpy.all(sao_fcmp(first, second, tol)), msg)
+        self.assertTrue(numpy.all(sao_fcmp(first, second, tol)), msg)
 
 
 def test_data_missing():

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -38,11 +38,12 @@ from sherpa.utils._psf import extract_kernel, normalize, set_origin, \
     pad_bounding_box
 from functools import wraps
 
-import logging
-warning = logging.getLogger("sherpa").warning
-
 from sherpa import get_config
 from ConfigParser import ConfigParser, NoSectionError
+
+import logging
+warning = logging.getLogger("sherpa").warning
+debug = logging.getLogger("sherpa").debug
 
 config = ConfigParser()
 config.read(get_config())
@@ -2011,9 +2012,8 @@ class QuadEquaRealRoot:
         else:
 
             discriminant = b * b - 4.0 * a * c
-            # TODO: this print should either be commented out or use
-            #       the logging class
-            print 'disc=', discriminant
+            # TODO: is this needed?
+            debug("disc={}".format(discriminant))
             sqrt_disc = numpy.sqrt( discriminant )
             t = - ( b + mysgn( b ) * sqrt_disc ) / 2.0
             return [ c / t, t / a ]
@@ -2037,9 +2037,8 @@ def bisection( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6 ):
             return [ [xb, fb], [ [xb, fb], [xb, fb] ], nfev[0] ]
 
         if mysgn( fa ) == mysgn( fb ):
-            # TODO: should this use the logging class?
-            sys.stderr.write( __name__ + ': ' + fcn.__name__ +
-                              ' fa * fb < 0 is not met\n' )
+            # TODO: is this a useful message for the user?
+            warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
             return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
 
         while nfev[0] < maxfev:
@@ -2294,9 +2293,8 @@ def new_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6 ):
             return [ [xb, fb], [ [xb, fb], [xb, fb] ], nfev[0] ]
 
         if mysgn( fa ) == mysgn( fb ):
-            # TODO: should this use the logging class?
-            sys.stderr.write( __name__ + ': ' + fcn.__name__ +
-                              ' fa * fb < 0 is not met\n' )
+            # TODO: is this a useful message for the user?
+            warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
             return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
 
         while nfev[0] < maxfev:
@@ -2392,9 +2390,8 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
             return [ [xb, fb], [ [xb,fb], [xb,fb] ], nfev[0] ]
 
         if mysgn( fa ) == mysgn( fb ):
-            # TODO: should this use the logging class?
-            sys.stderr.write( __name__ + ': ' + fcn.__name__ +
-                              ' fa * fb < 0 is not met\n' )
+            # TODO: is this a useful message for the user?
+            warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
             return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
 
         xc = ( xa + xb ) / 2.0
@@ -2553,9 +2550,8 @@ def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
             return [ [xb, fb], [ [xa, fa], [xb, fb] ], nfev[0] ]    
 
         if mysgn( fa ) == mysgn( fb ):
-            # TODO: should this use the logging class?
-            sys.stderr.write( __name__ + ': ' + fcn.__name__ +
-                              ' fa * fb < 0 is not met\n' )
+            # TODO: is this a useful message for the user?
+            warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
             return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
 
         xc = xa

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1104,6 +1104,9 @@ def interpolate(xout, xin, yin, function=linear_interp):
 
 def is_binary_file( filename ):
     """Estimate if a file is a binary file.
+
+    Returns True if a non-printable character is found in the first
+    1024 bytes of the file.
     """
     fd = open( filename, 'r')
     lines = fd.readlines(1024)
@@ -1486,13 +1489,13 @@ def run_tasks(procs, err_q, out_q, num):
 def parallel_map(function, sequence, numcores=None):
     """
     A parallelized version of the native Python map function that
-    utilizes the Python multiprocessing module to divide and 
+    utilizes the Python multiprocessing module to divide and
     conquer sequence.
 
     parallel_map does not yet support multiple argument sequences.
 
     :param function: callable function that accepts argument from iterable
-    :param sequence: iterable sequence 
+    :param sequence: iterable sequence
     :param numcores: number of cores to use
     """
     if not callable(function):
@@ -1560,40 +1563,45 @@ class NumDeriv:
 
 class NumDerivCentralOrdinary( NumDeriv ):
     """
-    Subtract the following Taylor series expansion:
+    Subtract the following Taylor series expansion::
 
                                              2
                                   '         h  ''            3
     f( x +/- h ) = f( x ) +/-  h f  ( x ) + - f  ( x ) + O( h  )
                                             2
-    gives:
+
+    gives::
+
                                               '            3
                f( x + h ) - f( x - h ) = 2 h f ( x ) + O( h  )
 
-                 ' 
-    solving for f ( x ):
+                 '
+    solving for f ( x )::
 
                      '        f( x + h ) - f( x - h )       2
                     f ( x ) = ----------------------- + O( h  )
                                         2 h
 
     In addition to the truncation error of order h^2, there is a round off
-    error due to the finite numerical precision ~ r f( x ).
+    error due to the finite numerical precision ~ r f( x )::
 
              '        f( x + h ) - f( x - h )    r f( x )         2
             f ( x ) = ----------------------- + ---------  +  O( h  )
                                 2 h                h
 
                             r      2
-                 Error  ~=  -  + h 
+                 Error  ~=  -  + h
                             h
-    minimizing the error by differentiating wrt h, the solve for h:
-    h ~ r^1/3"""
+    minimizing the error by differentiating wrt h, the solve for h::
 
-    def __init__( self, func, fval0=None ):
-        NumDeriv.__init__( self, func, fval0 )
+        h ~ r^1/3
 
-    def __call__( self, x, h ):
+    """
+
+    def __init__(self, func, fval0=None):
+        NumDeriv.__init__(self, func, fval0)
+
+    def __call__(self, x, h):
         if 0.0 == h:
             return numpy.Inf
         return ( self.func( x + h ) - self.func( x - h ) ) / ( 2.0 * h )
@@ -1632,27 +1640,25 @@ class NumDerivFowardPartial( NumDeriv ):
         fval /= deltai * deltaj
         return fval
 
-class NumDerivCentralPartial( NumDeriv ):
-    """
-
-    Add the following Taylor series expansion:
+class NumDerivCentralPartial(NumDeriv):
+    """Add the following Taylor series expansion::
 
                                              2
                                   '         h  ''            3
     f( x +/- h ) = f( x ) +/-  h f  ( x ) + - f  ( x ) + O( h  )
                                             2
                    ''
-    and solve for f  ( x ), gives:
+    and solve for f  ( x ), gives::
 
-              ''         f( x + h ) + f( x - h ) - 2 f( x )        2 
+              ''         f( x + h ) + f( x - h ) - 2 f( x )        2
              f  ( x ) = ------------------------------------ + O( h  )
                                          2
                                         h
 
     In addition to the truncation error of order h^2, there is a round off
-    error due to the finite numerical precision ~ r f( x ).
+    error due to the finite numerical precision ~ r f( x )::
 
-     ''         f( x + h ) + f( x - h ) - 2 f( x )    r f( x )       2 
+     ''         f( x + h ) + f( x - h ) - 2 f( x )    r f( x )       2
     f  ( x ) = ------------------------------------ + -------- + O( h  )
                                 2                        2
                                h                        h
@@ -1662,11 +1668,13 @@ class NumDerivCentralPartial( NumDeriv ):
                              2
                             h
 
-    minimizing the error by differentiating wrt h, the solve for h:
-    h ~ r^1/4"""
+    minimizing the error by differentiating wrt h, the solve for h::
 
-    def __init__( self, func, fval0 ):
-        NumDeriv.__init__( self, func, fval0 )
+        h ~ r^1/4
+    """
+
+    def __init__(self, func, fval0):
+        NumDeriv.__init__(self, func, fval0)
 
     def __call__( self, x, h, *args ):
 
@@ -1730,7 +1738,7 @@ class RichardsonExtrapolation( NoRichardsonExtrapolation ):
     1. Richardson, L. F. (1911). \"The approximate arithmetical solution by
     finite differences of physical problems including differential equations,
     with an application to the stresses in a masonry dam \". Philosophical
-    Transactions of the Royal Society of London, Series A 210. 
+    Transactions of the Royal Society of London, Series A 210.
     2. Richardson, L. F. (1927). \" The deferred approach to the limit \".
     Philosophical Transactions of the Royal Society of London, Series A 226:"""
 
@@ -1820,7 +1828,7 @@ def func_counter( func ):
     return nfev, func_counter_wrapper
 
 def func_counter_history( func, history ):
-    '''A function wrapper to count the number of times beingg called'''
+    '''A function wrapper to count the number of times being called'''
     nfev = [0]
     def func_counter_history_wrapper( x, *args ):
         nfev[0] += 1
@@ -2082,7 +2090,8 @@ def quad_coef( x, f ):
 
            = B x^2 + ( C - 2 * B xc ) x + f( xc ) - C xc  + B xc^2
 
-           = B x^2 + ( C - 2 * B x[2] ) x + f[ 2 ] + x[2] * ( B x[ 2 ] - C )"""
+           = B x^2 + ( C - 2 * B x[2] ) x + f[ 2 ] + x[2] * ( B x[ 2 ] - C )
+    """
 
 
     [B,C] = transformed_quad_coef( x, f )
@@ -2093,7 +2102,7 @@ def transformed_quad_coef( x, f ):
     """
     p( x ) = f( xc ) + A ( x - xc ) + B ( x - xc ) ( x - xb )
 
-       where A and B are the divided differences:
+       where A and B are the divided differences::
 
                                    f( xc ) - f( xb )
                                A = -----------------
@@ -2113,21 +2122,20 @@ def transformed_quad_coef( x, f ):
 
         where  C = A + B ( xc - xb )
 
-        The root of p( x ), using the quadratic formula:
+        The root of p( x ), using the quadratic formula::
 
                             1  (                                   )
                   x - xc = --- ( - C +/- sqrt( C^2 - 4 f( xc ) B ) )
                            2 B (                                   )
 
-        Rationalize the numerator to avoid subtractive cancellation:
+        Rationalize the numerator to avoid subtractive cancellation::
 
                                      2 f( xc )
                   x - xc = -------------------------------
                            C +/- sqrt( C^2 - 4 f( xc ) B )
 
         The sign should be chosen to maximize the denominator.  Therefore,
-        the next point in the iteration is:
-
+        the next point in the iteration is::
 
                                        2 f( xc )
                   x = xc - --------------------------------------
@@ -2135,7 +2143,8 @@ def transformed_quad_coef( x, f ):
 
                        {    -1,  x < 0
         where sgn(x) = {
-                       {     1,  x >= 0"""
+                       {     1,  x >= 0
+    """
 
     xa = x[ 0 ]; xb = x[ 1 ]; xc = x[ 2 ]
     fa = f[ 0 ]; fb = f[ 1 ]; fc = f[ 2 ]

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -50,7 +50,7 @@ config.read(get_config())
 
 _ncpu_val = "NONE"
 try:
-    _ncpu_val = config.get('parallel','numcores').strip().upper()
+    _ncpu_val = config.get('parallel', 'numcores').strip().upper()
 except NoSectionError:
     pass
 
@@ -177,8 +177,8 @@ class NoNewAttributesAfterInit(object):
         if self.__initialized and hasattr(self, name):
             if callable(getattr(self, name)) and not callable(val):
                 raise AttributeError(("'%s' object attribute '%s' cannot be " +
-                                      "replaced with a non-callable attribute")%
-                                     (type(self).__name__, name))
+                                      "replaced with a non-callable attribute")
+                                     % (type(self).__name__, name))
             elif not callable(getattr(self, name)) and callable(val):
                 raise AttributeError(("'%s' object attribute '%s' cannot be " +
                                       "replaced with a callable attribute") %
@@ -195,13 +195,14 @@ class NoNewAttributesAfterInit(object):
 
 def _get_datadir():
     import os
-    try: # First try to load the sherpatest module
+    try:
         import sherpatest
         datadir = os.path.dirname(sherpatest.__file__)
     except ImportError:
-        try: # Then try importing sherpa
+        try:
             import sherpa
-            datadir = os.path.join(os.path.dirname(sherpa.__file__), os.pardir, 'sherpa-test-data', 'sherpatest') # Try in a dir
+            datadir = os.path.join(os.path.dirname(sherpa.__file__), os.pardir,
+                                   'sherpa-test-data', 'sherpatest')
             if not os.path.exists(datadir) or not os.listdir(datadir):
                 # The dir is empty, maybe the submodule was not initialized
                 datadir = None
@@ -296,11 +297,13 @@ class SherpaTest(numpytest.NumpyTest):
 # at what precisions do we assume equality in energy grids?
 eps = numpy.finfo(numpy.float32).eps
 
+
 def erfinv(y):
-    return ndtri((y+1.0)/2.0)/numpy.sqrt(2.0)
+    return ndtri((y + 1.0) / 2.0) / numpy.sqrt(2.0)
+
 
 def filter_bins(mins, maxes, axislist):
-    mask=None
+    mask = None
 
     for lo,hi,axis in izip(mins,maxes,axislist):
 
@@ -309,15 +312,16 @@ def filter_bins(mins, maxes, axislist):
 
         if lo is None:
             # axismask = axis <= hi
-            axismask = (sao_fcmp(hi,axis,eps) >= 0)
+            axismask = (sao_fcmp(hi, axis, eps) >= 0)
 
         elif hi is None:
             # axismask = axis >= lo
-            axismask = (sao_fcmp(lo,axis,eps) <= 0)
+            axismask = (sao_fcmp(lo, axis, eps) <= 0)
 
         else:
             # axismask = (lo <= axis) & (axis <= hi)
-            axismask = (sao_fcmp(lo,axis,eps) <= 0) & (sao_fcmp(hi,axis,eps) >= 0)
+            axismask = (sao_fcmp(lo, axis, eps) <= 0) & \
+                       (sao_fcmp(hi, axis, eps) >= 0)
 
         if mask is None:
             mask = axismask
@@ -336,10 +340,10 @@ def bool_cast(val):
     elif type(val) == str:
         # since built in bool() only returns false for empty strings
         vlo = val.lower()
-        if vlo in ('false','off','no','0','f','n'):
+        if vlo in ('false', 'off', 'no', '0', 'f', 'n'):
             return False
 
-        elif vlo in ('true','on','yes','1','t','y'):
+        elif vlo in ('true', 'on', 'yes', '1', 't', 'y'):
             return True
 
         raise TypeError("unknown boolean value: '%s'" % str(val))
@@ -430,7 +434,7 @@ def get_keyword_names(func, skip=0):
     if argspec[3] is None:
         return []
     first = len(argspec[0]) - len(argspec[3])
-    return argspec[0][first+skip:]
+    return argspec[0][first + skip:]
 
 
 def get_keyword_defaults(func, skip=0):
@@ -445,7 +449,7 @@ def get_keyword_defaults(func, skip=0):
     if argspec[3] is None:
         return {}
     first = len(argspec[0]) - len(argspec[3])
-    return dict(izip(argspec[0][first+skip:], argspec[3][skip:]))
+    return dict(izip(argspec[0][first + skip:], argspec[3][skip:]))
 
 
 def get_func_usage(func):
@@ -545,7 +549,7 @@ def create_expr(vals, mask=None, format='%s', delim='-'):
     collapse a list of channels into an expression using hyphens
     and commas to indicate filtered intervals.
     """
-    expr=[]
+    expr = []
 
     if len(vals) == 0:
         return ''
@@ -560,7 +564,7 @@ def create_expr(vals, mask=None, format='%s', delim='-'):
     for ii, delta in enumerate(diffs):
         if ii == 0:
             expr.append(format % vals[ii])
-            if delta != 1 or len(diffs)==1:
+            if delta != 1 or len(diffs) == 1:
                 expr.append(',')
             continue
         if delta == 1:
@@ -569,11 +573,11 @@ def create_expr(vals, mask=None, format='%s', delim='-'):
             if expr[-1] != delim:
                 expr.append(delim)
         else:
-            if not expr[-1] in (',',delim):
+            if not expr[-1] in (',', delim):
                 expr.append(',')
             expr.append(format % vals[ii])
             expr.append(',')
-    if len(expr) and expr[-1] in (',',delim):
+    if len(expr) and expr[-1] in (',', delim):
         expr.append(format % vals[-1])
 
     return ''.join(expr)
@@ -586,24 +590,24 @@ def parse_expr(expr):
     """
     res = []
     if expr is None or str(expr).strip() == '':
-        res.append((None,None))
+        res.append((None, None))
         return res
     vals = str(expr).strip().split(',')
     for val in vals:
-        lo=None; hi=None
+        lo, hi = None, None
         interval = val.strip().split(':')
         if len(interval) == 1:
             lo = interval[0]
             if lo == '':
-                lo=None
+                lo = None
             hi = lo
         elif len(interval) > 1:
-            lo=interval[0]
-            hi=interval[1]
+            lo = interval[0]
+            hi = interval[1]
             if lo == '':
-                lo=None
+                lo = None
             if hi == '':
-                hi=None
+                hi = None
         else:
             raise TypeError("interval syntax requires a tuple, 'lo:hi'")
         if lo is not None:
@@ -645,12 +649,13 @@ def calc_total_error(staterror=None, syserror=None):
     elif (staterror is None) and (syserror is not None):
         error = syserror
     else:
-        error = numpy.sqrt(staterror*staterror + syserror*syserror)
+        error = numpy.sqrt(staterror * staterror + syserror * syserror)
     return error
 
 
 def quantile(sorted_array, f):
-    """Return the quantile element from sorted_array, where f is [0,1] using linear interpolation.
+    """Return the quantile element from sorted_array, where f is [0,1]
+    using linear interpolation.
 
     Based on the description of the GSL routine
     gsl_stats_quantile_from_sorted_data - e.g.
@@ -662,14 +667,14 @@ def quantile(sorted_array, f):
     sorted_array = numpy.asarray(sorted_array)
 
     if len(sorted_array.shape) != 1:
-        raise RuntimeError, "Error: input array is not 1D"
+        raise RuntimeError("Error: input array is not 1D")
     n = sorted_array.size
 
-    q = (n-1) * f
+    q = (n - 1) * f
     i = numpy.int(numpy.floor(q))
     delta = q - i
 
-    return (1.0-delta) * sorted_array[i] + delta * sorted_array[i+1]
+    return (1.0 - delta) * sorted_array[i] + delta * sorted_array[i + 1]
 
 
 def get_error_estimates(x, sorted=False):
@@ -700,8 +705,8 @@ def get_error_estimates(x, sorted=False):
 
     sigfrac = 0.682689
     median = quantile(xs, 0.5)
-    lval   = quantile(xs, (1-sigfrac)/2.0)
-    hval   = quantile(xs, (1+sigfrac)/2.0)
+    lval   = quantile(xs, (1 - sigfrac) / 2.0)
+    hval   = quantile(xs, (1 + sigfrac) / 2.0)
 
     return (median, lval, hval)
 
@@ -782,14 +787,14 @@ def multinormal_pdf(x, mu, sigma):
         raise TypeError("x and mu sizes do not match")
     if mu.size != sigma.diagonal().size:
         raise TypeError("sigma shape does not match x")
-    if numpy.min( numpy.linalg.eigvalsh(sigma))<=0 :
+    if numpy.min(numpy.linalg.eigvalsh(sigma)) <= 0:
         raise ValueError("sigma is not positive definite")
-    if numpy.max( numpy.abs(sigma-sigma.T))>=1.e-9 :
+    if numpy.max(numpy.abs(sigma - sigma.T)) >= 1.e-9:
         raise ValueError("sigma is not symmetric")
     rank     = mu.size
-    coeff    = 1./(numpy.power(2.*numpy.pi, rank/2.)*
-                   numpy.sqrt(numpy.abs(numpy.linalg.det(sigma))))
-    xmu      = numpy.mat(x-mu)
+    coeff    = 1.0 / (numpy.power(2.0 * numpy.pi, rank / 2.0) *
+                      numpy.sqrt(numpy.abs(numpy.linalg.det(sigma))))
+    xmu      = numpy.mat(x - mu)
     invsigma = numpy.mat(numpy.linalg.inv(sigma))
 
     # The matrix multiplication looks backwards, but mu and x
@@ -798,7 +803,7 @@ def multinormal_pdf(x, mu, sigma):
     #  mu = [[a,b,c]]
     #   x = [[d,e,f]]
     #
-    return float(coeff*numpy.exp(-0.5*((xmu*invsigma)*xmu.T)))
+    return float(coeff * numpy.exp(-0.5 * ((xmu * invsigma) * xmu.T)))
 
 
 def multit_pdf(x, mu, sigma, dof):
@@ -836,17 +841,18 @@ def multit_pdf(x, mu, sigma, dof):
         raise TypeError("x and mu sizes do not match")
     if mu.size != sigma.diagonal().size:
         raise TypeError("sigma shape does not match x")
-    if numpy.min( numpy.linalg.eigvalsh(sigma))<=0 :
+    if numpy.min(numpy.linalg.eigvalsh(sigma)) <= 0:
         raise ValueError("sigma is not positive definite")
-    if numpy.max( numpy.abs(sigma-sigma.T))>=1.e-9 :
+    if numpy.max(numpy.abs(sigma - sigma.T)) >= 1.e-9:
         raise ValueError("sigma is not symmetric")
 
     rank     = mu.size
-    np       = float(n+rank)
-    coeff    = (gamma(np/2.)/(gamma(n/2.)*numpy.power(n, rank/2.)*
-                              numpy.power(numpy.pi,rank/2.)*
-                              numpy.sqrt(numpy.abs(numpy.linalg.det(sigma)))))
-    xmu      = numpy.mat(x-mu)
+    np       = float(n + rank)
+    coeff    = (gamma(np / 2.0) /
+                (gamma(n / 2.0) * numpy.power(n, rank / 2.0) *
+                 numpy.power(numpy.pi, rank / 2.0) *
+                 numpy.sqrt(numpy.abs(numpy.linalg.det(sigma)))))
+    xmu      = numpy.mat(x - mu)
     invsigma = numpy.mat(numpy.linalg.inv(sigma))
 
     # The matrix multiplication looks backwards, but mu and x
@@ -855,18 +861,20 @@ def multit_pdf(x, mu, sigma, dof):
     #  mu = [[a,b,c]]
     #   x = [[d,e,f]]
     #
-    return float(coeff*numpy.power(1.+1./n*((xmu*invsigma)*xmu.T), -np/2.))
+    term = 1.0 + 1.0 / n * ((xmu * invsigma) * xmu.T)
+    return float(coeff * numpy.power(term, -np / 2.0))
 
 
-def _convolve( a, b ):
+def _convolve(a, b):
     if len(a) != len(b):
         raise TypeError("Input arrays are not equal in length, a: %s b: %s" %
-                      (len(a), len(b)))
+                        (len(a), len(b)))
 
-    imag = numpy.fft.fft(a)*numpy.fft.fft(b)
-    return numpy.asarray( numpy.fft.ifft(imag), dtype=SherpaFloat )
+    imag = numpy.fft.fft(a) * numpy.fft.fft(b)
+    return numpy.asarray(numpy.fft.ifft(imag), dtype=SherpaFloat)
 
-def numpy_convolve( a, b ):
+
+def numpy_convolve(a, b):
 
     if a.ndim > 1 or b.ndim > 1:
         raise TypeError("numpy_convolution is 1D only")
@@ -875,9 +883,9 @@ def numpy_convolve( a, b ):
     d = numpy.concatenate((b, numpy.zeros(len(a))))
 
     if len(a) > len(b):
-        return _convolve(c,d)[:len(a)]
+        return _convolve(c, d)[:len(a)]
 
-    return _convolve(c,d)[:len(b)]
+    return _convolve(c, d)[:len(b)]
 
 
 def dataspace1d(start, stop, step=1, numbins=None):
@@ -891,13 +899,13 @@ def dataspace1d(start, stop, step=1, numbins=None):
     """
     if start >= stop:
         raise TypeError("input should be start < stop, found start=%s stop=%s" %
-                      (start, stop))
+                        (start, stop))
 
     if numbins is None:
         if step <= 0:
             raise TypeError("input should be step > 0, found step=%s" % step)
 
-        if step >= (stop-start):
+        if step >= (stop - start):
             raise TypeError("input has produced less than 2 bins, found start=%s stop=%s step=%s" % (start, stop, step))
 
     # xx = numpy.arange(start, stop, step, dtype=float)
@@ -907,7 +915,7 @@ def dataspace1d(start, stop, step=1, numbins=None):
         if numbins <= 1:
             raise TypeError("input should be numbins > 1, found numbins=%s" % numbins)
 
-        xx = numpy.linspace(start, stop, numbins+1)
+        xx = numpy.linspace(start, stop, numbins + 1)
     else:
         xx = sao_arange(start, stop, step)
 
@@ -930,10 +938,10 @@ def dataspace2d(dim):
 
     if dim[0] < 1 or dim[1] < 1:
         raise TypeError("dimensions should be > 0, found dim0 %s dim1 %s"
-                      % (dim[0], dim[1]))
+                        % (dim[0], dim[1]))
 
-    x0 = numpy.arange(dim[0], dtype=numpy.float)+1.
-    x1 = numpy.arange(dim[1], dtype=numpy.float)+1.
+    x0 = numpy.arange(dim[0], dtype=numpy.float) + 1.0
+    x1 = numpy.arange(dim[1], dtype=numpy.float) + 1.0
 
     x0, x1 = numpy.meshgrid(x0, x1)
     shape = tuple(x0.shape)
@@ -944,7 +952,7 @@ def dataspace2d(dim):
     return x0, x1, y, shape
 
 
-def histogram1d( x, x_lo, x_hi ):
+def histogram1d(x, x_lo, x_hi):
     """Create a 1D histogram from a binned grid (``x_lo``, ``xhi``)
     and array of samples (``x``).
 
@@ -995,10 +1003,10 @@ def histogram1d( x, x_lo, x_hi ):
     x_lo.sort()
     x_hi.sort()
 
-    return hist1d( numpy.asarray(x), x_lo, x_hi )
+    return hist1d(numpy.asarray(x), x_lo, x_hi)
 
 
-def histogram2d( x, y, x_grid, y_grid ):
+def histogram2d(x, y, x_grid, y_grid):
     """Create 21D histogram from a binned grid (``x_grid``, ``y_grid``)
     and array of samples (``x``, and ``y``).
 
@@ -1042,42 +1050,42 @@ def histogram2d( x, y, x_grid, y_grid ):
     x_grid.sort()
     y_grid.sort()
 
-    vals = hist2d( numpy.asarray(x), numpy.asarray(y), x_grid, y_grid )
-    return vals.reshape( (len(x_grid),len(y_grid)) )
+    vals = hist2d(numpy.asarray(x), numpy.asarray(y), x_grid, y_grid)
+    return vals.reshape((len(x_grid), len(y_grid)))
 
-def interp_util( xout, xin, yin ):
+def interp_util(xout, xin, yin):
     lenxin = len(xin)
 
     i1 = numpy.searchsorted(xin, xout)
 
-    i1[ i1==0 ] = 1
-    i1[ i1==lenxin ] = lenxin-1
+    i1[i1 == 0] = 1
+    i1[i1 == lenxin] = lenxin - 1
 
 #     if 0 == i1:
 #         i1 = 1
 #     if lenxin == i1:
 #         i1 = lenxin - 1
 
-    x0 = xin[i1-1]
+    x0 = xin[i1 - 1]
     x1 = xin[i1]
-    y0 = yin[i1-1]
+    y0 = yin[i1 - 1]
     y1 = yin[i1]
     return x0, x1, y0, y1
 
 
-def linear_interp( xout, xin, yin ):
+def linear_interp(xout, xin, yin):
     """Linear interpolation of (xin,yin) onto xout."""
-    x0, x1, y0, y1 = interp_util( xout, xin, yin )
+    x0, x1, y0, y1 = interp_util(xout, xin, yin)
     val = (xout - x0) / (x1 - x0) * (y1 - y0) + y0
     if numpy.isnan(val).any():
         # to handle the case where two adjacent elements of xout are equal
-        return nearest_interp( xout, xin, yin )
+        return nearest_interp(xout, xin, yin)
     return val
 
 
-def nearest_interp( xout, xin, yin ):
+def nearest_interp(xout, xin, yin):
     """Nearest-neighbor interpolation of (xin,yin) onto xout."""
-    x0, x1, y0, y1 = interp_util( xout, xin, yin )
+    x0, x1, y0, y1 = interp_util(xout, xin, yin)
     return numpy.where((numpy.abs(xout - x0) < numpy.abs(xout - x1)), y0, y1)
 
 
@@ -1106,18 +1114,18 @@ def interpolate(xout, xin, yin, function=linear_interp):
 
     if not callable(function):
         raise TypeError("input function '%s' is not callable" %
-                           repr(function))
+                        repr(function))
 
-    return function( xout, xin, yin )
+    return function(xout, xin, yin)
 
 
-def is_binary_file( filename ):
+def is_binary_file(filename):
     """Estimate if a file is a binary file.
 
     Returns True if a non-printable character is found in the first
     1024 bytes of the file.
     """
-    fd = open( filename, 'r')
+    fd = open(filename, 'r')
     lines = fd.readlines(1024)
     fd.close()
 
@@ -1135,7 +1143,7 @@ def is_binary_file( filename ):
 
 def get_midpoint(a):
     # return numpy.abs(a.max() - a.min())/2. + a.min()
-    return numpy.abs(a.max() + a.min())/2.
+    return numpy.abs(a.max() + a.min()) / 2.0
 
 
 def get_peak(y, x, xhi=None):
@@ -1151,13 +1159,13 @@ def get_fwhm(y, x, xhi=None):
     x_max = x[y.argmax()]
     for ii, val in enumerate(y[:y.argmax()]):
         if val >= half_max_val:
-            return 2.0*numpy.abs(x[ii] - x_max)
+            return 2.0 * numpy.abs(x[ii] - x_max)
     return x_max
 
 
 def guess_fwhm(y, x, xhi=None, scale=1000):
     fwhm = get_fwhm(y, x, xhi)
-    return {'val': fwhm, 'min': fwhm/scale, 'max': fwhm*scale }
+    return {'val': fwhm, 'min': fwhm / scale, 'max': fwhm * scale}
 
 
 def param_apply_limits(param_limits, par, limits=True, values=True):
@@ -1173,14 +1181,14 @@ def param_apply_limits(param_limits, par, limits=True, values=True):
 
     if limits and values:
         default_val = par.val
-        par.set(param_limits['val'], param_limits['min'], param_limits['max'], 
-                default_min = par.min, default_max = par.max)
+        par.set(param_limits['val'], param_limits['min'], param_limits['max'],
+                default_min=par.min, default_max=par.max)
 
         # set original value as default outside the property interface
         par._default_val = default_val
 
         # set guessed flag to enable user-defined limit reset
-        par._guessed=True
+        par._guessed = True
 
     elif values:
         default_val = par.val
@@ -1190,11 +1198,11 @@ def param_apply_limits(param_limits, par, limits=True, values=True):
         par._default_val = default_val
 
     else:
-        par.set(min = param_limits['min'], max = param_limits['max'],
-                default_min = par.min, default_max = par.max)
+        par.set(min=param_limits['min'], max=param_limits['max'],
+                default_min=par.min, default_max=par.max)
 
         # set guessed flag to enable user-defined limit reset
-        par._guessed=True
+        par._guessed = True
 
 
 def get_amplitude_position(arr, mean=False):
@@ -1272,31 +1280,32 @@ def guess_amplitude_at_ref(r, y, x, xhi=None):
 
     t = 1.0
     if x[1] > x[0] and r < x[0]:
-        t = numpy.abs(y[0] + y[1])/2.0
+        t = numpy.abs(y[0] + y[1]) / 2.0
     elif x[1] > x[0] and r > x[-1]:
-        t = numpy.abs(y[-1] + y[-2])/2.0
+        t = numpy.abs(y[-1] + y[-2]) / 2.0
     elif x[1] < x[0] and r > x[0]:
-        t = numpy.abs( y[0] + y[1])/2.0
+        t = numpy.abs(y[0] + y[1]) / 2.0
     elif x[1] < x[0] and r < x[-1]:
-        t = numpy.abs( y[-1] + y[-2])/2.0
+        t = numpy.abs(y[-1] + y[-2]) / 2.0
     else:
-        for i in xrange(len(x)-1):
-            if ( ( r >= x[i] and r < x[i+1] ) or ( r >= x[i+1] and r < x[i] ) ):
-                t = numpy.abs(y[i] + y[i+1])/2.0
+        for i in xrange(len(x) - 1):
+            if ((r >= x[i] and r < x[i + 1]) or (r >= x[i + 1] and r < x[i])):
+                t = numpy.abs(y[i] + y[i + 1]) / 2.0
                 break
 
     if t == 0.0:
         totband = 0.0
         dv = 0.0
         i = 1
-        for j in xrange(len(x)-1):
-            dv = x[i] - x[i-1]
-            t += y[i]*dv
+        for j in xrange(len(x) - 1):
+            dv = x[i] - x[i - 1]
+            t += y[i] * dv
             totband += dv
             i += 1
-        t /= totband;
+        t /= totband
 
-    return { 'val':t, 'min':t/_guess_ampl_scale, 'max':t*_guess_ampl_scale }
+    return {'val': t,
+            'min': t / _guess_ampl_scale, 'max': t * _guess_ampl_scale}
 
 
 def guess_amplitude2d(y, x0lo, x1lo, x0hi=None, x1hi=None):
@@ -1368,15 +1377,19 @@ def guess_position(y, x0lo, x1lo, x0hi=None, x1hi=None):
 
     # pos = int(y.argmax())
     # return the average of location of brightest pixels
-    pos = numpy.where(y==y.max())
+    pos = numpy.where(y == y.max())
 
     x0, x1 = x0lo, x1lo
+    r1 = {'val': numpy.mean(x0[pos]), 'min': x0.min()}
+    r2 = {'val': numpy.mean(x1[pos]), 'min': x1.min()}
     if x0hi is None and x1hi is None:
-        return ({ 'val':numpy.mean(x0[pos]), 'min':x0.min(), 'max':x0.max() },
-                { 'val':numpy.mean(x1[pos]), 'min':x1.min(), 'max':x1.max() })
+        r1['max'] = x0.max()
+        r2['max'] = x1.max()
     else:
-        return ({ 'val':numpy.mean(x0[pos]), 'min':x0.min(), 'max':x0hi.max() },
-                { 'val':numpy.mean(x1[pos]), 'min':x1.min(), 'max':x1hi.max() })
+        r1['max'] = x0hi.max()
+        r2['max'] = x1hi.max()
+
+    return (r1, r2)
 
 
 def guess_bounds(x, xhi=True):
@@ -1413,9 +1426,10 @@ def guess_radius(x0lo, x1lo, x0hi=None, x1hi=None):
     x0 = x0lo
 
     delta = numpy.apply_along_axis(numpy.diff, 0, x0)[0]
-    rad = numpy.abs(10*delta)
+    rad = numpy.abs(10 * delta)
 
-    return { 'val':rad, 'min':rad/_guess_ampl_scale, 'max':rad*_guess_ampl_scale }
+    return {'val': rad,
+            'min': rad / _guess_ampl_scale, 'max': rad * _guess_ampl_scale}
 
 
 def split_array(arr, m):
@@ -1448,8 +1462,8 @@ def split_array(arr, m):
       split_array() - originated from Python users working group
     """
     n = len(arr)
-    idx = [int(round(i * n / float(m))) for i in range(m+1)]
-    return [arr[idx[i]:idx[i+1]] for i in range(m)]
+    idx = [int(round(i * n / float(m))) for i in range(m + 1)]
+    return [arr[idx[i]:idx[i + 1]] for i in range(m)]
 
 
 def worker(f, ii, chunk, out_q, err_q, lock):
@@ -1461,13 +1475,13 @@ def worker(f, ii, chunk, out_q, err_q, lock):
         return
 
     # output the result and task ID to output queue
-    out_q.put( (ii, vals) )
+    out_q.put((ii, vals))
 
 
 def run_tasks(procs, err_q, out_q, num):
 
-    die = (lambda vals : [val.terminate() for val in vals
-                          if val.exitcode is None])
+    die = (lambda vals: [val.terminate() for val in vals
+                         if val.exitcode is None])
 
     try:
         for proc in procs:
@@ -1485,7 +1499,7 @@ def run_tasks(procs, err_q, out_q, num):
         die(procs)
         raise err_q.get()
 
-    results=[None]*num;
+    results = [None] * num
     while not out_q.empty():
         idx, result = out_q.get()
         results[idx] = result
@@ -1511,11 +1525,11 @@ def parallel_map(function, sequence, numcores=None):
     """
     if not callable(function):
         raise TypeError("input function '%s' is not callable" %
-                           repr(function))
+                        repr(function))
 
     if not numpy.iterable(sequence):
         raise TypeError("input '%s' is not iterable" %
-                           repr(sequence))
+                        repr(sequence))
 
     size = len(sequence)
 
@@ -1541,7 +1555,7 @@ def parallel_map(function, sequence, numcores=None):
     # if sequence is less than numcores, only use len sequence number of
     # processes
     if size < numcores:
-        numcores = size  
+        numcores = size
 
     # group sequence into numcores-worth of chunks
     sequence = split_array(sequence, numcores)
@@ -1553,28 +1567,28 @@ def parallel_map(function, sequence, numcores=None):
     return run_tasks(procs, err_q, out_q, numcores)
 
 
+################################# Neville2d ###################################
 
-################################# Neville2d ###################################
-def neville2d( xinterp, yinterp, x, y, fval ):
-    nrow = fval.shape[ 0 ]
-    ncol = fval.shape[ 1 ]
-    tmp = numpy.zeros( nrow )
-    for row in xrange( nrow ):
-        tmp[ row ] = neville( yinterp, y, fval[ row ] )
-    return neville( xinterp, x, tmp )
-################################# Neville2d ###################################
+
+def neville2d(xinterp, yinterp, x, y, fval):
+    nrow = fval.shape[0]
+    # ncol = fval.shape[1]
+    tmp = numpy.zeros(nrow)
+    for row in xrange(nrow):
+        tmp[row] = neville(yinterp, y, fval[row])
+    return neville(xinterp, x, tmp)
 
 ################################## Hessian ####################################
 
 
 class NumDeriv:
 
-    def __init__( self, func, fval0 ):
-        self.nfev, self.func = func_counter( func )
+    def __init__(self, func, fval0):
+        self.nfev, self.func = func_counter(func)
         self.fval_0 = fval0
 
 
-class NumDerivCentralOrdinary( NumDeriv ):
+class NumDerivCentralOrdinary(NumDeriv):
     """
     Subtract the following Taylor series expansion::
 
@@ -1617,29 +1631,29 @@ class NumDerivCentralOrdinary( NumDeriv ):
     def __call__(self, x, h):
         if 0.0 == h:
             return numpy.Inf
-        return ( self.func( x + h ) - self.func( x - h ) ) / ( 2.0 * h )
+        return (self.func(x + h) - self.func(x - h)) / (2.0 * h)
 
 
-class NumDerivFowardPartial( NumDeriv ):
+class NumDerivFowardPartial(NumDeriv):
 
-    def __init__( self, func, fval0 ):
-        NumDeriv.__init__( self, func, fval0 )
+    def __init__(self, func, fval0):
+        NumDeriv.__init__(self, func, fval0)
 
-    def __call__( self, x, h, *args ):
+    def __call__(self, x, h, *args):
 
         if 0.0 == h:
-            h = pow( numpy.float_(numpy.finfo(numpy.float32)).eps, 1.0 / 3.0 )
+            h = pow(numpy.float_(numpy.finfo(numpy.float32)).eps, 1.0 / 3.0)
 
         ith = args[0]
         jth = args[1]
 
-        ei = numpy.zeros( len( x ), float )
-        ej = numpy.zeros( len( x ), float )        
+        ei = numpy.zeros(len(x), float)
+        ej = numpy.zeros(len(x), float)
 
-        deltai = h * abs( x[ ith ] )
+        deltai = h * abs(x[ith])
         if 0.0 == deltai:
             deltai = h
-        ei[ ith ] = deltai
+        ei[ith] = deltai
 
         deltaj = h * abs( x[ jth ] )
         if 0.0 == deltaj:
@@ -1647,9 +1661,9 @@ class NumDerivFowardPartial( NumDeriv ):
         ej[ jth ] = deltaj
 
         fval  = self.fval_0
-        fval += self.func( x + ei + ej )
-        fval -= self.func( x + ei )
-        fval -= self.func( x + ej )
+        fval += self.func(x + ei + ej)
+        fval -= self.func(x + ei)
+        fval -= self.func(x + ej)
         fval /= deltai * deltaj
         return fval
 
@@ -1689,61 +1703,61 @@ class NumDerivCentralPartial(NumDeriv):
     def __init__(self, func, fval0):
         NumDeriv.__init__(self, func, fval0)
 
-    def __call__( self, x, h, *args ):
+    def __call__(self, x, h, *args):
 
         if 0.0 == h:
-            h = pow( numpy.float_(numpy.finfo(numpy.float32)).eps, 1.0 / 3.0 )
+            h = pow(numpy.float_(numpy.finfo(numpy.float32)).eps, 1.0 / 3.0)
 
         ith = args[0]
         jth = args[1]
 
-        ei = numpy.zeros( len( x ), float )
+        ei = numpy.zeros(len(x), float)
 
         if ith == jth:
 
-            delta = h * abs( x[ ith ] )
+            delta = h * abs(x[ith])
             if 0.0 == delta:
                 delta = h
-            ei[ ith ] = delta
+            ei[ith] = delta
 
             fval = - 2.0 * self.fval_0
-            fval += self.func( x + ei ) + self.func( x - ei )
+            fval += self.func(x + ei) + self.func(x - ei)
             fval /= delta * delta
             return fval
 
         else:
 
-            ej = numpy.zeros( len( x ), float )
+            ej = numpy.zeros(len(x), float)
 
-            deltai = h * abs( x[ ith ] )
+            deltai = h * abs(x[ith])
             if 0.0 == deltai:
                 deltai = h
-            ei[ ith ] = deltai
+            ei[ith] = deltai
 
-            deltaj = h * abs( x[ jth ] )
+            deltaj = h * abs(x[jth])
             if 0.0 == deltaj:
                 deltaj = h
-            ej[ jth ] = deltaj
+            ej[jth] = deltaj
 
-            fval  = self.func( x + ei + ej )
-            fval -= self.func( x + ei - ej )
-            fval -= self.func( x - ei + ej )
-            fval += self.func( x - ei - ej )
-            fval /= ( 4.0 * deltai * deltaj )
+            fval  = self.func(x + ei + ej)
+            fval -= self.func(x + ei - ej)
+            fval -= self.func(x - ei + ej)
+            fval += self.func(x - ei - ej)
+            fval /= (4.0 * deltai * deltaj)
             return fval
 
 
 class NoRichardsonExtrapolation:
 
-    def __init__( self, sequence, verbose=False ):
+    def __init__(self, sequence, verbose=False):
         self.sequence = sequence
         self.verbose = verbose
 
-    def __call__( self, x, t, tol, maxiter, h, *args ):
-        self.sequence( x, h, *args )
+    def __call__(self, x, t, tol, maxiter, h, *args):
+        self.sequence(x, h, *args)
 
 
-class RichardsonExtrapolation( NoRichardsonExtrapolation ):
+class RichardsonExtrapolation(NoRichardsonExtrapolation):
     """From Wikipedia, the free encyclopedia
     In numerical analysis, Richardson extrapolation is a sequence acceleration
     method, used to improve the rate of convergence of a sequence. It is named
@@ -1757,71 +1771,72 @@ class RichardsonExtrapolation( NoRichardsonExtrapolation ):
     2. Richardson, L. F. (1927). \" The deferred approach to the limit \".
     Philosophical Transactions of the Royal Society of London, Series A 226:"""
 
-    def __init__( self, sequence, verbose=False ):
+    def __init__(self, sequence, verbose=False):
         self.sequence = sequence
         self.verbose = verbose
 
-    def __call__( self, x, t, tol, maxiter, h, *args ):
+    def __call__(self, x, t, tol, maxiter, h, *args):
 
-        richardson = numpy.zeros( (maxiter,maxiter), dtype=numpy.float_ )
-        richardson[ 0, 0 ] = self.sequence( x, h, *args )
+        richardson = numpy.zeros((maxiter,maxiter), dtype=numpy.float_)
+        richardson[0, 0] = self.sequence(x, h, *args)
 
         t_sqr = t * t
-        for ii in xrange( 1, maxiter ):
+        for ii in xrange(1, maxiter):
             h /= t
-            richardson[ ii, 0 ] = self.sequence( x, h, *args )
+            richardson[ii, 0] = self.sequence(x, h, *args)
             ii_1 = ii - 1
-            for jj in xrange( 1, ii + 1 ):
+            for jj in xrange(1, ii + 1):
                 # jjp1 = jj + 1  -- this variable is not used
                 jj_1 = jj - 1
-                factor = pow( t_sqr, jj )
+                factor = pow(t_sqr, jj)
                 factor_1 = factor - 1
-                richardson[ ii, jj ] = ( factor * richardson[ ii, jj_1 ] -
-                                         richardson[ ii_1, jj_1 ] ) / \
-                                         factor_1
-                arg_jj = richardson[ ii, jj ]
-                arg_jj -= richardson[ ii, jj_1 ]
-                arg_ii = richardson[ ii, jj ]
-                arg_ii -= richardson[ ii_1, jj_1 ]
-                if Knuth_close( richardson[ ii, ii ],
-                                richardson[ ii_1, ii_1 ], tol ):
+                richardson[ii, jj] = (factor * richardson[ii, jj_1] -
+                                      richardson[ii_1, jj_1] ) / factor_1
+                arg_jj = richardson[ii, jj]
+                arg_jj -= richardson[ii, jj_1]
+                arg_ii = richardson[ii, jj]
+                arg_ii -= richardson[ii_1, jj_1]
+                if Knuth_close(richardson[ii, ii],
+                               richardson[ii_1, ii_1], tol):
                     if self.verbose:
-                        print_low_triangle( richardson, jj )
-                    return richardson[ ii, ii ]
+                        print_low_triangle(richardson, jj)
+                    return richardson[ii, ii]
 
         if self.verbose:
-            print_low_triangle( richardson, maxiter - 1 )
-        return richardson[ maxiter - 1, maxiter - 1 ]
+            print_low_triangle(richardson, maxiter - 1)
+        return richardson[maxiter - 1, maxiter - 1]
 
-def hessian( func, par, extrapolation, algorithm, maxiter, h, tol, t ):
 
-    num_dif = algorithm( func, func( par ) )
-    deriv = extrapolation( num_dif )
-    npar = len( par )
-    Hessian = numpy.zeros( ( npar, npar ), dtype=numpy.float_ )
-    for ii in xrange( npar ):
-        for jj in xrange( ii + 1 ):
-            answer = deriv( par, t, tol, maxiter, h, ii, jj )
-            Hessian[ ii, jj ] = answer / 2.0
-            Hessian[ jj, ii ] = Hessian[ ii, jj ]
-    return Hessian, num_dif.nfev[ 0 ]
+def hessian(func, par, extrapolation, algorithm, maxiter, h, tol, t):
 
-def print_low_triangle( matrix, num ):
-    #print matrix
-    for ii in xrange( num ):
-        print matrix[ ii, 0 ],
-        for jj in xrange( 1, ii + 1 ):
-            print matrix[ ii, jj ],
+    num_dif = algorithm(func, func(par))
+    deriv = extrapolation(num_dif)
+    npar = len(par)
+    Hessian = numpy.zeros((npar, npar), dtype=numpy.float_)
+    for ii in xrange(npar):
+        for jj in xrange(ii + 1):
+            answer = deriv(par, t, tol, maxiter, h, ii, jj)
+            Hessian[ii, jj] = answer / 2.0
+            Hessian[jj, ii] = Hessian[ii, jj]
+    return Hessian, num_dif.nfev[0]
+
+
+def print_low_triangle(matrix, num):
+    # print matrix
+    for ii in xrange(num):
+        print matrix[ii, 0],
+        for jj in xrange(1, ii + 1):
+            print matrix[ii, jj],
         print
 
 
-def symmetric_to_low_triangle( matrix, num ):
+def symmetric_to_low_triangle(matrix, num):
     low_triangle = []
-    for ii in xrange( num ):
-        for jj in xrange( ii + 1 ):
-            low_triangle.append( matrix[ ii, jj ] )
-    #print_low_triangle( matrix, num )
-    #print low_triangle
+    for ii in xrange(num):
+        for jj in xrange(ii + 1):
+            low_triangle.append(matrix[ii, jj])
+    # print_low_triangle( matrix, num )
+    # print low_triangle
     return low_triangle
 
 
@@ -1835,47 +1850,47 @@ def printf(format, *args):
     return if_(args, args[-1], format)
 
 
-def func_counter( func ):
+def func_counter(func):
     '''A function wrapper to count the number of times being called'''
     nfev = [0]
 
-    def func_counter_wrapper( x, *args ):
+    def func_counter_wrapper(x, *args):
         nfev[0] += 1
-        return func( x, *args )
+        return func(x, *args)
 
     return nfev, func_counter_wrapper
 
 
-def func_counter_history( func, history ):
+def func_counter_history(func, history):
     '''A function wrapper to count the number of times being called'''
     nfev = [0]
 
-    def func_counter_history_wrapper( x, *args ):
+    def func_counter_history_wrapper(x, *args):
         nfev[0] += 1
-        y = func( x, *args )
-        history[ 0 ].append( x )
-        history[ 1 ].append( y )
+        y = func(x, *args)
+        history[0].append(x)
+        history[1].append(y)
         return y
 
     return nfev, func_counter_history_wrapper
 
 
-def is_in( arg, seq ):
+def is_in(arg, seq):
     for x in seq:
         if arg == x:
             return True
     return False
 
-def is_iterable( arg ):
-    return isinstance( arg, list ) or isinstance( arg, tuple ) \
-           or isinstance( arg, numpy.ndarray ) or numpy.iterable( arg )
+def is_iterable(arg):
+    return isinstance(arg, list) or isinstance(arg, tuple) \
+           or isinstance(arg, numpy.ndarray) or numpy.iterable(arg)
 
 
-def is_sequence( start, mid, end ):
+def is_sequence(start, mid, end):
     return (start < mid) and (mid < end)
 
 
-def Knuth_close( x, y, tol, myop=operator.__or__ ):
+def Knuth_close(x, y, tol, myop=operator.__or__):
     """Check whether two floating-point numbers are close together.
 
     Notes
@@ -1909,13 +1924,13 @@ def Knuth_close( x, y, tol, myop=operator.__or__ ):
 
     """
 
-    diff = abs( x - y )
+    diff = abs(x - y)
     if 0.0 == x or 0.0 == y:
         return diff <= tol
-    return myop( diff <= tol * abs( x ), diff <= tol * abs( y ) )
+    return myop(diff <= tol * abs(x), diff <= tol * abs(y))
 
 
-def safe_div( num, denom ):
+def safe_div(num, denom):
     import sys
     dbl_max = sys.float_info.max
     dbl_min = sys.float_info.min
@@ -1931,7 +1946,7 @@ def safe_div( num, denom ):
     return num / denom
 
 
-def Knuth_boost_close( x, y, tol, myop=operator.__or__ ):
+def Knuth_boost_close(x, y, tol, myop=operator.__or__):
     """ The following text was taken verbatim from:
 
     http://www.boost.org/doc/libs/1_35_0/libs/test/doc/components/test_tools/floating_point_comparison.html#Introduction
@@ -1960,22 +1975,22 @@ def Knuth_boost_close( x, y, tol, myop=operator.__or__ ):
     | u - v | / |u| <= e and | u - v | / |v| <= e          	     (1`)
     | u - v | / |u| <= e or  | u - v | / |v| <= e                    (2`)"""
 
-    diff = abs( x - y )
+    diff = abs(x - y)
     if 0.0 == x or 0.0 == y:
         return diff <= tol
-    diff_x = safe_div( diff, x )
-    diff_y = safe_div( diff, y )
-    return myop( diff_x <= tol, diff_y <= tol )
+    diff_x = safe_div(diff, x)
+    diff_y = safe_div(diff, y)
+    return myop(diff_x <= tol, diff_y <= tol)
 
 
-def list_to_open_interval( arg ):
+def list_to_open_interval(arg):
     if not numpy.iterable(arg):
         return arg
-    str = '(%e, %e)' % (arg[0],arg[1])
+    str = '(%e, %e)' % (arg[0], arg[1])
     return str
 
 
-def mysgn( arg ):
+def mysgn(arg):
     if arg == 0.0:
         return 0
     elif arg < 0.0:
@@ -1994,7 +2009,7 @@ class QuadEquaRealRoot:
     """ solve for the real roots of the quadratic equation:
     a * x^2 + b * x + c = 0"""
 
-    def __call__( self, a, b, c ):
+    def __call__(self, a, b, c):
 
         if 0.0 == a:
             #
@@ -2007,7 +2022,7 @@ class QuadEquaRealRoot:
                 # the folowing still works even if c == 0
                 #
                 answer = - c / b
-                return [ answer, answer ]
+                return [answer, answer]
 
             else:
 
@@ -2018,7 +2033,7 @@ class QuadEquaRealRoot:
                 # returning nan is not right. However if c != 0 then no
                 # roots exist.
                 #
-                return [ None, None ]
+                return [None, None]
 
         elif 0.0 == b:
 
@@ -2028,85 +2043,85 @@ class QuadEquaRealRoot:
             if 0.0 == c:
 
                 # a * x^2 + 0 * x + 0 = 0
-                return [ 0.0, 0.0 ]
+                return [0.0, 0.0]
             else:
 
                 # a * x^2 + 0 * x + c = 0
-                if mysgn( a ) == mysgn( c ):
-                    return [ None, None ]
-                answer = numpy.sqrt( c / a )
-                return [ -answer, answer ]
+                if mysgn(a) == mysgn(c):
+                    return [None, None]
+                answer = numpy.sqrt(c / a)
+                return [-answer, answer]
 
         elif 0.0 == c:
 
             #
             # a * x^2 + b * x + 0 = 0
             #
-            return [ 0.0, - b / a ]
+            return [0.0, - b / a]
 
         else:
 
             discriminant = b * b - 4.0 * a * c
             # TODO: is this needed?
             debug("disc={}".format(discriminant))
-            sqrt_disc = numpy.sqrt( discriminant )
-            t = - ( b + mysgn( b ) * sqrt_disc ) / 2.0
-            return [ c / t, t / a ]
+            sqrt_disc = numpy.sqrt(discriminant)
+            t = - (b + mysgn(b) * sqrt_disc) / 2.0
+            return [c / t, t / a]
 
 
-def bisection( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6 ):
+def bisection(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6):
 
-    history = [ [], [] ]
-    nfev, myfcn = func_counter_history( fcn, history )
+    history = [[], []]
+    nfev, myfcn = func_counter_history(fcn, history)
 
     try:
 
         if fa is None:
-            fa = myfcn( xa, *args )
-        if abs( fa ) <= tol:
-            return [ [xa, fa], [ [xa, fa], [xa, fa] ], nfev[0] ]
+            fa = myfcn(xa, *args)
+        if abs(fa) <= tol:
+            return [[xa, fa], [[xa, fa], [xa, fa]], nfev[0]]
 
         if fb is None:
-            fb = myfcn( xb, *args )
-        if abs( fb ) <= tol:
-            return [ [xb, fb], [ [xb, fb], [xb, fb] ], nfev[0] ]
+            fb = myfcn(xb, *args)
+        if abs(fb) <= tol:
+            return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
-        if mysgn( fa ) == mysgn( fb ):
+        if mysgn(fa) == mysgn(fb):
             # TODO: is this a useful message for the user?
             warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
-            return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
+            return [[None, None], [[None, None], [None, None]], nfev[0]]
 
         while nfev[0] < maxfev:
 
-            if abs( fa ) > tol and abs( fb ) > tol:
+            if abs(fa) > tol and abs(fb) > tol:
 
-                xc = ( xa + xb ) / 2.0
-                fc = myfcn( xc, *args )
+                xc = (xa + xb) / 2.0
+                fc = myfcn(xc, *args)
 
-                if abs( xa - xb ) < min( tol * abs( xb ), tol / 10.0 ):
-                    return [ [xc, fc], [ [xa, fa], [xb, fb] ], nfev[0] ]
+                if abs(xa - xb) < min(tol * abs(xb), tol / 10.0):
+                    return [[xc, fc], [[xa, fa], [xb, fb]], nfev[0]]
 
-                if mysgn( fa ) !=  mysgn( fc ):
-                    xb = xc; fb = fc                
+                if mysgn(fa) !=  mysgn(fc):
+                    xb, fb = xc, fc
                 else:
-                    xa = xc; fa = fc
+                    xa, fa = xc, fc
 
             else:
-                if abs( fa ) <= tol:
-                    return [ [xa, fa], [ [xa, fa], [xb, fb] ], nfev[0] ]
+                if abs(fa) <= tol:
+                    return [[xa, fa], [[xa, fa], [xb, fb]], nfev[0]]
                 else:
-                    return [ [xb, fb], [ [xa, fa], [xb, fb] ], nfev[0] ]
+                    return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
 
 
-        xc = ( xa + xb ) / 2.0
-        fc = myfcn( xc, *args )
-        return [ [xc, fc], [ [xa, fa], [xb, fb] ], nfev[0] ]
+        xc = (xa + xb) / 2.0
+        fc = myfcn(xc, *args)
+        return [[xc, fc], [[xa, fa], [xb, fb]], nfev[0]]
 
     except OutOfBoundErr:
-        return [ [None, None], [ [xa, fa], [xb, fb] ], nfev[0] ]
+        return [[None, None], [[xa, fa], [xb, fb]], nfev[0]]
 
 
-def quad_coef( x, f ):
+def quad_coef(x, f):
     """
     p( x ) = f( xc ) + A ( x - xc ) + B ( x - xc ) ( x - xb )
            = f( xc ) + A ( x - xc ) + B ( ( x - xc ) ( x - xc ) +
@@ -2122,12 +2137,12 @@ def quad_coef( x, f ):
            = B x^2 + ( C - 2 * B x[2] ) x + f[ 2 ] + x[2] * ( B x[ 2 ] - C )
     """
 
+    [B, C] = transformed_quad_coef(x, f)
+    B_x2 = B * x[2]
+    return [B, C - 2 * B_x2, f[2] + x[2] * (B_x2 - C)]
 
-    [B,C] = transformed_quad_coef( x, f )
-    B_x2 = B * x[ 2 ]
-    return [ B, C - 2 * B_x2, f[ 2 ] + x[ 2 ] * ( B_x2 - C ) ]
 
-def transformed_quad_coef( x, f ):
+def transformed_quad_coef(x, f):
     """
     p( x ) = f( xc ) + A ( x - xc ) + B ( x - xc ) ( x - xb )
 
@@ -2175,8 +2190,8 @@ def transformed_quad_coef( x, f ):
                        {     1,  x >= 0
     """
 
-    xa = x[ 0 ]; xb = x[ 1 ]; xc = x[ 2 ]
-    fa = f[ 0 ]; fb = f[ 1 ]; fc = f[ 2 ]
+    xa, xb, xc = x[0], x[1], x[2]
+    fa, fb, fc = f[0], f[1], f[2]
 
     xc_xb = xc - xb
     fc_fb = fc - fb
@@ -2184,13 +2199,13 @@ def transformed_quad_coef( x, f ):
     fb_fa = fb - fa
     xb_xa = xb - xa
     xc_xa = xc - xa
-    B = ( A - fb_fa / xb_xa ) / xc_xa
+    B = (A - fb_fa / xb_xa) / xc_xa
     C = A + B * xc_xb
-    return [ B, C ]
+    return [B, C]
 
 
-def demuller( fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(), 
-              maxfev=32, tol=1.0e-6 ):
+def demuller(fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(),
+             maxfev=32, tol=1.0e-6):
     """A root-finding algorithm using Muller's method [1]_.
 
     p( x ) = f( xc ) + A ( x - xc ) + B ( x - xc ) ( x - xb )
@@ -2237,49 +2252,49 @@ def demuller( fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(),
 
     """
 
-    def is_nan( arg ):
+    def is_nan(arg):
         if arg != arg:
             return True
         if arg is numpy.nan:
             return True
-        return numpy.isnan( arg )
+        return numpy.isnan(arg)
 
-    history = [ [], [] ]
-    nfev, myfcn = func_counter_history( fcn, history )
+    history = [[], []]
+    nfev, myfcn = func_counter_history(fcn, history)
 
     try:
 
         if fa is None:
-            fa = myfcn( xa, *args )
-        if abs( fa ) <= tol:
-            return [ [xa, fa], [ [xa, fa], [xa, fa] ], nfev[0] ]
+            fa = myfcn(xa, *args)
+        if abs(fa) <= tol:
+            return [[xa, fa], [[xa, fa], [xa, fa]], nfev[0]]
 
         if fb is None:
-            fb = myfcn( xb, *args )
-        if abs( fb ) <= tol:
-            return [ [xb, fb], [ [xb, fb], [xb, fb] ], nfev[0] ]
+            fb = myfcn(xb, *args)
+        if abs(fb) <= tol:
+            return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
         if fc is None:
-            fc = myfcn( xc, *args )
-        if abs( fc ) <= tol:
-            return [ [xc, fc], [ [xc, fc], [xc, fc] ], nfev[0] ]
+            fc = myfcn(xc, *args)
+        if abs(fc) <= tol:
+            return [[xc, fc], [[xc, fc], [xc, fc]], nfev[0]]
 
         while nfev[0] < maxfev:
 
-            [B, C] = transformed_quad_coef( [xa, xb, xc], [fa, fb, fc] )
+            [B, C] = transformed_quad_coef([xa, xb, xc], [fa, fb, fc])
 
-            discriminant = max( C * C - 4.0 * fc * B, 0.0 )
+            discriminant = max(C * C - 4.0 * fc * B, 0.0)
 
-            if is_nan( B ) or is_nan( C ) or \
-                    0.0 == C + mysgn( C ) * numpy.sqrt( discriminant ):
-                return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
+            if is_nan(B) or is_nan(C) or \
+                    0.0 == C + mysgn(C) * numpy.sqrt(discriminant):
+                return [[None, None], [[None, None], [None, None]], nfev[0]]
 
-            xd = xc - 2.0 * fc / ( C + mysgn( C ) * numpy.sqrt( discriminant ) )
+            xd = xc - 2.0 * fc / (C + mysgn(C) * numpy.sqrt(discriminant))
 
-            fd = myfcn( xd, *args )
+            fd = myfcn(xd, *args)
             # print 'fd(%e)=%e' % (xd, fd)
-            if abs( fd ) <= tol:
-                return [ [xd, fd], [ [None, None], [None, None] ], nfev[0] ]
+            if abs(fd) <= tol:
+                return [[xd, fd], [[None, None], [None, None]], nfev[0]]
 
             xa = xb
             fa = fb
@@ -2289,107 +2304,107 @@ def demuller( fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(),
             fc = fd
 
         # print 'demuller(): maxfev exceeded'
-        return [ [xd, fd], [ [None, None], [None, None] ], nfev[0] ]
+        return [[xd, fd], [[None, None], [None, None]], nfev[0]]
 
     except ZeroDivisionError:
 
         # print 'demuller(): fixme ZeroDivisionError'
         # for x, y in izip( history[0], history[1] ):
         #     print 'f(%e)=%e' % ( x, y )
-        return [ [xd, fd], [ [None, None], [None, None] ], nfev[0] ]
+        return [[xd, fd], [[None, None], [None, None]], nfev[0]]
 
 
-def new_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6 ):
+def new_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6):
 
     # This function does not appear to be used
-    def regula_falsi( x0, x1, f0, f1 ):
+    def regula_falsi(x0, x1, f0, f1):
         if f0 < f1:
-            xl = x0; fl = f0
-            xh = x1; fh = f1
+            xl, fl = x0, f0
+            xh, fh = x1, f1
         else:
-            xl = x1; fl = f1
-            xh = x0; fh = f0
-        x = xl + ( xh - xl ) * fl / ( fl - fh )
-        if is_sequence( x0, x, x1 ):
+            xl, fl = x1, f1
+            xh, fh = x0, f0
+        x = xl + (xh - xl) * fl / (fl - fh)
+        if is_sequence(x0, x, x1):
             return x
         else:
-            return ( x0 + x1 ) / 2.0
+            return (x0 + x1) / 2.0
 
-    history = [ [], [] ]
-    nfev, myfcn = func_counter_history( fcn, history )
+    history = [[], []]
+    nfev, myfcn = func_counter_history(fcn, history)
 
     try:
 
         if fa is None:
-            fa = myfcn( xa, *args )
-        if abs( fa ) <= tol:
-            return [ [xa, fa], [ [xa, fa], [xa, fa] ], nfev[0] ]
+            fa = myfcn(xa, *args)
+        if abs(fa) <= tol:
+            return [[xa, fa], [[xa, fa], [xa, fa]], nfev[0]]
 
         if fb is None:
-            fb = myfcn( xb, *args )
-        if abs( fb ) <= tol:
-            return [ [xb, fb], [ [xb, fb], [xb, fb] ], nfev[0] ]
+            fb = myfcn(xb, *args)
+        if abs(fb) <= tol:
+            return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
-        if mysgn( fa ) == mysgn( fb ):
+        if mysgn(fa) == mysgn(fb):
             # TODO: is this a useful message for the user?
             warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
-            return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
+            return [[None, None], [[None, None], [None, None]], nfev[0]]
 
         while nfev[0] < maxfev:
 
-            xc = ( xa + xb ) / 2.0
-            fc = myfcn( xc, *args )
-            if abs( fc ) <= tol:
-                return [ [xc, fc], [ [xa, fa], [xb, fb] ], nfev[0] ]
+            xc = (xa + xb) / 2.0
+            fc = myfcn(xc, *args)
+            if abs(fc) <= tol:
+                return [[xc, fc], [[xa, fa], [xb, fb]], nfev[0]]
 
-            tran = transformed_quad_coef( [xa, xb, xc], [fa, fb, fc] )
-            B = tran[ 0 ]
-            C = tran[ 1 ]
+            tran = transformed_quad_coef([xa, xb, xc], [fa, fb, fc])
+            B = tran[0]
+            C = tran[1]
 
-            discriminant = max( C * C - 4.0 * fc * B, 0.0 )
+            discriminant = max(C * C - 4.0 * fc * B, 0.0)
 
-            xd = xc - 2.0 * fc / ( C + mysgn( C ) * numpy.sqrt( discriminant ) )
+            xd = xc - 2.0 * fc / (C + mysgn(C) * numpy.sqrt(discriminant))
 
-            fd = myfcn( xd, *args )
+            fd = myfcn(xd, *args)
             # print 'fd(%e)=%e' % (xd, fd)
-            if abs( fd ) <= tol:
-                return [ [xd, fd], [ [xa, fa], [xb, fb] ], nfev[0] ]
+            if abs(fd) <= tol:
+                return [[xd, fd], [[xa, fa], [xb, fb]], nfev[0]]
 
-            if mysgn( fa ) != mysgn( fc ):
-                xb = xc; fb = fc
+            if mysgn(fa) != mysgn(fc):
+                xb, fb = xc, fc
                 continue
 
-            if mysgn( fd ) != mysgn( fc ) and xc < xd:
-                xa = xc; fa = fc
-                xb = xd; fb = fd
+            if mysgn(fd) != mysgn(fc) and xc < xd:
+                xa, fa = xc, fc
+                xb, fb = xd, fd
                 continue
 
-            if mysgn( fb ) != mysgn( fd ):
-                xa = xd; fa = fd
+            if mysgn(fb) != mysgn(fd):
+                xa, fa = xd, fd
                 continue
 
-            if mysgn( fa ) != mysgn( fd ):
-                xb = xd; fb = fd
+            if mysgn(fa) != mysgn(fd):
+                xb, fb = xd, fd
                 continue
 
-            if mysgn( fc ) != mysgn( fd ) and xd < xc:
-                xa = xd; fa = fd
-                xb = xc; fb = fc
+            if mysgn(fc) != mysgn(fd) and xd < xc:
+                xa, fa = xd, fd
+                xb, fb = xc, fc
                 continue
 
-            if mysgn( fc ) != mysgn( fd ):
-                xa = xc; fa = fc
+            if mysgn(fc) != mysgn(fd):
+                xa, fa = xc, fc
                 continue
 
         # print 'new_muller(): maxfev exceeded'
-        return [ [xd, fd], [ [xa, fa], [xb, fb] ], nfev[0] ]
+        return [[xd, fd], [[xa, fa], [xb, fb]], nfev[0]]
 
     except (ZeroDivisionError, OutOfBoundErr):
 
         # print 'new_muller(): fixme ZeroDivisionError'
         # for x, y in izip( history[0], history[1] ):
         #     print 'f(%e)=%e' % ( x, y )
-        return [ [xd, fd], [ [xa, fa], [xb, fb] ], nfev[0] ]
+        return [[xd, fd], [[xa, fa], [xb, fb]], nfev[0]]
 
 #
 # /*
@@ -2409,52 +2424,52 @@ def new_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6 ):
 #  * limitations under the License.
 #  */
 #
-def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
-                   tol=1.0e-6 ):
+def apache_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
+                  tol=1.0e-6):
 
-    history = [ [], [] ]
-    nfev, myfcn = func_counter_history( fcn, history )
+    history = [[], []]
+    nfev, myfcn = func_counter_history(fcn, history)
 
     try:
 
         if fa is None:
-            fa = myfcn( xa, *args )
-        if abs( fa ) <= tol:
-            return [ [xa, fa], [ [xa,fa], [xa,fa] ], nfev[0] ]
+            fa = myfcn(xa, *args)
+        if abs(fa) <= tol:
+            return [[xa, fa], [[xa, fa], [xa, fa]], nfev[0]]
 
         if fb is None:
-            fb = myfcn( xb, *args )
-        if abs( fb ) <= tol:
-            return [ [xb, fb], [ [xb,fb], [xb,fb] ], nfev[0] ]
+            fb = myfcn(xb, *args)
+        if abs(fb) <= tol:
+            return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
-        if mysgn( fa ) == mysgn( fb ):
+        if mysgn(fa) == mysgn(fb):
             # TODO: is this a useful message for the user?
             warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
-            return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
+            return [[None, None], [[None, None], [None, None]], nfev[0]]
 
-        xc = ( xa + xb ) / 2.0
-        fc = myfcn( xc, *args )
+        xc = (xa + xb) / 2.0
+        fc = myfcn(xc, *args)
         # print 'MullerBound() fc(%.14e)=%.14e' % (xc,fc)
-        if abs( fc ) <= tol:
-            return [ [ xc, fc ], [ [xc, fc], [xc, fc] ], nfev[0] ]
+        if abs(fc) <= tol:
+            return [[xc, fc], [[xc, fc], [xc, fc]], nfev[0]]
 
-        xbest = xa; fbest = fa
-        if abs( fb ) < abs( fa ):
-            xbest = xb; fbest = fb
-        if abs( fc ) < abs( fbest ):
-            xbest = xc; fbest = fc
+        xbest, fbest = xa, fa
+        if abs(fb) < abs(fa):
+            xbest, fbest = xb, fb
+        if abs(fc) < abs(fbest):
+            xbest, fbest = xc, fc
 
         oldx = 1.0e128
         while nfev[0] < maxfev:
 
-            tran = transformed_quad_coef( [xa, xb, xc], [fa, fb, fc] )
-            B = tran[ 0 ]
-            C = tran[ 1 ]
-            discriminant = max( C * C - 4.0 * fc * B, 0.0 )
-            den = mysgn( C ) * numpy.sqrt( discriminant )
-            xplus = xc - 2.0 * fc / ( C + den )
+            tran = transformed_quad_coef([xa, xb, xc], [fa, fb, fc])
+            B = tran[0]
+            C = tran[1]
+            discriminant = max(C * C - 4.0 * fc * B, 0.0)
+            den = mysgn(C) * numpy.sqrt(discriminant)
+            xplus = xc - 2.0 * fc / (C + den)
             if C != den:
-                xminus = xc - 2.0 * fc / ( C - den )
+                xminus = xc - 2.0 * fc / (C - den)
             else:
                 xminus = 1.0e128
 
@@ -2472,15 +2487,15 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
 
             # sanity check
             if not is_sequence(xa, x, xb):
-                x = ( xa + xb ) / 2.0
+                x = (xa + xb) / 2.0
 
-            y = myfcn( x, *args );
+            y = myfcn(x, *args)
             # print 'MullerBound() y(%.14e)=%.14e' % (x,y)
-            if abs( y ) < abs( fbest ):
-                xbest = x; fbest = y
-            tolerance = min( tol * abs( x ), tol )
-            if abs( y ) <= tol or abs( x - oldx ) <= tolerance:
-                return [ [x,y], [ [xa, fa], [xb, fb] ], nfev[0] ]
+            if abs(y) < abs(fbest):
+                xbest, fbest = x, y
+            tolerance = min(tol * abs(x), tol)
+            if abs(y) <= tol or abs(x - oldx) <= tolerance:
+                return [[x, y], [[xa, fa], [xb, fb]], nfev[0]]
 
             mybisect = (x < xc and (xc - xa) > 0.95 * (xb - xa)) or \
                        (x > xc and (xb - xc) > 0.95 * (xb - xa)) or \
@@ -2493,45 +2508,45 @@ def apache_muller( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
                 if x < xc:
                     xb = xc
                     fb = fc
-                xc = x; fc = y;
+                xc, fc = x, y
                 oldx = x
             else:
-                xmid = ( xa + xb ) / 2.0
-                fmid = myfcn( xmid, *args )
-                if abs( fmid ) < abs( fbest ):
-                    xbest = xmid; fbest = fmid
+                xmid = (xa + xb) / 2.0
+                fmid = myfcn(xmid, *args)
+                if abs(fmid) < abs(fbest):
+                    xbest, fbest = xmid, fmid
                 # print 'MullerBound() fmid(%.14e)=%.14e' % (xmid,fmid)
-                if abs( fmid ) <= tol:
-                    return [ [xmid, fmid], [ [xa, fa], [xb, fb] ], nfev[0] ]
-                if mysgn( fa ) + mysgn( fmid ) == 0:
+                if abs(fmid) <= tol:
+                    return [[xmid, fmid], [[xa, fa], [xb, fb]], nfev[0]]
+                if mysgn(fa) + mysgn(fmid) == 0:
                     xb = xmid
                     fb = fmid
                 else:
                     xa = xmid
                     fa = fmid
-                xc = ( xa + xb ) / 2.0
-                fc = myfcn( xc, *args )
-                if abs( fc ) < abs( fbest ):
-                    xbest = xc; fbest = fc                
+                xc = (xa + xb) / 2.0
+                fc = myfcn(xc, *args)
+                if abs(fc) < abs(fbest):
+                    xbest, fbest = xc, fc
                 # print 'MullerBound() fc(%.14e)=%.14e' % (xc,fc)
-                if abs( fc ) <= tol:
-                    return [ [xc, fc], [ [xa, fa], [xb, fb] ], nfev[0] ]
+                if abs(fc) <= tol:
+                    return [[xc, fc], [[xa, fa], [xb, fb]], nfev[0]]
                 oldx = 1.0e128
 
         #
         # maxfev has exceeded, return the minimum so far
         #
-        return [ [ xbest, fbest ], [ [xa, fa], [xb, fb] ], nfev[0] ]
+        return [[xbest, fbest], [[xa, fa], [xb, fb]], nfev[0]]
 
     #
     # Something drastic has happened
     #
     except (ZeroDivisionError, OutOfBoundErr):
 
-        return [ [xbest, fbest], [ [xa, fa], [xb, fb] ], nfev[0] ]
+        return [[xbest, fbest], [[xa, fa], [xb, fb]], nfev[0]]
 
 
-def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
+def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
     """Obtain a zero of a function of one variable using Brent's root finder.
 
     Return an approximate location for the root with accuracy::
@@ -2572,25 +2587,25 @@ def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
 
     """
 
-    history = [ [], [] ]
-    nfev, myfcn = func_counter_history( fcn, history )
+    history = [[], []]
+    nfev, myfcn = func_counter_history(fcn, history)
 
     try:
 
         if fa is None:
-            fa = myfcn( xa, *args )
-            if abs( fa ) <= tol:
-                return [ [xa, fa], [ [xa, fa], [xb, fb] ], nfev[0] ]
+            fa = myfcn(xa, *args)
+            if abs(fa) <= tol:
+                return [[xa, fa], [[xa, fa], [xb, fb]], nfev[0]]
 
         if fb is None:
-            fb = myfcn( xb, *args )
-        if abs( fb ) <= tol:
-            return [ [xb, fb], [ [xa, fa], [xb, fb] ], nfev[0] ]    
+            fb = myfcn(xb, *args)
+        if abs(fb) <= tol:
+            return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
 
-        if mysgn( fa ) == mysgn( fb ):
+        if mysgn(fa) == mysgn(fb):
             # TODO: is this a useful message for the user?
             warning(__name__ + ': ' + fcn.__name__ + ' fa * fb < 0 is not met')
-            return [ [None, None], [ [None, None], [None, None] ], nfev[0] ]
+            return [[None, None], [[None, None], [None, None]], nfev[0]]
 
         xc = xa
         fc = fa
@@ -2599,32 +2614,32 @@ def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
 
             prev_step = xb - xa
 
-            if abs( fc ) < abs( fb ):
-                xa = xb; fa = fb
-                xb = xc; fb = fc
-                xc = xa; fc = fa
+            if abs(fc) < abs(fb):
+                xa, fa = xb, fb
+                xb, fb = xc, fc
+                xc, fc = xa, fa
 
-            tol_act = 2.0 * DBL_EPSILON * abs( xb ) + tol / 2.0
-            new_step = ( xc - xb ) / 2.0
+            tol_act = 2.0 * DBL_EPSILON * abs(xb) + tol / 2.0
+            new_step = (xc - xb) / 2.0
 
-            if abs( fb ) <= tol:
-                return [ [xb, fb], [ [xa, fa], [xb, fb] ], nfev[0] ]
+            if abs(fb) <= tol:
+                return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
 
-            if abs( new_step ) <= tol_act:
-                if mysgn( fb ) != mysgn( fa ):
-                    tmp = apache_muller( fcn, xa, xb, fa, fb, args=args,
-                                         maxfev=maxfev-nfev[0], tol=tol )
-                    tmp[ -1 ] += nfev[0]
+            if abs(new_step) <= tol_act:
+                if mysgn(fb) != mysgn(fa):
+                    tmp = apache_muller(fcn, xa, xb, fa, fb, args=args,
+                                        maxfev=maxfev - nfev[0], tol=tol)
+                    tmp[-1] += nfev[0]
                     return tmp
-                elif mysgn( fb ) != mysgn( fc ):
-                    tmp = apache_muller( fcn, xb, xc, fb, fc, args=args,
-                                         maxfev=maxfev-nfev[0], tol=tol )
-                    tmp[ -1 ] += nfev[0]
-                    return tmp                
+                elif mysgn(fb) != mysgn(fc):
+                    tmp = apache_muller(fcn, xb, xc, fb, fc, args=args,
+                                        maxfev=maxfev - nfev[0], tol=tol)
+                    tmp[-1] += nfev[0]
+                    return tmp
                 else:
-                    return [ [xb, fb], [ [xa, fa], [xb, fb] ], nfev[0] ]
+                    return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
 
-            if abs( prev_step ) >= tol_act and abs( fa ) > abs( fb ):
+            if abs(prev_step) >= tol_act and abs(fa) > abs(fb):
 
                 cb = xc - xb
                 if xa == xc:
@@ -2635,18 +2650,19 @@ def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
                     t1 = fb / fc
                     t2 = fb / fa
                     q = fa / fc
-                    p = t2 * ( cb * q * (q-t1) - (xb-xa) * (t1-1.0) )
-                    q = (q-1.0) * (t1-1.0) * (t2-1.0)
+                    p = t2 * (cb * q * (q - t1) - (xb - xa) * (t1 - 1.0))
+                    q = (q - 1.0) * (t1 - 1.0) * (t2 - 1.0)
 
                 if p > 0:
                     q = -q
                 else:
                     p = -p
 
-                if 2*p < (1.5*cb*q-abs(tol_act*q)) and 2*p < abs(prev_step*q):
+                if 2 * p < (1.5 * cb * q - abs(tol_act * q)) and \
+                   2 * p < abs(prev_step * q):
                     new_step = p / q
 
-            if abs( new_step ) < tol_act:
+            if abs(new_step) < tol_act:
                 if new_step > 0:
                     new_step = tol_act
                 else:
@@ -2654,7 +2670,7 @@ def zeroin( fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2 ):
             xa = xb
             fa = fb
             xb += new_step
-            fb = myfcn( xb, *args )
+            fb = myfcn(xb, *args)
             # print 'fa(%f)=%f\tfb(%f)=%f\tfc(%f)=%f' % (xa,fa,xb,fb,xc,fc)
             if fb > 0 and fc > 0 or fb < 0 and fc < 0:
                 xc = xa

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -33,7 +33,10 @@ import numpy
 import numpy.random
 import numpytest
 import numpy.fft
-from sherpa.utils._utils import *
+# Note: _utils.gsl_fcmp is not exported from this module; is this intentional?
+from sherpa.utils._utils import calc_ftest, calc_mlr, igamc, igam, \
+    incbet, gamma, lgam, erf, ndtri, sao_fcmp, rebin, \
+    hist1d, hist2d, sum_intervals, neville, sao_arange
 from sherpa.utils._psf import extract_kernel, normalize, set_origin, \
     pad_bounding_box
 from functools import wraps

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1191,33 +1191,33 @@ def get_amplitude_position(arr, mean=False):
     """
 
     xpos = xmin = xmax = xval = 0
-    max = arr.max()
-    min = arr.min()
-    if((max > 0.0 and min >= 0.0) or
-       (max > 0.0 and min < 0.0 and (abs(min) <= max ))):
+    amax = arr.max()
+    amin = arr.min()
+    if((amax > 0.0 and amin >= 0.0) or
+       (amax > 0.0 and amin < 0.0 and (abs(amin) <= amax))):
         xpos = arr.argmax()
         if mean:
-            xpos = numpy.where(arr==max)
+            xpos = numpy.where(arr == amax)
 
-        xmax = max*_guess_ampl_scale
-        xmin = max/_guess_ampl_scale
-        xval = max
+        xmax = amax * _guess_ampl_scale
+        xmin = amax / _guess_ampl_scale
+        xval = amax
 
-    elif((max > 0.0 and min < 0.0 and abs(min) > max ) or
-         (max == 0.0 and min < 0.0 ) or ( max < 0.0 )):
+    elif((amax > 0.0 and amin < 0.0 and abs(amin) > amax ) or
+         (amax == 0.0 and amin < 0.0) or (amax < 0.0)):
         xpos = arr.argmin()
         if mean:
-            xpos = numpy.where(arr==min)
+            xpos = numpy.where(arr == amin)
 
-        xmax = min/_guess_ampl_scale
-        xmin = min*_guess_ampl_scale
-        xval = min
-    elif (max == 0.0 and min == 0.0):
+        xmax = amin / _guess_ampl_scale
+        xmin = amin * _guess_ampl_scale
+        xval = amin
+    elif (amax == 0.0 and amin == 0.0):
         xpos = arr.argmax()
         if mean:
-            xpos = numpy.where(arr==max)
+            xpos = numpy.where(arr == amax)
 
-        xmax = 100.0/_guess_ampl_scale
+        xmax = 100.0 / _guess_ampl_scale
         xmin = 0.0
         xval = 0.0
 
@@ -1232,21 +1232,20 @@ def guess_amplitude(y, x, xhi=None):
 
     val, ymin, ymax, pos = get_amplitude_position(y)
 
-    min = None; max = None
+    amin, amax = None, None
     if ymin != 0.0 or ymax != 0.0:
-        min = ymin
-        max = ymax
+        amin = ymin
+        amax = ymax
 
     if xhi is not None:
         binsize = numpy.abs(xhi[pos] - x[pos])
-        if min is not None:
-            min /= binsize
-        if max is not None:
-            max /= binsize
+        if amin is not None:
+            amin /= binsize
+        if amax is not None:
+            amax /= binsize
         val /= binsize
 
-    return { 'val' : val, 'min' : min, 'max' : max }
-
+    return {'val': val, 'min': amin, 'max': amax}
 
 
 def guess_amplitude_at_ref(r, y, x, xhi=None):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -28,6 +28,7 @@ from types import FunctionType as function
 from types import MethodType as instancemethod
 import string
 import sys
+import os
 import importlib
 import numpy
 import numpy.random
@@ -197,7 +198,6 @@ class NoNewAttributesAfterInit(object):
 ###############################################################################
 
 def _get_datadir():
-    import os
     try:
         import sherpatest
         datadir = os.path.dirname(sherpatest.__file__)
@@ -220,6 +220,26 @@ class SherpaTestCase(numpytest.NumpyTestCase):
 
     # The location of the Sherpa test data (it is optional)
     datadir = _get_datadir()
+
+    def make_path(self, *segments):
+        """Add the segments onto the test data location.
+
+        Parameters
+        ----------
+        *segments
+           Path segments to combine together with the location of the
+           test data.
+
+        Returns
+        -------
+        fullpath : None or string
+           The full path to the repository, or None if the
+           data directory is not set.
+
+        """
+        if self.datadir is None:
+            return None
+        return os.path.join(self.datadir, *segments)
 
     # What is the benefit of this over numpy.testing.assert_allclose(),
     # which was added in version 1.5 of NumPy?

--- a/sherpa/utils/src/_utils.cc
+++ b/sherpa/utils/src/_utils.cc
@@ -1052,7 +1052,33 @@ static PyMethodDef UtilsFcts[] = {
   FCTSPEC(gsl_fcmp, _sherpa_fcmp< gsl_fcmp >), 
 
   //Same as gsl_fcmp, but also handles the case where one of the args is 0.
-  FCTSPEC(sao_fcmp, _sherpa_fcmp< sao_fcmp >),
+  // FCTSPEC(sao_fcmp, _sherpa_fcmp< sao_fcmp >),
+  { (char*) "sao_fcmp", (PyCFunction)(_sherpa_fcmp< sao_fcmp >), METH_VARARGS,
+    (char*) "sao_fcmp(x, y, tol)\n\n"
+            "Compare y to x, using an absolute tolerance.\n"
+            PARAMETERSDOC
+            "first : number or array_like\n"
+            "   The expected value, or values.\n"
+            "second : number or array_like\n"
+            "   The value, or values, to check. If first is an array, then\n"
+            "   second must be an array of the same size. If first is\n"
+            "   a scalar then second can be a scalar or an array.\n"
+            "tol : number\n"
+            "   The absolute tolerance used for comparison.\n"
+            RETURNSDOC
+            "flags : int or array_like\n"
+            "   0, 1, or -1 for each value in second. If the values\n"
+            "   match, then 0, otherwise -1 if the expected value (x)\n"
+            "   is less than the comparison value (y) or +1 if x is\n"
+            "   larger than y.\n"
+            EXAMPLESDOC
+            ">>> sao_fcmp(1, 1.01, 0.01)\n"
+            "0\n\n"
+            ">>> sao_fcmp(1, [0.9, 1, 1.1], 0.01)\n"
+            "array([ 1,  0, -1], dtype=int32)\n\n"
+            ">>> utils.sao_fcmp([1.2, 2.3], [1.22, 2.29], 0.01)\n"
+            "array([-1,  0], dtype=int32)\n\n"
+  },
 
   //Rebin to new grid
   { (char*) "rebin", (PyCFunction)(rebin<SherpaFloatArray, SherpaFloat>), METH_VARARGS,


### PR DESCRIPTION
The aim was to add the `SherpaTestCase.make_path()` routine for adding paths to the data directory, and use it in the code. A secondary change was to improve support for running an individual file - e.g. `python sherpa/astro/datastack/tests/test_datastack.py` - with or without the Sherpa test directory.

Two tests which were previously skipped - due to name clashes - have been re-named: `sherpa/models/tests/test_template.py::test_grid_search_with_discrete_template_parvals` and `sherpa/ui/tests/test_ui.py::test_psf_model1d``.

For those tests that changed the logging level in their `setUp` method, the level has been restored in `tearDown` (not checked for all tests, just those looked at here). Similarly, some directory changes (in those tests with a `run_thread` method) were changed to ensure that the original directory was restored.

There was also some minor code cleanup (e.g. removal of unused imports and adding/deleting spaces).

I have not changed the XSpec module tests since I know there's changes (e.g. PR #63) so not worth working on here.

These changes build on the test-suite cleanup in PR #70. I am not convinced I "git-ted" things correctly to link things together properly.