### PR TITLE
enable ds9 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ matrix:
       python: "2.7"
       sudo: required
       dist: trusty
-#      addons:
-#        apt:
-#          packages:
-#            - *default_apt
-#            - [libwcs4 wcslib-dev libx11-dev tcl]
     - env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "2.7"
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5
@@ -63,6 +58,18 @@ before_install:
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;
      git submodule deinit -f .;
+    fi
+  - if [ -n "${XSPEC}" ];
+     then DS9_SITE=http://ds9.si.edu/download/linux64/;
+     XPA_SITE=http://ds9.si.edu/download/linux64_5/;
+     DS9_TAR=ds9.linux64.7.3.2.tar.gz;
+     XPA_TAR=xpa.linux64_5.2.1.14.tar.gz;
+     wget $DS9_SITE$DS9_TAR;
+     wget $XPA_SITE$XPA_TAR;
+     THIS_DIR=`pwd`;
+     cd $MINICONDA/bin; tar xf $THIS_DIR/$DS9_TAR; tar xf $THIS_DIR/$XPA_TAR; cd -;
+     export DISPLAY=:99;
+     /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16;
     fi
   - if [ -n "${XSPEC}" ];
      then sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -51,67 +51,64 @@ def get_arr_from_imager(im):
     return data_out
 
 class test_image(SherpaTestCase):
-    if (os.environ.has_key("DISPLAY") == True):
-        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                         "required package sherpa.image.ds9_backend not available")
-        def test_ds9(self):
-            im = sherpa.image.ds9_backend.DS9.DS9Win(sherpa.image.ds9_backend.DS9._DefTemplate, False)
-            im.doOpen()
-            im.showArray(data.y)
-            data_out = get_arr_from_imager(im)
-            im.xpaset("quit") 
-            self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                     "required package sherpa.image.ds9_backend not available")
+    def test_ds9(self):
+        im = sherpa.image.ds9_backend.DS9.DS9Win(sherpa.image.ds9_backend.DS9._DefTemplate, False)
+        im.doOpen()
+        im.showArray(data.y)
+        data_out = get_arr_from_imager(im)
+        im.xpaset("quit")
+        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                         "required package sherpa.image.ds9_backend not available")
-        def test_image(self):
-            im = Image()
-            im.image(data.y)
-            data_out = get_arr_from_imager(im)
-            im.xpaset("quit") 
-            self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                     "required package sherpa.image.ds9_backend not available")
+    def test_image(self):
+        im = Image()
+        im.image(data.y)
+        data_out = get_arr_from_imager(im)
+        im.xpaset("quit")
+        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                         "required package sherpa.image.ds9_backend not available")
-        def test_data_image(self):
-            im = DataImage()
-            im.prepare_image(data)
-            im.image()
-            data_out = get_arr_from_imager(im)
-            im.xpaset("quit") 
-            self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                     "required package sherpa.image.ds9_backend not available")
+    def test_data_image(self):
+        im = DataImage()
+        im.prepare_image(data)
+        im.image()
+        data_out = get_arr_from_imager(im)
+        im.xpaset("quit")
+        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                         "required package sherpa.image.ds9_backend not available")
-        def test_model_image(self):
-            im = ModelImage()
-            im.prepare_image(data, 1)
-            im.image()
-            data_out = get_arr_from_imager(im)
-            im.xpaset("quit") 
-            self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                     "required package sherpa.image.ds9_backend not available")
+    def test_model_image(self):
+        im = ModelImage()
+        im.prepare_image(data, 1)
+        im.image()
+        data_out = get_arr_from_imager(im)
+        im.xpaset("quit")
+        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                         "required package sherpa.image.ds9_backend not available")
-        def test_ratio_image(self):
-            im = RatioImage()
-            im.prepare_image(data, 1)
-            im.image()
-            data_out = get_arr_from_imager(im)
-            im.xpaset("quit") 
-            # The sum is 99, because the first model pixel
-            # will be zero, and therefore the ratio function
-            # reassigns the ratio there to be one.
-            self.assertEqualWithinTol(data_out.sum(), 99.0, 1e-4)
+    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                     "required package sherpa.image.ds9_backend not available")
+    def test_ratio_image(self):
+        im = RatioImage()
+        im.prepare_image(data, 1)
+        im.image()
+        data_out = get_arr_from_imager(im)
+        im.xpaset("quit")
+        # The sum is 99, because the first model pixel
+        # will be zero, and therefore the ratio function
+        # reassigns the ratio there to be one.
+        self.assertEqualWithinTol(data_out.sum(), 99.0, 1e-4)
 
-        @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                         "required package sherpa.image.ds9_backend not available")
-        def test_resid_image(self):
-            im = ResidImage()
-            im.prepare_image(data, 1)
-            im.image()
-            data_out = get_arr_from_imager(im)
-            im.xpaset("quit") 
-            self.assertEqualWithinTol(data_out.sum(), 0.0, 1e-4)
-    else:
-        pass
+    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
+                     "required package sherpa.image.ds9_backend not available")
+    def test_resid_image(self):
+        im = ResidImage()
+        im.prepare_image(data, 1)
+        im.image()
+        data_out = get_arr_from_imager(im)
+        im.xpaset("quit")
+        self.assertEqualWithinTol(data_out.sum(), 0.0, 1e-4)


### PR DESCRIPTION
This PR enables tests depending on DS9 to run on Travis CI. Also, tests are not silently skipped on headless systems (or wherever the `DISPLAY` env variable is unset).