### PR TITLE
Fix handling of non-contiguous grids in XSPEC models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy matplotlib
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy=1.9 matplotlib
   - conda config --add channels https://conda.binstar.org/sherpa
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
@@ -73,7 +73,7 @@ install:
   - python setup.py $INSTALL_TYPE
 
 script:
-  - if [ -n "${FITS}" ]; then conda install --yes ${FITS}; fi
+  - if [ -n "${FITS}" ]; then conda install --yes ${FITS} numpy=1.8; fi
   - if [ ${TEST} == submodule ]; then python setup.py test; fi
   - if [ ${TEST} == smoke ];
         then cd /home;

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -272,6 +272,7 @@ void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 
 // XSPEC convolution models
 void C_cflux(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_cpflux(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_xsgsmt(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_ireflct(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_kdblur(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
@@ -1275,19 +1276,20 @@ static PyMethodDef XSpecMethods[] = {
   XSPECTABLEMODEL_NORM( xsatbl ),
   XSPECTABLEMODEL_NORM( xsmtbl ),
   // XSPEC convolution models
-  XSPECMODELFCT_C(C_cflux, 3),
-  XSPECMODELFCT_C(C_xsgsmt, 2),
-  XSPECMODELFCT_C(C_ireflct, 7),
-  XSPECMODELFCT_C(C_kdblur, 4),
-  XSPECMODELFCT_C(C_kdblur2, 6),
-  XSPECMODELFCT_C(C_spinconv, 7),
-  XSPECMODELFCT_C(C_xslsmt, 2),
-  XSPECMODELFCT_C(C_PartialCovering, 1),
-  XSPECMODELFCT_C(C_rdblur, 4),
-  XSPECMODELFCT_C(C_reflct, 5),
-  XSPECMODELFCT_C(C_simpl, 3),
-  XSPECMODELFCT_C(C_zashift, 1),
-  XSPECMODELFCT_C(C_zmshift, 1),
+  XSPECMODELFCT_CON(C_cflux, 3),
+  XSPECMODELFCT_CON(C_cpflux, 3),
+  XSPECMODELFCT_CON(C_xsgsmt, 2),
+  XSPECMODELFCT_CON(C_ireflct, 7),
+  XSPECMODELFCT_CON(C_kdblur, 4),
+  XSPECMODELFCT_CON(C_kdblur2, 6),
+  XSPECMODELFCT_CON(C_spinconv, 7),
+  XSPECMODELFCT_CON(C_xslsmt, 2),
+  XSPECMODELFCT_CON(C_PartialCovering, 1),
+  XSPECMODELFCT_CON(C_rdblur, 4),
+  XSPECMODELFCT_CON(C_reflct, 5),
+  XSPECMODELFCT_CON(C_simpl, 3),
+  XSPECMODELFCT_CON(C_zashift, 1),
+  XSPECMODELFCT_CON(C_zmshift, 1),
   
   { NULL, NULL, 0, NULL }
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -122,6 +122,7 @@ class test_xspec(SherpaTestCase):
 
     def setUp(self):
         from sherpa.astro import xspec
+        ui.clean()
         self._defaults = xspec.get_xsstate()
 
     def tearDown(self):
@@ -187,7 +188,13 @@ class test_xspec(SherpaTestCase):
         import sherpa.astro.xspec as xs
         mdl = xs.XSpowerlaw()
 
+        # Check when input array is too small (< 2 elements)
         self.assertRaises(TypeError, mdl, [0.1])
+
+        # Check when input arrays are not the same size (when the
+        # low and high bin edges are given)
+        self.assertRaises(TypeError, mdl, [0.1, 0.2, 0.3], [0.2, 0.3])
+        self.assertRaises(TypeError, mdl, [0.1, 0.2], [0.2, 0.3, 0.4])
 
     def test_xspec_models(self):
         import sherpa.astro.xspec as xs
@@ -228,6 +235,23 @@ class test_xspec(SherpaTestCase):
             assert_allclose(evals1, wvals1,
                             err_msg=emsg + "energy to wavelength")
 
+    def test_tablemodel_checks_input_length(self):
+
+        # see test_table_model for more information on the table
+        # model being used.
+        #
+        ui.load_table_model('mdl',
+                            self.make_path('xspec/tablemodel/RCS.mod'))
+        mdl = ui.get_model_component('mdl')
+
+        # Check when input array is too small (< 2 elements)
+        self.assertRaises(TypeError, mdl, [0.1])
+
+        # Check when input arrays are not the same size (when the
+        # low and high bin edges are given)
+        self.assertRaises(TypeError, mdl, [0.1, 0.2, 0.3], [0.2, 0.3])
+        self.assertRaises(TypeError, mdl, [0.1, 0.2], [0.2, 0.3, 0.4])
+
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xspec_tablemodel(self):
         # Just test one table model; use the same scheme as
@@ -243,6 +267,8 @@ class test_xspec(SherpaTestCase):
         # when used in the test suite it appears that the tmod
         # global symbol is not created, so need to access the component
         tmod = ui.get_model_component('tmod')
+
+        self.assertEqual(tmod.name, 'xstablemodel.tmod')
 
         egrid, elo, ehi, wgrid, wlo, whi = make_grid()
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -19,12 +19,17 @@
 
 import unittest
 import numpy
+from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
 from sherpa.utils import SherpaTestCase, test_data_missing
 from sherpa.utils import has_package_from_list, has_fits_support
 
-import logging
-error = logging.getLogger(__name__).error
+
+# Conversion between wavelength (Angstrom) and energy (keV)
+# The values used are from sherpa/include/constants.hh
+#
+_hc = 6.6260693e-27 * 2.99792458e+18 / 1.60217653e-9
+
 
 def is_proper_subclass(obj, cls):
     if type(cls) is not tuple:
@@ -34,9 +39,94 @@ def is_proper_subclass(obj, cls):
     return issubclass(obj, cls)
 
 
+# Make it easier to run these tests on subsets of the XSPEC
+# model library, or in case model names get changed.
+#
+def remove_item(xs, x):
+    """Remove x from xs or do nothing (if x is not a member of xs)."""
+    try:
+        xs.remove(x)
+    except ValueError:
+        pass
+
+# There is an argument to be made that these tests only need
+# to exercise a small number of models (e.g. one each of the
+# different templates used in xspec_extension.hh - so single
+# precision, double precision, and table models) but there
+# is also benefit in testing them all (in particular, to check
+# that interface changes do not significantly change the
+# results for any model). For now stick with testing most of
+# the models.
+#
+def get_xspec_models(xs):
+    """What are the XSpec model names to test."""
+
+    # The alternate approach is to use that taken by
+    # test_create_model_instances
+    #
+    models = [model for model in dir(xs) if model.startswith('XS')]
+
+    # Could just exclude any names that end in 'Model', but this
+    # could remove valid model names, so be explicit.
+    remove_item(models, 'XSModel')
+    remove_item(models, 'XSMultiplicativeModel')
+    remove_item(models, 'XSAdditiveModel')
+    remove_item(models, 'XSTableModel')
+
+    # In XSPEC 12.8.2, the nteea model is written in such a way that
+    # it fails in Sherpa (but not from within XSPEC). This has
+    # been fixed in 12.9.0, but can cause problems for Sherpa tests
+    # when the model is evaluated multiple times.
+    #
+    version = [int(v) for v in xs.get_xsversion().split('.')[0:2]]
+    if tuple(version) < (12, 9):
+        remove_item(models, 'XSnteea')
+
+    return models
+
+
+def make_grid():
+    """Return the 'standard' contiguous grid used in these tests.
+
+    Returns egrid, elo, ehi, wgrid, wlo, whi where the e-xxx values
+    are in keV and the w-xxx values in Angstrom, *grid are a
+    single grid of values (i.e. one array) and the *lo/*hi values
+    are this grid separated out into bin edges.
+
+    The following condition holds: *hi[i] > *lo[i], and the
+    values in the two arrays are either monotonically increasing
+    or decreasing.
+    """
+
+    # This is close to the standard energy range used by Chandra,
+    # but it can take time to run when iterating through over
+    # 100 models. So chose a coarser grid and a smaller energy
+    # range.
+    #
+    # egrid = numpy.arange(0.1, 11.01, 0.01)
+
+    egrid = numpy.arange(0.1, 5.01, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    wgrid = _hc / egrid
+    whi = wgrid[:-1]
+    wlo = wgrid[1:]
+
+    return egrid, elo, ehi, wgrid, wlo, whi
+
+
 @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
                  "required sherpa.astro.xspec module missing")
 class test_xspec(SherpaTestCase):
+
+    def setUp(self):
+        from sherpa.astro import xspec
+        self._defaults = xspec.get_xsstate()
+
+    def tearDown(self):
+        from sherpa.astro import xspec
+        xspec.set_xsstate(self._defaults)
 
     def test_create_model_instances(self):
         import sherpa.astro.xspec as xs
@@ -50,60 +140,153 @@ class test_xspec(SherpaTestCase):
 
             if is_proper_subclass(cls, (xs.XSAdditiveModel,
                                         xs.XSMultiplicativeModel)):
-                m = cls()
+                # Ensure that we can create an instance, but do
+                # nothing with it.
+                cls()
                 count += 1
 
         self.assertEqual(count, 164)
 
+    def test_norm_works(self):
+        # Check that the norm parameter for additive models
+        # works, as it is handled separately from the other
+        # parameters.
+        import sherpa.astro.xspec as xs
+
+        # need an additive model
+        mdl = xs.XSpowerlaw()
+        mdl.PhoIndex = 2
+        egrid = [0.1, 0.2, 0.3, 0.4]
+
+        mdl.norm = 1.2
+        y1 = mdl(egrid)
+
+        mfactor = 2.1
+        mdl.norm = mdl.norm.val * mfactor
+        y2 = mdl(egrid)
+
+        # check that the sum is not 0 and that it
+        # scales as expected.
+        s1 = y1.sum()
+        s2 = y2.sum()
+        self.assertGreater(s1, 0.0, msg='powerlaw is positive')
+        self.assertAlmostEqual(s2, mfactor * s1, msg='powerlaw norm scaling')
+
     def test_evaluate_model(self):
         import sherpa.astro.xspec as xs
-        m = xs.XSbbody()
-        out = m([1,2,3,4])
-        if m.calc.__name__.startswith('C_'):
+        mdl = xs.XSbbody()
+        out = mdl([1, 2, 3, 4])
+        if mdl.calc.__name__.startswith('C_'):
             otype = numpy.float64
         else:
             otype = numpy.float32
-        self.assert_(out.dtype.type is otype)
+        self.assertEqual(out.dtype.type, otype)
         self.assertEqual(int(numpy.flatnonzero(out == 0.0)), 3)
 
+    def test_checks_input_length(self):
+        import sherpa.astro.xspec as xs
+        mdl = xs.XSpowerlaw()
+
+        self.assertRaises(TypeError, mdl, [0.1])
 
     def test_xspec_models(self):
         import sherpa.astro.xspec as xs
-        models = [model for model in dir(xs) if model[:2] == 'XS']
-        models.remove('XSModel')
-        models.remove('XSMultiplicativeModel')
-        models.remove('XSAdditiveModel')
-        models.remove('XSTableModel')
+        models = get_xspec_models(xs)
 
-        xx = numpy.arange(0.1, 11.01, 0.01, dtype=float)
-        xlo = numpy.array(xx[:-1])
-        xhi = numpy.array(xx[1:])
+        egrid, elo, ehi, wgrid, wlo, whi = make_grid()
         for model in models:
             cls = getattr(xs, model)
-            foo = cls(model)  # use an identifier in case there is an error
-            # The model checks that the values are all finite.
-            vals = foo(xlo,xhi)
+            mdl = cls(model)  # use an identifier in case there is an error
+
+            # The model checks that the values are all finite,
+            # so there is no need to check that the output of
+            # mdl does not contain non-finite values.
+            #
+            evals1 = mdl(egrid)
+            evals2 = mdl(elo, ehi)
+
+            wvals1 = mdl(wgrid)
+            wvals2 = mdl(wlo, whi)
+
+            emsg = "{} model evaluation failed: ".format(model)
+
+            # It might be expected that the test should be
+            #   assert_allclose(evals1[:-1], evals2)
+            # to ensure there's no floating-point issues,
+            # but in this case the grid and parameter
+            # values *should* be exactly the same, so the
+            # results *should* be exactly equal, hence
+            # the use of assert_array_equal
+            assert_array_equal(evals1[:-1], evals2,
+                               err_msg=emsg + "energy comparison")
+            assert_array_equal(wvals1[:-1], wvals2,
+                               err_msg=emsg + "wavelength comparison")
+
+            # When comparing wavelength to energy values, have
+            # to use allclose since the bins are not identically
+            # equal.
+            assert_allclose(evals1, wvals1,
+                            err_msg=emsg + "energy to wavelength")
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    def test_xspec_tablemodel(self):
+        # Just test one table model; use the same scheme as
+        # test_xspec_models_noncontiguous().
+        #
+        # The table model is from
+        # https://heasarc.gsfc.nasa.gov/xanadu/xspec/models/rcs.html
+        # retrieved July 9 2015. The exact model is irrelevant for this
+        # test, so this was chosen as it's relatively small.
+        ui.load_table_model('tmod',
+                            self.make_path('xspec/tablemodel/RCS.mod'))
+
+        # when used in the test suite it appears that the tmod
+        # global symbol is not created, so need to access the component
+        tmod = ui.get_model_component('tmod')
+
+        egrid, elo, ehi, wgrid, wlo, whi = make_grid()
+
+        evals1 = tmod(egrid)
+        evals2 = tmod(elo, ehi)
+
+        # wvals1 = tmod(wgrid)
+        # wvals2 = tmod(wlo, whi)
+
+        # Direct comparison of wavelength and energy grid.
+        #
+        emsg = "table model evaluation failed: "
+        rtol = 1e-3
+
+        assert_allclose(evals1[:-1], evals2, rtol=rtol,
+                        err_msg=emsg + "energy comparison")
+
+        # assert_allclose(evals1, wvals1, rtol=rtol,
+        #                 err_msg=emsg + "single arg")
+        # assert_allclose(evals2, wvals2, rtol=rtol,
+        #                 err_msg=emsg + "two args")
 
     @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits')
+                     'need pycrates, astropy.io.fits, or pyfits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_analysis_wave_fabrizio(self):
-        rmf = self.datadir + '/ciao4.3/fabrizio/Data/3c273.rmf'
-        arf = self.datadir + '/ciao4.3/fabrizio/Data/3c273.arf'
+        rmf = self.make_path('ciao4.3/fabrizio/Data/3c273.rmf')
+        arf = self.make_path('ciao4.3/fabrizio/Data/3c273.arf')
 
         ui.set_model("fabrizio", "xspowerlaw.p1")
         ui.fake_pha("fabrizio", arf, rmf, 10000)
 
+        parvals = [1, 1]
+
         model = ui.get_model("fabrizio")
         bare_model, _ = ui._session._get_model_status("fabrizio")
-        y = bare_model.calc([1,1], model.xlo, model.xhi)
+        y = bare_model.calc(parvals, model.xlo, model.xhi)
         y_m = numpy.mean(y)
 
-        ui.set_analysis("fabrizio","wave")
+        ui.set_analysis("fabrizio", "wave")
 
         model2 = ui.get_model("fabrizio")
         bare_model2, _ = ui._session._get_model_status("fabrizio")
-        y2 = bare_model2.calc([1,1], model2.xlo, model2.xhi)
+        y2 = bare_model2.calc(parvals, model2.xlo, model2.xhi)
         y2_m = numpy.mean(y2)
 
         self.assertAlmostEqual(y_m, y2_m)
@@ -116,6 +299,16 @@ class test_xspec(SherpaTestCase):
 
 
 if __name__ == '__main__':
+    import os
+    import sys
     import sherpa.astro.xspec as xs
     from sherpa.utils import SherpaTest
-    SherpaTest(xs).test()
+
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+        if not os.path.exists(datadir):
+            datadir = None
+    else:
+        datadir = None
+
+    SherpaTest(xs).test(datadir=datadir)

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -73,6 +73,13 @@ def get_xspec_models(xs):
     remove_item(models, 'XSAdditiveModel')
     remove_item(models, 'XSTableModel')
 
+    # The sirf model - in 12.8.2 and up to 12.9.0d at least - includes
+    # a read outside of an array. This has been seen to cause occasional
+    # errors in the Sherpa test case, so it is removed from the test
+    # for now. This problem has been reported to the XSPEC developers,
+    # so it will hopefully be fixed in one of ther 12.9.0 patches.
+    remove_item(models, 'XSsirf')
+
     # In XSPEC 12.8.2, the nteea model is written in such a way that
     # it fails in Sherpa (but not from within XSPEC). This has
     # been fixed in 12.9.0, but can cause problems for Sherpa tests

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -284,6 +284,7 @@ class test_xspec(SherpaTestCase):
             assert_allclose(evals2, wvals2,
                             err_msg=emsg + "energy to wavelength")
 
+    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_tablemodel_checks_input_length(self):
 
         # see test_table_model for more information on the table

--- a/sherpa/include/sherpa/array.hh
+++ b/sherpa/include/sherpa/array.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -91,6 +91,26 @@ namespace sherpa {
     const npy_intp* get_dims() const
     {
       return PyArray_DIMS( (PyArrayObject*) array );
+    }
+
+    // What should the ref field be set to: it seems like 1 will check that
+    // there are no references to the array, which seems to make sense
+    // here.
+    //
+    void resize1d( npy_intp newsize ) {
+      npy_intp dims[1] = { newsize };
+      PyArray_Dims newdims;
+      newdims.ptr = dims;
+      newdims.len = 1;
+
+      (void) PyArray_Resize( (PyArrayObject*) array, &newdims,
+                             1, NPY_ANYORDER );
+
+      // We know what the size value shoule be (newsize), but
+      // check with Python.
+      data = PyArray_BYTES( (PyArrayObject*) array );
+      size = PyArray_SIZE( (PyArrayObject*) array );
+      stride = PyArray_STRIDE( (PyArrayObject*) array, 0 );
     }
 
     const CType& operator[]( npy_intp index ) const


### PR DESCRIPTION
# Release Note

Fixes handling of non-contiguous bins - i.e. when a model is called with both xlo and xhi arguments but the bins do not fully cover the energy, or wavelenth, range. This fixes #62 (for XSPEC 12.8.2; switching to XSPEC 12.9.0 should also fix it) and #56. It also fixes an (un-reported) problem with handling of non-contiguous grids when using a table model, where a crash was likely.

When an XSPEC model is called with both low and high values for the grid - i.e. with two arguments - then the two arrays are checked to have the same length, and a ValueError is raised if this condition does not hold. This is a breaking change, but the results are not guaranteed to be correct if the two arrays are not the same length.

The experimental interface for XSPEC convolution models has changed, so that the function call takes pars, fluxes, xlo, with optional xhi whereas before it was pars, xlo, xhi, fluxes. This is a breaking change, but this is in the low-level API that is not documented to users, and adds useful functionality (the ability to have xhi be optional). The cpflux convolution model has been added. Note that these models do not have Python classes associated with them as they are still an experimental interface. 

The test suite has been updated to test the new and changed functionality in this PR. The choice of models is made so as to avoid known problematic models (with a version check where relevant).

It is believed that the changes in this PR fixes #42, although this is hard to prove conclusively as the cause of #42 have never been identified, but the clean up and fixes here are likely fixes.

# Other notes

This has been tested with XSPEC libraries 12.8.2q and 12.9.0b.

The code has seen a significant change, to improve clarity and to re-inforce the similarites between the various templates. A future change could be to re-write the templates to avoid the existing code duplication - as suggested by @dtnguyen2 - but that is outside the scope of this PR.

No performance testing has been done to see if the new approach is slower than the old one. Any performance tweaks should be done after the code has been consolidated, if found to be necessary.

The code for convolution models has been separated from that for "C-style" models as it is a lot cleaner to do so.

This should complete the set of fixes taken from #63, although the code is slightly different as different choices were made (based on experience developing both patches). Differences to those parts of #63 not already merged are:

- In #63 the grid sent in to "float *" models was converted straight away to float, rather than being handled as a double until it needed to be converted to float. This lead to some surprising behavior when using a model expression that contained both single- and double-precision models, so for nw this change has been scrapped
- #63 added checks for the grid being monotonic and to not have overlaps; these have been removed since at present it's not obvious that this is not going to cause problems due to float/double conversion tolerances (related to the previous point)
- the test suite is a lot simpler, since it avoids the comparison of the results of a non-contiguous array with the "parent" contiguous array (i.e. the grid from which the non-contiguous grid was created). This comparison is problematic since although the results should be the same in principle, in practice the XSPEC code often re-bins data, or uses the existing grid it is sent, so that you can get larger-than expected differences from the comparison. This lead to a confusing set of tolerances and manual choices of models to test or not in #63. The new approach is to compare the results for non-contiguous grids when evaluated on energy and wavelength grids, which I think is a sensible compromise here (given the other checks the test suite does for the contiguous case)