### PR TITLE
Ensure Xspec models return 0's in case of error.

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -80,14 +80,9 @@ class test_xspec(SherpaTestCase):
         xhi = numpy.array(xx[1:])
         for model in models:
             cls = getattr(xs, model)
-            foo = cls('foo')
+            foo = cls(model)  # use an identifier in case there is an error
+            # The model checks that the values are all finite.
             vals = foo(xlo,xhi)
-            try:
-                self.assert_(not numpy.isnan(vals).any() and
-                             not numpy.isinf(vals).any() )
-            except AssertionError:
-                error('XS%s model evaluation failed' % model)
-                raise
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits')

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -34,6 +34,14 @@ namespace sherpa { namespace astro { namespace xspec {
 typedef sherpa::Array< float, NPY_FLOAT > FloatArray;
 typedef float FloatArrayType;
 
+// When creating the flux and flux error arrays to be sent to
+// the XSpec routines, the arrays are filled with 0's - that is
+// the zeros array method is used, rather than create. This is
+// to ensure that a "sensible" answer is returned on error (all
+// 0's), as the XSpec model API does not provide a way to return
+// an error status. There is (likely; not checked) a run-time cost
+// to using zeros rather than create, but safety is better than
+// performance here.
 
 template <npy_intp NumPars, bool HasNorm,
 void (*XSpecFunc)( float* ear, int* ne, float* param, int* ifl,
@@ -170,13 +178,13 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
 		nelem--;
 
 	FloatArray result;
-	if ( EXIT_SUCCESS != result.create( xlo.get_ndim(), xlo.get_dims() ) )
+	if ( EXIT_SUCCESS != result.zeros( xlo.get_ndim(), xlo.get_dims() ) )
 		return NULL;
 
 	// The XSPEC functions require fluxError to be non-NULL, so we create
 	// it but discard it after the computation is done
 	FloatArray error;
-	if ( EXIT_SUCCESS != error.create( xlo.get_ndim(), xlo.get_dims() ) )
+	if ( EXIT_SUCCESS != error.zeros( xlo.get_ndim(), xlo.get_dims() ) )
 		return NULL;
 
 	// Even though the XSPEC model function is Fortran, it could call
@@ -377,7 +385,7 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
 		nelem--;
 
 	DoubleArray result;
-	if ( EXIT_SUCCESS != result.create( xlo.get_ndim(), xlo.get_dims() ) )
+	if ( EXIT_SUCCESS != result.zeros( xlo.get_ndim(), xlo.get_dims() ) )
 		return NULL;
 
 	if (fluxes) {
@@ -388,7 +396,7 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
 	// The XSPEC functions require fluxError to be non-NULL, so we create
 	// it but discard it after the computation is done
 	DoubleArray error;
-	if ( EXIT_SUCCESS != error.create( xlo.get_ndim(), xlo.get_dims() ) )
+	if ( EXIT_SUCCESS != error.zeros( xlo.get_ndim(), xlo.get_dims() ) )
 		return NULL;
 
 	// Swallow C++ exceptions
@@ -578,13 +586,13 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 		nelem--;
 
 	FloatArray result;
-	if ( EXIT_SUCCESS != result.create( xlo.get_ndim(), xlo.get_dims() ) )
+	if ( EXIT_SUCCESS != result.zeros( xlo.get_ndim(), xlo.get_dims() ) )
 		return NULL;
 
 	// The XSPEC functions require fluxError to be non-NULL, so we create
 	// it but discard it after the computation is done
 	FloatArray error;
-	if ( EXIT_SUCCESS != error.create( xlo.get_ndim(), xlo.get_dims() ) )
+	if ( EXIT_SUCCESS != error.zeros( xlo.get_ndim(), xlo.get_dims() ) )
 		return NULL;
 
 	// Even though the XSPEC model function is Fortran, it could call


### PR DESCRIPTION
# Release Notes

Ensure that XSPEC models which fail - for instance, because a data file it needs is missing - return 0's for all bins, rather than random values. This should make it more obvious that something has gone wrong (for instance if the XSPEC chatter level is low enough not to show any error messages, as is the case for the default setting used by Sherpa, namely 0).

If the model returns an invalid value - defined as an infinite value or NaN - then the model class will raise an error (using the Python `FloatingPointError` exception).

# Details

The XSpec model API does not provide a way of indicating that a
model failed. The common case is that an error message is printed,
often at a chatter level greater than the 0 used by default by Sherpa
(so that users do not see it) and the routine returns without filling
in the flux array. The flux (and error) arrays are now created so that
there contents are set to 0 rather than being undefined. This provides
a more-consistent, and more-obvious, signal to the user that a model
has failed (the result is 0). I believe this is what Xspec itself does when
using the Xspec fitting application.

Another option would be to use an 'out-of-bound' value (e.g. NaN or Inf) 
and then check for these after calling the model, so that an error can be 
thrown, but I am concerned with the extra checks and with coming up 
with a choice of a value that can never be returned by any Xspec model.

This is the second part of breaking up PR #63 into smaller chunks: #80 was the first.