### PR TITLE
Tweak test stat tolerance

### DIFF
--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -212,12 +212,12 @@ class test_stats(SherpaTestCase):
 
         for key in ["istatval", "statval"]:
             assert numpy.allclose(float(arg1[key]), float(getattr(arg2, key)),
-                                  1.e-7, 1.e-7)
+                                  1.e-6, 1.e-6)
 
         for key in ["parvals"]:
             try:
                 assert numpy.allclose(arg1[key], getattr(arg2, key),
-                                      1.e-4, 1.e-4)
+                                      1.e-3, 1.e-3)
             except AssertionError:
                 print 'parvals bench: ', arg1[key]
                 print 'parvals fit:   ', getattr(arg2, key)


### PR DESCRIPTION
This PR tweaks the tolerance requirements for the new statistics tests. We get somewhat different results on Linux and OSX, and the tests fail on OSX.

We did extensive research on the reasons for the discrepancy, and it looks like it is being triggered by a number of issues that conspire to get unstable results.

We may want to review the tests in the future (e.g. do not choose an xspec fortran model for the tests, add lower level unit tests, and so on). In the meantime, this is the easiest change we can make, and this PR allows the change to be included in CIAOD builds and tested.

Note that this PR depends on #117, but it will not be merged into the release branch. Rather, it will be rebased and merged into master when #117 is merged, after the CIAO release.

The commits relevant to this PR are b037be5 (cherry-picked from #127 so that travis builds can run) and 14dd51f.