### PR TITLE
Update travis xspec build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy=1.9 matplotlib
-  - conda config --add channels https://conda.binstar.org/sherpa
+  - conda config --add channels https://conda.anaconda.org/sherpa
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ addons:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: XSPEC="true" FITS="astropy" INSTALL_TYPE=develop TEST=submodule
   include:
     - env: XSPEC="true" FITS="astropy" INSTALL_TYPE=develop TEST=submodule
       python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     - env: XSPEC="true" FITS="astropy" INSTALL_TYPE=develop TEST=submodule
       python: "2.7"
       sudo: required
+      dist: trusty
 #      addons:
 #        apt:
 #          packages:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ install Sherpa.
 First you need to add the Sherpa channel to your configuration,
 and then install Sherpa:
 
-    $ conda config --add channels https://conda.binstar.org/sherpa
+    $ conda config --add channels https://conda.anaconda.org/sherpa
     $ conda install sherpa
 
 To test that your installation works, just type:
@@ -153,7 +153,7 @@ for BASH or `$HOME/.cshrc` for TCSH.
 
 Add the Sherpa conda repositories to your configuration:
 
-    $ conda config --add channels https://conda.binstar.org/sherpa
+    $ conda config --add channels https://conda.anaconda.org/sherpa
 
 Create a new environment and install Sherpa:
 


### PR DESCRIPTION
# Description
This PR introduces the new Google infrastructure for Xspec builds on Travis CI. After some positive testing the Xspec build can also be removed from the "allowed to fail" set.

This PR includes some basic changes cherry picked from #122.