### PR TITLE
fix miniconda path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,11 @@ env:
   - FITS="astropy" INSTALL_TYPE=install TEST=smoke
 
 before_install:
+  - export MINICONDA=/home/travis/miniconda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - ./miniconda.sh -b -p $MINICONDA
+  - export PATH=$MINICONDA/bin:$PATH
   - conda update --yes conda
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy=1.9 matplotlib
   - conda config --add channels https://conda.anaconda.org/sherpa
@@ -57,8 +58,8 @@ before_install:
   - if [ -n "${XSPEC}" ];
      then sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
      conda install --yes -c https://conda.anaconda.org/cxc/channel/dev xspec-modelsonly;
-     export HEADAS=/home/travis/miniconda/Xspec/spectral;
-     export LD_LIBRARY_PATH=/home/travis/miniconda/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
+     export HEADAS=$MINICONDA/Xspec/spectral;
+     export LD_LIBRARY_PATH=$MINICONDA/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
      sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
     fi


### PR DESCRIPTION
It looks like the default value for the miniconda installation prefix has changed with the latest versions, and both the old and new Travis builds would fail for Sherpa.

This PR explicitly sets the prefix for the miniconda installation. It also uses an environment variable instead of having the same string repeated over and over again in the configuration file.

The Travis builds are currently running, but I already made sure that they get past the point where they were failing.