### PR TITLE
Doc fix: EXPTIME -> EXPOSURE

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -2476,7 +2476,7 @@ class Session(sherpa.ui.utils.Session):
         """Change the exposure time of a PHA data set.
 
         The exposure time of a PHA data set is taken from the
-        ``EXPTIME`` keyword in its header, but it can be changed
+        ``EXPOSURE`` keyword in its header, but it can be changed
         once the file has been loaded.
 
         Parameters
@@ -2517,7 +2517,7 @@ class Session(sherpa.ui.utils.Session):
         >>> etime = get_exposure()
         >>> set_exposure(etime * 1.05)
 
-        Use the EXPOSURE value from the ARF, rather than the EXPTIME
+        Use the EXPOSURE value from the ARF, rather than the
         value from the PHA file, for data set 2:
 
         >>> set_exposure(2, get_arf(2).exposure)

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -249,8 +249,8 @@ class Chi2(Stat):
     the length of a background time segment, or a product of the two,
     etc.; and A(S) is the on-source "area". These terms may be defined
     for a particular type of data: for example, PHA data sets A(B) to
-    `BACKSCAL * EXPTIME` from the background data set and A(S) to
-    `BACKSCAL * EXPTIME` from the source data set.
+    `BACKSCAL * EXPOSURE` from the background data set and A(S) to
+    `BACKSCAL * EXPOSURE` from the source data set.
 
     There are different ways of defining the sigma(i) terms,
     supported by the sub-classes.
@@ -294,7 +294,7 @@ class LeastSq(Chi2):
 
     @staticmethod
     def calc_staterror(data):
-        return numpy.ones_like(data)        
+        return numpy.ones_like(data)
 
     @staticmethod
     def calc_stat(data, model, staterror, syserror=None, weight=None):


### PR DESCRIPTION
# Release Notes

Correct the documentation for the `set_exposure` function: the exposure value for PHA data sets is taken from the `EXPOSURE` keyword, not `EXPTIME`.