### PR TITLE
enforce usage of the python executable when building deps

### DIFF
--- a/helpers/deps/__init__.py
+++ b/helpers/deps/__init__.py
@@ -21,6 +21,7 @@
 from subprocess import call
 from multiprocessing import cpu_count
 import os
+import sys
 
 def clean_deps():
     prefix = os.getcwd()
@@ -38,7 +39,9 @@ def build_deps(configure):
         prefix=os.getcwd()
         os.chdir('extern')
         os.chmod(configure[0], 0755)
-        out = call(configure)
+        env = os.environ.copy()
+        env['PYTHON'] = sys.executable
+        out = call(configure, env=env)
         if out != 0: exit(out)
     #    cflags = '-fPIC'
     #    out = call(['make', 'CFLAGS='+cflags,'-j'+str(cpu_count()+1), 'install'])


### PR DESCRIPTION
Resolve #19 

# Release Note
[release-note]
The `python` executable used to call `setup.py` is now injected in the environment that kicks off the external dependencies build. This means that if `python2` is used to call `setup.py` but `python3` is the first `python` executable in the `$PATH`, `python2` will be used to run both the python and the external builds.
[/]

# Testing
I tested this locally by playing with the $PATH and using a python 3 conda environment. I could set up a Travis build to automatically test this, if somebody argues for it during review, but in my opinion this is not necessary. It would be good if the original reporter tested this fix, though, and I'll ask him in the comments.