### PR TITLE
Ensure astropy and crates behave the same with gzipped files

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -1,0 +1,124 @@
+#
+#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# break out some of the I/O tests in the UI layer into a separate set
+# of tests, in part to reduce file size, but also because some of these
+# may be better placed in tests of the sherpa.astro.io module, once that
+# becomes possible
+
+import unittest
+
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.utils import requires_data, requires_fits
+from sherpa.astro import ui
+from sherpa.astro.data import DataPHA
+from sherpa.astro.instrument import ARF1D, RMF1D
+
+import logging
+logger = logging.getLogger("sherpa")
+
+
+@requires_fits
+@requires_data
+class test_load_pha3_gzip(SherpaTestCase):
+    """Handle a .gz FITS PHA Type 3 file"""
+
+    longMessage = True
+
+    def setUp(self):
+        # hide warning messages from file I/O
+        self._old_logger_level = logger.level
+        logger.setLevel(logging.ERROR)
+
+        ui.clean()
+
+        self.head = self.make_path('acisf01575_001N001_r0085')
+
+    def tearDown(self):
+        logger.setLevel(self._old_logger_level)
+
+    def validate_pha(self, idval):
+        """Check that the PHA dataset in id=idval is
+        as expected.
+        """
+
+        self.assertEqual(ui.list_data_ids(), [idval])
+
+        pha = ui.get_data(idval)
+        self.assertIsInstance(pha, DataPHA)
+
+        arf = ui.get_arf(idval)
+        self.assertIsInstance(arf, ARF1D)
+
+        rmf = ui.get_rmf(idval)
+        self.assertIsInstance(rmf, RMF1D)
+
+        bpha = ui.get_bkg(idval, bkg_id=1)
+        self.assertIsInstance(bpha, DataPHA)
+
+        barf = ui.get_arf(idval, bkg_id=1)
+        self.assertIsInstance(barf, ARF1D)
+
+        brmf = ui.get_rmf(idval, bkg_id=1)
+        self.assertIsInstance(brmf, RMF1D)
+
+        # normally the background data set would have a different name,
+        # but this is a  PHA Type 3 file.
+        # self.assertEqual(pha.name, bpha.name)
+        self.assertEqual(arf.name, barf.name)
+        self.assertEqual(rmf.name, brmf.name)
+
+    def testReadExplicit(self):
+        """Include .gz in the file name"""
+
+        idval = 12
+        fname = self.head + '_pha3.fits.gz'
+        ui.load_pha(idval, fname)
+
+        self.validate_pha(idval)
+
+        # TODO: does this indicate that the file name, as read in,
+        #       should have the .gz added to it to match the data
+        #       read in, or left as is?
+        pha = ui.get_data(idval)
+        bpha = ui.get_bkg(idval, bkg_id=1)
+        self.assertEqual(pha.name, bpha.name + '.gz')
+
+    def testReadImplicit(self):
+        """Exclude .gz from the file name"""
+
+        idval = "13"
+        fname = self.head + '_pha3.fits'
+        ui.load_pha(idval, fname)
+
+        self.validate_pha(idval)
+
+        pha = ui.get_data(idval)
+        bpha = ui.get_bkg(idval, bkg_id=1)
+        self.assertEqual(pha.name, bpha.name)
+
+if __name__ == '__main__':
+
+    import sys
+    if len(sys.argv) > 1:
+        datadir = sys.argv[1]
+    else:
+        datadir = None
+
+    SherpaTest(ui).test(datadir=datadir)

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,6 @@
 # of tests, in part to reduce file size, but also because some of these
 # may be better placed in tests of the sherpa.astro.io module, once that
 # becomes possible
-
-import unittest
 
 from sherpa.utils import SherpaTest, SherpaTestCase
 from sherpa.utils import requires_data, requires_fits

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -25,7 +25,8 @@ from itertools import izip
 import sherpa.ui.utils
 from sherpa.ui.utils import _argument_type_error, _check_type, _send_to_pager
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange
-from sherpa.utils.err import *
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
+    IdentifierErr, IOErr, ModelErr
 from sherpa.data import Data1D
 import sherpa.astro.all
 import sherpa.astro.plot


### PR DESCRIPTION
# Release Notes

Change the behaviour of the AstroPy back end so that it matches that of Crates when given a file name which does not exist, but a compressed version, with the suffix `.gz` does. The Crates behavior is to read the file. This extends to PHA files whose ancillary files - e.g. those stored in the `BACKFILE`, `ANCRFILE`, and `RESPFILE` keywords - are given as unzipped names, but only the gzipped names exist on disk.

As an example: if `pha.fits.gz` exists but `pha.fits` does not, then

    load_pha('pha.fits')

will now load the file with either back end. If the response files are set to `arf.fits` and `rmf.fits` (via the `ANCRFILE` and `RESPFILE` keywords), but only the `.gz` versions exist, then they will now also be loaded by the AstroPy back end.

Tests have been added to cover this case (for both I/O backends).

# Notes

This is a rebase of PR #105.

This is particularly useful when loading Type 3 PHA files - as produced
by the Chandra Source Catalog.

An explicit import statement is used in sherpa/astro/ui/utils.py (PEP8 fix).