### PR TITLE
Bug #27 update pyfits deprecated interfaces

### DIFF
--- a/sherpa/astro/io/meta.py
+++ b/sherpa/astro/io/meta.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,19 +18,17 @@
 #
 
 
-import inspect
-import sys
 from sherpa.utils import NoNewAttributesAfterInit
-from sherpa.utils.err import NotImplementedErr
 
 
 __all__ = ('Meta',)
 
 
 class Meta(NoNewAttributesAfterInit):
+    """A key-value store."""
 
     def __init__(self):
-        self.__header={}
+        self.__header = {}
         NoNewAttributesAfterInit.__init__(self)
 
     def __getitem__(self, name):
@@ -57,7 +55,7 @@ class Meta(NoNewAttributesAfterInit):
         return keys
 
     def has_key(self, key):
-        return self.__header.has_key(key)
+        return key in self.__header
 
     def values(self):
         return [self.__header[key] for key in self.keys()]

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -29,7 +29,7 @@ from itertools import izip
 from sherpa.utils.err import IOErr
 from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat, is_binary_file
 from sherpa.io import get_ascii_data, write_arrays
-from sherpa.astro.io.meta import *
+from sherpa.astro.io.meta import Meta
 
 import logging
 warning = logging.getLogger(__name__).warning
@@ -47,6 +47,7 @@ __all__ = ('get_table_data', 'get_image_data', 'get_arf_data', 'get_rmf_data',
            'get_pha_data', 'set_table_data', 'set_image_data', 'set_pha_data',
            'get_column_data', 'get_ascii_data')
 
+# Should we drop support for earlier versions?
 try:
     # pyfits-1.3 support
     _VLF = pyfits.NP_pyfits._VLF
@@ -68,7 +69,6 @@ def _has_hdu(hdulist, id):
 
 
 def _has_key(hdu, name):
-    #return hdu.header.has_key(name)
     return name in hdu.header
 
 
@@ -109,12 +109,14 @@ def _get_meta_data(hdu):
 def _get_wcs_key(hdu, key0, key1, fix_type=False, dtype=SherpaFloat):
     if _has_key(hdu, key0) and _has_key(hdu, key1):
         return numpy.array([_try_key(hdu, key0, fix_type, dtype),
-                            _try_key(hdu, key1, fix_type, dtype)],dtype)
+                            _try_key(hdu, key1, fix_type, dtype)], dtype)
     return ()
 
+
 def _set_wcs_key(hdulist, name, val):
-    card = pyfits.Card( str(name), val )
+    card = pyfits.Card(str(name), val)
     hdulist.append(card)
+
 
 def _try_col(hdu, name, dtype=SherpaFloat, fix_type=False):
     if name not in hdu.columns.names:
@@ -132,6 +134,7 @@ def _try_col(hdu, name, dtype=SherpaFloat, fix_type=False):
 
     return col
 
+
 def _try_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
     if name not in hdu.columns.names:
         return (None,)
@@ -148,9 +151,10 @@ def _try_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
 
     return numpy.column_stack(col)
 
+
 def _try_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
     if name not in hdu.columns.names:
-        return numpy.array([None]*size)
+        return numpy.array([None] * size)
 
     col = hdu.data.field(name)
 
@@ -163,9 +167,10 @@ def _try_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
         col = col.astype(dtype)
 
     if col is None:
-        return numpy.array([None]*size)
+        return numpy.array([None] * size)
 
     return col
+
 
 def _require_col(hdu, name, dtype=SherpaFloat, fix_type=False):
     col = _try_col(hdu, name, dtype, fix_type)
@@ -173,11 +178,13 @@ def _require_col(hdu, name, dtype=SherpaFloat, fix_type=False):
         raise IOErr('reqcol', name, hdu._file.name)
     return col
 
+
 def _require_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
     col = _try_tbl_col(hdu, name, dtype, fix_type)
     if len(col) > 0 and col[0] is None:
         raise IOErr('reqcol', name, hdu._file.name)
     return col
+
 
 def _require_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
     col = _try_vec(hdu, name, size, dtype, fix_type)
@@ -185,21 +192,22 @@ def _require_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
         raise IOErr('reqcol', name, hdu._file.name)
     return col
 
+
 def _try_col_or_key(hdu, name, dtype=SherpaFloat, fix_type=False):
     col = _try_col(hdu, name, dtype, fix_type)
     if col is not None:
         return col
     return _try_key(hdu, name, fix_type, dtype)
 
+
 def _try_vec_or_key(hdu, name, size, dtype=SherpaFloat, fix_type=False):
     col = _try_col(hdu, name, dtype, fix_type)
     if col is not None:
         return col
-    return numpy.array([_try_key(hdu, name, fix_type, dtype)]*size)
+    return numpy.array([_try_key(hdu, name, fix_type, dtype)] * size)
 
 
-
-## Read Functions ##
+# Read Functions
 
 def read_table_blocks(arg, make_copy=False):
 
@@ -212,13 +220,14 @@ def read_table_blocks(arg, make_copy=False):
         filename = arg
         hdus = pyfits.open(arg)
     else:
-        raise IOErr('badfile', arg, "a binary FITS table or a PyFITS.BinTableHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS table or a PyFITS.BinTableHDU list")
 
     cols = {}
     hdr = {}
 
     for ii, hdu in enumerate(hdus):
-        blockidx = ii+1
+        blockidx = ii + 1
 
         hdr[blockidx] = {}
         header = hdu.header
@@ -237,24 +246,22 @@ def read_table_blocks(arg, make_copy=False):
     return filename, cols, hdr
 
 
-
-
-
-def get_header_data( arg, blockname=None, hdrkeys=None ):
+def get_header_data(arg, blockname=None, hdrkeys=None):
 
     filename = ''
     if type(arg) == str and is_binary_file(arg):
         tbl = pyfits.open(arg)
         filename = arg
-    elif ( (type(arg) is pyfits.HDUList) and
-           (len(arg) > 0) and
-           (arg[0].__class__ is pyfits.PrimaryHDU) ):
+    elif ((type(arg) is pyfits.HDUList) and
+          (len(arg) > 0) and
+          (arg[0].__class__ is pyfits.PrimaryHDU)):
         tbl = arg
         filename = tbl[0]._file.name
     else:
-        raise IOErr('badfile', arg, "a binary FITS table or a PyFITS.BinTableHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS table or a PyFITS.BinTableHDU list")
 
-    hdr={}
+    hdr = {}
     try:
         # Use the first binary table extension we find.  Throw an exception
         # if there aren't any.
@@ -283,7 +290,7 @@ def get_header_data( arg, blockname=None, hdrkeys=None ):
     return hdr
 
 
-def get_column_data( *args ):
+def get_column_data(*args):
     """
     get_column_data( *NumPy_args )
     """
@@ -298,30 +305,30 @@ def get_column_data( *args ):
         if arg is not None:
             vals = numpy.asarray(arg)
             for col in numpy.column_stack(vals):
-                cols.append( col )
+                cols.append(col)
         else:
-            cols.append( arg )
+            cols.append(arg)
 
     return cols
 
-def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
-                   blockname = None, hdrkeys=None):
-    """
-    get_table_data( filename , ncols=1 [, colkeys=None [, make_copy=False [, blockname=None [, hdrkeys=None ]]]])
 
-    get_table_data( [PrimaryHDU, BinTableHDU] , ncols=1 [, colkeys=None [, make_copy=False [, blockname=None [, hdrkeys=None ]]]])
+def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
+                   blockname=None, hdrkeys=None):
+    """
+    arg is a filename or a HDUList object.
     """
     filename = ''
     if type(arg) == str and is_binary_file(arg):
         tbl = pyfits.open(arg)
         filename = arg
-    elif ( (type(arg) is pyfits.HDUList) and
-           (len(arg) > 0) and
-           (arg[0].__class__ is pyfits.PrimaryHDU) ):
+    elif ((type(arg) is pyfits.HDUList) and
+          (len(arg) > 0) and
+          (arg[0].__class__ is pyfits.PrimaryHDU)):
         tbl = arg
         filename = tbl[0]._file.name
     else:
-        raise IOErr('badfile', arg, "a binary FITS table or a PyFITS.BinTableHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS table or a PyFITS.BinTableHDU list")
 
     try:
         # Use the first binary table extension we find.  Throw an exception
@@ -345,9 +352,9 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
             colkeys = [name.strip().upper() for name in list(colkeys)]
         # Try Channel, Counts or X,Y before defaulting to first two table cols
         elif ('CHANNEL' in cnames) and ('COUNTS' in cnames):
-            colkeys = ['CHANNEL','COUNTS']
+            colkeys = ['CHANNEL', 'COUNTS']
         elif ('X' in cnames) and ('Y' in cnames):
-            colkeys = ['X','Y']
+            colkeys = ['X', 'Y']
         else:
             colkeys = cnames[:ncols]
 
@@ -356,7 +363,7 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
             for col in _require_tbl_col(hdu, name, fix_type=fix_type):
                 cols.append(col)
 
-        hdr={}
+        hdr = {}
         if hdrkeys is not None:
             for key in hdrkeys:
                 hdr[key] = _require_key(hdu, key)
@@ -369,51 +376,50 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
 
 def get_image_data(arg, make_copy=False):
     """
-    get_image_data( filename [, make_copy=False ])
-
-    get_image_data( [PrimaryHDU] [, make_copy=False ])
+    arg is a filename or a HDUList object
     """
     filename = ''
     if type(arg) == str and is_binary_file(arg):
         hdu = pyfits.open(arg)
         filename = arg
-    elif ( (type(arg) is pyfits.HDUList) and
-           (len(arg) > 0 ) and
-           (arg[0].__class__ is pyfits.PrimaryHDU) ):
+    elif ((type(arg) is pyfits.HDUList) and
+          (len(arg) > 0 ) and
+          (arg[0].__class__ is pyfits.PrimaryHDU)):
         hdu = arg
         filename = hdu[0]._file.name
     else:
-        raise IOErr('badfile', arg, "a binary FITS file or a PyFITS.PrimaryHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS file or a PyFITS.PrimaryHDU list")
 
-#   FITS uses logical-to-world where we use physical-to-world.
-#   For all transforms, update their physical-to-world
-#   values from their logical-to-world values.
-#   Find the matching physical transform
-#      (same axis no, but sub = 'P' )
-#   and use it for the update.
-#   Physical tfms themselves do not get updated.
-#
-#  Fill the physical-to-world transform given the
-#  logical-to-world and the associated logical-to-physical.
-#      W = wv + wd * ( P - wp )
-#      P = pv + pd * ( L - pp )
-#      W = lv + ld * ( L - lp )
-# Then
-#      L = pp + ( P - pv ) / pd
-# so   W = lv + ld * ( pp + (P-pv)/pd - lp )
-#        = lv + ( ld / pd ) * ( P - [ pv +  (lp-pp)*pd ] )
-# Hence
-#      wv = lv
-#      wd = ld / pd
-#      wp = pv + ( lp - pp ) * pd
+    #   FITS uses logical-to-world where we use physical-to-world.
+    #   For all transforms, update their physical-to-world
+    #   values from their logical-to-world values.
+    #   Find the matching physical transform
+    #      (same axis no, but sub = 'P' )
+    #   and use it for the update.
+    #   Physical tfms themselves do not get updated.
+    #
+    #  Fill the physical-to-world transform given the
+    #  logical-to-world and the associated logical-to-physical.
+    #      W = wv + wd * ( P - wp )
+    #      P = pv + pd * ( L - pp )
+    #      W = lv + ld * ( L - lp )
+    # Then
+    #      L = pp + ( P - pv ) / pd
+    # so   W = lv + ld * ( pp + (P-pv)/pd - lp )
+    #        = lv + ( ld / pd ) * ( P - [ pv +  (lp-pp)*pd ] )
+    # Hence
+    #      wv = lv
+    #      wd = ld / pd
+    #      wp = pv + ( lp - pp ) * pd
 
-#  EG suppose phys-to-world is
-#         W =  1000 + 2.0 * ( P - 4.0 )
-#  and we bin and scale to generate a logical-to-phys of
-#         P =  20 + 4.0 * ( L - 10 )
-#  Then
-#         W = 1000 + 2.0 * ( (20-4) - 4 * 10 ) + 2 * 4 $
-#
+    #  EG suppose phys-to-world is
+    #         W =  1000 + 2.0 * ( P - 4.0 )
+    #  and we bin and scale to generate a logical-to-phys of
+    #         P =  20 + 4.0 * ( L - 10 )
+    #  Then
+    #         W = 1000 + 2.0 * ( (20-4) - 4 * 10 ) + 2 * 4 $
+    #
 
     try:
         data = {}
@@ -434,13 +440,13 @@ def get_image_data(arg, make_copy=False):
         crvalw = _get_wcs_key(img, 'CRVAL1', 'CRVAL2')
 
         # proper calculation of cdelt wrt PHYSICAL coords
-        if (( cdeltw != () ) and ( cdeltp != () ) ):
-            cdeltw = cdeltw/cdeltp
+        if ((cdeltw != ()) and (cdeltp != ())):
+            cdeltw = cdeltw / cdeltp
 
         # proper calculation of crpix wrt PHYSICAL coords
-        if (( crpixw != () ) and ( crvalp != () ) and
-            ( cdeltp != () ) and ( crpixp != () ) ):
-            crpixw = crvalp + ( crpixw - crpixp ) * cdeltp
+        if ((crpixw != ()) and (crvalp != ()) and
+                (cdeltp != ()) and (crpixp != ())):
+            crpixw = crvalp + (crpixw - crpixp) * cdeltp
 
         sky = None
         if(cdeltp != () and crpixp != () and crvalp != () and transformstatus):
@@ -454,10 +460,11 @@ def get_image_data(arg, make_copy=False):
         data['eqpos'] = eqpos
         data['header'] = _get_meta_data(img)
 
-        keys = ['MTYPE1','MFORM1','CTYPE1P','CTYPE2P','WCSNAMEP','CDELT1P',
-                'CDELT2P','CRPIX1P','CRPIX2P','CRVAL1P','CRVAL2P',
-                'MTYPE2','MFORM2','CTYPE1','CTYPE2','CDELT1','CDELT2','CRPIX1',
-                'CRPIX2','CRVAL1','CRVAL2','CUNIT1','CUNIT2','EQUINOX']
+        keys = ['MTYPE1', 'MFORM1', 'CTYPE1P', 'CTYPE2P', 'WCSNAMEP',
+                'CDELT1P', 'CDELT2P', 'CRPIX1P', 'CRPIX2P',
+                'CRVAL1P', 'CRVAL2P', 'MTYPE2', 'MFORM2', 'CTYPE1', 'CTYPE2',
+                'CDELT1', 'CDELT2', 'CRPIX1', 'CRPIX2', 'CRVAL1', 'CRVAL2',
+                'CUNIT1', 'CUNIT2', 'EQUINOX']
 
         for key in keys:
             try:
@@ -473,21 +480,20 @@ def get_image_data(arg, make_copy=False):
 
 def get_arf_data(arg, make_copy=False):
     """
-    get_arf_data( filename [, make_copy=False ])
-
-    get_arf_data( [PrimaryHDU, BinTableHDU] [, make_copy=False ])
+    arg is a filename or a HDUList object
     """
     filename = ''
     if type(arg) == str:
         arf = pyfits.open(arg)
         filename = arg
-    elif ( (type(arg) is pyfits.HDUList) and
-           (len(arg) > 0) and
-           (arg[0].__class__ is pyfits.PrimaryHDU) ):
+    elif ((type(arg) is pyfits.HDUList) and
+          (len(arg) > 0) and
+          (arg[0].__class__ is pyfits.PrimaryHDU)):
         arf = arg
         filename = arf[0]._file.name
     else:
-        raise IOErr('badfile', arg, "a binary FITS file or a PyFITS.BinTableHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS file or a PyFITS.BinTableHDU list")
 
     try:
         if _has_hdu(arf, 'SPECRESP'):
@@ -508,9 +514,9 @@ def get_arf_data(arg, make_copy=False):
         data['energ_lo'] = _require_col(hdu, 'ENERG_LO', fix_type=True)
         data['energ_hi'] = _require_col(hdu, 'ENERG_HI', fix_type=True)
         data['specresp'] = _require_col(hdu, 'SPECRESP', fix_type=True)
-        data['bin_lo']   = _try_col(hdu, 'BIN_LO', fix_type=True)
-        data['bin_hi']   = _try_col(hdu, 'BIN_HI', fix_type=True)
-        data['header']     = _get_meta_data(hdu)
+        data['bin_lo'] = _try_col(hdu, 'BIN_LO', fix_type=True)
+        data['bin_hi'] = _try_col(hdu, 'BIN_HI', fix_type=True)
+        data['header'] = _get_meta_data(hdu)
         data['header'].pop('EXPOSURE')
 
     finally:
@@ -521,21 +527,20 @@ def get_arf_data(arg, make_copy=False):
 
 def get_rmf_data(arg, make_copy=False):
     """
-    get_rmf_data( filename [, make_copy=False ])
-
-    get_rmf_data( [PrimaryHDU, BinTableHDU] [, make_copy=False ])
+    arg is a filename or a HDUList object.
     """
     filename = ''
     if type(arg) == str:
         rmf = pyfits.open(arg)
         filename = arg
-    elif ( (type(arg) is pyfits.HDUList) and
-           (len(arg) > 0) and
-           (arg[0].__class__ is pyfits.PrimaryHDU) ):
+    elif ((type(arg) is pyfits.HDUList) and
+          (len(arg) > 0) and
+          (arg[0].__class__ is pyfits.PrimaryHDU)):
         rmf = arg
         filename = rmf[0]._file.name
     else:
-        raise IOErr('badfile', arg, "a binary FITS file or a PyFITS.BinTableHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS file or a PyFITS.BinTableHDU list")
 
     try:
         if _has_hdu(rmf, 'MATRIX'):
@@ -556,26 +561,26 @@ def get_rmf_data(arg, make_copy=False):
         data['detchans'] = SherpaUInt(_require_key(hdu, 'DETCHANS'))
         data['energ_lo'] = _require_col(hdu, 'ENERG_LO', fix_type=True)
         data['energ_hi'] = _require_col(hdu, 'ENERG_HI', fix_type=True)
-        data['n_grp']    = _require_col(hdu, 'N_GRP', fix_type=True,
-                                        dtype=SherpaUInt)
-        data['f_chan']   = _require_vec(hdu, 'F_CHAN', fix_type=True,
-                                        dtype=SherpaUInt)
-        data['n_chan']   = _require_vec(hdu, 'N_CHAN', fix_type=True,
-                                        dtype=SherpaUInt)
+        data['n_grp'] = _require_col(hdu, 'N_GRP', fix_type=True,
+                                     dtype=SherpaUInt)
+        data['f_chan'] = _require_vec(hdu, 'F_CHAN', fix_type=True,
+                                      dtype=SherpaUInt)
+        data['n_chan'] = _require_vec(hdu, 'N_CHAN', fix_type=True,
+                                      dtype=SherpaUInt)
         # Read MATRIX as-is -- we will flatten it below, because
         # we need to remove all rows corresponding to n_grp[row] == 0
-        data['matrix']   = None
+        data['matrix'] = None
         if 'MATRIX' not in hdu.columns.names:
             pass
         else:
-            data['matrix']   = hdu.data.field('MATRIX')
+            data['matrix'] = hdu.data.field('MATRIX')
 
-        data['header']     = _get_meta_data(hdu)
+        data['header'] = _get_meta_data(hdu)
         data['header'].pop('DETCHANS')
 
         # Beginning of non-Chandra RMF support
         fchan_col = list(hdu.columns.names).index('F_CHAN') + 1
-        tlmin = _try_key(hdu, 'TLMIN'+str(fchan_col), True, SherpaUInt)
+        tlmin = _try_key(hdu, 'TLMIN' + str(fchan_col), True, SherpaUInt)
         if tlmin is not None:
             data['offset'] = tlmin
         else:
@@ -591,7 +596,7 @@ def get_rmf_data(arg, make_copy=False):
 
             # Beginning of non-Chandra RMF support
             chan_col = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, 'TLMIN'+str(chan_col), True, SherpaUInt)
+            tlmin = _try_key(hdu, 'TLMIN' + str(chan_col), True, SherpaUInt)
             if tlmin is not None:
                 data['offset'] = tlmin
 
@@ -601,37 +606,41 @@ def get_rmf_data(arg, make_copy=False):
     finally:
         rmf.close()
 
-    ### For every row i of the response matrix, such that
-    ### n_grp[i] == 0, we need to remove that row from the
-    ### n_chan, f_chan, and matrix arrays we are constructing
-    ### to be passed up to the DataRMF data structure.
+    # ## For every row i of the response matrix, such that
+    # ## n_grp[i] == 0, we need to remove that row from the
+    # ## n_chan, f_chan, and matrix arrays we are constructing
+    # ## to be passed up to the DataRMF data structure.
 
-    ### This is trivial for n_chan and f_chan.  For the matrix
-    ### array this can be more work -- can't just remove all
-    ### zeroes, because some rows where n_grp[row] > 0 might
-    ### still have zeroes in the matrix.  I add new code first
-    ### to deal with the matrix, then simpler code to remove zeroes
-    ### from n_chan and f_chan.
+    # ## This is trivial for n_chan and f_chan.  For the matrix
+    # ## array this can be more work -- can't just remove all
+    # ## zeroes, because some rows where n_grp[row] > 0 might
+    # ## still have zeroes in the matrix.  I add new code first
+    # ## to deal with the matrix, then simpler code to remove zeroes
+    # ## from n_chan and f_chan.
 
-    # Read in MATRIX column with structure as-is -- i.e., as an array of 
+    # Read in MATRIX column with structure as-is -- i.e., as an array of
     # arrays.  Then flatten it, but include only those arrays that come from
     # rows where n_grp[row] > 0.  Zero elements can only be included from
     # rows where n_grp[row] > 0.  SMD 05/23/13
 
     if not isinstance(data['matrix'], _VLF):
         data['matrix'] = None
-        raise IOErr('badfile', filename, " MATRIX column not a variable length field")
+        raise IOErr('badfile', filename,
+                    " MATRIX column not a variable length field")
 
     good = (data['n_grp'] > 0)
     data['matrix'] = data['matrix'][good]
-    data['matrix'] = numpy.concatenate([numpy.asarray(row) for row in data['matrix']])
+    data['matrix'] = numpy.concatenate([numpy.asarray(row) for
+                                        row in data['matrix']])
     data['matrix'] = data['matrix'].astype(SherpaFloat)
 
-    #Flatten f_chan and n_chan vectors into 1D arrays as crates does
+    # Flatten f_chan and n_chan vectors into 1D arrays as crates does
     # according to group
-    if( (data['f_chan'].ndim > 1) and ( data['n_chan'].ndim > 1) ):
-        f_chan = []; n_chan = [];
-        for grp,fch,nch, in izip(data['n_grp'],data['f_chan'],data['n_chan']):
+    if((data['f_chan'].ndim > 1) and (data['n_chan'].ndim > 1)):
+        f_chan = []
+        n_chan = []
+        for grp, fch, nch, in izip(data['n_grp'], data['f_chan'],
+                                   data['n_chan']):
             for i in xrange(grp):
                 f_chan.append(fch[i])
                 n_chan.append(nch[i])
@@ -639,7 +648,7 @@ def get_rmf_data(arg, make_copy=False):
         data['f_chan'] = numpy.asarray(f_chan, SherpaUInt)
         data['n_chan'] = numpy.asarray(n_chan, SherpaUInt)
     else:
-        if( len(data['n_grp']) == len(data['f_chan']) ):
+        if(len(data['n_grp']) == len(data['f_chan'])):
             # filter out groups with zeroes.
             good = (data['n_grp'] > 0)
             data['f_chan'] = data['f_chan'][good]
@@ -650,22 +659,20 @@ def get_rmf_data(arg, make_copy=False):
 
 def get_pha_data(arg, make_copy=False, use_background=False):
     """
-    get_pha_data( filename [, make_copy=False [, use_background=False[])
-
-    get_pha_data( [PrimaryHDU, BinTableHDU] [, make_copy=False
-                  [, use_background=False]])
+    arg is a filename or a HDUList object
     """
     filename = ''
     if type(arg) == str and is_binary_file(arg):
         pha = pyfits.open(arg)
         filename = arg
-    elif ( (type(arg) is pyfits.HDUList) and
-           (len(arg) > 0) and
-           (arg[0].__class__ is pyfits.PrimaryHDU) ):
+    elif ((type(arg) is pyfits.HDUList) and
+          (len(arg) > 0) and
+          (arg[0].__class__ is pyfits.PrimaryHDU)):
         pha = arg
         filename = pha[0]._file.name
     else:
-        raise IOErr('badfile', arg, "a binary FITS spectrum or a PyFITS.BinTableHDU list")
+        raise IOErr('badfile', arg,
+                    "a binary FITS spectrum or a PyFITS.BinTableHDU list")
 
     try:
         if _has_hdu(pha, 'SPECTRUM'):
@@ -675,15 +682,15 @@ def get_pha_data(arg, make_copy=False, use_background=False):
                (_try_key(pha[1], 'HDUCLAS2') == 'SPECTRUM'))):
             hdu = pha[1]
         else:
-            raise IOErr('notrsp',  filename, "a PHA spectrum")
+            raise IOErr('notrsp', filename, "a PHA spectrum")
 
         if use_background:
             for block in pha:
                 if (_try_key(block, 'HDUCLAS2') == 'BKG'):
                     hdu = block
 
-        keys = ['BACKFILE','ANCRFILE','RESPFILE',
-                'BACKSCAL','AREASCAL','EXPOSURE']
+        keys = ['BACKFILE', 'ANCRFILE', 'RESPFILE',
+                'BACKSCAL', 'AREASCAL', 'EXPOSURE']
         datasets = []
 
         if _try_col(hdu, 'SPEC_NUM') is None:
@@ -691,7 +698,7 @@ def get_pha_data(arg, make_copy=False, use_background=False):
 
             # Keywords
             data['exposure'] = _try_key(hdu, 'EXPOSURE', True, SherpaFloat)
-            #data['poisserr'] = _try_key(hdu, 'POISSERR', True, bool)
+            # data['poisserr'] = _try_key(hdu, 'POISSERR', True, bool)
             data['backfile'] = _try_key(hdu, 'BACKFILE')
             data['arffile']  = _try_key(hdu, 'ANCRFILE')
             data['rmffile']  = _try_key(hdu, 'RESPFILE')
@@ -703,25 +710,30 @@ def get_pha_data(arg, make_copy=False, use_background=False):
             data['areascal'] = _try_col_or_key(hdu, 'AREASCAL', fix_type=True)
 
             # Columns
-            data['channel']         = _require_col(hdu, 'CHANNEL', fix_type=True)
-            #Make sure channel numbers not indices
-            chan = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, 'TLMIN'+str(chan), True, SherpaUInt)
-            if int(data['channel'][0]) == 0 or ((tlmin is not None) and tlmin == 0):
-                data['channel'] = data['channel']+1
+            data['channel'] = _require_col(hdu, 'CHANNEL', fix_type=True)
 
-            data['counts']      = _try_col(hdu, 'COUNTS', fix_type=True)
+            # Make sure channel numbers not indices
+            chan = list(hdu.columns.names).index('CHANNEL') + 1
+            tlmin = _try_key(hdu, 'TLMIN' + str(chan), True, SherpaUInt)
+            if int(data['channel'][0]) == 0 or ((tlmin is not None) and
+                                                tlmin == 0):
+                data['channel'] = data['channel'] + 1
+
+            data['counts'] = _try_col(hdu, 'COUNTS', fix_type=True)
             if data['counts'] is None:
-                data['counts']  = _require_col(hdu, 'RATE', fix_type=True) * data['exposure']
-            data['staterror']       = _try_col(hdu, 'STAT_ERR')
-            data['syserror']        = _try_col(hdu, 'SYS_ERR')
-            data['background_up']   = _try_col(hdu, 'BACKGROUND_UP', fix_type=True)
-            data['background_down'] = _try_col(hdu, 'BACKGROUND_DOWN', fix_type=True)
-            data['bin_lo']          = _try_col(hdu, 'BIN_LO', fix_type=True)
-            data['bin_hi']          = _try_col(hdu, 'BIN_HI', fix_type=True)
-            data['grouping']        = _try_col(hdu, 'GROUPING', SherpaInt)
-            data['quality']         = _try_col(hdu, 'QUALITY', SherpaInt)
-            data['header']            = _get_meta_data(hdu)
+                data['counts'] = _require_col(hdu, 'RATE',
+                                              fix_type=True) * data['exposure']
+            data['staterror'] = _try_col(hdu, 'STAT_ERR')
+            data['syserror'] = _try_col(hdu, 'SYS_ERR')
+            data['background_up'] = _try_col(hdu, 'BACKGROUND_UP',
+                                             fix_type=True)
+            data['background_down'] = _try_col(hdu, 'BACKGROUND_DOWN',
+                                               fix_type=True)
+            data['bin_lo'] = _try_col(hdu, 'BIN_LO', fix_type=True)
+            data['bin_hi'] = _try_col(hdu, 'BIN_HI', fix_type=True)
+            data['grouping'] = _try_col(hdu, 'GROUPING', SherpaInt)
+            data['quality'] = _try_col(hdu, 'QUALITY', SherpaInt)
+            data['header'] = _get_meta_data(hdu)
             for key in keys:
                 try:
                     data['header'].pop(key)
@@ -743,7 +755,7 @@ def get_pha_data(arg, make_copy=False, use_background=False):
 
             # Keywords
             exposure = _try_key(hdu, 'EXPOSURE', True, SherpaFloat)
-            #poisserr = _try_key(hdu, 'POISSERR', True, bool)
+            # poisserr = _try_key(hdu, 'POISSERR', True, bool)
             backfile = _try_key(hdu, 'BACKFILE')
             arffile  = _try_key(hdu, 'ANCRFILE')
             rmffile  = _try_key(hdu, 'RESPFILE')
@@ -755,35 +767,37 @@ def get_pha_data(arg, make_copy=False, use_background=False):
             areascal = _try_vec_or_key(hdu, 'AREASCAL', num, fix_type=True)
 
             # Columns
-            channel         = _require_vec(hdu, 'CHANNEL', num, fix_type=True)
+            channel = _require_vec(hdu, 'CHANNEL', num, fix_type=True)
 
-            #Make sure channel numbers not indices
+            # Make sure channel numbers not indices
             chan = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, 'TLMIN'+str(chan), True, SherpaUInt)
+            tlmin = _try_key(hdu, 'TLMIN' + str(chan), True, SherpaUInt)
 
             for ii in range(num):
                 if int(channel[ii][0]) == 0:
                     channel[ii] += 1
-            #if ((tlmin is not None) and tlmin == 0) or int(channel[0]) == 0:
-            #    channel += 1
 
-            counts =  _try_vec(hdu, 'COUNTS', num, fix_type=True)
+            # if ((tlmin is not None) and tlmin == 0) or int(channel[0]) == 0:
+            #     channel += 1
+
+            counts = _try_vec(hdu, 'COUNTS', num, fix_type=True)
             if None in counts:
-                counts =  _require_vec(hdu, 'RATE', num, fix_type=True) * data['exposure']
-            staterror       = _try_vec(hdu, 'STAT_ERR', num)
-            syserror        = _try_vec(hdu, 'SYS_ERR', num)
-            background_up   = _try_vec(hdu, 'BACKGROUND_UP', num, fix_type=True)
-            background_down = _try_vec(hdu, 'BACKGROUND_DOWN', num, fix_type=True)
-            bin_lo          = _try_vec(hdu, 'BIN_LO', num, fix_type=True)
-            bin_hi          = _try_vec(hdu, 'BIN_HI', num, fix_type=True)
-            grouping        = _try_vec(hdu, 'GROUPING', num, SherpaInt)
-            quality         = _try_vec(hdu, 'QUALITY', num, SherpaInt)
+                counts = _require_vec(hdu, 'RATE', num,
+                                      fix_type=True) * data['exposure']
+            staterror = _try_vec(hdu, 'STAT_ERR', num)
+            syserror = _try_vec(hdu, 'SYS_ERR', num)
+            background_up = _try_vec(hdu, 'BACKGROUND_UP', num, fix_type=True)
+            background_down = _try_vec(hdu, 'BACKGROUND_DOWN', num,
+                                       fix_type=True)
+            bin_lo = _try_vec(hdu, 'BIN_LO', num, fix_type=True)
+            bin_hi = _try_vec(hdu, 'BIN_HI', num, fix_type=True)
+            grouping = _try_vec(hdu, 'GROUPING', num, SherpaInt)
+            quality = _try_vec(hdu, 'QUALITY', num, SherpaInt)
 
-            orders          = _try_vec(hdu, 'TG_M', num, SherpaInt)
-            parts           = _try_vec(hdu, 'TG_PART', num, SherpaInt)
-            specnums        = _try_vec(hdu, 'SPEC_NUM', num, SherpaInt)
-            srcids          = _try_vec(hdu, 'TG_SRCID', num, SherpaInt)
-
+            orders = _try_vec(hdu, 'TG_M', num, SherpaInt)
+            parts = _try_vec(hdu, 'TG_PART', num, SherpaInt)
+            specnums = _try_vec(hdu, 'SPEC_NUM', num, SherpaInt)
+            srcids = _try_vec(hdu, 'TG_SRCID', num, SherpaInt)
 
             # Iterate over all rows of channels, counts, errors, etc
             # Populate a list of dictionaries containing
@@ -798,29 +812,29 @@ def get_pha_data(arg, make_copy=False, use_background=False):
                 data = {}
 
                 data['exposure'] = exposure
-                #data['poisserr'] = poisserr
+                # data['poisserr'] = poisserr
                 data['backfile'] = backfile
-                data['arffile']  = arffile
-                data['rmffile']  = rmffile
+                data['arffile'] = arffile
+                data['rmffile'] = rmffile
 
                 data['backscal'] = bscal
                 data['backscup'] = bscup
                 data['backscdn'] = bscdn
                 data['areascal'] = arsc
 
-                data['channel']         = chan
-                data['counts']          = cnt
-                data['staterror']       = staterr
-                data['syserror']        = syserr
-                data['background_up']   = backup
+                data['channel'] = chan
+                data['counts'] = cnt
+                data['staterror'] = staterr
+                data['syserror'] = syserr
+                data['background_up'] = backup
                 data['background_down'] = backdown
-                data['bin_lo']          = binlo
-                data['bin_hi']          = binhi
-                data['grouping']        = group
-                data['quality']         = qual
-                data['header']            = _get_meta_data(hdu)
-                data['header']['TG_M']     = ordr
-                data['header']['TG_PART']  = prt
+                data['bin_lo'] = binlo
+                data['bin_hi'] = binhi
+                data['grouping'] = group
+                data['quality'] = qual
+                data['header'] = _get_meta_data(hdu)
+                data['header']['TG_M'] = ordr
+                data['header']['TG_PART'] = prt
                 data['header']['SPEC_NUM'] = specnum
                 data['header']['TG_SRCID'] = srcid
 
@@ -842,10 +856,7 @@ def get_pha_data(arg, make_copy=False, use_background=False):
     return datasets, filename
 
 
-#
-### Write Functions ###
-#
-
+# Write Functions
 
 def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
                    ascii=False, clobber=False, packup=False):
@@ -855,11 +866,11 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
 
     col_names = list(col_names)
     col_names.remove("name")
-    #hdrlist = pyfits.CardList()
+    # hdrlist = pyfits.CardList()
 
-    #for name in ['exposure','backscal', 'areascal']:
-    #    hdrlist.append(pyfits.Card(key=name.upper(),
-    #                   value=data[name]))
+    # for name in ['exposure','backscal', 'areascal']:
+    #     hdrlist.append(pyfits.Card(key=name.upper(),
+    #                    value=data[name]))
 
     collist = []
     cols = []
@@ -879,7 +890,7 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
         return
 
     tbl = pyfits.new_table(pyfits.ColDefs(collist))
-                           #, header=pyfits.Header(hdrlist))
+    # , header=pyfits.Header(hdrlist))
     tbl.name = 'HISTOGRAM'
     if packup:
         return tbl
@@ -897,7 +908,7 @@ def set_pha_data(filename, data, col_names, header=None,
     for key in header.keys():
         if header[key] is None:
             continue
-        hdrlist.append(pyfits.Card( str(key.upper()), header[key] ))
+        hdrlist.append(pyfits.Card(str(key.upper()), header[key]))
 
     collist = []
     cols = []
@@ -959,7 +970,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         _set_wcs_key(hdrlist, 'MFORM1', 'x,y     ')
         _set_wcs_key(hdrlist, 'CTYPE1P', 'x      ')
         _set_wcs_key(hdrlist, 'CTYPE2P', 'y      ')
-        _set_wcs_key(hdrlist, 'WCSNAMEP','PHYSICAL')
+        _set_wcs_key(hdrlist, 'WCSNAMEP', 'PHYSICAL')
         _set_wcs_key(hdrlist, 'CDELT1P', cdeltp[0])
         _set_wcs_key(hdrlist, 'CDELT2P', cdeltp[1])
         _set_wcs_key(hdrlist, 'CRPIX1P', crpixp[0])
@@ -1017,7 +1028,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
             raise IOErr('arraysnoteq')
 
     if fields is None:
-        fields = ['col%i' % (ii+1) for ii in range(len(args))]
+        fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
         raise IOErr("toomanycols", str(len(fields)), str(len(args)))

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -246,20 +246,43 @@ def read_table_blocks(arg, make_copy=False):
     return filename, cols, hdr
 
 
-def get_header_data(arg, blockname=None, hdrkeys=None):
+# @DougBurke thinks that nobinary may just be a sign of a
+# missed copy-and-paste edit, as it's not at all obvious why
+# it isn't included there (alternatively, it may make sense to
+# just remove the binary check entirely and let the file I/O
+# fall over if it can't read the file).
+#
+# @DougBurke thinks that the exptype argument also seems to be
+# wrong, since there is *no* check here that the HDUList has
+# a table (or image), so why change the error message.
+#
+def _get_file_contents(arg, exptype="PrimaryHDU", nobinary=False):
+    """arg is a filename or a list of HDUs, with the first
+    one a PrimaryHDU. The return value is the list of
+    HDUs and the filename.
 
-    filename = ''
-    if type(arg) == str and is_binary_file(arg):
+    Set nobinary to True to avoid checking that the input
+    file is a binary file (via the is_binary_file routine).
+    """
+
+    if type(arg) == str and (not nobinary or is_binary_file(arg)):
         tbl = pyfits.open(arg)
         filename = arg
-    elif ((type(arg) is pyfits.HDUList) and
-          (len(arg) > 0) and
-          (arg[0].__class__ is pyfits.PrimaryHDU)):
+    elif type(arg) is pyfits.HDUList and len(arg) > 0 and \
+            arg[0].__class__ is pyfits.PrimaryHDU:
         tbl = arg
         filename = tbl[0]._file.name
     else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS table or a PyFITS.BinTableHDU list")
+        msg = "a binary FITS table or a PyFITS.{} list".format(exptype)
+        raise IOErr('badfile', arg, msg)
+
+    return (tbl, filename)
+
+
+def get_header_data(arg, blockname=None, hdrkeys=None):
+    """Read in the header data."""
+
+    tbl, filename = _get_file_contents(arg, exptype="BinTableHDU")
 
     hdr = {}
     try:
@@ -271,7 +294,7 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
                     break
                 else:
                     continue
-            elif (hdu.name.lower() == str(blockname).strip().lower()):
+            elif hdu.name.lower() == str(blockname).strip().lower():
                 break
 
         else:
@@ -317,18 +340,8 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
     """
     arg is a filename or a HDUList object.
     """
-    filename = ''
-    if type(arg) == str and is_binary_file(arg):
-        tbl = pyfits.open(arg)
-        filename = arg
-    elif ((type(arg) is pyfits.HDUList) and
-          (len(arg) > 0) and
-          (arg[0].__class__ is pyfits.PrimaryHDU)):
-        tbl = arg
-        filename = tbl[0]._file.name
-    else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS table or a PyFITS.BinTableHDU list")
+
+    tbl, filename = _get_file_contents(arg, exptype="BinTableHDU")
 
     try:
         # Use the first binary table extension we find.  Throw an exception
@@ -339,8 +352,8 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
                     break
                 else:
                     continue
-            elif (hdu.name.lower() == str(blockname).strip().lower() and
-                  hdu.__class__ is pyfits.BinTableHDU):
+            elif hdu.name.lower() == str(blockname).strip().lower() and \
+                    hdu.__class__ is pyfits.BinTableHDU:
                 break
 
         else:
@@ -351,9 +364,9 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
         if colkeys is not None:
             colkeys = [name.strip().upper() for name in list(colkeys)]
         # Try Channel, Counts or X,Y before defaulting to first two table cols
-        elif ('CHANNEL' in cnames) and ('COUNTS' in cnames):
+        elif 'CHANNEL' in cnames and 'COUNTS' in cnames:
             colkeys = ['CHANNEL', 'COUNTS']
-        elif ('X' in cnames) and ('Y' in cnames):
+        elif 'X' in cnames and 'Y' in cnames:
             colkeys = ['X', 'Y']
         else:
             colkeys = cnames[:ncols]
@@ -378,18 +391,8 @@ def get_image_data(arg, make_copy=False):
     """
     arg is a filename or a HDUList object
     """
-    filename = ''
-    if type(arg) == str and is_binary_file(arg):
-        hdu = pyfits.open(arg)
-        filename = arg
-    elif ((type(arg) is pyfits.HDUList) and
-          (len(arg) > 0 ) and
-          (arg[0].__class__ is pyfits.PrimaryHDU)):
-        hdu = arg
-        filename = hdu[0]._file.name
-    else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS file or a PyFITS.PrimaryHDU list")
+
+    hdu, filename = _get_file_contents(arg)
 
     #   FITS uses logical-to-world where we use physical-to-world.
     #   For all transforms, update their physical-to-world
@@ -440,20 +443,19 @@ def get_image_data(arg, make_copy=False):
         crvalw = _get_wcs_key(img, 'CRVAL1', 'CRVAL2')
 
         # proper calculation of cdelt wrt PHYSICAL coords
-        if ((cdeltw != ()) and (cdeltp != ())):
+        if cdeltw != () and cdeltp != ():
             cdeltw = cdeltw / cdeltp
 
         # proper calculation of crpix wrt PHYSICAL coords
-        if ((crpixw != ()) and (crvalp != ()) and
-                (cdeltp != ()) and (crpixp != ())):
+        if crpixw != () and crvalp != () and cdeltp != () and crpixp != ():
             crpixw = crvalp + (crpixw - crpixp) * cdeltp
 
         sky = None
-        if(cdeltp != () and crpixp != () and crvalp != () and transformstatus):
+        if cdeltp != () and crpixp != () and crvalp != () and transformstatus:
             sky = WCS('physical', 'LINEAR', crvalp, crpixp, cdeltp)
 
         eqpos = None
-        if(cdeltw != () and crpixw != () and crvalw != () and transformstatus):
+        if cdeltw != () and crpixw != () and crvalw != () and transformstatus:
             eqpos = WCS('world', 'WCS', crvalw, crpixw, cdeltw)
 
         data['sky'] = sky
@@ -478,31 +480,35 @@ def get_image_data(arg, make_copy=False):
     return data, filename
 
 
+def _is_ogip_type(hdus, bltype, bltype2=None):
+    """Return True if hdus[1] exists and has
+    the given type (as determined by the HDUCLAS1 or HDUCLAS2
+    keywords). If bltype2 is None then bltype is used for
+    both checks, otherwise bltype2 is used for HDUCLAS2 and
+    bltype is for HDUCLAS1.
+    """
+
+    bnum = 1
+    if bltype2 is None:
+        bltype2 = bltype
+    return _has_hdu(hdus, bnum) and \
+        (_try_key(hdus[bnum], 'HDUCLAS1') == bltype or
+         _try_key(hdus[bnum], 'HDUCLAS2') == bltype2)
+
+
 def get_arf_data(arg, make_copy=False):
     """
     arg is a filename or a HDUList object
     """
-    filename = ''
-    if type(arg) == str:
-        arf = pyfits.open(arg)
-        filename = arg
-    elif ((type(arg) is pyfits.HDUList) and
-          (len(arg) > 0) and
-          (arg[0].__class__ is pyfits.PrimaryHDU)):
-        arf = arg
-        filename = arf[0]._file.name
-    else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS file or a PyFITS.BinTableHDU list")
+
+    arf, filename = _get_file_contents(arg, exptype="BinTableHDU", nobinary=True)
 
     try:
         if _has_hdu(arf, 'SPECRESP'):
             hdu = arf['SPECRESP']
         elif _has_hdu(arf, 'AXAF_ARF'):
             hdu = arf['AXAF_ARF']
-        elif (_has_hdu(arf, 1) and
-              ((_try_key(arf[1], 'HDUCLAS1') == 'SPECRESP') or
-               (_try_key(arf[1], 'HDUCLAS2') == 'SPECRESP'))):
+        elif _is_ogip_type(arf, 'SPECRESP'):
             hdu = arf[1]
         else:
             raise IOErr('notrsp', filename, 'an ARF')
@@ -529,18 +535,8 @@ def get_rmf_data(arg, make_copy=False):
     """
     arg is a filename or a HDUList object.
     """
-    filename = ''
-    if type(arg) == str:
-        rmf = pyfits.open(arg)
-        filename = arg
-    elif ((type(arg) is pyfits.HDUList) and
-          (len(arg) > 0) and
-          (arg[0].__class__ is pyfits.PrimaryHDU)):
-        rmf = arg
-        filename = rmf[0]._file.name
-    else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS file or a PyFITS.BinTableHDU list")
+
+    rmf, filename = _get_file_contents(arg, exptype="BinTableHDU", nobinary=True)
 
     try:
         if _has_hdu(rmf, 'MATRIX'):
@@ -549,9 +545,7 @@ def get_rmf_data(arg, make_copy=False):
             hdu = rmf['SPECRESP MATRIX']
         elif _has_hdu(rmf, 'AXAF_RMF'):
             hdu = rmf['AXAF_RMF']
-        elif (_has_hdu(rmf, 1) and
-              ((_try_key(rmf[1], 'HDUCLAS1') == 'RESPONSE') or
-               (_try_key(rmf[1], 'HDUCLAS2') == 'RSP_MATRIX'))):
+        elif _is_ogip_type(rmf, 'RESPONSE', bltype2='RSP_MATRIX'):
             hdu = rmf[1]
         else:
             raise IOErr('notrsp', filename, 'an RMF')
@@ -636,7 +630,7 @@ def get_rmf_data(arg, make_copy=False):
 
     # Flatten f_chan and n_chan vectors into 1D arrays as crates does
     # according to group
-    if((data['f_chan'].ndim > 1) and (data['n_chan'].ndim > 1)):
+    if data['f_chan'].ndim > 1 and data['n_chan'].ndim > 1:
         f_chan = []
         n_chan = []
         for grp, fch, nch, in izip(data['n_grp'], data['f_chan'],
@@ -648,7 +642,7 @@ def get_rmf_data(arg, make_copy=False):
         data['f_chan'] = numpy.asarray(f_chan, SherpaUInt)
         data['n_chan'] = numpy.asarray(n_chan, SherpaUInt)
     else:
-        if(len(data['n_grp']) == len(data['f_chan'])):
+        if len(data['n_grp']) == len(data['f_chan']):
             # filter out groups with zeroes.
             good = (data['n_grp'] > 0)
             data['f_chan'] = data['f_chan'][good]
@@ -661,32 +655,20 @@ def get_pha_data(arg, make_copy=False, use_background=False):
     """
     arg is a filename or a HDUList object
     """
-    filename = ''
-    if type(arg) == str and is_binary_file(arg):
-        pha = pyfits.open(arg)
-        filename = arg
-    elif ((type(arg) is pyfits.HDUList) and
-          (len(arg) > 0) and
-          (arg[0].__class__ is pyfits.PrimaryHDU)):
-        pha = arg
-        filename = pha[0]._file.name
-    else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS spectrum or a PyFITS.BinTableHDU list")
+
+    pha, filename = _get_file_contents(arg, exptype="BinTableHDU")
 
     try:
         if _has_hdu(pha, 'SPECTRUM'):
             hdu = pha['SPECTRUM']
-        elif (_has_hdu(pha, 1) and
-              ((_try_key(pha[1], 'HDUCLAS1') == 'SPECTRUM') or
-               (_try_key(pha[1], 'HDUCLAS2') == 'SPECTRUM'))):
+        elif _is_ogip_type(pha, 'SPECTRUM'):
             hdu = pha[1]
         else:
             raise IOErr('notrsp', filename, "a PHA spectrum")
 
         if use_background:
             for block in pha:
-                if (_try_key(block, 'HDUCLAS2') == 'BKG'):
+                if _try_key(block, 'HDUCLAS2') == 'BKG':
                     hdu = block
 
         keys = ['BACKFILE', 'ANCRFILE', 'RESPFILE',

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -92,6 +92,12 @@ if hasattr(fits.BinTableHDU, "from_columns"):
 else:
     _new_table = fits.new_table
 
+# fits.CardList is deprecated
+if hasattr(fits, 'Header'):
+    _new_header = fits.Header
+else:
+    _new_header = fits.CardList
+
 
 def _has_hdu(hdulist, id):
     try:
@@ -927,7 +933,7 @@ def set_pha_data(filename, data, col_names, header=None,
     if not packup and os.path.isfile(filename) and not clobber:
         raise IOErr("filefound", filename)
 
-    hdrlist = fits.CardList()
+    hdrlist = _new_header()
 
     for key in header.keys():
         if header[key] is None:
@@ -958,7 +964,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
                    ascii=ascii, clobber=clobber)
         return
 
-    hdrlist = fits.CardList()
+    hdrlist = _new_header()
 
     # Write Image Header Keys
     for key in header.keys():


### PR DESCRIPTION
# Release Note

The `astropy.io.fits`/`pyfits` interface used deprecated functionality. The code was updated to use the replacement classes/methods when available, falling back to the original code if not. The interfaces that were changed were, when the new symbols are availble, to:

 - use `astropy.io.fits.BinTableHDU.from_columns` rather than `astropy.io.fits.new_table`

- use `astropy.io.fits.Header` rather than `astropy.io.CardList`

# Code changes

The code went through some minor clean up (PEP8 style fixes and then some minor re-factoring to reduce repeated code), as well as changing from using the `pyfits` module name to `fits` (since astropy is now the preferred package) before removing the deprecated functionality. Fortunately for the routines used here, the replacement routines/classes have the same API, so it's an easy change.

The [PyFITS changelog](http://www.stsci.edu/institute/software_hardware/pyfits/release) was consulted - particularly for version 3.3 - to check what functionality we are using that has been deprecated.

# Testing

The full smoke test was run (with the testing submodule installed and with the XSPEC module compiled against version 12.9.0b and with ds9 available) using astropy version 1.0.4. I have *not* tested against pyfits (in particular to see if it works with old versions).

I used the following two scripts to check that the deprecation warnings are gone (I wasn't sure how/if this could be done as part of the smoke test). These are based on examples given in #27.

a) writing out a FITS binary table

```
# does writing out a FITS file cause warnings?
import sherpa
from sherpa.astro import ui
print("*** Sherpa version: {}".format(sherpa.__version__))
ui.load_arrays(1, [1,2,3], [4,5,6])
ui.save_data(1, 'test_fits.dat', ascii=True, clobber=True)
print("*** created test_fits.dat ***")
ui.save_data(1, 'test_fits.fits', ascii=False, clobber=True)
print("*** created test_fits.fits ***")
```

Before this PR this complained about

```
WARNING: AstropyDeprecationWarning: The new_table function is deprecated and may be removed in a future version.
        Use :meth:`BinTableHDU.from_columns` for new BINARY tables or :meth:`TableHDU.from_columns` for new ASCII tables instead. [astropy.utils.decorators]
```

whereas I know get the following (it's dirty because the `setup.cfg` is changed to build XSPEC and I haven't hidden it from git):

```
*** Sherpa version: 4.7+530.g6dacc53.dirty
*** created test_fits.dat ***
*** created test_fits.fits ***
```

b) writing out a PHA file

Unfortunately the PHA files we have available in sherpa all seem to use the `LONGSTRN` convention, which means that writing them out triggers #46 - but with

```
import sherpa
from sherpa.astro import ui
print("*** Sherpa version: {}".format(sherpa.__version__))

ui.load_pha(1, './sherpa/astro/datastack/tests/data/3c273.pi')
ui.save_data(1, 'test.fits', ascii=False, clobber=True)
print("*** created test.fits")
```

we used to get the following warnings:

```
WARNING: AstropyDeprecationWarning: The CardList class has been deprecated; all its former functionality has been subsumed by the Header class, so CardList objects should not be directly created.  See the PyFITS 3.1.0 CHANGELOG for more details. [astropy.io.fits.card]
WARNING: AstropyDeprecationWarning: The append function is deprecated and may be removed in a future version.
        Use :meth:`Header.append` instead. [astropy.utils.decorators]
```