### PR TITLE
Change spectrumNumber/ifl from 0 to 1.

### DIFF
--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -35,6 +35,17 @@ typedef sherpa::Array< float, NPY_FLOAT > FloatArray;
 typedef float FloatArrayType;
 
 
+// The spectrum number is set to 1. It used to be 0, but some code
+// (a user model, so not included in the XSpec model library being
+// built against) has been seen to behave strangely with a value of 0,
+// so a value of 1 is being used "just in case". A keyword argument
+// could be added so that the user can override this, but it is
+// only really woth doing once write access to the XFLT keywords
+// is added (and then working out how to take advantage of it; perhaps
+// a wrapper model that provides a parameter-like interface to the value
+// so that a model instance can be associated with a particular dataset).
+// This might be enough to then support the smaug model.
+
 template <npy_intp NumPars, bool HasNorm,
 void (*XSpecFunc)( float* ear, int* ne, float* param, int* ifl,
 		float* photar, float* photer )>
@@ -78,7 +89,7 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
 		return NULL;
 	}
 
-	int ifl = 0;
+	int ifl = 1;
 
 	double hc = (sherpa::constants::c_ang<SherpaFloat>() *
 			sherpa::constants::h_kev<SherpaFloat>());
@@ -395,7 +406,8 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
 
 	try {
 
-		XSpecFunc( &ear[0], nelem, &pars[0], 0, &result[0], &error[0], NULL );
+                int ifl = 1;
+		XSpecFunc( &ear[0], nelem, &pars[0], ifl, &result[0], &error[0], NULL );
 
 		// If there were gaps in the energy array, because of locations
 		// where xlo[i+1] != xhi[i], then this is place where we recalculate
@@ -419,7 +431,7 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
 			ear2[0] = ear[bin_number];
 			ear2[1] = ear2[0] + gap_widths.back();
 			int ear2_nelem = 1;
-			XSpecFunc( &ear2[0], ear2_nelem, &pars[0], 0, &result[bin_number],
+			XSpecFunc( &ear2[0], ear2_nelem, &pars[0], ifl, &result[bin_number],
 					&error[bin_number], NULL );
 
 			gaps.pop_back();
@@ -490,7 +502,7 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 	}
 
 	// FIXME how to handle the spectrum number??
-	int ifl = 0;
+	int ifl = 1;
 
 	double hc = (sherpa::constants::c_ang<SherpaFloat>() *
 			sherpa::constants::h_kev<SherpaFloat>());


### PR DESCRIPTION
# Release Note
The XSpec "spectrum number" value is now set to 1 rather than 0, as this value is 1-based in Xspec.

# Description
The XSpec "spectrum number" value is not used by Sherpa. It was set to
0, but this is not consistent with Xspec, as the value is 1-based.

A value of 0 has also been seen to cause strange behavior in an XSpec user
model (not shipped with Sherpa).

I also added some comments on how this value could be set by the user,
in the hope of supporting the smaug user model, but this is a long-term
change and may not work out as currently documented.

This is the third part of breaking up PR #63 into smaller chunks after #80 and #81.