### PR TITLE
Bug/improve save all

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -22,12 +22,20 @@ import logging
 import os
 import os.path
 from sherpa.utils import SherpaTestCase, test_data_missing
-from sherpa.utils import has_package_from_list, has_fits_support
-import sherpa.astro.ui as ui
+# from sherpa.utils import has_package_from_list, has_fits_support
+from sherpa.utils import has_fits_support
+from sherpa.astro import ui
 from sherpa.astro.data import DataPHA
 
 logger = logging.getLogger('sherpa')
 
+try:
+    from sherpa.astro import xspec
+    has_xspec = True
+except ImportError:
+    has_xspec = False
+
+# has_xspec = has_package_from_list("sherpa.astro.xspec")
 
 class test_threads(SherpaTestCase):
 
@@ -45,10 +53,17 @@ class test_threads(SherpaTestCase):
         self.old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.CRITICAL)
 
+        # Store XSPEC settings, if applicable
+        if has_xspec:
+            self.old_xspec = xspec.get_xsstate()
+
     def tearDown(self):
         os.chdir(self.startdir)
         ui._session.__dict__.update(self.old_state)
         logger.setLevel(self.old_level)
+
+        if has_xspec:
+            xspec.set_xsstate(self.old_xspec)
 
     def assign_model(self, name, obj):
         self.locals[name] = obj
@@ -62,7 +77,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pha_intro(self):
@@ -121,7 +136,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_simultaneous(self):
@@ -138,7 +153,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_sourceandbg(self):
@@ -174,7 +189,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_pileup(self):
@@ -214,7 +229,7 @@ class test_threads(SherpaTestCase):
         # Since any other I/O backend would not understand DM syntax,
         # I make this test a no-op unless CRATES is used as the I/O
         # backend.  SMD 05/23/13
-        if (True == self.is_crates_io):
+        if self.is_crates_io:
             self.run_thread('radpro_dm')
             self.assertEqualWithinTol(ui.get_fit_results().statval, 217.450, 1e-4)
             self.assertEqualWithinTol(ui.get_fit_results().rstat, 6.21287, 1e-4)
@@ -301,7 +316,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_spectrum(self):
@@ -330,7 +345,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xmm(self):
@@ -358,7 +373,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_proj(self):
@@ -433,7 +448,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_proj_bubble(self):
@@ -466,7 +481,7 @@ class test_threads(SherpaTestCase):
     # (if any occur) so SDS doesn't waste time tripping over them.
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_counts(self):
@@ -481,7 +496,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_stats_all(self):
@@ -512,7 +527,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_setfullmodel(self):
@@ -526,7 +541,7 @@ class test_threads(SherpaTestCase):
 
     @unittest.skipIf(not has_fits_support(),
                      'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+    @unittest.skipIf(not has_xspec,
                      "required sherpa.astro.xspec module missing")
     @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_xmm2(self):

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,0 +1,1183 @@
+#
+#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Serialize the Sherpa session state.
+
+This module is used by ``sherpa.astro.ui.utils`` and is not
+intended for public use. The API and semantics of the
+routines in this module are subject to change.
+"""
+
+import inspect
+import logging
+import sys
+
+import numpy
+
+import sherpa.utils
+from sherpa.utils.err import ArgumentErr
+
+from sherpa.data import Data1D, Data1DInt, Data2D, Data2DInt
+from sherpa.astro.data import DataIMG, DataPHA
+
+logger = logging.getLogger(__name__)
+warning = logger.warning
+
+# Note: a lot of the serialization logic should probably be moved into
+#       the objects (or modules) being serialized.
+#
+
+
+def _output(msg, fh=None):
+    """Display the message.
+
+    Parameters
+    ----------
+    msg : None or str
+       The message to output. If ``None`` then the routine
+       returns immediately (with no output).
+    fh : None or a file handle
+       The file handle to write the message to. If fh is ``None``
+       then the standard output is used.
+    """
+
+    if msg is None:
+        return
+
+    if fh is None:
+        fh = sys.stdout
+
+    fh.write(msg + '\n')
+
+
+def _id_to_str(id):
+    """Convert a data set identifier to a string value.
+
+    Parameters
+    ----------
+    id : int or str
+       The data set identifier.
+
+    Returns
+    -------
+    out : str
+       A string representation of the identifier for use
+       in the Python serialization.
+    """
+
+    if isinstance(id, basestring):
+        return '"{}"'.format(id)
+    else:
+        return str(id)
+
+
+def _save_intro(fh=None):
+    """The set-up for the serialized file (imports).
+
+    Parameters
+    ----------
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    # QUS: should numpy only be loaded if it is needed?
+    _output("import numpy", fh)
+
+    _output("from sherpa.astro.ui import *", fh)
+
+
+def _save_response(label, respfile, id, rid, bid=None, fh=None):
+    """Save the ARF or RMF
+
+    Parameters
+    ----------
+    label : str
+       Either ``arf`` or ``rmf``.
+    respfile : str
+       The name of the ARF or RMF.
+    id : id or str
+       The Sherpa data set identifier.
+    rid
+       The Sherpa response identifier for the data set.
+    bid
+       If not ``None`` then this indicates that this is the ARF for
+       a background dataset, and which such data set to use.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    id = _id_to_str(id)
+    rid = _id_to_str(rid)
+
+    cmd = 'load_{}({}, "{}", resp_id={}'.format(label, id, respfile, rid)
+    if bid is not None:
+        cmd += ", bkg_id={}".format(_id_to_str(bid))
+
+    cmd += ")"
+    _output(cmd, fh)
+
+
+def _save_arf_response(state, id, rid, bid=None, fh=None):
+    """Save the ARF.
+
+    Parameters
+    ----------
+    state
+    id : id or str
+       The Sherpa data set identifier.
+    rid
+       The Sherpa response identifier for the data set.
+    bid
+       If not ``None`` then this indicates that this is the ARF for
+       a background dataset, and which such data set to use.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    try:
+        respfile = state.get_arf(id, resp_id=rid, bkg_id=bid).name
+    except:
+        return
+
+    _save_response('arf', respfile, id, rid, bid=bid, fh=fh)
+
+
+def _save_rmf_response(state, id, rid, bid=None, fh=None):
+    """Save the RMF.
+
+    Parameters
+    ----------
+    state
+    id : id or str
+       The Sherpa data set identifier.
+    rid
+       The Sherpa response identifier for the data set.
+    bid
+       If not ``None`` then this indicates that this is the RMF for
+       a background dataset, and which such data set to use.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    try:
+        respfile = state.get_rmf(id, resp_id=rid, bkg_id=bid).name
+    except:
+        return
+
+    _save_response('rmf', respfile, id, rid, bid=bid, fh=fh)
+
+
+def _save_pha_array(state, label, id, bid=None, fh=None):
+    """Save a grouping or quality array for a PHA data set.
+
+    Parameters
+    ----------
+    state
+    label : "grouping" or "quality"
+    id : id or str
+       The Sherpa data set identifier.
+    bid
+       If not ``None`` then this indicates that the background dataset
+       is to be used.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    # This is an internal routine, so just protect against accidents
+    if label not in ['grouping', 'quality']:
+        raise ValueError("Invalid label={}".format(label))
+
+    if bid is None:
+        data = state.get_data(id)
+        lbl = 'Data'
+    else:
+        data = state.get_bkg(id, bid)
+        lbl = 'Background'
+
+    vals = getattr(data, label)
+    if vals is None:
+        return
+
+    _output("\n######### {} {} flags\n".format(lbl, label), fh)
+
+    # QUS: can we not use the vals variable here rather than
+    #      reassign it? i.e. isn't the "quality" (or "grouping"
+    #      field of get_data/get_bkg the same as state.get_grouping
+    #      or state.get_quality?
+    #
+    func = getattr(state, 'get_{}'.format(label))
+    vals = func(id, bkg_id=bid)
+
+    # The OGIP standard is for quality and grouping to be 2-byte
+    # integers -
+    # http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node7.html
+    # - then force that type here.
+    vals = vals.astype(numpy.int16)
+
+    cmd = "set_{}({}, ".format(label, _id_to_str(id)) + \
+          "val=numpy.array(" + repr(vals.tolist()) + \
+          ", numpy.{})".format(vals.dtype)
+    if bid is not None:
+        cmd += ", bkg_id={}".format(_id_to_str(bid))
+
+    cmd += ")"
+    _output(cmd, fh)
+
+
+def _save_pha_grouping(state, id, bid=None, fh=None):
+    """Save the grouping column values for a PHA data set.
+
+    Parameters
+    ----------
+    state
+    id : id or str
+       The Sherpa data set identifier.
+    bid
+       If not ``None`` then this indicates that the background dataset
+       is to be used.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    _save_pha_array(state, "grouping", id, bid=bid, fh=fh)
+
+
+def _save_pha_quality(state, id, bid=None, fh=None):
+    """Save the quality column values for a PHA data set.
+
+    Parameters
+    ----------
+    state
+    id : id or str
+       The Sherpa data set identifier.
+    bid
+       If not ``None`` then this indicates that the background dataset
+       is to be used.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    _save_pha_array(state, "quality", id, bid=bid, fh=fh)
+
+
+def _handle_filter(state, id, fh):
+    """Set any filter expressions for source and background
+    components for data set id.
+
+    It is expected that there is a dataset with the given id
+    in the Sherpa session object (state).
+    """
+
+    cmd_id = _id_to_str(id)
+    _output("\n######### Filter Data\n", fh)
+    d = state.get_data(id)
+    fvals = d.get_filter()
+    ndims = len(d.get_dims())
+    if ndims == 1:
+        cmd = 'notice_id({}, "{}")'.format(cmd_id, fvals)
+        _output(cmd, fh)
+    elif ndims == 2:
+        cmd = 'notice2d_id({}, "{}")'.format(cmd_id, fvals)
+        _output(cmd, fh)
+    else:
+        # just in case
+        _output('print("Set notice range of id={} to {}")'.format(cmd_id,
+                                                                  fvals),
+                fh)
+
+    try:
+        bids = state.list_bkg_ids(id)
+    except ArgumentErr:
+        # Not a PHA data set
+        return
+
+    # Only set the noticed range if the data set does not have
+    # the background subtracted. It might be useful to keep any
+    # noticed range the user may have previously set - if switching
+    # between fitting and subtracting the background - but that is
+    # probably beyond the use case of the serialization.
+    #
+    if d.subtracted:
+        return
+
+    # NOTE: have to clear out the source filter before applying the
+    #       background one.
+    for bid in bids:
+        bkg_id = _id_to_str(bid)
+        fvals = state.get_bkg(id, bkg_id=bid).get_filter()
+
+        if ndims == 1:
+            _output('notice_id({}, None, None, bkg_id={})'.format(cmd_id,
+                                                                  bkg_id),
+                    fh)
+            cmd = 'notice_id({}, "{}", bkg_id={})'.format(cmd_id,
+                                                          fvals, bkg_id)
+            _output(cmd, fh)
+        elif ndims == 2:
+            _output('notice2d_id({}, None, None, bkg_id={})'.format(cmd_id,
+                                                                    bkg_id),
+                    fh)
+            cmd = 'notice2d_id({}, "{}", bkg_id={})'.format(cmd_id,
+                                                            fvals, bkg_id)
+            _output(cmd, fh)
+        else:
+            # just in case
+            msg = "Set notice range of id={} bkg_id={} to {}".format(cmd_id,
+                                                                     fvals,
+                                                                     bkg_id)
+            _output('print("{}")'.format(msg), fh)
+
+
+def _save_data(state, funcs, fh=None):
+    """Save the data.
+
+    This can just be references to files, or serialization of
+    the data (or both).
+
+    Parameters
+    ----------
+    state
+    funcs : dict
+       A dictionary of function references with keys for ``load_data``
+       and ``set_coord``, where the function accepts the data set
+       identifier and returns a string representation of that command.
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+
+    Notes
+    -----
+    This does not - at least at present - save data to one or
+    more files to be read in by the script. If any data needs
+    to be serialized it is included in the script.
+    """
+
+    _output("\n######### Load Data Sets\n", fh)
+
+    cmd_id = ""
+    cmd_bkg_id = ""
+
+    for id in state.list_data_ids():
+        # But if id is a string, then quote as a string
+        # But what about the rest of any possible load_data() options;
+        # how do we replicate the optional keywords that were possibly
+        # used?  Store them with data object?
+        cmd_id = _id_to_str(id)
+
+        cmd = funcs['load_data'](id)
+        _output(cmd, fh)
+
+        # Set physical or WCS coordinates here if applicable
+        # If can't be done, just pass to next
+        try:
+            _output("\n######### Set Image Coordinates\n", fh)
+            cmd = funcs['set_coord'](id)
+            _output(cmd, fh)
+        except:
+            pass
+
+        # PHA attributes; group data if applicable
+        try:
+            # Only store group flags and quality flags if they were changed
+            # from flags in the file
+            if not state.get_data(id)._original_groups:
+                _save_pha_grouping(state, id, fh=fh)
+                _save_pha_quality(state, id, fh=fh)
+
+            # End check for original groups and quality flags
+            if state.get_data(id).grouped:
+                cmd = "if get_data(%s).grouping is not None and not get_data(%s).grouped:" % (
+                    cmd_id, cmd_id)
+                _output(cmd, fh)
+                _output("    ######### Group Data", fh)
+                cmd = "    group(%s)" % cmd_id
+                _output(cmd, fh)
+        except:
+            pass
+
+        # Add responses and ARFs, if any
+        try:
+            _output(
+                "\n######### Data Spectral Responses\n", fh)
+            rids = state.list_response_ids(id)
+
+            for rid in rids:
+                _save_arf_response(state, id, rid, fh=fh)
+                _save_rmf_response(state, id, rid, fh=fh)
+
+        except:
+            pass
+
+        # Check if this data set has associated backgrounds
+        try:
+            _output(
+                "\n######### Load Background Data Sets\n", fh)
+            bids = state.list_bkg_ids(id)
+            cmd_bkg_id = ""
+            for bid in bids:
+                cmd_bkg_id = _id_to_str(bid)
+
+                cmd = 'load_bkg(%s, "%s", bkg_id=%s)' % (
+                    cmd_id, state.get_bkg(id, bid).name, cmd_bkg_id)
+                _output(cmd, fh)
+
+                # Group data if applicable
+                try:
+                    # Only store group flags and quality flags if they were
+                    # changed from flags in the file
+                    if not state.get_bkg(id, bid)._original_groups:
+                        if state.get_bkg(id, bid).grouping is not None:
+                            _save_pha_grouping(state, id, bid, fh=fh)
+                            _save_pha_quality(state, id, bid, fh=fh)
+
+                    # End check for original groups and quality flags
+                    if state.get_bkg(id, bid).grouped:
+                        cmd = "if get_bkg(%s, %s).grouping is not None and not get_bkg(%s, %s).grouped:" % (
+                            cmd_id, cmd_bkg_id, cmd_id, cmd_bkg_id)
+                        _output(cmd, fh)
+                        _output(
+                            "    ######### Group Background", fh)
+                        cmd = "    group(%s, %s)" % (cmd_id, cmd_bkg_id)
+                        _output(cmd, fh)
+                except:
+                    pass
+
+                # Load background response, ARFs if any
+                _output(
+                    "\n######### Background Spectral Responses\n", fh)
+                rids = state.list_response_ids(id, bid)
+                for rid in rids:
+                    _save_arf_response(state, id, rid, bid, fh=fh)
+                    _save_rmf_response(state, id, rid, bid, fh=fh)
+
+        except:
+            pass
+
+        # Set energy units if applicable
+        # If can't be done, just pass to next
+        try:
+            _output(
+                "\n######### Set Energy or Wave Units\n", fh)
+            units = state.get_data(id).units
+            rate = state.get_data(id).rate
+            if rate:
+                rate = '"rate"'
+            else:
+                rate = '"counts"'
+            factor = state.get_data(id).plot_fac
+            cmd = "set_analysis(%s, %s, %s, %s)" % (cmd_id,
+                                                    repr(units),
+                                                    rate,
+                                                    repr(factor))
+            _output(cmd, fh)
+        except:
+            pass
+
+        # Subtract background data if applicable
+        try:
+            if state.get_data(id).subtracted:
+                cmd = "if not get_data(%s).subtracted:" % cmd_id
+                _output(cmd, fh)
+                _output(
+                    "    ######### Subtract Background Data", fh)
+                cmd = "    subtract(%s)" % cmd_id
+                _output(cmd, fh)
+        except:
+            pass
+
+        _handle_filter(state, id, fh)
+
+
+def _print_par(par):
+    """Convert a Sherpa parameter to a string.
+
+    Parameters
+    ----------
+    par
+       The Sherpa parameter object to serialize.
+
+    Returns
+    -------
+    out : str
+       A multi-line string serializing the contents of the
+       parameter.
+    """
+
+    linkstr = ""
+    if par.link is not None:
+        linkstr = "\nlink(%s, %s)\n" % (
+            par.fullname, par.link.fullname)
+
+    unitstr = ""
+    if isinstance(par.units, basestring):
+        unitstr = '"%s"' % par.units
+
+    return ((('%s.default_val = %s\n' +
+              '%s.default_min = %s\n' +
+              '%s.default_max = %s\n' +
+              '%s.val     = %s\n' +
+              '%s.min     = %s\n' +
+              '%s.max     = %s\n' +
+              '%s.units   = %s\n' +
+              '%s.frozen  = %s\n') %
+             (par.fullname, repr(par.default_val),
+              par.fullname, repr(par.default_min),
+              par.fullname, repr(par.default_max),
+              par.fullname, repr(par.val),
+              par.fullname, repr(par.min),
+              par.fullname, repr(par.max),
+              par.fullname, unitstr,
+              par.fullname, par.frozen)), linkstr)
+
+
+def _save_statistic(state, fh=None):
+    """Save the statistic settings.
+
+    Parameters
+    ----------
+    state
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    _output("\n######### Set Statistic\n", fh)
+    cmd = 'set_stat("%s")' % state.get_stat_name()
+    _output(cmd, fh)
+    _output("", fh)
+
+
+def _save_fit_method(state, fh=None):
+    """Save the fit method settings.
+
+    Parameters
+    ----------
+    state
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    # Save fitting method
+
+    _output("\n######### Set Fitting Method\n", fh)
+    cmd = 'set_method("%s")' % state.get_method_name()
+    _output(cmd, fh)
+    _output("", fh)
+
+    mdict = state.get_method_opt()
+    for key in mdict:
+        val = mdict.get(key)
+        cmd = 'set_method_opt("%s", %s)' % (key, val)
+        _output(cmd, fh)
+
+    _output("", fh)
+
+
+def _save_iter_method(state, fh=None):
+    """Save the iterated-fit method settings, if any.
+
+    Parameters
+    ----------
+    state
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    if state.get_iter_method_name() == 'none':
+        return
+
+    _output("\n######### Set Iterative Fitting Method\n", fh)
+    cmd = 'set_iter_method("%s")' % state.get_iter_method_name()
+    _output(cmd, fh)
+    _output("", fh)
+
+    mdict = state.get_iter_method_opt()
+    for key in mdict:
+        val = mdict.get(key)
+        cmd = 'set_iter_method_opt("%s", %s)' % (key, val)
+        _output(cmd, fh)
+
+    _output("", fh)
+
+
+# Is there something in the standard libraries that does this?
+def _reindent(code):
+    """Try to remove leading spaces. Somewhat hacky."""
+
+    # Assume the first line is 'def func()'
+    nspaces = code.find('def')
+    if nspaces < 1:
+        return code
+
+    # minimal safety checks (e.g. if there was an indented
+    # comment line).
+    out = []
+    for line in code.split("\n"):
+        if line[:nspaces].isspace():
+            out.append(line[nspaces:])
+        else:
+            out.append(line)
+
+    return "\n".join(out)
+
+# for user models, try to access the function definition via
+# the inspect module and then re-create it in the script.
+# An alternative would be to use the marshal module, and
+# store the bytecode for the function in the code (or use
+# pickle), but this is less readable and not guaranteed to
+# be compatible with different major versions of Python.
+# The idea is not to support all use case, but to try and
+# support the simple use case.
+#
+# The user warnings are displayed for each user model,
+# which could get annoying if there are many such models,
+# but probably better to tell the user about each one
+# than only the first.
+#
+def _handle_usermodel(mod, modelname, fh=None):
+
+    try:
+        pycode = inspect.getsource(mod.calc)
+    except IOError:
+        pycode = None
+
+    # in case getsource can return None, have check here
+    if pycode is None:
+        msg = "Unable to save Python code for user model " + \
+              "'{}' function {}".format(mod.name, )
+        warning(msg)
+        _output('print("{}")'.format(msg), fh)
+        _output("def {}(*args):".format(mod.calc.name), fh)
+        _output("    raise NotImplementedError('User model was " +
+                "not saved by save_all().'", fh)
+        _output("", fh)
+        return
+
+    msg = "Found user model '{}'; ".format(modelname) + \
+          "please check it is saved correctly."
+    warning(msg)
+
+    # Ensure the message is also seen if the script is run.
+    _output('print("{}")'.format(msg), fh)
+
+    _output(_reindent(pycode), fh)
+    cmd = 'load_user_model({}, "{}")'.format(
+        mod.calc.__name__, modelname)
+    _output(cmd, fh)
+
+    # Work out the add_user_pars call; this is explicit, i.e.
+    # it does not include logic to work out what arguments
+    # are not needed.
+    #
+    # Some of these values are over-written later on, but
+    # needed to set up the number of parameters, and good
+    # documentation (hopefully).
+    #
+    parnames = [p.name for p in mod.pars]
+    parvals = [p.default_val for p in mod.pars]
+    # parmins = [p.default_min for p in mod.pars]
+    # parmaxs = [p.default_max for p in mod.pars]
+    parmins = [p.min for p in mod.pars]
+    parmaxs = [p.max for p in mod.pars]
+    parunits = [p.units for p in mod.pars]
+    parfrozen = [p.frozen for p in mod.pars]
+
+    spaces = '              '
+    _output('add_user_pars("{}",'.format(modelname), fh)
+    _output("{}parnames={},".format(spaces, parnames), fh)
+    _output("{}parvals={},".format(spaces, parvals), fh)
+    _output("{}parmins={},".format(spaces, parmins), fh)
+    _output("{}parmaxs={},".format(spaces, parmaxs), fh)
+    _output("{}parunits={},".format(spaces, parunits), fh)
+    _output("{}parfrozen={}".format(spaces, parfrozen), fh)
+    _output("{})\n".format(spaces), fh)
+
+
+def _save_model_components(state, fh=None):
+    """Save the model components.
+
+    Parameters
+    ----------
+    state
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    # Have to call elements in list in reverse order (item at end of
+    # list was model first created), so that we get links right, if any
+
+    # To recreate attributes, print out dictionary as ordered pairs,
+    # for each parameter
+
+    _output("\n######### Set Model Components and Parameters\n", fh)
+    all_model_components = state.list_model_components()
+    all_model_components.reverse()
+
+    # If there are any links between parameters, store link commands here
+    # Then, *after* processing all models in the for loop below, send
+    # link commands to outfile -- *all* models need to be created before
+    # *any* links between parameters can be established.
+    linkstr = ""
+    for mod in all_model_components:
+
+        # get actual model instance from the name we are given
+        # then get model type, and name of this instance.
+        mod = eval(mod)
+        typename = mod.type
+        modelname = mod.name.split(".")[1]
+
+        # Special cases:
+
+        # account for PSF creation elsewhere (above, with load_data
+        # commands);
+
+        # for table models, use "load_table_model", to ensure we
+        # add to lists of known models *and* separate list of
+        # tabel models;
+
+        if typename == "usermodel":
+            _handle_usermodel(mod, modelname, fh)
+
+        elif typename == "psfmodel":
+            cmd = 'load_psf("%s", "%s")' % (mod._name, mod.kernel.name)
+            _output(cmd, fh)
+            try:
+                psfmod = state.get_psf(id)
+                cmd_id = _id_to_str(id)
+                cmd = "set_psf(%s, %s)" % (cmd_id, psfmod._name)
+                _output(cmd, fh)
+            except:
+                pass
+
+        elif typename == "tablemodel":
+            # Create table model with load_table_model
+            cmd = 'load_table_model("%s", "%s")' % (
+                modelname, mod.filename)
+            _output(cmd, fh)
+
+        else:
+            # Normal case:  create an instance of the model.
+            cmd = 'create_model_component("{}", "{}")'.format(
+                typename, modelname)
+            _output(cmd, fh)
+
+        # QUS: should this be included in the above checks?
+        #      @DougBurke doesn't think so, as the "normal
+        #      case" above should probably be run , but there's
+        #      no checks to verify this.
+        #
+        if typename == "convolutionkernel":
+            # Create general convolution kernel with load_conv
+            cmd = 'load_conv("%s", "%s")' % (
+                modelname, mod.kernel.name)
+            _output(cmd, fh)
+
+        if hasattr(mod, "integrate"):
+            cmd = "%s.integrate = %s" % (modelname, mod.integrate)
+            _output(cmd, fh)
+            _output("", fh)
+
+        from sherpa.models import Parameter
+        for par in mod.__dict__.values():
+            if isinstance(par, Parameter):
+                par_attributes, par_linkstr = _print_par(par)
+                _output(par_attributes, fh)
+                linkstr = linkstr + par_linkstr
+
+        # If the model is a PSFModel, could have special
+        # attributes "size" and "center" -- if so, record them.
+        if typename == "psfmodel":
+            if hasattr(mod, "size"):
+                cmd = "%s.size = %s" % (modelname, repr(mod.size))
+                _output(cmd, fh)
+                _output("", fh)
+            if hasattr(mod, "center"):
+                cmd = "%s.center = %s" % (modelname, repr(mod.center))
+                _output(cmd, fh)
+                _output("", fh)
+
+    # If there were any links made between parameters, send those
+    # link commands to outfile now; else, linkstr is just an empty string
+    _output(linkstr, fh)
+
+
+def _save_models(state, fh=None):
+    """Save the source, pileup, and background models.
+
+    Parameters
+    ----------
+    state
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    # Save all source, pileup and background models
+
+    _output("\n######### Set Source, Pileup and Background Models\n", fh)
+    for id in state.list_data_ids():
+        cmd_id = _id_to_str(id)
+
+        # If a data set has a source model associated with it,
+        # set that here -- try to distinguish cases where
+        # source model is different from whole model.
+        # If not, just pass
+        try:
+            try:
+                the_source = state.get_source(id)
+            except:
+                the_source = None
+
+            try:
+                the_full_model = state.get_model(id)
+            except:
+                the_full_model = None
+
+            have_source = the_source is not None
+            have_full_model = the_full_model is not None
+
+            if have_source:
+                if have_full_model:
+                    # for now assume that set_full_model is only
+                    # used by PHA data sets.
+                    try:
+                        is_pha = isinstance(state.get_data(id), DataPHA)
+                    except:
+                        is_pha = False
+
+                    if is_pha and repr(the_source) == repr(the_full_model):
+                        cmd = "set_full_model(%s, %s)" % (
+                            cmd_id, the_full_model.name)
+                    else:
+                        cmd = "set_source(%s, %s)" % (
+                            cmd_id, the_source.name)
+                else:
+                    cmd = "set_source(%s, %s)" % (cmd_id, the_source.name)
+
+            elif have_full_model:
+                cmd = "set_full_model(%s, %s)" % (
+                    cmd_id, the_full_model.name)
+
+            else:
+                cmd = ""
+
+            _output(cmd, fh)
+            _output("", fh)
+        except:
+            pass
+
+        # If any pileup models, try to set them.  If not, just pass.
+        try:
+            cmd = "set_pileup_model(%s, %s)" % (
+                cmd_id, state.get_pileup_model(id).name)
+            _output(cmd, fh)
+        except:
+            pass
+
+        # Set background models (if any) associated with backgrounds
+        # tied to this data set -- if none, then pass.  Again, try
+        # to distinguish cases where background "source" model is
+        # different from whole background model.
+        try:
+            bids = state.list_bkg_ids(id)
+            cmd_bkg_id = ""
+            for bid in bids:
+                cmd_bkg_id = _id_to_str(bid)
+
+                try:
+                    the_bkg_source = state.get_bkg_source(id, bkg_id=bid)
+                except:
+                    the_bkg_source = None
+
+                try:
+                    the_bkg_full_model = state.get_bkg_model(id, bkg_id=bid)
+                except:
+                    the_bkg_full_model = None
+
+                have_source = the_bkg_source is not None
+                have_full_model = the_bkg_full_model is not None
+
+                if have_source:
+                    # This does not check for the dataset being a DataPHA
+                    # object, since (at present) it has to be, as it's the
+                    # only one to support backgrounds
+                    if have_full_model:
+                        if repr(the_bkg_source) == repr(the_bkg_full_model):
+                            cmd = "set_bkg_full_model(%s, %s, bkg_id=%s)" % (
+                                cmd_id, the_bkg_full_model.name, cmd_bkg_id)
+                        else:
+                            cmd = "set_bkg_source(%s, %s, bkg_id=%s)" % (
+                                cmd_id, the_bkg_source.name, cmd_bkg_id)
+                    else:
+                        cmd = "set_bkg_source(%s, %s, bkg_id=%s)" % (
+                            cmd_id, the_bkg_source.name, cmd_bkg_id)
+
+                elif have_full_model:
+                    cmd = "set_bkg_full_model(%s, %s, bkg_id=%s)" % (
+                        cmd_id, the_bkg_full_model.name, cmd_bkg_id)
+
+                else:
+                    cmd = ""
+
+                _output(cmd, fh)
+                _output("", fh)
+
+        except:
+            pass
+
+
+def _save_xspec(fh=None):
+    """Save the XSPEC settings, if the module is loaded.
+
+    Parameters
+    ----------
+    fh : None or file-like
+       If ``None``, the information is printed to standard output,
+       otherwise the information is added to the file handle.
+    """
+
+    if not hasattr(sherpa.astro, "xspec"):
+        return
+
+    # TODO: should this make sure that the XSPEC module is in use?
+    #       i.e. only write these out if an XSPEC model is being used?
+    _output("\n######### XSPEC Module Settings\n", fh)
+    xspec_state = sherpa.astro.xspec.get_xsstate()
+
+    cmd = "set_xschatter(%d)" % xspec_state["chatter"]
+    _output(cmd, fh)
+    cmd = 'set_xsabund("%s")' % xspec_state["abund"]
+    _output(cmd, fh)
+    cmd = "set_xscosmo(%g, %g, %g)" % (xspec_state["cosmo"][0],
+                                       xspec_state["cosmo"][1],
+                                       xspec_state["cosmo"][2])
+    _output(cmd, fh)
+    cmd = 'set_xsxsect("%s")' % xspec_state["xsect"]
+    _output(cmd, fh)
+    for name in xspec_state["modelstrings"].keys():
+        mstring = xspec_state["modelstrings"][name]
+        cmd = 'set_xsxset("%s", "%s")' % (name, mstring)
+        _output(cmd, fh)
+
+
+def _save_dataset(state, id):
+    """Given a dataset identifier, return the text needed to
+    re-create it.
+
+    The data set design does not make it easy to tell:
+
+    - if the data was read in from a file, or by load_arrays
+      (and the name field set by the user)
+
+    - if the data has been modified - e.g. by a call to set_counts -
+      after it was loaded.
+
+    - if in the correct directory (so paths may be wrong)
+
+    """
+
+    idstr = _id_to_str(id)
+    dset = state.get_data(id)
+
+    # For now assume that a missing name indicates the data
+    # was created by the user, otherwise it's a file name.
+    # The checks and error messages do not cover all situations,
+    # but hopefully the common ones.
+    #
+    # This logic should be moved into the DataXXX objects, since
+    # this is more extensible, and also the data object can
+    # retain knowledge of where the data came from.
+    #
+    if dset.name.strip() == '':
+        # Do not attempt to recreate all data sets at this
+        # time. They could be serialized, but leave for a
+        # later time (it may also make sense to actually
+        # save the data to an external file).
+        #
+        if isinstance(dset, DataPHA):
+            msg = "Unable to re-create PHA data set '{}'".format(id)
+            warning(msg)
+            return 'print("{}")'.format(msg)
+
+        elif isinstance(dset, DataIMG):
+            msg = "Unable to re-create image data set '{}'".format(id)
+            warning(msg)
+            return 'print("{}")'.format(msg)
+
+        # Fall back to load_arrays. As using isinstance,
+        # need to order the checks, since Data1DInt is
+        # a subclass of Data1D.
+        #
+        xs = dset.get_indep()
+        ys = dset.get_dep()
+        stat = dset.get_staterror()
+        sys = dset.get_syserror()
+
+        need_sys = sys is not None
+        if need_sys:
+            sys = "{}".format(sys.tolist())
+        else:
+            sys = "None"
+
+        need_stat = stat is not None or need_sys
+        if stat is not None:
+            stat = "{}".format(stat.tolist())
+        else:
+            stat = "None"
+
+        ys = "{}".format(ys.tolist())
+
+        out = 'load_arrays({},\n'.format(idstr)
+        if isinstance(dset, Data1DInt):
+            out += '            {},\n'.format(xs[0].tolist())
+            out += '            {},\n'.format(xs[1].tolist())
+            out += '            {},\n'.format(ys)
+            if need_stat:
+                out += '            {},\n'.format(stat)
+            if need_sys:
+                out += '            {},\n'.format(sys)
+            out += '            Data1DInt)'
+
+        elif isinstance(dset, Data1D):
+            out += '            {},\n'.format(xs[0].tolist())
+            out += '            {},\n'.format(ys)
+            if need_stat:
+                out += '            {},\n'.format(stat)
+            if need_sys:
+                out += '            {},\n'.format(sys)
+            out += '            Data1D)'
+
+        elif isinstance(dset, Data2DInt):
+            msg = "Unable to re-create Data2DInt data set '{}'".format(id)
+            warning(msg)
+            out = 'print("{}")'.format(msg)
+
+        elif isinstance(dset, Data2D):
+            out += '            {},\n'.format(xs[0].tolist())
+            out += '            {},\n'.format(xs[1].tolist())
+            out += '            {},\n'.format(ys)
+            out += '            {},\n'.format(dset.shape)
+            if need_stat:
+                out += '            {},\n'.format(stat)
+            if need_sys:
+                out += '            {},\n'.format(sys)
+            out += '            Data2D)'
+
+        else:
+            msg = "Unable to re-create {} data set '{}'".format(dset.__class__,
+                                                                id)
+            warning(msg)
+            out = 'print("{}")'.format(msg)
+
+        return out
+
+    # TODO: this does not handle options like selecting the columns
+    #       from a file, or the number of columns.
+    #
+    if isinstance(dset, DataPHA):
+        dtype = 'pha'
+    elif isinstance(dset, DataIMG):
+        dtype = 'image'
+    else:
+        dtype = 'data'
+
+    return 'load_{}({}, "{}")'.format(dtype, idstr, dset.name)
+
+
+def save_all(state, fh=None):
+    """Save the information about the current session to a file handle.
+
+    This differs to the `save` command in that the output is human
+    readable. Three consequences are:
+
+     1. numeric values may not be recorded to their full precision
+
+     2. data sets are not included in the file
+
+     3. some settings and values may not be recorded.
+
+    Parameters
+    ----------
+    fh : file_like, optional
+       If not given the results are displayed to standard out,
+       otherwise they are written to this file handle.
+
+    See Also
+    --------
+    save : Save the current Sherpa session to a file.
+    restore : Load in a Sherpa session from a file.
+
+    Notes
+    -----
+
+    This command will create a series of commands that restores
+    the current Sherpa set up. It does not save the set of commands
+    used. Not all Sherpa settings are saved. Items not fully restored
+    include:
+
+    - data created by calls to `load_arrays`, or changed from the
+      version on disk - e.g. by calls to `sherpa.astro.ui.set_counts`.
+
+    - any optional keywords to comands such as `load_data`
+      or `load_pha`
+
+    - user models may not be restored correctly
+
+    - only a subset of Sherpa commands are saved.
+
+    Examples
+    --------
+
+    Write the current Sherpa session to the standard output:
+
+    >>> save_all()
+
+    Save the session to a StringIO handle:
+
+    >>> import StringIO
+    >>> store = StringIO.StringIO()
+    >>> save_all(store)
+
+    """
+
+    funcs = {
+        'load_data': lambda id: _save_dataset(state, id),
+        'set_coord': lambda id:
+        'set_coord({}, {})'.format(_id_to_str(id), repr(state.get_coord(id))),
+    }
+
+    _save_intro(fh)
+    _save_data(state, funcs, fh)
+    _output("", fh)
+    _save_statistic(state, fh)
+    _save_fit_method(state, fh)
+    _save_iter_method(state, fh)
+    _save_model_components(state, fh)
+    _save_models(state, fh)
+    _save_xspec(fh)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -873,7 +873,7 @@ class test_ui(SherpaTestCase):
         StringIO object) to the string value expected.
         """
         output = StringIO.StringIO()
-        ui.save_all(outfh=output)
+        ui.save_all(output)
         output = output.getvalue()
 
         # check the output is a valid Python program.
@@ -891,7 +891,7 @@ class test_ui(SherpaTestCase):
         """
 
         output = StringIO.StringIO()
-        ui.save_all(outfh=output)
+        ui.save_all(output)
         output = output.getvalue()
         ui.clean()
         try:

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,0 +1,1235 @@
+#
+#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test the functions in sherpa.astro.ui.serialize, also testing the
+corresponding functions in sherpa.astro.ui.utils.
+"""
+
+# TODO add tests:
+#    set_full_model
+#    multiple sources
+#    linked parameters
+#    iter fit method
+#    check the noticed range after restoring it
+#    pha dataset; wavelength analysis
+#    pha2 dataset
+#    Chandra Source Catalog "pha3" dataset (src and bgnd in different
+#      extensions); DougBurke has noted that astropy backend fails if
+#      response files are gzipp-ed [may be acceptable behavior] but
+#      want test to check basic behavior
+#    psf model
+#    table model
+#
+
+import re
+import StringIO
+import tempfile
+import unittest
+
+import numpy
+from numpy.testing import assert_array_equal
+
+from sherpa.utils import SherpaTest, SherpaTestCase, has_package_from_list, \
+    test_data_missing
+from sherpa.astro import ui
+# from sherpa.astro.ui import serialize
+
+import logging
+logger = logging.getLogger('sherpa')
+
+has_xspec = has_package_from_list("sherpa.astro.xspec")
+
+# The tests can either check that the output ASCII is identical
+# to a canonical form, or try to execute the saved file and
+# check that the restored version matches the input version
+# for selected metrics (e.g. data values, source expression,
+# parameter values). There's merit in having both (since the
+# latter is also a check that the saved form catches all
+# relevant information).
+#
+# It is likely that the first case - comparing against a canonical
+# form - is going to be limited by numerical accuracy. If the
+# tests against a canonical form are to be used then it probably
+# makes sense to store the output in external files, and read in
+# the content, rather than write them directly to this file (although
+# then have to deal with multiple versions depending on the modules
+# that are available).
+
+# A representation of the default Sherpa state
+_canonical_empty = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("verbose", 0)
+set_method_opt("factor", 100.0)
+set_method_opt("gtol", 1.19209289551e-07)
+set_method_opt("maxfev", None)
+set_method_opt("xtol", 1.19209289551e-07)
+set_method_opt("epsfcn", 1.19209289551e-07)
+set_method_opt("ftol", 1.19209289551e-07)
+
+
+######### Set Model Components and Parameters
+
+
+
+######### Set Source, Pileup and Background Models
+
+"""
+
+# Change a few settings for statistic/method
+_canonical_empty_stats = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+
+
+######### Set Statistic
+
+set_stat("leastsq")
+
+
+######### Set Fitting Method
+
+set_method("neldermead")
+
+set_method_opt("iquad", 1)
+set_method_opt("initsimplex", 0)
+set_method_opt("verbose", 1)
+set_method_opt("step", None)
+set_method_opt("finalsimplex", 9)
+set_method_opt("maxfev", 5000)
+set_method_opt("ftol", 1.19209289551e-07)
+
+
+######### Set Model Components and Parameters
+
+
+
+######### Set Source, Pileup and Background Models
+
+"""
+
+# use @@ as a marker to indicate that the location of the data directory
+# needs to be inserted into the text before testing.
+#
+_canonical_pha_basic = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_pha(1, "@@/threads/pha_intro/3c273.pi")
+
+######### Set Image Coordinates
+
+if get_data(1).grouping is not None and not get_data(1).grouped:
+    ######### Group Data
+    group(1)
+
+######### Data Spectral Responses
+
+load_arf(1, "@@/threads/pha_intro/3c273.arf", resp_id=1)
+load_rmf(1, "@@/threads/pha_intro/3c273.rmf", resp_id=1)
+
+######### Load Background Data Sets
+
+load_bkg(1, "@@/threads/pha_intro/3c273_bg.pi", bkg_id=1)
+if get_bkg(1, 1).grouping is not None and not get_bkg(1, 1).grouped:
+    ######### Group Background
+    group(1, 1)
+
+######### Background Spectral Responses
+
+load_arf(1, "@@/threads/pha_intro/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf(1, "@@/threads/pha_intro/3c273.rmf", resp_id=1, bkg_id=1)
+
+######### Set Energy or Wave Units
+
+set_analysis(1, 'energy', "rate", 0)
+if not get_data(1).subtracted:
+    ######### Subtract Background Data
+    subtract(1)
+
+######### Filter Data
+
+notice_id(1, "0.518300011754:8.219800233841")
+
+
+######### Set Statistic
+
+set_stat("chi2datavar")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("verbose", 0)
+set_method_opt("factor", 100.0)
+set_method_opt("gtol", 1.19209289551e-07)
+set_method_opt("maxfev", None)
+set_method_opt("xtol", 1.19209289551e-07)
+set_method_opt("epsfcn", 1.19209289551e-07)
+set_method_opt("ftol", 1.19209289551e-07)
+
+
+######### Set Model Components and Parameters
+
+create_model_component("xsapec", "src")
+src.integrate = True
+
+src.redshift.default_val = 0.0
+src.redshift.default_min = -0.999
+src.redshift.default_max = 10.0
+src.redshift.val     = 0.0
+src.redshift.min     = -0.999
+src.redshift.max     = 10.0
+src.redshift.units   = ""
+src.redshift.frozen  = True
+
+src.Abundanc.default_val = 1.0
+src.Abundanc.default_min = 0.0
+src.Abundanc.default_max = 5.0
+src.Abundanc.val     = 1.0
+src.Abundanc.min     = 0.0
+src.Abundanc.max     = 5.0
+src.Abundanc.units   = ""
+src.Abundanc.frozen  = True
+
+src.kT.default_val = 1.0
+src.kT.default_min = 0.0080000000000000002
+src.kT.default_max = 64.0
+src.kT.val     = 1.0
+src.kT.min     = 0.0080000000000000002
+src.kT.max     = 64.0
+src.kT.units   = "keV"
+src.kT.frozen  = False
+
+src.norm.default_val = 1.0
+src.norm.default_min = 0.0
+src.norm.default_max = 9.9999999999999998e+23
+src.norm.val     = 1.0
+src.norm.min     = 0.0
+src.norm.max     = 9.9999999999999998e+23
+src.norm.units   = ""
+src.norm.frozen  = False
+
+create_model_component("powlaw1d", "pl")
+pl.integrate = True
+
+pl.ampl.default_val = 1.0
+pl.ampl.default_min = 0.0
+pl.ampl.default_max = 3.4028234663852886e+38
+pl.ampl.val     = 1.0
+pl.ampl.min     = 0.0
+pl.ampl.max     = 3.4028234663852886e+38
+pl.ampl.units   = ""
+pl.ampl.frozen  = False
+
+pl.ref.default_val = 1.0
+pl.ref.default_min = -3.4028234663852886e+38
+pl.ref.default_max = 3.4028234663852886e+38
+pl.ref.val     = 1.0
+pl.ref.min     = -3.4028234663852886e+38
+pl.ref.max     = 3.4028234663852886e+38
+pl.ref.units   = ""
+pl.ref.frozen  = True
+
+pl.gamma.default_val = 1.0
+pl.gamma.default_min = -10.0
+pl.gamma.default_max = 10.0
+pl.gamma.val     = 1.0
+pl.gamma.min     = -10.0
+pl.gamma.max     = 10.0
+pl.gamma.units   = ""
+pl.gamma.frozen  = False
+
+create_model_component("xsphabs", "gal")
+gal.integrate = True
+
+gal.nH.default_val = 1.0
+gal.nH.default_min = 0.0
+gal.nH.default_max = 100000.0
+gal.nH.val     = 1.0
+gal.nH.min     = 0.0
+gal.nH.max     = 100000.0
+gal.nH.units   = "10^22 atoms / cm^2"
+gal.nH.frozen  = False
+
+
+
+######### Set Source, Pileup and Background Models
+
+set_source(1, (xsphabs.gal * (powlaw1d.pl + xsapec.src)))
+
+
+
+"""
+
+_canonical_pha_grouped = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_pha("grp", "@@/threads/pha_intro/3c273.pi")
+
+######### Set Image Coordinates
+
+
+######### Data grouping flags
+
+set_grouping("grp", val=numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, 1, -1, -1, 1, -1, -1, -1, -1, -1, 1, -1, -1, 1, -1, -1, 1, -1, 1, -1, 1, 1, -1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, -1, 1, -1, 1, -1, -1, 1, -1, -1, 1, -1, -1, 1, -1, 1, -1, -1, -1, -1, 1, -1, -1, -1, 1, -1, -1, -1, 1, -1, -1, -1, -1, 1, -1, -1, -1, 1, -1, -1, -1, -1, -1, 1, -1, -1, -1, 1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, 1, -1, -1, -1, -1, 1, -1, 1, -1, -1, -1, 1, -1, -1, 1, -1, -1, -1, 1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, 1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], numpy.int16))
+
+######### Data quality flags
+
+set_quality("grp", val=numpy.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], numpy.int16))
+if get_data("grp").grouping is not None and not get_data("grp").grouped:
+    ######### Group Data
+    group("grp")
+
+######### Data Spectral Responses
+
+load_arf("grp", "@@/threads/pha_intro/3c273.arf", resp_id=1)
+load_rmf("grp", "@@/threads/pha_intro/3c273.rmf", resp_id=1)
+
+######### Load Background Data Sets
+
+load_bkg("grp", "@@/threads/pha_intro/3c273_bg.pi", bkg_id=1)
+
+######### Background grouping flags
+
+set_grouping("grp", val=numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], numpy.int16), bkg_id=1)
+
+######### Background quality flags
+
+set_quality("grp", val=numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], numpy.int16), bkg_id=1)
+if get_bkg("grp", 1).grouping is not None and not get_bkg("grp", 1).grouped:
+    ######### Group Background
+    group("grp", 1)
+
+######### Background Spectral Responses
+
+load_arf("grp", "@@/threads/pha_intro/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf("grp", "@@/threads/pha_intro/3c273.rmf", resp_id=1, bkg_id=1)
+
+######### Set Energy or Wave Units
+
+set_analysis("grp", 'energy', "rate", 0)
+if not get_data("grp").subtracted:
+    ######### Subtract Background Data
+    subtract("grp")
+
+######### Filter Data
+
+notice_id("grp", "0.489099994302:6.131999969482")
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("verbose", 0)
+set_method_opt("factor", 100.0)
+set_method_opt("gtol", 1.19209289551e-07)
+set_method_opt("maxfev", None)
+set_method_opt("xtol", 1.19209289551e-07)
+set_method_opt("epsfcn", 1.19209289551e-07)
+set_method_opt("ftol", 1.19209289551e-07)
+
+
+######### Set Model Components and Parameters
+
+create_model_component("powlaw1d", "gpl")
+gpl.integrate = True
+
+gpl.ampl.default_val = 1.0
+gpl.ampl.default_min = 0.0
+gpl.ampl.default_max = 3.4028234663852886e+38
+gpl.ampl.val     = 1.0
+gpl.ampl.min     = 0.0
+gpl.ampl.max     = 3.4028234663852886e+38
+gpl.ampl.units   = ""
+gpl.ampl.frozen  = False
+
+gpl.ref.default_val = 1.0
+gpl.ref.default_min = -3.4028234663852886e+38
+gpl.ref.default_max = 3.4028234663852886e+38
+gpl.ref.val     = 1.0
+gpl.ref.min     = -3.4028234663852886e+38
+gpl.ref.max     = 3.4028234663852886e+38
+gpl.ref.units   = ""
+gpl.ref.frozen  = True
+
+gpl.gamma.default_val = 1.0
+gpl.gamma.default_min = -10.0
+gpl.gamma.default_max = 10.0
+gpl.gamma.val     = 1.0
+gpl.gamma.min     = -10.0
+gpl.gamma.max     = 5.0
+gpl.gamma.units   = ""
+gpl.gamma.frozen  = False
+
+create_model_component("xsphabs", "ggal")
+ggal.integrate = True
+
+ggal.nH.default_val = 2.0
+ggal.nH.default_min = 0.0
+ggal.nH.default_max = 100000.0
+ggal.nH.val     = 2.0
+ggal.nH.min     = 0.0
+ggal.nH.max     = 100000.0
+ggal.nH.units   = "10^22 atoms / cm^2"
+ggal.nH.frozen  = True
+
+
+
+######### Set Source, Pileup and Background Models
+
+set_source("grp", (xsphabs.ggal * powlaw1d.gpl))
+
+
+
+"""
+
+_canonical_pha_back = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_pha("bgrp", "@@/threads/pha_intro/3c273.pi")
+
+######### Set Image Coordinates
+
+if get_data("bgrp").grouping is not None and not get_data("bgrp").grouped:
+    ######### Group Data
+    group("bgrp")
+
+######### Data Spectral Responses
+
+load_arf("bgrp", "@@/threads/pha_intro/3c273.arf", resp_id=1)
+load_rmf("bgrp", "@@/threads/pha_intro/3c273.rmf", resp_id=1)
+
+######### Load Background Data Sets
+
+load_bkg("bgrp", "@@/threads/pha_intro/3c273_bg.pi", bkg_id=1)
+
+######### Background grouping flags
+
+set_grouping("bgrp", val=numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], numpy.int16), bkg_id=1)
+
+######### Background quality flags
+
+set_quality("bgrp", val=numpy.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], numpy.int16), bkg_id=1)
+if get_bkg("bgrp", 1).grouping is not None and not get_bkg("bgrp", 1).grouped:
+    ######### Group Background
+    group("bgrp", 1)
+
+######### Background Spectral Responses
+
+load_arf("bgrp", "@@/threads/pha_intro/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf("bgrp", "@@/threads/pha_intro/3c273.rmf", resp_id=1, bkg_id=1)
+
+######### Set Energy or Wave Units
+
+set_analysis("bgrp", 'energy', "rate", 0)
+
+######### Filter Data
+
+notice_id("bgrp", "0.518300011754:6.234200000763")
+notice_id("bgrp", None, None, bkg_id=1)
+notice_id("bgrp", "1.890699982643:7.723400115967", bkg_id=1)
+
+
+######### Set Statistic
+
+set_stat("chi2xspecvar")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("verbose", 0)
+set_method_opt("factor", 100.0)
+set_method_opt("gtol", 1.19209289551e-07)
+set_method_opt("maxfev", None)
+set_method_opt("xtol", 1.19209289551e-07)
+set_method_opt("epsfcn", 1.19209289551e-07)
+set_method_opt("ftol", 1.19209289551e-07)
+
+
+######### Set Model Components and Parameters
+
+create_model_component("powlaw1d", "gpl")
+gpl.integrate = True
+
+gpl.ampl.default_val = 1.0
+gpl.ampl.default_min = 0.0
+gpl.ampl.default_max = 3.4028234663852886e+38
+gpl.ampl.val     = 1.0
+gpl.ampl.min     = 0.0
+gpl.ampl.max     = 3.4028234663852886e+38
+gpl.ampl.units   = ""
+gpl.ampl.frozen  = False
+
+gpl.ref.default_val = 1.0
+gpl.ref.default_min = -3.4028234663852886e+38
+gpl.ref.default_max = 3.4028234663852886e+38
+gpl.ref.val     = 1.0
+gpl.ref.min     = -3.4028234663852886e+38
+gpl.ref.max     = 3.4028234663852886e+38
+gpl.ref.units   = ""
+gpl.ref.frozen  = True
+
+gpl.gamma.default_val = 1.0
+gpl.gamma.default_min = -10.0
+gpl.gamma.default_max = 10.0
+gpl.gamma.val     = 1.0
+gpl.gamma.min     = -5.0
+gpl.gamma.max     = 10.0
+gpl.gamma.units   = ""
+gpl.gamma.frozen  = False
+
+create_model_component("xsphabs", "ggal")
+ggal.integrate = True
+
+ggal.nH.default_val = 2.0
+ggal.nH.default_min = 0.0
+ggal.nH.default_max = 100000.0
+ggal.nH.val     = 2.0
+ggal.nH.min     = 0.0
+ggal.nH.max     = 100000.0
+ggal.nH.units   = "10^22 atoms / cm^2"
+ggal.nH.frozen  = True
+
+create_model_component("steplo1d", "bstep")
+bstep.integrate = True
+
+bstep.ampl.default_val = 1.0
+bstep.ampl.default_min = 0.0
+bstep.ampl.default_max = 3.4028234663852886e+38
+bstep.ampl.val     = 1.0
+bstep.ampl.min     = 0.0
+bstep.ampl.max     = 3.4028234663852886e+38
+bstep.ampl.units   = ""
+bstep.ampl.frozen  = False
+
+bstep.xcut.default_val = 0.0
+bstep.xcut.default_min = -3.4028234663852886e+38
+bstep.xcut.default_max = 3.4028234663852886e+38
+bstep.xcut.val     = 0.0
+bstep.xcut.min     = -3.4028234663852886e+38
+bstep.xcut.max     = 3.4028234663852886e+38
+bstep.xcut.units   = ""
+bstep.xcut.frozen  = False
+
+create_model_component("polynom1d", "bpoly")
+bpoly.integrate = True
+
+bpoly.c8.default_val = 0.0
+bpoly.c8.default_min = -3.4028234663852886e+38
+bpoly.c8.default_max = 3.4028234663852886e+38
+bpoly.c8.val     = 0.0
+bpoly.c8.min     = -3.4028234663852886e+38
+bpoly.c8.max     = 3.4028234663852886e+38
+bpoly.c8.units   = ""
+bpoly.c8.frozen  = True
+
+bpoly.offset.default_val = 0.0
+bpoly.offset.default_min = -3.4028234663852886e+38
+bpoly.offset.default_max = 3.4028234663852886e+38
+bpoly.offset.val     = 0.0
+bpoly.offset.min     = -3.4028234663852886e+38
+bpoly.offset.max     = 3.4028234663852886e+38
+bpoly.offset.units   = ""
+bpoly.offset.frozen  = True
+
+bpoly.c3.default_val = 0.0
+bpoly.c3.default_min = -3.4028234663852886e+38
+bpoly.c3.default_max = 3.4028234663852886e+38
+bpoly.c3.val     = 0.0
+bpoly.c3.min     = -3.4028234663852886e+38
+bpoly.c3.max     = 3.4028234663852886e+38
+bpoly.c3.units   = ""
+bpoly.c3.frozen  = True
+
+bpoly.c2.default_val = 0.0
+bpoly.c2.default_min = -3.4028234663852886e+38
+bpoly.c2.default_max = 3.4028234663852886e+38
+bpoly.c2.val     = 0.0
+bpoly.c2.min     = -3.4028234663852886e+38
+bpoly.c2.max     = 3.4028234663852886e+38
+bpoly.c2.units   = ""
+bpoly.c2.frozen  = True
+
+bpoly.c1.default_val = 0.0
+bpoly.c1.default_min = -3.4028234663852886e+38
+bpoly.c1.default_max = 3.4028234663852886e+38
+bpoly.c1.val     = 0.0
+bpoly.c1.min     = -3.4028234663852886e+38
+bpoly.c1.max     = 3.4028234663852886e+38
+bpoly.c1.units   = ""
+bpoly.c1.frozen  = True
+
+bpoly.c0.default_val = 1.0
+bpoly.c0.default_min = -3.4028234663852886e+38
+bpoly.c0.default_max = 3.4028234663852886e+38
+bpoly.c0.val     = 1.0
+bpoly.c0.min     = -3.4028234663852886e+38
+bpoly.c0.max     = 3.4028234663852886e+38
+bpoly.c0.units   = ""
+bpoly.c0.frozen  = True
+
+bpoly.c7.default_val = 0.0
+bpoly.c7.default_min = -3.4028234663852886e+38
+bpoly.c7.default_max = 3.4028234663852886e+38
+bpoly.c7.val     = 0.0
+bpoly.c7.min     = -3.4028234663852886e+38
+bpoly.c7.max     = 3.4028234663852886e+38
+bpoly.c7.units   = ""
+bpoly.c7.frozen  = True
+
+bpoly.c6.default_val = 0.0
+bpoly.c6.default_min = -3.4028234663852886e+38
+bpoly.c6.default_max = 3.4028234663852886e+38
+bpoly.c6.val     = 0.0
+bpoly.c6.min     = -3.4028234663852886e+38
+bpoly.c6.max     = 3.4028234663852886e+38
+bpoly.c6.units   = ""
+bpoly.c6.frozen  = True
+
+bpoly.c5.default_val = 0.0
+bpoly.c5.default_min = -3.4028234663852886e+38
+bpoly.c5.default_max = 3.4028234663852886e+38
+bpoly.c5.val     = 0.0
+bpoly.c5.min     = -3.4028234663852886e+38
+bpoly.c5.max     = 3.4028234663852886e+38
+bpoly.c5.units   = ""
+bpoly.c5.frozen  = True
+
+bpoly.c4.default_val = 0.0
+bpoly.c4.default_min = -3.4028234663852886e+38
+bpoly.c4.default_max = 3.4028234663852886e+38
+bpoly.c4.val     = 0.0
+bpoly.c4.min     = -3.4028234663852886e+38
+bpoly.c4.max     = 3.4028234663852886e+38
+bpoly.c4.units   = ""
+bpoly.c4.frozen  = True
+
+
+
+######### Set Source, Pileup and Background Models
+
+set_source("bgrp", (xsphabs.ggal * powlaw1d.gpl))
+
+set_bkg_source("bgrp", (steplo1d.bstep + polynom1d.bpoly), bkg_id=1)
+
+
+######### XSPEC Module Settings
+
+set_xschatter(0)
+set_xsabund("lodd")
+set_xscosmo(72, 0.02, 0.71)
+set_xsxsect("vern")
+"""
+
+
+# The serialization of the user model is not ideal, but check that
+# we return something useful.
+#
+# This is also a good test of serializing data sets that was
+# created by load_arrays (currently not very well).
+#
+_canonical_usermodel = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_arrays(3,
+            [1.0, 12.2, 2.0, 14.0],
+            [4, 8, 12, 4],
+            Data1D)
+
+######### Set Image Coordinates
+
+
+######### Data Spectral Responses
+
+
+######### Load Background Data Sets
+
+
+######### Set Energy or Wave Units
+
+
+######### Filter Data
+
+notice_id(3, "1.0000:14.0000")
+
+
+######### Set Statistic
+
+set_stat("cash")
+
+
+######### Set Fitting Method
+
+set_method("neldermead")
+
+set_method_opt("iquad", 1)
+set_method_opt("initsimplex", 0)
+set_method_opt("verbose", 0)
+set_method_opt("step", None)
+set_method_opt("finalsimplex", 9)
+set_method_opt("maxfev", None)
+set_method_opt("ftol", 1.19209289551e-07)
+
+
+######### Set Model Components and Parameters
+
+create_model_component("sin", "sin_model")
+sin_model.integrate = True
+
+sin_model.ampl.default_val = 1.0
+sin_model.ampl.default_min = 1.0000000000000001e-05
+sin_model.ampl.default_max = 3.4028234663852886e+38
+sin_model.ampl.val     = 1.0
+sin_model.ampl.min     = 1.0000000000000001e-05
+sin_model.ampl.max     = 3.4028234663852886e+38
+sin_model.ampl.units   = ""
+sin_model.ampl.frozen  = False
+
+sin_model.period.default_val = 1.0
+sin_model.period.default_min = 1e-10
+sin_model.period.default_max = 10.0
+sin_model.period.val     = 1.0
+sin_model.period.min     = 1e-10
+sin_model.period.max     = 10.0
+sin_model.period.units   = ""
+sin_model.period.frozen  = False
+
+sin_model.offset.default_val = 0.0
+sin_model.offset.default_min = 0.0
+sin_model.offset.default_max = 3.4028234663852886e+38
+sin_model.offset.val     = 0.0
+sin_model.offset.min     = 0.0
+sin_model.offset.max     = 3.4028234663852886e+38
+sin_model.offset.units   = ""
+sin_model.offset.frozen  = False
+
+print("Found user model 'mymodel'; please check it is saved correctly.")
+def mymodel_func(pars, x, xhi=None):
+    return pars[0] + pars[1] * x
+
+load_user_model(mymodel_func, "mymodel")
+add_user_pars("mymodel",
+              parnames=['c', 'm'],
+              parvals=[2.0, 0.5],
+              parmins=[-10.0, 0.0],
+              parmaxs=[10.0, 5.5],
+              parunits=['m', ''],
+              parfrozen=[False, True]
+              )
+
+mymodel.integrate = True
+
+mymodel.c.default_val = 2.0
+mymodel.c.default_min = -3.4028234663852886e+38
+mymodel.c.default_max = 3.4028234663852886e+38
+mymodel.c.val     = 2.0
+mymodel.c.min     = -10.0
+mymodel.c.max     = 10.0
+mymodel.c.units   = "m"
+mymodel.c.frozen  = False
+
+mymodel.m.default_val = 0.5
+mymodel.m.default_min = -3.4028234663852886e+38
+mymodel.m.default_max = 3.4028234663852886e+38
+mymodel.m.val     = 0.5
+mymodel.m.min     = 0.0
+mymodel.m.max     = 5.5
+mymodel.m.units   = ""
+mymodel.m.frozen  = True
+
+
+
+######### Set Source, Pileup and Background Models
+
+set_source(3, (sin.sin_model + usermodel.mymodel))
+
+"""
+
+if has_xspec:
+    _canonical_extra = """
+######### XSPEC Module Settings
+
+set_xschatter(0)
+set_xsabund("angr")
+set_xscosmo(70, 0, 0.73)
+set_xsxsect("bcmc")
+"""
+
+else:
+    _canonical_extra = ""
+
+_canonical_empty += _canonical_extra
+_canonical_empty_stats += _canonical_extra
+_canonical_pha_basic += _canonical_extra
+_canonical_pha_grouped += _canonical_extra
+_canonical_usermodel += _canonical_extra
+
+def _dump_lines(cts):
+    """Dump outcts, an array of strings, to stdout, with line numbering"""
+    print("***\n")
+    for i, l in enumerate(cts):
+        print("{:02d} {}".format(i, l))
+    print("***\n")
+
+
+class test_ui(SherpaTestCase):
+
+    def setUp(self):
+        ui.clean()  # I thought the test harness did this anyway
+        self._old_logging_level = logger.level
+        logger.setLevel(logging.ERROR)
+        if has_xspec:
+            from sherpa.astro import xspec
+            self._xspec_state = xspec.get_xsstate()
+            ui.set_xschatter(0)
+
+    def tearDown(self):
+        logger.setLevel(self._old_logging_level)
+        if has_xspec:
+            from sherpa.astro import xspec
+            xspec.set_xsstate(self._xspec_state)
+
+        ui.clean()
+
+    def _add_datadir_path(self, output):
+        """Replace any @@ characters by the value of self.datadir,
+        making sure that the replacement text does not end in a /."""
+
+        dname = self.datadir
+        if dname.endswith('/'):
+            dname = dname[:-1]
+
+        return re.sub('@@', dname, output, count=0)
+
+    def _compare_lines(self, expected, got):
+        """Check that each line in got matches that in
+        expected. This is to provide a more-readable
+        set of error messages (may prefer a diff-style
+        analysis).
+        """
+
+        elines = expected.split('\n')
+        glines = got.split('\n')
+
+        # _dump_lines(elines)
+        # _dump_lines(glines)
+
+        for e, g in zip(elines, glines):
+            self.assertEqual(e, g)
+
+        # Do the line length after checking for the file
+        # contents as it is easier to see what the difference
+        # is this way around, since a difference in the
+        # number of lines is often not very informative.
+        self.assertEqual(len(elines), len(glines))
+
+    def _compare(self, expected):
+        """Run save_all and check the output (saved to a
+        StringIO object) to the string value expected.
+        """
+        output = StringIO.StringIO()
+        ui.save_all(outfh=output)
+        output = output.getvalue()
+        self._compare_lines(expected, output)
+
+    def _restore(self):
+        """Run save_all then call clean and try to restore
+        the Sherpa state from the saved file. Will raise
+        a test failure if there was an error when
+        executing the save file.
+        """
+
+        output = StringIO.StringIO()
+        ui.save_all(outfh=output)
+        output = output.getvalue()
+        ui.clean()
+        try:
+            exec(output)
+            success = True
+            e = "no exception"
+        except Exception as e:
+            success = False
+
+        self.assertTrue(success, msg="exception={}".format(e))
+
+    def _setup_pha_basic(self):
+        """Load up a PHA file and make "simple" changes to the
+        Sherpa state. Returns the name of the file that is
+        loaded and the canonical output.
+        """
+
+        ui.clean()
+        fname = self.make_path('threads', 'pha_intro', '3c273.pi')
+        ui.load_pha(1, fname)
+        ui.subtract()
+        ui.set_stat('chi2datavar')
+        ui.notice(0.5, 7)
+        ui.set_source(ui.xsphabs.gal * (ui.powlaw1d.pl +
+                                        ui.xsapec.src))
+        return fname, self._add_datadir_path(_canonical_pha_basic)
+
+    def _setup_pha_grouped(self):
+        """Add in grouping and a few different choices.
+
+        Returns the name of the file that is
+        loaded, the new grouping and quality arrays,
+        and the canonical output.
+        """
+
+        ui.clean()
+        fname = self.make_path('threads', 'pha_intro', '3c273.pi')
+        ui.load_pha('grp', fname)
+        channels = ui.get_data('grp').channel
+
+        exclude = (channels < 20) | (channels > 800)
+        qual = exclude * 1
+
+        ui.subtract('grp')
+        ui.group_counts('grp', 10, tabStops=exclude)
+        ui.set_quality('grp', exclude)
+
+        grp = ui.get_data('grp').grouping
+
+        ui.set_stat('chi2gehrels')
+        ui.notice_id('grp', 0.5, 6)
+        ui.set_source('grp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
+        gpl.gamma.max = 5
+        ui.set_par('ggal.nh', val=2.0, frozen=True)
+
+        return fname, (grp, qual), \
+            self._add_datadir_path(_canonical_pha_grouped)
+
+    def _setup_pha_back(self):
+        """Fit the background, rather than subtract it.
+        """
+
+        ui.clean()
+        fname = self.make_path('threads', 'pha_intro', '3c273.pi')
+        ui.load_pha('bgrp', fname)
+
+        # Note: do not group the source dataset
+
+        bchannels = ui.get_bkg('bgrp').channel
+
+        bexclude = (bchannels < 10) | (bchannels > 850)
+        bqual = bexclude * 1
+
+        ui.group_counts('bgrp', 10, tabStops=bexclude, bkg_id=1)
+        ui.set_quality('bgrp', bexclude, bkg_id=1)
+
+        bgrp = ui.get_bkg('bgrp').grouping
+
+        ui.set_stat('chi2xspecvar')
+
+        # This call sets the noticed range for both source and
+        # background data sets.
+        ui.notice_id('bgrp', 0.5, 6)
+
+        # Remove the "source" filter
+        ui.notice_id('bgrp', None, None, bkg_id=1)
+        ui.notice_id('bgrp', 2, 7, bkg_id=1)
+
+        ui.set_source('bgrp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
+        ui.set_bkg_source('bgrp', ui.steplo1d.bstep + ui.polynom1d.bpoly)
+
+        ui.set_xsabund('lodd')
+        ui.set_xsxsect('vern')
+        ui.set_xscosmo(72, 0.02, 0.71)
+
+        gpl.gamma.min = -5
+        ui.freeze(bpoly.c0)
+
+        ui.set_par('ggal.nh', val=2.0, frozen=True)
+
+        return fname, (bgrp, bqual), \
+            self._add_datadir_path(_canonical_pha_back)
+
+    def _setup_usermodel(self):
+        """Try a user model.
+        """
+
+        ui.clean()
+        # Note: array is not sorted on purpose, and float/int
+        # values.
+        ui.load_arrays(3, [1, 12.2, 2, 14], [4, 8, 12, 4])
+
+        def mymodel_func(pars, x, xhi=None):
+            return pars[0] + pars[1] * x
+
+        ui.load_user_model(mymodel_func, "mymodel")
+        ui.add_user_pars("mymodel",
+                         parnames=["c", "m"],
+                         parvals=[2, 0.5],
+                         parmins=[-10, 0],
+                         parmaxs=[10, 5.5],
+                         parunits=["m", ""],
+                         parfrozen=[False, True])
+
+        ui.set_source(3, ui.sin.sin_model + mymodel)
+
+        ui.set_stat('cash')
+        ui.set_method('simplex')
+
+    def test_restore_empty(self):
+        "Can the empty state be evaluated?"
+
+        ui.clean()
+
+        # At present the only check is that the file can be
+        # loaded.
+        self._restore()
+
+    def test_canonical_empty(self):
+        self._compare(_canonical_empty)
+
+    def test_canonical_empty_outfile(self):
+        tfile = tempfile.NamedTemporaryFile(suffix='.sherpa')
+        ui.save_all(tfile.name, clobber=True)
+        with open(tfile.name, 'r') as fh:
+            output = fh.read()
+        self._compare_lines(_canonical_empty, output)
+
+    def test_canonical_empty_stats(self):
+
+        ui.set_stat('leastsq')
+
+        ui.set_method('simplex')
+        ui.set_method_opt('maxfev', 5000)
+        ui.set_method_opt('verbose', 1)
+
+        self._compare(_canonical_empty_stats)
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @unittest.skipIf(not has_xspec, "xspec module is required")
+    def test_canonical_pha_basic(self):
+
+        _, canonical = self._setup_pha_basic()
+        self._compare(canonical)
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @unittest.skipIf(not has_xspec, "xspec module is required")
+    def test_restore_pha_basic(self):
+        "Can the state be evaluated?"
+
+        fname, _ = self._setup_pha_basic()
+        statval = ui.calc_stat()
+
+        self._restore()
+
+        self.assertEqual([1], ui.list_data_ids())
+        self.assertEqual(fname, ui.get_data(1).name)
+        self.assertTrue(ui.get_data().subtracted,
+                        msg='Data should be subtracted')
+
+        src_expr = ui.get_source()
+        self.assertEqual(src_expr.name,
+                         '(xsphabs.gal * (powlaw1d.pl + xsapec.src))')
+        self.assertEqual(gal.name, 'xsphabs.gal')
+        self.assertEqual(pl.name, 'powlaw1d.pl')
+        self.assertEqual(src.name, 'xsapec.src')
+
+        self.assertAlmostEqual(ui.calc_stat(), statval)
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @unittest.skipIf(not has_xspec, "xspec module is required")
+    def test_canonical_pha_grouped(self):
+
+        _, _, canonical = self._setup_pha_grouped()
+        self._compare(canonical)
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @unittest.skipIf(not has_xspec, "xspec module is required")
+    def test_restore_pha_grouped(self):
+        "Can the state be evaluated?"
+
+        fname, (grp, qual), _ = self._setup_pha_grouped()
+        statval = ui.calc_stat('grp')
+
+        self._restore()
+
+        self.assertEqual(['grp'], ui.list_data_ids())
+        self.assertEqual(fname, ui.get_data('grp').name)
+        self.assertTrue(ui.get_data('grp').subtracted,
+                        msg='Data should be subtracted')
+
+        g = ui.get_grouping('grp')
+        q = ui.get_quality('grp')
+        self.assertEqual(g.dtype, numpy.int16)
+        self.assertEqual(q.dtype, numpy.int16)
+
+        assert_array_equal(grp, g, err_msg='grouping column')
+        assert_array_equal(qual, q, err_msg='grouping column')
+
+        src_expr = ui.get_source('grp')
+        self.assertEqual(src_expr.name,
+                         '(xsphabs.ggal * powlaw1d.gpl)')
+        self.assertTrue(ggal.nh.frozen, msg="is ggal.nh frozen?")
+        self.assertEqual(ggal.nh.val, 2.0)
+        self.assertEqual(gpl.gamma.max, 5.0)
+
+        self.assertAlmostEqual(ui.calc_stat('grp'), statval)
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @unittest.skipIf(not has_xspec, "xspec module is required")
+    def test_canonical_pha_back(self):
+
+        _, _, canonical = self._setup_pha_back()
+        self._compare(canonical)
+
+    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @unittest.skipIf(not has_xspec, "xspec module is required")
+    def test_restore_pha_back(self):
+        "Can the state be evaluated?"
+
+        fname, (bgrp, bqual), _ = self._setup_pha_back()
+        statval = ui.calc_stat('bgrp')
+
+        # At present the model is not saved correctly for the
+        # background component - it includes apply_arf/rmf
+        # statements - which means that running the saved script
+        # results in an error.
+        self._restore()
+
+        self.assertEqual(['bgrp'], ui.list_data_ids())
+        self.assertEqual(fname, ui.get_data('bgrp').name)
+        self.assertFalse(ui.get_data('bgrp').subtracted,
+                         msg='Data should not be subtracted')
+        self.assertFalse(ui.get_bkg('bgrp').subtracted,
+                         msg='Background should not be subtracted')
+
+        # TODO: at present the source is grouped; is this "correct"?
+        # self.assertFalse(ui.get_data('bgrp').grouped,
+        #                  msg='Data should not be grouped')
+        self.assertTrue(ui.get_data('bgrp').grouped,
+                        msg='Data should be grouped')  # FIXME?
+        self.assertTrue(ui.get_bkg('bgrp').grouped,
+                        msg='Background should be grouped')
+
+        # g = ui.get_grouping('bgrp')
+        # q = ui.get_quality('bgrp')
+        # The data types are '>i2' / int16
+        # self.assertEqual(g.dtype, numpy.int16)
+        # self.assertEqual(q.dtype, numpy.int16)
+
+        # TODO set up correct grouping bins...
+        # nchan = ui.get_data('bgrp').channel.size
+        # assert_array_equal(g, numpy.ones(nchan), err_msg='src grouping')
+        # assert_array_equal(q, numpy.zeros(nchan), err_msg='src quality')
+
+        bg = ui.get_grouping('bgrp', bkg_id=1)
+        bq = ui.get_quality('bgrp', bkg_id=1)
+        self.assertEqual(bg.dtype, numpy.int16)
+        self.assertEqual(bq.dtype, numpy.int16)
+
+        assert_array_equal(bg, bgrp, err_msg='bgnd grouping')
+        assert_array_equal(bq, bqual, err_msg='bgnd quality')
+
+        # TODO: check noticed range
+
+        src_expr = ui.get_source('bgrp')
+        self.assertEqual(src_expr.name,
+                         '(xsphabs.ggal * powlaw1d.gpl)')
+
+        bg_expr = ui.get_bkg_source('bgrp')
+        self.assertEqual(bg_expr.name,
+                         '(steplo1d.bstep + polynom1d.bpoly)')
+
+        self.assertTrue(ggal.nh.frozen, msg="is ggal.nh frozen?")
+        self.assertTrue(bpoly.c0.frozen, msg="is bpoly.c0 frozen?")
+        self.assertEqual(ggal.nh.val, 2.0)
+        self.assertEqual(gpl.gamma.min, -5.0)
+
+        self.assertEqual(ui.get_xsabund(), 'lodd')
+        self.assertEqual(ui.get_xsxsect(), 'vern')
+        cosmo = ui.get_xscosmo()
+        self.assertAlmostEqual(cosmo[0], 72.0)
+        self.assertAlmostEqual(cosmo[1], 0.02)
+        self.assertAlmostEqual(cosmo[2], 0.71)
+
+        self.assertAlmostEqual(ui.calc_stat('bgrp'), statval)
+
+    def test_canonical_usermodel(self):
+
+        self._setup_usermodel()
+        self._compare(_canonical_usermodel)
+
+    def test_restore_usermodel(self):
+        "Can the state be evaluated?"
+
+        self._setup_usermodel()
+        statval = ui.calc_stat(3)
+        self._restore()
+
+        # TODO: For the moment the source expression is created, in
+        # the serialized form, using set_full_model. This should
+        # be changed so that get_source can be used below.
+        #
+        # src_expr = ui.get_source(3)
+        src_expr = ui.get_model(3)
+        self.assertEqual(src_expr.name,
+                         '(sin.sin_model + usermodel.mymodel)')
+        self.assertTrue(mymodel.m.frozen, msg="is mymodel.m frozen?")
+        self.assertEqual(mymodel.c.val, 2.0)
+        self.assertEqual(mymodel.c.units, "m")
+        self.assertEqual(mymodel.m.max, 5.5)
+        self.assertEqual(mymodel.m.units, "")
+
+        self.assertEqual(ui.calc_stat(3), statval)
+
+if __name__ == '__main__':
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -812,13 +812,6 @@ _canonical_pha_basic += _canonical_extra
 _canonical_pha_grouped += _canonical_extra
 _canonical_usermodel += _canonical_extra
 
-def _dump_lines(cts):
-    """Dump outcts, an array of strings, to stdout, with line numbering"""
-    print("***\n")
-    for i, l in enumerate(cts):
-        print("{:02d} {}".format(i, l))
-    print("***\n")
-
 
 class test_ui(SherpaTestCase):
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -849,6 +849,10 @@ class test_ui(SherpaTestCase):
 
         return re.sub('@@', dname, output, count=0)
 
+    def _compile(self, output):
+        # Let it just throw an exception in case of failure.
+        compile(output, "test.py", "exec")
+
     def _compare_lines(self, expected, got):
         """Check that each line in got matches that in
         expected. This is to provide a more-readable
@@ -878,6 +882,12 @@ class test_ui(SherpaTestCase):
         output = StringIO.StringIO()
         ui.save_all(outfh=output)
         output = output.getvalue()
+
+        # check the output is a valid Python program.
+        # this check does not guard against potential issues,
+        # but ensures that the program can compile.
+        self._compile(output)
+
         self._compare_lines(expected, output)
 
     def _restore(self):
@@ -1017,6 +1027,13 @@ class test_ui(SherpaTestCase):
 
         ui.set_stat('cash')
         ui.set_method('simplex')
+
+    def test_compile_failure(self):
+        try:
+            self._compile("foo bar")
+        except:
+            return
+        self.fail("Compilation should have failed")
 
     def test_restore_empty(self):
         "Can the empty state be evaluated?"

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -944,7 +944,7 @@ class test_ui(SherpaTestCase):
         ui.set_stat('chi2gehrels')
         ui.notice_id('grp', 0.5, 6)
         ui.set_source('grp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
-        gpl.gamma.max = 5
+        ui.powlaw1d.gpl.gamma.max = 5
         ui.set_par('ggal.nh', val=2.0, frozen=True)
 
         return fname, (grp, qual), \
@@ -987,8 +987,8 @@ class test_ui(SherpaTestCase):
         ui.set_xsxsect('vern')
         ui.set_xscosmo(72, 0.02, 0.71)
 
-        gpl.gamma.min = -5
-        ui.freeze(bpoly.c0)
+        ui.powlaw1d.gpl.gamma.min = -5
+        ui.freeze(ui.polynom1d.bpoly.c0)
 
         ui.set_par('ggal.nh', val=2.0, frozen=True)
 
@@ -1016,6 +1016,7 @@ class test_ui(SherpaTestCase):
                          parunits=["m", ""],
                          parfrozen=[False, True])
 
+        mymodel = ui.get_model_component("mymodel")
         ui.set_source(3, ui.sin.sin_model + mymodel)
 
         ui.set_stat('cash')
@@ -1082,9 +1083,9 @@ class test_ui(SherpaTestCase):
         src_expr = ui.get_source()
         self.assertEqual(src_expr.name,
                          '(xsphabs.gal * (powlaw1d.pl + xsapec.src))')
-        self.assertEqual(gal.name, 'xsphabs.gal')
-        self.assertEqual(pl.name, 'powlaw1d.pl')
-        self.assertEqual(src.name, 'xsapec.src')
+        self.assertEqual(ui.xsphabs.gal.name, 'xsphabs.gal')
+        self.assertEqual(ui.powlaw1d.pl.name, 'powlaw1d.pl')
+        self.assertEqual(ui.xsapec.src.name, 'xsapec.src')
 
         self.assertAlmostEqual(ui.calc_stat(), statval)
 
@@ -1121,9 +1122,9 @@ class test_ui(SherpaTestCase):
         src_expr = ui.get_source('grp')
         self.assertEqual(src_expr.name,
                          '(xsphabs.ggal * powlaw1d.gpl)')
-        self.assertTrue(ggal.nh.frozen, msg="is ggal.nh frozen?")
-        self.assertEqual(ggal.nh.val, 2.0)
-        self.assertEqual(gpl.gamma.max, 5.0)
+        self.assertTrue(ui.xsphabs.ggal.nh.frozen, msg="is ggal.nh frozen?")
+        self.assertEqual(ui.xsphabs.ggal.nh.val, 2.0)
+        self.assertEqual(ui.powlaw1d.gpl.gamma.max, 5.0)
 
         self.assertAlmostEqual(ui.calc_stat('grp'), statval)
 
@@ -1192,10 +1193,10 @@ class test_ui(SherpaTestCase):
         self.assertEqual(bg_expr.name,
                          '(steplo1d.bstep + polynom1d.bpoly)')
 
-        self.assertTrue(ggal.nh.frozen, msg="is ggal.nh frozen?")
-        self.assertTrue(bpoly.c0.frozen, msg="is bpoly.c0 frozen?")
-        self.assertEqual(ggal.nh.val, 2.0)
-        self.assertEqual(gpl.gamma.min, -5.0)
+        self.assertTrue(ui.xsphabs.ggal.nh.frozen, msg="is ggal.nh frozen?")
+        self.assertTrue(ui.polynom1d.bpoly.c0.frozen, msg="is bpoly.c0 frozen?")
+        self.assertEqual(ui.xsphabs.ggal.nh.val, 2.0)
+        self.assertEqual(ui.powlaw1d.gpl.gamma.min, -5.0)
 
         self.assertEqual(ui.get_xsabund(), 'lodd')
         self.assertEqual(ui.get_xsxsect(), 'vern')
@@ -1226,6 +1227,7 @@ class test_ui(SherpaTestCase):
         src_expr = ui.get_model(3)
         self.assertEqual(src_expr.name,
                          '(sin.sin_model + usermodel.mymodel)')
+        mymodel = ui.get_model_component("mymodel")
         self.assertTrue(mymodel.m.frozen, msg="is mymodel.m frozen?")
         self.assertEqual(mymodel.c.val, 2.0)
         self.assertEqual(mymodel.c.units, "m")

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12368,7 +12368,7 @@ class Session(sherpa.ui.utils.Session):
     # Session Text Save Function
     ###########################################################################
 
-    def save_all(self, outfile=None, clobber=False, outfh=None):
+    def save_all(self, outfile=None, clobber=False):
         """Save the information about the current session to a text file.
 
         This differs to the `save` command in that the output is human
@@ -12382,20 +12382,18 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        outfile : str, optional
+        outfile : str or file-like, optional
            If given, the output is written to this file, and the
            ``clobber`` parameter controls what happens if the
-           file already exists. If not given, then the
-           ``outfh`` parameter is used.
+           file already exists.
+           ``outfile`` can be a filename string or a file handle
+           (or file-like object, such as ``StringIO``) to write
+           to. If not set then the standard output is used.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If ``outfile`` is a filename, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
-        outfh : file-like, optional
-           If ``outfile`` is ``None`` then this is the file handle
-           (or file-like object, such as ``StringIO``) to write
-           to. If not set then the standard output is used.
 
         Raises
         ------
@@ -12441,7 +12439,7 @@ class Session(sherpa.ui.utils.Session):
 
         >>> import StringIO
         >>> store = StringIO.StringIO()
-        >>> save_all(outfh=store)
+        >>> save_all(store)
 
         """
 
@@ -12455,12 +12453,9 @@ class Session(sherpa.ui.utils.Session):
             with open(outfile, 'w') as fh:
                 serialize.save_all(self, fh)
 
-        elif outfile is not None:
-            raise ArgumentTypeErr('badarg', 'string or None')
-
         else:
-            if outfh is not None:
-                fh = outfh
+            if outfile is not None:
+                fh = outfile
             else:
                 fh = sys.stdout
 


### PR DESCRIPTION
# Note

This PR replaces #98.

[OL] I squashed the commit history into one single commit after rebasing. This seems to make sense as the whole change, however large, is rather atomic:
  * move serialization code to its own module (+ refactor and add docstrings)
  * add tests for the serialization code
  * include a file handler as a possible argument for save_all, as per tests

The one change that does not seem so atomic is the one to `test_astro.py`. It is not clear why this change is required in the first place, and it might imply that something is wrong with the skipping of `xspec` tests. I'll keep looking into it.

# Release Notes
[release note]
This commit fixes and enhances the output of the `save_all` command. 

User-visible changes:

- added a new argument to `save_all`: if `outfile` is `None` then the `outfh` argument is used 
  to define the output handle (the argument can be any file-like argument, such as a file
  handle like `sys.stdout` or the output of `open`, or a `StringIO` object)
- setting the `clobber` argument to `save_all` now means that the output file (the `outfile`
  argument, if not `None`) is deleted if it already exists; prior to this, the file would be
  appended to instead
- the source expression is now saved correctly for most cases (e.g. when not using
  `set_full_model`); this is bug #97 but also affects non-PHA data sets
- the background model expression was not always written out correctly when using PHA
  data sets
- quality and grouping arrays of PHA data sets are now stored as 16-byte integers rather
  than a floating-point value (this has no affect on the results, but matches the OGIP standard)
- fixed up saving the grouping and quality arrays of background PHA data sets (this would only
  be an issue if the background is being fit, rather than subtracted)
- basic data sets created with the `load_arrays` function are now written out by `save_all`
  as part of the script; this is intended for small datasets and may have problems with
  precision if used with floating-point arrays
- calls to `load_psf` are now correctly restored (they may not have been written out correctly
  if multiple data sets were loaded)
- user models are now written out to disk; this consists of two parts:
  - writing out the function that defines the model, which may or may not be possible (if
    not, a place-holder function is added to the output and a warning displayed).
  - the necessary calls to `load_user_model` and `add_user_pars` are now included in
    the output
- the Python code created by `save` all has undergone several minor changes:
  - it now explicitly imports the `sherpa.astro.ui` module, so that it can be run from the
    IPython prompt using the `%run <filename>` command, or directly as `python <filename>`
  - it uses the `create_model_component` function rather than `eval` to create model
    components (this is CXC bug 12146)
  - many optional arguments to functions are now given as `name=value` rather than
    being a positional argument, to make it clearer what the script is doing.
  - calls to `load_data` have been replaced by more-specific versions - e.g. `load_pha`
    and `load_image` - if appropriate
  - there have seen several minor syntactic clean ups to better follow the suggestions from PEP8 

When writing out code that defines a user-model, there is no attempt to make sure that
modules used by the function are available. These will need to be added, either directly
or imported, manually to the output.
[/]

Internal changes:

- adds a test suite; this requires a small change to the `test_astro.py` test script just to make
  sure that the default XSPEC settings are restored on test tear-down (to avoid the new tests
  from failing). The test suite covers some of the basic situations expected to be served by
  `save_all` - such as basic arrays, PHA datasets - but does not cover all functionality
- moves the code out to `sherpa/astro/ui/serialize.py` from `sherpa/astro/ui/utils.py`, as the
  latter is rather large
- code has been refactored to promote sharing and improve readability
- code has seen PEP 8 fixes and other simplifications, such as:
  - replace `x == True` and `y == False` by `x` and `not y`
  - remove extra brackets in conditionals
  - use `isinstance(x, basestring)` rather than `type(x) == str`, which has been a problem for
    other parts of the Sherpa UI when given a string stored in a numpy array (since these
    aren't treated as `str` but do match the `isinstance` check)

#  Notes

The test suite has only been tested on one machine. It is likely that it will need changing to account for running on different configurations (in particular 32 vs 64 bit or different OS values); in particular, the regression tests that ensure the textual output is correct may need updating to allow numerical differences or changed to a different approach.

**ADDED NOTE** the tests include regression tests, where the output is compared against an expected string. These strings are currently stored within `test_serialize.py` itself, but it may make sense to move them into the `sherpa-test-data` repository, once the patch has been accepted (and the approach vindicated by more testing, to make sure it's worth approach).

Not all functionality is tested - e.g. serializing sessions that use image data, or an iterative fit, or more corner cases in various options. This set of changes is large enough as is, and significantly improves the overall coverage of Sherpa (from around 50% to 55%) that I think it's worth looking at now. The coverage of `serialize.py` is 68% (when the equivalent before this PR was 0% for the code that is now in `serialize.py`).

A lot of the logic in `serialize.py` should really be moved into the classes, so that rather than this code being changed whenever a new statistic needs to be serialized (say), the object itself can be queried. I'm wondering about a `Serializable` class which could be imported from to provide a `serialize` method (names open to discussion), or if not a class, just make sure that each object we want to serialize provides a method. This is way outside the scope of this PR, but some of the refactoring done in this PR was done to highlight places where this would be useful.

# Example

With the following code

```
from sherpa.astro import ui
ui.load_arrays(1, [1,2,3], [5,6,7])
ui.set_source(ui.const1d.m1)
```

the difference in the output of `save_all` from CIAO 4.7 (`out.ciao47`, which is what `master` gives) and this PR (`out.pr98`) is:

```
% diff out.ciao47 out.pr98 
1a2
> from sherpa.astro.ui import *
5c6,9
< load_data(1,"")
---
> load_arrays(1,
>             [1, 2, 3],
>             [5, 6, 7],
>             Data1D)
7c11
< ######### Set Image Coordinates 
---
> ######### Set Image Coordinates
21c25
< notice_id(1,"1.0000:3.0000")
---
> notice_id(1, "1.0000:3.0000")
44c48
< eval("const1d.m1")
---
> create_model_component("const1d", "m1")
60c64
< set_full_model(1, const1d.m1)
---
> set_source(1, const1d.m1)
```

which shows several of the enhancements and bug fixes, namely:

- import of the `sherpa.astro.ui` module
- simple datasets created by `load_arrays` are now written out to file
- `create_model_component` is used rather than `eval`
- the source model is written out correctly (using `set_source` and not `set_full_model`)
