### PR TITLE
Tests cleanup

### DIFF
--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -22,7 +22,7 @@ from sherpa.utils import SherpaTestCase
 import os
 import sys
 import unittest
-from sherpa.utils import has_fits_support
+from sherpa.utils import requires_fits
 from sherpa.astro import ui
 from sherpa.astro import datastack
 from acis_bkg_model import acis_bkg_model
@@ -49,8 +49,7 @@ class test_design(SherpaTestCase):
         datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
+    @requires_fits
     def test_case_1(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, '3c273.lis'))
@@ -276,8 +275,7 @@ class test_load(SherpaTestCase):
         datastack.set_stack_verbose(False)
         logger.setLevel(self.loggingLevel)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
+    @requires_fits
     def test_case_3(self):
         datastack.load_ascii("@{}".format(self.lisname))
         assert len(ui._session._data) == 2
@@ -597,8 +595,7 @@ class test_pha(SherpaTestCase):
         datastack.set_template_id("__ID")
         logger.setLevel(self.loggingLevel)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
+    @requires_fits
     def test_case_6(self):
         datadir = '/'.join((self._this_dir, 'data'))
         ls = '@'+'/'.join((datadir, 'pha.lis'))
@@ -668,8 +665,7 @@ class test_query(SherpaTestCase):
         datastack.set_stack_verbose(False)
         logger.setLevel(self.loggingLevel)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
+    @requires_fits
     def test_case_7(self):
         datastack.load_pha('@'+'/'.join((self._this_dir, 'data', 'pha.lis')))
 

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, has_fits_support, has_package_from_list, test_data_missing
+from sherpa.utils import SherpaTestCase, requires_data, requires_fits, requires_xspec
 from sherpa.astro import ui
 
 from unittest import skipIf
@@ -29,16 +29,16 @@ class test_89_issues(SherpaTestCase):
     def setUp(self):
         ui.clean()
 
-    @skipIf(not has_package_from_list("sherpa.astro.xspec"), "xspec required")
-    @skipIf(not has_fits_support(), "fits support required")
-    @skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
+    @requires_xspec
     def test_mod_fits(self):
         tablemodelfile = self.make_path("xspec", "tablemodel", "RCS.mod")
         ui.load_table_model("tmod", tablemodelfile)
         tmod = ui.get_model_component("tmod")
         self.assertEqual("xstablemodel.tmod", tmod.name)
 
-    @skipIf(not has_package_from_list("sherpa.astro.io.pyfits_backend"), "this is a pyfits/astropy test")
+    @requires_fits
     def test_warnings_are_gone_arrays(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -49,8 +49,8 @@ class test_89_issues(SherpaTestCase):
                 ui.save_data(1, f.name, ascii=False, clobber=True)
             assert len(w) == 0
 
-    @skipIf(not has_package_from_list("sherpa.astro.io.pyfits_backend"), "this is a pyfits/astropy test")
-    @skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_data
     def test_warnings_are_gone_pha(self):
         pha = self.make_path("threads", "pha_intro", "3c273.pi")
         with warnings.catch_warnings(record=True) as w:

--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -19,8 +19,8 @@
 
 import unittest
 import logging
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
-from sherpa.utils import has_package_from_list, has_fits_support
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.utils import requires_data, requires_fits, requires_xspec
 from sherpa.astro import sim
 
 from sherpa.astro.instrument import Response1D
@@ -34,10 +34,8 @@ logger = logging.getLogger('sherpa')
 
 class test_sim(SherpaTestCase):
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                     "required sherpa.astro.xspec module missing")
+    @requires_fits
+    @requires_xspec
     def setUp(self):
         try:
             from sherpa.astro.io import read_pha
@@ -71,9 +69,8 @@ class test_sim(SherpaTestCase):
         if hasattr(self, 'old_level'):
             logger.setLevel(self.old_level)
 
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_xspec
+    @requires_data
     def test_pragbayes_simarf(self):
         mcmc = sim.MCMC()
 
@@ -98,9 +95,8 @@ class test_sim(SherpaTestCase):
         #     print 'param: ', str(params.std(1))
         #     raise
 
-    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_xspec
+    @requires_data
     def test_pragbayes_pcaarf(self):
         mcmc = sim.MCMC()
 

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -21,10 +21,9 @@ import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTestCase, test_data_missing
-# from sherpa.utils import has_package_from_list, has_fits_support
-from sherpa.utils import has_fits_support
-from sherpa.astro import ui
+from sherpa.utils import SherpaTestCase
+from sherpa.utils import requires_data, requires_fits, requires_xspec
+import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
 
 logger = logging.getLogger('sherpa')
@@ -37,6 +36,7 @@ except ImportError:
 
 # has_xspec = has_package_from_list("sherpa.astro.xspec")
 
+@requires_data
 class test_threads(SherpaTestCase):
 
     def setUp(self):
@@ -75,11 +75,9 @@ class test_threads(SherpaTestCase):
         os.chdir(self.make_path('ciao4.3', name))
         execfile(scriptname, {}, self.locals)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+
+    @requires_fits
+    @requires_xspec
     def test_pha_intro(self):
         self.run_thread('pha_intro')
         # astro.ui imported as ui, instead of
@@ -105,16 +103,12 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints,44)
         self.assertEqual(ui.get_fit_results().dof,42)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_pha_read(self):
         self.run_thread('pha_read')
         self.assertEqual(type(ui.get_data()), DataPHA)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_basic(self):
         # In data1.dat for this test, there is a comment with one
         # word at the beginning -- deliberately would break when reading
@@ -134,11 +128,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 11)
         self.assertEqual(ui.get_fit_results().dof, 9)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_simultaneous(self):
         self.run_thread('simultaneous')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 7.4429, 1e-4)
@@ -151,11 +142,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 18)
         self.assertEqual(ui.get_fit_results().dof, 14)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_sourceandbg(self):
         self.run_thread('sourceandbg')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 947.5, 1e-4)
@@ -169,9 +157,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 1330)
         self.assertEqual(ui.get_fit_results().dof, 1325)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_spatial(self):
         self.run_thread('spatial')
         self.assertEqualWithinTol(ui.get_fit_results().statval, -59229.749441, 1e-4)
@@ -187,11 +173,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 4881)
         self.assertEqual(ui.get_fit_results().dof, 4877)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_pileup(self):
         self.run_thread('pileup')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 53.6112, 1e-4)
@@ -205,9 +188,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 42)
         self.assertEqual(ui.get_fit_results().dof, 37)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_radpro(self):
         self.run_thread('radpro')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 217.450, 1e-4)
@@ -221,7 +202,6 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 38)
         self.assertEqual(ui.get_fit_results().dof, 35)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_radpro_dm(self):
         # This test is completely redundant to test_radpro above.
         # The only difference is that here I test if using DM syntax
@@ -242,9 +222,7 @@ class test_threads(SherpaTestCase):
             self.assertEqual(ui.get_fit_results().numpoints, 38)
             self.assertEqual(ui.get_fit_results().dof, 35)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_psf2d(self):
         self.run_thread('psf')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 4066.78, 1e-4)
@@ -256,9 +234,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 4899)
         self.assertEqual(ui.get_fit_results().dof, 4895)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_fpsf2d(self):
         self.run_thread('fpsf')
         self.assertEqualWithinTol(ui.get_fit_results().statval, -4053.6635, 1e-4)
@@ -275,9 +251,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 4899)
         self.assertEqual(ui.get_fit_results().dof, 4895)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_radpro_psf(self):
         self.run_thread('radpro_psf')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 200.949, 1e-4)
@@ -288,9 +262,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 38)
         self.assertEqual(ui.get_fit_results().dof, 35)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_linepro(self):
         self.run_thread('linepro')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 203.34, 1e-4)
@@ -301,9 +273,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 75)
         self.assertEqual(ui.get_fit_results().dof, 72)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_kernel(self):
         self.run_thread('kernel')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 98.5793, 1e-4)
@@ -314,11 +284,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 75)
         self.assertEqual(ui.get_fit_results().dof, 72)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_spectrum(self):
         self.run_thread('spectrum')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 0.0496819, 1e-4)
@@ -330,9 +297,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 446)
         self.assertEqual(ui.get_fit_results().dof, 441)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_histo(self):
         self.run_thread('histo')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 14.7264, 1e-4)
@@ -343,11 +308,8 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 50)
         self.assertEqual(ui.get_fit_results().dof, 47)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_xmm(self):
         self.run_thread('xmm')
         self.assertEqualWithinTol(ui.get_fit_results().statval, 118.085, 1e-4)
@@ -358,9 +320,7 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 162)
         self.assertEqual(ui.get_fit_results().dof, 159)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     # As of CIAO 4.5, can filter on channel number, even when
     # data are grouped! Test results should exactly match CIAO 4.4
     # fit results in grouped/fit.py
@@ -371,11 +331,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.83906, 1e-4)
         self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000301258, 1e-4)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_proj(self):
         self.run_thread('proj')
         # Fit 1
@@ -446,11 +403,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['proj_res2'].parmaxes[2],
                                   0.0981627, 1e-2)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_proj_bubble(self):
         self.run_thread('proj_bubble')
         # Fit -- Results from reminimize
@@ -479,11 +433,8 @@ class test_threads(SherpaTestCase):
 
     # New tests based on SDS threads -- we should catch these errors
     # (if any occur) so SDS doesn't waste time tripping over them.
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_counts(self):
         self.run_thread('counts')
         self.assertEqualWithinTol(self.locals['counts_data1'], 52701.0, 1e-4)
@@ -494,11 +445,8 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['eflux2'], 1.39662954483e-08, 1e-3)
         self.assertEqualWithinTol(self.locals['pflux1'], 1.6178938637, 1e-2)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_stats_all(self):
         self.run_thread('stats_all')
         self.assertEqualWithinTol(self.locals['stat_lsqr'],213746.236464,1e-4)
@@ -510,9 +458,7 @@ class test_threads(SherpaTestCase):
         self.assertEqualWithinTol(self.locals['stat_chi2x'],1204.69363458,1e-4)
         self.assertEqualWithinTol(self.locals['stat_cstat'],1210.56896183,1e-4)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_lev3fft(self):
         self.run_thread('lev3fft', scriptname='bar.py')
         self.assertEqualWithinTol(self.locals['src'].fwhm.val, 0.04418584, 1e-4)
@@ -525,25 +471,17 @@ class test_threads(SherpaTestCase):
         self.assertEqual(ui.get_fit_results().numpoints, 3307)
         self.assertEqual(ui.get_fit_results().dof, 3302)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_setfullmodel(self):
         self.run_thread('setfullmodel')
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
     def test_bug13537(self):
         self.run_thread('bug13537')
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(not has_xspec,
-                     "required sherpa.astro.xspec module missing")
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_fits
+    @requires_xspec
     def test_xmm2(self):
         self.run_thread('xmm2')
         self.assertEqualWithinTol(ui.get_data().channel[0], 1.0, 1e-4)

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -16,12 +16,13 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
-import unittest
-from sherpa.utils import SherpaTestCase, test_data_missing
+import numpy
+from sherpa.utils import SherpaTestCase
 from sherpa.astro.data import DataPHA
-from sherpa.all import *
-from sherpa.astro.all import *
+from sherpa.astro.plot import SourcePlot
+from sherpa.models.basic import PowLaw1D
+from sherpa.astro.optical import AbsorptionGaussian
+
 import logging
 logger = logging.getLogger('sherpa')
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -17,11 +17,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
+import numpy
 from sherpa.astro.data import DataPHA
-from sherpa.utils import SherpaTestCase, test_data_missing
-from sherpa.all import *
-from sherpa.astro.all import *
+from sherpa.utils import SherpaTestCase
+
 import logging
 logger = logging.getLogger('sherpa')
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -68,15 +68,6 @@ class test_ui(SherpaTestCase):
         ui.load_table(1, self.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
                       ui.Data1DInt)
 
-    def test_load_table_fits(self):
-        # QUS: why is this not in the sherpa-test-data repository?
-        this_dir = os.path.dirname(os.path.abspath(__file__))
-        ui.load_table(1, os.path.join(this_dir, 'data',
-                                      'two_column_x_y.fits.gz'))
-        data = ui.get_data(1)
-        self.assertEqualWithinTol(data.x, [1, 2, 3])
-        self.assertEqualWithinTol(data.y, [4, 5, 6])
-
     # Test table model
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.singledat)
@@ -522,6 +513,21 @@ class test_save_pha(SherpaTestCase):
             oldval = getattr(self._pha, key)
             self.assertEqual(oldval, newval, msg=key)
         """
+
+
+@requires_fits
+class test_basic_io(SherpaTestCase):
+    def setUp(self):
+        ui.clean()
+
+    def test_load_table_fits(self):
+        # QUS: why is this not in the sherpa-test-data repository?
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        ui.load_table(1, os.path.join(this_dir, 'data',
+                                      'two_column_x_y.fits.gz'))
+        data = ui.get_data(1)
+        self.assertEqualWithinTol(data.x, [1, 2, 3])
+        self.assertEqualWithinTol(data.y, [4, 5, 6])
 
 if __name__ == '__main__':
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -34,9 +34,10 @@ import logging
 logger = logging.getLogger("sherpa")
 
 
+@requires_fits
+@requires_data
 class test_ui(SherpaTestCase):
 
-    @requires_data
     def setUp(self):
         self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
         self.fits = self.make_path('1838_rprofile_rmid.fits')
@@ -55,15 +56,11 @@ class test_ui(SherpaTestCase):
         self.func = lambda x: x
         ui.dataspace1d(1, 1000, dstype=ui.Data1D)
 
-    @requires_data
-    @requires_fits
     def test_ascii(self):
         ui.load_ascii(1, self.ascii)
         ui.load_ascii(1, self.ascii, 2)
         ui.load_ascii(1, self.ascii, 2, ("col2", "col1"))
 
-    @requires_data
-    @requires_fits
     def test_table(self):
         ui.load_table(1, self.fits)
         ui.load_table(1, self.fits, 3)
@@ -71,7 +68,6 @@ class test_ui(SherpaTestCase):
         ui.load_table(1, self.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
                       ui.Data1DInt)
 
-    @requires_fits
     def test_load_table_fits(self):
         # QUS: why is this not in the sherpa-test-data repository?
         this_dir = os.path.dirname(os.path.abspath(__file__))
@@ -82,45 +78,31 @@ class test_ui(SherpaTestCase):
         self.assertEqualWithinTol(data.y, [4, 5, 6])
 
     # Test table model
-    @requires_data
-    @requires_fits
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.singledat)
         ui.load_table_model('tbl', self.doubledat)
 
-    @requires_data
-    @requires_fits
     def test_table_model_fits_table(self):
         ui.load_table_model('tbl', self.singletbl)
         ui.load_table_model('tbl', self.doubletbl)
 
-    @requires_data
-    @requires_fits
     def test_table_model_fits_image(self):
         ui.load_table_model('tbl', self.img)
 
     # Test user model
-    @requires_data
-    @requires_fits
     def test_user_model_ascii_table(self):
         ui.load_user_model(self.func, 'mdl', self.singledat)
         ui.load_user_model(self.func, 'mdl', self.doubledat)
 
-    @requires_data
-    @requires_fits
     def test_user_model_fits_table(self):
         ui.load_user_model(self.func, 'mdl', self.singletbl)
         ui.load_user_model(self.func, 'mdl', self.doubletbl)
 
-    @requires_data
-    @requires_fits
     def test_filter_ascii(self):
         ui.load_filter(self.filter_single_int_ascii)
         ui.load_filter(self.filter_single_int_ascii, ignore=True)
 
     # Test load_filter
-    @requires_data
-    @requires_fits
     def test_filter_table(self):
         ui.load_filter(self.filter_single_int_table)
         ui.load_filter(self.filter_single_int_table, ignore=True)
@@ -132,7 +114,7 @@ class test_ui(SherpaTestCase):
 @requires_data
 @requires_fits
 class test_more_ui(SherpaTestCase):
-    @requires_data
+
     def setUp(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
@@ -253,8 +235,10 @@ class test_psf_ui(SherpaTestCase):
 
     # bug #12503
     def test_psf_pars_are_frozen(self):
-        ui.load_psf('psf', ui.beta2d.p1)
-        self.assertEqual([], ui.beta2d.p1.thawedpars)
+        ui.create_model_component("beta2d", "p1")
+        p1 = ui.get_model_component("p1")
+        ui.load_psf('psf', p1)
+        self.assertEqual([], p1.thawedpars)
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -25,7 +25,7 @@ import numpy
 from numpy.testing import assert_allclose
 
 from sherpa.utils import SherpaTest, SherpaTestCase
-from sherpa.utils import test_data_missing, has_fits_support
+from sherpa.utils import requires_data, requires_fits
 from sherpa.astro import ui
 from sherpa.data import Data1D
 from sherpa.astro.data import DataPHA
@@ -36,7 +36,7 @@ logger = logging.getLogger("sherpa")
 
 class test_ui(SherpaTestCase):
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
     def setUp(self):
         self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
         self.fits = self.make_path('1838_rprofile_rmid.fits')
@@ -55,17 +55,15 @@ class test_ui(SherpaTestCase):
         self.func = lambda x: x
         ui.dataspace1d(1, 1000, dstype=ui.Data1D)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_ascii(self):
         ui.load_ascii(1, self.ascii)
         ui.load_ascii(1, self.ascii, 2)
         ui.load_ascii(1, self.ascii, 2, ("col2", "col1"))
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_table(self):
         ui.load_table(1, self.fits)
         ui.load_table(1, self.fits, 3)
@@ -73,8 +71,7 @@ class test_ui(SherpaTestCase):
         ui.load_table(1, self.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
                       ui.Data1DInt)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
+    @requires_fits
     def test_load_table_fits(self):
         # QUS: why is this not in the sherpa-test-data repository?
         this_dir = os.path.dirname(os.path.abspath(__file__))
@@ -85,52 +82,45 @@ class test_ui(SherpaTestCase):
         self.assertEqualWithinTol(data.y, [4, 5, 6])
 
     # Test table model
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.singledat)
         ui.load_table_model('tbl', self.doubledat)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_table_model_fits_table(self):
         ui.load_table_model('tbl', self.singletbl)
         ui.load_table_model('tbl', self.doubletbl)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_table_model_fits_image(self):
         ui.load_table_model('tbl', self.img)
 
     # Test user model
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_user_model_ascii_table(self):
         ui.load_user_model(self.func, 'mdl', self.singledat)
         ui.load_user_model(self.func, 'mdl', self.doubledat)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_user_model_fits_table(self):
         ui.load_user_model(self.func, 'mdl', self.singletbl)
         ui.load_user_model(self.func, 'mdl', self.doubletbl)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_filter_ascii(self):
         ui.load_filter(self.filter_single_int_ascii)
         ui.load_filter(self.filter_single_int_ascii, ignore=True)
 
     # Test load_filter
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_filter_table(self):
         ui.load_filter(self.filter_single_int_table)
         ui.load_filter(self.filter_single_int_table, ignore=True)
@@ -139,8 +129,10 @@ class test_ui(SherpaTestCase):
         ui.load_filter(self.filter_single_log_table, ignore=True)
 
 
+@requires_data
+@requires_fits
 class test_more_ui(SherpaTestCase):
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
     def setUp(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
@@ -153,9 +145,6 @@ class test_more_ui(SherpaTestCase):
         logger.setLevel(self._old_logger_level)
 
     # bug #12732
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_string_model_with_rmf(self):
         ui.load_pha("foo", self.pha)
         ui.load_rmf("foo", self.rmf)
@@ -170,10 +159,7 @@ class test_more_ui(SherpaTestCase):
         from sherpa.astro.instrument import RMFModelPHA
         self.assertTrue(isinstance(m, RMFModelPHA))
 
-    # bug #38
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    #bug #38
     def test_bug38(self):
         ui.load_pha('3c273', self.pha3c273)
         ui.notice_id('3c273', 0.3, 2)
@@ -181,8 +167,9 @@ class test_more_ui(SherpaTestCase):
         ui.group_counts('3c273', 15)
 
 
+@requires_data
+@requires_fits
 class test_image_12578(SherpaTestCase):
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.img = self.make_path('img.fits')
         self.loggingLevel = logger.getEffectiveLevel()
@@ -194,9 +181,6 @@ class test_image_12578(SherpaTestCase):
             logger.setLevel(self.loggingLevel)
 
     # bug #12578
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_coord_bad_coord(self):
         from sherpa.utils.err import IdentifierErr, DataErr
 
@@ -270,20 +254,17 @@ class test_psf_ui(SherpaTestCase):
     # bug #12503
     def test_psf_pars_are_frozen(self):
         ui.load_psf('psf', ui.beta2d.p1)
-        self.assertEqual([], p1.thawedpars)
+        self.assertEqual([], ui.beta2d.p1.thawedpars)
 
 
+@requires_data
+@requires_fits
 class test_stats_ui(SherpaTestCase):
-
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.data = self.make_path('threads/chi2/3c273.pi')
         ui.clean()
 
     # bugs #11400, #13297, #12365
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits or astropy.io.fits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_chi2(self):
 
         # Case 1: first ds has no error, second has, chi2-derived (chi2gehrels)
@@ -417,8 +398,7 @@ class test_stats_ui(SherpaTestCase):
         self.assertEqual('chi2', stat12)
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, astropy.io.fits, or pyfits')
+@requires_fits
 class test_save_arrays_base(SherpaTestCase):
 
     # _colnames:  specify column names (True) or not
@@ -465,8 +445,7 @@ class test_save_arrays_base(SherpaTestCase):
         self.assertIsNone(out.syserror, msg="syserror")
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, astropy.io.fits, or pyfits')
+@requires_fits
 class test_save_arrays_nocols_FITS(test_save_arrays_base):
 
     _fits = True
@@ -478,8 +457,7 @@ class test_save_arrays_nocols_FITS(test_save_arrays_base):
         self.save_arrays()
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, astropy.io.fits, or pyfits')
+@requires_fits
 class test_save_arrays_cols_FITS(test_save_arrays_nocols_FITS):
 
     _colnames = True
@@ -488,8 +466,7 @@ class test_save_arrays_cols_FITS(test_save_arrays_nocols_FITS):
         self.save_arrays()
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, astropy.io.fits, or pyfits')
+@requires_fits
 class test_save_arrays_nocols_ASCII(test_save_arrays_base):
 
     _fits = False
@@ -501,8 +478,7 @@ class test_save_arrays_nocols_ASCII(test_save_arrays_base):
         self.save_arrays()
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, astropy.io.fits, or pyfits')
+@requires_fits
 class test_save_arrays_cols_ASCII(test_save_arrays_nocols_ASCII):
 
     _colnames = True
@@ -511,9 +487,8 @@ class test_save_arrays_cols_ASCII(test_save_arrays_nocols_ASCII):
         self.save_arrays()
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, astropy.io.fits, or pyfits')
-@unittest.skipIf(test_data_missing(), 'required test data missing')
+@requires_fits
+@requires_data
 class test_save_pha(SherpaTestCase):
     """Write out a PHA data set as a FITS file."""
 

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -18,8 +18,8 @@
 #
 
 import unittest
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
-from sherpa.utils import has_fits_support
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.utils import requires_data, requires_fits
 from sherpa.astro import ui
 import logging
 import os
@@ -27,6 +27,8 @@ import numpy
 logger = logging.getLogger("sherpa")
 
 
+@requires_data
+@requires_fits
 class test_more_ui(SherpaTestCase):
     def assign_model(self, name, obj):
         self.locals[name] = obj
@@ -42,7 +44,6 @@ class test_more_ui(SherpaTestCase):
         finally:
             os.chdir(cwd)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.img = self.make_path('img.fits')
         self.pha = self.make_path('threads/simultaneous/pi2286.fits')
@@ -56,9 +57,6 @@ class test_more_ui(SherpaTestCase):
             logger.setLevel(self.loggingLevel)
 
     # bug 12784
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, pyfits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_nan(self):
         self.run_thread('filternan')
         self.assertFalse(numpy.isnan(ui.get_fit_results().statval))

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -40,20 +40,18 @@ corresponding functions in sherpa.astro.ui.utils.
 import re
 import StringIO
 import tempfile
-import unittest
 
 import numpy
 from numpy.testing import assert_array_equal
 
-from sherpa.utils import SherpaTest, SherpaTestCase, has_package_from_list, \
-    test_data_missing
+from sherpa.utils import SherpaTest, SherpaTestCase, requires_data, requires_xspec, _has_package_from_list
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
 
 import logging
 logger = logging.getLogger('sherpa')
 
-has_xspec = has_package_from_list("sherpa.astro.xspec")
+has_xspec = _has_package_from_list("sherpa.astro.xspec")
 
 # The tests can either check that the output ASCII is identical
 # to a canonical form, or try to execute the saved file and
@@ -1058,15 +1056,15 @@ class test_ui(SherpaTestCase):
 
         self._compare(_canonical_empty_stats)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
-    @unittest.skipIf(not has_xspec, "xspec module is required")
+    @requires_data
+    @requires_xspec
     def test_canonical_pha_basic(self):
 
         _, canonical = self._setup_pha_basic()
         self._compare(canonical)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
-    @unittest.skipIf(not has_xspec, "xspec module is required")
+    @requires_data
+    @requires_xspec
     def test_restore_pha_basic(self):
         "Can the state be evaluated?"
 
@@ -1089,15 +1087,15 @@ class test_ui(SherpaTestCase):
 
         self.assertAlmostEqual(ui.calc_stat(), statval)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
-    @unittest.skipIf(not has_xspec, "xspec module is required")
+    @requires_data
+    @requires_xspec
     def test_canonical_pha_grouped(self):
 
         _, _, canonical = self._setup_pha_grouped()
         self._compare(canonical)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
-    @unittest.skipIf(not has_xspec, "xspec module is required")
+    @requires_data
+    @requires_xspec
     def test_restore_pha_grouped(self):
         "Can the state be evaluated?"
 
@@ -1128,15 +1126,15 @@ class test_ui(SherpaTestCase):
 
         self.assertAlmostEqual(ui.calc_stat('grp'), statval)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
-    @unittest.skipIf(not has_xspec, "xspec module is required")
+    @requires_data
+    @requires_xspec
     def test_canonical_pha_back(self):
 
         _, _, canonical = self._setup_pha_back()
         self._compare(canonical)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
-    @unittest.skipIf(not has_xspec, "xspec module is required")
+    @requires_data
+    @requires_xspec
     def test_restore_pha_back(self):
         "Can the state be evaluated?"
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -21,8 +21,8 @@ import unittest
 import numpy
 from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
-from sherpa.utils import SherpaTestCase, test_data_missing
-from sherpa.utils import has_package_from_list, has_fits_support
+from sherpa.utils import SherpaTestCase
+from sherpa.utils import requires_data, requires_fits, requires_xspec
 
 
 # Conversion between wavelength (Angstrom) and energy (keV)
@@ -141,8 +141,7 @@ def make_grid_noncontig2():
     return elo[idx], ehi[idx], wlo[idx], whi[idx]
 
 
-@unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                 "required sherpa.astro.xspec module missing")
+@requires_xspec
 class test_xspec(SherpaTestCase):
 
     def setUp(self):
@@ -284,7 +283,7 @@ class test_xspec(SherpaTestCase):
             assert_allclose(evals2, wvals2,
                             err_msg=emsg + "energy to wavelength")
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
     def test_tablemodel_checks_input_length(self):
 
         # see test_table_model for more information on the table
@@ -302,7 +301,7 @@ class test_xspec(SherpaTestCase):
         self.assertRaises(TypeError, mdl, [0.1, 0.2, 0.3], [0.2, 0.3])
         self.assertRaises(TypeError, mdl, [0.1, 0.2], [0.2, 0.3, 0.4])
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
     def test_xspec_tablemodel(self):
         # Just test one table model; use the same scheme as
         # test_xspec_models_noncontiguous().
@@ -337,7 +336,7 @@ class test_xspec(SherpaTestCase):
         assert_allclose(evals2, wvals2,
                         err_msg=emsg + "two args")
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
     def test_xspec_tablemodel_noncontiguous2(self):
 
         ui.load_table_model('tmod',
@@ -445,9 +444,8 @@ class test_xspec(SherpaTestCase):
         self.assertRaises(ValueError, xs._xspec.C_cpflux, pars, y1, elo, ehi)
         self.assertRaises(ValueError, xs._xspec.C_cpflux, pars, y1, wlo, whi)
 
-    @unittest.skipIf(not has_fits_support(),
-                     'need pycrates, astropy.io.fits, or pyfits')
-    @unittest.skipIf(test_data_missing(), "required test data missing")
+    @requires_data
+    @requires_fits
     def test_set_analysis_wave_fabrizio(self):
         rmf = self.make_path('ciao4.3/fabrizio/Data/3c273.rmf')
         arf = self.make_path('ciao4.3/fabrizio/Data/3c273.arf')

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -22,7 +22,7 @@ import numpy
 import os
 import sherpa
 from sherpa.image import *
-from sherpa.utils import SherpaTestCase, has_package_from_list
+from sherpa.utils import SherpaTestCase, requires_ds9
 
 # Create a 10x10 array for the tests.
 class Data(object):
@@ -50,9 +50,9 @@ def get_arr_from_imager(im):
     data_out = numpy.float_(data_out)
     return data_out
 
+
+@requires_ds9
 class test_image(SherpaTestCase):
-    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                     "required package sherpa.image.ds9_backend not available")
     def test_ds9(self):
         im = sherpa.image.ds9_backend.DS9.DS9Win(sherpa.image.ds9_backend.DS9._DefTemplate, False)
         im.doOpen()
@@ -61,8 +61,6 @@ class test_image(SherpaTestCase):
         im.xpaset("quit")
         self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                     "required package sherpa.image.ds9_backend not available")
     def test_image(self):
         im = Image()
         im.image(data.y)
@@ -70,8 +68,6 @@ class test_image(SherpaTestCase):
         im.xpaset("quit")
         self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                     "required package sherpa.image.ds9_backend not available")
     def test_data_image(self):
         im = DataImage()
         im.prepare_image(data)
@@ -80,8 +76,6 @@ class test_image(SherpaTestCase):
         im.xpaset("quit")
         self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                     "required package sherpa.image.ds9_backend not available")
     def test_model_image(self):
         im = ModelImage()
         im.prepare_image(data, 1)
@@ -90,8 +84,6 @@ class test_image(SherpaTestCase):
         im.xpaset("quit")
         self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
 
-    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                     "required package sherpa.image.ds9_backend not available")
     def test_ratio_image(self):
         im = RatioImage()
         im.prepare_image(data, 1)
@@ -103,8 +95,6 @@ class test_image(SherpaTestCase):
         # reassigns the ratio there to be one.
         self.assertEqualWithinTol(data_out.sum(), 99.0, 1e-4)
 
-    @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
-                     "required package sherpa.image.ds9_backend not available")
     def test_resid_image(self):
         im = ResidImage()
         im.prepare_image(data, 1)

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -21,7 +21,7 @@
 import unittest
 from sherpa.models import TableModel, Gauss1D
 from sherpa.models.template import create_template_model
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTest, SherpaTestCase, requires_data
 from sherpa.utils.err import ModelErr
 from sherpa import ui
 import numpy
@@ -31,6 +31,7 @@ import os
 logger = logging.getLogger("sherpa")
 
 
+@requires_data
 class test_new_templates_ui(SherpaTestCase):
     def assign_model(self, name, obj):
         self.locals[name] = obj
@@ -57,12 +58,10 @@ class test_new_templates_ui(SherpaTestCase):
     # When restoring a file saved with an older version of sherpa,
     # we need to make sure models are assigned an is_discrete field.
     # For model that do not have the is_discrete field, fallback to False.
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_restore_is_discrete(self):
         self.run_thread('template_restore', 'test.py')
 
     # TestCase 1 load_template_model enables interpolation by default
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_with_interpolation(self):
         self.run_thread('load_template_with_interpolation')
         try:
@@ -72,14 +71,12 @@ class test_new_templates_ui(SherpaTestCase):
             self.assertEqualWithinTol(2743.47, ui.get_fit_results().parvals[0], 0.001)
             self.assertEqualWithinTol(2023.46, ui.get_fit_results().parvals[1], 0.001)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_interpolator(self):
         self.run_thread('load_template_interpolator')
         self.assertEqualWithinTol(2743.91, ui.get_fit_results().parvals[0], 0.001)
 
     # TestCase 2 load_template_model with template_interpolator_name=None disables interpolation
     # TestCase 3.1 discrete templates fail when probed for values they do not represent (gridsearch with wrong values)
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
         try:
             self.run_thread('load_template_without_interpolation',
@@ -89,7 +86,6 @@ class test_new_templates_ui(SherpaTestCase):
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
 
     # TestCase 3.2 discrete templates fail when probed for values they do not represent (continuous method with discrete template)
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_load_template_model_without_interpolation(self):
         try:
             self.run_thread('load_template_without_interpolation',
@@ -99,13 +95,11 @@ class test_new_templates_ui(SherpaTestCase):
         self.fail('Fit should have failed: using gridsearch with wrong parvals')
 
     # TestCase 4 gridsearch with right values succeeds
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_grid_search_with_discrete_template(self):
         self.run_thread('load_template_without_interpolation',
                         scriptname='test_case_4.py')
 
     # TestCase 5 user can access interpolators' parvals
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_grid_search_with_discrete_template_parvals(self):
         self.run_thread('load_template_with_interpolation',
                         scriptname='test_case_5.py')

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -20,7 +20,7 @@
 import unittest
 import numpy
 import sherpa.all as sherpa
-from sherpa.utils import SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTestCase, requires_data
 
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
@@ -115,9 +115,9 @@ class test_plot(SherpaTestCase):
         # sp.addplot(rp)
 
 
+@requires_data
 class test_contour(SherpaTestCase):
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.data = sherpa.read_data(self.make_path('gauss2d.dat'),
                                      ncols=3, sep='\t', dstype=sherpa.Data2D)
@@ -127,35 +127,30 @@ class test_contour(SherpaTestCase):
         self.f = sherpa.Fit(self.data, self.g1)
         self.levels = numpy.array([0.5, 2, 5, 10, 20])
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_datacontour(self):
         dc = sherpa.DataContour()
         dc.prepare(self.data)
         dc.levels = self.levels
         # dc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_modelcontour(self):
         mc = sherpa.ModelContour()
         mc.prepare(self.data, self.g1, self.f.stat)
         mc.levels = self.levels
         # mc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_residcontour(self):
         rc = sherpa.ResidContour()
         rc.prepare(self.data, self.g1, self.f.stat)
         rc.levels = self.levels
         # rc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ratiocontour(self):
         tc = sherpa.RatioContour()
         tc.prepare(self.data, self.g1, self.f.stat)
         tc.levels = self.levels
         # tc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_fitcontour(self):
         dc = sherpa.DataContour()
         dc.prepare(self.data)
@@ -167,7 +162,6 @@ class test_contour(SherpaTestCase):
         fc.prepare(dc, mc)
         # fc.contour()
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_splitcontour(self):
         dc = sherpa.DataContour()
         dc.levels = self.levels
@@ -190,6 +184,7 @@ class test_contour(SherpaTestCase):
         # sp.addcontour(fc)
         # sp.addcontour(rc)
 
+
 class test_confidence(SherpaTestCase):
 
     def setUp(self):
@@ -202,7 +197,6 @@ class test_confidence(SherpaTestCase):
         self.rp = sherpa.RegionProjection()
         self.ru = sherpa.RegionUncertainty()
 
-    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_projection(self):
         _ipx = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -223,8 +217,6 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_ipy, self.ip.y, 1e-4)
         # self.ip.plot()
 
-
-    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_interval_uncertainty(self):
         _iux = numpy.array(
             [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
@@ -246,7 +238,6 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_iuy, self.iu.y, 1e-4)
         # self.iu.plot()
 
-    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_projection(self):
         _rpx0 = numpy.array(
             [ 11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
@@ -326,8 +317,6 @@ class test_confidence(SherpaTestCase):
         self.assertEqualWithinTol(_rpy, self.rp.y, 1e-4)
         # self.rp.contour()
 
-
-    # @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_region_uncertainty(self):
         _rux0 = numpy.array(
             [ 12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -47,6 +47,7 @@ _datay = numpy.array(
        0.])
 
 
+# TODO: many tests in this class do not perform any assertions
 class test_plot(SherpaTestCase):
 
     def setUp(self):

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -17,11 +17,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, has_package_from_list
-from unittest import skipIf
+from sherpa.utils import SherpaTestCase, requires_pylab
 
 
-@skipIf(not has_package_from_list("pylab"), "pylab required")
+@requires_pylab
 class pylab_test(SherpaTestCase):
 
     def test_axes_default(self):

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -22,8 +22,8 @@ import os.path
 import numpy
 import unittest
 
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
-from sherpa.utils import has_package_from_list, has_fits_support
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.utils import requires_data, requires_xspec, requires_fits
 
 from sherpa.models import PowLaw1D
 from sherpa.fit import Fit
@@ -114,11 +114,9 @@ class MyChiNoBkg(UserStat):
     calc_staterror = mycal_staterror
 
 
-@unittest.skipIf(not has_fits_support(),
-                 'need pycrates, pyfits or astropy.io.fits')
-@unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
-                 "required sherpa.astro.xspec module missing")
-@unittest.skipIf(test_data_missing(), "required test data missing")
+@requires_fits
+@requires_xspec
+@requires_data
 class test_stats(SherpaTestCase):
 
     _fit_mycash_results_bench = {

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -17,38 +17,33 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import os.path
 import sherpa
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTest, SherpaTestCase, requires_data
 from sherpa import ui
 
 
+@requires_data
 class test_sherpa(SherpaTestCase):
 
     def test_include_dir(self):
         incdir = os.path.join(sherpa.get_include(), 'sherpa')
         self.assert_(os.path.isdir(incdir))
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.agn2 = self.make_path('ciao4.3/faulty_load_data/agn2')
         self.agn2_fixed = self.make_path('ciao4.3/faulty_load_data/agn2_fixed')
         self.template_idx = self.make_path('ciao4.3/faulty_load_data/table.txt')
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_not_reading_header_without_comment(self):
         self.assertRaises(ValueError, ui.load_data, self.agn2)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_reading_floats(self):
         ui.load_data(self.agn2_fixed)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_reading_strings(self):
         ui.load_data(self.template_idx, require_floats=False)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_require_float(self):
         self.assertRaises(ValueError, ui.load_data, self.agn2)
 

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -17,9 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
-import unittest
-from sherpa.utils import SherpaTest, SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTest, SherpaTestCase, requires_data
 from sherpa.models import ArithmeticModel, Parameter
 from sherpa import ui
 import numpy
@@ -38,9 +36,9 @@ class UserModel(ArithmeticModel):
         return p[0]*x+p[1]
 
 
+@requires_data
 class test_ui(SherpaTestCase):
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def setUp(self):
         self.ascii = self.make_path('threads/ascii_table/sim.poisson.1.dat')
         self.single = self.make_path('single.dat')
@@ -50,7 +48,6 @@ class test_ui(SherpaTestCase):
 
         ui.dataspace1d(1,1000,dstype=ui.Data1D)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_ascii(self):
         ui.load_data(1, self.ascii)
         ui.load_data(1, self.ascii, 2)
@@ -58,30 +55,24 @@ class test_ui(SherpaTestCase):
 
 
     # Test table model
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_table_model_ascii_table(self):
         ui.load_table_model('tbl', self.single)
         ui.load_table_model('tbl', self.double)
 
 
     # Test user model
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_user_model_ascii_table(self):
         ui.load_user_model(self.func, 'mdl', self.single)
         ui.load_user_model(self.func, 'mdl', self.double)
 
-
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_filter_ascii(self):
         ui.load_filter(self.filter)
         ui.load_filter(self.filter, ignore=True)
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_add_model(self):
         ui.add_model(UserModel)
         ui.set_model('usermodel.user1')
 
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_set_full_model(self):
         ui.load_psf('psf1', 'gauss2d.g1')
         ui.set_full_model('psf1(gauss2d.g2)+const2d.c1')
@@ -89,7 +80,6 @@ class test_ui(SherpaTestCase):
 #        ui.get_source()
 
     # Bug 12644
-    @unittest.skipIf(test_data_missing(), "required test data missing")
     def test_source_methods_with_full_model(self):
         from sherpa.utils.err import IdentifierErr
 


### PR DESCRIPTION
This PR simplifies the tests-skipping logic and makes it more robust to changes.

It is based on #116 for simplicity, as I was annoyed by the complexity of the process while adding tests for that PR. Since it also changes the way some tests added by #116 are decorated for being skipped, I'll just leave it like this.

This is likely to conflict with existing PRs, in particular #140.