### PR TITLE
make xspec verbose during tests, in case of failure

### DIFF
--- a/helpers/test.py
+++ b/helpers/test.py
@@ -17,6 +17,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+
+def set_xspec_chatter():
+    try:
+        from sherpa.astro import xspec
+        xspec.set_xschatter(50)
+    except ImportError:
+        # Well, it looks like xspec is not available. Passing.
+        pass
+
 try:
     from setuptools.command.test import test
 
@@ -36,6 +45,7 @@ try:
             self.test_suite = True
 
         def run_tests(self):
+            set_xspec_chatter()
             # import here, cause outside the eggs aren't loaded
             import pytest
             if not self.pytest_args:

--- a/helpers/test.py
+++ b/helpers/test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This PR sets the xspec chatter level to 50 by default when running tests.

Despite the chatter level, pytest will redirect the stdout and err, and none will be printed to the console if everything is OK.

However, if an error occurs, the output from xspec will be logged along with the error.

This PR should not impact the current CIAO testing infrastructure.