### PR TITLE
Remove the check for non-finite values from XSPEC models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy=1.9 matplotlib
-  - conda config --add channels https://conda.binstar.org/sherpa
+  - conda config --add channels https://conda.anaconda.org/sherpa
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     - env: XSPEC="true" FITS="astropy" INSTALL_TYPE=develop TEST=submodule
       python: "2.7"
       sudo: required
+      dist: trusty
 #      addons:
 #        apt:
 #          packages:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ install Sherpa.
 First you need to add the Sherpa channel to your configuration,
 and then install Sherpa:
 
-    $ conda config --add channels https://conda.binstar.org/sherpa
+    $ conda config --add channels https://conda.anaconda.org/sherpa
     $ conda install sherpa
 
 To test that your installation works, just type:
@@ -153,7 +153,7 @@ for BASH or `$HOME/.cshrc` for TCSH.
 
 Add the Sherpa conda repositories to your configuration:
 
-    $ conda config --add channels https://conda.binstar.org/sherpa
+    $ conda config --add channels https://conda.anaconda.org/sherpa
 
 Create a new environment and install Sherpa:
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -49,9 +49,7 @@ used either `print` or `sys.stderr.write`.
 it needs is missing - return 0's for all bins, rather than random values. This
 should make it more obvious that something has gone wrong (for instance if the
 XSPEC chatter level is low enough not to show any error messages, as is the
-case for the default setting used by Sherpa, namely 0). If the model returns
-an invalid value - defined as an infinite value or NaN - then the model class
-will raise an error (using the Python `FloatingPointError` exception)
+case for the default setting used by Sherpa, namely 0).
 
 #82: The XSpec "spectrum number" value is now set to 1 rather than 0, as this
 value is 1-based in Xspec.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import numpy
+# import numpy
 
 import string
 from sherpa.models import Parameter, ArithmeticModel, modelCacher1d
@@ -160,6 +160,7 @@ __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'get_xsversion', 'set_xsxset', 'get_xsxset', 'set_xsstate',
            'get_xsstate')
 
+
 class XSModel(ArithmeticModel):
 
     @modelCacher1d
@@ -171,12 +172,18 @@ class XSModel(ArithmeticModel):
         #  - it allows for the user to find out what bins are bad,
         #    by directly calling the _calc function of a model
         out = self._calc(*args, **kwargs)
-        if not numpy.isfinite(out).all():
-            # TODO: Should this be using a "Sherpa error class"?
-            # I am not convinced that FloatingPointError is the best
-            # type.
-            msg = "model {} has produced NaN or +/-Inf value".format(self.name)
-            raise FloatingPointError(msg)
+
+        # This check is being skipped in the 4.8.0 release as it
+        # has had un-intended consequences. It should be re-evaluated
+        # once we have had more experience with the issue.
+        #
+        # if not numpy.isfinite(out).all():
+        #     # TODO: Should this be using a "Sherpa error class"?
+        #     # I am not convinced that FloatingPointError is the best
+        #     # type.
+        #     msg = "model {} has created NaN or +/-Inf value".format(
+        #           self.name)
+        #     raise FloatingPointError(msg)
 
         return out
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -49,6 +49,7 @@ def remove_item(xs, x):
     except ValueError:
         pass
 
+
 # There is an argument to be made that these tests only need
 # to exercise a small number of models (e.g. one each of the
 # different templates used in xspec_extension.hh - so single
@@ -154,6 +155,17 @@ class test_xspec(SherpaTestCase):
         from sherpa.astro import xspec
         xspec.set_xsstate(self._defaults)
 
+    # In Sherpa 4.8.0 development, the XSPEC model class included
+    # an explicit check that all the bins were finite. This has
+    # been removed as testing has shown there are complications when
+    # using this with some real-world responses. So add in an
+    # explicit - hopefully temporary - test here.
+    #
+    def assertFinite(self, vals, model, label):
+        emsg = "model {} is finite [{}]".format(model, label)
+        self.assertTrue(numpy.isfinite(vals).all(),
+                        msg=emsg)
+
     def test_create_model_instances(self):
         import sherpa.astro.xspec as xs
         count = 0
@@ -196,7 +208,8 @@ class test_xspec(SherpaTestCase):
         s1 = y1.sum()
         s2 = y2.sum()
         self.assertGreater(s1, 0.0, msg='powerlaw is positive')
-        self.assertAlmostEqual(s2, mfactor * s1, msg='powerlaw norm scaling')
+        self.assertAlmostEqual(s2, mfactor * s1,
+                               msg='powerlaw norm scaling')
 
     def test_evaluate_model(self):
         import sherpa.astro.xspec as xs
@@ -228,17 +241,23 @@ class test_xspec(SherpaTestCase):
         egrid, elo, ehi, wgrid, wlo, whi = make_grid()
         for model in models:
             cls = getattr(xs, model)
-            mdl = cls(model)  # use an identifier in case there is an error
+            # use an identifier in case there is an error
+            mdl = cls(model)
 
             # The model checks that the values are all finite,
             # so there is no need to check that the output of
             # mdl does not contain non-finite values.
+            # NOTE: this is no-longer the case, so include an
+            #       explicit check for the single-argument forms
             #
             evals1 = mdl(egrid)
             evals2 = mdl(elo, ehi)
 
             wvals1 = mdl(wgrid)
             wvals2 = mdl(wlo, whi)
+
+            self.assertFinite(evals1, model, "energy")
+            self.assertFinite(wvals1, model, "wavelength")
 
             emsg = "{} model evaluation failed: ".format(model)
 
@@ -275,12 +294,17 @@ class test_xspec(SherpaTestCase):
         elo, ehi, wlo, whi = make_grid_noncontig2()
         for model in models:
             cls = getattr(xs, model)
-            mdl = cls(model)  # use an identifier in case there is an error
+            # use an identifier in case there is an error
+            mdl = cls(model)
 
             evals2 = mdl(elo, ehi)
             wvals2 = mdl(wlo, whi)
-            emsg = "{} non-contiguous model evaluation failed: ".format(model)
 
+            self.assertFinite(evals2, model, "energy")
+            self.assertFinite(wvals2, model, "wavelength")
+
+            emsg = "{} non-contiguous model evaluation " + \
+                "failed: ".format(model)
             assert_allclose(evals2, wvals2,
                             err_msg=emsg + "energy to wavelength")
 
@@ -328,6 +352,9 @@ class test_xspec(SherpaTestCase):
         wvals1 = tmod(wgrid)
         wvals2 = tmod(wlo, whi)
 
+        self.assertFinite(evals1, tmod, "energy")
+        self.assertFinite(wvals1, tmod, "wavelength")
+
         emsg = "table model evaluation failed: "
         assert_array_equal(evals1[:-1], evals2,
                            err_msg=emsg + "energy comparison")
@@ -348,6 +375,9 @@ class test_xspec(SherpaTestCase):
 
         evals2 = tmod(elo, ehi)
         wvals2 = tmod(wlo, whi)
+
+        self.assertFinite(evals2, tmod, "energy")
+        self.assertFinite(wvals2, tmod, "wavelength")
 
         emsg = "table model non-contiguous evaluation failed: "
         rtol = 1e-3
@@ -401,6 +431,8 @@ class test_xspec(SherpaTestCase):
         pars = [elo, ehi, lflux]
         y2 = xs._xspec.C_cflux(pars, y1, egrid)
 
+        self.assertFinite(y2, "cflux", "energy")
+
         elo = egrid[:-1]
         ehi = egrid[1:]
         wgrid = _hc / egrid
@@ -413,6 +445,7 @@ class test_xspec(SherpaTestCase):
 
         y1 = mdl1(wgrid)
         y2 = xs._xspec.C_cflux(pars, y1, wgrid)
+        self.assertFinite(y2, "cflux", "wavelength")
         numpy.testing.assert_allclose(expected, y2,
                                       err_msg='wavelength, single grid')
 


### PR DESCRIPTION
The XSPEC interface changes in Sherpa 4.8.0 development included a
change where the sherpa.astro.xspec.XSModel class would check that the
model had created only finite values, raising an error if this
constraint did not hold. This was suggested as a good thing to do
during a meeting between the Sherpa developers and Keith Arnaud.

This change caused problems with some of the external regression tests
in CIAO, which use a problematic (i.e.  does not confirm to OGIP
standards) RMF file with an energy bin that includes 0 keV. This
causes the XSpowerlaw model to create a non-finite value in this bin
when the photon index is positive.

This commit reverts this change (by commenting out the code that added
the check), and adds in explicit checks in the test suite.  Hopefully
the check for non-finite values can be added back in once the handling
of this case has been reviewed.