### PR TITLE
Ignore .cache/ and .coverage.xxx files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,10 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+.coverage.*
 .tox
 nosetests.xml
+.cache
 
 # Translations
 *.mo


### PR DESCRIPTION
# Release Notes

Updated the .gitignore file.

# Notes

Recent tests have created a `.cache` directory and a number of `.coverage.xxx` files. I could have combined the `.coverage` and `.coverage.*` rules, but decided to leave them separate for now.