### PR TITLE
WIP Move test code out from sherpa.utils

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007,2014,2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -109,9 +109,7 @@ def test(level=1, verbosity=1, datadir=None):
     (including the discipline-specific ones)
 
     """
-    # import sherpa.all
-    # import sherpa.astro.all
-    from sherpa.utils import SherpaTest
+    from sherpa.utils.test import SherpaTest
     SherpaTest().test(level, verbosity, datadir)
 
 

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -18,10 +18,9 @@
 #
 
 
-from sherpa.utils.test import SherpaTestCase, requires_fits
+from sherpa.utils.test import SherpaTest, SherpaTestCase, requires_fits
 import os
 import sys
-import unittest
 from sherpa.astro import ui
 from sherpa.astro import datastack
 from acis_bkg_model import acis_bkg_model
@@ -690,9 +689,6 @@ class test_query(SherpaTestCase):
 
 if __name__ == '__main__':
 
-    from sherpa.utils import SherpaTest
-
-    import sys
     if len(sys.argv) > 1:
         datadir = sys.argv[1]
     else:

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,11 +18,10 @@
 #
 
 
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase, requires_fits
 import os
 import sys
 import unittest
-from sherpa.utils import requires_fits
 from sherpa.astro import ui
 from sherpa.astro import datastack
 from acis_bkg_model import acis_bkg_model

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -17,10 +17,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, requires_data, requires_fits, requires_xspec
+from sherpa.utils.test import SherpaTestCase, requires_data, \
+    requires_fits, requires_xspec
 from sherpa.astro import ui
 
-from unittest import skipIf
 from tempfile import NamedTemporaryFile
 import warnings
 

--- a/sherpa/astro/models/tests/test_models.py
+++ b/sherpa/astro/models/tests/test_models.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,8 @@
 
 from numpy import arange
 import sherpa.astro.models as models
-from sherpa.utils import SherpaFloat, SherpaTestCase
+from sherpa.utils import SherpaFloat
+from sherpa.utils.test import SherpaTestCase
 from sherpa.models.model import ArithmeticModel
 
 

--- a/sherpa/astro/optical/tests/test_optical.py
+++ b/sherpa/astro/optical/tests/test_optical.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,8 @@
 
 from numpy import arange, array
 import sherpa.astro.optical as models
-from sherpa.utils import SherpaFloat, SherpaTestCase
+from sherpa.utils import SherpaFloat
+from sherpa.utils.test import SherpaTestCase
 from sherpa.models.model import ArithmeticModel
 
 

--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,10 +17,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import logging
-from sherpa.utils import SherpaTest, SherpaTestCase
-from sherpa.utils import requires_data, requires_fits, requires_xspec
+from sherpa.utils.test import SherpaTest, SherpaTestCase, \
+    requires_data, requires_fits, requires_xspec
 from sherpa.astro import sim
 
 from sherpa.astro.instrument import Response1D

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -20,7 +20,7 @@
 import logging
 import os
 import os.path
-from sherpa.utils.test import SherpaTestCase, requires_data, \
+from sherpa.utils.test import SherpaTest, SherpaTestCase, requires_data, \
     requires_fits, requires_xspec
 import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
@@ -496,7 +496,6 @@ class test_threads(SherpaTestCase):
 
 if __name__ == '__main__':
 
-    from sherpa.utils import SherpaTest
     from sherpa import astro
 
     import sys

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,12 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import logging
 import os
 import os.path
-from sherpa.utils import SherpaTestCase
-from sherpa.utils import requires_data, requires_fits, requires_xspec
+from sherpa.utils.test import SherpaTestCase, requires_data, \
+    requires_fits, requires_xspec
 import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
 
@@ -35,6 +34,7 @@ except ImportError:
     has_xspec = False
 
 # has_xspec = has_package_from_list("sherpa.astro.xspec")
+
 
 @requires_data
 class test_threads(SherpaTestCase):
@@ -70,7 +70,6 @@ class test_threads(SherpaTestCase):
         ui.clean()
         ui.set_model_autoassign_func(self.assign_model)
         super(test_threads, self).run_thread(name, scriptname=scriptname)
-
 
     @requires_fits
     @requires_xspec

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import numpy
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 from sherpa.astro.data import DataPHA
 from sherpa.astro.plot import SourcePlot
 from sherpa.models.basic import PowLaw1D

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -19,7 +19,7 @@
 
 import numpy
 from sherpa.astro.data import DataPHA
-from sherpa.utils.test import SherpaTestCase
+from sherpa.utils.test import SherpaTest, SherpaTestCase
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -251,6 +251,5 @@ class test_filter_wave_grid(SherpaTestCase):
 
 if __name__ == '__main__':
 
-    from sherpa.utils import SherpaTest
     import sherpa.astro
     SherpaTest(sherpa.astro).test()

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,15 +19,16 @@
 
 import numpy
 from sherpa.astro.data import DataPHA
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 
 import logging
 logger = logging.getLogger('sherpa')
 
+
 class test_filter_energy_grid(SherpaTestCase):
 
     _notice = numpy.ones(46, dtype=bool)
-    _notice[44:46]=False
+    _notice[44:46] = False
 
     _ignore = numpy.zeros(46, dtype=bool)
     _ignore[14:33]=True
@@ -71,7 +72,7 @@ class test_filter_energy_grid(SherpaTestCase):
 
     def test_notice(self):
         #clear mask
-        self.pha.notice()        
+        self.pha.notice()
         self.pha.notice(0.0, 6.0)
         #self.assertEqual(self._notice, self.pha.mask)
         assert (self._notice==numpy.asarray(self.pha.mask)).all()
@@ -244,7 +245,7 @@ class test_filter_wave_grid(SherpaTestCase):
         #clear mask
         self.pha.notice()
         self.pha.ignore(30.01, 225.0)
-        self.pha.ignore(0.1, 6.0)        
+        self.pha.ignore(0.1, 6.0)
         assert (self._ignore==numpy.asarray(self.pha.mask)).all()
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -25,8 +25,8 @@ import tempfile
 import numpy
 from numpy.testing import assert_allclose
 
-from sherpa.utils import SherpaTest, SherpaTestCase
-from sherpa.utils import requires_data, requires_fits
+from sherpa.utils.test import SherpaTest, SherpaTestCase, \
+    requires_data, requires_fits
 from sherpa.astro import ui
 from sherpa.data import Data1D
 from sherpa.astro.data import DataPHA

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2013, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2013, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,9 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
-from sherpa.utils import SherpaTest, SherpaTestCase
-from sherpa.utils import requires_data, requires_fits
+from sherpa.utils.test import SherpaTest, SherpaTestCase, \
+    requires_data, requires_fits
 from sherpa.astro import ui
 import logging
 import os

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -44,7 +44,8 @@ import tempfile
 import numpy
 from numpy.testing import assert_array_equal
 
-from sherpa.utils import SherpaTest, SherpaTestCase, requires_data, requires_xspec, _has_package_from_list
+from sherpa.utils.test import SherpaTest, SherpaTestCase, \
+    requires_data, requires_xspec, _has_package_from_list
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
 

--- a/sherpa/astro/utils/tests/test_astro_utils.py
+++ b/sherpa/astro/utils/tests/test_astro_utils.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2008  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2008, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,8 +18,9 @@
 #
 
 
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 from sherpa.astro.utils import is_in
+
 
 class test_utils(SherpaTestCase):
 
@@ -36,7 +37,7 @@ class test_utils(SherpaTestCase):
         self.assert_( is_in(self.long, 100, 200) )
 
         # hi case
-        self.assert_( is_in(self.long, 50, 1024) ) 
+        self.assert_( is_in(self.long, 50, 1024) )
 
         # 'hidden' lo case
         self.assert_( is_in(self.long, 250, 2000) )

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -20,7 +20,7 @@
 import numpy
 from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
-from sherpa.utils.test import SherpaTestCase, \
+from sherpa.utils.test import SherpaTest, SherpaTestCase, \
     requires_data, requires_fits, requires_xspec
 
 
@@ -512,7 +512,6 @@ if __name__ == '__main__':
     import os
     import sys
     import sherpa.astro.xspec as xs
-    from sherpa.utils import SherpaTest
 
     if len(sys.argv) > 1:
         datadir = sys.argv[1]

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,12 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import numpy
 from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
-from sherpa.utils import SherpaTestCase
-from sherpa.utils import requires_data, requires_fits, requires_xspec
+from sherpa.utils.test import SherpaTestCase, \
+    requires_data, requires_fits, requires_xspec
 
 
 # Conversion between wavelength (Angstrom) and energy (keV)

--- a/sherpa/estmethods/tests/test_estmethods.py
+++ b/sherpa/estmethods/tests/test_estmethods.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,8 +18,8 @@
 #
 
 import numpy
-from sherpa.estmethods import *
-from sherpa.utils import SherpaTestCase
+from sherpa.estmethods import Covariance, Projection
+from sherpa.utils.test import SherpaTestCase
 
 # Test data arrays -- together this makes a line best fit with a
 # 1D Gaussian function.
@@ -52,7 +52,7 @@ y = numpy.array(
 # These parameter values are known to be the best-fit parameter values
 # of a Gaussian to the x- and y-arrays above.
 fittedpars = numpy.array([32.3536, 807.863, 117.826])
-limit_parnums = numpy.array([0,1,2])
+limit_parnums = numpy.array([0, 1, 2])
 maxpars = numpy.array([200, 900, 200])
 minpars = numpy.array([1, 0, 0])
 hardmaxpars = numpy.array([1.0e+120, 1.0e+120, 1.0e+120])
@@ -60,23 +60,29 @@ hardminpars = numpy.array([1.0e-120, -1.0e+120, -1.0e+120])
 
 gfactor = 4.0 * 0.6931471805599453094172321214581766
 
+
 def freeze_par(pars, parmins, parmaxes, i):
     return (pars, parmins, parmaxes)
+
 
 def thaw_par(i):
     pass
 
+
 def report_progress(i, lower, upper):
     pass
 
-def get_par_name( ii ):
+
+def get_par_name(ii):
     pass
+
 
 # Here's the 1D Gaussian function to use to generate predicted
 # data, which will be compared to the y-array above
 def gauss_func(p):
     return p[2] * numpy.exp(-1.0 * gfactor *
                             (x - p[1]) * (x - p[1]) / p[0] / p[0])
+
 
 # Compare the y-array above to values calculated with gauss_func,
 # and calculate chi-squared, using Gehrel's approximation for
@@ -86,12 +92,14 @@ def stat(p):
     fvec = (y - gauss_func(p) ) / errors
     return ((fvec * fvec).sum(),)
 
+
 # Easiest "fit" function for unit tests is actually just to
 # return current parameter values.  In this test, that will
 # have the effect of making projection act like the old
 # uncertainty method, but that is OK for the unit test.
 def fitter(scb, pars, parmins, parmaxs):
     return (1, pars, scb(pars)[0])
+
 
 class test_estmethods(SherpaTestCase):
 
@@ -108,13 +116,13 @@ class test_estmethods(SherpaTestCase):
                           thaw_par, report_progress, get_par_name)
 
         self.assertRaises(RuntimeError, Covariance().compute,
-                          stat, fitter, numpy.array([1,2]),
+                          stat, fitter, numpy.array([1, 2]),
                           minpars, maxpars, hardminpars, hardmaxpars,
                           limit_parnums, freeze_par, thaw_par,
                           report_progress, get_par_name)
 
         self.assertRaises(RuntimeError, Covariance().compute,
-                          stat, fitter, fittedpars, numpy.array([1,2]),
+                          stat, fitter, fittedpars, numpy.array([1, 2]),
                           maxpars, hardminpars, hardmaxpars, limit_parnums,
                           freeze_par, thaw_par, report_progress, get_par_name)
 
@@ -130,13 +138,13 @@ class test_estmethods(SherpaTestCase):
                           freeze_par, thaw_par, report_progress, get_par_name)
 
         self.assertRaises(RuntimeError, Projection().compute,
-                          stat, fitter, numpy.array([1,2]),
+                          stat, fitter, numpy.array([1, 2]),
                           minpars, maxpars, hardminpars, hardmaxpars,
                           limit_parnums, freeze_par, thaw_par,
                           report_progress, get_par_name)
 
         self.assertRaises(RuntimeError, Projection().compute,
-                          stat, fitter, fittedpars, numpy.array([1,2]),
+                          stat, fitter, fittedpars, numpy.array([1, 2]),
                           maxpars, hardminpars, hardmaxpars, limit_parnums,
                           freeze_par, thaw_par, report_progress, get_par_name)
 
@@ -150,7 +158,7 @@ class test_estmethods(SherpaTestCase):
                                        limit_parnums, freeze_par, thaw_par,
                                        report_progress, get_par_name)
         self.assertEqualWithinTol(standard.diagonal(),
-                                  #results[2].diagonal(), 1e-4)
+                                  # results[2].diagonal(), 1e-4)
                                   results[1], 1e-4)
 
     def test_projection(self):
@@ -161,5 +169,5 @@ class test_estmethods(SherpaTestCase):
                                        hardminpars, hardmaxpars,
                                        limit_parnums, freeze_par, thaw_par,
                                        report_progress, get_par_name)
-        self.assertEqualWithinTol(standard_elo,results[0], 1e-4)
-        self.assertEqualWithinTol(standard_ehi,results[1], 1e-4)
+        self.assertEqualWithinTol(standard_elo, results[0], 1e-4)
+        self.assertEqualWithinTol(standard_ehi, results[1], 1e-4)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,23 +17,22 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import numpy
-import os
 import sherpa
-from sherpa.image import *
-from sherpa.utils import SherpaTestCase, requires_ds9
+from sherpa.image import Image, DataImage, ModelImage, RatioImage, ResidImage
+from sherpa.utils.test import SherpaTestCase, requires_ds9
+
 
 # Create a 10x10 array for the tests.
 class Data(object):
     def __init__(self):
         self.name = None
-        self.y = numpy.arange(0,(10*10)/2,0.5)
-        self.y = self.y.reshape(10,10)
+        self.y = numpy.arange(0, (10 * 10) / 2, 0.5)
+        self.y = self.y.reshape(10, 10)
         self.eqpos = None
         self.sky = None
 
-    def get_img(self,model=None):
+    def get_img(self, model=None):
         if model is not None:
             return (self.y, self.y)
         else:
@@ -41,12 +40,13 @@ class Data(object):
 
 data = Data()
 
+
 def get_arr_from_imager(im):
     # DS9 returns data as unordered string
     # Turn it into a 10x10 array
     data_out = im.xpaget("data image 1 1 10 10 yes")
     data_out = data_out.split()
-    data_out = numpy.array(data_out).reshape(10,10)
+    data_out = numpy.array(data_out).reshape(10, 10)
     data_out = numpy.float_(data_out)
     return data_out
 

--- a/sherpa/models/tests/test_basic.py
+++ b/sherpa/models/tests/test_basic.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,11 +19,14 @@
 
 from numpy import arange
 import sherpa.models.basic as basic
-from sherpa.utils import SherpaFloat, SherpaTestCase
+from sherpa.utils import SherpaFloat
+from sherpa.utils.test import SherpaTestCase
 from sherpa.models.model import ArithmeticModel
+
 
 def userfunc(pars, x, *args, **kwargs):
     return x
+
 
 class test_basic(SherpaTestCase):
 
@@ -47,7 +50,7 @@ class test_basic(SherpaTestCase):
             if isinstance(m, basic.TableModel):
                 m.load(x,x)
             if isinstance(m, basic.UserModel):
-                m.calc = userfunc 
+                m.calc = userfunc
             self.assertEqual(type(m).__name__.lower(), m.name)
             count += 1
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,15 +20,16 @@
 import logging
 import operator
 import numpy
-from sherpa.utils import SherpaFloat, SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 from sherpa.utils.err import ModelErr
-from sherpa.models.model import *
+from sherpa.models.model import ArithmeticConstantModel, BinaryOpModel, \
+    UnaryOpModel, FilterModel, NestedModel
 from sherpa.models.basic import Sin, Const1D
 
 
 def my_sin(pars, x):
     return (pars[2].val *
-            numpy.sin(2.0*numpy.pi * (x - pars[1].val) / pars[0].val))
+            numpy.sin(2.0 * numpy.pi * (x - pars[1].val) / pars[0].val))
 
 
 class test_model(SherpaTestCase):
@@ -140,7 +141,7 @@ class test_composite_model(SherpaTestCase):
         cmplx = (3 * self.m + self.m2) / (self.m ** 3.2)
         m = self.m(self.x)
         m2 = self.m2(self.x)
-        self.assertEqual(cmplx(self.x), (3*m + m2) / (m ** 3.2))
+        self.assertEqual(cmplx(self.x), (3 * m + m2) / (m ** 3.2))
 
     def test_filter(self):
         m = self.s[::2]

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,8 +19,10 @@
 
 import operator
 from numpy import arange
-from sherpa.utils import SherpaFloat, SherpaTestCase
-from sherpa.models.parameter import *
+from sherpa.utils import SherpaFloat
+from sherpa.utils.test import SherpaTestCase
+from sherpa.models.parameter import Parameter, UnaryOpParameter, \
+    BinaryOpParameter, ConstantParameter
 from sherpa.utils.err import ParameterErr
 
 
@@ -62,9 +64,9 @@ class test_parameter(SherpaTestCase):
 
     def test_min_max(self):
         for attr, sign in (('min', -1), ('max', 1)):
-            setattr(self.p, attr, sign*99)
+            setattr(self.p, attr, sign * 99)
             val = getattr(self.p, attr)
-            self.assertEqual(val, sign*99)
+            self.assertEqual(val, sign * 99)
             self.assert_(type(val) is SherpaFloat)
             self.assertRaises(ValueError, setattr, self.p, attr, 'ham')
             self.assertRaises(ParameterErr, setattr, self.p, attr, -101)
@@ -96,7 +98,7 @@ class test_parameter(SherpaTestCase):
         self.assertRaises(ParameterErr, setattr, self.afp, 'link', self.p)
         self.assertRaises(ParameterErr, setattr, self.p, 'link', 3)
         self.assertRaises(ParameterErr, setattr, self.p, 'link',
-                          3*self.p + 2)
+                          3 * self.p + 2)
 
     def test_iter(self):
         for part in self.p:
@@ -136,4 +138,4 @@ class test_composite_parameter(SherpaTestCase):
         cmplx = (3 * self.p + self.p2) / (self.p ** 3.2)
         p = self.p.val
         p2 = self.p2.val
-        self.assertEqual(cmplx.val, (3*p + p2) / (p ** 3.2))
+        self.assertEqual(cmplx.val, (3 * p + p2) / (p ** 3.2))

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -20,7 +20,7 @@
 
 from sherpa.models import TableModel, Gauss1D
 from sherpa.models.template import create_template_model
-from sherpa.utils import SherpaTest, SherpaTestCase, requires_data
+from sherpa.utils.test import SherpaTest, SherpaTestCase, requires_data
 from sherpa.utils.err import ModelErr
 from sherpa import ui
 import numpy

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,11 +17,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from math import sqrt
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 from sherpa.optmethods import optfcts
-## from sherpa.optmethods import stogo
 from sherpa.optmethods import _tstoptfct
+
 
 class test_optmethods(SherpaTestCase):
 

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils.test import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase, SherpaTest
 from sherpa.optmethods import optfcts
 from sherpa.optmethods import _tstoptfct
 
@@ -295,7 +295,6 @@ class test_optmethods(SherpaTestCase):
         self.tst_all( name, _tstoptfct.chebyquad, fmin, x0, xmin, xmax )
 
 def tstme():
-    from sherpa.utils import SherpaTest
     import sherpa.optmethods
     SherpaTest(sherpa.optmethods).test()
 

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,10 +17,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import numpy
 import sherpa.all as sherpa
-from sherpa.utils import SherpaTestCase, requires_data
+from sherpa.utils.test import SherpaTestCase, requires_data
 
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -19,7 +19,7 @@
 
 import numpy
 import sherpa.all as sherpa
-from sherpa.utils.test import SherpaTestCase, requires_data
+from sherpa.utils.test import SherpaTest, SherpaTestCase, requires_data
 
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
@@ -397,7 +397,6 @@ class test_confidence(SherpaTestCase):
         # self.ru.contour()
 
 if __name__ == '__main__':
-    from sherpa.utils import SherpaTest
     import sherpa.plot
 
     import sys

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, requires_pylab
+from sherpa.utils.test import SherpaTestCase, requires_pylab
 
 
 @requires_pylab
@@ -27,4 +27,3 @@ class pylab_test(SherpaTestCase):
         from sherpa.plot.pylab_backend import _errorbar_defaults
         # assert all needed defaults have been found
         assert all(e in _errorbar_defaults for e in ('ecolor', 'capsize', 'barsabove'))
-

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -27,9 +27,9 @@ from sherpa.fit import Fit
 from sherpa.stats import Cash, Chi2DataVar, CStat
 from sherpa.optmethods import NelderMead, LevMar
 from sherpa.estmethods import Covariance
-from sherpa.sim import *
+from sherpa import sim
 
-from sherpa.utils import SherpaTestCase, SherpaTest
+from sherpa.utils.test import SherpaTestCase, SherpaTest
 
 
 _max  = numpy.finfo(numpy.float32).max
@@ -48,7 +48,7 @@ class test_sim(SherpaTestCase):
         'nfev': 93,
         'statval': 8483.0287367571564,
         'parnames': ['p1.gamma', 'p1.ampl', 'g1.fwhm',
-                     'g1.pos', 'g1.ampl'], 
+                     'g1.pos', 'g1.ampl'],
         'parvals': numpy.array(
             [1.0701938169914813,
              9.1826254677279469,
@@ -70,8 +70,7 @@ class test_sim(SherpaTestCase):
            1,  0,  1,  0
           ]
         )
-    _err = numpy.ones(100)*0.4
-
+    _err = numpy.ones(100) * 0.4
 
     def setUp(self):
         data = Data1D('fake', self._x, self._y, self._err)
@@ -83,7 +82,7 @@ class test_sim(SherpaTestCase):
         p1 = PowLaw1D('p1')
         p1.gamma.set(1.0, -10, 10, frozen=False)
         p1.ampl.set(1.0, 0.0, _max, frozen=False)
-        p1.ref.set(1.0, -_max, _max, frozen=True)      
+        p1.ref.set(1.0, -_max, _max, frozen=True)
         model = p1 + g1
 
         method = LevMar()
@@ -122,69 +121,69 @@ class test_sim(SherpaTestCase):
         self.cov = numpy.array(covresults.extra_output)
         self.num = 10
 
-
     def test_student_t(self):
-        multivariate_t(self.mu, self.cov, self.dof, self.num)
+        sim.multivariate_t(self.mu, self.cov, self.dof, self.num)
 
     def test_cauchy(self):
-        multivariate_cauchy(self.mu, self.cov, self.num)       
+        sim.multivariate_cauchy(self.mu, self.cov, self.num)
 
     def test_parameter_scale_vector(self):
-        ps = ParameterScaleVector()
+        ps = sim.ParameterScaleVector()
         ps.get_scales(self.fit)
 
     def test_parameter_scale_matrix(self):
-        ps = ParameterScaleMatrix()
+        ps = sim.ParameterScaleMatrix()
         ps.get_scales(self.fit)
 
     def test_uniform_parameter_sample(self):
-        up = UniformParameterSampleFromScaleVector()
+        up = sim.UniformParameterSampleFromScaleVector()
         up.get_sample(self.fit, num=self.num)
 
     def test_normal_parameter_sample_vector(self):
-        np = NormalParameterSampleFromScaleVector()
+        np = sim.NormalParameterSampleFromScaleVector()
         np.get_sample(self.fit, num=self.num)
 
     def test_normal_parameter_sample_matrix(self):
-        np = NormalParameterSampleFromScaleMatrix()
+        np = sim.NormalParameterSampleFromScaleMatrix()
         np.get_sample(self.fit, num=self.num)
 
     def test_t_parameter_sample_matrix(self):
-        np = StudentTParameterSampleFromScaleMatrix()
+        np = sim.StudentTParameterSampleFromScaleMatrix()
         np.get_sample(self.fit, self.dof, num=self.num)
 
+    # TODO: this is over-ridden by a later test with the same name
     def test_uniform_sample(self):
-        up = UniformSampleFromScaleVector()
+        up = sim.UniformSampleFromScaleVector()
         up.get_sample(self.fit, num=self.num)
 
     def test_normal_sample_vector(self):
-        np = NormalSampleFromScaleVector()
+        np = sim.NormalSampleFromScaleVector()
         np.get_sample(self.fit, num=self.num)
 
     def test_normal_sample_matrix(self):
-        np = NormalSampleFromScaleMatrix()
+        np = sim.NormalSampleFromScaleMatrix()
         np.get_sample(self.fit, num=self.num)
 
     def test_t_sample_matrix(self):
-        np = StudentTSampleFromScaleMatrix()
+        np = sim.StudentTSampleFromScaleMatrix()
         np.get_sample(self.fit, self.num, self.dof)
 
+    # TODO: this overrides the earlier definition
     def test_uniform_sample(self):
-        uniform_sample(self.fit, num=self.num)
+        sim.uniform_sample(self.fit, num=self.num)
 
     def test_normal_sample(self):
-        normal_sample(self.fit, num=self.num, correlate=False)
+        sim.normal_sample(self.fit, num=self.num, correlate=False)
 
     def test_normal_sample_correlated(self):
-        normal_sample(self.fit, num=self.num, correlate=True)
+        sim.normal_sample(self.fit, num=self.num, correlate=True)
 
     def test_t_sample(self):
-        t_sample(self.fit, self.num, self.dof)
+        sim.t_sample(self.fit, self.num, self.dof)
 
     def test_lrt(self):
-        results = LikelihoodRatioTest.run(self.fit, self.fit.model.lhs,
-                                          self.fit.model, niter=25)
-
+        results = sim.LikelihoodRatioTest.run(self.fit, self.fit.model.lhs,
+                                              self.fit.model, niter=25)
 
     def test_mh(self):
 
@@ -194,12 +193,12 @@ class test_sim(SherpaTestCase):
         results = self.fit.est_errors()
         cov = results.extra_output
 
-        mcmc = MCMC()
+        mcmc = sim.MCMC()
 
         samplers = mcmc.list_samplers()
         priors = mcmc.list_priors()
         for par in self.fit.model.pars:
-            mcmc.set_prior(par, flat)
+            mcmc.set_prior(par, sim.flat)
             prior = mcmc.get_prior(par)
 
         sampler = mcmc.get_sampler()
@@ -209,14 +208,13 @@ class test_sim(SherpaTestCase):
 
         opt = mcmc.get_sampler_opt('defaultprior')
         mcmc.set_sampler_opt('defaultprior', opt)
-        #mcmc.set_sampler_opt('verbose', True)
+        # mcmc.set_sampler_opt('verbose', True)
 
         log = logging.getLogger("sherpa")
         level = log.level
         log.setLevel(logging.ERROR)
         stats, accept, params = mcmc.get_draws(self.fit, cov, niter=1e2)
         log.setLevel(level)
-
 
     def test_metropolisMH(self):
 
@@ -226,9 +224,9 @@ class test_sim(SherpaTestCase):
         results = self.fit.est_errors()
         cov = results.extra_output
 
-        mcmc = MCMC()
+        mcmc = sim.MCMC()
         mcmc.set_sampler('MetropolisMH')
-        #mcmc.set_sampler_opt('verbose', True)
+        # mcmc.set_sampler_opt('verbose', True)
 
         log = logging.getLogger("sherpa")
         level = log.level
@@ -236,12 +234,10 @@ class test_sim(SherpaTestCase):
         stats, accept, params = mcmc.get_draws(self.fit, cov, niter=1e2)
         log.setLevel(level)
 
-
     def tearDown(self):
         pass
 
 
 if __name__ == '__main__':
 
-    import sherpa.sim as sim
     SherpaTest(sim).test()

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,17 +20,16 @@
 import os.path
 
 import numpy
-import unittest
 
-from sherpa.utils import SherpaTest, SherpaTestCase
-from sherpa.utils import requires_data, requires_xspec, requires_fits
+from sherpa.utils.test import SherpaTest, SherpaTestCase, \
+    requires_data, requires_xspec, requires_fits
 
 from sherpa.models import PowLaw1D
 from sherpa.fit import Fit
-from sherpa.stats import Stat, Cash, LeastSq, UserStat, WStat
+from sherpa.stats import Cash, UserStat, WStat
 from sherpa.optmethods import LevMar, NelderMead
 from sherpa.utils.err import StatErr
-from sherpa.astro import ui
+
 import logging
 logger = logging.getLogger("sherpa")
 

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 
 import os.path
 import sherpa
-from sherpa.utils import SherpaTest, SherpaTestCase, requires_data
+from sherpa.utils.test import SherpaTest, SherpaTestCase, requires_data
 from sherpa import ui
 
 

--- a/sherpa/tests/test_stack.py
+++ b/sherpa/tests/test_stack.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,11 +18,12 @@
 #
 
 
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 import stk
 
 import os
 _this_dir = os.path.dirname(__file__)
+
 
 class test_stack(SherpaTestCase):
 

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTest, SherpaTestCase, requires_data
+from sherpa.utils.test import SherpaTest, SherpaTestCase, requires_data
 from sherpa.models import ArithmeticModel, Parameter
 from sherpa import ui
 import numpy

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
@@ -38,6 +39,9 @@ from sherpa.utils._utils import calc_ftest, calc_mlr, igamc, igam, \
 from sherpa.utils._psf import extract_kernel, normalize, set_origin, \
     pad_bounding_box
 from functools import wraps
+
+import warnings
+from . import test
 
 from sherpa import get_config
 from ConfigParser import ConfigParser, NoSectionError
@@ -95,7 +99,11 @@ __all__ = ('NoNewAttributesAfterInit',
            'parse_expr', 'poisson_noise', 'print_fields', 'rebin',
            'sao_arange', 'sao_fcmp', 'set_origin', 'sum_intervals', 'zeroin',
            'multinormal_pdf', 'multit_pdf', 'get_error_estimates', 'quantile',
-           'get_valid_args')
+           'get_valid_args',
+           # re-export from sherpa.utils.test for backwards compatibility
+           'SherpaTest', 'SherpaTestCase',
+           'requires_data', 'requires_fits', 'requires_package'
+           )
 
 _guess_ampl_scale = 1.e+3
 
@@ -2600,3 +2608,44 @@ def get_valid_args(func):
     kwargs_length = len(func.func_defaults) if func.func_defaults else 0 # number of keyword arguments
     valid_kwargs = valid_args[-kwargs_length:] if kwargs_length else []  # because kwargs are last
     return valid_kwargs
+
+
+# Testing routines: these are deprecated and the routines in
+# sherpa.utils.test should be used instead. Should this use
+# a decorator so that the original doc string can be retained?
+#
+class SherpaTest(test.SherpaTest):
+    """Deprecated: use sherpa.utils.test.SherpaTest"""
+    def __init__(self, *args, **kwargs):
+        m = 'SherpaTest is deprecated: use sherpa.utils.test.SherpaTest'
+        warnings.warn(m, DeprecationWarning, stacklevel=2)
+        test.SherpaTest.__init__(self, *args, **kwargs)
+
+
+class SherpaTestCase(test.SherpaTestCase):
+    """Deprecated: use sherpa.utils.test.SherpaTestCase"""
+    def __init__(self, *args, **kwargs):
+        m = 'SherpaTestCase is deprecated: use sherpa.utils.test.SherpaTestCase'
+        warnings.warn(m, DeprecationWarning, stacklevel=2)
+        test.SherpaTestCase.__init__(self, *args, **kwargs)
+
+
+def requires_data(*args, **kwargs):
+    """Deprecated: use sherpa.utils.test.requires_data"""
+    m = 'requires_data is deprecated: use sherpa.utils.test.requires_data'
+    warnings.warn(m, DeprecationWarning, stacklevel=2)
+    test.requires_data(*args, **kwargs)
+
+
+def requires_fits(*args, **kwargs):
+    """Deprecated: use sherpa.utils.test.requires_fits"""
+    m = 'requires_fits is deprecated: use sherpa.utils.test.requires_fits'
+    warnings.warn(m, DeprecationWarning, stacklevel=2)
+    test.requires_fits(*args, **kwargs)
+
+
+def requires_package(*args, **kwargs):
+    """Deprecated: use sherpa.utils.test.requires_package"""
+    m = 'requires_package is deprecated: use sherpa.utils.test.requires_package'
+    warnings.warn(m, DeprecationWarning, stacklevel=2)
+    test.requires_package(*args, **kwargs)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -28,14 +28,10 @@ from types import FunctionType as function
 from types import MethodType as instancemethod
 import string
 import sys
-import os
-import importlib
 import numpy
 import numpy.random
-import numpytest
 import numpy.fft
 # Note: _utils.gsl_fcmp is not exported from this module; is this intentional?
-from unittest import skipIf
 from sherpa.utils._utils import calc_ftest, calc_mlr, igamc, igam, \
     incbet, gamma, lgam, erf, ndtri, sao_fcmp, rebin, \
     hist1d, hist2d, sum_intervals, neville, sao_arange
@@ -80,7 +76,7 @@ except Exception, e:
 del _ncpu_val, config, get_config, ConfigParser, NoSectionError
 
 
-__all__ = ('NoNewAttributesAfterInit', 'SherpaTest', 'SherpaTestCase',
+__all__ = ('NoNewAttributesAfterInit',
            '_guess_ampl_scale', 'apache_muller', 'bisection', 'bool_cast',
            'calc_ftest', 'calc_mlr', 'calc_total_error', 'create_expr',
            'dataspace1d', 'dataspace2d', 'demuller',
@@ -93,7 +89,7 @@ __all__ = ('NoNewAttributesAfterInit', 'SherpaTest', 'SherpaTestCase',
            'guess_reference', 'histogram1d', 'histogram2d', 'igam', 'igamc',
            'incbet', 'interpolate', 'is_binary_file', 'Knuth_close',
            'lgam', 'linear_interp', 'nearest_interp',
-           'neville', 'neville2d', 'requires_data', 'requires_fits', 'requires_package',
+           'neville', 'neville2d',
            'new_muller', 'normalize', 'numpy_convolve',
            'pad_bounding_box', 'parallel_map', 'param_apply_limits',
            'parse_expr', 'poisson_noise', 'print_fields', 'rebin',
@@ -154,221 +150,6 @@ class NoNewAttributesAfterInit(object):
                                      (type(self).__name__, name))
 
         object.__setattr__(self, name, val)
-
-
-###############################################################################
-#
-# Testing stuff
-#
-###############################################################################
-
-def _get_datadir():
-    import os
-    try:
-        import sherpatest
-        datadir = os.path.dirname(sherpatest.__file__)
-    except ImportError:
-        try:
-            import sherpa
-            datadir = os.path.join(os.path.dirname(sherpa.__file__), os.pardir,
-                                   'sherpa-test-data', 'sherpatest')
-            if not os.path.exists(datadir) or not os.listdir(datadir):
-                # The dir is empty, maybe the submodule was not initialized
-                datadir = None
-        except ImportError:
-            # neither sherpatest nor sherpa can be found, falling back to None
-            datadir = None
-    return datadir
-
-
-class SherpaTestCase(numpytest.NumpyTestCase):
-    "Base class for Sherpa unit tests"
-
-    # The location of the Sherpa test data (it is optional)
-    datadir = _get_datadir()
-
-    def make_path(self, *segments):
-        """Add the segments onto the test data location.
-
-        Parameters
-        ----------
-        *segments
-           Path segments to combine together with the location of the
-           test data.
-
-        Returns
-        -------
-        fullpath : None or string
-           The full path to the repository, or None if the
-           data directory is not set.
-
-        """
-        if self.datadir is None:
-            return None
-        return os.path.join(self.datadir, *segments)
-
-    # What is the benefit of this over numpy.testing.assert_allclose(),
-    # which was added in version 1.5 of NumPy?
-    def assertEqualWithinTol(self, first, second, tol=1e-7, msg=None):
-        """Check that the values are equal within an absolute tolerance.
-
-        Parameters
-        ----------
-        first : number or array_like
-           The expected value, or values.
-        second : number or array_like
-           The value, or values, to check. If first is an array, then
-           second must be an array of the same size. If first is
-           a scalar then second can be a scalar or an array.
-        tol : number
-           The absolute tolerance used for comparison.
-        msg : string
-           The message to display if the check fails.
-
-        """
-
-        self.assertFalse(numpy.any(sao_fcmp(first, second, tol)), msg)
-
-    def assertNotEqualWithinTol(self, first, second, tol=1e-7, msg=None):
-        """Check that the values are not equal within an absolute tolerance.
-
-        Parameters
-        ----------
-        first : number or array_like
-           The expected value, or values.
-        second : number or array_like
-           The value, or values, to check. If first is an array, then
-           second must be an array of the same size. If first is
-           a scalar then second can be a scalar or an array.
-        tol : number
-           The absolute tolerance used for comparison.
-        msg : string
-           The message to display if the check fails.
-
-        """
-
-        self.assertTrue(numpy.all(sao_fcmp(first, second, tol)), msg)
-
-    # for running regression tests from sherpa-test-data
-    def run_thread(self, name, scriptname='fit.py'):
-        """Run a regression test from the sherpa-test-data submodule.
-
-        Parameters
-        ----------
-        name : string
-           The name of the science thread to run (e.g., pha_read,
-           radpro). The name should match the corresponding thread
-           name in the sherpa-test-data submodule. See examples below.
-        scriptname : string
-           The suffix of the test script file name, usually "fit.py."
-
-        Examples
-        --------
-        Regression test script file names have the structure
-        "name-scriptname.py." By default, scriptname is set to "fit.py."
-        For example, if one wants to run the regression test
-        "pha_read-fit.py," they would write
-
-        >>> run_thread("pha_read")
-
-        If the regression test name is "lev3fft-bar.py," they would do
-
-        >>> run_thread("lev3fft", scriptname="bar.py")
-
-        """
-
-        self.locals = {}
-        cwd = os.getcwd()
-        os.chdir(self.datadir)
-        scriptname = name + "-" + scriptname
-        try:
-            execfile(scriptname, {}, self.locals)
-        finally:
-            os.chdir(cwd)
-
-
-def requires_data(test_function):
-    """
-    Decorator for functions requiring external data (i.e. data not distributed with Sherpa
-    itself) is missing.  This is used to skip tests that require such data.
-    """
-    condition = SherpaTestCase.datadir is None
-    msg = "required test data missing"
-    return skipIf(condition, msg)(test_function)
-
-
-def _has_package_from_list(*packages):
-    """
-    Returns True if at least one of the ``packages`` args is importable.
-    """
-    for package in packages:
-        try:
-            importlib.import_module(package)
-            return True
-        except:
-            pass
-    return False
-
-
-def requires_package(msg=None, *packages):
-    """
-    Decorator for test functions requiring specific packages.
-    """
-    condition = _has_package_from_list(*packages)
-    msg = msg or "required module missing among {}.".format(", ".join(packages))
-
-    def decorator(test_function):
-        return skipIf(not condition, msg)(test_function)
-    return decorator
-
-
-def requires_xspec(test_function):
-    """Decorator for test functions requiring xspec"""
-    return requires_package('xspec required', 'sherpa.astro.xspec')(test_function)
-
-
-def requires_ds9(test_function):
-    """Decorator for test functions requiring ds9"""
-    return requires_package('ds9 required', 'sherpa.image.ds9_backend')(test_function)
-
-
-def requires_fits(test_function):
-    """
-    Returns True if there is an importable backend for FITS I/O.
-    Used to skip tests requiring fits_io
-    """
-    packages = ('pyfits',
-                'astropy.io.fits',
-                'pycrates',
-                )
-    msg = "FITS backend required"
-    return requires_package(msg, *packages)(test_function)
-
-
-def requires_pylab(test_function):
-    """
-    Returns True if the pylab module is available (pylab).
-    Used to skip tests requiring matplotlib
-    """
-    packages = ('pylab',
-                )
-    msg = "matplotlib backend required"
-    return requires_package(msg, *packages)(test_function)
-
-
-class SherpaTest(numpytest.NumpyTest):
-    "Sherpa test suite manager"
-
-    def test(self, level=1, verbosity=1, datadir=None):
-        old_datadir = SherpaTestCase.datadir
-        SherpaTestCase.datadir = datadir
-
-        try:
-            result = numpytest.NumpyTest.test(self, level, verbosity)
-            if result is None or result.failures or result.errors or result.unexpectedSuccesses:
-                raise Exception("Test failures were detected")
-        finally:
-            SherpaTestCase.datadir = old_datadir
 
 
 ###############################################################################
@@ -1793,6 +1574,7 @@ class NumDerivFowardPartial(NumDeriv):
         fval /= deltai * deltaj
         return fval
 
+
 class NumDerivCentralPartial(NumDeriv):
     """Add the following Taylor series expansion::
 
@@ -1969,6 +1751,10 @@ def symmetric_to_low_triangle(matrix, num):
 ############################### Root of all evil ##############################
 
 
+# TODO: can this routine be removed?
+#
+# This function calls an undefined function - if_ - but it is not
+# used here, or exported by the module.
 def printf(format, *args):
     """Format args with the first argument as format string, and write.
     Return the last arg, or format itself if there are no args."""
@@ -2238,7 +2024,6 @@ def bisection(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6):
                     return [[xa, fa], [[xa, fa], [xb, fb]], nfev[0]]
                 else:
                     return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
-
 
         xc = (xa + xb) / 2.0
         fc = myfcn(xc, *args)
@@ -2532,6 +2317,7 @@ def new_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6):
         # for x, y in izip( history[0], history[1] ):
         #     print 'f(%e)=%e' % ( x, y )
         return [[xd, fd], [[xa, fa], [xb, fb]], nfev[0]]
+
 
 #
 # /*

--- a/sherpa/utils/test.py
+++ b/sherpa/utils/test.py
@@ -1,0 +1,242 @@
+#
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Utility routines for the Sherpa test suite.
+"""
+
+import importlib
+import os
+
+from unittest import skipIf
+
+import numpy
+import numpytest
+
+from sherpa.utils._utils import sao_fcmp
+
+__all__ = ('SherpaTest', 'SherpaTestCase',
+           'requires_data', 'requires_fits', 'requires_package')
+
+
+def _get_datadir():
+    try:
+        import sherpatest
+        datadir = os.path.dirname(sherpatest.__file__)
+    except ImportError:
+        try:
+            import sherpa
+            datadir = os.path.join(os.path.dirname(sherpa.__file__), os.pardir,
+                                   'sherpa-test-data', 'sherpatest')
+            if not os.path.exists(datadir) or not os.listdir(datadir):
+                # The dir is empty, maybe the submodule was not initialized
+                datadir = None
+        except ImportError:
+            # neither sherpatest nor sherpa can be found, falling back to None
+            datadir = None
+    return datadir
+
+
+class SherpaTestCase(numpytest.NumpyTestCase):
+    "Base class for Sherpa unit tests"
+
+    # The location of the Sherpa test data (it is optional)
+    datadir = _get_datadir()
+
+    def make_path(self, *segments):
+        """Add the segments onto the test data location.
+
+        Parameters
+        ----------
+        *segments
+           Path segments to combine together with the location of the
+           test data.
+
+        Returns
+        -------
+        fullpath : None or string
+           The full path to the repository, or None if the
+           data directory is not set.
+
+        """
+        if self.datadir is None:
+            return None
+        return os.path.join(self.datadir, *segments)
+
+    # What is the benefit of this over numpy.testing.assert_allclose(),
+    # which was added in version 1.5 of NumPy?
+    def assertEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
+        """
+
+        self.assertFalse(numpy.any(sao_fcmp(first, second, tol)), msg)
+
+    def assertNotEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are not equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
+        """
+
+        self.assertTrue(numpy.all(sao_fcmp(first, second, tol)), msg)
+
+    # for running regression tests from sherpa-test-data
+    def run_thread(self, name, scriptname='fit.py'):
+        """Run a regression test from the sherpa-test-data submodule.
+
+        Parameters
+        ----------
+        name : string
+           The name of the science thread to run (e.g., pha_read,
+           radpro). The name should match the corresponding thread
+           name in the sherpa-test-data submodule. See examples below.
+        scriptname : string
+           The suffix of the test script file name, usually "fit.py."
+
+        Examples
+        --------
+        Regression test script file names have the structure
+        "name-scriptname.py." By default, scriptname is set to "fit.py."
+        For example, if one wants to run the regression test
+        "pha_read-fit.py," they would write
+
+        >>> run_thread("pha_read")
+
+        If the regression test name is "lev3fft-bar.py," they would do
+
+        >>> run_thread("lev3fft", scriptname="bar.py")
+
+        """
+
+        self.locals = {}
+        cwd = os.getcwd()
+        os.chdir(self.datadir)
+        scriptname = name + "-" + scriptname
+        try:
+            execfile(scriptname, {}, self.locals)
+        finally:
+            os.chdir(cwd)
+
+
+def requires_data(test_function):
+    """Decorator to skip a test if the external data is not available.
+
+    This decorator causes tests to be skipped if the `sherpa-test-data`
+    directory of the Sherpa distribution has not been initialized (it
+    is a git submodule).
+    """
+    condition = SherpaTestCase.datadir is None
+    msg = "required test data missing"
+    return skipIf(condition, msg)(test_function)
+
+
+def _has_package_from_list(*packages):
+    """Returns True if at least one of the ``packages`` args is importable.
+    """
+    for package in packages:
+        try:
+            importlib.import_module(package)
+            return True
+        except:
+            pass
+    return False
+
+
+def requires_package(msg=None, *packages):
+    """Decorator for test functions requiring specific packages.
+    """
+    condition = _has_package_from_list(*packages)
+    msg = msg or "required module missing among {}.".format(", ".join(packages))
+
+    def decorator(test_function):
+        return skipIf(not condition, msg)(test_function)
+    return decorator
+
+
+def requires_xspec(test_function):
+    """Decorator for test functions requiring XSPEC"""
+    return requires_package('xspec required', 'sherpa.astro.xspec')(test_function)
+
+
+def requires_ds9(test_function):
+    """Decorator for test functions requiring ds9"""
+    return requires_package('ds9 required', 'sherpa.image.ds9_backend')(test_function)
+
+
+def requires_fits(test_function):
+    """Returns True if there is an importable backend for FITS I/O.
+
+    Used to skip tests requiring fits_io
+    """
+    packages = ('pyfits',
+                'astropy.io.fits',
+                'pycrates',
+                )
+    msg = "FITS backend required"
+    return requires_package(msg, *packages)(test_function)
+
+
+def requires_pylab(test_function):
+    """Returns True if the pylab module is available (pylab).
+
+    Used to skip tests requiring matplotlib
+    """
+    packages = ('pylab',
+                )
+    msg = "matplotlib backend required"
+    return requires_package(msg, *packages)(test_function)
+
+
+class SherpaTest(numpytest.NumpyTest):
+    "Sherpa test suite manager"
+
+    def test(self, level=1, verbosity=1, datadir=None):
+        old_datadir = SherpaTestCase.datadir
+        SherpaTestCase.datadir = datadir
+
+        try:
+            result = numpytest.NumpyTest.test(self, level, verbosity)
+            if result is None or result.failures or result.errors or result.unexpectedSuccesses:
+                raise Exception("Test failures were detected")
+        finally:
+            SherpaTestCase.datadir = old_datadir

--- a/sherpa/utils/tests/test_err.py
+++ b/sherpa/utils/tests/test_err.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2013  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2013, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,21 +17,23 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import *
+from sherpa import utils
+from sherpa.utils.test import SherpaTestCase, SherpaTest
 from sherpa.utils.err import SherpaErr
 from sherpa.utils.err import ModelErr
+
 
 class test_err(SherpaTestCase):
 
     def test_NewSherpaErr(self):
-        class OldSherpaErr( Exception ): 
-            "Old class for all Sherpa exceptions" 
-            def __init__( self, dict, key, *args ): 
-                if dict.has_key( key ): 
-                    errmsg = dict[ key ] % args 
-                else: 
-                    errmsg = "unknown key '%s'" % key 
-                Exception.__init__(self, errmsg) 
+        class OldSherpaErr(Exception):
+            "Old class for all Sherpa exceptions"
+            def __init__(self, dict, key, *args):
+                if key in dict:
+                    errmsg = dict[key] % args
+                else:
+                    errmsg = "unknown key '%s'" % key
+                Exception.__init__(self, errmsg)
 
         dict = {'simple':'simple message', 'arg':'argument: %s'}
 
@@ -53,11 +55,10 @@ class test_err(SherpaTestCase):
         self.assertEqual('My Error', err.message)
 
         # Test #5: verify the user provided example, which exercises a derived class
-        err = ModelErr("Unable to frobnicate model %s" % 'modelname') 
+        err = ModelErr("Unable to frobnicate model %s" % 'modelname')
         self.assertEqual('Unable to frobnicate model modelname', err.message)
 
 
 if __name__ == '__main__':
 
-    import sherpa.utils as utils
     SherpaTest(utils).test()

--- a/sherpa/utils/tests/test_integration.py
+++ b/sherpa/utils/tests/test_integration.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,7 +18,7 @@
 #
 
 import sherpa.utils.integration as integration
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.test import SherpaTestCase
 
 
 class test_integration(SherpaTestCase):

--- a/sherpa/utils/tests/test_root.py
+++ b/sherpa/utils/tests/test_root.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,144 +20,188 @@
 
 import numpy
 import sys
-from sherpa.utils import *
 
-def sqr( x, *args ):
-    return x*x
+from sherpa.utils.test import SherpaTest, SherpaTestCase
+from sherpa import utils
 
-def prob1( x, *args ):
-    return numpy.cos( x ) - pow( x, 3.0 )
 
-def prob2( x, *args ):
-    return pow( x, 4.0 ) - x - 1.0
+def sqr(x, *args):
+    return x * x
 
-def prob3( x, *args ):
-    return ( x + 3.0 ) * ( x - 1.0 ) * ( x - 1.0 )
 
-def prob4( x, *args ):
-    return numpy.exp( x ) + x - 2.0
+def prob1(x, *args):
+    return numpy.cos(x) - pow(x, 3.0)
 
-def prob5( x, *args ):
-    return x + numpy.exp( x )
 
-def prob6( x, *args ):
-    return numpy.sqrt( x ) + x * x - 5.0
+def prob2(x, *args):
+    return pow(x, 4.0) - x - 1.0
 
-def prob7( x, *args ):
+
+def prob3(x, *args):
+    return (x + 3.0) * (x - 1.0) * (x - 1.0)
+
+
+def prob4(x, *args):
+    return numpy.exp(x) + x - 2.0
+
+
+def prob5(x, *args):
+    return x + numpy.exp(x)
+
+
+def prob6(x, *args):
+    return numpy.sqrt(x) + x * x - 5.0
+
+
+def prob7(x, *args):
     return x + numpy.sin(x) - 4.0
 
-def prob8( x, *args ):
-    return x * x - numpy.exp( x )
 
-def prob9( x, *args ):
-    return numpy.sin( x ) + numpy.cos( x )
+def prob8(x, *args):
+    return x * x - numpy.exp(x)
 
-def prob10( x, *args ):
+
+def prob9(x, *args):
+    return numpy.sin(x) + numpy.cos(x)
+
+
+def prob10(x, *args):
     return x * x - 2.0
 
-def prob11( x, *args ):
-    x2 = sqr( x )
-    x4 = sqr( x2 )
-    x8 = sqr( x4 )
+
+def prob11(x, *args):
+    x2 = sqr(x)
+    x4 = sqr(x2)
+    x8 = sqr(x4)
     return x8 * x
 
-def prob12( x, *args ):
+
+def prob12(x, *args):
     if x == 0.0:
         return 0.0
-    return x - numpy.exp( -1.0 / ( x * x ) )
+    return x - numpy.exp(-1.0 / (x * x))
 
-def prob13( x, *args ):
-    x2 = sqr( x - 1.0 )
+
+def prob13(x, *args):
+    x2 = sqr(x - 1.0)
     x4 = x2 * x2
-    return x * x4 * ( x - 1.0 )
+    return x * x4 * (x - 1.0)
 
-def prob14( x, *args ):
-    return ( x - 5.0 ) * ( x - 2.0 )
 
-def prob15( x, *args ):
-    return ( x - 50.0 ) * ( x + 20.0 )
+def prob14(x, *args):
+    return (x - 5.0) * (x - 2.0)
 
-def prob16( x, *args ):
-    return (sqr(x)-2.0)*x - 5.0
 
-def prob17( x, *args ):
-    return sqr( x - 1.0e-5 ) - 3.0
+def prob15(x, *args):
+    return (x - 50.0) * (x + 20.0)
 
-def prob18( x, *args ):
+
+def prob16(x, *args):
+    return (sqr(x) - 2.0) * x - 5.0
+
+
+def prob17(x, *args):
+    return sqr(x - 1.0e-5) - 3.0
+
+
+def prob18(x, *args):
     return numpy.cos(x) - x
 
-def prob19( x, *args ):
+
+def prob19(x, *args):
     return numpy.sin(x) - x
 
-def prob20( x, *args ):
+
+def prob20(x, *args):
     return x * x * x - 2.0 * x - 5.0
 
-def prob21( x, *args ):
+
+def prob21(x, *args):
     return numpy.sin(x) - 0.5 * x
 
-def prob22( x, *args ):
-    return 2 * x - numpy.exp( - x )
 
-def prob23( x, *args ):
-    return x * numpy.exp( -x )
+def prob22(x, *args):
+    return 2 * x - numpy.exp(- x)
 
-def prob24( x, *args ):
-    return numpy.exp( x ) - 1. / (100*x*x)
 
-def prob25( x, *args ):
+def prob23(x, *args):
+    return x * numpy.exp(-x)
+
+
+def prob24(x, *args):
+    return numpy.exp(x) - 1. / (100 * x * x)
+
+
+def prob25(x, *args):
     tmp = x - 1
-    return ( x + 3 ) * tmp * tmp
+    return (x + 3) * tmp * tmp
 
-def prob26( x, *args ):
-    return numpy.exp(x) - 2 - 1 / ( 10 * x )**2 - 2 / ( 100 * x )**3
 
-def prob27( x, *args ):
+def prob26(x, *args):
+    return numpy.exp(x) - 2 - 1 / (10 * x)**2 - 2 / (100 * x)**3
+
+
+def prob27(x, *args):
     return x**3
 
-def prob28( x, *args ):
-    return numpy.cos( x ) - x
+
+def prob28(x, *args):
+    return numpy.cos(x) - x
+
 
 # root is 1.83 the convergence rate for Muller's method
-def prob29( x, *args ):
-    return pow( x, 3.0 ) - x*x - x - 1
+def prob29(x, *args):
+    return pow(x, 3.0) - x * x - x - 1
+
 
 # muller gets it wrong but muller_bound got it right
-def prob30( x, *args ):
-    return numpy.exp( x ) - 1
+def prob30(x, *args):
+    return numpy.exp(x) - 1
 
-def prob31( x, *args ):
-    return x * numpy.exp( x ) - 1
 
-def prob32( x, *args ):
-    return 11.0 * pow( x, 11.0 ) - 1.0
+def prob31(x, *args):
+    return x * numpy.exp(x) - 1
 
-def prob33( x, *args ):
-    return numpy.exp( (1.0*x+7)*x -30.0 ) - 1.0
 
-def prob34( x, *args ):
-    return 1.0 / x - numpy.sin( x ) + 1.0
+def prob32(x, *args):
+    return 11.0 * pow(x, 11.0) - 1.0
 
-def prob35( x, *args ):
-    return ( x*x - 2.0 ) * x - 5.0
 
-def prob36( x, *args ):
+def prob33(x, *args):
+    return numpy.exp((1.0 * x + 7) * x - 30.0) - 1.0
+
+
+def prob34(x, *args):
+    return 1.0 / x - numpy.sin(x) + 1.0
+
+
+def prob35(x, *args):
+    return (x * x - 2.0) * x - 5.0
+
+
+def prob36(x, *args):
     return 1.0 / x - 1.0
 
-def prob37( x, *args ):
-    return numpy.log( x )
 
-def prob38( x, *args ):
-    return x - numpy.exp( numpy.sin(x) )
+def prob37(x, *args):
+    return numpy.log(x)
 
-def repeller( x, *args ):
-    return  20.0 * x / ( 100.0 * x * x + 1.0 )
 
-def pinhead( x, *args ):
+def prob38(x, *args):
+    return x - numpy.exp(numpy.sin(x))
+
+
+def repeller(x, *args):
+    return 20.0 * x / (100.0 * x * x + 1.0)
+
+
+def pinhead(x, *args):
     epsilon = 0.00001
     if epsilon == 0.0:
-        return ( 16.0 - x**4 ) / ( 16.0 * x**4 )
+        return (16.0 - x**4) / (16.0 * x**4)
     else:
-        return  ( 16.0 - x**4 ) / ( 16.0 * x**4 + epsilon )
+        return (16.0 - x**4) / (16.0 * x**4 + epsilon)
+
 
 #    Sample results:
 #
@@ -178,272 +222,276 @@ def pinhead( x, *args ):
 #    0.750   70  110.302
 #    0.990    2   32.361007
 
-def kepler( x, *args ):
+def kepler(x, *args):
     e = 0.8
     m = 5.0
     pi = 3.141592653589793
-    return ( pi * ( x - m ) / 180.0 - e * numpy.sin ( pi * x / 180.0 ) )
+    return (pi * (x - m) / 180.0 - e * numpy.sin(pi * x / 180.0))
 
-def wallis( x, *args ):
-    return x**3 - 2*x - 5
 
-def thinpole( x, *args ):
+def wallis(x, *args):
+    return x**3 - 2 * x - 5
+
+
+def thinpole(x, *args):
     pi = 3.141592653589793
-    return  3.0 * x**2 + 1.0 + ( numpy.log ( ( x - pi )**2 ) ) / pi**4
+    return 3.0 * x**2 + 1.0 + (numpy.log((x - pi)**2)) / pi**4
+
 
 def muller_convergence_rate(x):
-    return x - pow(x,3.0)/3.0
+    return x - pow(x, 3.0) / 3.0
 
-class test_root( SherpaTestCase ):
+
+class test_root(SherpaTestCase):
 
     def setUp(self):
         self.verbose = False
         self.tol = 1.0e-6
 
-    def demuller2( self, fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
-                   tol=1.0e-6 ):
-        return demuller( fcn, xa, xb, (xa+xb)/2.0, args=args, maxfev=maxfev,
-                         tol=tol)
+    def demuller2(self, fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
+                   tol=1.0e-6):
+        return utils.demuller(fcn, xa, xb, (xa+xb)/2.0, args=args, maxfev=maxfev,
+                              tol=tol)
 
-    def tst_solve( self, fct, a, b, tol, iprint=False ):
-        methods = [ bisection, self.demuller2, new_muller, apache_muller, zeroin ]
+    def tst_solve(self, fct, a, b, tol, iprint=False):
+        methods = [ utils.bisection, self.demuller2, utils.new_muller,
+                    utils.apache_muller, utils.zeroin ]
         if self.verbose or iprint:
-            sys.stdout.write( '\n' )
+            sys.stdout.write('\n')
 
         for solve_func in methods:
             # demuller2 cannot solve prob30 & pinhead so may as well skip them
             if fct.__name__ == 'prob30' or fct.__name__ == 'pinhead':
-                self.assert_( 0 == 0 )
+                self.assert_(0 == 0)
                 return
-            result = solve_func( fct, a, b, tol=tol )
-            [ root, froot ] = result[ 0 ]
+            result = solve_func(fct, a, b, tol=tol)
+            [root, froot] = result[0]
             if self.verbose or iprint:
                 solve_name = solve_func.__name__
                 fct_name = fct.__name__
                 nfev = result[ -1 ]
-                msg = '%s:\t%s(%e) = %e in %d nfevs\n' % ( solve_name, fct_name, root, froot, nfev )
-                sys.stdout.write( msg )
-            self.assert_( abs( froot ) <= tol )
+                msg = '%s:\t%s(%e) = %e in %d nfevs\n' % (solve_name, fct_name, root, froot, nfev)
+                sys.stdout.write(msg)
+            self.assert_(abs(froot) <= tol)
 
-    def test_prob1( self ):
+    def test_prob1(self):
         a = 0.0
         b = 1.0
-        self.tst_solve( prob1, a, b, self.tol )
+        self.tst_solve(prob1, a, b, self.tol)
 
-    def test_prob2( self ):
+    def test_prob2(self):
         a = -5.0
         b = 1.2
-        self.tst_solve( prob2, a, b, self.tol )
+        self.tst_solve(prob2, a, b, self.tol)
 
-    def test_prob3( self ):
+    def test_prob3(self):
         a = -10.0
         b = 10.0
-        self.tst_solve( prob3, a, b, self.tol )
+        self.tst_solve(prob3, a, b, self.tol)
 
-    def test_prob4( self ):
+    def test_prob4(self):
         a = -1.0
         b = 1.0
-        self.tst_solve( prob4, a, b, self.tol )
+        self.tst_solve(prob4, a, b, self.tol)
 
-    def test_prob5( self ):
+    def test_prob5(self):
         a = -1.0
         b = 1.0
-        self.tst_solve( prob5, a, b, self.tol )
+        self.tst_solve(prob5, a, b, self.tol)
 
-    def test_prob6( self ):
+    def test_prob6(self):
         a = 0.0
         b = 3.0
-        self.tst_solve( prob6, a, b, self.tol )
+        self.tst_solve(prob6, a, b, self.tol)
 
-    def test_prob7( self ):
+    def test_prob7(self):
         a = 0.0
         b = 5.0
-        self.tst_solve( prob7, a, b, self.tol )
+        self.tst_solve(prob7, a, b, self.tol)
 
-    def test_prob8( self ):
+    def test_prob8(self):
         a = -5.0
         b = 0.0
-        self.tst_solve( prob8, a, b, self.tol )
+        self.tst_solve(prob8, a, b, self.tol)
 
-    def test_prob9( self ):
+    def test_prob9(self):
         a = 0.0
         b = 3.14
-        self.tst_solve( prob9, a, b, self.tol )
+        self.tst_solve(prob9, a, b, self.tol)
 
-    def test_prob10( self ):
+    def test_prob10(self):
         a = 0.0
         b = 2.0
-        self.tst_solve( prob10, a, b, self.tol )
+        self.tst_solve(prob10, a, b, self.tol)
 
-    def test_prob11( self ):
+    def test_prob11(self):
         a = -1.0
         b = 1.5
-        self.tst_solve( prob11, a, b, self.tol )
+        self.tst_solve(prob11, a, b, self.tol)
 
-    def test_prob12( self ):
+    def test_prob12(self):
         a = -1.0
         b = 1.0
-        self.tst_solve( prob12, a, b, self.tol )
+        self.tst_solve(prob12, a, b, self.tol)
 
-    def test_prob13( self ):
+    def test_prob13(self):
         a = -0.5
         b = 0.99
-        self.tst_solve( prob13, a, b, self.tol )
+        self.tst_solve(prob13, a, b, self.tol)
 
-    def test_prob14( self ):
+    def test_prob14(self):
         a = 1.0
         b = 3.0
-        self.tst_solve( prob14, a, b, self.tol )
+        self.tst_solve(prob14, a, b, self.tol)
 
-    def test_prob15( self ):
+    def test_prob15(self):
         a = 15.0
         b = 75.0
-        self.tst_solve( prob15, a, b, self.tol )
+        self.tst_solve(prob15, a, b, self.tol)
 
-    def test_prob16( self ):
+    def test_prob16(self):
         a = 2.0
         b = 3.0
-        self.tst_solve( prob16, a, b, self.tol )
+        self.tst_solve(prob16, a, b, self.tol)
 
-    def test_prob17( self ):
+    def test_prob17(self):
         a = -1.0
         b = 3.0
-        self.tst_solve( prob17, a, b, self.tol )
+        self.tst_solve(prob17, a, b, self.tol)
 
-    def test_prob18( self ):
+    def test_prob18(self):
         a = -1.0
         b = 3.0
-        self.tst_solve( prob18, a, b, self.tol )
+        self.tst_solve(prob18, a, b, self.tol)
 
-    def test_prob19( self ):
+    def test_prob19(self):
         a = -1.0
         b = 3.0
-        self.tst_solve( prob19, a, b, self.tol )
+        self.tst_solve(prob19, a, b, self.tol)
 
-    def test_prob20( self ):
+    def test_prob20(self):
         a = 2.0
         b = 3.0
-        self.tst_solve( prob20, a, b, self.tol )
+        self.tst_solve(prob20, a, b, self.tol)
 
-    def test_prob21( self ):
+    def test_prob21(self):
         a = -1000.0
         b =  1000.0
-        self.tst_solve( prob21, a, b, self.tol )
+        self.tst_solve(prob21, a, b, self.tol)
 
-    def test_prob22( self ):
+    def test_prob22(self):
         a = -10.0
         b = 100.0
-        self.tst_solve( prob22, a, b, self.tol )
+        self.tst_solve(prob22, a, b, self.tol)
 
-    def test_prob23( self ):
+    def test_prob23(self):
         a = -10.0
         b = 100.0
-        self.tst_solve( prob23, a, b, self.tol )
+        self.tst_solve(prob23, a, b, self.tol)
 
-    def test_prob24( self ):
+    def test_prob24(self):
         a = 1.0e-4
         b = 20.0
-        self.tst_solve( prob24, a, b, self.tol )
+        self.tst_solve(prob24, a, b, self.tol)
 
-    def test_prob25( self ):
+    def test_prob25(self):
         a = -1000.0
         b = 1000.0
-        self.tst_solve( prob25, a, b, self.tol )
+        self.tst_solve(prob25, a, b, self.tol)
 
-    def test_prob26( self ):
+    def test_prob26(self):
         a = 1.0e-4
         b = 20.0
-        self.tst_solve( prob26, a, b, self.tol )
+        self.tst_solve(prob26, a, b, self.tol)
 
-    def test_prob27( self ):
+    def test_prob27(self):
         a = -1000.0
         b =  1000.0
-        self.tst_solve( prob27, a, b, self.tol )
+        self.tst_solve(prob27, a, b, self.tol)
 
-    def test_prob28( self ):
+    def test_prob28(self):
         a = -10.0
         b =  10.0
-        self.tst_solve( prob28, a, b, self.tol )
+        self.tst_solve(prob28, a, b, self.tol)
 
-    def test_prob29( self ):
+    def test_prob29(self):
         a = 0
         b = 10
-        self.tst_solve( prob29, a, b, self.tol )
+        self.tst_solve(prob29, a, b, self.tol)
 
-    def test_prob30( self ):
+    def test_prob30(self):
         a = -50
         b = 100.0
-        self.tst_solve( prob30, a, b, self.tol )
+        self.tst_solve(prob30, a, b, self.tol)
 
-    def test_prob31( self ):
+    def test_prob31(self):
         a = -1.0
         b = 1.0
-        self.tst_solve( prob31, a, b, self.tol )
+        self.tst_solve(prob31, a, b, self.tol)
 
-    def test_prob32( self ):
+    def test_prob32(self):
         a = 0.1
         b = 0.9
-        self.tst_solve( prob32, a, b, self.tol )
+        self.tst_solve(prob32, a, b, self.tol)
 
-    def test_prob33( self ):
+    def test_prob33(self):
         a = 2.8
         b = 3.1
-        self.tst_solve( prob33, a, b, self.tol )
+        self.tst_solve(prob33, a, b, self.tol)
 
-    def test_prob34( self ):
+    def test_prob34(self):
         a = -1.3
         b = -0.5
-        self.tst_solve( prob34, a, b, self.tol )
+        self.tst_solve(prob34, a, b, self.tol)
 
-    def test_prob35( self ):
+    def test_prob35(self):
         a = 2.0
         b = 3.0
-        self.tst_solve( prob35, a, b, self.tol )
+        self.tst_solve(prob35, a, b, self.tol)
 
-    def test_prob36( self ):
+    def test_prob36(self):
         a = 0.5
         b = 1.5
-        self.tst_solve( prob36, a, b, self.tol )
+        self.tst_solve(prob36, a, b, self.tol)
 
-    def test_prob37( self ):
+    def test_prob37(self):
         a = 0.5
         b = 5.0
-        self.tst_solve( prob37, a, b, self.tol )
+        self.tst_solve(prob37, a, b, self.tol)
 
-    def test_prob38( self ):
+    def test_prob38(self):
         a = 1.0
         b = 4.0
-        self.tst_solve( prob38, a, b, self.tol )
+        self.tst_solve(prob38, a, b, self.tol)
 
-    def test_repeller( self ):
+    def test_repeller(self):
         a = -10.0
         b =  10.0
-        self.tst_solve( repeller, a, b, self.tol )
+        self.tst_solve(repeller, a, b, self.tol)
 
-    def test_pinhead( self ):
+    def test_pinhead(self):
         a =  1.0e-5
         b =  10.0
-        self.tst_solve( pinhead, a, b, self.tol )
+        self.tst_solve(pinhead, a, b, self.tol)
 
-    def test_kepler( self ):
+    def test_kepler(self):
         a = -175.0
         b =  185.0
-        self.tst_solve( kepler, a, b, self.tol )
+        self.tst_solve(kepler, a, b, self.tol)
 
-    def test_wallis( self ):
+    def test_wallis(self):
         a = 2.0
         b = 3.0
-        self.tst_solve( wallis, a, b, self.tol )
+        self.tst_solve(wallis, a, b, self.tol)
 
-    def test_muller_convergence_rate( self ):
+    def test_muller_convergence_rate(self):
         a = 1.7
         b = 10.0
-        self.tst_solve( muller_convergence_rate, a, b, self.tol )
+        self.tst_solve(muller_convergence_rate, a, b, self.tol)
+
 
 def tstme():
-    from sherpa.utils import SherpaTest
-    import sherpa.utils
-    SherpaTest(sherpa.utils).test()
+    SherpaTest(utils).test()
 
 #
 # pushd ../../.. ; makeme ; popd ; python test_root.py

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,8 +18,11 @@
 #
 
 import numpy
-from sherpa.utils import *
 from sherpa.utils import SherpaFloat
+from sherpa.utils.test import SherpaTest, SherpaTestCase
+
+from sherpa import utils
+
 
 class test_utils(SherpaTestCase):
 
@@ -33,13 +36,13 @@ class test_utils(SherpaTestCase):
         self.f2 = f2
 
     def test_NoNewAttributesAfterInit(self):
-        class C(NoNewAttributesAfterInit):
+        class C(utils.NoNewAttributesAfterInit):
             def __init__(self):
                 self.x = 1
                 self.y = 2
                 self.z = 3
                 del self.z
-                NoNewAttributesAfterInit.__init__(self)
+                utils.NoNewAttributesAfterInit.__init__(self)
 
         c = C()
         self.assertEqual(c.x, 1)
@@ -71,7 +74,7 @@ class test_utils(SherpaTestCase):
 
         # Basic usage
         for meth in (c.m, c.cm, c.sm):
-            m = export_method(meth)
+            m = utils.export_method(meth)
             self.assertEqual(m.__name__, meth.__name__)
             self.assert_(m.__doc__ is not None)
             self.assertEqual(m.__doc__, meth.__doc__)
@@ -88,105 +91,104 @@ class test_utils(SherpaTestCase):
 
         # Non-method argument
         def f(x):  return 2*x
-        self.assert_(export_method(f) is f)
+        self.assert_(utils.export_method(f) is f)
 
         # Name and module name
-        m = export_method(c.m, 'foo', 'bar')
+        m = utils.export_method(c.m, 'foo', 'bar')
         self.assertEqual(m.__name__, 'foo')
         self.assertEqual(m.__module__, 'bar')
         self.assertEqual(m(3), 6)
         self.assertEqual(m(3, 7), 21)
 
     def test_get_keyword_names(self):
-        self.assertEqual(get_keyword_names(self.f1), [])
+        self.assertEqual(utils.get_keyword_names(self.f1), [])
         l = ['b', 'c', 'd', 'e']
-        self.assertEqual(get_keyword_names(self.f2), l)
-        self.assertEqual(get_keyword_names(self.f2, 2), l[2:])
+        self.assertEqual(utils.get_keyword_names(self.f2), l)
+        self.assertEqual(utils.get_keyword_names(self.f2, 2), l[2:])
 
     def test_get_keyword_defaults(self):
-        self.assertEqual(get_keyword_defaults(self.f1), {})
+        self.assertEqual(utils.get_keyword_defaults(self.f1), {})
         d = {'b':1, 'c':2, 'd':3, 'e':4}
-        self.assertEqual(get_keyword_defaults(self.f2), d)
+        self.assertEqual(utils.get_keyword_defaults(self.f2), d)
         del d['b']
         del d['c']
-        self.assertEqual(get_keyword_defaults(self.f2, 2), d)
+        self.assertEqual(utils.get_keyword_defaults(self.f2, 2), d)
 
     def test_print_fields(self):
         names = ['a', 'bb', 'ccc']
         vals = {'a': 3, 'bb': 'Ham', 'ccc': numpy.array([1.0, 2.0, 3.0])}
-        self.assertEqual(print_fields(names, vals),
+        self.assertEqual(utils.print_fields(names, vals),
                          'a   = 3\nbb  = Ham\nccc = Float64[3]')
 
     def test_calc_total_error(self):
-        stat = numpy.array([1,2])
-        sys = numpy.array([3,4])
-        self.assert_(calc_total_error(None, None) is None)
-        self.assert_(calc_total_error(stat, None) is stat)
-        self.assert_(calc_total_error(None, sys) is sys)
-        self.assert_(numpy.all(calc_total_error(stat, sys) ==
-                               numpy.sqrt(stat*stat + sys*sys)))
+        stat = numpy.array([1, 2])
+        sys = numpy.array([3, 4])
+        self.assert_(utils.calc_total_error(None, None) is None)
+        self.assert_(utils.calc_total_error(stat, None) is stat)
+        self.assert_(utils.calc_total_error(None, sys) is sys)
+        self.assert_(numpy.all(utils.calc_total_error(stat, sys) ==
+                               numpy.sqrt(stat * stat + sys * sys)))
 
     def test_poisson_noise(self):
-        out = poisson_noise(1000)
+        out = utils.poisson_noise(1000)
         self.assert_(type(out) is SherpaFloat)
         self.assert_(out > 0.0)
 
         for x in (-1000, 0):
-            out = poisson_noise(x)
+            out = utils.poisson_noise(x)
             self.assert_(type(out) is SherpaFloat)
             self.assert_(out == 0.0)
 
-        out = poisson_noise([1001, 1002, 0.0, 1003, -1004])
+        out = utils.poisson_noise([1001, 1002, 0.0, 1003, -1004])
         self.assert_(type(out) is numpy.ndarray)
         self.assert_(out.dtype.type is SherpaFloat)
         self.assert_(numpy.all(numpy.flatnonzero(out > 0.0) ==
                                numpy.array([0, 1, 3])))
 
-        self.assertRaises(ValueError, poisson_noise, 'ham')
-        self.assertRaises(TypeError, poisson_noise, [1, 2, 'ham'])
+        self.assertRaises(ValueError, utils.poisson_noise, 'ham')
+        self.assertRaises(TypeError, utils.poisson_noise, [1, 2, 'ham'])
 
-
-    def test_neville( self ):
+    def test_neville(self):
         func = numpy.exp
         tol = 1.0e-6
         num = 10
         x = []
         y = []
-        for ii in xrange( num ):
-            x.append( ii / float( num ) )
-            y.append( func( x[ ii ] ) )
-        xx = numpy.array( x )
-        yy = numpy.array( y )
-        for ii in xrange( num ):
-            tmp = 1.01 * ( ii/ float( num ) )
-            answer = func( tmp )
-            val = neville( tmp, xx, yy )
-            self.assert_( Knuth_close( answer, val, tol ) )
+        for ii in xrange(num):
+            x.append(ii / float(num))
+            y.append(func(x[ii]))
+        xx = numpy.array(x)
+        yy = numpy.array(y)
+        for ii in xrange(num):
+            tmp = 1.01 * (ii / float(num))
+            answer = func(tmp)
+            val = utils.neville(tmp, xx, yy)
+            self.assert_(utils.Knuth_close(answer, val, tol))
 
-    def test_neville2d( self ):
+    def test_neville2d(self):
         funcx = numpy.sin
         funcy = numpy.exp
         nrow = 10
         ncol = 10
         tol = 1.0e-4
-        x = numpy.zeros( (nrow,) )
-        y = numpy.zeros( (ncol,) )
-        fval = numpy.empty( ( nrow, ncol ) )
+        x = numpy.zeros((nrow, ))
+        y = numpy.zeros((ncol, ))
+        fval = numpy.empty((nrow, ncol))
         row_tmp = numpy.pi / nrow
-        col_tmp = 1.0 / float( ncol )
-        for row in xrange( nrow ):
-            x[ row ] = ( row + 1.0 ) * row_tmp
-            for col in xrange( ncol ):
-                y[ col ] = ( col + 1.0 ) / float( ncol )
-                fval[ row ][ col ] = funcx( x[ row ] ) * funcy( y[ col ] )
+        # col_tmp = 1.0 / float(ncol)
+        for row in xrange(nrow):
+            x[row] = (row + 1.0) * row_tmp
+            for col in xrange(ncol):
+                y[col] = (col + 1.0) / float(ncol)
+                fval[row][col] = funcx(x[row]) * funcy(y[col])
 
-        for row in xrange( ncol ):
-            xx = ( -0.1 + ( row + 1.0 ) / float( nrow ) ) * numpy.pi
-            for col in xrange( 4 ):
-                yy = -0.1 +( col + 1.0 )/ float( ncol )
-                answer = funcx( xx ) * funcy( yy )
-                val = neville2d( xx, yy, x, y, fval )
-                self.assert_( Knuth_close( answer, val, tol ) )
+        for row in xrange(ncol):
+            xx = (-0.1 + (row + 1.0) / float(nrow)) * numpy.pi
+            for col in xrange(4):
+                yy = -0.1 + (col + 1.0) / float(ncol)
+                answer = funcx(xx) * funcy(yy)
+                val = utils.neville2d(xx, yy, x, y, fval)
+                self.assert_(utils.Knuth_close(answer, val, tol))
 
     def test_parallel_map(self):
 
@@ -199,24 +201,22 @@ class test_utils(SherpaTestCase):
             return
 
         numtasks = 8
-        size = (64,64)
+        size = (64, 64)
         vals = numpy.random.rand(*size)
         f = numpy.linalg.eigvals
-        iterable = [vals]*numtasks
+        iterable = [vals] * numtasks
 
-        result = map(f, iterable)
+        result = numpy.asarray(map(f, iterable))
 
-        pararesult = parallel_map(f, iterable, ncpus)
+        pararesult = utils.parallel_map(f, iterable, ncpus)
 
         pool = Pool(ncpus)
         poolresult = pool.map(f, iterable)
 
-        self.assert_((numpy.asarray(result) == numpy.asarray(pararesult)).all())
-        self.assert_((numpy.asarray(result) == numpy.asarray(poolresult)).all())
-
+        self.assert_((result == numpy.asarray(pararesult)).all())
+        self.assert_((result == numpy.asarray(poolresult)).all())
 
 
 if __name__ == '__main__':
 
-    import sherpa.utils as utils
     SherpaTest(utils).test()

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -20,8 +20,8 @@
 import numpy
 from sherpa.utils import SherpaFloat
 from sherpa.utils.test import SherpaTest, SherpaTestCase
-
 from sherpa import utils
+import warnings
 
 
 class test_utils(SherpaTestCase):
@@ -215,6 +215,42 @@ class test_utils(SherpaTestCase):
 
         self.assert_((result == numpy.asarray(pararesult)).all())
         self.assert_((result == numpy.asarray(poolresult)).all())
+
+    def test_members(self):
+        """Make sure members moved to sherpa.utils.test are still accessible through sherpa.utils"""
+
+        from sherpa.utils import SherpaTestCase
+        from sherpa.utils import SherpaTest
+        from sherpa.utils import requires_data, requires_fits, requires_package
+        # from sherpa.utils import requires_ds9, requires_xspec, requires_pylab
+
+        # Make sure deprecation warnings are issued
+        class FakeClass(SherpaTestCase):
+            def runTest(self):
+                pass
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            FakeClass()
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "SherpaTestCase is deprecated: use sherpa.utils.test.SherpaTestCase" in str(w[-1].message)
+
+            SherpaTest()
+            # Verify some things
+            assert len(w) == 2
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "SherpaTest is deprecated: use sherpa.utils.test.SherpaTest" in str(w[-1].message)
+
+            requires_data(FakeClass)
+            # Verify some things
+            assert len(w) == 3
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "requires_data is deprecated: use sherpa.utils.test.requires_data" in str(w[-1].message)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Status

This is on hold until after the Python 3 migration has been completed. It can be reviewed at that time (added 30 June 2016).

# Release Notes

There is no functional change in the PR.

Move the test code out from `sherpa.utils` to `sherpa.utils.test` and
update the test code to match. Some minor PEP8 cleanup (mainly handling
of space characters, but several changes to use explicit import
statements).

# Notes

This is based on the discussion of PR #141 where it was noted that
the `sherpa.utils` module is too large and needs separating out. This
is the first step in the process.

The PR adds a new file: `sherpa/utils/test.py`. Does this need to be added to any manifest-like file in the distribution?

# Test of the changes

The test suite passes with these changes, with the same number of tests
run (and tests skipped, as the tests were ran without ds9 or XSPEC
support) as before the code change.