### PR TITLE
Feature/xspec remove xopen source redefinition warning

### DIFF
--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -22,9 +22,11 @@
 int _sherpa_init_xspec_library();
 #define INIT_XSPEC _sherpa_init_xspec_library
 
+// Have sherpa include first so that Python.h is first, to avoid warning
+// messages about redefining _XOPEN_SOURCE
+#include "sherpa/astro/xspec_extension.hh"
 #include <iostream>
 #include <fstream>
-#include "sherpa/astro/xspec_extension.hh"
 
 #define ABUND_SIZE (30) // number of elements in Solar Abundance table
 

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -20,9 +20,11 @@
 #ifndef __sherpa_astro_xspec_extension_hh__
 #define __sherpa_astro_xspec_extension_hh__
 
-#include <cfloat>
+// Have sherpa includes first so that Python.h is first, to avoid warning
+// messages about redefining _XOPEN_SOURCE
 #include <sherpa/extension.hh>
 #include <sherpa/constants.hh>
+#include <cfloat>
 #include <vector>
 #include <sstream>
 #include <iostream>

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Avoid warnings about _POSIX_C_SOURCE and _XOPEN_SOURCE symbols being redefined when
compiling _xspec.cc. The trick is to make sure Python.h is the first file to be included (it is included by sherpa/array.hh which is included by sherpa/extension.hh).

This is the first part of breaking up PR #63 into smaller chunks.