### PR TITLE
First tiny step towards Python 3 support

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -18,13 +18,13 @@
 #
 
 
-from clean import clean
-from develop import develop
-from install import install
-from sdist import sdist
-from test import PyTest
-from sherpa_config import sherpa_config
-from xspec_config import xspec_config
+from .clean import clean
+from .develop import develop
+from .install import install
+from .sdist import sdist
+from .test import PyTest
+from .sherpa_config import sherpa_config
+from .xspec_config import xspec_config
 
 commands = {
     'clean': clean,

--- a/helpers/clean.py
+++ b/helpers/clean.py
@@ -19,7 +19,7 @@
 
 
 from distutils.command.clean import clean as _clean
-from deps import clean_deps
+from .deps import clean_deps
 
 class clean(_clean):
     def run(self):

--- a/helpers/deps/__init__.py
+++ b/helpers/deps/__init__.py
@@ -38,7 +38,7 @@ def build_deps(configure):
     if not os.path.exists('extern/built'):
         prefix=os.getcwd()
         os.chdir('extern')
-        os.chmod(configure[0], 0755)
+        os.chmod(configure[0], 0o755)
         env = os.environ.copy()
         env['PYTHON'] = sys.executable
         out = call(configure, env=env)

--- a/helpers/install.py
+++ b/helpers/install.py
@@ -21,7 +21,7 @@
 from numpy.distutils.command.install import install as _install
 import os
 
-from deps import build_deps
+from .deps import build_deps
 
 class install(_install):
     def run(self):

--- a/helpers/sdist.py
+++ b/helpers/sdist.py
@@ -20,7 +20,7 @@
 
 from distutils.command.sdist import sdist as _sdist
 from numpy.distutils.misc_util import get_data_files
-from deps import clean_deps
+from .deps import clean_deps
 
 class sdist(_sdist):
 

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -18,8 +18,8 @@
 #
 
 
-from extensions import build_ext, build_lib_arrays
-from deps import build_deps
+from .extensions import build_ext, build_lib_arrays
+from .deps import build_deps
 
 from numpy.distutils.core import Command
 import os

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -19,7 +19,7 @@
 
 
 from numpy.distutils.core import Command
-from extensions import build_ext, build_lib_arrays
+from .extensions import build_ext, build_lib_arrays
 
 def clean(xs):
     "Remove all '' entries from xs, returning the new list."


### PR DESCRIPTION
Work in progress ... do not merge!

This PR is a first tiny step towards Python 3 support (see #76).

As I've mentioned at https://github.com/sherpa/sherpa/pull/160#issuecomment-178194122 and https://github.com/sherpa/sherpa/issues/133#issuecomment-175887835, I think it could be useful to try to start the port to Python 3 with small steps. The changes in this PR have no effect on Python 2, but they do allow running `python3 setup.py egg_info` with Python 3, i.e. a Python 3 test build for `python setup.py egg_info` could be added here on travis-ci and then future PRs would try to expand Python 3 support in steps.

@olaurino - Do you think getting started like on Python 3 porting is at all useful?

I have some time to work on this in the coming weeks, but I don't know if this is a good way or time to get started, and if you prefer many small PRs that are easy to review, or fewer large PRs that e.g. change all imports in the codebase to implicit relative imports, touching many files.
