### PR TITLE
Startup scripts update

### DIFF
--- a/sherpa/00-sherpa_startup.py
+++ b/sherpa/00-sherpa_startup.py
@@ -51,7 +51,7 @@ import ipython_cxc
 import ahelp_interface
 
 def _initialize_sherpa_app_():
-    # These are the minimum CIAO version supported by this version of Sherpa.
+    # These are the versions Sherpa was tested and packaged with.
     min_chips_version = "4.8.0"
     min_crates_version = "4.8.0"
 

--- a/sherpa/00-sherpa_startup.py
+++ b/sherpa/00-sherpa_startup.py
@@ -1,5 +1,5 @@
 # -*- Mode: Shell-Script -*-  Not really, but shows comments correctly
-# 
+#
 #  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
@@ -51,11 +51,12 @@ import ipython_cxc
 import ahelp_interface
 
 def _initialize_sherpa_app_():
-    sherpa_version = 0
-    chips_version = 0
-    chips_version_str = "0"
-    crates_version = 0
-    crates_version_str = '0.0.0'
+    # These are the minimum CIAO version supported by this version of Sherpa.
+    min_chips_version = "4.8.0"
+    min_crates_version = "4.8.0"
+
+    chips_version = "0.0.0"
+    crates_version = '0.0.0'
     sherpa_path = ''
 
     try:
@@ -69,39 +70,30 @@ def _initialize_sherpa_app_():
         pass
 
     try:
-        from pycrates import __versionstr__ as crates_version_str
-    except:
-        pass
-
-    try:
-        from pychips import __versionstr__ as chips_version_str
-    except:
-        pass
-
-    try:
-        from sherpa import __version__ as sherpa_version
-    except:
-        pass
-
-    try:
         from sherpa import __file__ as sherpa_path
         sherpa_path = os.path.dirname(sherpa_path)
     except:
         pass
     site_path = sherpa_path.replace('/sherpa','',-1)
 
-    if sherpa_version > 0 and crates_version < 40501:
-        print "Warning: Importing CRATES version {0}; CRATES version 4.5.1 is now available, consider upgrading".format (crates_version_str)
+    versions = zip(min_crates_version.split('.'), crates_version.split('.'))
 
-    if sherpa_version > 0 and chips_version < 40501:
-        print "Warning: Importing ChIPS version {0}; ChIPS version 4.5.1 is now available, consider upgrading".format (chips_version_str)
+    for min_crates_ver, creates_ver in versions[:-1]:
+        if int(min_crates_ver) > int(crates_ver):
+            print "Warning: Importing CRATES version {}. This version is different than the one Sherpa {} was built and tested with and you may get unexpected results.".format(crates_version, sherpa_version)
+            break
 
+    versions = zip(min_chips_version.split('.'), chips_version.split('.'))
 
+    for min_chips_ver, chips_ver in versions[:-1]:
+        if int(min_chips_ver) > int(chips_ver):
+            print "Warning: Importing CHiPS version {}. This version is different than the one Sherpa {} was built and tested with and you may get unexpected results.".format(chips_version, sherpa_version)
+            break
 
 _initialize_sherpa_app_()
 
 ahelp_interface.__ciao_ahelp_context__ = 'py.sherpa'
-ipython_cxc.init ("sherpa")
+ipython_cxc.init("sherpa")
 
 set_preference_autoload(True)
 

--- a/sherpa/sherpa
+++ b/sherpa/sherpa
@@ -35,15 +35,17 @@ usage()
 
 banner()
 {
-   default_versionstr="Sherpa 4.7.1"
+   default_versionstr="Sherpa 4.8.0"
    echo "-----------------------------------------------------"
    echo "Welcome to Sherpa: CXC's Modeling and Fitting Package"
    echo "-----------------------------------------------------"
    if [ "x${ASCDS_INSTALL}" != "x" ]; then
-       if [ -r ${ASCDS_INSTALL}/VERSION ]; then
-	   numfields=`head -n 1 $ASCDS_INSTALL/VERSION | awk '{print NF}'`
+       if [ -r ${ASCDS_INSTALL}/VERSION_sherpa ]; then
+	   numfields=`head -n 1 $ASCDS_INSTALL/VERSION_sherpa | awk '{print NF}'`
 	   if [ $numfields = "6" ]; then
-	       echo "CIAO 4.7 Sherpa version 1 `awk '{print $3" "$4" "$5" "$6}' ${ASCDS_INSTALL}/VERSION`"
+           ciao_version=`awk '{print $2}' ${ASCDS_INSTALL}/VERSION_sherpa | cut -d '.' -f 1-2`
+           sherpa_version=`awk '{print $2}' ${ASCDS_INSTALL}/VERSION_sherpa | cut -d '.' -f 3` 
+	       echo "CIAO ${ciao_version} Sherpa version ${sherpa_version} `awk '{print $3" "$4" "$5" "$6}' ${ASCDS_INSTALL}/VERSION_sherpa`"
 	   else
 	       echo $default_versionstr
 	   fi

--- a/sherpa/sherpa
+++ b/sherpa/sherpa
@@ -159,11 +159,7 @@ if test -s $HOME/.sherpa.rc ; then
 fi
 
 # setup the users home directory with all the Sherpa, ChIPS config files
-if test "$batch" = "yes"; then
-    sherpa_py "batch"
-else
-    sherpa_py
-fi
+ciao_app_setup.sh sherpa .sherpa.rc .chips.rc $batch
 
 cmd=""
 


### PR DESCRIPTION
# Description
Update startup scripts.

In particular, we need to compensate for the disappearance of `__versionstr__` and the fact that `__version__` is now a string.

From now on, since Sherpa will have its own versioning scheme independent of CIAO, we will need to state what versions of the CIAO packages are supported by a Sherpa version.
In this PR, we state that ChIPS >=4.7.0 and Crates >=4.7.0 are required. These values are conservative, and it is possible that Sherpa 4.8.0 would work just fine with earlier versions.

The `sherpa` wrapper script now uses the `ciao_app_setup.sh` script that will be available in CIAO for setting up user startup scripts, or update them in case of a version mismatch. This obsoletes the `sherpa_py` script, which will be removed.

More clean-up will be needed as there are obsolete files and statements to be removed. Also, I would like to move the CIAO-specific files to a specific folder rather than having them mixed within the main package directory.