### PR TITLE
Support matplotlib 1.5RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ addons:
       - flex
       - bison
 
+# We use matrix include so that xspec builds (which are more complicated and long) are started first
 matrix:
   fast_finish: true
   include:
-    - env: XSPEC="true" FITS="astropy" INSTALL_TYPE=develop TEST=submodule
+    - env: XSPEC="true" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "2.7"
       sudo: required
       dist: trusty
@@ -29,27 +30,35 @@ matrix:
 #          packages:
 #            - *default_apt
 #            - [libwcs4 wcslib-dev libx11-dev tcl]
-    - env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule
+    - env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "2.7"
-    - env: INSTALL_TYPE=install TEST=package
+    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5
       python: "2.7"
-    - env: INSTALL_TYPE=install TEST=smoke NOSETUPTOOLS="true"
+    - env: INSTALL_TYPE=install TEST=smoke NOSETUPTOOLS="true" MATPLOTLIBVER=1.5
+      python: "2.7"
+    - env: FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
+      python: "2.7"
+    - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.4 NUMPYVER=1.9
+      python: "2.7"
+    - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
 
-env:
-  - FITS="astropy" INSTALL_TYPE=develop TEST=submodule
-  - FITS="astropy" INSTALL_TYPE=install TEST=package
-  - FITS="astropy" INSTALL_TYPE=install TEST=smoke
+env:  FITS="astropy" INSTALL_TYPE=install TEST=smoke MATPLOTLIBVER=1.5
 
 before_install:
+  - export SHERPA_CHANNEL=https://conda.anaconda.org/sherpa
   - export MINICONDA=/home/travis/miniconda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p $MINICONDA
   - export PATH=$MINICONDA/bin:$PATH
   - conda update --yes conda
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy=1.9 matplotlib
-  - conda config --add channels https://conda.anaconda.org/sherpa
+  - if [ -n "${FITS}" ]; then conda install --yes -c ${SHERPA_CHANNEL} ${FITS}; fi
+  - if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
+  - if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
+  - echo ${MATPLOTLIB} ${NUMPY} ${FITS}
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY}
+  - conda config --add channels ${SHERPA_CHANNEL}
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;
@@ -73,7 +82,6 @@ install:
   - python setup.py $INSTALL_TYPE
 
 script:
-  - if [ -n "${FITS}" ]; then conda install --yes ${FITS} numpy=1.8; fi
   - if [ ${TEST} == submodule ]; then python setup.py test; fi
   - if [ ${TEST} == smoke ];
         then cd /home;

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,4 +1,4 @@
-# 
+#
 #  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -35,7 +35,7 @@ __all__ = ('clear_window','point','plot','histo','contour','set_subplot','init',
            'get_ratio_contour_defaults','get_confid_plot_defaults',
            'get_confid_contour_defaults', 'set_window_redraw', 'set_jointplot',
            'get_model_histo_defaults', 'get_histo_defaults',
-           'get_component_plot_defaults','get_component_histo_defaults', 
+           'get_component_plot_defaults','get_component_histo_defaults',
            'vline', 'hline', 'get_scatter_plot_defaults', 'get_cdf_plot_defaults',
            'get_latex_for_string')
 
@@ -59,7 +59,11 @@ def _choose(test, iftrue, iffalse=None):
     return iffalse
 
 
-_errorbar_defaults = get_keyword_defaults(pylab.Axes.errorbar)
+# In matplotlib 1.5RC1 the kwargs to pylab.Axes.errorbar are not
+# explictit, but they appear to be set for pybal.errorbar, so
+# switch to that.
+# _errorbar_defaults = get_keyword_defaults(pylab.Axes.errorbar)
+_errorbar_defaults = get_keyword_defaults(pylab.errorbar)
 
 
 def clear_window():
@@ -122,7 +126,7 @@ _linestyle_map = {
     'noline'  : ' ',
     'solid'   : '-',
     'dot'     : ':',
-    'dash'    : '--', 
+    'dash'    : '--',
     'dotdash' : '-.',
     }
 

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -1,0 +1,31 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from sherpa.utils import SherpaTestCase, has_package_from_list
+from unittest import skipIf
+
+
+@skipIf(not has_package_from_list("pylab"), "pylab required")
+class pylab_test(SherpaTestCase):
+
+    def test_axes_default(self):
+        from sherpa.plot.pylab_backend import _errorbar_defaults
+        # assert all needed defaults have been found
+        assert all(e in _errorbar_defaults for e in ('ecolor', 'capsize', 'barsabove'))
+


### PR DESCRIPTION
Resolve #103.
Resolve #113.

# Release Notes

Support matplotlib 1.5 RC1.

# Details

Switch extraction of keyword defaults from `pylab.Axes.errorbar` to `pylab.errorbar` to support running with matplotlib 1.5RC1. See #103 for details. This should be a backwards-compatible change.

This change allows the matplotlib backend to be loaded and a simple plot created (by `plot_data`). I have not done any investigation to see if further changes may be needed.

Also, in order to make the tests with matplotlib 1.5 pass, we had to fix outstanding issue #113.