### PR TITLE
add argument to get_draws for supplying a covariance matrix

### DIFF
--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -206,7 +206,6 @@ import numpy
 import logging
 info = logging.getLogger("sherpa").info
 _log = logging.getLogger("sherpa")
-_level = _log.getEffectiveLevel()
 
 _tol = numpy.finfo(numpy.float).eps
 
@@ -670,6 +669,7 @@ class MCMC(NoNewAttributesAfterInit):
             raise ValueError("Fit statistic must be cash, cstat or wstat, not %s" %
                              fit.stat.name)
 
+        _level = _log.getEffectiveLevel()
         mu = fit.model.thawedpars
         dof = len(mu)
 

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -41,6 +41,7 @@ class UserModel(ArithmeticModel):
 class test_ui(SherpaTestCase):
 
     def setUp(self):
+        ui.clean()
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
@@ -55,6 +56,7 @@ class test_ui(SherpaTestCase):
     def tearDown(self):
         if hasattr(self, '_old_logger_level'):
             logger.setLevel(self._old_logger_level)
+        ui.clean()
 
     def test_ascii(self):
         ui.load_data(1, self.ascii)
@@ -102,7 +104,7 @@ class test_ui(SherpaTestCase):
         try:
             ui.plot_source('full')
         except IdentifierErr as e:
-            self.assertEquals("Convolved model\n'p1'\n is set for dataset full. You should use plot_model instead.", str(e))
+            self.assertRegexpMatches(str(e), "Convolved model\n.*\n is set for dataset full. You should use plot_model instead.", str(e))
 
         # Test Case 2
         ui.set_source('full', 'powlaw1d.p2')

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9964,7 +9964,7 @@ class Session(NoNewAttributesAfterInit):
         return self._pyblocxs.list_samplers()
 
     # DOC-TODO: add pointers on what to do with the return values
-    def get_draws(self, id=None, otherids=(), niter=1000):
+    def get_draws(self, id=None, otherids=(), niter=1000, covar_matrix=None):
         """Run the pyBLoCXS MCMC algorithm.
 
         The function runs a Markov Chain Monte Carlo (MCMC) algorithm
@@ -10069,11 +10069,12 @@ class Session(NoNewAttributesAfterInit):
         # if fit_results is None:
         #    raise TypeError("Fit has not been run")
 
-        covar_results = self.get_covar_results()
-        if covar_results is None:
-            raise TypeError("Covariance has not been calculated")
+        if covar_matrix is None:
+            covar_results = self.get_covar_results()
+            if covar_results is None:
+                raise TypeError("Covariance has not been calculated")
 
-        covar_matrix = covar_results.extra_output
+            covar_matrix = covar_results.extra_output
 
         stats, accept, params = self._pyblocxs.get_draws(
             fit, covar_matrix, niter=niter)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9987,6 +9987,9 @@ class Session(NoNewAttributesAfterInit):
            Other data sets to use in the calculation.
         niter : int, optional
            The number of draws to use. The default is ``1000``.
+        covar_matrix : 2D array, optional
+           The covariance matrix to use. If ``None`` then the
+           result from `get_covar_matrix` is used.
 
         Returns
         -------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9969,11 +9969,10 @@ class Session(NoNewAttributesAfterInit):
 
         The function runs a Markov Chain Monte Carlo (MCMC) algorithm
         designed to carry out Bayesian Low-Count X-ray Spectral
-        (BLoCXS) analysis. Unlike many MCMC algorithms, it is
-        designed to explore the parameter space at the suspected
-        statistic minimum (i.e.  after using `fit`). The return
-        values include the statistic value, parameter values, and a
-        flag indicating whether the row represents a jump from the
+        (BLoCXS) analysis. It explores the model parameter space at
+        the suspected statistic minimum (i.e.  after using `fit`). The return
+        values include the statistic value, parameter values, and an
+        acceptance flag indicating whether the row represents a jump from the
         current location or not. For more information see the
         `sherpa.sim` module and [1]_.
 
@@ -9989,7 +9988,7 @@ class Session(NoNewAttributesAfterInit):
            The number of draws to use. The default is ``1000``.
         covar_matrix : 2D array, optional
            The covariance matrix to use. If ``None`` then the
-           result from `get_covar_matrix` is used.
+           result from `get_covar_results().extra_output` is used.
 
         Returns
         -------
@@ -10017,6 +10016,7 @@ class Session(NoNewAttributesAfterInit):
         plot_trace : Create a trace plot of row number versus value.
         set_prior : Set the prior function to use with a parameter.
         set_sampler : Set the MCMC sampler.
+        get_sampler : Return information about the current MCMC sampler.
 
         Notes
         -----


### PR DESCRIPTION
# Release Note
The `get_draws` function now accepts a user-provided covariance matrix. If no covariance matrix is provided, the covariance matrix computed by the default implementation is used. Note that `covar()` must be invoked before invoking `get_draws` if no covariance matrix is provided, otherwise `get_draws` will exit with an error.

# Description
This PR introduces a new attribute to the `get_draws` function, for allowing users to provide a custom covariance matrix.

# Testing
Tests provide as much coverage as possible. Unfortunately, without `mock` some advertised behavior cannot be checked (at least not in a simple, sustainable way). For instance, it cannot be checked that if no covariance matrix is provided then `extra_output` is used. This means that some lines are not covered by tests.

I planned to add additional tests in a similar fashion to what was done with #196 (datastack tests), but it would be complicated to include commits from #196 and then keep up with changes. I don't think it's worth it in this case. We'll add tests if possible in a future pass.

An additional test is provided in c6b0345, but for now it is not included in the PR because it requires a change in sherpa/sherpa-test-data@03600ca, and I am not sure this is worth the footprint.