### PR TITLE
Bug #39 plotting counts vs channel

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1507,8 +1507,8 @@ class DataPHA(Data1DInt):
                 ylabel += '/keV'
             elif self.units == 'wavelength':
                 ylabel += '/Angstrom'
-            elif self.units == 'channel':
-                ylabel += '/channel'
+            # elif self.units == 'channel':
+                # ylabel += '/channel'
 
         if self.plot_fac:
             ylabel += ' X %s^%s' % (self.units.capitalize(), str(self.plot_fac))

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1439,7 +1439,7 @@ class DataPHA(Data1DInt):
             elif self.units == 'wavelength':
                 ebin = self._hc/elo - self._hc/ehi
             elif self.units == 'channel':
-                ebin = ehi - elo
+                ebin = 1
             else:
                 raise DataErr("bad", "quantity", self.units)
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -22,6 +22,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.utils import SherpaTestCase, test_data_missing
 from sherpa.all import *
 from sherpa.astro.all import *
+from sherpa.astro import ui
 import logging
 logger = logging.getLogger('sherpa')
 
@@ -248,6 +249,14 @@ class test_filter_wave_grid(SherpaTestCase):
         self.pha.ignore(0.1, 6.0)        
         assert (self._ignore==numpy.asarray(self.pha.mask)).all()
 
+class test_grouping(SherpaTestCase):
+    def test_grouping_basic(self):
+        ui.load_arrays("grouping", [1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 7, 8, 10], DataPHA)
+        numpy.testing.assert_array_equal(ui.get_counts("grouping"), [0, 1, 2, 3, 7, 8, 10])
+        self.assertEqual(ui.get_counts("grouping").sum(), 31)
+        ui.group_counts("grouping", 5)
+        numpy.testing.assert_array_equal(ui.get_counts("grouping"), [6, 7, 8, 10])
+        self.assertEqual(ui.get_counts("grouping").sum(), 31)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Resolve #39.
# Release Note

Sherpa incorrectly divided counts by the number of channels in a bin, so that, for instance, `get_counts()` would return `counts per channel` rather than `counts`. Similarly, the default `plot_data` function would show a plot of `counts/channel` vs `channel`. Now Sherpa always assumes that a channel always has width 1, even when it is the result of a grouping scheme, so that `get_counts().sum()` is invariant. The plot's `ylabel` has been updated accordingly from `counts/channel` to `counts`.
# Description

This is a rather simple fix, but I wonder whether there was a good reason for Sherpa to behave the way it did. I am pushing this sooner rather than later, so that we can start the review. So far I tested the fix visually, but I am adding more automated tests.
