### PR TITLE
Feature/issue sherpa-test-data#7 refactor test data

### DIFF
--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -33,7 +33,7 @@ class test_89_issues(SherpaTestCase):
     @requires_fits
     @requires_xspec
     def test_mod_fits(self):
-        tablemodelfile = self.make_path("xspec", "tablemodel", "RCS.mod")
+        tablemodelfile = self.make_path("xspec-tablemodel-RCS.mod")
         ui.load_table_model("tmod", tablemodelfile)
         tmod = ui.get_model_component("tmod")
         self.assertEqual("xstablemodel.tmod", tmod.name)
@@ -52,7 +52,7 @@ class test_89_issues(SherpaTestCase):
     @requires_fits
     @requires_data
     def test_warnings_are_gone_pha(self):
-        pha = self.make_path("threads", "pha_intro", "3c273.pi")
+        pha = self.make_path("3c273.pi")
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             with NamedTemporaryFile() as f:

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -69,14 +69,7 @@ class test_threads(SherpaTestCase):
     def run_thread(self, name, scriptname='fit.py'):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
-        self.locals = {}
-        cwd = os.getcwd()
-        os.chdir(self.datadir)
-        scriptname = name + "-" + scriptname
-        try:
-            execfile(scriptname, {}, self.locals)
-        finally:
-            os.chdir(cwd)
+        super(test_threads, self).run_thread(name, scriptname=scriptname)
 
 
     @requires_fits

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -48,7 +48,6 @@ class test_threads(SherpaTestCase):
                 self.is_crates_io = True
         except:
             self.is_crates_io = False
-        self.startdir = os.getcwd()
         self.old_state = ui._session.__dict__.copy()
         self.old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.CRITICAL)
@@ -58,7 +57,6 @@ class test_threads(SherpaTestCase):
             self.old_xspec = xspec.get_xsstate()
 
     def tearDown(self):
-        os.chdir(self.startdir)
         ui._session.__dict__.update(self.old_state)
         logger.setLevel(self.old_level)
 
@@ -72,8 +70,13 @@ class test_threads(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
-        os.chdir(self.make_path('ciao4.3', name))
-        execfile(scriptname, {}, self.locals)
+        cwd = os.getcwd()
+        os.chdir(self.datadir)
+        scriptname = name + "-" + scriptname
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
 
 
     @requires_fits

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("sherpa")
 class test_ui(SherpaTestCase):
 
     def setUp(self):
-        self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
+        self.ascii = self.make_path('sim.poisson.1.dat')
         self.fits = self.make_path('1838_rprofile_rmid.fits')
         self.singledat = self.make_path('single.dat')
         self.singletbl = self.make_path('single.fits')
@@ -110,9 +110,9 @@ class test_more_ui(SherpaTestCase):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
         self.img = self.make_path('img.fits')
-        self.pha = self.make_path('threads/simultaneous/pi2286.fits')
-        self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
-        self.pha3c273 = self.make_path('ciao4.3/pha_intro/3c273.pi')
+        self.pha = self.make_path('pi2286.fits')
+        self.rmf = self.make_path('rmf2286.fits')
+        self.pha3c273 = self.make_path('3c273.pi')
 
     def tearDown(self):
         logger.setLevel(self._old_logger_level)
@@ -236,7 +236,7 @@ class test_psf_ui(SherpaTestCase):
 @requires_fits
 class test_stats_ui(SherpaTestCase):
     def setUp(self):
-        self.data = self.make_path('threads/chi2/3c273.pi')
+        self.data = self.make_path('3c273.pi')
         ui.clean()
 
     # bugs #11400, #13297, #12365

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -475,7 +475,7 @@ class test_save_pha(SherpaTestCase):
         logger.setLevel(logging.ERROR)
 
         self._id = 1
-        fname = self.make_path('ciao4.3/pha_intro/3c273.pi')
+        fname = self.make_path('3c273.pi')
         ui.load_pha(self._id, fname)
         self._pha = ui.get_data(self._id)
 

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -36,14 +36,7 @@ class test_more_ui(SherpaTestCase):
     def run_thread(self, name, scriptname='fit.py'):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
-        self.locals = {}
-        cwd = os.getcwd()
-        os.chdir(self.datadir)
-        try:
-            scriptname = name + "-" + scriptname
-            execfile(scriptname, {}, self.locals)
-        finally:
-            os.chdir(cwd)
+        super(test_more_ui, self).run_thread(name, scriptname=scriptname)
 
     def setUp(self):
         self.img = self.make_path('img.fits')

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -38,17 +38,18 @@ class test_more_ui(SherpaTestCase):
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
         cwd = os.getcwd()
-        os.chdir(self.make_path('ciao4.3', name))
+        os.chdir(self.datadir)
         try:
+            scriptname = name + "-" + scriptname
             execfile(scriptname, {}, self.locals)
         finally:
             os.chdir(cwd)
 
     def setUp(self):
         self.img = self.make_path('img.fits')
-        self.pha = self.make_path('threads/simultaneous/pi2286.fits')
-        self.rmf = self.make_path('threads/simultaneous/rmf2286.fits')
-        self.nan = self.make_path('ciao4.3/filternan/with_nan.fits')
+        self.pha = self.make_path('pi2286.fits')
+        self.rmf = self.make_path('rmf2286.fits')
+        self.nan = self.make_path('with_nan.fits')
         self.loggingLevel = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -908,7 +908,7 @@ class test_ui(SherpaTestCase):
         """
 
         ui.clean()
-        fname = self.make_path('threads', 'pha_intro', '3c273.pi')
+        fname = self.make_path('3c273.pi')
         ui.load_pha(1, fname)
         ui.subtract()
         ui.set_stat('chi2datavar')
@@ -926,7 +926,7 @@ class test_ui(SherpaTestCase):
         """
 
         ui.clean()
-        fname = self.make_path('threads', 'pha_intro', '3c273.pi')
+        fname = self.make_path('3c273.pi')
         ui.load_pha('grp', fname)
         channels = ui.get_data('grp').channel
 
@@ -953,7 +953,7 @@ class test_ui(SherpaTestCase):
         """
 
         ui.clean()
-        fname = self.make_path('threads', 'pha_intro', '3c273.pi')
+        fname = self.make_path('3c273.pi')
         ui.load_pha('bgrp', fname)
 
         # Note: do not group the source dataset

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -145,7 +145,7 @@ from sherpa.astro.ui import *
 
 ######### Load Data Sets
 
-load_pha(1, "@@/threads/pha_intro/3c273.pi")
+load_pha(1, "@@/3c273.pi")
 
 ######### Set Image Coordinates
 
@@ -155,20 +155,20 @@ if get_data(1).grouping is not None and not get_data(1).grouped:
 
 ######### Data Spectral Responses
 
-load_arf(1, "@@/threads/pha_intro/3c273.arf", resp_id=1)
-load_rmf(1, "@@/threads/pha_intro/3c273.rmf", resp_id=1)
+load_arf(1, "@@/3c273.arf", resp_id=1)
+load_rmf(1, "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg(1, "@@/threads/pha_intro/3c273_bg.pi", bkg_id=1)
+load_bkg(1, "@@/3c273_bg.pi", bkg_id=1)
 if get_bkg(1, 1).grouping is not None and not get_bkg(1, 1).grouped:
     ######### Group Background
     group(1, 1)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/threads/pha_intro/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf(1, "@@/threads/pha_intro/3c273.rmf", resp_id=1, bkg_id=1)
+load_arf(1, "@@/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf(1, "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -298,7 +298,7 @@ from sherpa.astro.ui import *
 
 ######### Load Data Sets
 
-load_pha("grp", "@@/threads/pha_intro/3c273.pi")
+load_pha("grp", "@@/3c273.pi")
 
 ######### Set Image Coordinates
 
@@ -316,12 +316,12 @@ if get_data("grp").grouping is not None and not get_data("grp").grouped:
 
 ######### Data Spectral Responses
 
-load_arf("grp", "@@/threads/pha_intro/3c273.arf", resp_id=1)
-load_rmf("grp", "@@/threads/pha_intro/3c273.rmf", resp_id=1)
+load_arf("grp", "@@/3c273.arf", resp_id=1)
+load_rmf("grp", "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg("grp", "@@/threads/pha_intro/3c273_bg.pi", bkg_id=1)
+load_bkg("grp", "@@/3c273_bg.pi", bkg_id=1)
 
 ######### Background grouping flags
 
@@ -336,8 +336,8 @@ if get_bkg("grp", 1).grouping is not None and not get_bkg("grp", 1).grouped:
 
 ######### Background Spectral Responses
 
-load_arf("grp", "@@/threads/pha_intro/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf("grp", "@@/threads/pha_intro/3c273.rmf", resp_id=1, bkg_id=1)
+load_arf("grp", "@@/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf("grp", "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -428,7 +428,7 @@ from sherpa.astro.ui import *
 
 ######### Load Data Sets
 
-load_pha("bgrp", "@@/threads/pha_intro/3c273.pi")
+load_pha("bgrp", "@@/3c273.pi")
 
 ######### Set Image Coordinates
 
@@ -438,12 +438,12 @@ if get_data("bgrp").grouping is not None and not get_data("bgrp").grouped:
 
 ######### Data Spectral Responses
 
-load_arf("bgrp", "@@/threads/pha_intro/3c273.arf", resp_id=1)
-load_rmf("bgrp", "@@/threads/pha_intro/3c273.rmf", resp_id=1)
+load_arf("bgrp", "@@/3c273.arf", resp_id=1)
+load_rmf("bgrp", "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg("bgrp", "@@/threads/pha_intro/3c273_bg.pi", bkg_id=1)
+load_bkg("bgrp", "@@/3c273_bg.pi", bkg_id=1)
 
 ######### Background grouping flags
 
@@ -458,8 +458,8 @@ if get_bkg("bgrp", 1).grouping is not None and not get_bkg("bgrp", 1).grouped:
 
 ######### Background Spectral Responses
 
-load_arf("bgrp", "@@/threads/pha_intro/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf("bgrp", "@@/threads/pha_intro/3c273.rmf", resp_id=1, bkg_id=1)
+load_arf("bgrp", "@@/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf("bgrp", "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -290,7 +290,7 @@ class test_xspec(SherpaTestCase):
         # model being used.
         #
         ui.load_table_model('mdl',
-                            self.make_path('xspec/tablemodel/RCS.mod'))
+                            self.make_path('xspec-tablemodel-RCS.mod'))
         mdl = ui.get_model_component('mdl')
 
         # Check when input array is too small (< 2 elements)
@@ -311,7 +311,7 @@ class test_xspec(SherpaTestCase):
         # retrieved July 9 2015. The exact model is irrelevant for this
         # test, so this was chosen as it's relatively small.
         ui.load_table_model('tmod',
-                            self.make_path('xspec/tablemodel/RCS.mod'))
+                            self.make_path('xspec-tablemodel-RCS.mod'))
 
         # when used in the test suite it appears that the tmod
         # global symbol is not created, so need to access the component
@@ -340,7 +340,7 @@ class test_xspec(SherpaTestCase):
     def test_xspec_tablemodel_noncontiguous2(self):
 
         ui.load_table_model('tmod',
-                            self.make_path('xspec/tablemodel/RCS.mod'))
+                            self.make_path('xspec-tablemodel-RCS.mod'))
         tmod = ui.get_model_component('tmod')
 
         elo, ehi, wlo, whi = make_grid_noncontig2()
@@ -447,8 +447,8 @@ class test_xspec(SherpaTestCase):
     @requires_data
     @requires_fits
     def test_set_analysis_wave_fabrizio(self):
-        rmf = self.make_path('ciao4.3/fabrizio/Data/3c273.rmf')
-        arf = self.make_path('ciao4.3/fabrizio/Data/3c273.arf')
+        rmf = self.make_path('3c273.rmf')
+        arf = self.make_path('3c273.arf')
 
         ui.set_model("fabrizio", "xspowerlaw.p1")
         ui.fake_pha("fabrizio", arf, rmf, 10000)

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -39,14 +39,7 @@ class test_new_templates_ui(SherpaTestCase):
     def run_thread(self, name, scriptname='fit.py'):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
-        self.locals = {}
-        cwd = os.getcwd()
-        os.chdir(self.datadir)
-        try:
-            scriptname = name + "-" + scriptname
-            execfile(scriptname, {}, self.locals)
-        finally:
-            os.chdir(cwd)
+        super(test_new_templates_ui, self).run_thread(name, scriptname=scriptname)
 
     def setUp(self):
         self.loggingLevel = logger.getEffectiveLevel()

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -41,8 +41,9 @@ class test_new_templates_ui(SherpaTestCase):
         ui.set_model_autoassign_func(self.assign_model)
         self.locals = {}
         cwd = os.getcwd()
-        os.chdir(self.make_path('ciao4.3', name))
+        os.chdir(self.datadir)
         try:
+            scriptname = name + "-" + scriptname
             execfile(scriptname, {}, self.locals)
         finally:
             os.chdir(cwd)
@@ -59,6 +60,9 @@ class test_new_templates_ui(SherpaTestCase):
     # we need to make sure models are assigned an is_discrete field.
     # For model that do not have the is_discrete field, fallback to False.
     def test_restore_is_discrete(self):
+        # TODO: test.py test is a dummy test. We need to implement a real
+        # test. Take a look at the old testdata/ciao4.3/template_restore
+        # directory for help.
         self.run_thread('template_restore', 'test.py')
 
     # TestCase 1 load_template_model enables interpolation by default

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -192,11 +192,11 @@ class test_stats(SherpaTestCase):
         except:
             return
 
-        pha_fname = self.make_path("stats/9774.pi")
+        pha_fname = self.make_path("9774.pi")
         self.data = read_pha(pha_fname)
         self.data.notice(0.5, 7.0)
 
-        bkg_fname = self.make_path("stats/9774_bg.pi")
+        bkg_fname = self.make_path("9774_bg.pi")
         self.bkg = read_pha(bkg_fname)
 
         abs1 = XSphabs('abs1')

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -31,9 +31,9 @@ class test_sherpa(SherpaTestCase):
         self.assert_(os.path.isdir(incdir))
 
     def setUp(self):
-        self.agn2 = self.make_path('ciao4.3/faulty_load_data/agn2')
-        self.agn2_fixed = self.make_path('ciao4.3/faulty_load_data/agn2_fixed')
-        self.template_idx = self.make_path('ciao4.3/faulty_load_data/table.txt')
+        self.agn2 = self.make_path('agn2')
+        self.agn2_fixed = self.make_path('agn2_fixed')
+        self.template_idx = self.make_path('table.txt')
 
     def test_not_reading_header_without_comment(self):
         self.assertRaises(ValueError, ui.load_data, self.agn2)

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -40,7 +40,7 @@ class UserModel(ArithmeticModel):
 class test_ui(SherpaTestCase):
 
     def setUp(self):
-        self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
+        self.ascii = self.make_path('sim.poisson.1.dat')
         self.single = self.make_path('single.dat')
         self.double = self.make_path('double.dat')
         self.filter = self.make_path('filter_single_integer.dat')

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -285,6 +285,43 @@ class SherpaTestCase(numpytest.NumpyTestCase):
 
         self.assertTrue(numpy.all(sao_fcmp(first, second, tol)), msg)
 
+    # for running regression tests from sherpa-test-data
+    def run_thread(self, name, scriptname='fit.py'):
+        """Run a regression test from the sherpa-test-data submodule.
+
+        Parameters
+        ----------
+        name : string
+           The name of the science thread to run (e.g., pha_read,
+           radpro). The name should match the corresponding thread
+           name in the sherpa-test-data submodule. See examples below.
+        scriptname : string
+           The suffix of the test script file name, usually "fit.py."
+
+        Examples
+        --------
+        Regression test script file names have the structure
+        "name-scriptname.py." By default, scriptname is set to "fit.py."
+        For example, if one wants to run the regression test
+        "pha_read-fit.py," they would write
+
+        >>> run_thread("pha_read")
+
+        If the regression test name is "lev3fft-bar.py," they would do
+
+        >>> run_thread("lev3fft", scriptname="bar.py")
+
+        """
+
+        self.locals = {}
+        cwd = os.getcwd()
+        os.chdir(self.datadir)
+        scriptname = name + "-" + scriptname
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
+
 
 def requires_data(test_function):
     """


### PR DESCRIPTION
Depends on PR sherpa/sherpa-test-data#10

Release Notes
=====

This PR addresses issue sherpa/sherpa-test-data#7, which flattens the regression test data directory.

All hard-written paths to the data files were updated.

The method `run_thread(self, name, scriptname="fit.py")`, which was repeated in files 

sherpa/astro/tests/test_astro.py
sherpa/astro/ui/tests/test_nan.py
sherpa/models/tests/test_template.py

is now refractored under `SherpaTestCase()`. This method runs the Python regression test scripts in [sherpa/sherpa-test-data](http://github.com/sherpa/sherpa-test-data). Documentation on using `run_thread()` is provided in a docstring. `run_thread()` is still called the same way as it was before:

```
# runs sherpa-test-data/sherpatest/pha_read-fit.py
run_thread("pha_read")

# runs sherpa-test-data/sherpatest/lev3fft-bar.py
run_thread("lev3fft", scriptname="bar.py")
```

The main change in the method is updating the script name that is passed into `execfile()` to follow the new naming structure in sherpa/sherpa-test-data#10.

Tests
=====

I cloned the sherpa repository, switched to the branch `feature/issue-#7-refractor-test-data`, added jbudynk/sherpa-test-data as a remote, updated the git submodules, and ran `python setup.py develop; python setup.py test`.

To test the new changes yourself, use the following steps. Note that you need to add jbudynk/sherpa-test-data to your list of remotes *and* update your `.gitmodules` file in order to get the correct sherpa-test-data repository.

Steps (I'm sure these could be simplified, but this works):

```
#  clone the sherpa repository
git clone https://github.com/sherpa/sherpa
cd sherpa
git submodule init
git submodule update

# get PR updates, including corresponding sherpa-test-data
git remote add jbudynk https://github.com/jbudynk/sherpa.git
git remote add jbudynk_std https://github.com/jbudynk/sherpa-test-data.git
git fetch jbudynk
git checkout feature/issue-#7-refractor-test-data
emacs .gitmodules   # set url=https://github.com/jbudynk/sherpa-test-data.git
git submodule sync
git submodule update

# test the changes
python setup.py develop
python setup.py test
```

Notes
=====

The SherpaTestCase children that call `run_thread()` must still call `ui.clean()` and `ui.set_model_autoassign_func()` because the test classes may import different UI flavors (sherpa.ui versus sherpa.astro.ui).

Test scriptname's are updated to new sherpa-test-data file names. All `run_thread()` methods use try/final to run regression test scripts. Goes with sherpa/sherpa-test-data#7 and sherpa/sherpa-test-data#5.