### PR TITLE
fix chi2datavar comparison <=0 bug

### DIFF
--- a/sherpa/include/sherpa/stats.hh
+++ b/sherpa/include/sherpa/stats.hh
@@ -247,7 +247,7 @@ namespace sherpa { namespace stats {
 				ArrayType& err ) {
 
     for ( IndexType ii = num - 1; ii >= 0; --ii )
-      if ( yraw[ ii ] <= 0.0 )
+      if ( yraw[ ii ] < 0.0 )
 	return EXIT_FAILURE;
       else
 	err[ ii ] = std::sqrt( yraw[ ii ] );

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -308,8 +308,7 @@ class test_stats(SherpaTestCase):
         ui.load_arrays(1, xy, xy, Data1D)
         ui.set_stat('chi2datavar')
         err = ui.get_staterror()
-        for index, yyy in enumerate(xy):
-            assert numpy.allclose(err[index], numpy.sqrt(yyy), 1.0e-7, 1.0e-7)
+        numpy.testing.assert_allclose(err, numpy.sqrt(xy), rtol=1e-7, atol=1e-7)
 
 
 def tstme(datadir=None):

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -20,14 +20,14 @@
 import os.path
 
 import numpy
-import unittest
 
-from sherpa.utils import SherpaTest, SherpaTestCase
 from sherpa.utils import requires_data, requires_xspec, requires_fits
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.data import Data1D
 
 from sherpa.models import PowLaw1D
 from sherpa.fit import Fit
-from sherpa.stats import Stat, Cash, LeastSq, UserStat, WStat
+from sherpa.stats import Cash, UserStat, WStat
 from sherpa.optmethods import LevMar, NelderMead
 from sherpa.utils.err import StatErr
 from sherpa.astro import ui
@@ -301,6 +301,15 @@ class test_stats(SherpaTestCase):
         data.notice(0.5, 7.0)
         fit = Fit(data, self.model, WStat(), NelderMead())
         self.assertRaises(StatErr, fit.fit)
+
+    def test_chi2datavar(self):
+        num = 3
+        xy = numpy.array(range(num))
+        ui.load_arrays(1, xy, xy, Data1D)
+        ui.set_stat('chi2datavar')
+        err = ui.get_staterror()
+        for index, yyy in enumerate(xy):
+            assert numpy.allclose(err[index], numpy.sqrt(yyy), 1.0e-7, 1.0e-7)
 
 
 def tstme(datadir=None):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
@@ -32,7 +33,7 @@ import os
 import importlib
 import numpy
 import numpy.random
-import numpytest
+from . import numpytest
 import numpy.fft
 # Note: _utils.gsl_fcmp is not exported from this module; is this intentional?
 from unittest import skipIf


### PR DESCRIPTION
The comparison test within calc_chi2datavar _errors is too stringent, after all sqrt(x) where x >=0 is legit.