### PR TITLE
Bug #46 astropy handle commentary cards

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,7 +17,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from itertools import izip, repeat
+"""
+Provide I/O routines to Sherpa, focussing on FITS.
+
+This module should not be imported directly if there is no
+FITS support present (i.e. neither the crates or astropy
+back ends are in use).
+"""
+
+from itertools import izip
 import logging
 import os
 import os.path
@@ -25,15 +33,15 @@ import sys
 import numpy
 import sherpa.io
 from sherpa.utils.err import IOErr
-from sherpa.utils import SherpaFloat, SherpaInt, get_num_args
+from sherpa.utils import SherpaFloat
 from sherpa.data import Data2D, Data1D, BaseData, Data2DInt
-from sherpa.astro.data import *
+from sherpa.astro.data import DataIMG, DataIMGInt, DataARF, DataRMF, DataPHA
 from sherpa import get_config
 from ConfigParser import ConfigParser
 
 config = ConfigParser()
 config.read(get_config())
-io_opt = config.get('options','io_pkg')
+io_opt = config.get('options', 'io_pkg')
 io_opt = str(io_opt).strip().lower()
 
 if io_opt.startswith('pycrates') or io_opt.startswith('crates'):
@@ -50,12 +58,13 @@ info    = logging.getLogger(__name__).info
 read_table_blocks = backend.read_table_blocks
 
 __all__ = ('read_table', 'read_image', 'read_arf', 'read_rmf', 'read_arrays',
-           'read_pha', 'write_image','write_pha', 'write_table',
+           'read_pha', 'write_image', 'write_pha', 'write_table',
            'pack_table', 'pack_image', 'pack_pha', 'read_table_blocks')
 
 
 def _is_subclass(t1, t2):
     return isinstance(t1, type) and issubclass(t1, t2) and (t1 is not t2)
+
 
 def read_arrays(*args):
     """
@@ -63,22 +72,23 @@ def read_arrays(*args):
 
     read_table( *CrateData_args [, dstype = Data1D ] )
 
-    read_table( *NumPy_and_CrateData_args [, dstype = Data1D ] )    
+    read_table( *NumPy_and_CrateData_args [, dstype = Data1D ] )
     """
     args = list(args)
     if len(args) == 0:
         raise IOErr('noarrays')
 
-    dstype=Data1D
+    dstype = Data1D
     if _is_subclass(args[-1], BaseData):
         dstype = args.pop()
 
     args = backend.get_column_data(*args)
 
     # Determine max number of args for dataset constructor
-    sherpa.io._check_args( len(args), dstype )
+    sherpa.io._check_args(len(args), dstype)
 
     return dstype('', *args)
+
 
 def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
     """
@@ -89,13 +99,14 @@ def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
     colnames, cols, name, hdr = backend.get_table_data(arg, ncols, colkeys)
 
     # Determine max number of args for dataset constructor
-    sherpa.io._check_args( len(cols), dstype )
+    sherpa.io._check_args(len(cols), dstype)
 
     return dstype(name, *cols)
 
-def read_ascii(filename , ncols=2, colkeys=None, dstype=Data1D, **kwargs):
+
+def read_ascii(filename, ncols=2, colkeys=None, dstype=Data1D, **kwargs):
     """
-    read_ascii( filename [, ncols=2 [, colkeys=None [, sep=' ' [, 
+    read_ascii( filename [, ncols=2 [, colkeys=None [, sep=' ' [,
                 dstype=Data1D [, comment='#' ]]]]] )
     """
     colnames, cols, name = backend.get_ascii_data(filename, ncols=ncols,
@@ -103,9 +114,10 @@ def read_ascii(filename , ncols=2, colkeys=None, dstype=Data1D, **kwargs):
                                                   dstype=dstype, **kwargs)
 
     # Determine max number of args for dataset constructor
-    sherpa.io._check_args( len(cols), dstype )
+    sherpa.io._check_args(len(cols), dstype)
 
     return dstype(name, *cols)
+
 
 def read_image(arg, coord='logical', dstype=DataIMG):
     """
@@ -116,8 +128,8 @@ def read_image(arg, coord='logical', dstype=DataIMG):
     data, filename = backend.get_image_data(arg)
     axlens = data['y'].shape
 
-    x0 = numpy.arange(axlens[1], dtype=SherpaFloat)+1.
-    x1 = numpy.arange(axlens[0], dtype=SherpaFloat)+1.
+    x0 = numpy.arange(axlens[1], dtype=SherpaFloat) + 1.
+    x1 = numpy.arange(axlens[0], dtype=SherpaFloat) + 1.
     x0, x1 = numpy.meshgrid(x0, x1)
     x0 = x0.ravel()
     x1 = x1.ravel()
@@ -126,13 +138,14 @@ def read_image(arg, coord='logical', dstype=DataIMG):
     data['coord'] = coord
     data['shape'] = axlens
 
-    datset = None
     if issubclass(dstype, DataIMGInt):
-        dataset = dstype(filename, x0-0.5, x1-0.5, x0+0.5, x1+0.5, **data)
+        dataset = dstype(filename, x0 - 0.5, x1 - 0.5, x0 + 0.5, x1 + 0.5,
+                         **data)
     elif issubclass(dstype, Data2DInt):
         for name in ['coord', 'eqpos', 'sky', 'header']:
             data.pop(name, None)
-        dataset = dstype(filename, x0-0.5, x1-0.5, x0+0.5, x1+0.5, **data)
+        dataset = dstype(filename, x0 - 0.5, x1 - 0.5, x0 + 0.5, x1 + 0.5,
+                         **data)
     else:
         dataset = dstype(filename, x0, x1, **data)
 
@@ -159,68 +172,81 @@ def read_rmf(arg):
     return DataRMF(filename, **data)
 
 
+def _read_ancillary(data, key, label, dname,
+                    read_func, output_once=True):
+    """Read in the file, if the key in data is set,
+    replacing the value with the full path to the file,
+    and return the resulf of calling read_func on the
+    file. dname is the directory where the input file is,
+    and is used to create the full path if it is not an
+    absolute path.
+    """
+
+    if not(data[key]) or data[key].lower() == 'none':
+        return None
+
+    out = None
+    try:
+        if os.path.dirname(data[key]) == '':
+            data[key] = os.path.join(dname, data[key])
+
+        out = read_func(data[key])
+        if output_once:
+            info('read {} file {}'.format(label, data[key]))
+
+    except:
+        if output_once:
+            warning(str(sys.exc_info()[1]))
+
+    return out
+
+
 def read_pha(arg, use_errors=False, use_background=False):
     """
     read_pha( filename [, use_errors=False [, use_background=False]] )
 
     read_pha( PHACrate [, use_errors=False [, use_background=False]] )
     """
-    datasets, filename = backend.get_pha_data(arg,use_background=use_background)
+    datasets, filename = backend.get_pha_data(arg,
+                                              use_background=use_background)
     phasets = []
     output_once = True
     for data in datasets:
         if not use_errors:
-            if( (data['staterror'] is not None) or
-                (data['syserror'] is not None) ):
+            if data['staterror'] is not None or data['syserror'] is not None:
                 if data['staterror'] is None:
                     msg = 'systematic'
                 elif data['syserror'] is None:
                     msg = 'statistical'
                     if output_once:
-                        warning("systematic errors were not found in file '%s'" % filename)
+                        wmsg = "systematic errors were not found in " + \
+                               "file '{}'".format(filename)
+                        warning(wmsg)
                 else:
                     msg = 'statistical and systematic'
                 if output_once:
-                    info((msg + " errors were found in file '%s' \nbut not used; "
-                          'to use them, re-read with use_errors=True') % filename)
+                    imsg = msg + " errors were found in file " + \
+                           "'{}' \nbut not used; ".format(filename) + \
+                           "to use them, re-read with use_errors=True"
+                    info(imsg)
                 data['staterror'] = None
                 data['syserror'] = None
 
-        arf = None
-        if data['arffile'] and (data['arffile'].lower() != 'none'):
-            is_bkg = ' '
-            if use_background:
-                is_bkg = ' (background) '
-            try:
-                if os.path.dirname(data['arffile']) == '':
-                    data['arffile'] =os.path.join(os.path.dirname(filename),
-                                                  data['arffile'])
-                arf = read_arf(data['arffile'])
-                if output_once:
-                    info('read ARF%sfile %s' % (is_bkg, data['arffile']))
-            except:
-                if output_once:
-                    warning("%s" % sys.exc_info()[1])
+        dname = os.path.dirname(filename)
+        albl = 'ARF'
+        rlbl = 'RMF'
+        if use_background:
+            albl = albl + ' (background)'
+            rlbl = rlbl + ' (background)'
 
-        rmf = None
-        if data['rmffile'] and (data['rmffile'].lower() != 'none'):
-            is_bkg = ' '
-            if use_background:
-                is_bkg = ' (background) '
-            try:
-                if os.path.dirname(data['rmffile']) == '':
-                    data['rmffile'] = os.path.join(os.path.dirname(filename),
-                                                   data['rmffile'])
-                rmf = read_rmf(data['rmffile'])
-                if output_once:
-                    info('read RMF%sfile %s' % (is_bkg, data['rmffile']))
-            except:
-                if output_once:
-                    warning("%s" % sys.exc_info()[1])
+        arf = _read_ancillary(data, 'arffile', albl, dname, read_arf,
+                              output_once)
+        rmf = _read_ancillary(data, 'rmffile', rlbl, dname, read_rmf,
+                              output_once)
 
         backgrounds = []
 
-        if data['backfile'] and (data['backfile'].lower() != 'none'):
+        if data['backfile'] and data['backfile'].lower() != 'none':
             try:
                 if os.path.dirname(data['backfile']) == '':
                     data['backfile'] = os.path.join(os.path.dirname(filename),
@@ -232,23 +258,24 @@ def read_pha(arg, use_errors=False, use_background=False):
                     bkg_datasets = read_pha(data['backfile'], use_errors, True)
 
                     if output_once:
-                        info('read background file %s' % data['backfile'])
+                        info('read background file {}'.format(
+                            data['backfile']))
 
                 if numpy.iterable(bkg_datasets):
                     for bkg_dataset in bkg_datasets:
-                        if ((bkg_dataset.get_response() == (None,None)) and
-                            (rmf is not None)):
+                        if bkg_dataset.get_response() == (None, None) and \
+                           rmf is not None:
                             bkg_dataset.set_response(arf, rmf)
                         backgrounds.append(bkg_dataset)
                 else:
-                    if ((bkg_datasets.get_response() == (None,None)) and
-                        (rmf is not None)):
+                    if bkg_datasets.get_response() == (None, None) and \
+                       rmf is not None:
                         bkg_datasets.set_response(arf, rmf)
                     backgrounds.append(bkg_datasets)
 
             except:
                 if output_once:
-                    warning("%s" % sys.exc_info()[1])
+                    warning(str(sys.exc_info()[1]))
 
         for bkg_type, bscal_type in izip(('background_up', 'background_down'),
                                          ('backscup', 'backscdn')):
@@ -265,12 +292,12 @@ def read_pha(arg, use_errors=False, use_background=False):
                             header=data['header'])
                 b.set_response(arf, rmf)
                 if output_once:
-                    info("read %s into a dataset from file %s" %
-                         (bkg_type, filename) )
+                    info("read {} into a dataset from file {}".format(
+                        bkg_type, filename))
                 backgrounds.append(b)
 
         for k in ['backfile', 'arffile', 'rmffile', 'backscup', 'backscdn',
-                  'background_up','background_down' ]:
+                  'background_up', 'background_down']:
             data.pop(k, None)
 
         pha = DataPHA(filename, **data)
@@ -281,17 +308,18 @@ def read_pha(arg, use_errors=False, use_background=False):
                 b.grouped = (b.grouping is not None)
             if b.quality is None:
                 b.quality = pha.quality
-            pha.set_background(b, id+1)
+            pha.set_background(b, id + 1)
 
         # set units *after* bkgs have been set
         pha._set_initial_quantity()
         phasets.append(pha)
-        output_once=False
+        output_once = False
 
     if len(phasets) == 1:
         phasets = phasets[0]
 
     return phasets
+
 
 def _pack_table(dataset):
     names = dataset._fields
@@ -299,11 +327,12 @@ def _pack_table(dataset):
     data = dict(cols)
     return data, names
 
+
 def _pack_image(dataset):
-    if (not(isinstance(dataset, Data2D) or
-            isinstance(dataset, DataIMG))):
+    if not(isinstance(dataset, Data2D) or
+           isinstance(dataset, DataIMG)):
         raise IOErr('notimage', dataset.name)
-    data={}
+    data = {}
 
     header = {}
     if hasattr(dataset, 'header') and type(dataset.header) is dict:
@@ -314,6 +343,23 @@ def _pack_image(dataset):
     data['eqpos'] = getattr(dataset, 'eqpos', None)
 
     return data, header
+
+
+def _set_keyword(header, label, value):
+    """Extract the string form of the value, and store
+    the last path element in the header using the label
+    key.
+    """
+
+    if value is None:
+        return
+
+    name = getattr(value, 'name', 'none')
+    if name is not None and name.find('/') != -1:
+        name = name.split('/')[-1]
+
+    header[label] = name
+
 
 def _pack_pha(dataset):
     if not isinstance(dataset, DataPHA):
@@ -326,30 +372,14 @@ def _pack_pha(dataset):
 
     # Header Keys
     header = {}
-    if hasattr(dataset,'header'): #and type(dataset.header) is dict:
+    if hasattr(dataset, 'header'):  # and type(dataset.header) is dict:
         header = dataset.header.copy()
 
     header['EXPOSURE'] = getattr(dataset, 'exposure', 'none')
 
-    if rmf is not None:
-        name = getattr(rmf, 'name', 'none')
-        if( ( name is not None ) and ( name.find('/') != -1 ) ):
-            name = name.split('/').pop()
-        header['RESPFILE'] = name
-
-
-    if bkg is not None:
-        name = getattr(bkg, 'name', 'none')
-        if( ( name is not None ) and ( name.find('/') != -1 ) ):
-            name = name.split('/').pop()
-        header['BACKFILE'] = name
-
-
-    if arf is not None:
-        name = getattr(arf, 'name', 'none')
-        if( ( name is not None ) and ( name.find('/') != -1 ) ):
-            name = name.split('/').pop()
-        header['ANCRFILE'] = name
+    _set_keyword(header, 'RESPFILE', rmf)
+    _set_keyword(header, 'ANCRFILE', arf)
+    _set_keyword(header, 'BACKFILE', bkg)
 
     # Columns
     col_names = ['channel', 'counts', 'stat_err', 'sys_err',
@@ -386,27 +416,33 @@ def _pack_pha(dataset):
 def write_arrays(filename, args, fields=None, ascii=True, clobber=False):
     backend.set_arrays(filename, args, fields, ascii=ascii, clobber=clobber)
 
+
 def write_table(filename, dataset, ascii=True, clobber=False):
-    data, names = _pack_table( dataset )
+    data, names = _pack_table(dataset)
     backend.set_table_data(filename, data, names, ascii=ascii, clobber=clobber)
+
 
 def write_image(filename, dataset, ascii=True, clobber=False):
     data, hdr = _pack_image(dataset)
     backend.set_image_data(filename, data, hdr, ascii=ascii, clobber=clobber )
 
+
 def write_pha(filename, dataset, ascii=True, clobber=False):
-    data, col_names, hdr = _pack_pha( dataset )
+    data, col_names, hdr = _pack_pha(dataset)
     backend.set_pha_data(filename, data, col_names, hdr, ascii=ascii,
                          clobber=clobber)
 
+
 def pack_table(dataset):
-    data, names = _pack_table( dataset )
+    data, names = _pack_table(dataset)
     return backend.set_table_data('', data, names, packup=True)
+
 
 def pack_image(dataset):
     data, hdr = _pack_image(dataset)
     return backend.set_image_data('', data, hdr, packup=True)
 
+
 def pack_pha(dataset):
-    data, col_names, hdr = _pack_pha( dataset )
+    data, col_names, hdr = _pack_pha(dataset)
     return backend.set_pha_data('', data, col_names, hdr, packup=True)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -532,7 +532,6 @@ class test_save_pha(SherpaTestCase):
     def tearDown(self):
         logger.setLevel(self._old_logger_level)
 
-    @unittest.expectedFailure
     def testWrite(self):
         ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
         ui.save_pha(self._id, ofh.name, ascii=False, clobber=True)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -19,10 +19,17 @@
 
 import os
 import unittest
+import tempfile
+
+import numpy
+from numpy.testing import assert_allclose
+
 from sherpa.utils import SherpaTest, SherpaTestCase
 from sherpa.utils import test_data_missing, has_fits_support
 from sherpa.astro import ui
-import numpy
+from sherpa.data import Data1D
+from sherpa.astro.data import DataPHA
+
 import logging
 logger = logging.getLogger("sherpa")
 
@@ -38,12 +45,15 @@ class test_ui(SherpaTestCase):
         self.doubledat = self.make_path('double.dat')
         self.doubletbl = self.make_path('double.fits')
         self.img = self.make_path('img.fits')
-        self.filter_single_int_ascii = self.make_path('filter_single_integer.dat')
-        self.filter_single_int_table = self.make_path('filter_single_integer.fits')
-        self.filter_single_log_table = self.make_path('filter_single_logical.fits')
+        self.filter_single_int_ascii = self.make_path(
+            'filter_single_integer.dat')
+        self.filter_single_int_table = self.make_path(
+            'filter_single_integer.fits')
+        self.filter_single_log_table = self.make_path(
+            'filter_single_logical.fits')
 
         self.func = lambda x: x
-        ui.dataspace1d(1,1000,dstype=ui.Data1D)
+        ui.dataspace1d(1, 1000, dstype=ui.Data1D)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -59,8 +69,8 @@ class test_ui(SherpaTestCase):
     def test_table(self):
         ui.load_table(1, self.fits)
         ui.load_table(1, self.fits, 3)
-        ui.load_table(1, self.fits, 3, ["RMID","SUR_BRI","SUR_BRI_ERR"])
-        ui.load_table(1, self.fits, 4, ('R',"SUR_BRI",'SUR_BRI_ERR'),
+        ui.load_table(1, self.fits, 3, ["RMID", "SUR_BRI", "SUR_BRI_ERR"])
+        ui.load_table(1, self.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
                       ui.Data1DInt)
 
     @unittest.skipIf(not has_fits_support(),
@@ -68,7 +78,8 @@ class test_ui(SherpaTestCase):
     def test_load_table_fits(self):
         # QUS: why is this not in the sherpa-test-data repository?
         this_dir = os.path.dirname(os.path.abspath(__file__))
-        ui.load_table(1, os.path.join(this_dir, 'data', 'two_column_x_y.fits.gz'))
+        ui.load_table(1, os.path.join(this_dir, 'data',
+                                      'two_column_x_y.fits.gz'))
         data = ui.get_data(1)
         self.assertEqualWithinTol(data.x, [1, 2, 3])
         self.assertEqualWithinTol(data.y, [4, 5, 6])
@@ -159,7 +170,7 @@ class test_more_ui(SherpaTestCase):
         from sherpa.astro.instrument import RMFModelPHA
         self.assertTrue(isinstance(m, RMFModelPHA))
 
-    #bug #38
+    # bug #38
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -168,6 +179,7 @@ class test_more_ui(SherpaTestCase):
         ui.notice_id('3c273', 0.3, 2)
         ui.group_counts('3c273', 30)
         ui.group_counts('3c273', 15)
+
 
 class test_image_12578(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -208,7 +220,8 @@ class test_image_12578(SherpaTestCase):
         try:
             ui.set_coord("sky")
         except DataErr as e:
-            okmsg = "unknown coordinates: 'sky'\nValid options: logical, image, physical, world, wcs"
+            okmsg = "unknown coordinates: 'sky'\nValid options: " + \
+                    "logical, image, physical, world, wcs"
             self.assertEqual(okmsg, e.message)
             caught = True
         if not caught:
@@ -232,7 +245,7 @@ class test_psf_ui(SherpaTestCase):
         ui.dataspace1d(1, 10)
         for model in self.models1d:
             try:
-                ui.load_psf('psf1d', model+'.mdl')
+                ui.load_psf('psf1d', model + '.mdl')
                 ui.set_psf('psf1d')
                 mdl = ui.get_model_component('mdl')
                 self.assertTrue((numpy.array(mdl.get_center()) ==
@@ -242,14 +255,14 @@ class test_psf_ui(SherpaTestCase):
                 raise
 
     def test_psf_model2d(self):
-        ui.dataspace2d([216,261])
+        ui.dataspace2d([216, 261])
         for model in self.models2d:
             try:
-                ui.load_psf('psf2d', model+'.mdl')
+                ui.load_psf('psf2d', model + '.mdl')
                 ui.set_psf('psf2d')
                 mdl = ui.get_model_component('mdl')
                 self.assertTrue((numpy.array(mdl.get_center()) ==
-                                 numpy.array([108,130])).all())
+                                 numpy.array([108, 130])).all())
             except:
                 print model
                 raise
@@ -403,6 +416,154 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat1)
         self.assertEqual('chi2', stat12)
 
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_base(SherpaTestCase):
+
+    # _colnames:  specify column names (True) or not
+    # _fits:      use FITS format for output?
+
+    _colnames = False
+    _fits = None
+
+    def _read_func(self, filename):
+        raise NotImplementedError
+
+    def save_arrays(self):
+        """Write out a small set of data using ui.save_arrays
+        and then read it back in, to check it was written out
+        correctly (or, at least, in a way that can be read back
+        in).
+        """
+
+        # It looks like the input arrays to `write_arrays` should be numpy
+        # arrays, so enforce that invariant.
+        a = numpy.asarray([1, 3, 9])
+        b = numpy.sqrt(numpy.asarray(a))
+        c = b * 0.1
+
+        if self._colnames:
+            fields = ["x", "yy", "z"]
+        else:
+            fields = None
+
+        ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+        ui.save_arrays(ofh.name, [a, b, c], fields=fields,
+                       ascii=not self._fits, clobber=True)
+
+        out = self._read_func(ofh.name)
+
+        rtol = 0
+        atol = 1e-5
+        self.assertIsInstance(out, Data1D)
+        self.assertEqual(out.name, ofh.name, msg="file name")
+        assert_allclose(out.x, a, rtol=rtol, atol=atol, err_msg="x column")
+        assert_allclose(out.y, b, rtol=rtol, atol=atol, err_msg="y column")
+        assert_allclose(out.staterror, c, rtol=rtol, atol=atol,
+                        err_msg="staterror")
+        self.assertIsNone(out.syserror, msg="syserror")
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_nocols_FITS(test_save_arrays_base):
+
+    _fits = True
+
+    def _read_func(self, filename):
+        return ui.unpack_table(filename, ncols=3)
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_cols_FITS(test_save_arrays_nocols_FITS):
+
+    _colnames = True
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_nocols_ASCII(test_save_arrays_base):
+
+    _fits = False
+
+    def _read_func(self, filename):
+        return ui.unpack_ascii(filename, ncols=3)
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_cols_ASCII(test_save_arrays_nocols_ASCII):
+
+    _colnames = True
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+@unittest.skipIf(test_data_missing(), 'required test data missing')
+class test_save_pha(SherpaTestCase):
+    """Write out a PHA data set as a FITS file."""
+
+    longMessage = True
+
+    def setUp(self):
+        # hide warning messages from file I/O
+        self._old_logger_level = logger.level
+        logger.setLevel(logging.ERROR)
+
+        self._id = 1
+        fname = self.make_path('ciao4.3/pha_intro/3c273.pi')
+        ui.load_pha(self._id, fname)
+        self._pha = ui.get_data(self._id)
+
+    def tearDown(self):
+        logger.setLevel(self._old_logger_level)
+
+    @unittest.expectedFailure
+    def testWrite(self):
+        ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+        ui.save_pha(self._id, ofh.name, ascii=False, clobber=True)
+
+        # limited checks
+        pha = ui.unpack_pha(ofh.name)
+        self.assertIsInstance(pha, DataPHA)
+
+        for key in ["channel", "counts"]:
+            newval = getattr(pha, key)
+            oldval = getattr(self._pha, key)
+            assert_allclose(oldval, newval, err_msg=key)
+
+        # at present grouping and quality are not written out
+
+        for key in ["exposure", "backscal", "areascal"]:
+            newval = getattr(pha, key)
+            oldval = getattr(self._pha, key)
+            self.assertAlmostEqual(oldval, newval, msg=key)
+
+        """
+        Since the original file has RMF and ARF, the units
+        are energy, but on write out these files are not
+        created/saved, so when read back in the PHA has no
+        ARF/RMF, and will have units=channel.
+
+        for key in ["units"]:
+            newval = getattr(pha, key)
+            oldval = getattr(self._pha, key)
+            self.assertEqual(oldval, newval, msg=key)
+        """
 
 if __name__ == '__main__':
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -22,9 +22,10 @@ import logging
 import numpy
 from itertools import izip
 import sherpa.ui.utils
-from sherpa.ui.utils import _check_type, _send_to_pager
+from sherpa.ui.utils import _argument_type_error, _check_type, _send_to_pager
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange
-from sherpa.utils.err import *
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
+    IdentifierErr, IOErr, ModelErr
 from sherpa.data import Data1D
 import sherpa.astro.all
 import sherpa.astro.plot
@@ -101,7 +102,7 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
 
     def __setstate__(self, state):
-        if not state.has_key('_background_sources'):
+        if '_background_sources' not in state:
             self.__dict__['_background_sources'] = state.pop(
                 '_background_models')
 
@@ -4156,7 +4157,8 @@ class Session(sherpa.ui.utils.Session):
         self.save_arrays(filename, [x, err], ['X', 'ERR'],
                          ascii, clobber)
 
-    def save_pha(self, id, filename=None, bkg_id=None, ascii=False, clobber=False):
+    def save_pha(self, id, filename=None, bkg_id=None, ascii=False,
+                 clobber=False):
         """Save a PHA data set to a file.
 
         Parameters
@@ -8006,13 +8008,14 @@ class Session(sherpa.ui.utils.Session):
 
         """
         d = sherpa.astro.data.DataPHA('', None, None)
-        if self._data.has_key(id):
+        if id in self._data:
             d = self._get_pha_data(id)
         else:
             # Make empty header OGIP compliant
             # And add appropriate values to header from input values
-            d.header = dict(HDUCLASS="OGIP", HDUCLAS1="SPECTRUM", HDUCLAS2="TOTAL",
-                            HDUCLAS3="TYPE:I", HDUCLAS4="COUNT", HDUVERS="1.1.0")
+            d.header = dict(HDUCLASS="OGIP", HDUCLAS1="SPECTRUM",
+                            HDUCLAS2="TOTAL", HDUCLAS3="TYPE:I",
+                            HDUCLAS4="COUNT", HDUVERS="1.1.0")
             self.set_data(id, d)
 
         if rmf is None:
@@ -8969,9 +8972,7 @@ class Session(sherpa.ui.utils.Session):
                                       nint=nint, addmodel=addmodel,
                                       addredshift=addredshift)
 
-        except Exception, e:
-            # print e, type(e)
-            #raise e
+        except Exception:
             x = None
             y = None
             try:
@@ -9142,7 +9143,7 @@ class Session(sherpa.ui.utils.Session):
             for bi in data.background_ids:
                 mod = None
                 ds = self.get_bkg(i, bi)
-                if bkg_models.has_key(bi) or bkg_sources.has_key(bi):
+                if bi in bkg_models or bi in bkg_sources:
                     mod = self.get_bkg_model(i, bi)
 
                 if mod is not None:
@@ -9339,12 +9340,12 @@ class Session(sherpa.ui.utils.Session):
         ids = f = None
         fit_bkg = False
 
-        if kwargs.has_key('bkg_only') and kwargs.pop('bkg_only'):
+        if 'bkg_only' in kwargs and kwargs.pop('bkg_only'):
             fit_bkg = True
 
         # validate the kwds to f.fit() so user typos do not
         # result in regular fit
-        #valid_keys = sherpa.utils.get_keyword_names(sherpa.fit.Fit.fit)
+        # valid_keys = sherpa.utils.get_keyword_names(sherpa.fit.Fit.fit)
         valid_keys = ('outfile', 'clobber', 'filter_nan')
         for key in kwargs.keys():
             if key not in valid_keys:
@@ -9355,7 +9356,7 @@ class Session(sherpa.ui.utils.Session):
         else:
             ids, f = self._get_fit(id, otherids)
 
-        if kwargs.has_key('filter_nan') and kwargs.pop('filter_nan'):
+        if 'filter_nan' in kwargs and kwargs.pop('filter_nan'):
             for i in ids:
                 self.get_data(i).mask = self.get_data(
                     i).mask & numpy.isfinite(self.get_data(i).get_x())
@@ -10438,7 +10439,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg(1, 2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgdataplot, None, bkg_id, **kwargs)
 
     def plot_bkg_model(self, id=None, bkg_id=None, **kwargs):
@@ -10489,7 +10490,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_model('jet', bkg_id=2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgmodelhisto, None, bkg_id, **kwargs)
 
     def plot_bkg_resid(self, id=None, bkg_id=None, **kwargs):
@@ -10541,7 +10542,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_resid('jet', bkg_id=2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgresidplot, None, bkg_id, **kwargs)
 
     def plot_bkg_ratio(self, id=None, bkg_id=None, **kwargs):
@@ -10593,7 +10594,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_ratio('jet', bkg_id=2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgratioplot, None, bkg_id, **kwargs)
 
     def plot_bkg_delchi(self, id=None, bkg_id=None, **kwargs):
@@ -10645,7 +10646,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_delchi('jet', bkg_id=2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgdelchiplot, None, bkg_id, **kwargs)
 
     def plot_bkg_chisqr(self, id=None, bkg_id=None, **kwargs):
@@ -10697,7 +10698,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_chisqr('jet', bkg_id=2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgchisqrplot, None, bkg_id, **kwargs)
 
     def plot_bkg_fit(self, id=None, bkg_id=None, **kwargs):
@@ -10747,7 +10748,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_fit()
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgfitplot, None, bkg_id, **kwargs)
 
     def plot_bkg_source(self, id=None, lo=None, hi=None, bkg_id=None, **kwargs):
@@ -10801,7 +10802,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_source('jet', bkg_id=2, overplot=True)
 
         """
-        bkg = self.get_bkg(id, bkg_id)
+        _ = self.get_bkg(id, bkg_id)
         self._plot(id, self._bkgsourceplot, None, bkg_id, lo, hi, **kwargs)
 
     # DOC-TODO: I am assuming it accepts a scales parameter
@@ -10892,7 +10893,8 @@ class Session(sherpa.ui.utils.Session):
         efplot = self._energyfluxplot
         if sherpa.utils.bool_cast(kwargs.pop('recalc', True)):
             efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id, num,
-                                                    bins, correlated, numcores, bkg_id)
+                                                    bins, correlated,
+                                                    numcores, bkg_id)
         try:
             sherpa.plot.begin()
             efplot.plot(**kwargs)
@@ -10992,7 +10994,8 @@ class Session(sherpa.ui.utils.Session):
         pfplot = self._photonfluxplot
         if sherpa.utils.bool_cast(kwargs.pop('recalc', True)):
             pfplot = self._prepare_photon_flux_plot(pfplot, lo, hi, id, num,
-                                                    bins, correlated, numcores, bkg_id)
+                                                    bins, correlated,
+                                                    numcores, bkg_id)
         try:
             sherpa.plot.begin()
             pfplot.plot(**kwargs)
@@ -11070,9 +11073,9 @@ class Session(sherpa.ui.utils.Session):
                                     clearwindow=clearwindow)
 
             oldval = rp.plot_prefs['xlog']
-            if ((self._bkgdataplot.plot_prefs.has_key('xlog') and
+            if (('xlog' in self._bkgdataplot.plot_prefs and
                  self._bkgdataplot.plot_prefs['xlog']) or
-                (self._bkgmodelplot.plot_prefs.has_key('xlog') and
+                ('xlog' in self._bkgmodelplot.plot_prefs and
                  self._bkgmodelplot.plot_prefs['xlog'])):
                 rp.plot_prefs['xlog'] = True
 
@@ -11154,9 +11157,9 @@ class Session(sherpa.ui.utils.Session):
                                     clearwindow=clearwindow)
 
             oldval = dp.plot_prefs['xlog']
-            if ((self._bkgdataplot.plot_prefs.has_key('xlog') and
+            if (('xlog' in self._bkgdataplot.plot_prefs and
                  self._bkgdataplot.plot_prefs['xlog']) or
-                (self._bkgmodelplot.plot_prefs.has_key('xlog') and
+                ('xlog' in self._bkgmodelplot.plot_prefs and
                  self._bkgmodelplot.plot_prefs['xlog'])):
                 dp.plot_prefs['xlog'] = True
 
@@ -11496,7 +11499,7 @@ class Session(sherpa.ui.utils.Session):
         else:
             src = self.get_source(id)
 
-        if None == modelcomponent:
+        if modelcomponent is None:
             modelcomponent = src
 
         correlated = sherpa.utils.bool_cast(correlated)
@@ -11504,7 +11507,7 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(modelcomponent, sherpa.models.model.Model):
             raise ArgumentTypeErr('badarg', 'modelcomponent', 'a model')
 
-        if False == Xrays:
+        if not Xrays:
             samples = self.calc_energy_flux(lo=lo, hi=hi, id=id,
                                             bkg_id=bkg_id)
         else:


### PR DESCRIPTION
This replaces #91 - the commit history is a lot cleaner and does not conflict with the `master` branch.

Resolve #46 

# Release Notes

Fix for writing out FITS files using the save_pha and save_table commands - and the associated pack_pha and pack_table commands - when using the astropy I/O back end (issue #46). It does not affect CIAO users (i.e. users of the crates back end).

Fix for when the `notice2d_id`, `notice2d_image`, and the `ignore` version functions are called with an invalid identifier (i.e. an identifier that i snot an integer or string value). The error is now an `ArgumentTypeErr` with the message "'ids' must be an identifier or list of identifiers". It was a `NameError` with the message "global name '_argument_type_error' is not defined".

Improves the `sherpa/astro/ui/tests/test_astro_ui.py` test suite.

# Notes

The primary fix is to handle the so-called commentary cards (i.e. those with a keyword of HISTORY, COMMENT, or blank) properly, when converting from the Sherpa data structure (the header field in the DataXXX object) to an astropy FITS header. This is a general-purpose change (so both FITS tables, images) but testing has focussed on the PHA case, as that was where the issue was first seen. More tests are needed for sherpa.astro.ui, but that's outside the scope of this PR.

The NameError fix was just that the _argument_type_error routine has not been imported from the necessary module.

The code has seen PEP-8 fixes and minor refactorings.

The tests are not added to `sherpa/astro/io/tests/test_astro_io.py` since there are issues with 