### PR TITLE
Use $HOME rather than /home when running tests on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
         python -c "import sherpa; sherpa.test()";
     fi
   - if [ ${TEST} == package ];
-        then cd /home;
+        then cd $HOME;
         sherpa_test;
     fi
 


### PR DESCRIPTION
# Release Notes

Address issues with the Travis-CI test build code. It has no user-visible changes.

# Notes

With pytest-2.8.0 (possibly one of its related dependencies), the
Travis-CI tests fail because they can not write to /home/.cache,
so change to $HOME since this should be writeable.