### PR TITLE
No longer replace docstrings of Sherpa functions.

### DIFF
--- a/sherpa/00-sherpa_startup.py
+++ b/sherpa/00-sherpa_startup.py
@@ -1,6 +1,6 @@
 # -*- Mode: Shell-Script -*-  Not really, but shows comments correctly
 # 
-#  Copyright (C) 2012  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -107,10 +107,3 @@ set_preference_autoload(True)
 
 sys.path = old_sys_path
 
-# Replace native help text, for Sherpa HLUI functions, with pointer to
-# ahelp text for these functions.
-for func in get_functions(): 
-    try:
-        eval(func).__doc__="Type ahelp("+func+") for more details."
-    except:
-        pass


### PR DESCRIPTION
The following applies to the CIAO-supplied ipython customization
routines used by the "sherpa application" in CIAO (which is a thin
wrapper around ipython). It does not change the behavior of the
stand-alone build of Sherpa.

Prior to this change, routines from sherpa.astro.ui had their
docstrings replaced with the text "Type ahelp(func) for more deails.",
where func was replaced by the function name. As the docstrings have
now been updated to contain the ahelp text, this replacement is
not needed. Note that the ahelp() function is not removed, so
users who enter `ahelp(func)` will get the ahelp message displayed.