### PR TITLE
Normalize plot labels (PHA data sets)

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2008  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2008, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,14 +21,18 @@
 Classes for storing, inspecting, and manipulating astronomical data sets
 """
 
-from itertools import izip
 import os.path
 import numpy
 from sherpa.data import BaseData, Data1DInt, Data2D, DataND
 from sherpa.utils.err import DataErr, ImportErr
 from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
     create_expr, parse_expr, bool_cast, rebin, filter_bins
-from sherpa.astro.utils import *
+
+# There are currently (Sep 2015) no tests that exercise the code that
+# uses the compile_energy_grid or Region symbols.
+from sherpa.astro.utils import arf_fold, rmf_fold, filter_resp, \
+    compile_energy_grid, do_group, expand_grouped_mask, \
+    Region, region_mask
 
 import logging
 warning = logging.getLogger(__name__).warning
@@ -39,23 +43,24 @@ try:
     groupstatus = True
 except:
     groupstatus = False
-    warning('the group module (from the CIAO tools package) is not installed.'
-            + '\nDynamic grouping functions will not be available.')
+    warning('the group module (from the CIAO tools package) is not ' +
+            'installed.\nDynamic grouping functions will not be available.')
 
 
 __all__ = ('DataARF', 'DataRMF', 'DataPHA', 'DataIMG', 'DataIMGInt')
 
+
 def _notice_resp(chans, arf, rmf):
-    bin_mask=None
+    bin_mask = None
 
     if rmf is not None and arf is not None:
 
-        bin_mask = rmf.notice(chans)        
+        bin_mask = rmf.notice(chans)
         if len(rmf.energ_lo) == len(arf.energ_lo):
             arf.notice(bin_mask)
 
-        # If the response is mis-matched, determine which energy bins in the RMF
-        # coorespond to energy bins in the ARF and which are noticed.
+        # If the response is mis-matched, determine which energy bins in the
+        # RMF correspond to energy bins in the ARF and which are noticed.
         # Propogate the noticed RMF energy bins to the ARF energy  bins.
         elif len(rmf.energ_lo) < len(arf.energ_lo):
             arf_mask = None
@@ -63,9 +68,11 @@ def _notice_resp(chans, arf, rmf):
                 arf_mask = numpy.zeros(len(arf.energ_lo), dtype=bool)
                 for ii, val in enumerate(bin_mask):
                     if val:
-                        slice = filter_bins( (rmf.energ_lo[ii],), (rmf.energ_hi[ii],),
-                                             (arf.energ_lo,arf.energ_hi) ).nonzero()[0]
-                        arf_mask[slice]=True
+                        los = (rmf.energ_lo[ii],)
+                        his = (rmf.energ_hi[ii],)
+                        grid = (arf.energ_lo, arf.energ_hi)
+                        idx = filter_bins(los, his, grid).nonzero()[0]
+                        arf_mask[idx] = True
             arf.notice(arf_mask)
 
     else:
@@ -100,22 +107,20 @@ class DataARF(Data1DInt):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x!='header'), self._fields)
+            self._fields = filter((lambda x: x != 'header'), self._fields)
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
         return ss
 
-
     def __setstate__(self, state):
-        if not state.has_key('header'):
-            self.header=None
+        if 'header' not in state:
+            self.header = None
         self.__dict__.update(state)
 
-        if not state.has_key('_specresp'):
-            self.__dict__['_specresp'] = state.get('specresp',None)
-            self.__dict__['_rsp'] = state.get('specresp',None)
-
+        if '_specresp' not in state:
+            self.__dict__['_specresp'] = state.get('specresp', None)
+            self.__dict__['_rsp'] = state.get('specresp', None)
 
     def apply_arf(self, src, *args, **kwargs):
         "Fold the source array src through the ARF and return the result"
@@ -130,7 +135,6 @@ class DataARF(Data1DInt):
 
         return model
 
-
     def notice(self, bin_mask=None):
         self._rsp = self.specresp
         self._lo = self.energ_lo
@@ -141,11 +145,11 @@ class DataARF(Data1DInt):
             self._hi = self.energ_hi[bin_mask]
 
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return (self._lo, self._hi)
 
     def get_dep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return self._rsp
 
     def get_xlabel(self):
@@ -154,16 +158,21 @@ class DataARF(Data1DInt):
     def get_ylabel(self):
         return 'cm^2'
 
+
 class DataRMF(Data1DInt):
     "RMF data set"
 
     mask = property(BaseData._get_mask, BaseData._set_mask)
 
     def __init__(self, name, detchans, energ_lo, energ_hi, n_grp, f_chan,
-                 n_chan, matrix, offset=1, e_min=None, e_max=None, header=None):
-        self._fch = f_chan;  self._nch = n_chan
-        self._grp = n_grp;   self._rsp = matrix
-        self._lo = energ_lo; self._hi = energ_hi
+                 n_chan, matrix, offset=1, e_min=None, e_max=None,
+                 header=None):
+        self._fch = f_chan
+        self._nch = n_chan
+        self._grp = n_grp
+        self._rsp = matrix
+        self._lo = energ_lo
+        self._hi = energ_hi
         BaseData.__init__(self)
 
     def __str__(self):
@@ -171,18 +180,16 @@ class DataRMF(Data1DInt):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x!='header'), self._fields)
+            self._fields = filter((lambda x: x != 'header'), self._fields)
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
         return ss
 
-
     def __setstate__(self, state):
-        if not state.has_key('header'):
-            self.header=None
+        if 'header' not in state:
+            self.header = None
         self.__dict__.update(state)
-
 
     def apply_rmf(self, src, *args, **kwargs):
         "Fold the source array src through the RMF and return the result"
@@ -201,10 +208,13 @@ class DataRMF(Data1DInt):
                         self.detchans, self.offset)
 
     def notice(self, noticed_chans=None):
-        bin_mask=None
-        self._fch = self.f_chan;  self._nch = self.n_chan
-        self._grp = self.n_grp;   self._rsp = self.matrix
-        self._lo = self.energ_lo; self._hi = self.energ_hi
+        bin_mask = None
+        self._fch = self.f_chan
+        self._nch = self.n_chan
+        self._grp = self.n_grp
+        self._rsp = self.matrix
+        self._lo = self.energ_lo
+        self._hi = self.energ_hi
         if noticed_chans is not None:
             (self._grp, self._fch, self._nch, self._rsp,
              bin_mask) = filter_resp(noticed_chans, self.n_grp, self.f_chan,
@@ -214,18 +224,12 @@ class DataRMF(Data1DInt):
 
         return bin_mask
 
-    #def get_indep(self):
-    #    if (self.e_min is not None) and (self.e_max is not None):
-    #        return (self.e_min, self.e_max)
-    #    channels = numpy.arange(1.0, self.detchans+1.0, 1.0, SherpaFloat)
-    #    return (channels - 0.5, channels + 0.5)
-
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return (self._lo, self._hi)
 
     def get_dep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return self.apply_rmf(numpy.ones(self.energ_lo.shape, SherpaFloat))
 
     def get_xlabel(self):
@@ -244,6 +248,7 @@ class DataPHA(Data1DInt):
 
     def _get_grouped(self):
         return self._grouped
+
     def _set_grouped(self, val):
         val = bool(val)
 
@@ -260,23 +265,27 @@ class DataPHA(Data1DInt):
                 self.ignore()
                 for vals in parse_expr(old_filter):
                     self.notice(*vals)
-            #self.mask = True
+            # self.mask = True
 
         self._grouped = val
+
     grouped = property(_get_grouped, _set_grouped, doc='Are the data grouped?')
 
     def _get_subtracted(self):
         return self._subtracted
+
     def _set_subtracted(self, val):
         val = bool(val)
         if len(self._backgrounds) == 0:
             raise DataErr('nobkg', self.name)
         self._subtracted = val
+
     subtracted = property(_get_subtracted, _set_subtracted,
                           doc='Are the background data subtracted?')
 
     def _get_units(self):
         return self._units
+
     def _set_units(self, val):
         units = str(val).strip().lower()
 
@@ -303,8 +312,8 @@ class DataPHA(Data1DInt):
 
         for id in self.background_ids:
             bkg = self.get_background(id)
-            if (bkg.get_response() != (None,None) or
-                (bkg.bin_lo is not None and bkg.bin_hi is not None)):
+            if bkg.get_response() != (None, None) or \
+               (bkg.bin_lo is not None and bkg.bin_hi is not None):
                 bkg.units = units
 
         self._units = units
@@ -313,22 +322,26 @@ class DataPHA(Data1DInt):
 
     def _get_rate(self):
         return self._rate
+
     def _set_rate(self, val):
         self._rate = bool_cast(val)
         for id in self.background_ids:
             self.get_background(id).rate = val
 
-    rate = property(_get_rate, _set_rate, doc='Quantity of y-axis: counts or counts/sec')
+    rate = property(_get_rate, _set_rate,
+                    doc='Quantity of y-axis: counts or counts/sec')
 
     def _get_plot_fac(self):
         return self._plot_fac
+
     def _set_plot_fac(self, val):
         self._plot_fac = int(val)
         for id in self.background_ids:
             self.get_background(id).plot_fac = val
 
-    plot_fac = property(_get_plot_fac, _set_plot_fac, doc='Number of times to multiply' +
-                        ' the y-axis quantity by x-axis bin size')
+    plot_fac = property(_get_plot_fac, _set_plot_fac,
+                        doc='Number of times to multiply the y-axis ' +
+                        'quantity by x-axis bin size')
 
     def _get_response_ids(self):
         return self._response_ids
@@ -364,7 +377,7 @@ class DataPHA(Data1DInt):
                               doc='IDs of defined background data sets')
 
     _extra_fields = ('grouped', 'subtracted', 'units', 'rate', 'plot_fac',
-                     'response_ids','background_ids')
+                     'response_ids', 'background_ids')
 
     def __init__(self, name, channel, counts, staterror=None, syserror=None,
                  bin_lo=None, bin_hi=None, grouping=None, quality=None,
@@ -376,8 +389,8 @@ class DataPHA(Data1DInt):
         self._background_ids = []
         self._responses   = {}
         self._backgrounds = {}
-        self._rate=True
-        self._plot_fac=0
+        self._rate = True
+        self._plot_fac = 0
         self.units = 'channel'
         self.quality_filter = None
         BaseData.__init__(self)
@@ -387,12 +400,11 @@ class DataPHA(Data1DInt):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x!='header'), self._fields)
+            self._fields = filter((lambda x: x != 'header'), self._fields)
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
         return ss
-
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -405,13 +417,11 @@ class DataPHA(Data1DInt):
         self._backgrounds = state['_backgrounds']
         self._set_units(state['_units'])
 
-        if not state.has_key('header'):
-            self.header=None
+        if 'header' not in state:
+            self.header = None
         self.__dict__.update(state)
 
-
     primary_response_id = 1
-
 
     def set_analysis(self, quantity, type='rate', factor=0):
         self.plot_fac = factor
@@ -420,18 +430,19 @@ class DataPHA(Data1DInt):
         if not (type.startswith('counts') or type.startswith('rate')):
             raise DataErr("plottype", type, "'rate' or 'counts'")
 
-        self.rate = (type=='rate')
+        self.rate = (type == 'rate')
 
         arf, rmf = self.get_response()
         if rmf is not None and rmf.detchans != len(self.channel):
             raise DataErr("incompatibleresp", rmf.name, self.name)
 
-        if ( (rmf is None and arf is None) and
-             (self.bin_lo is None and self.bin_hi is None) and quantity != 'channel'):
+        if (rmf is None and arf is None) and \
+           (self.bin_lo is None and self.bin_hi is None) and \
+           quantity != 'channel':
             raise DataErr('noinstr', self.name)
 
-        if (rmf is None and arf is not None and quantity != 'channel' and 
-            len(arf.energ_lo) != len(self.channel)):
+        if rmf is None and arf is not None and quantity != 'channel' and \
+           len(arf.energ_lo) != len(self.channel):
             raise DataErr("incompleteresp", self.name)
 
         self.units = quantity
@@ -464,7 +475,7 @@ class DataPHA(Data1DInt):
         self._responses.pop(id, None)
         ids = self.response_ids[:]
         ids.remove(id)
-        self.response_ids=ids
+        self.response_ids = ids
 
     def get_arf(self, id=None):
         return self.get_response(id)[0]
@@ -477,7 +488,6 @@ class DataPHA(Data1DInt):
 
     def set_rmf(self, rmf, id=None):
         self.set_response(self.get_arf(id), rmf, id)
-
 
     def get_specresp(self, filter=False):
         """Return the effective area values for the data set.
@@ -495,10 +505,10 @@ class DataPHA(Data1DInt):
            component).
 
         """
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         self.notice_response(False)
-        arf,rmf = self.get_response()
-        newarf=None
+        arf, rmf = self.get_response()
+        newarf = None
 
         if arf is not None and rmf is not None:
             specresp = arf.get_dep()
@@ -506,7 +516,7 @@ class DataPHA(Data1DInt):
             lo, hi = self._get_ebins(group=False)
 
             newarf = interpolate(lo, elo, specresp)
-            newarf[newarf<=0]=1.
+            newarf[newarf <= 0] = 1.
 
             if filter:
                 newarf = self.apply_filter(newarf, self._middle)
@@ -520,7 +530,7 @@ class DataPHA(Data1DInt):
     # is automatically followed by grouping.  Grouping the data
     # twice is an error.
     def _get_ebins(self, response_id=None, group=True):
-        group=bool_cast(group)
+        group = bool_cast(group)
         arf, rmf = self.get_response(response_id)
         if (self.bin_lo is not None) and (self.bin_hi is not None):
             elo = self.bin_lo
@@ -554,13 +564,11 @@ class DataPHA(Data1DInt):
 
         return (elo, ehi)
 
-
     def get_indep(self, filter=True):
         if filter:
             return (self.get_noticed_channels(),)
 
         return (self.channel,)
-
 
     def _get_indep(self, filter=False):
         if (self.bin_lo is not None) and (self.bin_hi is not None):
@@ -577,7 +585,8 @@ class DataPHA(Data1DInt):
             energylist = []
             for id in self.response_ids:
                 arf, rmf = self.get_response(id)
-                lo = None; hi = None
+                lo = None
+                hi = None
 
                 if rmf is not None:
                     lo = rmf.energ_lo
@@ -591,24 +600,23 @@ class DataPHA(Data1DInt):
                     if filter:
                         lo, hi = arf.get_indep()
 
-                energylist.append((lo,hi))
+                energylist.append((lo, hi))
 
             if len(energylist) > 1:
                 elo, ehi, lookuptable = compile_energy_grid(energylist)
             elif (not energylist or
-                  ( len(energylist) == 1 and
-                    numpy.equal(energylist[0], None).any() )):
+                  (len(energylist) == 1 and
+                      numpy.equal(energylist[0], None).any())):
                 raise DataErr('noenergybins', 'Response')
             else:
                 elo, ehi = energylist[0]
 
         lo, hi = elo, ehi
         if self.units == 'wavelength':
-            lo = self._hc/ehi
-            hi = self._hc/elo
+            lo = self._hc / ehi
+            hi = self._hc / elo
 
-        return (lo,hi)
-
+        return (lo, hi)
 
     def _channel_to_energy(self, val, group=True, response_id=None):
         elo, ehi = self._get_ebins(response_id=response_id, group=group)
@@ -625,20 +633,20 @@ class DataPHA(Data1DInt):
         res = []
         for v in val.flat:
             if tuple(numpy.flatnonzero(elo <= v)) == ():
-                if elo[0] > elo[-1] and  ehi[0] > ehi[-1]:
+                if elo[0] > elo[-1] and ehi[0] > ehi[-1]:
                     res.append(SherpaFloat(len(elo)))
                 else:
                     res.append(SherpaFloat(1))
             elif tuple(numpy.flatnonzero(ehi > v)) == ():
-                if elo[0] > elo[-1] and  ehi[0] > ehi[-1]:
+                if elo[0] > elo[-1] and ehi[0] > ehi[-1]:
                     res.append(SherpaFloat(1))
                 else:
                     res.append(SherpaFloat(len(ehi)))
-            elif tuple(numpy.flatnonzero((elo <= v) & (ehi > v) ) + 1) != ():
+            elif tuple(numpy.flatnonzero((elo <= v) & (ehi > v)) + 1) != ():
                 res.append(SherpaFloat(
-                        numpy.flatnonzero((elo <= v) & (ehi > v) ) + 1))
-            elif (elo<=v).argmin() == (ehi>v).argmax():
-                res.append(SherpaFloat((elo<=v).argmin()))
+                    numpy.flatnonzero((elo <= v) & (ehi > v)) + 1))
+            elif (elo <= v).argmin() == (ehi > v).argmax():
+                res.append(SherpaFloat((elo <= v).argmin()))
             else:
                 raise DataErr("energytochannel", v)
 
@@ -653,9 +661,10 @@ class DataPHA(Data1DInt):
         tiny = numpy.finfo(numpy.float32).tiny
         vals = numpy.asarray(self._channel_to_energy(val, group, response_id))
         if vals.shape == ():
-            if vals == 0.0:  vals = tiny
+            if vals == 0.0:
+                vals = tiny
         else:
-            vals[ vals == 0.0 ] = tiny
+            vals[vals == 0.0] = tiny
         vals = self._hc / vals
         return vals
 
@@ -663,9 +672,10 @@ class DataPHA(Data1DInt):
         tiny = numpy.finfo(numpy.float32).tiny
         vals = numpy.asarray(val)
         if vals.shape == ():
-            if vals == 0.0:  vals = tiny
+            if vals == 0.0:
+                vals = tiny
         else:
-            vals[ vals == 0.0 ] = tiny
+            vals[vals == 0.0] = tiny
         vals = self._hc / vals
         return self._energy_to_channel(vals)
 
@@ -692,12 +702,11 @@ class DataPHA(Data1DInt):
         id = self._fix_background_id(id)
         self._backgrounds.pop(id, None)
         if len(self._backgrounds) == 0:
-            self._subtracted = False            
+            self._subtracted = False
         ids = self.background_ids[:]
         if id in ids:
             ids.remove(id)
         self.background_ids = ids
-
 
     def get_background_scale(self):
         if len(self.background_ids) == 0:
@@ -715,7 +724,7 @@ class DataPHA(Data1DInt):
                 else:
                     scale = self.apply_grouping(scale, self._middle)
 
-            scale[scale<=0.0] = 1.0
+            scale[scale <= 0.0] = 1.0
         return scale
 
     def get_backscal(self, group=True, filter=False):
@@ -745,8 +754,8 @@ class DataPHA(Data1DInt):
             if mask is not None:
                 counts[mask] = numpy.asarray(data, dtype=SherpaFloat)
                 data = counts
-#            else:
-#                raise DataErr('mismatch', "filter", "data array")
+            # else:
+            #     raise DataErr('mismatch', "filter", "data array")
         return Data1DInt.apply_filter(self,
                                       self.apply_grouping(data, groupfunc))
 
@@ -765,18 +774,17 @@ class DataPHA(Data1DInt):
         groups = self.grouping
         filter = self.quality_filter
         if filter is None:
-            return do_group( data, groups, groupfunc.__name__ )
+            return do_group(data, groups, groupfunc.__name__)
 
-        if (len(data) != len(filter) or
-            len(groups) != len(filter)):
+        if (len(data) != len(filter) or len(groups) != len(filter)):
             raise DataErr('mismatch', "quality filter", "data array")
 
         filtered_data = numpy.asarray(data)[filter]
         groups = numpy.asarray(groups)[filter]
-        grouped_data = do_group( filtered_data, groups, groupfunc.__name__ )
+        grouped_data = do_group(filtered_data, groups, groupfunc.__name__)
 
         if data is self.channel and groupfunc is self._make_groups:
-            return numpy.arange(1, len(grouped_data)+1, dtype=int)
+            return numpy.arange(1, len(grouped_data) + 1, dtype=int)
 
         return grouped_data
 
@@ -811,14 +819,14 @@ class DataPHA(Data1DInt):
 
         qual_flags = ~numpy.asarray(self.quality, bool)
 
-        if self.grouped and (not self.mask is True):
+        if self.grouped and (self.mask is not True):
             self.notice()
             warning('filtering grouped data with quality flags,' +
                     ' previous filters deleted' )
 
         elif not self.grouped:
             # if ungrouped, create/combine with self.mask
-            if not self.mask is True:
+            if self.mask is not True:
                 self.mask = self.mask & qual_flags
                 return
             else:
@@ -850,7 +858,7 @@ class DataPHA(Data1DInt):
             for vals in parse_expr(old_filter):
                 self.notice(*vals)
 
-        #warning('grouping flags have changed, noticing all bins')
+        # warning('grouping flags have changed, noticing all bins')
 
     # Have to move this check here; as formerly written, reference
     # to pygroup functions happened *before* checking groupstatus,
@@ -861,9 +869,9 @@ class DataPHA(Data1DInt):
     # The groupstatus check thus has to be done in *each* of the following
     # group functions.
 
-    ## Dynamic grouping functions now automatically impose the
-    ## same grouping conditions on *all* associated background data sets.
-    ## CIAO 4.5 bug fix, 05/01/2012
+    # # Dynamic grouping functions now automatically impose the
+    # # same grouping conditions on *all* associated background data sets.
+    # # CIAO 4.5 bug fix, 05/01/2012
     def group_bins(self, num, tabStops=None):
         """Group into a fixed number of bins.
 
@@ -907,7 +915,7 @@ class DataPHA(Data1DInt):
         self._dynamic_group(pygroup.grpNumBins, len(self.channel), num,
                             tabStops=tabStops)
         for bkg_id in self.background_ids:
-            bkg = self.get_background(bkg_id) 
+            bkg = self.get_background(bkg_id)
             if (hasattr(bkg, "group_bins")):
                 bkg.group_bins(num, tabStops=tabStops)
 
@@ -952,7 +960,7 @@ class DataPHA(Data1DInt):
         self._dynamic_group(pygroup.grpBinWidth, len(self.channel), val,
                             tabStops=tabStops)
         for bkg_id in self.background_ids:
-            bkg = self.get_background(bkg_id) 
+            bkg = self.get_background(bkg_id)
             if (hasattr(bkg, "group_width")):
                 bkg.group_width(val, tabStops=tabStops)
 
@@ -1001,7 +1009,7 @@ class DataPHA(Data1DInt):
         self._dynamic_group(pygroup.grpNumCounts, self.counts, num,
                             maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
-            bkg = self.get_background(bkg_id) 
+            bkg = self.get_background(bkg_id)
             if (hasattr(bkg, "group_counts")):
                 bkg.group_counts(num, maxLength=maxLength, tabStops=tabStops)
 
@@ -1058,9 +1066,10 @@ class DataPHA(Data1DInt):
                             maxLength=maxLength, tabStops=tabStops,
                             errorCol=errorCol)
         for bkg_id in self.background_ids:
-            bkg = self.get_background(bkg_id) 
+            bkg = self.get_background(bkg_id)
             if (hasattr(bkg, "group_snr")):
-                bkg.group_snr(snr, maxLength=maxLength, tabStops=tabStops, errorCol=errorCol)
+                bkg.group_snr(snr, maxLength=maxLength, tabStops=tabStops,
+                              errorCol=errorCol)
 
     def group_adapt(self, minimum, maxLength=None, tabStops=None):
         """Adaptively group to a minimum number of counts.
@@ -1110,12 +1119,14 @@ class DataPHA(Data1DInt):
         self._dynamic_group(pygroup.grpAdaptive, self.counts, minimum,
                             maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
-            bkg = self.get_background(bkg_id) 
+            bkg = self.get_background(bkg_id)
             if (hasattr(bkg, "group_adapt")):
-                bkg.group_adapt(minimum, maxLength=maxLength, tabStops=tabStops)
+                bkg.group_adapt(minimum, maxLength=maxLength,
+                                tabStops=tabStops)
 
     ### DOC-TODO: see discussion in astro.ui.utils regarding errorCol
-    def group_adapt_snr(self, minimum, maxLength=None, tabStops=None, errorCol=None):
+    def group_adapt_snr(self, minimum, maxLength=None, tabStops=None,
+                        errorCol=None):
         """Adaptively group to a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
@@ -1170,9 +1181,10 @@ class DataPHA(Data1DInt):
                             maxLength=maxLength, tabStops=tabStops,
                             errorCol=errorCol)
         for bkg_id in self.background_ids:
-            bkg = self.get_background(bkg_id) 
+            bkg = self.get_background(bkg_id)
             if (hasattr(bkg, "group_adapt_snr")):
-                bkg.group_adapt_snr(minimum, maxLength=maxLength, tabStops=tabStops, errorCol=errorCol)
+                bkg.group_adapt_snr(minimum, maxLength=maxLength,
+                                    tabStops=tabStops, errorCol=errorCol)
 
     def eval_model(self, modelfunc):
         return modelfunc(*self.get_indep(filter=False))
@@ -1180,12 +1192,11 @@ class DataPHA(Data1DInt):
     def eval_model_to_fit(self, modelfunc):
         return self.apply_filter(modelfunc(*self.get_indep(filter=True)))
 
-
     def sum_background_data(self,
                             get_bdata_func=(lambda key, bkg: bkg.counts)):
         bdata_list = []
 
-        #for key, bkg in self._backgrounds.items():
+        # for key, bkg in self._backgrounds.items():
         for key in self.background_ids:
             bkg = self.get_background(key)
             bdata = get_bdata_func(key, bkg)
@@ -1230,11 +1241,11 @@ class DataPHA(Data1DInt):
     def get_dep(self, filter=False):
         # FIXME: Aneta says we need to group *before* subtracting, but that
         # won't work (I think) when backscal is an array
-        #if not self.subtracted:
-        #    return self.counts
-        #return self.counts - self.sum_background_data()
+        # if not self.subtracted:
+        #     return self.counts
+        # return self.counts - self.sum_background_data()
         dep = self.counts
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if self.subtracted:
             bkg = self.sum_background_data()
             if len(dep) != len(bkg):
@@ -1250,12 +1261,12 @@ class DataPHA(Data1DInt):
             dep = numpy.asarray(val, SherpaFloat)
         else:
             val = SherpaFloat(val)
-            dep = numpy.array([val]*len(self.get_indep()[0]))
+            dep = numpy.array([val] * len(self.get_indep()[0]))
         setattr(self, 'counts', dep)
 
     def get_staterror(self, filter=False, staterrfunc=None):
         staterr = self.staterror
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             staterr = self.apply_filter(staterr, self._sum_sq)
         else:
@@ -1273,7 +1284,7 @@ class DataPHA(Data1DInt):
         if (staterr is not None) and self.subtracted:
             bkg_staterr_list = []
 
-            #for bkg in self._backgrounds.values():
+            # for bkg in self._backgrounds.values():
             for key in self.background_ids:
                 bkg = self.get_background(key)
                 berr = bkg.staterror
@@ -1289,10 +1300,10 @@ class DataPHA(Data1DInt):
                     else:
                         bkg_cnts = self.apply_grouping(bkg_cnts)
 
-                    if (hasattr(staterrfunc,'__name__') and
-                        staterrfunc.__name__ == 'calc_chi2datavar_errors' and
-                        0.0 in bkg_cnts):
-                        mask = (numpy.asarray(bkg_cnts)!=0.0)
+                    if hasattr(staterrfunc, '__name__') and \
+                       staterrfunc.__name__ == 'calc_chi2datavar_errors' and \
+                       0.0 in bkg_cnts:
+                        mask = (numpy.asarray(bkg_cnts) != 0.0)
                         berr = numpy.zeros(len(bkg_cnts))
                         berr[mask] = staterrfunc(bkg_cnts[mask])
                     else:
@@ -1348,14 +1359,14 @@ class DataPHA(Data1DInt):
             nbkg = SherpaFloat(nbkg)
 
             if staterr is not None:
-                staterr = staterr*staterr + bkgsum / (nbkg * nbkg)
+                staterr = staterr * staterr + bkgsum / (nbkg * nbkg)
                 staterr = numpy.sqrt(staterr)
 
         return staterr
 
     def get_syserror(self, filter=False):
         syserr = self.syserror
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             syserr = self.apply_filter(syserr, self._sum_sq)
         else:
@@ -1367,10 +1378,10 @@ class DataPHA(Data1DInt):
         # is always ungrouped.  In any other space, we must
         # disable grouping when calling self._from_channel.
         if self.units != 'channel':
-            elo,ehi = self._get_ebins(group=False)
+            elo, ehi = self._get_ebins(group=False)
             if len(elo) != len(self.channel):
                 raise DataErr("incompleteresp", self.name)
-            return self._from_channel(self.channel,group=False,
+            return self._from_channel(self.channel, group=False,
                                       response_id=response_id)
         else:
             return self._from_channel(self.channel)
@@ -1381,10 +1392,9 @@ class DataPHA(Data1DInt):
             xlabel += ' (keV)'
         elif self.units == 'wavelength':
             xlabel += ' (Angstrom)'
-        #elif self.units == 'channel' and self.grouped:
-        #    xlabel = 'Group Number'
+        # elif self.units == 'channel' and self.grouped:
+        #     xlabel = 'Group Number'
         return xlabel
-
 
     def _set_initial_quantity(self):
         arf, rmf = self.get_response()
@@ -1401,12 +1411,11 @@ class DataPHA(Data1DInt):
                 raise DataErr("incompatibleresp", rmf.name, self.name)
             self.units = 'energy'
 
-
     def _fix_y_units(self, val, filter=False, response_id=None):
         if val is None:
             return val
 
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         # make a copy of data for units manipulation
         val = numpy.array(val, dtype=SherpaFloat)
 
@@ -1422,7 +1431,7 @@ class DataPHA(Data1DInt):
             if self.units != 'channel':
                 elo, ehi = self._get_ebins(response_id, group=False)
             else:
-                elo, ehi = (self.channel, self.channel+1.)
+                elo, ehi = (self.channel, self.channel + 1.)
 
             if filter:
                 # If we apply a filter, make sure that
@@ -1437,7 +1446,7 @@ class DataPHA(Data1DInt):
             if self.units == 'energy':
                 ebin = ehi - elo
             elif self.units == 'wavelength':
-                ebin = self._hc/elo - self._hc/ehi
+                ebin = self._hc / elo - self._hc / ehi
             elif self.units == 'channel':
                 ebin = ehi - elo
             else:
@@ -1451,10 +1460,9 @@ class DataPHA(Data1DInt):
 
         return val
 
-
     def get_y(self, filter=False, yfunc=None, response_id=None):
         vallist = Data1DInt.get_y(self, yfunc=yfunc)
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
 
         if not isinstance(vallist, tuple):
             vallist = (vallist,)
@@ -1477,14 +1485,13 @@ class DataPHA(Data1DInt):
         return vallist
 
     def get_yerr(self, filter=False, staterrfunc=None, response_id=None):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         err = self.get_error(filter, staterrfunc)
         return self._fix_y_units(err, filter, response_id)
 
-
     def get_xerr(self, filter=False, response_id=None):
         elo, ehi = self._get_ebins(response_id=response_id)
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             # If we apply a filter, make sure that
             # ebins are ungrouped before applying
@@ -1493,8 +1500,7 @@ class DataPHA(Data1DInt):
             elo = self.apply_filter(elo, self._min)
             ehi = self.apply_filter(ehi, self._max)
 
-        return ehi-elo
-
+        return ehi - elo
 
     def get_ylabel(self):
         ylabel = 'Counts'
@@ -1511,7 +1517,8 @@ class DataPHA(Data1DInt):
                 ylabel += '/channel'
 
         if self.plot_fac:
-            ylabel += ' X %s^%s' % (self.units.capitalize(), str(self.plot_fac))
+            ylabel += ' X %s^%s' % (self.units.capitalize(),
+                                    str(self.plot_fac))
 
         return ylabel
 
@@ -1569,14 +1576,14 @@ class DataPHA(Data1DInt):
             return 'No noticed channels'
         return create_expr(chans, format='%i')
 
-    def get_filter(self, group=True, format = '%.12f', delim=':'):
-        """  
+    def get_filter(self, group=True, format='%.12f', delim=':'):
+        """
         Integrated values returned are measured from center of bin
         """
         if self.mask is False:
             return 'No noticed bins'
 
-        x = self.get_noticed_channels() # ungrouped noticed channels
+        x = self.get_noticed_channels()  # ungrouped noticed channels
         if group:
             # grouped noticed channels
             x = self.apply_filter(self.channel, self._make_groups)
@@ -1585,7 +1592,7 @@ class DataPHA(Data1DInt):
         x = self._from_channel(x, group=group)  # knows the units underneath
 
         if self.units in ('channel',):
-            format = '%i'            
+            format = '%i'
 
         mask = numpy.ones(len(x), dtype=bool)
         if numpy.iterable(self.mask):
@@ -1601,7 +1608,7 @@ class DataPHA(Data1DInt):
                 ' ' + self.get_xlabel())
 
     def notice_response(self, notice_resp=True, noticed_chans=None):
-        notice_resp=bool_cast(notice_resp)
+        notice_resp = bool_cast(notice_resp)
 
         if notice_resp and noticed_chans is None:
             noticed_chans = self.get_noticed_channels()
@@ -1609,7 +1616,6 @@ class DataPHA(Data1DInt):
         for id in self.response_ids:
             arf, rmf = self.get_response(id)
             _notice_resp(noticed_chans, arf, rmf)
-
 
     def notice(self, lo=None, hi=None, ignore=False, bkg_id=None):
         # If any background IDs are actually given, then impose
@@ -1636,25 +1642,25 @@ class DataPHA(Data1DInt):
             bkg.units = old_bkg_units
 
         # If we're only supposed to filter backgrounds, return
-        if (filter_background_only == True):
+        if filter_background_only:
             return
 
         # Go on if we are also supposed to filter the source data
-        ignore=bool_cast(ignore)
+        ignore = bool_cast(ignore)
         if lo is None and hi is None:
-            self.quality_filter=None
+            self.quality_filter = None
             self.notice_response(False)
 
-        elo,ehi = self._get_ebins()
+        elo, ehi = self._get_ebins()
         if lo is not None and type(lo) != str:
             lo = self._to_channel(lo)
         if hi is not None and type(hi) != str:
             hi = self._to_channel(hi)
 
-        if( ( self.units=="wavelength" and
-              elo[0] < elo[-1] and  ehi[0] < ehi[-1] ) or
-            ( self.units=="energy" and
-              elo[0] > elo[-1] and  ehi[0] > ehi[-1] ) ):
+        if ((self.units == "wavelength" and
+             elo[0] < elo[-1] and ehi[0] < ehi[-1]) or
+            (self.units == "energy" and
+             elo[0] > elo[-1] and ehi[0] > ehi[-1])):
             lo, hi = hi, lo
 
         # If we are working in channel space, and the data are
@@ -1664,37 +1670,35 @@ class DataPHA(Data1DInt):
         # energy and wavelength conversions above already take care of
         # the distinction between grouped and ungrouped.
 
-        if (self.units=="channel" and self.grouped==True):
+        if self.units == "channel" and self.grouped:
 
-            if (lo is not None and 
-                type(lo) != str and 
-                not(lo < self.channel[0])):
+            if lo is not None and type(lo) != str and \
+               not(lo < self.channel[0]):
 
                 # Find the location of the first channel greater than
                 # or equal to lo in self.channel
                 # Then find out how many groups there are that contain
-                # the channels less than lo, and convert lo from a 
-                # channel number to the first group number that has channels 
+                # the channels less than lo, and convert lo from a
+                # channel number to the first group number that has channels
                 # greater than or equal to lo.
 
                 lo_index = numpy.where(self.channel >= lo)[0][0]
                 lo = len(numpy.where(self.grouping[:lo_index] > -1)[0]) + 1
 
-            if (hi is not None and 
-                type(hi) != str and 
-                not(hi > self.channel[-1])):
+            if hi is not None and type(hi) != str and \
+               not(hi > self.channel[-1]):
 
                 # Find the location of the first channel greater than
                 # or equal to hi in self.channel
                 # Then find out how many groups there are that contain
-                # the channels less than hi, and convert hi from a 
-                # channel number to the first group number that has channels 
+                # the channels less than hi, and convert hi from a
+                # channel number to the first group number that has channels
                 # greater than or equal to hi.
                 hi_index = numpy.where(self.channel >= hi)[0][0]
                 hi = len(numpy.where(self.grouping[:hi_index] > -1)[0])
 
                 # If the original channel hi starts a new group,
-                # increment the group number 
+                # increment the group number
                 if (self.grouping[hi_index] > -1):
                     hi = hi + 1
 
@@ -1704,7 +1708,7 @@ class DataPHA(Data1DInt):
                 # in the filter. Avoid indexing beyond the end of the
                 # grouping array.
                 if (hi_index + 1 < len(self.grouping)):
-                    if (not(self.grouping[hi_index+1] > -1)):
+                    if not(self.grouping[hi_index + 1] > -1):
                         hi = hi - 1
 
         # Don't use the middle of the channel anymore as the
@@ -1719,21 +1723,20 @@ class DataPHA(Data1DInt):
         elo, ehi = self._get_ebins(group=False)
         elo = self.apply_filter(elo, self._min)
         ehi = self.apply_filter(ehi, self._max)
-        if self.units=="wavelength":
+        if self.units == "wavelength":
             lo = self._hc / ehi
             hi = self._hc / elo
-            elo = lo; ehi = hi
+            elo = lo
+            ehi = hi
         cnt = self.get_dep(True)
         arf = self.get_specresp(filter=True)
 
-        y = cnt/(ehi-elo)
+        y = cnt / (ehi - elo)
         if self.exposure is not None:
-            y /= self.exposure           # photons/keV/sec or
-                                         # photons/Ang/sec
-        #y = cnt/arf/self.exposure
+            y /= self.exposure   # photons/keV/sec or photons/Ang/sec
+        # y = cnt/arf/self.exposure
         if arf is not None:
-            y /= arf                     # photons/keV/cm^2/sec or 
-                                         # photons/Ang/cm^2/sec
+            y /= arf  # photons/keV/cm^2/sec or photons/Ang/cm^2/sec
         return (y, elo, ehi)
 
     def to_fit(self, staterrfunc=None):
@@ -1742,7 +1745,8 @@ class DataPHA(Data1DInt):
                 self.get_syserror(True))
 
     def to_plot(self, yfunc=None, staterrfunc=None, response_id=None):
-        return (self.apply_filter(self.get_x(response_id=response_id), self._middle),
+        return (self.apply_filter(self.get_x(response_id=response_id),
+                                  self._middle),
                 self.get_y(True, yfunc, response_id=response_id),
                 self.get_yerr(True, staterrfunc, response_id=response_id),
                 self.get_xerr(True, response_id=response_id),
@@ -1765,6 +1769,7 @@ class DataPHA(Data1DInt):
         "Remove background subtraction"
         self.subtracted = False
 
+
 class DataIMG(Data2D):
     "Image data set, including functions for coordinate transformations"
 
@@ -1781,7 +1786,7 @@ class DataIMG(Data2D):
             self._check_physical_transform()
             coord = 'physical'
 
-        elif coord in ('world','wcs'):
+        elif coord in ('world', 'wcs'):
             self._check_world_transform()
             coord = 'world'
 
@@ -1801,27 +1806,25 @@ class DataIMG(Data2D):
         self._region = None
         BaseData.__init__(self)
 
-
     def __str__(self):
         # Print the metadata first
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x!='header'), self._fields)
+            self._fields = filter((lambda x: x != 'header'), self._fields)
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
         return ss
-
 
     def __getstate__(self):
         state = self.__dict__.copy()
         # Function pointers to methods of the class
         # (of type 'instancemethod') are NOT picklable
         # remove them and restore later with a coord init
-        #del state['_get_logical']
-        #del state['_get_physical']
-        #del state['_get_world']
+        # del state['_get_logical']
+        # del state['_get_physical']
+        # del state['_get_world']
 
         # PyRegion objects (of type 'extension') are NOT picklable, yet.
         # preserve the region string and restore later with constructor
@@ -1831,12 +1834,12 @@ class DataIMG(Data2D):
     def __setstate__(self, state):
         # Populate the function pointers we deleted at pickle time with
         # no-ops.
-        #self.__dict__['_get_logical']=(lambda : None)
-        #self.__dict__['_get_physical']=(lambda : None)
-        #self.__dict__['_get_world']=(lambda : None)
+        # self.__dict__['_get_logical']=(lambda : None)
+        # self.__dict__['_get_physical']=(lambda : None)
+        # self.__dict__['_get_world']=(lambda : None)
 
-        if not state.has_key('header'):
-            self.header=None
+        if 'header' not in state:
+            self.header = None
 
         self.__dict__.update(state)
 
@@ -1938,7 +1941,7 @@ class DataIMG(Data2D):
         if coord is not 'logical':
             x0 = x0.copy()
             x1 = x1.copy()
-            x0, x1 = getattr(self, '_'+coord+'_to_logical')(x0, x1)
+            x0, x1 = getattr(self, '_' + coord + '_to_logical')(x0, x1)
         return (x0, x1)
 
     def get_physical(self):
@@ -1947,9 +1950,8 @@ class DataIMG(Data2D):
         if coord is not 'physical':
             x0 = x0.copy()
             x1 = x1.copy()
-            x0, x1 = getattr(self, '_'+coord+'_to_physical')(x0, x1)
+            x0, x1 = getattr(self, '_' + coord + '_to_physical')(x0, x1)
         return (x0, x1)
-
 
     def get_world(self):
         coord = self.coord
@@ -1957,9 +1959,8 @@ class DataIMG(Data2D):
         if coord is not 'world':
             x0 = x0.copy()
             x1 = x1.copy()
-            x0, x1 = getattr(self, '_'+coord+'_to_world')(x0, x1)
+            x0, x1 = getattr(self, '_' + coord + '_to_world')(x0, x1)
         return (x0, x1)
-
 
     # For compatibility with old Sherpa keywords
     get_image = get_logical
@@ -1968,7 +1969,7 @@ class DataIMG(Data2D):
     def set_coord(self, coord):
         coord = str(coord).strip().lower()
         # Destroys original data to conserve memory for big imgs
-        good = ('logical','image','physical','world','wcs')
+        good = ('logical', 'image', 'physical', 'world', 'wcs')
         if coord not in good:
             raise DataErr('badchoices', 'coordinates', coord, ", ".join(good))
 
@@ -1977,7 +1978,7 @@ class DataIMG(Data2D):
         elif coord.startswith('image'):
             coord = 'logical'
 
-        self.x0, self.x1 = getattr(self, 'get_'+coord)()
+        self.x0, self.x1 = getattr(self, 'get_' + coord)()
         self._x0 = self.apply_filter(self.x0)
         self._x1 = self.apply_filter(self.x1)
 
@@ -1992,7 +1993,7 @@ class DataIMG(Data2D):
 
     def notice2d(self, val=None, ignore=False):
         mask = None
-        ignore=bool_cast(ignore)
+        ignore = bool_cast(ignore)
         if val is not None:
             val = str(val).strip()
             (self._region,
@@ -2019,8 +2020,8 @@ class DataIMG(Data2D):
             else:
                 self.mask &= mask
 
-#        self._x0 = self.apply_filter(self.x0)
-#        self._x1 = self.apply_filter(self.x1)
+        # self._x0 = self.apply_filter(self.x0)
+        # self._x1 = self.apply_filter(self.x1)
 
     def get_bounding_mask(self):
         mask = self.mask
@@ -2035,8 +2036,9 @@ class DataIMG(Data2D):
             x1_lo = x1_i.min()
             x1_hi = x1_i.max()
 
-            shape = mask[x0_lo:x0_hi+1,x1_lo:x1_hi+1].shape
-            mask = mask[x0_lo:x0_hi+1,x1_lo:x1_hi+1]
+            # TODO: subset mask and then ask its shape
+            shape = mask[x0_lo:x0_hi + 1, x1_lo:x1_hi + 1].shape
+            mask = mask[x0_lo:x0_hi + 1, x1_lo:x1_hi + 1]
 
             mask = mask.ravel()
         return mask, shape
@@ -2065,8 +2067,8 @@ class DataIMG(Data2D):
         self._check_shape()
 
         # dummy placeholders needed b/c img shape may not be square!
-        axis0 = numpy.arange(self.shape[1], dtype=float)+1.
-        axis1 = numpy.arange(self.shape[0], dtype=float)+1.
+        axis0 = numpy.arange(self.shape[1], dtype=float) + 1.
+        axis1 = numpy.arange(self.shape[0], dtype=float) + 1.
         dummy0 = numpy.ones(axis0.size, dtype=float)
         dummy1 = numpy.ones(axis1.size, dtype=float)
 
@@ -2094,7 +2096,7 @@ class DataIMG(Data2D):
     def get_x1label(self):
         """
         Return label for second dimension in 2-D view of independent axis/axes
-        """        
+        """
         if self.coord in ('logical', 'image'):
             return 'x1'
         elif self.coord in ('physical',):
@@ -2123,9 +2125,10 @@ class DataIMG(Data2D):
     def filter_region(self, data):
         if data is not None and numpy.iterable(self.mask):
             filter = numpy.ones(len(self.mask), dtype=SherpaFloat)
-            filter[~self.mask]=numpy.nan
-            return data*filter
+            filter[~self.mask] = numpy.nan
+            return data * filter
         return data
+
 
 class DataIMGInt(DataIMG):
 
@@ -2145,7 +2148,7 @@ class DataIMGInt(DataIMG):
     mask = property(DataND._get_mask, _set_mask,
                     doc='Mask array for dependent variable')
 
-    def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None, 
+    def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None,
                  staterror=None, syserror=None, sky=None, eqpos=None,
                  coord='logical', header=None):
         self._x0lo = x0lo
@@ -2158,7 +2161,7 @@ class DataIMGInt(DataIMG):
     def set_coord(self, coord):
         coord = str(coord).strip().lower()
         # Destroys original data to conserve memory for big imgs
-        good = ('logical','image','physical','world','wcs')
+        good = ('logical', 'image', 'physical', 'world', 'wcs')
         if coord not in good:
             raise DataErr('bad', 'coordinates', coord)
 
@@ -2167,7 +2170,8 @@ class DataIMGInt(DataIMG):
         elif coord.startswith('image'):
             coord = 'logical'
 
-        self.x0lo, self.x1lo, self.x0hi, self.x1hi = getattr(self, 'get_'+coord)()
+        func = getattr(self, 'get_' + coord)
+        self.x0lo, self.x1lo, self.x0hi, self.x1hi = func()
         self._x0lo = self.apply_filter(self.x0lo)
         self._x0hi = self.apply_filter(self.x0hi)
         self._x1lo = self.apply_filter(self.x1lo)
@@ -2180,11 +2184,12 @@ class DataIMGInt(DataIMG):
         if coord is not 'logical':
             x0lo = x0lo.copy()
             x1lo = x1lo.copy()
-            x0lo, x1lo = getattr(self, '_'+coord+'_to_logical')(x0lo, x1lo)
+            convert = getattr(self, '_' + coord + '_to_logical')
+            x0lo, x1lo = convert(x0lo, x1lo)
 
             x0hi = x0hi.copy()
             x1hi = x1hi.copy()
-            x0hi, x1hi = getattr(self, '_'+coord+'_to_logical')(x0hi, x1hi)
+            x0hi, x1hi = convert(x0hi, x1hi)
 
         return (x0lo, x1lo, x0hi, x1hi)
 
@@ -2194,11 +2199,12 @@ class DataIMGInt(DataIMG):
         if coord is not 'physical':
             x0lo = x0lo.copy()
             x1lo = x1lo.copy()
-            x0lo, x1lo = getattr(self, '_'+coord+'_to_physical')(x0lo, x1lo)
+            convert = getattr(self, '_' + coord + '_to_physical')
+            x0lo, x1lo = convert(x0lo, x1lo)
 
             x0hi = x0hi.copy()
             x1hi = x1hi.copy()
-            x0hi, x1hi = getattr(self, '_'+coord+'_to_physical')(x0hi, x1hi)
+            x0hi, x1hi = convert(x0hi, x1hi)
 
         return (x0lo, x1lo, x0hi, x1hi)
 
@@ -2208,14 +2214,14 @@ class DataIMGInt(DataIMG):
         if coord is not 'world':
             x0lo = x0lo.copy()
             x1lo = x1lo.copy()
-            x0lo, x1lo = getattr(self, '_'+coord+'_to_world')(x0lo, x1lo)
+            convert = getattr(self, '_' + coord + '_to_world')
+            x0lo, x1lo = convert(x0lo, x1lo)
 
             x0hi = x0hi.copy()
             x1hi = x1hi.copy()
-            x0hi, x1hi = getattr(self, '_'+coord+'_to_world')(x0hi, x1hi)
+            x0hi, x1hi = convert(x0hi, x1hi)
 
         return (x0lo, x1lo, x0hi, x1hi)
-
 
     # def get_indep(self, filter=False):
     #     x0, x1 = DataIMG.get_indep(self, filter=filter)
@@ -2229,9 +2235,8 @@ class DataIMGInt(DataIMG):
     #     return (x0-halfwidth[0],x1-halfwidth[1],
     #             x0+halfwidth[0],x1+halfwidth[1])
 
-
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             return (self._x0lo, self._x1lo, self._x0hi, self._x1hi)
         return (self.x0lo, self.x1lo, self.x0hi, self.x1hi)
@@ -2244,17 +2249,16 @@ class DataIMGInt(DataIMG):
         indep = self.get_indep(filter)
         return (indep[1] + indep[3]) / 2.0
 
-
     def get_axes(self):
         # FIXME: how to filter an axis when self.mask is size of self.y?
         self._check_shape()
 
         # dummy placeholders needed b/c img shape may not be square!
-        axis0lo = numpy.arange(self.shape[1], dtype=float)-0.5
-        axis1lo = numpy.arange(self.shape[0], dtype=float)-0.5
+        axis0lo = numpy.arange(self.shape[1], dtype=float) - 0.5
+        axis1lo = numpy.arange(self.shape[0], dtype=float) - 0.5
 
-        axis0hi = numpy.arange(self.shape[1], dtype=float)+0.5
-        axis1hi = numpy.arange(self.shape[0], dtype=float)+0.5
+        axis0hi = numpy.arange(self.shape[1], dtype=float) + 0.5
+        axis1hi = numpy.arange(self.shape[0], dtype=float) + 0.5
 
         dummy0 = numpy.ones(axis0lo.size, dtype=float)
         dummy1 = numpy.ones(axis1lo.size, dtype=float)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -156,7 +156,8 @@ class DataARF(Data1DInt):
         return 'Energy (keV)'
 
     def get_ylabel(self):
-        return 'cm^2'
+        from sherpa.plot import backend
+        return 'cm' + backend.get_latex_for_string('^2')
 
 
 class DataRMF(Data1DInt):
@@ -1517,8 +1518,10 @@ class DataPHA(Data1DInt):
                 ylabel += '/channel'
 
         if self.plot_fac:
-            ylabel += ' X %s^%s' % (self.units.capitalize(),
-                                    str(self.plot_fac))
+            from sherpa.plot import backend
+            latex = backend.get_latex_for_string(
+                '^{}'.format(self.plot_fac))
+            ylabel += ' X {}{}'.format(self.units.capitalize(), latex)
 
         return ylabel
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -40,6 +40,25 @@ __all__ = ('SourcePlot', 'ARFPlot', 'BkgDataPlot', 'BkgModelPlot',
            'OrderPlot', 'ModelHistogram', 'BkgModelHistogram')
 
 
+def to_latex(txt):
+    """Add any backend-specific markup to indicate LaTeX.
+
+    Parameters
+    ----------
+    txt : str
+       The LaTeX input (the contents are going to be interpreted
+       as LaTeX so do not send in text that is not to be converted).
+
+    Returns
+    -------
+    out : str
+       The LaTeX text including the markup to indicate to the
+       plotting backend to display as LaTeX.
+    """
+
+    return backend.get_latex_for_string(txt)
+
+
 class ModelHistogram(HistogramPlot):
     "Derived class for creating 1D PHA model histogram plots"
     histo_prefs = backend.get_model_histo_defaults()
@@ -128,14 +147,20 @@ class SourcePlot(HistogramPlot):
         quant = 'keV'
 
         if self.units == "wavelength":
-            prefix_quant = '\\lambda'
-            quant = '\\AA'
+            # No other labels use the LaTeX forms for lambda and
+            # Angstrom, so use the text version here too.
+            # prefix_quant = to_latex('\\lambda')
+            # quant = to_latex('\\AA')
+            prefix_quant = 'lambda'
+            quant = 'Angstrom'
             (self.xlo, self.xhi) = (self.xhi, self.xlo)
 
         xmid = abs(self.xhi - self.xlo)
 
+        sqr = to_latex('^2')
+
         self.xlabel = '%s (%s)' % (self.units.capitalize(), quant)
-        self.ylabel = '%s  Photons/sec/cm^2%s'
+        self.ylabel = '%s  Photons/sec/cm' + sqr + '%s'
 
         if data.plot_fac == 0:
             self.y /= xmid
@@ -148,8 +173,8 @@ class SourcePlot(HistogramPlot):
 
         elif data.plot_fac == 2:
             self.y *= xmid
-            self.ylabel = self.ylabel % ('%s^{2} f(%s)' % (prefix_quant,
-                                                           prefix_quant),
+            self.ylabel = self.ylabel % ('%s%s f(%s)' % (prefix_quant, sqr,
+                                                         prefix_quant),
                                          ' %s ' % quant)
         else:
             raise PlotErr('plotfac', 'Source', data.plot_fac)
@@ -459,7 +484,8 @@ class EnergyFluxHistogram(FluxHistogram):
     def __init__(self):
         FluxHistogram.__init__(self)
         self.title = "Energy flux distribution"
-        self.xlabel = "Energy flux (ergs cm^{-2} sec^{-1})"
+        self.xlabel = "Energy flux (ergs cm{} sec{})".format(
+            to_latex('^{-2}'), to_latex('^{-1}'))
         self.ylabel = "Frequency"
 
 
@@ -469,5 +495,6 @@ class PhotonFluxHistogram(FluxHistogram):
     def __init__(self):
         FluxHistogram.__init__(self)
         self.title = "Photon flux distribution"
-        self.xlabel = "Photon flux (Photons cm^{-2} sec^{-1})"
+        self.xlabel = "Photon flux (Photons cm{} sec{})".format(
+            to_latex('^{-2}'), to_latex('^{-1}'))
         self.ylabel = "Frequency"

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -25,7 +25,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.plot import DataPlot, ModelPlot, FitPlot, DelchiPlot, ResidPlot, \
     RatioPlot, ChisqrPlot, HistogramPlot, backend, Histogram
 from sherpa.plot import ComponentSourcePlot as _ComponentSourcePlot
-from sherpa.astro.utils import compile_energy_grid, bounds_check
+from sherpa.astro.utils import bounds_check
 from sherpa.utils.err import PlotErr, IOErr
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins
 from numpy import iterable, array2string, asarray
@@ -34,9 +34,10 @@ import logging
 
 warning = logging.getLogger(__name__).warning
 
-__all__ = ('SourcePlot','ARFPlot', 'BkgDataPlot', 'BkgModelPlot', 'BkgFitPlot',
-           'BkgSourcePlot', 'BkgDelchiPlot', 'BkgResidPlot', 'BkgRatioPlot',
-           'BkgChisqrPlot', 'OrderPlot', 'ModelHistogram', 'BkgModelHistogram')
+__all__ = ('SourcePlot', 'ARFPlot', 'BkgDataPlot', 'BkgModelPlot',
+           'BkgFitPlot', 'BkgSourcePlot', 'BkgDelchiPlot', 'BkgResidPlot',
+           'BkgRatioPlot', 'BkgChisqrPlot',
+           'OrderPlot', 'ModelHistogram', 'BkgModelHistogram')
 
 
 class ModelHistogram(HistogramPlot):
@@ -65,13 +66,13 @@ class ModelHistogram(HistogramPlot):
             if data.units != 'channel':
                 elo, ehi = data._get_ebins(group=False)
             else:
-                elo, ehi = (data.channel,data.channel+1.)
+                elo, ehi = (data.channel, data.channel + 1.)
 
             self.xlo = data.apply_filter(elo, data._min)
             self.xhi = data.apply_filter(ehi, data._max)
             if data.units == 'wavelength':
-                self.xlo = data._hc/self.xlo
-                self.xhi = data._hc/self.xhi
+                self.xlo = data._hc / self.xlo
+                self.xhi = data._hc / self.xhi
 
         finally:
             if old_group:
@@ -79,7 +80,6 @@ class ModelHistogram(HistogramPlot):
                 data.group()
                 for interval in old_filter:
                     data.notice(*interval)
-
 
 
 class SourcePlot(HistogramPlot):
@@ -122,7 +122,7 @@ class SourcePlot(HistogramPlot):
         self.xlabel = data.get_xlabel()
         self.title  = 'Source Model of %s' % data.name
         self.xlo, self.xhi = data._get_indep(filter=False)
-        self.mask = filter_bins( (lo,), (hi,), (self.xlo,) )
+        self.mask = filter_bins((lo,), (hi,), (self.xlo,))
         self.y = src(self.xlo, self.xhi)
         prefix_quant = 'E'
         quant = 'keV'
@@ -132,25 +132,27 @@ class SourcePlot(HistogramPlot):
             quant = '\\AA'
             (self.xlo, self.xhi) = (self.xhi, self.xlo)
 
-        xmid = abs(self.xhi-self.xlo)
+        xmid = abs(self.xhi - self.xlo)
 
         self.xlabel = '%s (%s)' % (self.units.capitalize(), quant)
         self.ylabel = '%s  Photons/sec/cm^2%s'
 
         if data.plot_fac == 0:
             self.y /= xmid
-            self.ylabel = self.ylabel % ('f(%s)' % prefix_quant, '/%s ' % quant)
+            self.ylabel = self.ylabel % ('f(%s)' % prefix_quant,
+                                         '/%s ' % quant)
 
         elif data.plot_fac == 1:
-            self.ylabel = self.ylabel % ('%s f(%s)' % (prefix_quant, prefix_quant), '')
+            self.ylabel = self.ylabel % ('%s f(%s)' % (prefix_quant,
+                                                       prefix_quant), '')
 
         elif data.plot_fac == 2:
             self.y *= xmid
-            self.ylabel = self.ylabel % ('%s^{2} f(%s)' % (prefix_quant, prefix_quant),
+            self.ylabel = self.ylabel % ('%s^{2} f(%s)' % (prefix_quant,
+                                                           prefix_quant),
                                          ' %s ' % quant)
         else:
             raise PlotErr('plotfac', 'Source', data.plot_fac)
-
 
     def plot(self, overplot=False, clearwindow=True):
         xlo = self.xlo
@@ -182,7 +184,7 @@ class ComponentModelPlot(_ComponentSourcePlot, ModelHistogram):
         self.title = 'Model component: %s' % model.name
 
     def plot(self, overplot=False, clearwindow=True):
-        ModelHistogram.plot(self, overplot, clearwindow)  
+        ModelHistogram.plot(self, overplot, clearwindow)
 
 
 class ComponentSourcePlot(_ComponentSourcePlot, SourcePlot):
@@ -247,8 +249,8 @@ class ARFPlot(HistogramPlot):
                 raise PlotErr('notpha', data.name)
             if data.units == "wavelength":
                 self.xlabel = 'Wavelength (Angstrom)'
-                self.xlo = data._hc/self.xlo
-                self.xhi = data._hc/self.xhi
+                self.xlo = data._hc / self.xlo
+                self.xhi = data._hc / self.xhi
 
 
 class BkgDataPlot(DataPlot):
@@ -263,15 +265,18 @@ class BkgModelPlot(ModelPlot):
         ModelPlot.__init__(self)
         self.title = 'Background Model Contribution'
 
+
 class BkgFitPlot(FitPlot):
     "Derived class for creating plots of background counts with fitted model"
     def __init__(self):
         FitPlot.__init__(self)
 
+
 class BkgDelchiPlot(DelchiPlot):
     "Derived class for creating background plots of 1D delchi chi ((data-model)/error)"
     def __init__(self):
         DelchiPlot.__init__(self)
+
 
 class BkgResidPlot(ResidPlot):
     "Derived class for creating background plots of 1D residual (data-model)"
@@ -282,6 +287,7 @@ class BkgResidPlot(ResidPlot):
         ResidPlot.prepare(self, data, model, stat)
         self.title = 'Residuals of %s - Bkg Model' % data.name
 
+
 class BkgRatioPlot(RatioPlot):
     "Derived class for creating background plots of 1D ratio (data:model)"
     def __init__(self):
@@ -291,10 +297,12 @@ class BkgRatioPlot(RatioPlot):
         RatioPlot.prepare(self, data, model, stat)
         self.title = 'Ratio of %s : Bkg Model' % data.name
 
+
 class BkgChisqrPlot(ChisqrPlot):
     "Derived class for creating background plots of 1D chi**2 ((data-model)/error)**2"
     def __init__(self):
         ChisqrPlot.__init__(self)
+
 
 class BkgSourcePlot(SourcePlot):
     "Derived class for plotting the background unconvolved source model"
@@ -304,14 +312,14 @@ class BkgSourcePlot(SourcePlot):
 
 class OrderPlot(ModelHistogram):
     """
-    Derived class for creating plots of the convolved source model using 
+    Derived class for creating plots of the convolved source model using
     selected multiple responses
     """
 
     def __init__(self):
-        self.orders=None
-        self.colors=None
-        self.use_default_colors=True
+        self.orders = None
+        self.colors = None
+        self.use_default_colors = True
         ModelHistogram.__init__(self)
 
     def prepare(self, data, model, orders=None, colors=None):
@@ -324,20 +332,20 @@ class OrderPlot(ModelHistogram):
                 self.orders = [orders]
 
         if colors is not None:
-            self.use_default_colors=False
+            self.use_default_colors = False
             if iterable(colors):
                 self.colors = list(colors)
             else:
                 self.colors = [colors]
         else:
-            self.colors=[]
+            self.colors = []
             top_color = '0xffffff'
             bot_color = '0x0000bf'
             num = len(self.orders)
-            jump = (int(top_color, 16) - int(bot_color,16))/(num+1)
+            jump = (int(top_color, 16) - int(bot_color, 16)) / (num + 1)
             for order in self.orders:
                 self.colors.append(top_color)
-                top_color = hex(int(top_color,16)-jump)
+                top_color = hex(int(top_color, 16) - jump)
 
         if not self.use_default_colors and len(colors) != len(orders):
             raise PlotErr('ordercolors', len(orders), len(colors))
@@ -351,10 +359,10 @@ class OrderPlot(ModelHistogram):
                 for interval in old_filter:
                     data.notice(*interval)
 
-            self.xlo=[]
-            self.xhi=[]
-            self.y=[]
-            (xlo, y, yerr,xerr,
+            self.xlo = []
+            self.xhi = []
+            self.y = []
+            (xlo, y, yerr, xerr,
              self.xlabel, self.ylabel) = data.to_plot(model)
             y = y[1]
             if data.units != 'channel':
@@ -362,8 +370,8 @@ class OrderPlot(ModelHistogram):
                 xlo = data.apply_filter(elo, data._min)
                 xhi = data.apply_filter(ehi, data._max)
                 if data.units == 'wavelength':
-                    xlo = data._hc/xlo
-                    xhi = data._hc/xhi
+                    xlo = data._hc / xlo
+                    xhi = data._hc / xhi
             else:
                 xhi = xlo + 1.
 
@@ -373,8 +381,8 @@ class OrderPlot(ModelHistogram):
                 if len(data.response_ids) > 2:
                     if order < 1 or order > len(model.rhs.orders):
                         raise PlotErr('notorder', order)
-                    y = data.apply_filter(model.rhs.orders[order-1])
-                    y = data._fix_y_units(y,True)
+                    y = data.apply_filter(model.rhs.orders[order - 1])
+                    y = data._fix_y_units(y, True)
                     if data.exposure:
                         y = data.exposure * y
                 self.y.append(y)
@@ -391,20 +399,21 @@ class OrderPlot(ModelHistogram):
         if len(self.xlo) != len(self.y):
             raise PlotErr("orderarrfail")
 
-
     def plot(self, overplot=False, clearwindow=True):
         default_color = self.histo_prefs['linecolor']
         count = 0
-        for xlo, xhi, y, color in izip(self.xlo, self.xhi, self.y, self.colors):
+        for xlo, xhi, y, color in \
+                izip(self.xlo, self.xhi, self.y, self.colors):
             if count != 0:
-                overplot=True
-                self.histo_prefs['linecolor']=color
+                overplot = True
+                self.histo_prefs['linecolor'] = color
             Histogram.plot(self, xlo, xhi, y, title=self.title,
                            xlabel=self.xlabel, ylabel=self.ylabel,
                            overplot=overplot, clearwindow=clearwindow)
             count += 1
 
         self.histo_prefs['linecolor'] = default_color
+
 
 class BkgModelHistogram(ModelHistogram):
     "Derived class for creating 1D background PHA model histogram plots"
@@ -416,30 +425,32 @@ class BkgModelHistogram(ModelHistogram):
 class FluxHistogram(ModelHistogram):
     "Derived class for creating 1D flux distribution plots"
     def __init__(self):
-        self.modelvals=None
-        self.flux=None
+        self.modelvals = None
+        self.flux = None
         ModelHistogram.__init__(self)
 
     def __str__(self):
         vals = self.modelvals
         if self.modelvals is not None:
-            vals = array2string(asarray(self.modelvals), separator=',', precision=4, suppress_small=False)
+            vals = array2string(asarray(self.modelvals), separator=',',
+                                precision=4, suppress_small=False)
 
         flux = self.flux
         if self.flux is not None:
-            flux = array2string(asarray(self.flux), separator=',', precision=4, suppress_small=False)
+            flux = array2string(asarray(self.flux), separator=',',
+                                precision=4, suppress_small=False)
 
-        return '\n'.join(['modelvals = %s' % vals,'flux = %s' % flux,
+        return '\n'.join(['modelvals = %s' % vals, 'flux = %s' % flux,
                           ModelHistogram.__str__(self)])
 
-
     def prepare(self, fluxes, bins):
-        y = asarray(fluxes[:,0])
+        y = asarray(fluxes[:, 0])
         self.flux = y
-        self.modelvals = asarray(fluxes[:,1:])
-        self.xlo, self.xhi = dataspace1d(y.min(), y.max(), numbins=bins+1)[:2]
+        self.modelvals = asarray(fluxes[:, 1:])
+        self.xlo, self.xhi = dataspace1d(y.min(), y.max(),
+                                         numbins=bins + 1)[:2]
         y = histogram1d(y, self.xlo, self.xhi)
-        self.y = y/float(y.max())
+        self.y = y / float(y.max())
 
 
 class EnergyFluxHistogram(FluxHistogram):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -23,12 +23,8 @@ A visualization interface to Sherpa
 
 
 from __future__ import division
-import os
-import logging
-warning = logging.getLogger(__name__).warning
-
 import numpy
-_ = numpy.seterr(invalid='ignore')
+import logging
 
 from sherpa.utils import NoNewAttributesAfterInit, erf, SherpaFloat, \
     bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates
@@ -39,10 +35,14 @@ from sherpa.stats import Likelihood, LeastSq, Chi2XspecVar
 from sherpa import get_config
 from ConfigParser import ConfigParser
 
+warning = logging.getLogger(__name__).warning
+
+_ = numpy.seterr(invalid='ignore')
+
 config = ConfigParser()
 config.read(get_config())
 
-plot_opt = config.get('options','plot_pkg')
+plot_opt = config.get('options', 'plot_pkg')
 plot_opt = str(plot_opt).strip().lower() + '_backend'
 if plot_opt == 'matplotlib_backend':
     plot_opt = 'pylab_backend'
@@ -63,14 +63,13 @@ except:
 backend.init()
 
 
-
 __all__ = ('Plot', 'Contour', 'Point', 'SplitPlot', 'JointPlot',
            'DataPlot', 'DataContour', 'DelchiPlot', 'ComponentModelPlot',
            'ModelPlot', 'ModelContour', 'FitPlot', 'FitContour',
-           'ResidPlot', 'ResidContour','RatioPlot', 'RatioContour',
+           'ResidPlot', 'ResidContour', 'RatioPlot', 'RatioContour',
            'IntervalProjection', 'IntervalUncertainty', 'ChisqrPlot',
            'RegionProjection', 'RegionUncertainty', 'ComponentSourcePlot',
-           'PSFPlot','PSFContour','begin', 'end', 'exceptions', 'backend',
+           'PSFPlot', 'PSFContour', 'begin', 'end', 'exceptions', 'backend',
            'SourcePlot', 'SourceContour', 'Histogram')
 
 _stats_noerr = ('cash', 'cstat', 'leastsq', 'wstat')
@@ -79,6 +78,7 @@ begin = backend.begin
 end = backend.end
 exceptions = backend.exceptions
 get_latex_for_string = backend.get_latex_for_string
+
 
 def _make_title(title, name=''):
     """Return the plot title to use.
@@ -103,6 +103,7 @@ def _make_title(title, name=''):
     else:
         return "{} for {}".format(title, name)
 
+
 class Plot(NoNewAttributesAfterInit):
     "Base class for line plots"
     plot_prefs = backend.get_plot_defaults()
@@ -120,7 +121,6 @@ class Plot(NoNewAttributesAfterInit):
         self.plot_prefs = self.plot_prefs.copy()
         NoNewAttributesAfterInit.__init__(self)
 
-
     @staticmethod
     def vline(x, ymin=0, ymax=1,
               linecolor=None, linestyle=None, linewidth=None,
@@ -129,7 +129,6 @@ class Plot(NoNewAttributesAfterInit):
         backend.vline(x, ymin=ymin, ymax=ymax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
                       overplot=overplot, clearwindow=clearwindow)
-
 
     @staticmethod
     def hline(y, xmin=0, xmax=1,
@@ -140,7 +139,6 @@ class Plot(NoNewAttributesAfterInit):
                       linestyle=linestyle, linewidth=linewidth,
                       overplot=overplot, clearwindow=clearwindow)
 
-
     def plot(self, x, y, yerr=None, xerr=None, title=None, xlabel=None,
              ylabel=None, overplot=False, clearwindow=True):
         backend.plot(x, y, yerr, xerr, title, xlabel, ylabel, overplot,
@@ -150,6 +148,7 @@ class Plot(NoNewAttributesAfterInit):
         "Add the data to an existing plot."
         kwargs['overplot'] = True
         self.plot(*args, **kwargs)
+
 
 class Contour(NoNewAttributesAfterInit):
     "Base class for contour plots"
@@ -176,6 +175,7 @@ class Contour(NoNewAttributesAfterInit):
     def overcontour(self, *args, **kwargs):
         kwargs['overcontour'] = True
         self.contour(*args, **kwargs)
+
 
 class Point(NoNewAttributesAfterInit):
     "Base class for point plots"
@@ -218,7 +218,7 @@ class Histogram(NoNewAttributesAfterInit):
     def plot(self, xlo, xhi, y, yerr=None, title=None, xlabel=None,
              ylabel=None, overplot=False, clearwindow=True):
         backend.histo(xlo, xhi, y, yerr, title, xlabel, ylabel, overplot,
-                     clearwindow, **self.histo_prefs)
+                      clearwindow, **self.histo_prefs)
 
     def overplot(self, *args, **kwargs):
         kwargs['overplot'] = True
@@ -239,15 +239,18 @@ class HistogramPlot(Histogram):
     def __str__(self):
         xlo = self.xlo
         if self.xlo is not None:
-            xlo = numpy.array2string(numpy.asarray(self.xlo), separator=',', precision=4, suppress_small=False)
+            xlo = numpy.array2string(numpy.asarray(self.xlo), separator=',',
+                                     precision=4, suppress_small=False)
 
         xhi = self.xhi
         if self.xhi is not None:
-            xhi = numpy.array2string(numpy.asarray(self.xhi), separator=',', precision=4, suppress_small=False)
+            xhi = numpy.array2string(numpy.asarray(self.xhi), separator=',',
+                                     precision=4, suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(numpy.asarray(self.y), separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(numpy.asarray(self.y), separator=',',
+                                   precision=4, suppress_small=False)
 
         return (('xlo    = %s\n' +
                  'xhi    = %s\n' +
@@ -256,13 +259,13 @@ class HistogramPlot(Histogram):
                  'ylabel = %s\n' +
                  'title  = %s\n' +
                  'histo_prefs = %s') %
-                ( xlo,
-                  xhi,
-                  y,
-                  self.xlabel,
-                  self.ylabel,
-                  self.title,
-                  self.histo_prefs))
+                (xlo,
+                 xhi,
+                 y,
+                 self.xlabel,
+                 self.ylabel,
+                 self.title,
+                 self.histo_prefs))
 
     def plot(self, overplot=False, clearwindow=True):
         Histogram.plot(self, self.xlo, self.xhi, self.y, title=self.title,
@@ -276,14 +279,14 @@ class PDFPlot(HistogramPlot):
         self.points = None
         HistogramPlot.__init__(self)
 
-
     def __str__(self):
         points = self.points
         if self.points is not None:
-            points = numpy.array2string(numpy.asarray(self.points), separator=',', precision=4, suppress_small=False)
+            points = numpy.array2string(numpy.asarray(self.points),
+                                        separator=',', precision=4,
+                                        suppress_small=False)
 
-        return ('points = %s\n'%(points) +
-                HistogramPlot.__str__(self))
+        return ('points = %s\n' % (points) + HistogramPlot.__str__(self))
 
     def prepare(self, points, bins=12, normed=True, xlabel="x", name="x"):
         self.points = points
@@ -292,8 +295,7 @@ class PDFPlot(HistogramPlot):
         self.xhi = xx[1:]
         self.ylabel = "probability density"
         self.xlabel = xlabel
-        self.title  = "PDF: %s"%name
-
+        self.title  = "PDF: %s" % name
 
 
 class CDFPlot(Plot):
@@ -319,18 +321,20 @@ class CDFPlot(Plot):
         self.title = None
         Plot.__init__(self)
 
-
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4, suppress_small=False)
+            x = numpy.array2string(self.x, separator=',', precision=4,
+                                   suppress_small=False)
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         points = self.points
         if self.points is not None:
-            points = numpy.array2string(self.points, separator=',', precision=4, suppress_small=False)
+            points = numpy.array2string(self.points, separator=',',
+                                        precision=4, suppress_small=False)
 
         return (('points = %s\n' +
                  'x      = %s\n' +
@@ -342,17 +346,16 @@ class CDFPlot(Plot):
                  'ylabel = %s\n' +
                  'title  = %s\n' +
                  'plot_prefs = %s') %
-                ( x,
-                  y,
-                  points,
-                  self.median,
-                  self.lower,
-                  self.upper,
-                  self.xlabel,
-                  self.ylabel,
-                  self.title,
-                  self.plot_prefs))
-
+                (x,
+                 y,
+                 points,
+                 self.median,
+                 self.lower,
+                 self.upper,
+                 self.xlabel,
+                 self.ylabel,
+                 self.title,
+                 self.plot_prefs))
 
     def prepare(self, points, xlabel="x", name="x"):
         self.points = points
@@ -362,9 +365,8 @@ class CDFPlot(Plot):
         xsize = len(self.x)
         self.y = (numpy.arange(xsize) + 1.0) / xsize
         self.xlabel = xlabel
-        self.ylabel = "p(<=%s)"%(xlabel)
-        self.title  = "CDF: %s"%(name)
-
+        self.ylabel = "p(<=%s)" % (xlabel)
+        self.title  = "CDF: %s" % (name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, title=self.title,
@@ -381,47 +383,49 @@ class CDFPlot(Plot):
 class LRHistogram(HistogramPlot):
     "Derived class for creating 1D likelihood ratio distribution plots"
     def __init__(self):
-        self.ratios=None
-        self.lr=None
-        self.ppp=None
+        self.ratios = None
+        self.lr = None
+        self.ppp = None
         HistogramPlot.__init__(self)
-
 
     def __str__(self):
         ratios = self.ratios
         if self.ratios is not None:
-            ratios = numpy.array2string(numpy.asarray(self.ratios), separator=',', precision=4, suppress_small=False)
+            ratios = numpy.array2string(numpy.asarray(self.ratios),
+                                        separator=',', precision=4,
+                                        suppress_small=False)
 
         return '\n'.join(['ratios = %s' % ratios,
                           'lr = %s' % str(self.lr),
                           HistogramPlot.__str__(self)])
-
 
     def prepare(self, ratios, bins, niter, lr, ppp):
         self.ppp = float(ppp)
         self.lr = float(lr)
         y = numpy.asarray(ratios)
         self.ratios = y
-        self.xlo, self.xhi = dataspace1d(y.min(), y.max(), numbins=bins+1)[:2]
+        self.xlo, self.xhi = dataspace1d(y.min(), y.max(),
+                                         numbins=bins + 1)[:2]
         y = histogram1d(y, self.xlo, self.xhi)
-        self.y = y/float(niter)
+        self.y = y / float(niter)
         self.title = "Likelihood Ratio Distribution"
         self.xlabel = "Likelihood Ratio"
         self.ylabel = "Frequency"
-
 
     def plot(self, overplot=False, clearwindow=True):
         Histogram.plot(self, self.xlo, self.xhi, self.y, title=self.title,
                        xlabel=self.xlabel, ylabel=self.ylabel,
                        overplot=overplot, clearwindow=clearwindow)
 
-        if self.lr is not None:
-            if self.lr <= self.xhi.max() and self.lr >= self.xlo.min():
-                Plot.vline(self.lr, linecolor="orange", linestyle="solid",
-                           linewidth=1.5, overplot=True, clearwindow=False)
+        if self.lr is None:
+            return
+
+        if self.lr <= self.xhi.max() and self.lr >= self.xlo.min():
+            Plot.vline(self.lr, linecolor="orange", linestyle="solid",
+                       linewidth=1.5, overplot=True, clearwindow=False)
 
 
-class SplitPlot(Plot,Contour):
+class SplitPlot(Plot, Contour):
     """Create multiple plots.
 
     Attributes
@@ -446,9 +450,9 @@ class SplitPlot(Plot,Contour):
         return (('rows   = %s\n' +
                  'cols   = %s\n' +
                  'plot_prefs = %s') %
-                ( self.rows,
-                  self.cols,
-                  self.plot_prefs))
+                (self.rows,
+                 self.cols,
+                 self.plot_prefs))
 
     def reset(self, rows=2, cols=1):
         "Prepare for a new set of plots or contours."
@@ -523,7 +527,7 @@ class SplitPlot(Plot,Contour):
     def overlaycontour(self, plot, *args, **kwargs):
         "Add the contour to the current space without destroying the contents."
         self.overcontour(self._current[0], self._current[1], plot, *args,
-                      **kwargs)
+                         **kwargs)
 
     # FIXME: work on overplot issue
     def overplot(self, row, col, plot, *args, **kwargs):
@@ -535,6 +539,7 @@ class SplitPlot(Plot,Contour):
         "Add a contour plot to the given space without destroying the contents."
         kwargs['overcontour'] = True
         self.contour(row, col, plot, *args, **kwargs)
+
 
 class JointPlot(SplitPlot):
     def __init__(self):
@@ -553,23 +558,23 @@ class JointPlot(SplitPlot):
 
     def plottop(self, plot, *args, **kwargs):
         clearaxes = kwargs.get('clearwindow', True)
-        self._clear_window(0,0,clearaxes)
+        self._clear_window(0, 0, clearaxes)
 
         # FIXME: should not know about FitPlot, terrible hack to remove label
-        if isinstance(plot,FitPlot):
-            plot.dataplot.xlabel=''
-            plot.modelplot.xlabel=''
+        if isinstance(plot, FitPlot):
+            plot.dataplot.xlabel = ''
+            plot.modelplot.xlabel = ''
         else:
-            plot.xlabel=''
+            plot.xlabel = ''
 
         kwargs['clearwindow'] = False
         plot.plot(*args, **kwargs)
 
     def plotbot(self, plot, *args, **kwargs):
-        self._clear_window(1,0)
+        self._clear_window(1, 0)
 
         # FIXME: terrible hack to remove title from bottom
-        plot.title=''
+        plot.title = ''
         kwargs['clearwindow'] = False
         plot.plot(*args, **kwargs)
 
@@ -609,19 +614,23 @@ class DataPlot(Plot):
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4, suppress_small=False)
+            x = numpy.array2string(self.x, separator=',', precision=4,
+                                   suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         yerr = self.yerr
         if self.yerr is not None:
-            yerr = numpy.array2string(self.yerr, separator=',', precision=4, suppress_small=False)
+            yerr = numpy.array2string(self.yerr, separator=',', precision=4,
+                                      suppress_small=False)
 
         xerr = self.xerr
         if self.xerr is not None:
-            xerr = numpy.array2string(self.xerr, separator=',', precision=4, suppress_small=False)
+            xerr = numpy.array2string(self.xerr, separator=',', precision=4,
+                                      suppress_small=False)
 
         return (('x      = %s\n' +
                  'y      = %s\n' +
@@ -631,20 +640,20 @@ class DataPlot(Plot):
                  'ylabel = %s\n' +
                  'title  = %s\n' +
                  'plot_prefs = %s') %
-                ( x,
-                  y,
-                  yerr,
-                  xerr,
-                  self.xlabel,
-                  self.ylabel,
-                  self.title,
-                  self.plot_prefs))
+                (x,
+                 y,
+                 yerr,
+                 xerr,
+                 self.xlabel,
+                 self.ylabel,
+                 self.title,
+                 self.plot_prefs))
 
     def prepare(self, data, stat=None):
         (self.x, self.y, self.yerr, self.xerr, self.xlabel,
          self.ylabel) = data.to_plot()
 
-        #if self.yerr is None and stat is not None:
+        # if self.yerr is None and stat is not None:
         if stat is not None:
             msg = ("The displayed errorbars have been supplied with the data or calculated using chi2xspecvar; the errors are not used in fits with %s" % stat.name)
             if stat.name in _stats_noerr:
@@ -672,7 +681,7 @@ class TracePlot(DataPlot):
         self.y = points
         self.xlabel = "iteration"
         self.ylabel = name
-        self.title  = "Trace: %s"%(name)
+        self.title  = "Trace: %s" % (name)
 
 
 class ScatterPlot(DataPlot):
@@ -684,7 +693,7 @@ class ScatterPlot(DataPlot):
         self.y = numpy.asarray(y, dtype=SherpaFloat)
         self.xlabel = xlabel
         self.ylabel = ylabel
-        self.title  = "Scatter: %s"%(name)
+        self.title  = "Scatter: %s" % (name)
 
 
 class PSFKernelPlot(DataPlot):
@@ -693,8 +702,8 @@ class PSFKernelPlot(DataPlot):
     def prepare(self, psf, data=None, stat=None):
         psfdata = psf.get_kernel(data)
         DataPlot.prepare(self, psfdata, stat)
-        #self.ylabel = 'PSF value'
-        #self.xlabel = 'PSF Kernel size'
+        # self.ylabel = 'PSF value'
+        # self.xlabel = 'PSF Kernel size'
         self.title  = 'PSF Kernel'
 
 
@@ -733,15 +742,18 @@ class DataContour(Contour):
     def __str__(self):
         x0 = self.x0
         if self.x0 is not None:
-            x0 = numpy.array2string(self.x0, separator=',', precision=4, suppress_small=False)
+            x0 = numpy.array2string(self.x0, separator=',', precision=4,
+                                    suppress_small=False)
 
         x1 = self.x1
         if self.x1 is not None:
-            x1 = numpy.array2string(self.x1, separator=',', precision=4, suppress_small=False)
+            x1 = numpy.array2string(self.x1, separator=',', precision=4,
+                                    suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         return (('x0     = %s\n' +
                  'x1     = %s\n' +
@@ -751,14 +763,14 @@ class DataContour(Contour):
                  'title  = %s\n' +
                  'levels = %s\n' +
                  'contour_prefs = %s') %
-                ( x0,
-                  x1,
-                  y,
-                  self.xlabel,
-                  self.ylabel,
-                  self.title,
-                  self.levels,
-                  self.contour_prefs))
+                (x0,
+                 x1,
+                 y,
+                 self.xlabel,
+                 self.ylabel,
+                 self.title,
+                 self.levels,
+                 self.contour_prefs))
 
     def prepare(self, data, stat=None):
         (self.x0, self.x1, self.y, self.xlabel,
@@ -767,8 +779,9 @@ class DataContour(Contour):
 
     def contour(self, overcontour=False, clearwindow=True):
         Contour.contour(self, self.x0, self.x1, self.y,
-                        self.levels,self.title, self.xlabel,
+                        self.levels, self.title, self.xlabel,
                         self.ylabel, overcontour, clearwindow)
+
 
 class PSFKernelContour(DataContour):
     "Derived class for creating 2D PSF Kernel contours"
@@ -776,8 +789,8 @@ class PSFKernelContour(DataContour):
     def prepare(self, psf, data=None, stat=None):
         psfdata = psf.get_kernel(data)
         DataContour.prepare(self, psfdata)
-        #self.xlabel = 'PSF Kernel size x0'
-        #self.ylabel = 'PSF Kernel size x1'
+        # self.xlabel = 'PSF Kernel size x0'
+        # self.ylabel = 'PSF Kernel size x1'
         self.title  = 'PSF Kernel'
 
 
@@ -816,19 +829,23 @@ class ModelPlot(Plot):
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4, suppress_small=False)
+            x = numpy.array2string(self.x, separator=',', precision=4,
+                                   suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         yerr = self.yerr
         if self.yerr is not None:
-            yerr = numpy.array2string(self.yerr, separator=',', precision=4, suppress_small=False)
+            yerr = numpy.array2string(self.yerr, separator=',', precision=4,
+                                      suppress_small=False)
 
         xerr = self.xerr
         if self.xerr is not None:
-            xerr = numpy.array2string(self.xerr, separator=',', precision=4, suppress_small=False)
+            xerr = numpy.array2string(self.xerr, separator=',', precision=4,
+                                      suppress_small=False)
 
         return (('x      = %s\n' +
                  'y      = %s\n' +
@@ -838,14 +855,14 @@ class ModelPlot(Plot):
                  'ylabel = %s\n' +
                  'title  = %s\n' +
                  'plot_prefs = %s') %
-                ( x,
-                  y,
-                  yerr,
-                  xerr,
-                  self.xlabel,
-                  self.ylabel,
-                  self.title,
-                  self.plot_prefs))
+                (x,
+                 y,
+                 yerr,
+                 xerr,
+                 self.xlabel,
+                 self.ylabel,
+                 self.title,
+                 self.plot_prefs))
 
     def prepare(self, data, model, stat=None):
         (self.x, self.y, self.yerr, self.xerr,
@@ -854,7 +871,8 @@ class ModelPlot(Plot):
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,
-                  ylabel=self.ylabel, overplot=overplot, clearwindow=clearwindow)
+                  ylabel=self.ylabel, overplot=overplot,
+                  clearwindow=clearwindow)
 
 
 class ComponentModelPlot(ModelPlot):
@@ -874,6 +892,7 @@ class ComponentTemplateModelPlot(ComponentModelPlot):
         self.xlabel = data.get_xlabel()
         self.ylabel = data.get_ylabel()
         self.title = 'Model component: %s' % model.name
+
 
 class SourcePlot(ModelPlot):
     """Create 1D plots of unconcolved model values.
@@ -926,8 +945,6 @@ class ComponentTemplateSourcePlot(ComponentSourcePlot):
         self.title = 'Source model component: %s' % model.name
 
 
-
-
 class PSFPlot(DataPlot):
     "Derived class for creating 1D PSF kernel data plots"
 
@@ -954,15 +971,18 @@ class ModelContour(Contour):
     def __str__(self):
         x0 = self.x0
         if self.x0 is not None:
-            x0 = numpy.array2string(self.x0, separator=',', precision=4, suppress_small=False)
+            x0 = numpy.array2string(self.x0, separator=',', precision=4,
+                                    suppress_small=False)
 
         x1 = self.x1
         if self.x1 is not None:
-            x1 = numpy.array2string(self.x1, separator=',', precision=4, suppress_small=False)
+            x1 = numpy.array2string(self.x1, separator=',', precision=4,
+                                    suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         return (('x0     = %s\n' +
                  'x1     = %s\n' +
@@ -972,14 +992,14 @@ class ModelContour(Contour):
                  'title  = %s\n' +
                  'levels = %s\n' +
                  'contour_prefs = %s') %
-                ( x0,
-                  x1,
-                  y,
-                  self.xlabel,
-                  self.ylabel,
-                  self.title,
-                  self.levels,
-                  self.contour_prefs))
+                (x0,
+                 x1,
+                 y,
+                 self.xlabel,
+                 self.ylabel,
+                 self.title,
+                 self.levels,
+                 self.contour_prefs))
 
     def prepare(self, data, model, stat):
         (self.x0, self.x1, self.y, self.xlabel,
@@ -988,7 +1008,8 @@ class ModelContour(Contour):
 
     def contour(self, overcontour=False, clearwindow=True):
         Contour.contour(self, self.x0, self.x1, self.y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+                        title=self.title, xlabel=self.xlabel,
+                        ylabel=self.ylabel,
                         overcontour=overcontour, clearwindow=clearwindow)
 
 
@@ -1018,15 +1039,15 @@ class FitPlot(Plot):
         Plot.__init__(self)
 
     def __str__(self):
-        data_title=None
+        data_title = None
         if self.dataplot is not None:
             data_title = self.dataplot.title
 
-        model_title=None
+        model_title = None
         if self.modelplot is not None:
             model_title = self.modelplot.title
 
-        return (('dataplot   = %s'+'\n%s\n\n'+'modelplot  = %s'+'\n%s') %
+        return (('dataplot   = %s\n%s\n\nmodelplot  = %s\n%s') %
                 (data_title,
                  self.dataplot,
                  model_title,
@@ -1053,14 +1074,14 @@ class FitContour(Contour):
         Contour.__init__(self)
 
     def __str__(self):
-        data_title=None
+        data_title = None
         if self.datacontour is not None:
             data_title = self.datacontour.title
 
-        model_title=None
+        model_title = None
         if self.modelcontour is not None:
             model_title = self.modelcontour.title
-        return (('datacontour = %s'+'\n%s\n\n'+'modelcontour = %s'+'\n%s') %
+        return (('datacontour = %s\n%s\n\nmodelcontour = %s\n%s') %
                 (data_title,
                  self.datacontour,
                  model_title,
@@ -1071,7 +1092,7 @@ class FitContour(Contour):
         self.modelcontour = modelcontour
 
     def contour(self, overcontour=False, clearwindow=True):
-        self.datacontour.contour( overcontour, clearwindow)
+        self.datacontour.contour(overcontour, clearwindow)
         self.modelcontour.overcontour()
 
 
@@ -1100,7 +1121,7 @@ class DelchiPlot(ModelPlot):
     plot_prefs = backend.get_resid_plot_defaults()
 
     def _calc_delchi(self, ylist, staterr):
-        return (ylist[0] - ylist[1])/staterr
+        return (ylist[0] - ylist[1]) / staterr
 
     def prepare(self, data, model, stat):
         (self.x, y, staterr, self.xerr,
@@ -1109,16 +1130,17 @@ class DelchiPlot(ModelPlot):
         if staterr is None:
             if stat.name in _stats_noerr:
                 raise StatErr('badstat', "DelchiPlot", stat.name)
-            staterr = data.get_yerr(True,stat.calc_staterror)
+            staterr = data.get_yerr(True, stat.calc_staterror)
 
         self.y = self._calc_delchi(y, staterr)
-        self.yerr = staterr/staterr
+        self.yerr = staterr / staterr
         self.ylabel = 'Sigma'
         self.title = _make_title('Sigma Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
                   self.xlabel, self.ylabel, overplot, clearwindow)
+
 
 class ChisqrPlot(ModelPlot):
     """Create plots of the chi-square value per point.
@@ -1144,24 +1166,26 @@ class ChisqrPlot(ModelPlot):
     plot_prefs = backend.get_model_plot_defaults()
 
     def _calc_chisqr(self, ylist, staterr):
-        return (ylist[0] - ylist[1])*(ylist[0] - ylist[1]) / (staterr*staterr)
+        dy = ylist[0] - ylist[1]
+        return dy * dy / (staterr * staterr)
 
     def prepare(self, data, model, stat):
         (self.x, y, staterr, self.xerr,
          self.xlabel, self.ylabel) = data.to_plot(model)
 
-        #if staterr is None:
+        # if staterr is None:
         if stat.name in _stats_noerr:
             raise StatErr('badstat', "ChisqrPlot", stat.name)
-        staterr = data.get_yerr(True,stat.calc_staterror)
+        staterr = data.get_yerr(True, stat.calc_staterror)
 
         self.y = self._calc_chisqr(y, staterr)
         self.ylabel = get_latex_for_string('\chi^2')
         self.title = _make_title(get_latex_for_string('\chi^2'), data.name)
 
     def plot(self, overplot=False, clearwindow=True):
-        Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,
-                  ylabel=self.ylabel, overplot=overplot, clearwindow=clearwindow)
+        Plot.plot(self, self.x, self.y, title=self.title,
+                  xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow)
 
 
 class ResidPlot(ModelPlot):
@@ -1196,12 +1220,12 @@ class ResidPlot(ModelPlot):
          self.xlabel, self.ylabel) = data.to_plot(model)
 
         self.y = self._calc_resid(y)
-#        if self.yerr is None:
+        # if self.yerr is None:
         if stat.name in _stats_noerr:
             self.yerr = data.get_yerr(True, Chi2XspecVar.calc_staterror)
             warning("The displayed errorbars have been supplied with the data or calculated using chi2xspecvar; the errors are not used in fits with %s" % stat.name)
         else:
-            self.yerr = data.get_yerr(True,stat.calc_staterror)
+            self.yerr = data.get_yerr(True, stat.calc_staterror)
 
         # Some data sets (e.g. DataPHA, which shows the units) have a y
         # label that could (should?) be displayed (or added to the label).
@@ -1234,7 +1258,8 @@ class ResidContour(ModelContour):
 
     def contour(self, overcontour=False, clearwindow=True):
         Contour.contour(self, self.x0, self.x1, self.y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+                        title=self.title,
+                        xlabel=self.xlabel, ylabel=self.ylabel,
                         overcontour=overcontour, clearwindow=clearwindow)
 
 
@@ -1275,14 +1300,14 @@ class RatioPlot(ModelPlot):
          self.xlabel, self.ylabel) = data.to_plot(model)
 
         self.y = self._calc_ratio(y)
-        #if self.yerr is None:
+        # if self.yerr is None:
         if stat.name in _stats_noerr:
             self.yerr = data.get_yerr(True, Chi2XspecVar.calc_staterror)
-            self.yerr = self.yerr/y[1]
+            self.yerr = self.yerr / y[1]
             warning("The displayed errorbars have been supplied with the data or calculated using chi2xspecvar; the errors are not used in fits with %s" % stat.name)
         else:
-            staterr = data.get_yerr(True,stat.calc_staterror)
-            self.yerr = staterr/y[1]
+            staterr = data.get_yerr(True, stat.calc_staterror)
+            self.yerr = staterr / y[1]
 
         self.ylabel = 'Data / Model'
         self.title = _make_title('Ratio of Data to Model', data.name)
@@ -1318,7 +1343,6 @@ class RatioContour(ModelContour):
                         overcontour=overcontour, clearwindow=clearwindow)
 
 
-
 class Confidence1D(DataPlot):
 
     plot_prefs = backend.get_confid_plot_defaults()
@@ -1338,23 +1362,25 @@ class Confidence1D(DataPlot):
     def __setstate__(self, state):
         self.__dict__.update(state)
 
-        if not state.has_key('stat'):
+        if 'stat' not in state:
             self.__dict__['stat'] = None
 
-        if not state.has_key('parval'):
+        if 'parval' not in state:
             self.__dict__['parval'] = None
 
-        if not state.has_key('numcores'):
+        if 'numcores' not in state:
             self.__dict__['numcores'] = None
 
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4, suppress_small=False)
+            x = numpy.array2string(self.x, separator=',', precision=4,
+                                   suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         return (('x     = %s\n' +
                  'y     = %s\n' +
@@ -1373,7 +1399,6 @@ class Confidence1D(DataPlot):
                  self.fac,
                  self.log))
 
-
     def prepare(self, min=None, max=None, nloop=20,
                 delv=None, fac=1, log=False, numcores=None):
         self.min = min
@@ -1383,7 +1408,6 @@ class Confidence1D(DataPlot):
         self.fac = fac
         self.log = log
         self.numcores = numcores
-
 
     def _interval_init(self, fit, par):
 
@@ -1416,9 +1440,8 @@ class Confidence1D(DataPlot):
             self.min = v - self.fac * dv
             self.max = v + self.fac * dv
 
-        if( not numpy.isscalar( self.min ) or
-            not numpy.isscalar( self.max ) ):
-            raise ConfidenceErr('badarg','Parameter limits', 'scalars')
+        if not numpy.isscalar(self.min) or not numpy.isscalar(self.max):
+            raise ConfidenceErr('badarg', 'Parameter limits', 'scalars')
 
         # check user limits for errors
         if self.min >= self.max:
@@ -1433,10 +1456,11 @@ class Confidence1D(DataPlot):
             self.max = par.max
 
         if self.delv is None:
-            self.x = numpy.linspace(self.min,self.max,self.nloop)
+            self.x = numpy.linspace(self.min, self.max, self.nloop)
         else:
             eps = numpy.finfo(numpy.float32).eps
-            self.x = numpy.arange(self.min,self.max+self.delv-eps,self.delv)
+            self.x = numpy.arange(self.min, self.max + self.delv - eps,
+                                  self.delv)
 
         x = self.x
         if self.log:
@@ -1446,10 +1470,9 @@ class Confidence1D(DataPlot):
             self.max = numpy.log10(self.max)
             self.min = numpy.log10(self.min)
 
-            x = numpy.linspace(self.min,self.max,len(x))
+            x = numpy.linspace(self.min, self.max, len(x))
 
         return x
-
 
     def calc(self, fit, par):
         if type(fit.stat) in (LeastSq,):
@@ -1457,7 +1480,7 @@ class Confidence1D(DataPlot):
 
     def plot(self, overplot=False, clearwindow=True):
         if self.log:
-            self.plot_prefs['xlog']=True
+            self.plot_prefs['xlog'] = True
 
         Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,
                   ylabel=self.ylabel, overplot=overplot,
@@ -1465,14 +1488,14 @@ class Confidence1D(DataPlot):
 
         if self.stat is not None:
             Plot.hline(self.stat, linecolor="green", linestyle="dash",
-                       linewidth=1.5,overplot=True, clearwindow=False)
+                       linewidth=1.5, overplot=True, clearwindow=False)
 
         if self.parval is not None:
             Plot.vline(self.parval, linecolor="orange", linestyle="dash",
-                       linewidth=1.5,overplot=True, clearwindow=False)
+                       linewidth=1.5, overplot=True, clearwindow=False)
 
         if self.log:
-            self.plot_prefs['xlog']=False
+            self.plot_prefs['xlog'] = False
 
 
 class Confidence2D(DataContour, Point):
@@ -1483,11 +1506,11 @@ class Confidence2D(DataContour, Point):
     def __init__(self):
         self.min = None
         self.max = None
-        self.nloop = (10,10)
+        self.nloop = (10, 10)
         self.fac = 4
         self.delv = None
-        self.log = (False,False)
-        self.sigma = (1,2,3)
+        self.log = (False, False)
+        self.sigma = (1, 2, 3)
         self.parval0 = None
         self.parval1 = None
         self.stat = None
@@ -1497,25 +1520,27 @@ class Confidence2D(DataContour, Point):
     def __setstate__(self, state):
         self.__dict__.update(state)
 
-        if not state.has_key('stat'):
+        if 'stat' not in state:
             self.__dict__['stat'] = None
 
-        if not state.has_key('numcores'):
+        if 'numcores' not in state:
             self.__dict__['numcores'] = None
-
 
     def __str__(self):
         x0 = self.x0
         if self.x0 is not None:
-            x0 = numpy.array2string(self.x0, separator=',', precision=4, suppress_small=False)
+            x0 = numpy.array2string(self.x0, separator=',', precision=4,
+                                    suppress_small=False)
 
         x1 = self.x1
         if self.x1 is not None:
-            x1 = numpy.array2string(self.x1, separator=',', precision=4, suppress_small=False)
+            x1 = numpy.array2string(self.x1, separator=',', precision=4,
+                                    suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4, suppress_small=False)
+            y = numpy.array2string(self.y, separator=',', precision=4,
+                                   suppress_small=False)
 
         return (('x0      = %s\n' +
                  'x1      = %s\n' +
@@ -1544,10 +1569,9 @@ class Confidence2D(DataContour, Point):
                  self.parval1,
                  self.levels))
 
-
-    def prepare(self, min=None, max=None, nloop=(10,10),
-                delv=None, fac=4, log=(False,False),
-                sigma=(1,2,3), levels=None, numcores=None):
+    def prepare(self, min=None, max=None, nloop=(10, 10),
+                delv=None, fac=4, log=(False, False),
+                sigma=(1, 2, 3), levels=None, numcores=None):
         self.min = min
         self.max = max
         self.nloop = nloop
@@ -1575,7 +1599,7 @@ class Confidence2D(DataContour, Point):
             thelevels = numpy.zeros(len(self.sigma), SherpaFloat)
             for i in range(len(self.sigma)):
                 thelevels[i] = stat - (2. * numpy.log(1. - erf(
-                    self.sigma[i]/numpy.sqrt(2.))))
+                    self.sigma[i] / numpy.sqrt(2.))))
             self.levels = thelevels
 
         if self.min is None or self.max is None:
@@ -1611,80 +1635,77 @@ class Confidence2D(DataContour, Point):
                     self.max[1] = par1.val + max1
 
             # check user limits for errors
-            if( numpy.isscalar( self.min ) or
-                numpy.isscalar( self.max ) ):
-                raise ConfidenceErr('badarg','Parameter limits', 'a list')
+            if numpy.isscalar(self.min) or numpy.isscalar(self.max):
+                raise ConfidenceErr('badarg', 'Parameter limits', 'a list')
 
-            for i in [0,1]:
+            for i in [0, 1]:
                 v = (self.max[i] + self.min[i]) / 2.
                 dv = numpy.fabs(v - self.min[i])
                 self.min[i] = v - self.fac * dv
                 self.max[i] = v + self.fac * dv
 
-        hmin = numpy.array([ par0.min, par1.min ])
-        hmax = numpy.array([ par0.max, par1.max ])
+        hmin = numpy.array([par0.min, par1.min])
+        hmax = numpy.array([par0.max, par1.max])
 
-        for i in [0,1]:
+        for i in [0, 1]:
             # check user limits for errors
-            if( numpy.isscalar( self.min ) or
-                numpy.isscalar( self.max ) ):
-                raise ConfidenceErr('badarg','Parameter limits', 'a list')
+            if numpy.isscalar(self.min) or numpy.isscalar(self.max):
+                raise ConfidenceErr('badarg', 'Parameter limits', 'a list')
 
             if self.min[i] >= self.max[i]:
                 raise ConfidenceErr('badlimits')
 
-            if numpy.isscalar( self.nloop ) or self.nloop[i] <= 1:
-                raise ConfidenceErr('badarg', 'Nloop parameter','a list with' +
-                                      ' elements > 1')
+            if numpy.isscalar(self.nloop) or self.nloop[i] <= 1:
+                raise ConfidenceErr('badarg', 'Nloop parameter',
+                                    'a list with elements > 1')
 
             if self.min[i] < hmin[i]:
                 self.min[i] = hmin[i]
             if self.max[i] > hmax[i]:
                 self.max[i] = hmax[i]
 
-
         if self.delv is None:
-            self.x0 = numpy.linspace(self.min[0],self.max[0],self.nloop[0])
-            self.x1 = numpy.linspace(self.min[1],self.max[1],self.nloop[1])
+            self.x0 = numpy.linspace(self.min[0], self.max[0], self.nloop[0])
+            self.x1 = numpy.linspace(self.min[1], self.max[1], self.nloop[1])
 
         else:
             eps = numpy.finfo(numpy.float32).eps
-            self.x0 = numpy.arange(self.min[0],self.max[0]+self.delv[0]-eps,
+            self.x0 = numpy.arange(self.min[0],
+                                   self.max[0] + self.delv[0] - eps,
                                    self.delv[0])
-            self.x1 = numpy.arange(self.min[1],self.max[1]+self.delv[1]-eps,
+            self.x1 = numpy.arange(self.min[1],
+                                   self.max[1] + self.delv[1] - eps,
                                    self.delv[1])
 
-        #x = numpy.array([self.x0, self.x1])
+        # x = numpy.array([self.x0, self.x1])
         x = [self.x0, self.x1]
 
         self.x0, self.x1 = numpy.meshgrid(self.x0, self.x1)
         self.x0 = self.x0.ravel()
         self.x1 = self.x1.ravel()
 
-        for i in [0,1]:
+        for i in [0, 1]:
             if self.log[i]:
                 if self.max[i] <= 0.0 or self.min[i] <= 0.0:
                     raise ConfidenceErr('badarg', 'Log scale',
                                         'on positive boundaries')
                 self.max[i] = numpy.log10(self.max[i])
                 self.min[i] = numpy.log10(self.min[i])
-                x[i] = numpy.linspace(self.min[i],self.max[i],len(x[i]))
+                x[i] = numpy.linspace(self.min[i], self.max[i], len(x[i]))
 
         x0, x1 = numpy.meshgrid(x[0], x[1])
         return numpy.array([x0.ravel(), x1.ravel()]).T
-
 
     def calc(self, fit, par0, par1):
         if type(fit.stat) in (LeastSq,):
             raise ConfidenceErr('badargconf', fit.stat.name)
 
-
     def contour(self, overplot=False, clearwindow=True):
 
         if self.log[0]:
-            self.contour_prefs['xlog']=True
+            self.contour_prefs['xlog'] = True
         if self.log[1]:
-            self.contour_prefs['ylog']=True
+            self.contour_prefs['ylog'] = True
 
         Contour.contour(self, self.x0, self.x1, self.y, levels=self.levels,
                         title=self.title, xlabel=self.xlabel,
@@ -1694,9 +1715,9 @@ class Confidence2D(DataContour, Point):
                     overplot=True, clearwindow=False)
 
         if self.log[0]:
-            self.contour_prefs['xlog']=False
+            self.contour_prefs['xlog'] = False
         if self.log[1]:
-            self.contour_prefs['ylog']=False
+            self.contour_prefs['ylog'] = False
 
 
 class IntervalProjection(Confidence1D):
@@ -1705,12 +1726,10 @@ class IntervalProjection(Confidence1D):
         self.fast = True
         Confidence1D.__init__(self)
 
-
     def prepare(self, fast=True, min=None, max=None, nloop=20,
                 delv=None, fac=1, log=False, numcores=None):
         self.fast = fast
         Confidence1D.prepare(self, min, max, nloop, delv, fac, log, numcores)
-
 
     def calc(self, fit, par, methoddict=None):
         self.title = 'Interval-Projection'
@@ -1740,13 +1759,13 @@ class IntervalProjection(Confidence1D):
             if (isinstance(fit.stat, Likelihood)):
                 if (type(fit.method) is not NelderMead):
                     fit.method = methoddict['neldermead']
-                    warning("Setting optimization to " + fit.method.name
-                            + " for interval projection plot")
+                    warning("Setting optimization to " + fit.method.name +
+                            " for interval projection plot")
             else:
                 if (type(fit.method) is not LevMar):
                     fit.method = methoddict['levmar']
-                    warning("Setting optimization to " + fit.method.name
-                            + " for interval projection plot")
+                    warning("Setting optimization to " + fit.method.name +
+                            " for interval projection plot")
 
         xvals = self._interval_init(fit, par)
         oldpars = fit.model.thawedpars
@@ -1767,9 +1786,9 @@ class IntervalProjection(Confidence1D):
             # store the class methods for startup and teardown
             # these calls are unnecessary for every fit
             startup = fit.model.startup
-            fit.model.startup = lambda : None
+            fit.model.startup = lambda: None
             teardown = fit.model.teardown
-            fit.model.teardown = lambda : None
+            fit.model.teardown = lambda: None
 
             self.y = numpy.asarray(parallel_map(eval_proj, xvals,
                                                 self.numcores))
@@ -1832,17 +1851,15 @@ class RegionProjection(Confidence2D):
         self.fast = True
         Confidence2D.__init__(self)
 
-
-    def prepare(self, fast=True, min=None, max=None, nloop=(10,10),
-                delv=None, fac=4, log=(False,False),
-                sigma=(1,2,3), levels=None, numcores=None):
+    def prepare(self, fast=True, min=None, max=None, nloop=(10, 10),
+                delv=None, fac=4, log=(False, False),
+                sigma=(1, 2, 3), levels=None, numcores=None):
         self.fast = fast
         Confidence2D.prepare(self, min, max, nloop, delv, fac, log,
                              sigma, levels, numcores)
 
-
     def calc(self, fit, par0, par1, methoddict=None):
-        self.title='Region-Projection'
+        self.title = 'Region-Projection'
 
         Confidence2D.calc(self, fit, par0, par1)
         if par0.frozen:
@@ -1872,17 +1889,16 @@ class RegionProjection(Confidence2D):
             if (isinstance(fit.stat, Likelihood)):
                 if (type(fit.method) is not NelderMead):
                     fit.method = methoddict['neldermead']
-                    warning("Setting optimization to " + fit.method.name
-                            + " for region projection plot")
+                    warning("Setting optimization to " + fit.method.name +
+                            " for region projection plot")
             else:
                 if (type(fit.method) is not LevMar):
                     fit.method = methoddict['levmar']
-                    warning("Setting optimization to " + fit.method.name
-                            + " for region projection plot")
-
+                    warning("Setting optimization to " + fit.method.name +
+                            " for region projection plot")
 
         def eval_proj(pars):
-            for ii in [0,1]:
+            for ii in [0, 1]:
                 if self.log[ii]:
                     pars[ii] = numpy.power(10, pars[ii])
             (par0.val, par1.val) = pars
@@ -1899,9 +1915,9 @@ class RegionProjection(Confidence2D):
             # store the class methods for startup and teardown
             # these calls are unnecessary for every fit
             startup = fit.model.startup
-            fit.model.startup = lambda : None
+            fit.model.startup = lambda: None
             teardown = fit.model.teardown
-            fit.model.teardown = lambda : None
+            fit.model.teardown = lambda: None
 
             grid = self._region_init(fit, par0, par1)
 
@@ -1927,7 +1943,7 @@ class RegionProjection(Confidence2D):
 class RegionUncertainty(Confidence2D):
 
     def calc(self, fit, par0, par1, methoddict=None):
-        self.title='Region-Uncertainty'
+        self.title = 'Region-Uncertainty'
 
         Confidence2D.calc(self, fit, par0, par1)
         if par0.frozen:
@@ -1943,7 +1959,7 @@ class RegionUncertainty(Confidence2D):
             raise ConfidenceErr('thawed', par1.fullname, fit.model.name)
 
         def eval_uncert(pars):
-            for ii in [0,1]:
+            for ii in [0, 1]:
                 if self.log[ii]:
                     pars[ii] = numpy.power(10, pars[ii])
             (par0.val, par1.val) = pars


### PR DESCRIPTION
# Release Notes
    
There are two main changes for plots of PHA data sets (and related quantities, such as the source, model, and ARF):
    
- plots with matplotlib now use the LaTeX support - so that 'cm^2' is
  now displayed as a superscript; previously they were displayed
  directly. This does not change the display with the ChIPS backend.
    
- plots created with `plot_source` used a different format to other
  plots when analysis=wavelength, in that LaTeX symbols were used for
  Angstrom and lambda (in other plots the string 'Angstrom' is used
  instead). The source plots now match the other plots.

There have also been a number of PEP 8 changes that do not change the behaviour of the code.

# Notes

The choice to replace `\AA` by the word `Angstrom` was the easier change. It would also be possible to go the other way - i.e. replace `Angstrom` by `\AA`, but it would have been a larger change, and so requires some discussion. This can be done after this PR is merged.

The plot labels are created in multiple places - e.g. data sets (`sherpa.astro.data`) and within the plot code - which makes the logic of where labels are created a bit hard to track down.

# Rebase

The branch was rebased on Sep 23 2015 10:18AM EST to pull in the Travis-CI fixes from PR #108.