### PR TITLE
Ensure astropy and crates behave the same with gzipped files

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,7 +17,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from itertools import izip, repeat
+"""
+Provide I/O routines to Sherpa, focussing on FITS.
+
+This module should not be imported directly if there is no
+FITS support present (i.e. neither the crates or astropy
+back ends are in use).
+"""
+
+from itertools import izip
 import logging
 import os
 import os.path
@@ -25,15 +33,15 @@ import sys
 import numpy
 import sherpa.io
 from sherpa.utils.err import IOErr
-from sherpa.utils import SherpaFloat, SherpaInt, get_num_args
+from sherpa.utils import SherpaFloat
 from sherpa.data import Data2D, Data1D, BaseData, Data2DInt
-from sherpa.astro.data import *
+from sherpa.astro.data import DataIMG, DataIMGInt, DataARF, DataRMF, DataPHA
 from sherpa import get_config
 from ConfigParser import ConfigParser
 
 config = ConfigParser()
 config.read(get_config())
-io_opt = config.get('options','io_pkg')
+io_opt = config.get('options', 'io_pkg')
 io_opt = str(io_opt).strip().lower()
 
 if io_opt.startswith('pycrates') or io_opt.startswith('crates'):
@@ -50,12 +58,13 @@ info    = logging.getLogger(__name__).info
 read_table_blocks = backend.read_table_blocks
 
 __all__ = ('read_table', 'read_image', 'read_arf', 'read_rmf', 'read_arrays',
-           'read_pha', 'write_image','write_pha', 'write_table',
+           'read_pha', 'write_image', 'write_pha', 'write_table',
            'pack_table', 'pack_image', 'pack_pha', 'read_table_blocks')
 
 
 def _is_subclass(t1, t2):
     return isinstance(t1, type) and issubclass(t1, t2) and (t1 is not t2)
+
 
 def read_arrays(*args):
     """
@@ -63,22 +72,23 @@ def read_arrays(*args):
 
     read_table( *CrateData_args [, dstype = Data1D ] )
 
-    read_table( *NumPy_and_CrateData_args [, dstype = Data1D ] )    
+    read_table( *NumPy_and_CrateData_args [, dstype = Data1D ] )
     """
     args = list(args)
     if len(args) == 0:
         raise IOErr('noarrays')
 
-    dstype=Data1D
+    dstype = Data1D
     if _is_subclass(args[-1], BaseData):
         dstype = args.pop()
 
     args = backend.get_column_data(*args)
 
     # Determine max number of args for dataset constructor
-    sherpa.io._check_args( len(args), dstype )
+    sherpa.io._check_args(len(args), dstype)
 
     return dstype('', *args)
+
 
 def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
     """
@@ -89,13 +99,14 @@ def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
     colnames, cols, name, hdr = backend.get_table_data(arg, ncols, colkeys)
 
     # Determine max number of args for dataset constructor
-    sherpa.io._check_args( len(cols), dstype )
+    sherpa.io._check_args(len(cols), dstype)
 
     return dstype(name, *cols)
 
-def read_ascii(filename , ncols=2, colkeys=None, dstype=Data1D, **kwargs):
+
+def read_ascii(filename, ncols=2, colkeys=None, dstype=Data1D, **kwargs):
     """
-    read_ascii( filename [, ncols=2 [, colkeys=None [, sep=' ' [, 
+    read_ascii( filename [, ncols=2 [, colkeys=None [, sep=' ' [,
                 dstype=Data1D [, comment='#' ]]]]] )
     """
     colnames, cols, name = backend.get_ascii_data(filename, ncols=ncols,
@@ -103,9 +114,10 @@ def read_ascii(filename , ncols=2, colkeys=None, dstype=Data1D, **kwargs):
                                                   dstype=dstype, **kwargs)
 
     # Determine max number of args for dataset constructor
-    sherpa.io._check_args( len(cols), dstype )
+    sherpa.io._check_args(len(cols), dstype)
 
     return dstype(name, *cols)
+
 
 def read_image(arg, coord='logical', dstype=DataIMG):
     """
@@ -116,8 +128,8 @@ def read_image(arg, coord='logical', dstype=DataIMG):
     data, filename = backend.get_image_data(arg)
     axlens = data['y'].shape
 
-    x0 = numpy.arange(axlens[1], dtype=SherpaFloat)+1.
-    x1 = numpy.arange(axlens[0], dtype=SherpaFloat)+1.
+    x0 = numpy.arange(axlens[1], dtype=SherpaFloat) + 1.
+    x1 = numpy.arange(axlens[0], dtype=SherpaFloat) + 1.
     x0, x1 = numpy.meshgrid(x0, x1)
     x0 = x0.ravel()
     x1 = x1.ravel()
@@ -126,13 +138,14 @@ def read_image(arg, coord='logical', dstype=DataIMG):
     data['coord'] = coord
     data['shape'] = axlens
 
-    datset = None
     if issubclass(dstype, DataIMGInt):
-        dataset = dstype(filename, x0-0.5, x1-0.5, x0+0.5, x1+0.5, **data)
+        dataset = dstype(filename, x0 - 0.5, x1 - 0.5, x0 + 0.5, x1 + 0.5,
+                         **data)
     elif issubclass(dstype, Data2DInt):
         for name in ['coord', 'eqpos', 'sky', 'header']:
             data.pop(name, None)
-        dataset = dstype(filename, x0-0.5, x1-0.5, x0+0.5, x1+0.5, **data)
+        dataset = dstype(filename, x0 - 0.5, x1 - 0.5, x0 + 0.5, x1 + 0.5,
+                         **data)
     else:
         dataset = dstype(filename, x0, x1, **data)
 
@@ -159,68 +172,81 @@ def read_rmf(arg):
     return DataRMF(filename, **data)
 
 
+def _read_ancillary(data, key, label, dname,
+                    read_func, output_once=True):
+    """Read in the file, if the key in data is set,
+    replacing the value with the full path to the file,
+    and return the resulf of calling read_func on the
+    file. dname is the directory where the input file is,
+    and is used to create the full path if it is not an
+    absolute path.
+    """
+
+    if not(data[key]) or data[key].lower() == 'none':
+        return None
+
+    out = None
+    try:
+        if os.path.dirname(data[key]) == '':
+            data[key] = os.path.join(dname, data[key])
+
+        out = read_func(data[key])
+        if output_once:
+            info('read {} file {}'.format(label, data[key]))
+
+    except:
+        if output_once:
+            warning(str(sys.exc_info()[1]))
+
+    return out
+
+
 def read_pha(arg, use_errors=False, use_background=False):
     """
     read_pha( filename [, use_errors=False [, use_background=False]] )
 
     read_pha( PHACrate [, use_errors=False [, use_background=False]] )
     """
-    datasets, filename = backend.get_pha_data(arg,use_background=use_background)
+    datasets, filename = backend.get_pha_data(arg,
+                                              use_background=use_background)
     phasets = []
     output_once = True
     for data in datasets:
         if not use_errors:
-            if( (data['staterror'] is not None) or
-                (data['syserror'] is not None) ):
+            if data['staterror'] is not None or data['syserror'] is not None:
                 if data['staterror'] is None:
                     msg = 'systematic'
                 elif data['syserror'] is None:
                     msg = 'statistical'
                     if output_once:
-                        warning("systematic errors were not found in file '%s'" % filename)
+                        wmsg = "systematic errors were not found in " + \
+                               "file '{}'".format(filename)
+                        warning(wmsg)
                 else:
                     msg = 'statistical and systematic'
                 if output_once:
-                    info((msg + " errors were found in file '%s' \nbut not used; "
-                          'to use them, re-read with use_errors=True') % filename)
+                    imsg = msg + " errors were found in file " + \
+                           "'{}' \nbut not used; ".format(filename) + \
+                           "to use them, re-read with use_errors=True"
+                    info(imsg)
                 data['staterror'] = None
                 data['syserror'] = None
 
-        arf = None
-        if data['arffile'] and (data['arffile'].lower() != 'none'):
-            is_bkg = ' '
-            if use_background:
-                is_bkg = ' (background) '
-            try:
-                if os.path.dirname(data['arffile']) == '':
-                    data['arffile'] =os.path.join(os.path.dirname(filename),
-                                                  data['arffile'])
-                arf = read_arf(data['arffile'])
-                if output_once:
-                    info('read ARF%sfile %s' % (is_bkg, data['arffile']))
-            except:
-                if output_once:
-                    warning("%s" % sys.exc_info()[1])
+        dname = os.path.dirname(filename)
+        albl = 'ARF'
+        rlbl = 'RMF'
+        if use_background:
+            albl = albl + ' (background)'
+            rlbl = rlbl + ' (background)'
 
-        rmf = None
-        if data['rmffile'] and (data['rmffile'].lower() != 'none'):
-            is_bkg = ' '
-            if use_background:
-                is_bkg = ' (background) '
-            try:
-                if os.path.dirname(data['rmffile']) == '':
-                    data['rmffile'] = os.path.join(os.path.dirname(filename),
-                                                   data['rmffile'])
-                rmf = read_rmf(data['rmffile'])
-                if output_once:
-                    info('read RMF%sfile %s' % (is_bkg, data['rmffile']))
-            except:
-                if output_once:
-                    warning("%s" % sys.exc_info()[1])
+        arf = _read_ancillary(data, 'arffile', albl, dname, read_arf,
+                              output_once)
+        rmf = _read_ancillary(data, 'rmffile', rlbl, dname, read_rmf,
+                              output_once)
 
         backgrounds = []
 
-        if data['backfile'] and (data['backfile'].lower() != 'none'):
+        if data['backfile'] and data['backfile'].lower() != 'none':
             try:
                 if os.path.dirname(data['backfile']) == '':
                     data['backfile'] = os.path.join(os.path.dirname(filename),
@@ -232,23 +258,24 @@ def read_pha(arg, use_errors=False, use_background=False):
                     bkg_datasets = read_pha(data['backfile'], use_errors, True)
 
                     if output_once:
-                        info('read background file %s' % data['backfile'])
+                        info('read background file {}'.format(
+                            data['backfile']))
 
                 if numpy.iterable(bkg_datasets):
                     for bkg_dataset in bkg_datasets:
-                        if ((bkg_dataset.get_response() == (None,None)) and
-                            (rmf is not None)):
+                        if bkg_dataset.get_response() == (None, None) and \
+                           rmf is not None:
                             bkg_dataset.set_response(arf, rmf)
                         backgrounds.append(bkg_dataset)
                 else:
-                    if ((bkg_datasets.get_response() == (None,None)) and
-                        (rmf is not None)):
+                    if bkg_datasets.get_response() == (None, None) and \
+                       rmf is not None:
                         bkg_datasets.set_response(arf, rmf)
                     backgrounds.append(bkg_datasets)
 
             except:
                 if output_once:
-                    warning("%s" % sys.exc_info()[1])
+                    warning(str(sys.exc_info()[1]))
 
         for bkg_type, bscal_type in izip(('background_up', 'background_down'),
                                          ('backscup', 'backscdn')):
@@ -265,12 +292,12 @@ def read_pha(arg, use_errors=False, use_background=False):
                             header=data['header'])
                 b.set_response(arf, rmf)
                 if output_once:
-                    info("read %s into a dataset from file %s" %
-                         (bkg_type, filename) )
+                    info("read {} into a dataset from file {}".format(
+                        bkg_type, filename))
                 backgrounds.append(b)
 
         for k in ['backfile', 'arffile', 'rmffile', 'backscup', 'backscdn',
-                  'background_up','background_down' ]:
+                  'background_up', 'background_down']:
             data.pop(k, None)
 
         pha = DataPHA(filename, **data)
@@ -281,17 +308,18 @@ def read_pha(arg, use_errors=False, use_background=False):
                 b.grouped = (b.grouping is not None)
             if b.quality is None:
                 b.quality = pha.quality
-            pha.set_background(b, id+1)
+            pha.set_background(b, id + 1)
 
         # set units *after* bkgs have been set
         pha._set_initial_quantity()
         phasets.append(pha)
-        output_once=False
+        output_once = False
 
     if len(phasets) == 1:
         phasets = phasets[0]
 
     return phasets
+
 
 def _pack_table(dataset):
     names = dataset._fields
@@ -299,11 +327,12 @@ def _pack_table(dataset):
     data = dict(cols)
     return data, names
 
+
 def _pack_image(dataset):
-    if (not(isinstance(dataset, Data2D) or
-            isinstance(dataset, DataIMG))):
+    if not(isinstance(dataset, Data2D) or
+           isinstance(dataset, DataIMG)):
         raise IOErr('notimage', dataset.name)
-    data={}
+    data = {}
 
     header = {}
     if hasattr(dataset, 'header') and type(dataset.header) is dict:
@@ -314,6 +343,23 @@ def _pack_image(dataset):
     data['eqpos'] = getattr(dataset, 'eqpos', None)
 
     return data, header
+
+
+def _set_keyword(header, label, value):
+    """Extract the string form of the value, and store
+    the last path element in the header using the label
+    key.
+    """
+
+    if value is None:
+        return
+
+    name = getattr(value, 'name', 'none')
+    if name is not None and name.find('/') != -1:
+        name = name.split('/')[-1]
+
+    header[label] = name
+
 
 def _pack_pha(dataset):
     if not isinstance(dataset, DataPHA):
@@ -326,30 +372,14 @@ def _pack_pha(dataset):
 
     # Header Keys
     header = {}
-    if hasattr(dataset,'header'): #and type(dataset.header) is dict:
+    if hasattr(dataset, 'header'):  # and type(dataset.header) is dict:
         header = dataset.header.copy()
 
     header['EXPOSURE'] = getattr(dataset, 'exposure', 'none')
 
-    if rmf is not None:
-        name = getattr(rmf, 'name', 'none')
-        if( ( name is not None ) and ( name.find('/') != -1 ) ):
-            name = name.split('/').pop()
-        header['RESPFILE'] = name
-
-
-    if bkg is not None:
-        name = getattr(bkg, 'name', 'none')
-        if( ( name is not None ) and ( name.find('/') != -1 ) ):
-            name = name.split('/').pop()
-        header['BACKFILE'] = name
-
-
-    if arf is not None:
-        name = getattr(arf, 'name', 'none')
-        if( ( name is not None ) and ( name.find('/') != -1 ) ):
-            name = name.split('/').pop()
-        header['ANCRFILE'] = name
+    _set_keyword(header, 'RESPFILE', rmf)
+    _set_keyword(header, 'ANCRFILE', arf)
+    _set_keyword(header, 'BACKFILE', bkg)
 
     # Columns
     col_names = ['channel', 'counts', 'stat_err', 'sys_err',
@@ -386,27 +416,33 @@ def _pack_pha(dataset):
 def write_arrays(filename, args, fields=None, ascii=True, clobber=False):
     backend.set_arrays(filename, args, fields, ascii=ascii, clobber=clobber)
 
+
 def write_table(filename, dataset, ascii=True, clobber=False):
-    data, names = _pack_table( dataset )
+    data, names = _pack_table(dataset)
     backend.set_table_data(filename, data, names, ascii=ascii, clobber=clobber)
+
 
 def write_image(filename, dataset, ascii=True, clobber=False):
     data, hdr = _pack_image(dataset)
     backend.set_image_data(filename, data, hdr, ascii=ascii, clobber=clobber )
 
+
 def write_pha(filename, dataset, ascii=True, clobber=False):
-    data, col_names, hdr = _pack_pha( dataset )
+    data, col_names, hdr = _pack_pha(dataset)
     backend.set_pha_data(filename, data, col_names, hdr, ascii=ascii,
                          clobber=clobber)
 
+
 def pack_table(dataset):
-    data, names = _pack_table( dataset )
+    data, names = _pack_table(dataset)
     return backend.set_table_data('', data, names, packup=True)
+
 
 def pack_image(dataset):
     data, hdr = _pack_image(dataset)
     return backend.set_image_data('', data, hdr, packup=True)
 
+
 def pack_pha(dataset):
-    data, col_names, hdr = _pack_pha( dataset )
+    data, col_names, hdr = _pack_pha(dataset)
     return backend.set_pha_data('', data, col_names, hdr, packup=True)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -45,7 +45,8 @@ except ImportError:
 import os
 from itertools import izip
 from sherpa.utils.err import IOErr
-from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat, is_binary_file
+from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat
+import sherpa.utils
 from sherpa.io import get_ascii_data, write_arrays
 from sherpa.astro.io.meta import Meta
 
@@ -261,6 +262,66 @@ def _try_vec_or_key(hdu, name, size, dtype=SherpaFloat, fix_type=False):
 
 # Read Functions
 
+# Crates supports reading gzipped files both when the '.gz' suffix
+# is given and even when it is not (i.e. if you ask to load 'foo.fits'
+# and 'foo.fits.gz' exists, then it will use this). This requires some
+# effort to emulate with the astropy backend.
+
+def is_binary_file(fname):
+    """Do we think the file contains binary data?
+
+    Parameters
+    ----------
+    fname : str
+       The file name.
+
+    Returns
+    -------
+    flag : bool
+       ``True`` if the file appears to contain binary data,
+       ``False`` otherwise.
+
+    Notes
+    -----
+    This is a wrapper around the version in sherpa.utils which
+    attempts to transparently support reading from a `.gz`
+    version if the input file name does not exist.
+    """
+
+    if not os.path.exists(fname):
+        fname = fname + '.gz'
+
+    return sherpa.utils.is_binary_file(fname)
+
+
+def open_fits(filename):
+    """Try and open filename as a FITS file.
+
+    Parameters
+    ----------
+    filename : str
+       The name of the FITS file to open. If the file
+       can not be opened then '.gz' is appended to the
+       name and the attempt is tried again.
+
+    Returns
+    -------
+    out
+       The return value from the `astropy.io.fits.open`
+       function.
+    """
+
+    try:
+        return fits.open(filename)
+    except IOError as e:
+        try:
+            # This will try 'foo.gz.gz'.
+            return fits.open(filename + '.gz')
+        except IOError:
+            # Raise the original error
+            raise e
+
+
 def read_table_blocks(arg, make_copy=False):
 
     filename = ''
@@ -270,7 +331,7 @@ def read_table_blocks(arg, make_copy=False):
         hdus = arg
     elif type(arg) in (str, unicode, numpy.str_) and is_binary_file(arg):
         filename = arg
-        hdus = fits.open(arg)
+        hdus = open_fits(arg)
     else:
         raise IOErr('badfile', arg,
                     "a binary FITS table or a BinTableHDU list")
@@ -318,7 +379,7 @@ def _get_file_contents(arg, exptype="PrimaryHDU", nobinary=False):
     """
 
     if type(arg) == str and (not nobinary or is_binary_file(arg)):
-        tbl = fits.open(arg)
+        tbl = open_fits(arg)
         filename = arg
     elif type(arg) is fits.HDUList and len(arg) > 0 and \
             arg[0].__class__ is fits.PrimaryHDU:

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -532,7 +532,6 @@ class test_save_pha(SherpaTestCase):
     def tearDown(self):
         logger.setLevel(self._old_logger_level)
 
-    @unittest.expectedFailure
     def testWrite(self):
         ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
         ui.save_pha(self._id, ofh.name, ascii=False, clobber=True)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -19,10 +19,17 @@
 
 import os
 import unittest
+import tempfile
+
+import numpy
+from numpy.testing import assert_allclose
+
 from sherpa.utils import SherpaTest, SherpaTestCase
 from sherpa.utils import test_data_missing, has_fits_support
 from sherpa.astro import ui
-import numpy
+from sherpa.data import Data1D
+from sherpa.astro.data import DataPHA
+
 import logging
 logger = logging.getLogger("sherpa")
 
@@ -38,12 +45,15 @@ class test_ui(SherpaTestCase):
         self.doubledat = self.make_path('double.dat')
         self.doubletbl = self.make_path('double.fits')
         self.img = self.make_path('img.fits')
-        self.filter_single_int_ascii = self.make_path('filter_single_integer.dat')
-        self.filter_single_int_table = self.make_path('filter_single_integer.fits')
-        self.filter_single_log_table = self.make_path('filter_single_logical.fits')
+        self.filter_single_int_ascii = self.make_path(
+            'filter_single_integer.dat')
+        self.filter_single_int_table = self.make_path(
+            'filter_single_integer.fits')
+        self.filter_single_log_table = self.make_path(
+            'filter_single_logical.fits')
 
         self.func = lambda x: x
-        ui.dataspace1d(1,1000,dstype=ui.Data1D)
+        ui.dataspace1d(1, 1000, dstype=ui.Data1D)
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
@@ -59,8 +69,8 @@ class test_ui(SherpaTestCase):
     def test_table(self):
         ui.load_table(1, self.fits)
         ui.load_table(1, self.fits, 3)
-        ui.load_table(1, self.fits, 3, ["RMID","SUR_BRI","SUR_BRI_ERR"])
-        ui.load_table(1, self.fits, 4, ('R',"SUR_BRI",'SUR_BRI_ERR'),
+        ui.load_table(1, self.fits, 3, ["RMID", "SUR_BRI", "SUR_BRI_ERR"])
+        ui.load_table(1, self.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
                       ui.Data1DInt)
 
     @unittest.skipIf(not has_fits_support(),
@@ -68,7 +78,8 @@ class test_ui(SherpaTestCase):
     def test_load_table_fits(self):
         # QUS: why is this not in the sherpa-test-data repository?
         this_dir = os.path.dirname(os.path.abspath(__file__))
-        ui.load_table(1, os.path.join(this_dir, 'data', 'two_column_x_y.fits.gz'))
+        ui.load_table(1, os.path.join(this_dir, 'data',
+                                      'two_column_x_y.fits.gz'))
         data = ui.get_data(1)
         self.assertEqualWithinTol(data.x, [1, 2, 3])
         self.assertEqualWithinTol(data.y, [4, 5, 6])
@@ -159,7 +170,7 @@ class test_more_ui(SherpaTestCase):
         from sherpa.astro.instrument import RMFModelPHA
         self.assertTrue(isinstance(m, RMFModelPHA))
 
-    #bug #38
+    # bug #38
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -168,6 +179,7 @@ class test_more_ui(SherpaTestCase):
         ui.notice_id('3c273', 0.3, 2)
         ui.group_counts('3c273', 30)
         ui.group_counts('3c273', 15)
+
 
 class test_image_12578(SherpaTestCase):
     @unittest.skipIf(test_data_missing(), "required test data missing")
@@ -208,7 +220,8 @@ class test_image_12578(SherpaTestCase):
         try:
             ui.set_coord("sky")
         except DataErr as e:
-            okmsg = "unknown coordinates: 'sky'\nValid options: logical, image, physical, world, wcs"
+            okmsg = "unknown coordinates: 'sky'\nValid options: " + \
+                    "logical, image, physical, world, wcs"
             self.assertEqual(okmsg, e.message)
             caught = True
         if not caught:
@@ -232,7 +245,7 @@ class test_psf_ui(SherpaTestCase):
         ui.dataspace1d(1, 10)
         for model in self.models1d:
             try:
-                ui.load_psf('psf1d', model+'.mdl')
+                ui.load_psf('psf1d', model + '.mdl')
                 ui.set_psf('psf1d')
                 mdl = ui.get_model_component('mdl')
                 self.assertTrue((numpy.array(mdl.get_center()) ==
@@ -242,14 +255,14 @@ class test_psf_ui(SherpaTestCase):
                 raise
 
     def test_psf_model2d(self):
-        ui.dataspace2d([216,261])
+        ui.dataspace2d([216, 261])
         for model in self.models2d:
             try:
-                ui.load_psf('psf2d', model+'.mdl')
+                ui.load_psf('psf2d', model + '.mdl')
                 ui.set_psf('psf2d')
                 mdl = ui.get_model_component('mdl')
                 self.assertTrue((numpy.array(mdl.get_center()) ==
-                                 numpy.array([108,130])).all())
+                                 numpy.array([108, 130])).all())
             except:
                 print model
                 raise
@@ -403,6 +416,154 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat1)
         self.assertEqual('chi2', stat12)
 
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_base(SherpaTestCase):
+
+    # _colnames:  specify column names (True) or not
+    # _fits:      use FITS format for output?
+
+    _colnames = False
+    _fits = None
+
+    def _read_func(self, filename):
+        raise NotImplementedError
+
+    def save_arrays(self):
+        """Write out a small set of data using ui.save_arrays
+        and then read it back in, to check it was written out
+        correctly (or, at least, in a way that can be read back
+        in).
+        """
+
+        # It looks like the input arrays to `write_arrays` should be numpy
+        # arrays, so enforce that invariant.
+        a = numpy.asarray([1, 3, 9])
+        b = numpy.sqrt(numpy.asarray(a))
+        c = b * 0.1
+
+        if self._colnames:
+            fields = ["x", "yy", "z"]
+        else:
+            fields = None
+
+        ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+        ui.save_arrays(ofh.name, [a, b, c], fields=fields,
+                       ascii=not self._fits, clobber=True)
+
+        out = self._read_func(ofh.name)
+
+        rtol = 0
+        atol = 1e-5
+        self.assertIsInstance(out, Data1D)
+        self.assertEqual(out.name, ofh.name, msg="file name")
+        assert_allclose(out.x, a, rtol=rtol, atol=atol, err_msg="x column")
+        assert_allclose(out.y, b, rtol=rtol, atol=atol, err_msg="y column")
+        assert_allclose(out.staterror, c, rtol=rtol, atol=atol,
+                        err_msg="staterror")
+        self.assertIsNone(out.syserror, msg="syserror")
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_nocols_FITS(test_save_arrays_base):
+
+    _fits = True
+
+    def _read_func(self, filename):
+        return ui.unpack_table(filename, ncols=3)
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_cols_FITS(test_save_arrays_nocols_FITS):
+
+    _colnames = True
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_nocols_ASCII(test_save_arrays_base):
+
+    _fits = False
+
+    def _read_func(self, filename):
+        return ui.unpack_ascii(filename, ncols=3)
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+class test_save_arrays_cols_ASCII(test_save_arrays_nocols_ASCII):
+
+    _colnames = True
+
+    def test_save_arrays(self):
+        self.save_arrays()
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+@unittest.skipIf(test_data_missing(), 'required test data missing')
+class test_save_pha(SherpaTestCase):
+    """Write out a PHA data set as a FITS file."""
+
+    longMessage = True
+
+    def setUp(self):
+        # hide warning messages from file I/O
+        self._old_logger_level = logger.level
+        logger.setLevel(logging.ERROR)
+
+        self._id = 1
+        fname = self.make_path('ciao4.3/pha_intro/3c273.pi')
+        ui.load_pha(self._id, fname)
+        self._pha = ui.get_data(self._id)
+
+    def tearDown(self):
+        logger.setLevel(self._old_logger_level)
+
+    @unittest.expectedFailure
+    def testWrite(self):
+        ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+        ui.save_pha(self._id, ofh.name, ascii=False, clobber=True)
+
+        # limited checks
+        pha = ui.unpack_pha(ofh.name)
+        self.assertIsInstance(pha, DataPHA)
+
+        for key in ["channel", "counts"]:
+            newval = getattr(pha, key)
+            oldval = getattr(self._pha, key)
+            assert_allclose(oldval, newval, err_msg=key)
+
+        # at present grouping and quality are not written out
+
+        for key in ["exposure", "backscal", "areascal"]:
+            newval = getattr(pha, key)
+            oldval = getattr(self._pha, key)
+            self.assertAlmostEqual(oldval, newval, msg=key)
+
+        """
+        Since the original file has RMF and ARF, the units
+        are energy, but on write out these files are not
+        created/saved, so when read back in the PHA has no
+        ARF/RMF, and will have units=channel.
+
+        for key in ["units"]:
+            newval = getattr(pha, key)
+            oldval = getattr(self._pha, key)
+            self.assertEqual(oldval, newval, msg=key)
+        """
 
 if __name__ == '__main__':
 

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -85,7 +85,6 @@ class test_load_pha3_gzip(SherpaTestCase):
         self.assertEqual(arf.name, barf.name)
         self.assertEqual(rmf.name, brmf.name)
 
-    @unittest.expectedFailure
     def testReadExplicit(self):
         """Include .gz in the file name"""
 
@@ -102,7 +101,6 @@ class test_load_pha3_gzip(SherpaTestCase):
         bpha = ui.get_bkg(idval, bkg_id=1)
         self.assertEqual(pha.name, bpha.name + '.gz')
 
-    @unittest.expectedFailure
     def testReadImplicit(self):
         """Exclude .gz from the file name"""
 

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -1,0 +1,127 @@
+#
+#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# break out some of the I/O tests in the UI layer into a separate set
+# of tests, in part to reduce file size, but also because some of these
+# may be better placed in tests of the sherpa.astro.io module, once that
+# becomes possible
+
+import unittest
+
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.utils import test_data_missing, has_fits_support
+from sherpa.astro import ui
+from sherpa.astro.data import DataPHA
+from sherpa.astro.instrument import ARF1D, RMF1D
+
+import logging
+logger = logging.getLogger("sherpa")
+
+
+@unittest.skipIf(not has_fits_support(),
+                 'need pycrates, astropy.io.fits, or pyfits')
+@unittest.skipIf(test_data_missing(), 'required test data missing')
+class test_load_pha3_gzip(SherpaTestCase):
+    """Handle a .gz FITS PHA Type 3 file"""
+
+    longMessage = True
+
+    def setUp(self):
+        # hide warning messages from file I/O
+        self._old_logger_level = logger.level
+        logger.setLevel(logging.ERROR)
+
+        ui.clean()
+
+        self.head = self.make_path('data/fits/gz/acisf01575_001N001_r0085')
+
+    def tearDown(self):
+        logger.setLevel(self._old_logger_level)
+
+    def validate_pha(self, idval):
+        """Check that the PHA dataset in id=idval is
+        as expected.
+        """
+
+        self.assertEqual(ui.list_data_ids(), [idval])
+
+        pha = ui.get_data(idval)
+        self.assertIsInstance(pha, DataPHA)
+
+        arf = ui.get_arf(idval)
+        self.assertIsInstance(arf, ARF1D)
+
+        rmf = ui.get_rmf(idval)
+        self.assertIsInstance(rmf, RMF1D)
+
+        bpha = ui.get_bkg(idval, bkg_id=1)
+        self.assertIsInstance(bpha, DataPHA)
+
+        barf = ui.get_arf(idval, bkg_id=1)
+        self.assertIsInstance(barf, ARF1D)
+
+        brmf = ui.get_rmf(idval, bkg_id=1)
+        self.assertIsInstance(brmf, RMF1D)
+
+        # normally the background data set would have a different name,
+        # but this is a  PHA Type 3 file.
+        # self.assertEqual(pha.name, bpha.name)
+        self.assertEqual(arf.name, barf.name)
+        self.assertEqual(rmf.name, brmf.name)
+
+    @unittest.expectedFailure
+    def testReadExplicit(self):
+        """Include .gz in the file name"""
+
+        idval = 12
+        fname = self.head + '_pha3.fits.gz'
+        ui.load_pha(idval, fname)
+
+        self.validate_pha(idval)
+
+        # TODO: does this indicate that the file name, as read in,
+        #       should have the .gz added to it to match the data
+        #       read in, or left as is?
+        pha = ui.get_data(idval)
+        bpha = ui.get_bkg(idval, bkg_id=1)
+        self.assertEqual(pha.name, bpha.name + '.gz')
+
+    @unittest.expectedFailure
+    def testReadImplicit(self):
+        """Exclude .gz from the file name"""
+
+        idval = "13"
+        fname = self.head + '_pha3.fits'
+        ui.load_pha(idval, fname)
+
+        self.validate_pha(idval)
+
+        pha = ui.get_data(idval)
+        bpha = ui.get_bkg(idval, bkg_id=1)
+        self.assertEqual(pha.name, bpha.name)
+
+if __name__ == '__main__':
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)


### PR DESCRIPTION
# Release Notes

Change the behaviour of the AstroPy back end so that it matches that of Crates when given a file name which does not exist, but a compressed version, with the suffix `.gz` does. The Crates behavior is to read the file. This extends to PHA files whose ancillary files - e.g. those stored in the `BACKFILE`, `ANCRFILE`, and `RESPFILE` keywords - are given as unzipped names, but only the gzipped names exist on disk.

As an example: if `pha.fits.gz` exists but `pha.fits` does not, then

    load_pha('pha.fits')

will now load the file with either back end. If the response files are set to `arf.fits` and `rmf.fits` (via the `ANCRFILE` and `RESPFILE` keywords), but only the `.gz` versions exist, then they will now also be loaded by the AstroPy back end. 

Tests have been added to cover this case.

# Notes

This requires an update to `sherpa-test-data`, which adds several gzipped files for the test suite.

I have checked the changes against a CIAO build (with crates) and they pass.

This commit depends on PR #102 (although with the rebase to include #108 this may now not be as obvious).