### PR TITLE
force numpy 1.9/1.8 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy matplotlib
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy=1.9 matplotlib
   - conda config --add channels https://conda.binstar.org/sherpa
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
@@ -73,7 +73,7 @@ install:
   - python setup.py $INSTALL_TYPE
 
 script:
-  - if [ -n "${FITS}" ]; then conda install --yes ${FITS}; fi
+  - if [ -n "${FITS}" ]; then conda install --yes ${FITS} numpy=1.8; fi
   - if [ ${TEST} == submodule ]; then python setup.py test; fi
   - if [ ${TEST} == smoke ];
         then cd /home;


### PR DESCRIPTION
# Release Note
This PR reverts the changes made by PR #89, as there have been some (yet unknown) incompatibilities with PR #101. In order to support the CIAO 4.8 release, we are giving priority to #101 and reverting #89.

We will need to look into the reason for the test errors triggered by #89.

Also, the current pyfits conda binaries list numpy 1.8* as dependency, making it incompatible with 1.9, so when testing pyfits I force numpy to 1.8 instead.