### PR TITLE
Add missing skipIf and ensure legacy test runner fails when tests fails

### DIFF
--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -50,6 +50,7 @@ class test_89_issues(SherpaTestCase):
             assert len(w) == 0
 
     @skipIf(not has_package_from_list("sherpa.astro.io.pyfits_backend"), "this is a pyfits/astropy test")
+    @skipIf(test_data_missing(), "required test data missing")
     def test_warnings_are_gone_pha(self):
         pha = self.make_path("threads", "pha_intro", "3c273.pi")
         with warnings.catch_warnings(record=True) as w:

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -325,7 +325,9 @@ class SherpaTest(numpytest.NumpyTest):
         SherpaTestCase.datadir = datadir
 
         try:
-            numpytest.NumpyTest.test(self, level, verbosity)
+            result = numpytest.NumpyTest.test(self, level, verbosity)
+            if result is None or result.failures or result.errors or result.unexpectedSuccesses:
+                raise Exception("Test failures were detected")
         finally:
             SherpaTestCase.datadir = old_datadir
 


### PR DESCRIPTION
This PR adds a missing `skipIf` to a test. The Travis CI build that was supposed to catch this issue did not fail because the legacy test runner that is triggered by that build (what we call the "smoke" test, i.e. a test run with the `sherpa.test()` function) was not failing even though the tests were.

So, this PR also ensures that failing tests make the Travis build fail by throwing an Exception. This behavior was tested locally.