### PR TITLE
test cleanup

### DIFF
--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,6 +37,7 @@ class test_design(SherpaTestCase):
         clear_stack()
         ui.clean()
         set_template_id("ID")
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         set_stack_verbosity(logging.ERROR)
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
@@ -45,6 +46,7 @@ class test_design(SherpaTestCase):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -126,10 +128,12 @@ class test_design(SherpaTestCase):
         assert 0 == len(ui._session._data)
         assert 3 == len(ds.datasets)
 
+
 class test_global(SherpaTestCase):
     def setUp(self):
         clear_stack()
         ui.clean()
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         set_stack_verbosity(logging.ERROR)
         set_template_id("__ID")
@@ -138,8 +142,7 @@ class test_global(SherpaTestCase):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
-
-
+        logger.setLevel(self.loggingLevel)
 
     def test_case_2(self):
         x1 = np.arange(50)+100
@@ -201,6 +204,8 @@ class test_global(SherpaTestCase):
         vals = get_par([], 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
+        # QUS: pars is not checked, so is this just
+        # checking that get_par doesn't fail?
         pars = get_par([], 'const.c0')
 
         fit([])
@@ -257,6 +262,8 @@ class test_load(SherpaTestCase):
         set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.create_files()
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         clear_stack()
@@ -266,6 +273,7 @@ class test_load(SherpaTestCase):
         os.remove(self.name1)
         os.remove(self.name2)
         set_stack_verbose(False)
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -281,7 +289,6 @@ class test_load(SherpaTestCase):
         load_data("@"+"/".join((self._this_dir, 'data', 'pha.lis')))
         assert len(ui._session._data) == 6
         assert len(DATASTACK.datasets) == 6
-
 
     def create_files(self):
         fd1, self.name1 = tempfile.mkstemp()
@@ -321,12 +328,15 @@ class test_partial_oo(SherpaTestCase):
         set_template_id("__ID")
         clear_stack()
         ui.clean()
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         self.ds.clear_stack()
         clear_stack()
         set_template_id("__ID")
         ui.clean()
+        logger.setLevel(self.loggingLevel)
 
     def test_case_4(self):
         x1 = np.arange(50)+100
@@ -390,6 +400,8 @@ class test_partial_oo(SherpaTestCase):
         vals = get_par(ds, 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
+        # QUS: pars is not checked, so is this just
+        # checking that get_par doesn't fail?
         pars = get_par(ds, 'const.c0')
 
         fit(ds)
@@ -446,12 +458,15 @@ class test_oo(SherpaTestCase):
         datastack.set_template_id("__ID")
         ui.clean()
         self.ds = datastack.DataStack()
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         self.ds.clear_stack()
         datastack.clear_stack()
         datastack.set_template_id("__ID")
         ui.clean()
+        logger.setLevel(self.loggingLevel)
 
     def test_case_5(self):
         x1 = np.arange(50)+100
@@ -515,6 +530,8 @@ class test_oo(SherpaTestCase):
         vals = ds.get_par('poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
+        # QUS: pars is not checked, so is this just
+        # checking that get_par doesn't fail?
         pars = ds.get_par('const.c0')
 
         ds.fit()
@@ -563,17 +580,21 @@ class test_oo(SherpaTestCase):
 
         assert const3.c0._link is not const2.c0
 
+
 class test_pha(SherpaTestCase):
     def setUp(self):
         clear_stack()
         ui.clean()
         set_template_id("ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -587,7 +608,6 @@ class test_pha(SherpaTestCase):
 
         load_bkg_arf([], '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits")))
         load_bkg_arf([], '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits")))
-
 
         # Define background models
         bkg_arfs = get_bkg_arf([])
@@ -620,10 +640,11 @@ class test_pha(SherpaTestCase):
                       src_model * const1d.ratio_12]
         for i in range(2):
             id_ = i + 1
-            set_full_model(id_, (rsps[i](src_models[i])
-                                 + bkg_scales[i] * bkg_rsps[i](bkg_models[i])))
+            set_full_model(id_, (rsps[i](src_models[i]) +
+                                 bkg_scales[i] * bkg_rsps[i](bkg_models[i])))
 
         fit()
+
 
 class test_query(SherpaTestCase):
     def setUp(self):
@@ -631,12 +652,15 @@ class test_query(SherpaTestCase):
         ui.clean()
         set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         clear_stack()
         ui.clean()
         set_template_id("__ID")
         set_stack_verbose(False)
+        logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -662,3 +686,15 @@ class test_query(SherpaTestCase):
         f = query_by_obsid(ds, '7867')
 
         assert f == [4]
+
+if __name__ == '__main__':
+
+    from sherpa.utils import SherpaTest
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(datastack).test(datadir=datadir)

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -20,32 +20,33 @@
 
 from sherpa.utils import SherpaTestCase
 import os
+import sys
 import unittest
 from sherpa.utils import has_fits_support
-from sherpa.astro.ui import *
-from sherpa.astro.datastack import *
+from sherpa.astro import ui
 from sherpa.astro import datastack
 from acis_bkg_model import acis_bkg_model
 import numpy as np
 import tempfile
+import logging
 
 logger = logging.getLogger('sherpa')
 
 
 class test_design(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("ID")
+        datastack.set_template_id("ID")
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        set_stack_verbosity(logging.ERROR)
+        datastack.set_stack_verbosity(logging.ERROR)
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
@@ -53,48 +54,48 @@ class test_design(SherpaTestCase):
     def test_case_1(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, '3c273.lis'))
-        load_pha(ls, use_errors=True)
+        datastack.load_pha(ls, use_errors=True)
 
-        assert 2 == len(DATASTACK.datasets)
+        assert 2 == len(datastack.DATASTACK.datasets)
         assert 2 == len(ui._session._data)
 
-        load_pha("myid", '/'.join((datadir, "3c273.pi")))
+        datastack.load_pha("myid", '/'.join((datadir, "3c273.pi")))
 
-        assert 2 == len(DATASTACK.datasets)
+        assert 2 == len(datastack.DATASTACK.datasets)
         assert 3 == len(ui._session._data)
 
-        load_pha('/'.join((datadir, "3c273.pi")))
+        datastack.load_pha('/'.join((datadir, "3c273.pi")))
 
-        assert 3 == len(DATASTACK.datasets)
+        assert 3 == len(datastack.DATASTACK.datasets)
         assert 4 == len(ui._session._data)
 
-        load_pha([], '/'.join((datadir, "3c273.pi")))
+        datastack.load_pha([], '/'.join((datadir, "3c273.pi")))
 
-        assert 4 == len(DATASTACK.datasets)
+        assert 4 == len(datastack.DATASTACK.datasets)
         assert 5 == len(ui._session._data)
 
-        ds = DataStack()
+        ds = datastack.DataStack()
 
-        load_pha(ds, ls)
+        datastack.load_pha(ds, ls)
 
-        assert 4 == len(DATASTACK.datasets)
+        assert 4 == len(datastack.DATASTACK.datasets)
         assert 7 == len(ui._session._data)
         assert 2 == len(ds.datasets)
 
-        load_pha(ds, '/'.join((datadir, "3c273.pi")))
+        datastack.load_pha(ds, '/'.join((datadir, "3c273.pi")))
 
-        assert 4 == len(DATASTACK.datasets)
+        assert 4 == len(datastack.DATASTACK.datasets)
         assert 8 == len(ui._session._data)
         assert 3 == len(ds.datasets)
 
-        dids = DATASTACK.get_stack_ids()
+        dids = datastack.DATASTACK.get_stack_ids()
         assert dids == [1,2,3,4]
 
         sids = ui._session._data.keys()
         assert sids == [1,2,3,4,5,6,7, "myid"]
 
-        set_source([1,2], "powlaw1d.pID")
-        set_source([3,4], "brokenpowerlaw.bpID")
+        datastack.set_source([1,2], "powlaw1d.pID")
+        datastack.set_source([3,4], "brokenpowerlaw.bpID")
 
         dsids = ds.get_stack_ids()
         assert dsids == [5,6,7]
@@ -109,8 +110,8 @@ class test_design(SherpaTestCase):
         assert bp3 is not None
         assert bp4 is not None
 
-        set_source(1, "polynom1d.poly1")
-        set_source([2,3,4], "atten.attID")
+        datastack.set_source(1, "polynom1d.poly1")
+        datastack.set_source([2,3,4], "atten.attID")
 
         poly1 = ui._session._model_components['poly1']
         a2 = ui._session._model_components['att2']
@@ -122,26 +123,26 @@ class test_design(SherpaTestCase):
         assert a3 is not None
         assert a4 is not None
 
-        clean()
+        datastack.clean()
 
-        assert 0 == len(DATASTACK.datasets)
+        assert 0 == len(datastack.DATASTACK.datasets)
         assert 0 == len(ui._session._data)
         assert 3 == len(ds.datasets)
 
 
 class test_global(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        set_stack_verbosity(logging.ERROR)
-        set_template_id("__ID")
+        datastack.set_stack_verbosity(logging.ERROR)
+        datastack.set_template_id("__ID")
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
     def test_case_2(self):
@@ -152,20 +153,20 @@ class test_global(SherpaTestCase):
         x3 = np.arange(50)+200
         y3 = 2*(x3**2+3*x3)
 
-        load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        set_source([], 'const1d.const * polynom1d.poly__ID')
+        datastack.set_source([], 'const1d.const * polynom1d.poly__ID')
 
         poly1 = ui._session._get_model_component('poly1')
         poly2 = ui._session._get_model_component('poly2')
         poly3 = ui._session._get_model_component('poly3')
         const = ui._session._get_model_component('const')
 
-        freeze([], 'poly')
-        thaw([], 'poly.c0')
-        thaw([], 'poly.c1')
-        thaw([], 'poly.c2')
-        thaw([], 'const')
+        datastack.freeze([], 'poly')
+        datastack.thaw([], 'poly.c0')
+        datastack.thaw([], 'poly.c1')
+        datastack.thaw([], 'poly.c2')
+        datastack.thaw([], 'const')
 
         assert poly1.c0.frozen is False
         assert poly1.c1.frozen is False
@@ -182,33 +183,33 @@ class test_global(SherpaTestCase):
         assert poly3.c2.frozen is False
         assert poly3.c3.frozen is True
 
-        set_par([], 'poly.c1', 0.45)
+        datastack.set_par([], 'poly.c1', 0.45)
 
         assert poly1.c1.val == 0.45
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par([1], 'poly.c1', 0.1)
+        datastack.set_par([1], 'poly.c1', 0.1)
 
         assert poly1.c1.val == 0.1
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par([], 'const.c0', 2)
+        datastack.set_par([], 'const.c0', 2)
 
         assert const.c0.val == 2
 
-        set_par([], 'const.integrate', False)
-        freeze([], 'const.c0')
+        datastack.set_par([], 'const.integrate', False)
+        datastack.freeze([], 'const.c0')
 
-        vals = get_par([], 'poly.c1.val')
+        vals = datastack.get_par([], 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
         # QUS: pars is not checked, so is this just
         # checking that get_par doesn't fail?
-        pars = get_par([], 'const.c0')
+        pars = datastack.get_par([], 'const.c0')
 
-        fit([])
+        datastack.fit([])
 
         assert round(poly1.c1.val) == 1
         assert round(poly1.c2.val) == 3
@@ -217,7 +218,7 @@ class test_global(SherpaTestCase):
         assert round(poly3.c1.val) == 3
         assert round(poly3.c2.val) == 1
 
-        clear_stack()
+        datastack.clear_stack()
 
         x1 = np.arange(50)+100
         y1 = 7*(3*x1**2 + x1)
@@ -226,69 +227,69 @@ class test_global(SherpaTestCase):
         x3 = np.arange(50)+200
         y3 = 2*(x3**2+3*x3)
 
-        load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        set_template_id("foo")
+        datastack.set_template_id("foo")
 
-        set_source([], 'const1d.constfoo * polynom1d.polyfoo')
+        datastack.set_source([], 'const1d.constfoo * polynom1d.polyfoo')
 
         const1 = ui._session._get_model_component('const1')
         const2 = ui._session._get_model_component('const2')
         const3 = ui._session._get_model_component('const3')
 
-        link([2,3], 'const.c0')
+        datastack.link([2,3], 'const.c0')
 
-        set_par([2], 'const.c0', 3)
-        set_par([1], 'const.c0', 7)
+        datastack.set_par([2], 'const.c0', 3)
+        datastack.set_par([1], 'const.c0', 7)
 
-        freeze([1], 'const.c0')
+        datastack.freeze([1], 'const.c0')
 
         assert const2.c0.frozen is False
 
-        fit([])
+        datastack.fit([])
 
         assert const2.c0.val == const3.c0.val
         assert const3.c0._link is const2.c0
 
-        unlink([], "const.c0")
+        datastack.unlink([], "const.c0")
 
         assert const3.c0._link is not const2.c0
 
 
 class test_load(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.create_files()
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         os.remove(self.lisname)
         os.remove(self.name1)
         os.remove(self.name2)
-        set_stack_verbose(False)
+        datastack.set_stack_verbose(False)
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     def test_case_3(self):
-        load_ascii("@{}".format(self.lisname))
+        datastack.load_ascii("@{}".format(self.lisname))
         assert len(ui._session._data) == 2
-        assert len(DATASTACK.datasets) == 2
+        assert len(datastack.DATASTACK.datasets) == 2
 
-        load_data("@{}".format(self.lisname))
+        datastack.load_data("@{}".format(self.lisname))
         assert len(ui._session._data) == 4
-        assert len(DATASTACK.datasets) == 4
+        assert len(datastack.DATASTACK.datasets) == 4
 
-        load_data("@"+"/".join((self._this_dir, 'data', 'pha.lis')))
+        datastack.load_data("@"+"/".join((self._this_dir, 'data', 'pha.lis')))
         assert len(ui._session._data) == 6
-        assert len(DATASTACK.datasets) == 6
+        assert len(datastack.DATASTACK.datasets) == 6
 
     def create_files(self):
         fd1, self.name1 = tempfile.mkstemp()
@@ -324,17 +325,17 @@ class test_load(SherpaTestCase):
 class test_partial_oo(SherpaTestCase):
 
     def setUp(self):
-        self.ds = DataStack()
-        set_template_id("__ID")
-        clear_stack()
+        self.ds = datastack.DataStack()
+        datastack.set_template_id("__ID")
+        datastack.clear_stack()
         ui.clean()
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         self.ds.clear_stack()
-        clear_stack()
-        set_template_id("__ID")
+        datastack.clear_stack()
+        datastack.set_template_id("__ID")
         ui.clean()
         logger.setLevel(self.loggingLevel)
 
@@ -348,20 +349,20 @@ class test_partial_oo(SherpaTestCase):
 
         ds = self.ds
 
-        load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
 
-        set_source(ds, 'const1d.const * polynom1d.poly__ID')
+        datastack.set_source(ds, 'const1d.const * polynom1d.poly__ID')
 
         poly1 = ui._session._get_model_component('poly1')
         poly2 = ui._session._get_model_component('poly2')
         poly3 = ui._session._get_model_component('poly3')
         const = ui._session._get_model_component('const')
 
-        freeze(ds, 'poly')
-        thaw(ds, 'poly.c0')
-        thaw(ds, 'poly.c1')
-        thaw(ds, 'poly.c2')
-        thaw(ds, 'const')
+        datastack.freeze(ds, 'poly')
+        datastack.thaw(ds, 'poly.c0')
+        datastack.thaw(ds, 'poly.c1')
+        datastack.thaw(ds, 'poly.c2')
+        datastack.thaw(ds, 'const')
 
         assert poly1.c0.frozen is False
         assert poly1.c1.frozen is False
@@ -378,33 +379,33 @@ class test_partial_oo(SherpaTestCase):
         assert poly3.c2.frozen is False
         assert poly3.c3.frozen is True
 
-        set_par(ds, 'poly.c1', 0.45)
+        datastack.set_par(ds, 'poly.c1', 0.45)
 
         assert poly1.c1.val == 0.45
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par(ds[1], 'poly.c1', 0.1)
+        datastack.set_par(ds[1], 'poly.c1', 0.1)
 
         assert poly1.c1.val == 0.1
         assert poly2.c1.val == 0.45
         assert poly3.c1.val == 0.45
 
-        set_par(ds, 'const.c0', 2)
+        datastack.set_par(ds, 'const.c0', 2)
 
         assert const.c0.val == 2
 
-        set_par(ds, 'const.integrate', False)
-        freeze(ds, 'const.c0')
+        datastack.set_par(ds, 'const.integrate', False)
+        datastack.freeze(ds, 'const.c0')
 
-        vals = get_par(ds, 'poly.c1.val')
+        vals = datastack.get_par(ds, 'poly.c1.val')
         assert ([0.1, 0.45, 0.45] == vals).all()
 
         # QUS: pars is not checked, so is this just
         # checking that get_par doesn't fail?
-        pars = get_par(ds, 'const.c0')
+        pars = datastack.get_par(ds, 'const.c0')
 
-        fit(ds)
+        datastack.fit(ds)
 
         assert round(poly1.c1.val) == 1
         assert round(poly1.c2.val) == 3
@@ -422,31 +423,31 @@ class test_partial_oo(SherpaTestCase):
         x3 = np.arange(50)+200
         y3 = 2*(x3**2+3*x3)
 
-        load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
+        datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
 
-        set_template_id("foo")
+        datastack.set_template_id("foo")
 
-        set_source(ds, 'const1d.constfoo * polynom1d.polyfoo')
+        datastack.set_source(ds, 'const1d.constfoo * polynom1d.polyfoo')
 
         const1 = ui._session._get_model_component('const1')
         const2 = ui._session._get_model_component('const2')
         const3 = ui._session._get_model_component('const3')
 
-        link(ds[2,3], 'const.c0')
+        datastack.link(ds[2,3], 'const.c0')
 
-        set_par(ds[2], 'const.c0', 3)
-        set_par(ds[1], 'const.c0', 7)
+        datastack.set_par(ds[2], 'const.c0', 3)
+        datastack.set_par(ds[1], 'const.c0', 7)
 
-        freeze(ds[1], 'const.c0')
+        datastack.freeze(ds[1], 'const.c0')
 
         assert const2.c0.frozen is False
 
-        fit(ds)
+        datastack.fit(ds)
 
         assert const2.c0.val == const3.c0.val
         assert const3.c0._link is const2.c0
 
-        unlink(ds, "const.c0")
+        datastack.unlink(ds, "const.c0")
 
         assert const3.c0._link is not const2.c0
 
@@ -583,17 +584,17 @@ class test_oo(SherpaTestCase):
 
 class test_pha(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("ID")
+        datastack.set_template_id("ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
@@ -601,81 +602,86 @@ class test_pha(SherpaTestCase):
     def test_case_6(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, 'pha.lis'))
-        load_pha(ls)
+        rmf1 = '/'.join((datadir, "acisf04938_000N002_r0043_rmf3.fits"))
+        rmf2 = '/'.join((datadir, "acisf07867_000N001_r0002_rmf3.fits"))
+        arf1 = '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits"))
+        arf2 = '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits"))
+        datastack.load_pha(ls)
 
-        load_bkg_rmf([], '/'.join((datadir, "acisf04938_000N002_r0043_rmf3.fits")))
-        load_bkg_rmf([], '/'.join((datadir, "acisf07867_000N001_r0002_rmf3.fits")))
+        datastack.load_bkg_rmf([], rmf1)
+        datastack.load_bkg_rmf([], rmf2)
 
-        load_bkg_arf([], '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits")))
-        load_bkg_arf([], '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits")))
+        datastack.load_bkg_arf([], arf1)
+        datastack.load_bkg_arf([], arf2)
 
         # Define background models
-        bkg_arfs = get_bkg_arf([])
-        bkg_scales = get_bkg_scale([])
-        bkg_models = [const1d.c1 * acis_bkg_model('acis7s'),
-                      const1d.c2 * acis_bkg_model('acis7s')]
-        bkg_rsps = get_response([], bkg_id=1)
+        bkg_arfs = datastack.get_bkg_arf([])
+        bkg_scales = datastack.get_bkg_scale([])
+        bkg_models = [ui.const1d.c1 * acis_bkg_model('acis7s'),
+                      ui.const1d.c2 * acis_bkg_model('acis7s')]
+        bkg_rsps = datastack.get_response([], bkg_id=1)
         for i in range(2):
             id_ = i + 1
             # Make the ARF spectral response flat.  This is required for using
             # the acis_bkg_model.
             bkg_arfs[i].specresp = bkg_arfs[i].specresp * 0 + 1.
-            set_bkg_full_model(id_, bkg_rsps[i](bkg_models[i]))
+            datastack.set_bkg_full_model(id_, bkg_rsps[i](bkg_models[i]))
 
         # Fit background
-        notice(0.5, 8.)
-        set_method("neldermead")
-        set_stat("cash")
+        datastack.notice(0.5, 8.)
+        datastack.set_method("neldermead")
+        datastack.set_stat("cash")
 
-        thaw(c1.c0)
-        thaw(c2.c0)
-        fit_bkg()
-        freeze(c1.c0)
-        freeze(c2.c0)
+        datastack.thaw(c1.c0)
+        datastack.thaw(c2.c0)
+        datastack.fit_bkg()
+        datastack.freeze(c1.c0)
+        datastack.freeze(c2.c0)
 
         # Define source models
-        rsps = get_response([])
-        src_model = powlaw1d.pow1
+        rsps = datastack.get_response([])
+        src_model = ui.powlaw1d.pow1
         src_models = [src_model,
-                      src_model * const1d.ratio_12]
+                      src_model * ui.const1d.ratio_12]
         for i in range(2):
             id_ = i + 1
-            set_full_model(id_, (rsps[i](src_models[i]) +
-                                 bkg_scales[i] * bkg_rsps[i](bkg_models[i])))
+            datastack.set_full_model(id_, (rsps[i](src_models[i]) +
+                                           bkg_scales[i] *
+                                           bkg_rsps[i](bkg_models[i])))
 
-        fit()
+        datastack.fit()
 
 
 class test_query(SherpaTestCase):
     def setUp(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
+        datastack.set_template_id("__ID")
         self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
     def tearDown(self):
-        clear_stack()
+        datastack.clear_stack()
         ui.clean()
-        set_template_id("__ID")
-        set_stack_verbose(False)
+        datastack.set_template_id("__ID")
+        datastack.set_stack_verbose(False)
         logger.setLevel(self.loggingLevel)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     def test_case_7(self):
-        load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
+        datastack.load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
 
-        f = query_by_header_keyword('INSTRUME', 'ACIS')
+        f = datastack.query_by_header_keyword('INSTRUME', 'ACIS')
 
         assert f == [1,2]
 
-        f = query_by_obsid('7867')
+        f = datastack.query_by_obsid('7867')
 
         assert f == [2]
 
-        ds = DataStack()
+        ds = datastack.DataStack()
 
         ds.load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
 
@@ -683,7 +689,7 @@ class test_query(SherpaTestCase):
 
         assert f == [3]
 
-        f = query_by_obsid(ds, '7867')
+        f = datastack.query_by_obsid(ds, '7867')
 
         assert f == [4]
 

--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -17,22 +17,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
 import unittest
 import logging
-import os
-import os.path
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils import has_package_from_list, has_fits_support
-import sherpa.astro.sim as sim
+from sherpa.astro import sim
 
 from sherpa.astro.instrument import Response1D
-from sherpa.astro.data import DataPHA
 from sherpa.fit import Fit
-from sherpa.stats import Cash, CStat
+from sherpa.stats import CStat
 from sherpa.optmethods import NelderMead
 from sherpa.estmethods import Covariance
-
 
 logger = logging.getLogger('sherpa')
 
@@ -49,20 +44,16 @@ class test_sim(SherpaTestCase):
             from sherpa.astro.xspec import XSwabs, XSpowerlaw
         except:
             return
-        #self.startdir = os.getcwd()
+        # self.startdir = os.getcwd()
         self.old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.CRITICAL)
 
-        datadir = SherpaTestCase.datadir
-        if datadir is None:
-            return
+        pha = self.make_path("refake_0934_1_21_1e4.fak")
+        # rmf = self.make_path("ccdid7_default.rmf")
+        # arf = self.make_path("quiet_0934.arf")
 
-        pha = os.path.join(datadir, "refake_0934_1_21_1e4.fak")
-        rmf = os.path.join(datadir, "ccdid7_default.rmf")
-        arf = os.path.join(datadir, "quiet_0934.arf")
-
-        self.simarf = os.path.join(datadir, "aref_sample.fits")
-        self.pcaarf = os.path.join(datadir, "aref_Cedge.fits")
+        self.simarf = self.make_path("aref_sample.fits")
+        self.pcaarf = self.make_path("aref_Cedge.fits")
 
         data = read_pha(pha)
         data.ignore(None,0.3)
@@ -75,20 +66,15 @@ class test_sim(SherpaTestCase):
 
         self.fit = Fit(data, model, CStat(), NelderMead(), Covariance())
 
-
     def tearDown(self):
-        #os.chdir(self.startdir)
-        if hasattr(self,'old_level'):
+        # os.chdir(self.startdir)
+        if hasattr(self, 'old_level'):
             logger.setLevel(self.old_level)
 
     @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_simarf(self):
-        datadir = SherpaTestCase.datadir
-        if datadir is None:
-            return
-
         mcmc = sim.MCMC()
 
         self.abs1.nh = 0.092886
@@ -116,10 +102,6 @@ class test_sim(SherpaTestCase):
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pragbayes_pcaarf(self):
-        datadir = SherpaTestCase.datadir
-        if datadir is None:
-            return
-
         mcmc = sim.MCMC()
 
         self.abs1.nh = 0.092886
@@ -146,5 +128,10 @@ class test_sim(SherpaTestCase):
 
 if __name__ == '__main__':
 
-    import sherpa.astro.sim as sim
-    SherpaTest(sim).test(datadir="/data/scialg/testdata")
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(sim).test(datadir=datadir)

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -28,6 +28,7 @@ from sherpa.astro.data import DataPHA
 
 logger = logging.getLogger('sherpa')
 
+
 class test_threads(SherpaTestCase):
 
     def setUp(self):
@@ -56,7 +57,7 @@ class test_threads(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
+        os.chdir(self.make_path('ciao4.3', name))
         execfile(scriptname, {}, self.locals)
 
     @unittest.skipIf(not has_fits_support(),
@@ -78,7 +79,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(ui.calc_energy_flux(), 9.614847e-13, 1e-4)
         self.assertEqualWithinTol(ui.calc_data_sum(), 706.85714092, 1e-4)
         self.assertEqualWithinTol(ui.calc_model_sum(), 638.45693377, 1e-4)
-        self.assertEqualWithinTol(ui.calc_source_sum(),0.046996409, 1e-4)
+        self.assertEqualWithinTol(ui.calc_source_sum(), 0.046996409, 1e-4)
         self.assertEqualWithinTol(ui.eqwidth(self.locals['p1'],
                                              ui.get_source()),-0.57731725, 1e-4)
         self.assertEqualWithinTol(ui.calc_kcorr([1,1.2,1.4,1.6,1.8,2], 0.5, 2),
@@ -114,9 +115,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['m1'].c3.val, -0.00277729, 1e-4)
         self.assertEqualWithinTol(self.locals['m2'].c0.val, 1.75548, 1e-4)
         self.assertEqualWithinTol(self.locals['m2'].c1.val, 0.198455, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,9)
-        self.assertEqual(ui.get_fit_results().numpoints,11)
-        self.assertEqual(ui.get_fit_results().dof,9)
+        self.assertEqual(ui.get_fit_results().nfev, 9)
+        self.assertEqual(ui.get_fit_results().numpoints, 11)
+        self.assertEqual(ui.get_fit_results().dof, 9)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -132,8 +133,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['pl1'].gamma.val, 1.645, 1e-4)
         self.assertEqualWithinTol(self.locals['pl1'].ampl.val, 2.28323e-05, 1e-3)
         self.assertEqualWithinTol(self.locals['pl2'].ampl.val, 2.44585e-05, 1e-3)
-        self.assertEqual(ui.get_fit_results().numpoints,18)
-        self.assertEqual(ui.get_fit_results().dof,14)
+        self.assertEqual(ui.get_fit_results().numpoints, 18)
+        self.assertEqual(ui.get_fit_results().dof, 14)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -150,8 +151,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['b1'].norm.val, 0.00953809, 1e-2)
         self.assertEqualWithinTol(self.locals['b2'].kt.val, 0.563109, 1e-2)
         self.assertEqualWithinTol(self.locals['b2'].norm.val, 1.16118e-05, 1e-2)
-        self.assertEqual(ui.get_fit_results().numpoints,1330)
-        self.assertEqual(ui.get_fit_results().dof,1325)
+        self.assertEqual(ui.get_fit_results().numpoints, 1330)
+        self.assertEqual(ui.get_fit_results().dof, 1325)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -167,9 +168,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g2'].xpos.val, 4070.78, 1e-4)
         self.assertEqualWithinTol(self.locals['g2'].ypos.val, 4249.33, 1e-4)
         self.assertEqualWithinTol(self.locals['g2'].ampl.val, 226.563, 1e-4)
-        #self.assertEqual(ui.get_fit_results().nfev,371)
-        self.assertEqual(ui.get_fit_results().numpoints,4881)
-        self.assertEqual(ui.get_fit_results().dof,4877)
+        # self.assertEqual(ui.get_fit_results().nfev,371)
+        self.assertEqual(ui.get_fit_results().numpoints, 4881)
+        self.assertEqual(ui.get_fit_results().dof, 4877)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -186,8 +187,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['abs1'].nh.val, 6.12101, 1e-2)
         self.assertEqualWithinTol(self.locals['power'].gamma.val, 1.41887, 1e-2)
         self.assertEqualWithinTol(self.locals['power'].ampl.val, 0.00199457, 1e-2)
-        self.assertEqual(ui.get_fit_results().numpoints,42)
-        self.assertEqual(ui.get_fit_results().dof,37)
+        self.assertEqual(ui.get_fit_results().numpoints, 42)
+        self.assertEqual(ui.get_fit_results().dof, 37)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -201,9 +202,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['src'].beta.val, 4.1633, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].xpos.val, 0.0, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].ampl.val, 4.42821, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,92)
-        self.assertEqual(ui.get_fit_results().numpoints,38)
-        self.assertEqual(ui.get_fit_results().dof,35)
+        self.assertEqual(ui.get_fit_results().nfev, 92)
+        self.assertEqual(ui.get_fit_results().numpoints, 38)
+        self.assertEqual(ui.get_fit_results().dof, 35)
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro_dm(self):
@@ -222,9 +223,9 @@ class test_threads(SherpaTestCase):
             self.assertEqualWithinTol(self.locals['src'].beta.val, 4.1633, 1e-4)
             self.assertEqualWithinTol(self.locals['src'].xpos.val, 0.0, 1e-4)
             self.assertEqualWithinTol(self.locals['src'].ampl.val, 4.42821, 1e-4)
-            self.assertEqual(ui.get_fit_results().nfev,92)
-            self.assertEqual(ui.get_fit_results().numpoints,38)
-            self.assertEqual(ui.get_fit_results().dof,35)
+            self.assertEqual(ui.get_fit_results().nfev, 92)
+            self.assertEqual(ui.get_fit_results().numpoints, 38)
+            self.assertEqual(ui.get_fit_results().dof, 35)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -236,9 +237,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g1'].ypos.val, 77.2271, 1e-2)
         self.assertEqualWithinTol(self.locals['g1'].xpos.val, 88.661, 1e-2)
         self.assertEqualWithinTol(self.locals['g1'].ampl.val, 166.649, 1e-2)
-        #self.assertEqual(ui.get_fit_results().nfev,342)
-        self.assertEqual(ui.get_fit_results().numpoints,4899)
-        self.assertEqual(ui.get_fit_results().dof,4895)
+        # self.assertEqual(ui.get_fit_results().nfev,342)
+        self.assertEqual(ui.get_fit_results().numpoints, 4899)
+        self.assertEqual(ui.get_fit_results().dof, 4895)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -255,9 +256,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g1'].xpos.val, 88.940712, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].ypos.val, 76.577265, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].ampl.val, 36344.48324, 1e-4)
-        #self.assertEqual(ui.get_fit_results().nfev,978)
-        self.assertEqual(ui.get_fit_results().numpoints,4899)
-        self.assertEqual(ui.get_fit_results().dof,4895)
+        # self.assertEqual(ui.get_fit_results().nfev,978)
+        self.assertEqual(ui.get_fit_results().numpoints, 4899)
+        self.assertEqual(ui.get_fit_results().dof, 4895)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -268,9 +269,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['src'].r0.val, 83.0997, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].beta.val, 2.97737, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].ampl.val, 5.27604, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,48)
-        self.assertEqual(ui.get_fit_results().numpoints,38)
-        self.assertEqual(ui.get_fit_results().dof,35)
+        self.assertEqual(ui.get_fit_results().nfev, 48)
+        self.assertEqual(ui.get_fit_results().numpoints, 38)
+        self.assertEqual(ui.get_fit_results().dof, 35)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -281,9 +282,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['b1'].r0.val, 4.25557, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].beta.val, 0.492232, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].ampl.val, 11.8129, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,17)
-        self.assertEqual(ui.get_fit_results().numpoints,75)
-        self.assertEqual(ui.get_fit_results().dof,72)
+        self.assertEqual(ui.get_fit_results().nfev, 17)
+        self.assertEqual(ui.get_fit_results().numpoints, 75)
+        self.assertEqual(ui.get_fit_results().dof, 72)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -294,9 +295,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['b1'].r0.val, 19.2278, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].beta.val, 0.555464, 1e-4)
         self.assertEqualWithinTol(self.locals['b1'].ampl.val, 1.93706, 1e-4)
-        self.assertEqual(ui.get_fit_results().nfev,21)
-        self.assertEqual(ui.get_fit_results().numpoints,75)
-        self.assertEqual(ui.get_fit_results().dof,72)
+        self.assertEqual(ui.get_fit_results().nfev, 21)
+        self.assertEqual(ui.get_fit_results().numpoints, 75)
+        self.assertEqual(ui.get_fit_results().dof, 72)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -311,8 +312,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['mek1'].norm.val, 0.699761, 1e-4)
         self.assertEqualWithinTol(self.locals['mek2'].kt.val, 2.35845, 1e-4)
         self.assertEqualWithinTol(self.locals['mek2'].norm.val, 1.03724, 1e-4)
-        self.assertEqual(ui.get_fit_results().numpoints,446)
-        self.assertEqual(ui.get_fit_results().dof,441)
+        self.assertEqual(ui.get_fit_results().numpoints, 446)
+        self.assertEqual(ui.get_fit_results().dof, 441)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -323,9 +324,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['g1'].fwhm.val, 0.0232473, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].pos.val, 1.26713, 1e-4)
         self.assertEqualWithinTol(self.locals['g1'].ampl.val, 40.4503, 1e-4)
-        #self.assertEqual(ui.get_fit_results().nfev,19)
-        self.assertEqual(ui.get_fit_results().numpoints,50)
-        self.assertEqual(ui.get_fit_results().dof,47)
+        # self.assertEqual(ui.get_fit_results().nfev,19)
+        self.assertEqual(ui.get_fit_results().numpoints, 50)
+        self.assertEqual(ui.get_fit_results().dof, 47)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -338,9 +339,9 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['intrin'].nh.val, 11.0769, 1e-2)
         self.assertEqualWithinTol(self.locals['phard'].phoindex.val, 1.49055, 1e-2)
         self.assertEqualWithinTol(self.locals['phard'].norm.val, 0.00140301, 1e-2)
-        self.assertEqual(ui.get_fit_results().nfev,95)
-        self.assertEqual(ui.get_fit_results().numpoints,162)
-        self.assertEqual(ui.get_fit_results().dof,159)
+        self.assertEqual(ui.get_fit_results().nfev, 95)
+        self.assertEqual(ui.get_fit_results().numpoints, 162)
+        self.assertEqual(ui.get_fit_results().dof, 159)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -548,5 +549,12 @@ class test_threads(SherpaTestCase):
 if __name__ == '__main__':
 
     from sherpa.utils import SherpaTest
-    import sherpa.astro as astro
-    SherpaTest(astro).test(datadir="/data/scialg/testdata")
+    from sherpa import astro
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(astro).test(datadir=datadir)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -136,7 +136,7 @@ class test_more_ui(SherpaTestCase):
         self.img = self.make_path('img.fits')
         self.pha = self.make_path('threads/simultaneous/pi2286.fits')
         self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
-        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi'
+        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi')
 
     def tearDown(self):
         logger.setLevel(self._old_logger_level)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -21,25 +21,26 @@ import os
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase
 from sherpa.utils import test_data_missing, has_fits_support
-import sherpa.astro.ui as ui
+from sherpa.astro import ui
 import numpy
 import logging
 logger = logging.getLogger("sherpa")
+
 
 class test_ui(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.ascii = self.datadir + '/threads/ascii_table/sim.poisson.1.dat'
-        self.fits = self.datadir + '/1838_rprofile_rmid.fits'
-        self.singledat = self.datadir + '/single.dat'
-        self.singletbl = self.datadir + '/single.fits'
-        self.doubledat = self.datadir + '/double.dat'
-        self.doubletbl = self.datadir + '/double.fits'
-        self.img = self.datadir + '/img.fits'
-        self.filter_single_int_ascii = self.datadir + '/filter_single_integer.dat'
-        self.filter_single_int_table = self.datadir + '/filter_single_integer.fits'
-        self.filter_single_log_table = self.datadir + '/filter_single_logical.fits'
+        self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
+        self.fits = self.make_path('1838_rprofile_rmid.fits')
+        self.singledat = self.make_path('single.dat')
+        self.singletbl = self.make_path('single.fits')
+        self.doubledat = self.make_path('double.dat')
+        self.doubletbl = self.make_path('double.fits')
+        self.img = self.make_path('img.fits')
+        self.filter_single_int_ascii = self.make_path('filter_single_integer.dat')
+        self.filter_single_int_table = self.make_path('filter_single_integer.fits')
+        self.filter_single_log_table = self.make_path('filter_single_logical.fits')
 
         self.func = lambda x: x
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
@@ -65,6 +66,7 @@ class test_ui(SherpaTestCase):
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     def test_load_table_fits(self):
+        # QUS: why is this not in the sherpa-test-data repository?
         this_dir = os.path.dirname(os.path.abspath(__file__))
         ui.load_table(1, os.path.join(this_dir, 'data', 'two_column_x_y.fits.gz'))
         data = ui.get_data(1)
@@ -92,7 +94,6 @@ class test_ui(SherpaTestCase):
     def test_table_model_fits_image(self):
         ui.load_table_model('tbl', self.img)
 
-
     # Test user model
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -115,7 +116,6 @@ class test_ui(SherpaTestCase):
         ui.load_filter(self.filter_single_int_ascii)
         ui.load_filter(self.filter_single_int_ascii, ignore=True)
 
-
     # Test load_filter
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -133,16 +133,15 @@ class test_more_ui(SherpaTestCase):
     def setUp(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        self.img = self.datadir + '/img.fits'
-        self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
-        self.rmf = self.datadir + '/threads/simultaneous/rmf2286.fits'
-        self.pha3c273 = self.datadir + '/ciao4.3/pha_intro/3c273.pi'
-        logger.setLevel(logging.ERROR)
+        self.img = self.make_path('img.fits')
+        self.pha = self.make_path('threads/simultaneous/pi2286.fits')
+        self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
+        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi'
 
     def tearDown(self):
         logger.setLevel(self._old_logger_level)
 
-    #bug #12732
+    # bug #12732
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -152,7 +151,7 @@ class test_more_ui(SherpaTestCase):
         # Check that get_rmf(id)('modelexpression') works
         caught = False
         try:
-            m=ui.get_rmf("foo")("powlaw1d.pl1")
+            m = ui.get_rmf("foo")("powlaw1d.pl1")
         except:
             caught = True
         if caught:
@@ -170,22 +169,27 @@ class test_more_ui(SherpaTestCase):
         ui.group_counts('3c273', 30)
         ui.group_counts('3c273', 15)
 
-
 class test_image_12578(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.img = self.datadir + '/img.fits'
+        self.img = self.make_path('img.fits')
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         ui.clean()
 
-    #bug #12578
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
+
+    # bug #12578
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_coord_bad_coord(self):
         from sherpa.utils.err import IdentifierErr, DataErr
 
-        # Test Case #1: if the list of ids is empty, raise a IdentifierErr['nodatasets']
+        # Test Case #1: if the list of ids is empty, raise
+        # IdentifierErr['nodatasets']
         caught = False
         try:
             ui.set_coord('image')
@@ -194,8 +198,9 @@ class test_image_12578(SherpaTestCase):
         if not caught:
             self.fail("Test Case #1: IdentifierErr Exception not caught")
 
-        # Test Case #2: check the user expected behavior. The call set_coord("sky")
-        # will result in the error message DataErr: unknown coordinates: 'sky'\n \
+        # Test Case #2: check the user expected behavior. The call
+        # set_coord("sky") will result in the error message
+        # DataErr: unknown coordinates: 'sky'\n \
         # Valid coordinates: logical, image, physical, world, wcs
         ui.load_image(self.img)
 
@@ -208,6 +213,7 @@ class test_image_12578(SherpaTestCase):
             caught = True
         if not caught:
             self.fail("Test Case #2: DataErr Exception not caught")
+
 
 class test_psf_ui(SherpaTestCase):
 
@@ -229,8 +235,8 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf1d', model+'.mdl')
                 ui.set_psf('psf1d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([4])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([4])).all())
             except:
                 print model
                 raise
@@ -242,22 +248,23 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf2d', model+'.mdl')
                 ui.set_psf('psf2d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([108,130])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([108,130])).all())
             except:
                 print model
                 raise
 
-    #bug #12503
+    # bug #12503
     def test_psf_pars_are_frozen(self):
         ui.load_psf('psf', ui.beta2d.p1)
         self.assertEqual([], p1.thawedpars)
+
 
 class test_stats_ui(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.data = self.datadir + '/threads/chi2/3c273.pi'
+        self.data = self.make_path('threads/chi2/3c273.pi')
         ui.clean()
 
     # bugs #11400, #13297, #12365
@@ -266,8 +273,9 @@ class test_stats_ui(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_chi2(self):
 
-        #Case 1: first ds has no error, second has, chi2-derived (chi2gehrels) statistic
-        #I expect stat.name to be chi2gehrels for ds1, chi2 for ds2, chi2gehrels for ds1,2
+        # Case 1: first ds has no error, second has, chi2-derived (chi2gehrels)
+        # statistic. I expect stat.name to be chi2gehrels for ds1, chi2 for
+        # ds2, chi2gehrels for ds1,2
         ui.load_data(1, self.data)
         ui.load_data(2, self.data, use_errors=True)
 
@@ -276,7 +284,7 @@ class test_stats_ui(SherpaTestCase):
 
         ui.set_stat("chi2gehrels")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
@@ -286,105 +294,106 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat2)
         self.assertEqual('chi2gehrels', stat12)
 
-        #Case 2: first ds has errors, second has not, chi2-derived (chi2gehrels) statistic
-        #I expect stat.name to be chi2 for ds1, chi2gehrels for ds2, chi2gehrels for ds1,2
+        # Case 2: first ds has errors, second has not, chi2-derived
+        # (chi2gehrels) statistic. I expect stat.name to be chi2 for ds1,
+        # chi2gehrels for ds2, chi2gehrels for ds1,2
         ui.load_data(2, self.data)
         ui.load_data(1, self.data, use_errors=True)
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('chi2gehrels', stat2)
         self.assertEqual('chi2', stat1)
         self.assertEqual('chi2gehrels', stat12)
 
-        #Case 3: both datasets have errors, chi2-derived (chi2gehrels) statistic
-        #I expect stat.name to be chi2 for ds1, chi2 for ds2, chi2 for ds1,2
+        # Case 3: both datasets have errors, chi2-derived (chi2gehrels)
+        # statistic. I expect stat.name to be chi2 for all of them.
         ui.load_data(2, self.data, use_errors=True)
         ui.load_data(1, self.data, use_errors=True)
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('chi2', stat2)
         self.assertEqual('chi2', stat1)
         self.assertEqual('chi2', stat12)
 
-        #Case 4: first ds has errors, second has not, LeastSq statistic
-        #I expect stat.name to be leastsq for ds1, leastsq for ds2, leastsq for ds1,2
+        # Case 4: first ds has errors, second has not, LeastSq statistic
+        # I expect stat.name to be leastsq for all of them.
         ui.load_data(2, self.data)
         ui.load_data(1, self.data, use_errors=True)
 
         ui.set_stat("leastsq")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('leastsq', stat2)
         self.assertEqual('leastsq', stat1)
         self.assertEqual('leastsq', stat12)
 
-        #Case 5: both ds have errors, LeastSq statistic
-        #I expect stat.name to be leastsq for ds1, leastsq for ds2, leastsq for ds1,2
+        # Case 5: both ds have errors, LeastSq statistic
+        # I expect stat.name to be leastsq for all of them.
         ui.load_data(2, self.data, use_errors=True)
         ui.load_data(1, self.data, use_errors=True)
 
         ui.set_stat("leastsq")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('leastsq', stat2)
         self.assertEqual('leastsq', stat1)
         self.assertEqual('leastsq', stat12)
 
-        #Case 6: first ds has errors, second has not, CStat statistic
-        #I expect stat.name to be cstat for ds1, cstat for ds2, cstat for ds1,2
+        # Case 6: first ds has errors, second has not, CStat statistic
+        # I expect stat.name to be cstat for all of them.
         ui.load_data(2, self.data)
         ui.load_data(1, self.data, use_errors=True)
 
         ui.set_stat("cstat")
 
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
-        stat12 = si[2].statname	
+        stat12 = si[2].statname
 
         self.assertEqual('cstat', stat2)
         self.assertEqual('cstat', stat1)
         self.assertEqual('cstat', stat12)
 
-        #Case7: select chi2 as statistic. One of the ds does not provide errors
-        #I expect sherpa to raise a StatErr exception.
+        # Case7: select chi2 as statistic. One of the ds does not provide
+        # errors. I expect sherpa to raise a StatErr exception.
         ui.set_stat('chi2')
 
-        caught=False
+        caught = False
 
         from sherpa.utils.err import StatErr
         try:
             ui.get_stat_info()
         except StatErr:
-            caught=True
+            caught = True
 
-        self.assertTrue(caught)
+        self.assertTrue(caught, msg='StatErr was not caught')
 
-        #Case8: select chi2 as statistic. Both datasets provide errors
-        #I expect stat to be 'chi2'
+        # Case8: select chi2 as statistic. Both datasets provide errors
+        # I expect stat to be 'chi2'
         ui.load_data(2, self.data, use_errors=True)
-        si=ui.get_stat_info()
+        si = ui.get_stat_info()
 
         stat1 = si[0].statname
         stat2 = si[1].statname
@@ -395,9 +404,12 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat12)
 
 
-
 if __name__ == '__main__':
 
     import sys
     if len(sys.argv) > 1:
-        SherpaTest(ui).test(datadir=sys.argv[1])
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2013, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -17,16 +17,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
-
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils import has_fits_support
-import sherpa.astro.ui as ui
+from sherpa.astro import ui
 import logging
 import os
 import numpy
 logger = logging.getLogger("sherpa")
+
 
 class test_more_ui(SherpaTestCase):
     def assign_model(self, name, obj):
@@ -36,16 +35,25 @@ class test_more_ui(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
-        execfile(scriptname, {}, self.locals)
+        cwd = os.getcwd()
+        os.chdir(self.make_path('ciao4.3', name))
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.img = self.datadir + '/img.fits'
-        self.pha = self.datadir + '/threads/simultaneous/pi2286.fits'
-        self.rmf = self.datadir + '/threads/simultaneous/rmf2286.fits'
-        self.nan = self.datadir + '/ciao4.3/filternan/with_nan.fits'
+        self.img = self.make_path('img.fits')
+        self.pha = self.make_path('threads/simultaneous/pi2286.fits')
+        self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
+        self.nan = self.make_path('ciao4.3/filternan/with_nan.fits')
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
+
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
 
     # bug 12784
     @unittest.skipIf(not has_fits_support(),
@@ -59,4 +67,8 @@ if __name__ == '__main__':
 
     import sys
     if len(sys.argv) > 1:
-        SherpaTest(ui).test(datadir=sys.argv[1])
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -95,9 +95,9 @@ class test_new_templates_ui(SherpaTestCase):
 
     # TestCase 5 user can access interpolators' parvals
     @unittest.skipIf(test_data_missing(), "required test data missing")
-    def test_grid_search_with_discrete_template(self):
-        self.run_thread('load_template_with_interpolation', scriptname='test_case_5.py')
-
+    def test_grid_search_with_discrete_template_parvals(self):
+        self.run_thread('load_template_with_interpolation',
+                        scriptname='test_case_5.py')
 
 
 class test_template(SherpaTestCase):

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -20,13 +20,16 @@
 
 import unittest
 from sherpa.models import TableModel, Gauss1D
-from sherpa.models.template import TemplateModel, create_template_model
+from sherpa.models.template import create_template_model
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.utils.err import ModelErr
 from sherpa import ui
-import numpy, logging, os
+import numpy
+import logging
+import os
 
 logger = logging.getLogger("sherpa")
+
 
 class test_new_templates_ui(SherpaTestCase):
     def assign_model(self, name, obj):
@@ -36,12 +39,19 @@ class test_new_templates_ui(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(os.path.join(self.datadir, 'ciao4.3', name))
-        execfile(scriptname, {}, self.locals)
+        cwd = os.getcwd()
+        os.chdir(self.make_path('ciao4.3', name))
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
 
     def setUp(self):
+        self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
+    def tearDown(self):
+        logger.setLevel(self.loggingLevel)
 
     # Regression reported by Aneta (original report by Fabrizio Nicastro)
     # When restoring a file saved with an older version of sherpa,
@@ -51,12 +61,11 @@ class test_new_templates_ui(SherpaTestCase):
     def test_restore_is_discrete(self):
         self.run_thread('template_restore', 'test.py')
 
-
     # TestCase 1 load_template_model enables interpolation by default
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_with_interpolation(self):
         self.run_thread('load_template_with_interpolation')
-        try:   
+        try:
             self.assertEqualWithinTol(2023.46, ui.get_fit_results().parvals[0], 0.001)
             self.assertEqualWithinTol(2743.47, ui.get_fit_results().parvals[1], 0.001)
         except:
@@ -69,11 +78,12 @@ class test_new_templates_ui(SherpaTestCase):
         self.assertEqualWithinTol(2743.91, ui.get_fit_results().parvals[0], 0.001)
 
     # TestCase 2 load_template_model with template_interpolator_name=None disables interpolation
-    # TestCase 3.1 discrete templates fail when probed for values they do not represent (gridsearch with wrong values) 
+    # TestCase 3.1 discrete templates fail when probed for values they do not represent (gridsearch with wrong values)
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
-        try:   
-            self.run_thread('load_template_without_interpolation', scriptname='test_case_2_and_3.1.py')
+        try:
+            self.run_thread('load_template_without_interpolation',
+                            scriptname='test_case_2_and_3.1.py')
         except ModelErr:
             return
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
@@ -81,17 +91,18 @@ class test_new_templates_ui(SherpaTestCase):
     # TestCase 3.2 discrete templates fail when probed for values they do not represent (continuous method with discrete template)
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
-        try:   
-            self.run_thread('load_template_without_interpolation', scriptname='test_case_3.2.py')
+        try:
+            self.run_thread('load_template_without_interpolation',
+                            scriptname='test_case_3.2.py')
         except ModelErr:
             return
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
 
-
     # TestCase 4 gridsearch with right values succeeds
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_grid_search_with_discrete_template(self):
-        self.run_thread('load_template_without_interpolation', scriptname='test_case_4.py')
+        self.run_thread('load_template_without_interpolation',
+                        scriptname='test_case_4.py')
 
     # TestCase 5 user can access interpolators' parvals
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -128,10 +139,10 @@ class test_template(SherpaTestCase):
     def tearDown(self):
         self.model = None
 
-
     def test_template_model_evaluation(self):
         self.model.thawedpars = [0,1,0,1]
-        vals = self.model(self.x)
+        # We want to evaluate the model, but do not check the result
+        self.model(self.x)
 
 #    def test_template_query_index(self):
 #        expected = 5
@@ -143,8 +154,14 @@ class test_template(SherpaTestCase):
 #        result = self.model.query([0,1,0,1])
 
 
-
 if __name__ == '__main__':
 
-    import sherpa.models as models
-    SherpaTest(models).test()
+    from sherpa import models
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(models).test(datadir=datadir)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,9 +20,8 @@
 import unittest
 import numpy
 from sherpa.all import *
-#FIXME change from full import 
+# FIXME change from full import
 from sherpa.utils import SherpaTestCase, test_data_missing
-
 
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
@@ -48,6 +47,7 @@ _datay = numpy.array(
        0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,
        0.])
 
+
 class test_plot(SherpaTestCase):
 
     def setUp(self):
@@ -58,32 +58,32 @@ class test_plot(SherpaTestCase):
     def test_dataplot(self):
         dp = DataPlot()
         dp.prepare(self.data, self.f.stat)
-        #dp.plot()
+        # dp.plot()
 
     def test_modelplot(self):
         mp = ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
-        #mp.plot()
+        # mp.plot()
 
     def test_residplot(self):
         rp = ResidPlot()
         rp.prepare(self.data, self.g1, self.f.stat)
-        #rp.plot()
+        # rp.plot()
 
     def test_delchiplot(self):
         dp = DelchiPlot()
         dp.prepare(self.data, self.g1, self.f.stat)
-        #dp.plot()
+        # dp.plot()
 
     def test_chisqrplot(self):
         cs = ChisqrPlot()
         cs.prepare(self.data, self.g1, self.f.stat)
-        #cs.plot()
+        # cs.plot()
 
     def test_ratioplot(self):
         tp = RatioPlot()
         tp.prepare(self.data, self.g1, self.f.stat)
-        #tp.plot()
+        # tp.plot()
 
     def test_fitplot(self):
         dp = DataPlot()
@@ -94,7 +94,7 @@ class test_plot(SherpaTestCase):
 
         fp = FitPlot()
         fp.prepare(dp,mp)
-        #fp.plot()
+        # fp.plot()
 
     def test_splitplot(self):
         dp = DataPlot()
@@ -110,16 +110,17 @@ class test_plot(SherpaTestCase):
         fp.prepare(dp,mp)
 
         sp = SplitPlot(2,2)
-        #sp.addplot(dp)
-        #sp.addplot(mp)
-        #sp.addplot(fp)
-        #sp.addplot(rp)
+        # sp.addplot(dp)
+        # sp.addplot(mp)
+        # sp.addplot(fp)
+        # sp.addplot(rp)
+
 
 class test_contour(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.data = read_data(self.datadir+'/gauss2d.dat',
+        self.data = read_data(self.make_path('gauss2d.dat'),
                               ncols=3, sep='\t', dstype=Data2D)
         self.g1 = Gauss2D('g1')
         self.g1.ellip.freeze()
@@ -127,33 +128,33 @@ class test_contour(SherpaTestCase):
         self.f = Fit(self.data, self.g1)
         self.levels = numpy.array([0.5, 2, 5, 10, 20])
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")    
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_datacontour(self):
         dc = DataContour()
         dc.prepare(self.data)
-        dc.levels=self.levels
-        #dc.contour()
+        dc.levels = self.levels
+        # dc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")    
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_modelcontour(self):
         mc = ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
-        mc.levels=self.levels
-        #mc.contour()
+        mc.levels = self.levels
+        # mc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")   
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_residcontour(self):
         rc = ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
-        rc.levels=self.levels
-        #rc.contour()
+        rc.levels = self.levels
+        # rc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ratiocontour(self):
         tc = RatioContour()
         tc.prepare(self.data, self.g1, self.f.stat)
-        tc.levels=self.levels
-        #tc.contour()
+        tc.levels = self.levels
+        # tc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fitcontour(self):
@@ -163,37 +164,37 @@ class test_contour(SherpaTestCase):
         mc = ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()        
+        fc = FitContour()
         fc.prepare(dc, mc)
-        #fc.contour()
+        # fc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_splitcontour(self):
         dc = DataContour()
-        dc.levels=self.levels
+        dc.levels = self.levels
         dc.prepare(self.data)
 
         mc = ModelContour()
-        mc.levels=self.levels
+        mc.levels = self.levels
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()        
+        fc = FitContour()
         fc.prepare(dc, mc)
 
         rc = ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
-        rc.levels=self.levels
+        rc.levels = self.levels
 
         sp = SplitPlot(2,2)
-        #sp.addcontour(dc)
-        #sp.addcontour(mc)
-        #sp.addcontour(fc)
-        #sp.addcontour(rc)
+        # sp.addcontour(dc)
+        # sp.addcontour(mc)
+        # sp.addcontour(fc)
+        # sp.addcontour(rc)
 
 class test_confidence(SherpaTestCase):
 
     def setUp(self):
-        self.data = Data1D('testdata',_datax,_datay)
+        self.data = Data1D('testdata', _datax, _datay)
         self.g1 = Gauss1D('g1')
         self.f = Fit(self.data, self.g1)
         self.f.fit()
@@ -202,7 +203,7 @@ class test_confidence(SherpaTestCase):
         self.rp = RegionProjection()
         self.ru = RegionUncertainty()
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_projection(self):
         _ipx = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -221,10 +222,10 @@ class test_confidence(SherpaTestCase):
         self.ip.calc(self.f, self.g1.fwhm)
         self.assertEqualWithinTol(_ipx, self.ip.x, 1e-4)
         self.assertEqualWithinTol(_ipy, self.ip.y, 1e-4)
-        #self.ip.plot()
+        # self.ip.plot()
 
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_uncertainty(self):
         _iux = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -244,9 +245,9 @@ class test_confidence(SherpaTestCase):
         self.iu.calc(self.f, self.g1.fwhm)
         self.assertEqualWithinTol(_iux, self.iu.x, 1e-4)
         self.assertEqualWithinTol(_iuy, self.iu.y, 1e-4)
-        #self.iu.plot()
+        # self.iu.plot()
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_projection(self):
         _rpx0 = numpy.array(
             [ 11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
@@ -324,10 +325,10 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_rpx0, self.rp.x0, 1e-4)
         self.assertEqualWithinTol(_rpx1, self.rp.x1, 1e-4)
         self.assertEqualWithinTol(_rpy, self.rp.y, 1e-4)
-        #self.rp.contour()
+        # self.rp.contour()
 
 
-    #@unittest.skipIf(test_data_missing(), "required test data missing")
+    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_uncertainty(self):
         _rux0 = numpy.array(
             [ 12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
@@ -405,9 +406,16 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_rux0, self.ru.x0, 1e-4)
         self.assertEqualWithinTol(_rux1, self.ru.x1, 1e-4)
         self.assertEqualWithinTol(_ruy, self.ru.y, 1e-4)
-        #self.ru.contour()
+        # self.ru.contour()
 
 if __name__ == '__main__':
     from sherpa.utils import SherpaTest
     import sherpa.plot
-    SherpaTest(sherpa.plot).test()
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(sherpa.plot).test(datadir=datadir)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -19,8 +19,7 @@
 
 import unittest
 import numpy
-from sherpa.all import *
-# FIXME change from full import
+import sherpa.all as sherpa
 from sherpa.utils import SherpaTestCase, test_data_missing
 
 _datax = numpy.array(
@@ -51,65 +50,65 @@ _datay = numpy.array(
 class test_plot(SherpaTestCase):
 
     def setUp(self):
-        self.data = Data1D('testdata',_datax,_datay)
-        self.g1 = Gauss1D('g1')
-        self.f = Fit(self.data, self.g1)
+        self.data = sherpa.Data1D('testdata',_datax,_datay)
+        self.g1 = sherpa.Gauss1D('g1')
+        self.f = sherpa.Fit(self.data, self.g1)
 
     def test_dataplot(self):
-        dp = DataPlot()
+        dp = sherpa.DataPlot()
         dp.prepare(self.data, self.f.stat)
         # dp.plot()
 
     def test_modelplot(self):
-        mp = ModelPlot()
+        mp = sherpa.ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
         # mp.plot()
 
     def test_residplot(self):
-        rp = ResidPlot()
+        rp = sherpa.ResidPlot()
         rp.prepare(self.data, self.g1, self.f.stat)
         # rp.plot()
 
     def test_delchiplot(self):
-        dp = DelchiPlot()
+        dp = sherpa.DelchiPlot()
         dp.prepare(self.data, self.g1, self.f.stat)
         # dp.plot()
 
     def test_chisqrplot(self):
-        cs = ChisqrPlot()
+        cs = sherpa.ChisqrPlot()
         cs.prepare(self.data, self.g1, self.f.stat)
         # cs.plot()
 
     def test_ratioplot(self):
-        tp = RatioPlot()
+        tp = sherpa.RatioPlot()
         tp.prepare(self.data, self.g1, self.f.stat)
         # tp.plot()
 
     def test_fitplot(self):
-        dp = DataPlot()
+        dp = sherpa.DataPlot()
         dp.prepare(self.data, self.f.stat)
 
-        mp = ModelPlot()
+        mp = sherpa.ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
 
-        fp = FitPlot()
+        fp = sherpa.FitPlot()
         fp.prepare(dp,mp)
         # fp.plot()
 
     def test_splitplot(self):
-        dp = DataPlot()
+        dp = sherpa.DataPlot()
         dp.prepare(self.data, self.f.stat)
 
-        mp = ModelPlot()
+        mp = sherpa.ModelPlot()
         mp.prepare(self.data, self.g1, self.f.stat)
 
-        rp = ResidPlot()
+        rp = sherpa.ResidPlot()
         rp.prepare(self.data, self.g1, self.f.stat)
 
-        fp = FitPlot()
+        fp = sherpa.FitPlot()
         fp.prepare(dp,mp)
 
-        sp = SplitPlot(2,2)
+        sp = sherpa.SplitPlot(2,2)
         # sp.addplot(dp)
         # sp.addplot(mp)
         # sp.addplot(fp)
@@ -120,72 +119,72 @@ class test_contour(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.data = read_data(self.make_path('gauss2d.dat'),
-                              ncols=3, sep='\t', dstype=Data2D)
-        self.g1 = Gauss2D('g1')
+        self.data = sherpa.read_data(self.make_path('gauss2d.dat'),
+                                     ncols=3, sep='\t', dstype=sherpa.Data2D)
+        self.g1 = sherpa.Gauss2D('g1')
         self.g1.ellip.freeze()
         self.g1.theta.freeze()
-        self.f = Fit(self.data, self.g1)
+        self.f = sherpa.Fit(self.data, self.g1)
         self.levels = numpy.array([0.5, 2, 5, 10, 20])
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_datacontour(self):
-        dc = DataContour()
+        dc = sherpa.DataContour()
         dc.prepare(self.data)
         dc.levels = self.levels
         # dc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_modelcontour(self):
-        mc = ModelContour()
+        mc = sherpa.ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
         mc.levels = self.levels
         # mc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_residcontour(self):
-        rc = ResidContour()
+        rc = sherpa.ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
         rc.levels = self.levels
         # rc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ratiocontour(self):
-        tc = RatioContour()
+        tc = sherpa.RatioContour()
         tc.prepare(self.data, self.g1, self.f.stat)
         tc.levels = self.levels
         # tc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fitcontour(self):
-        dc = DataContour()
+        dc = sherpa.DataContour()
         dc.prepare(self.data)
 
-        mc = ModelContour()
+        mc = sherpa.ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()
+        fc = sherpa.FitContour()
         fc.prepare(dc, mc)
         # fc.contour()
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_splitcontour(self):
-        dc = DataContour()
+        dc = sherpa.DataContour()
         dc.levels = self.levels
         dc.prepare(self.data)
 
-        mc = ModelContour()
+        mc = sherpa.ModelContour()
         mc.levels = self.levels
         mc.prepare(self.data, self.g1, self.f.stat)
 
-        fc = FitContour()
+        fc = sherpa.FitContour()
         fc.prepare(dc, mc)
 
-        rc = ResidContour()
+        rc = sherpa.ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
         rc.levels = self.levels
 
-        sp = SplitPlot(2,2)
+        sp = sherpa.SplitPlot(2,2)
         # sp.addcontour(dc)
         # sp.addcontour(mc)
         # sp.addcontour(fc)
@@ -194,14 +193,14 @@ class test_contour(SherpaTestCase):
 class test_confidence(SherpaTestCase):
 
     def setUp(self):
-        self.data = Data1D('testdata', _datax, _datay)
-        self.g1 = Gauss1D('g1')
-        self.f = Fit(self.data, self.g1)
+        self.data = sherpa.Data1D('testdata', _datax, _datay)
+        self.g1 = sherpa.Gauss1D('g1')
+        self.f = sherpa.Fit(self.data, self.g1)
         self.f.fit()
-        self.ip = IntervalProjection()
-        self.iu = IntervalUncertainty()
-        self.rp = RegionProjection()
-        self.ru = RegionUncertainty()
+        self.ip = sherpa.IntervalProjection()
+        self.iu = sherpa.IntervalUncertainty()
+        self.rp = sherpa.RegionProjection()
+        self.ru = sherpa.RegionUncertainty()
 
     # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_projection(self):

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -23,6 +23,7 @@ import sherpa
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa import ui
 
+
 class test_sherpa(SherpaTestCase):
 
     def test_include_dir(self):
@@ -31,9 +32,9 @@ class test_sherpa(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.agn2 = self.datadir + '/ciao4.3/faulty_load_data/agn2'
-        self.agn2_fixed = self.datadir + '/ciao4.3/faulty_load_data/agn2_fixed'
-        self.template_idx = self.datadir + '/ciao4.3/faulty_load_data/table.txt'
+        self.agn2 = self.make_path('ciao4.3/faulty_load_data/agn2')
+        self.agn2_fixed = self.make_path('ciao4.3/faulty_load_data/agn2_fixed')
+        self.template_idx = self.make_path('ciao4.3/faulty_load_data/table.txt')
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_not_reading_header_without_comment(self):
@@ -50,3 +51,15 @@ class test_sherpa(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_require_float(self):
         self.assertRaises(ValueError, ui.load_data, self.agn2)
+
+if __name__ == '__main__':
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    # This is probably not what you want, since it also runs
+    # all the tests in sub-modules
+    SherpaTest(sherpa).test(datadir=datadir)

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -21,11 +21,9 @@
 import unittest
 from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
 from sherpa.models import ArithmeticModel, Parameter
-from sherpa.utils.err import ModelErr
-import sherpa.ui as ui
-import numpy, logging, os
+from sherpa import ui
+import numpy
 
-logger = logging.getLogger("sherpa")
 
 class UserModel(ArithmeticModel):
 
@@ -39,14 +37,15 @@ class UserModel(ArithmeticModel):
     def calc(self, p, x, *args, **kwargs):
         return p[0]*x+p[1]
 
+
 class test_ui(SherpaTestCase):
 
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
-        self.ascii = self.datadir + '/threads/ascii_table/sim.poisson.1.dat'
-        self.single = self.datadir + '/single.dat'
-        self.double = self.datadir + '/double.dat'
-        self.filter = self.datadir + '/filter_single_integer.dat'
+        self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
+        self.single = self.make_path('single.dat')
+        self.double = self.make_path('double.dat')
+        self.filter = self.make_path('filter_single_integer.dat')
         self.func = lambda x: x
 
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
@@ -137,8 +136,8 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf1d', model+'.mdl')
                 ui.set_psf('psf1d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([4])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([4])).all())
             except:
                 print model
                 raise
@@ -151,8 +150,8 @@ class test_psf_ui(SherpaTestCase):
                 ui.load_psf('psf2d', model+'.mdl')
                 ui.set_psf('psf2d')
                 mdl = ui.get_model_component('mdl')
-                self.assert_( (numpy.array(mdl.get_center()) ==
-                               numpy.array([108,130])).all() )
+                self.assertTrue((numpy.array(mdl.get_center()) ==
+                                 numpy.array([108,130])).all())
             except:
                 print model
                 raise

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -130,7 +130,7 @@ class test_psf_ui(SherpaTestCase):
     def tearDown(self):
         pass
 
-    def test_psf_model2d(self):
+    def test_psf_model1d(self):
         ui.dataspace1d(1, 10)
         for model in self.models1d:
             try:
@@ -162,4 +162,8 @@ if __name__ == '__main__':
 
     import sys
     if len(sys.argv) > 1:
-        SherpaTest(ui).test(datadir=sys.argv[1])
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -211,31 +211,50 @@ def _get_datadir():
 class SherpaTestCase(numpytest.NumpyTestCase):
     "Base class for Sherpa unit tests"
 
+    # The location of the Sherpa test data (it is optional)
     datadir = _get_datadir()
 
+    # What is the benefit of this over numpy.testing.assert_allclose(),
+    # which was added in version 1.5 of NumPy?
     def assertEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
         """
 
-        Test first and second for floating-point equality to within
-        the given tolerance.  If first and second are arrays, then
-        they will be tested for equality on an element-by-element
-        basis.
-
-        """
-
-        self.assert_(not numpy.any(sao_fcmp(first, second, tol)), msg)
+        self.assertFalse(numpy.any(sao_fcmp(first, second, tol)), msg)
 
     def assertNotEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are not equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
         """
 
-        Test first and second for floating-point inequality to within
-        the given tolerance.  If first and second are arrays, then
-        they will be tested for inequality on an element-by-element
-        basis.
-
-        """
-
-        self.assert_(numpy.all(sao_fcmp(first, second, tol)), msg)
+        self.assertTrue(numpy.all(sao_fcmp(first, second, tol)), msg)
 
 
 def test_data_missing():

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -29,6 +29,7 @@ from types import FunctionType as function
 from types import MethodType as instancemethod
 import string
 import sys
+import os
 import importlib
 import numpy
 import numpy.random
@@ -213,6 +214,26 @@ class SherpaTestCase(numpytest.NumpyTestCase):
 
     # The location of the Sherpa test data (it is optional)
     datadir = _get_datadir()
+
+    def make_path(self, *segments):
+        """Add the segments onto the test data location.
+
+        Parameters
+        ----------
+        *segments
+           Path segments to combine together with the location of the
+           test data.
+
+        Returns
+        -------
+        fullpath : None or string
+           The full path to the repository, or None if the
+           data directory is not set.
+
+        """
+        if self.datadir is None:
+            return None
+        return os.path.join(self.datadir, *segments)
 
     # What is the benefit of this over numpy.testing.assert_allclose(),
     # which was added in version 1.5 of NumPy?

--- a/sherpa/utils/src/_utils.cc
+++ b/sherpa/utils/src/_utils.cc
@@ -1052,7 +1052,33 @@ static PyMethodDef UtilsFcts[] = {
   FCTSPEC(gsl_fcmp, _sherpa_fcmp< gsl_fcmp >), 
 
   //Same as gsl_fcmp, but also handles the case where one of the args is 0.
-  FCTSPEC(sao_fcmp, _sherpa_fcmp< sao_fcmp >),
+  // FCTSPEC(sao_fcmp, _sherpa_fcmp< sao_fcmp >),
+  { (char*) "sao_fcmp", (PyCFunction)(_sherpa_fcmp< sao_fcmp >), METH_VARARGS,
+    (char*) "sao_fcmp(x, y, tol)\n\n"
+            "Compare y to x, using an absolute tolerance.\n"
+            PARAMETERSDOC
+            "first : number or array_like\n"
+            "   The expected value, or values.\n"
+            "second : number or array_like\n"
+            "   The value, or values, to check. If first is an array, then\n"
+            "   second must be an array of the same size. If first is\n"
+            "   a scalar then second can be a scalar or an array.\n"
+            "tol : number\n"
+            "   The absolute tolerance used for comparison.\n"
+            RETURNSDOC
+            "flags : int or array_like\n"
+            "   0, 1, or -1 for each value in second. If the values\n"
+            "   match, then 0, otherwise -1 if the expected value (x)\n"
+            "   is less than the comparison value (y) or +1 if x is\n"
+            "   larger than y.\n"
+            EXAMPLESDOC
+            ">>> sao_fcmp(1, 1.01, 0.01)\n"
+            "0\n\n"
+            ">>> sao_fcmp(1, [0.9, 1, 1.1], 0.01)\n"
+            "array([ 1,  0, -1], dtype=int32)\n\n"
+            ">>> utils.sao_fcmp([1.2, 2.3], [1.22, 2.29], 0.01)\n"
+            "array([-1,  0], dtype=int32)\n\n"
+  },
 
   //Rebin to new grid
   { (char*) "rebin", (PyCFunction)(rebin<SherpaFloatArray, SherpaFloat>), METH_VARARGS,


### PR DESCRIPTION
This PR replaces #71.

The aim was to add the `SherpaTestCase.make_path()` routine for adding paths to the data directory, and use it in the code. A secondary change was to improve support for running an individual file - e.g. `python sherpa/astro/datastack/tests/test_datastack.py` - with or without the Sherpa test directory.

Two tests which were previously skipped - due to name clashes - have been re-named: `sherpa/models/tests/test_template.py::test_grid_search_with_discrete_template_parvals` and `sherpa/ui/tests/test_ui.py::test_psf_model1d``.

For those tests that changed the logging level in their `setUp` method, the level has been restored in `tearDown` (not checked for all tests, just those looked at here). Similarly, some directory changes (in those tests with a `run_thread` method) were changed to ensure that the original directory was restored.

There was also some minor code cleanup (e.g. removal of unused imports and adding/deleting spaces).

I have not changed the XSpec module tests since I know there's changes (e.g. PR #63) so not worth working on here.

These changes build on the test-suite cleanup in PR #70. I am not convinced I "git-ted" things correctly to link things together properly.