### PR TITLE
Improve documentation on ASCII file support and minor bug fix

### DIFF
--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -126,6 +126,99 @@ def get_column_data(*args):
 
 def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
                    comment='#', require_floats=True):
+    """Read in columns from an ASCII file.
+
+    Parameters
+    ----------
+    filename : str
+       The name of the ASCII file to read in.
+    ncols : int, optional
+       The number of columns to read in (the first ``ncols`` columns
+       in the file). This is ignored if ``colkeys`` is given.
+    colkeys : array of str, optional
+       An array of the column name to read in. The default is
+       ``None``.
+    sep : str, optional
+       The separator character. The default is ``' '``.
+    dstype : data class to use, optional
+       Used to check that the data file contains enough columns.
+    comment : str, optional
+       The comment character. The default is ``'#'``.
+    require_floats : bool, optional
+       If ``True`` (the default), non-numeric data values will
+       raise a `ValueError`.
+
+    Returns
+    -------
+    (colnames, coldata, filename)
+       The column names read in, the data for the columns
+       as an array, with each element being the data for the column
+       (the order matches ``colnames``), and the name of the file.
+
+    Raises
+    ------
+    sherpa.utils.IOErr
+       Raised if a requested column is missing or the file appears
+       to be a binary file.
+    ValueError
+       If a column value can not be converted into a numeric value
+       and the ``require_floats`` parameter is True.
+
+    See Also
+    --------
+    read_arrays, read_data, write_arrays, write_data
+
+    Notes
+    -----
+
+    The file is processed by reading in each line, stripping out any
+    unsupported characters (replacing them by the ``sep`` argument),
+    skipping empty lines, and then identifying comment and data lines.
+
+    The list of unsupported characters are: ``\t``, ``\n``,
+    ``\r``, comma, semi-colon, colon, space, and ``|``.
+
+    The last comment line before the data is used to define the
+    column names, splitting the line by the ``sep`` argument.
+    If there are no comment lines then the columns are named
+    starting at ``col1``, ``col2``, up to the number of columns.
+
+    Data lines are separated into columns - splitting by the
+    ``sep`` comment - and then converted to NumPy arrays.
+    If the ``require_floats`` argument is ``True`` then the
+    column will be converted to the `sherpa.utils.SherpaFloat`
+    type, with an error raised if this fails.
+
+    An error is raised if the number of columns per row
+    is not constant.
+
+    If the ``colkeys`` argument is used then a case-sensitive
+    match is used to determine what columns to return.
+
+    Examples
+    --------
+
+    Read in the first column from the file:
+
+    >>> (colnames, coldata, fname) = get_ascii_data('src.dat')
+
+    Read in the first three columns from the file:
+
+    >>> colinfo = get_ascii_data('src.dat', ncols=3)
+
+    Read in a histogram data set, using the columns XLO, XHI,
+    and Y:
+
+    >>> cols = ['XLO', 'XHI', 'Y']
+    >>> res = get_ascii_data('hist.dat', colkeys=cols,
+                             dstype=sherpa.data.Data1DInt)
+
+    Read in the first and third column from the file cols.dat,
+    where the file has no header information:
+
+    >>> res = get_ascii_data('cols.dat', colkeys=['col1', 'col3'])
+
+    """
 
     if is_binary_file(filename):
         raise IOErr('notascii', filename)
@@ -158,6 +251,76 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
 
 def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
               comment='#', require_floats=True):
+    """Create a data object from an ASCII file.
+
+    Parameters
+    ----------
+    filename : str
+       The name of the ASCII file to read in.
+    ncols : int, optional
+       The number of columns to read in (the first ``ncols`` columns
+       in the file). This is ignored if ``colkeys`` is given.
+    colkeys : array of str, optional
+       An array of the column name to read in. The default is
+       ``None``.
+    sep : str, optional
+       The separator character. The default is ``' '``.
+    dstype : data class to use, optional
+       The class of the data object to create.
+    comment : str, optional
+       The comment character. The default is ``'#'``.
+    require_floats : bool, optional
+       If ``True`` (the default), non-numeric data values will
+       raise a `ValueError`.
+
+    Returns
+    -------
+    data
+       The data object (created by calling the dstype constructor
+       with the filename and then the data columns from the file).
+
+    Raises
+    ------
+    sherpa.utils.IOErr
+       Raised if a requested column is missing or the file appears
+       to be a binary file.
+    ValueError
+       If a column value can not be converted into a numeric value
+       and the ``require_floats`` parameter is True.
+
+    See Also
+    --------
+    get_ascii_data, read_arrays, write_data
+
+    Notes
+    -----
+
+    The file format is described in `get_ascii_data`.
+
+    Examples
+    --------
+
+    Create a 1D data object from the first two columns in the file:
+
+    >>> dat = read_data('src.dat')
+
+    Use the third column as the error column (statistical):
+
+    >>> dat = read_data('src.dat', ncols=3)
+
+    Read in a histogram data set, using the columns XLO, XHI,
+    and Y:
+
+    >>> cols = ['XLO', 'XHI', 'Y']
+    >>> dat = read_data('hist.dat', colkeys=cols,
+                        dstype=sherpa.data.Data1DInt)
+
+    Use the first and third column from the file cols.dat,
+    where the file has no header information:
+
+    >>> dat = read_data('cols.dat', colkeys=['col1', 'col3'])
+
+    """
 
     colnames, args, name = get_ascii_data(filename, ncols, colkeys,
                                           sep, dstype, comment, require_floats)
@@ -165,8 +328,46 @@ def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
 
 
 def read_arrays(*args):
-    """
-    read_table( *NumPy_args [, dstype = Data1D ] )
+    """Create a data object from arrays.
+
+    Parameters
+    ----------
+    col1, ... coln : array_like
+       The data columns.
+    dstype : optional, default=`sherpa.data.Data1D`
+       The data type to create. It must be a subclass of
+       `sherpa.data.BaseData`.
+
+    Returns
+    -------
+    data
+       The data object (created by calling the dstype constructor
+       with the filename and then the data columns from the file).
+
+    Raises
+    ------
+    sherpa.utils.IOErr
+       Raised if no arrays are sent in.
+
+    See Also
+    --------
+    get_ascii_data, write_arrays
+
+    Examples
+    --------
+
+    Create a 1D data object from the x and y arrays:
+
+    >>> dat = read_arrays(x, y)
+
+    Include a statistical error column:
+
+    >>> dat = read_arrays(x, y, dy)
+
+    Create an integrated (i.e. histogram) data set:
+
+    >>> dat = read_arrays(xlo, xhi, y, dstype=sherpa.data.Data1DInt)
+
     """
     args = list(args)
     if len(args) == 0:
@@ -186,7 +387,55 @@ def read_arrays(*args):
 
 def write_arrays(filename, args, fields=None, sep=' ', comment='#',
                  clobber=False, linebreak='\n', format='%g'):
+    """Write a list of arrays to an ASCII file.
 
+    Parameters
+    ----------
+    filename : str
+       The name of the file to write the array to.
+    args : array_like
+       The arrays to write out.
+    fields : array_like of str
+       The column names (should match the size of ``args`` if given).
+    sep : str, optional
+       The separator character. The default is ``' '``.
+    comment : str, optional
+       The comment character. The default is ``'#'``. This is only used
+       to write out the column names when ``fields`` is not None.
+    clobber : bool, optional
+       If ``filename`` is not ``None``, then this flag controls
+       whether an existing file can be overwritten (``True``)
+       or if it raises an exception (``False``, the default
+       setting).
+    linebreak : str, optional
+       Indicate a new line. The default is ``'\\n'``.
+    format : str, optional
+       The format used to write out the numeric values. The
+       default is ``'%g%'``.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+       If ``filename`` already exists and ``clobber`` is ``False``
+       or if there is no data to write.
+
+    See Also
+    --------
+    get_ascii_data
+
+    Examples
+    --------
+
+    Write the x and y arrays to the file 'src.dat':
+
+    >>> write_arrays('src.dat', [x, y])
+
+    Use the column names "r" and "surbri" for the columns:
+
+    >>> write_arrays('prof.txt', [x, y], fields=["r", "surbri"],
+                     clobber=True)
+
+    """
     if os.path.isfile(filename) and not clobber:
         raise IOErr("filefound", filename)
 
@@ -224,6 +473,54 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
 
 def write_data(filename, dataset, fields=None, sep=' ', comment='#',
                clobber=False, linebreak='\n', format='%g'):
+    """Write out a dataset as an ASCII file.
+
+    Parameters
+    ----------
+    filename : str
+       The name of the file to write the array to.
+    dataset :
+       The data object to write out.
+    fields : array_like of str
+       The column names (should match the size of ``args`` if given).
+       Any unknown columns are skipped. If not given then the field
+       names from the data set will be used (for those columns which
+       contain data).
+    sep : str, optional
+       The separator character. The default is ``' '``.
+    comment : str, optional
+       The comment character. The default is ``'#'``. This is used to
+       write out the column names (after converting to upper case)
+       before the data.
+    clobber : bool, optional
+       If ``filename`` is not ``None``, then this flag controls
+       whether an existing file can be overwritten (``True``)
+       or if it raises an exception (``False``, the default
+       setting).
+    linebreak : str, optional
+       Indicate a new line. The default is ``'\\n'``.
+    format : str, optional
+       The format used to write out the numeric values. The
+       default is ``'%g%'``.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+       If ``filename`` already exists and ``clobber`` is ``False``
+       or if there is no data to write.
+
+    See Also
+    --------
+    get_ascii_data, read_data
+
+    Examples
+    --------
+
+    Write the x and y arrays to the file 'src.dat':
+
+    >>> write_data('src.dat', dat)
+
+    """
 
     if fields is None:
         fields = dataset._fields

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2358,9 +2358,7 @@ class Session(NoNewAttributesAfterInit):
            the default identifier is used, as returned by
            `get_default_id`.
         filename : str
-           The name of the file to read in. Supported formats depends
-           on the I/O library in use (Crates or AstroPy) and the
-           type of data set (e.g. 1D or 2D).
+           The name of the ASCII file to read in.
         ncols : int, optional
            The number of columns to read in (the first ``ncols`` columns
            in the file).
@@ -2400,15 +2398,10 @@ class Session(NoNewAttributesAfterInit):
 
         >>> load_staterror('tbl.dat', colkeys=['col3'])
 
-        When using the Crates I/O library, the file name can include
-        CIAO Data Model syntax, such as column selection:
-
-        >>> load_staterror('tbl.dat[cols col3]')
-
-        Read in the first column from the file 'errors.fits' as the
+        Read in the first column from the file 'errors.dat' as the
         statistical errors for the 'core' data set:
 
-        >>> load_staterror('core', 'errors.fits')
+        >>> load_staterror('core', 'errors.dat')
 
         """
         if filename is None:
@@ -2432,9 +2425,7 @@ class Session(NoNewAttributesAfterInit):
            the default identifier is used, as returned by
            `get_default_id`.
         filename : str
-           The name of the file to read in. Supported formats depends
-           on the I/O library in use (Crates or AstroPy) and the
-           type of data set (e.g. 1D or 2D).
+           The name of the ASCII file to read in.
         ncols : int, optional
            The number of columns to read in (the first ``ncols`` columns
            in the file).
@@ -2473,15 +2464,10 @@ class Session(NoNewAttributesAfterInit):
 
         >>> load_syserror('tbl.dat', colkeys=['col3'])
 
-        When using the Crates I/O library, the file name can include
-        CIAO Data Model syntax, such as column selection:
-
-        >>> load_syserror('tbl.dat[cols col3]')
-
-        Read in the first column from the file 'errors.fits' as the
+        Read in the first column from the file 'errors.dat' as the
         systematic errors for the 'core' data set:
 
-        >>> load_syserror('core', 'errors.fits')
+        >>> load_syserror('core', 'errors.dat')
 
         """
         if filename is None:
@@ -2492,8 +2478,6 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_filter(self, id, filename=None, ignore=False, ncols=2,
                     *args, **kwargs):
         """Load the filter array from a file and add to a data set.
@@ -2505,10 +2489,8 @@ class Session(NoNewAttributesAfterInit):
            the default identifier is used, as returned by
            `get_default_id`.
         filename : str
-           The name of the file that contains the filter
-           information. This file can be a FITS table or an ASCII
-           file. Selection of the relevant column depends on the I/O
-           library in use (Crates or AstroPy).
+           The name of the ASCII file that contains the filter
+           information.
         ignore : bool, optional
            If ``False`` (the default) then include bins with a non-zero
            filter value, otherwise exclude these bins.
@@ -2549,11 +2531,6 @@ class Session(NoNewAttributesAfterInit):
         Select the FILTER column of the file:
 
         >>> load_filter(2, 'filt.dat', colkeys=['FILTER'])
-
-        When using Crates as the I/O library, the above can
-        also be written as
-
-        >>> load_filter(2, 'filt.dat[cols filter]')
 
         """
         if filename is None:
@@ -3503,9 +3480,7 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         filename : str
-           The name of the file to read in. Supported formats depends
-           on the I/O library in use (Crates or AstroPy) and the
-           type of data set (e.g. 1D or 2D).
+           The name of the ASCII file to read in.
         ncols : int, optional
            The number of columns to read in (the first ``ncols`` columns
            in the file).
@@ -3543,6 +3518,10 @@ class Session(NoNewAttributesAfterInit):
         set_data : Set a data set.
         unpack_arrays : Create a sherpa data object from arrays of data.
 
+        Notes
+        -----
+        The file reading is performed by `sherpa.io.read_data`.
+
         Examples
         --------
 
@@ -3572,9 +3551,7 @@ class Session(NoNewAttributesAfterInit):
         id : int or str
            The identifier for the data set to use.
         filename : str
-           The name of the file to read in. Supported formats depends
-           on the I/O library in use (Crates or AstroPy) and the
-           type of data set (e.g. 1D or 2D).
+           The name of the ASCII file to read in.
         ncols : int, optional
            The number of columns to read in (the first ``ncols`` columns
            in the file).
@@ -3624,7 +3601,7 @@ class Session(NoNewAttributesAfterInit):
         >>> load_data('hist.dat', dstype=Data1DInt)
 
         >>> cols = ['rmid', 'sur_bri', 'sur_bri_err']
-        >>> load_data(2, 'profile.fits', colkeys=cols)
+        >>> load_data(2, 'profile.dat', colkeys=cols)
 
         """
         if filename is None:
@@ -4921,7 +4898,6 @@ class Session(NoNewAttributesAfterInit):
         --------
         create_model_component : Create a model component.
         list_models : List the available model types.
-        load_table : Load a FITS binary file as a data set.
         load_table_model : Load tabular data and use it as a model component.
         load_user_model : Create a user-defined model.
         set_model : Set the source model expression for a data set.
@@ -5685,8 +5661,8 @@ class Session(NoNewAttributesAfterInit):
         Apply different PSFs to different components, as well as an
         unconvolved component:
 
-        >>> load_psf("psf1", "psf1.fits")
-        >>> load_psf("psf2", "psf2.fits")
+        >>> load_psf("psf1", "psf1.dat")
+        >>> load_psf("psf2", "psf2.dat")
         >>> smodel = psf1(gauss2d.src1) + psf2(beta2d.src2) + const2d.bgnd
         >>> set_full_model("src", smodel)
 
@@ -6136,6 +6112,7 @@ class Session(NoNewAttributesAfterInit):
         The data file - the last column of the template index file -
         is read in and the first two columns used to set up the x and
         y values (`Data1D`) or xlo, xhi, and y values (`Data1DInt`).
+        These files must be in ASCII format.
 
         The ``method`` parameter determines how the template data values
         are interpolated onto the source data grid.
@@ -6268,8 +6245,6 @@ class Session(NoNewAttributesAfterInit):
         sherpa.models.template.interpolators[
             name] = (interpolator_class, kwargs)
 
-    # also in sherpa.astro.utils
-    # DOC-NOTE: does it make sense to allow ncols to vary here?
     def load_table_model(self, modelname, filename, ncols=2, colkeys=None,
                          dstype=sherpa.data.Data1D, sep=' ', comment='#',
                          method=sherpa.utils.linear_interp):
@@ -6286,11 +6261,10 @@ class Session(NoNewAttributesAfterInit):
         modelname : str
            The identifier for this table model.
         filename : str
-           The name of the file to read in. Supported formats depends
-           on the I/O library in use (Crates or AstroPy).
+           The name of the ASCII file to read in.
         ncols : int, optional
            The number of columns to read in (the first ``ncols`` columns
-           in the file).
+           in the file). It should be 1 or 2.
         colkeys : array of str, optional
            An array of the column name to read in. The default is
            ``None``.
@@ -6324,12 +6298,12 @@ class Session(NoNewAttributesAfterInit):
         Examples
         --------
 
-        Load in the data from filt.fits and use it to multiply
+        Load in the data from filt.dat and use it to multiply
         the source model (a power law and a gaussian). Allow
         the amplitude for the table model to vary between 1
         and 1e6, starting at 1e3.
 
-        >>> load_table_model('filt', 'filt.fits')
+        >>> load_table_model('filt', 'filt.dat')
         >>> set_source(filt * (powlaw1d.pl + gauss1d.gline))
         >>> set_par(filt.ampl, 1e3, min=1, max=1e6)
 
@@ -6388,7 +6362,6 @@ class Session(NoNewAttributesAfterInit):
         --------
         add_model : Create a user-defined model class.
         add_user_pars : Add parameter information to a user model.
-        load_table : Load a FITS binary file as a data set.
         load_table_model : Load tabular data and use it as a model component.
         load_template_model : Load a set of templates and use it as a model component.
         set_model : Set the source model expression for a data set.
@@ -6655,9 +6628,7 @@ class Session(NoNewAttributesAfterInit):
         modelname : str
            The identifier for this PSF model.
         filename_or_model : str or model instance
-           The form of the model. This can be a file name, which will
-           be read in using the chosen Sherpa I/O library, or a
-           model component.
+           This can be the name of an ASCII file or a Sherpa model component.
         *args, **kwargs
            Arguments for `unpack_data` if ``filename_or_model``
            is a file.
@@ -6730,9 +6701,7 @@ class Session(NoNewAttributesAfterInit):
         modelname : str
            The identifier for this PSF model.
         filename_or_model : str or model instance
-           The form of the PSF. This can be a file name, which will
-           be read in using the chosen Sherpa I/O library, or a
-           model component.
+           This can be the name of an ASCII file or a Sherpa model component.
         *args, **kwargs
            Arguments for `unpack_data` if ``filename_or_model``
            is a file.
@@ -6758,11 +6727,11 @@ class Session(NoNewAttributesAfterInit):
         >>> gpsf.theta = 30 * np.pi / 180
         >>> image_psf()
 
-        Create a PSF model from the data in the file
-        'line_profile.fits' and apply it to the data set called
+        Create a PSF model from the data in the ASCII file
+        'line_profile.dat' and apply it to the data set called
         'bgnd':
 
-        >>> load_psf('pmodel', 'line_profile.fits')
+        >>> load_psf('pmodel', 'line_profile.dat')
         >>> set_psf('bgnd', 'pmodel')
 
         """
@@ -6871,10 +6840,10 @@ class Session(NoNewAttributesAfterInit):
         Examples
         --------
 
-        Use the data in the file 'line_profile.fits' as the PSF for
+        Use the data in the ASCII file 'line_profile.dat' as the PSF for
         the default data set:
 
-        >>> load_psf('psf1', 'line_profile.fits')
+        >>> load_psf('psf1', 'line_profile.dat')
         >>> set_psf(psf1)
 
         Use the same PSF for different data sets:

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,25 +20,24 @@
 import copy
 import copy_reg
 import cPickle as pickle
-import inspect
 from itertools import izip
 import logging
 import sys
 import os
-import re
 import numpy
 import sherpa.all
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, export_method
-from sherpa.utils.err import *
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
+    IdentifierErr, IOErr, ModelErr, SessionErr
 
-info = logging.getLogger(__name__).info
-warning = logging.getLogger(__name__).warning
+# There are three "raise AttributeErr(..)" lines below which have been changed
+# to the Python AttributeError class, as Sherpa has no AttributeErr class.
 
 from sherpa import get_config
 from ConfigParser import ConfigParser
 
-import readline
-import inspect
+info = logging.getLogger(__name__).info
+warning = logging.getLogger(__name__).warning
 
 config = ConfigParser()
 config.read(get_config())
@@ -96,7 +95,7 @@ def _send_to_pager(all, filename=None, clobber=False):
     clobber = sherpa.utils.bool_cast(clobber)
     try:
         if filename is None:
-            if (os.environ.has_key('PAGER') == True):
+            if 'PAGER' in os.environ:
                 pager = os.popen(os.environ['PAGER'], 'w')
             else:
                 if (os.access('/bin/more', os.X_OK) == 1):
@@ -237,7 +236,7 @@ class Session(NoNewAttributesAfterInit):
 
         self._model_globals.update(state['_model_types'])
 
-        if not state.has_key('_sources'):
+        if '_sources' not in state:
             self.__dict__['_sources'] = state.pop('_models')
 
         self.__dict__.update(state)
@@ -1912,7 +1911,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         if isinstance(meth, basestring):
-            if (self._itermethods.has_key(meth) == True):
+            if meth in self._itermethods:
                 self._current_itermethod = self._itermethods[meth]
             else:
                 raise TypeError(meth + ' is not an iterative fitting method')
@@ -3492,8 +3491,10 @@ class Session(NoNewAttributesAfterInit):
         return sherpa.io.read_arrays(*args)
 
     # DOC-NOTE: also in sherpa.utils
+
     def unpack_data(self, filename, ncols=2, colkeys=None,
-                    dstype=sherpa.data.Data1D, sep=' ', comment='#', require_floats=True):
+                    dstype=sherpa.data.Data1D, sep=' ', comment='#',
+                    require_floats=True):
         """Create a sherpa data object from a file.
 
         The object returned by `unpack_data` can be used in a
@@ -3562,7 +3563,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: also in sherpa.astro.utils
     def load_data(self, id, filename=None, ncols=2, colkeys=None,
-                  dstype=sherpa.data.Data1D, sep=' ', comment='#', require_floats=True):
+                  dstype=sherpa.data.Data1D, sep=' ', comment='#',
+                  require_floats=True):
         """Load a data set from a file.
 
         Parameters
@@ -3629,7 +3631,8 @@ class Session(NoNewAttributesAfterInit):
             id, filename = filename, id
         self.set_data(id, self.unpack_data(filename, ncols=ncols,
                                            colkeys=colkeys, dstype=dstype,
-                                           sep=sep, comment=comment, require_floats=require_floats))
+                                           sep=sep, comment=comment,
+                                           require_floats=require_floats))
 
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-TODO: rework the Data type notes section (also needed by unpack_arrays)
@@ -3714,23 +3717,34 @@ class Session(NoNewAttributesAfterInit):
         fields = None
 
         if type(d) in (sherpa.data.Data2D, sherpa.data.Data2DInt):
-            backup = d.y
             if objtype == 'delchi':
-                raise AttributeErr('badfunc', "save_delchi()", "images")
+                # raise AttributeErr('badfunc', "save_delchi()", "images")
+                raise AttributeError("save_delchi() can not be used " +
+                                     "with 2D datasets")
 
-            imgtype = getattr(self, 'get_' + objtype + '_image', None)
+            funcname = "get_{}_image()".format(objtype)
+            """
+            imgtype = getattr(self, funcname, None)
             if imgtype is None:
-                raise AttributeErr(
-                    'attributeerr', 'session', 'get_%s_image()' % objtype)
+                # raise AttributeErr('attributeerr', 'session', fname)
+                raise AttributeError("Unable to find " + funcname)
+            """
+            imgtype = getattr(self, funcname)
+
             obj = imgtype(id)
             args = [obj.y]
             fields = [str(objtype).upper()]
 
         else:
-            plottype = getattr(self, 'get_' + objtype + '_plot', None)
+            funcname = "get_{}_plot".format(objtype)
+            """
+            plottype = getattr(self, funcname, None)
             if plottype is None:
-                raise AttributeErr(
-                    'attributeerr', 'session', 'get_%s_plot()' % objtype)
+                # raise AttributeErr('attributeerr', 'session', funcname)
+                raise AttributeError("Unable to find " + funcname)
+            """
+            plottype = getattr(self, funcname)
+
             obj = plottype(id)
             args = [obj.x, obj.y]
             fields = ["X", str(objtype).upper()]
@@ -5115,12 +5129,12 @@ class Session(NoNewAttributesAfterInit):
         # If model component name is a model type name
         # or session function name, don't create it, raise
         # warning
-        if (self._model_types.has_key(cmpt.name) is True):
+        if cmpt.name in self._model_types:
             modeltype = cmpt.name
             del cmpt
             raise IdentifierErr('badidmodel', modeltype)
 
-        if (cmpt.name.lower() in _builtin_symbols_):
+        if cmpt.name.lower() in _builtin_symbols_:
             modeltype = cmpt.name
             del cmpt
             raise IdentifierErr('badidnative', modeltype)
@@ -6045,16 +6059,16 @@ class Session(NoNewAttributesAfterInit):
         try:
             data = self.unpack_data(filename, ncols, colkeys,
                                     dstype, sep, comment)
-            y = data.get_y()
             x = data.get_x()
-        # we have to check for the case of a *single* column in ascii file
-        # extract the single array from the read and bypass the dataset
+            y = data.get_y()
+
         except TypeError:
+            # we have to check for the case of a *single* column in the file
+            # extract the single array from the read and bypass the dataset
             y = sherpa.io.get_ascii_data(filename, ncols=1, colkeys=colkeys,
                                          sep=sep, dstype=dstype,
                                          comment=comment)[1].pop()
-        except:
-            raise
+
         return (x, y)
 
     # DOC-TODO: I am not sure I have the data format correct.
@@ -6163,7 +6177,8 @@ class Session(NoNewAttributesAfterInit):
             raise sherpa.utils.err.IOErr('notascii', templatefile)
 
         names, cols = sherpa.io.read_file_data(templatefile,
-                                               sep=sep, comment=comment, require_floats=False)
+                                               sep=sep, comment=comment,
+                                               require_floats=False)
 
         if len(names) > len(cols):
             raise sherpa.utils.err.IOErr('toomanycols')
@@ -7373,7 +7388,7 @@ class Session(NoNewAttributesAfterInit):
         for i in ids:
             ds = self.get_data(i)
             mod = None
-            if self._models.has_key(i) or self._sources.has_key(i):
+            if i in self._models or i in self._sources:
                 mod = self._get_model(i)
 
             # The issue with putting a try/catch here is that if an exception
@@ -11203,7 +11218,7 @@ class Session(NoNewAttributesAfterInit):
                 # Using _get_fit becomes very complicated using simulfit
                 # models and datasets
                 #
-                #ids, f = self._get_fit(id)
+                # ids, f = self._get_fit(id)
                 plotobj.prepare(self.get_data(id), self.get_model(id),
                                 self.get_stat())
 
@@ -11258,7 +11273,7 @@ class Session(NoNewAttributesAfterInit):
         else:
             sherpa.plot.end()
 
-    def _plot(self, id, plotobj, *args,  **kwargs):
+    def _plot(self, id, plotobj, *args, **kwargs):
         # if len(args) > 0:
         #    raise SherpaError("cannot create plot for multiple data sets")
         obj = plotobj
@@ -12334,9 +12349,9 @@ class Session(NoNewAttributesAfterInit):
                                     clearwindow=clearwindow)
 
             oldval = rp.plot_prefs['xlog']
-            if ((self._dataplot.plot_prefs.has_key('xlog') and
+            if (('xlog' in self._dataplot.plot_prefs and
                  self._dataplot.plot_prefs['xlog']) or
-                (self._modelplot.plot_prefs.has_key('xlog') and
+                ('xlog' in self._modelplot.plot_prefs and
                  self._modelplot.plot_prefs['xlog'])):
                 rp.plot_prefs['xlog'] = True
 
@@ -12418,9 +12433,9 @@ class Session(NoNewAttributesAfterInit):
                                     clearwindow=clearwindow)
 
             oldval = dp.plot_prefs['xlog']
-            if ((self._dataplot.plot_prefs.has_key('xlog') and
+            if (('xlog' in self._dataplot.plot_prefs and
                  self._dataplot.plot_prefs['xlog']) or
-                (self._modelplot.plot_prefs.has_key('xlog') and
+                ('xlog' in self._modelplot.plot_prefs and
                  self._modelplot.plot_prefs['xlog'])):
                 dp.plot_prefs['xlog'] = True
 
@@ -12748,7 +12763,7 @@ class Session(NoNewAttributesAfterInit):
 
     def _contour(self, id, plotobj, **kwargs):
         # if len(args) > 0:
-        #raise SherpaError("cannot create contour plot for multiple data sets")
+        # raise SherpaError("cannot create contour plot for multiple data sets")
         obj = plotobj
 
         if not sherpa.utils.bool_cast(kwargs.pop('replot', False)):
@@ -12764,7 +12779,7 @@ class Session(NoNewAttributesAfterInit):
 
     def _overcontour(self, id, plotobj, **kwargs):
         # if len(args) > 0:
-        #raise SherpaError("cannot overplot contours for multiple data sets")
+        # raise SherpaError("cannot overplot contours for multiple data sets")
         obj = plotobj
 
         if not sherpa.utils.bool_cast(kwargs.pop('replot', False)):
@@ -13523,9 +13538,9 @@ class Session(NoNewAttributesAfterInit):
         return self._regproj
 
     def get_reg_unc(self, par0=None, par1=None, id=None, otherids=None,
-                    recalc=False, min=None, max=None, nloop=(10, 10), delv=None,
-                    fac=4, log=(False, False), sigma=(1, 2, 3), levels=None,
-                    numcores=None):
+                    recalc=False, min=None, max=None, nloop=(10, 10),
+                    delv=None, fac=4, log=(False, False), sigma=(1, 2, 3),
+                    levels=None, numcores=None):
         """Return the region-uncertainty object.
 
         This returns (and optionally calculates) the data used to
@@ -13635,9 +13650,9 @@ class Session(NoNewAttributesAfterInit):
         prepare_dict = sherpa.utils.get_keyword_defaults(plotobj.prepare)
         plot_dict = sherpa.utils.get_keyword_defaults(plotobj.plot)
         for key in kwargs.keys():
-            if prepare_dict.has_key(key):
+            if key in prepare_dict:
                 prepare_dict[key] = kwargs[key]
-            if plot_dict.has_key(key):
+            if key in plot_dict:
                 plot_dict[key] = kwargs[key]
 
         if sherpa.utils.bool_cast(kwargs['replot']):
@@ -13890,9 +13905,9 @@ class Session(NoNewAttributesAfterInit):
         prepare_dict = sherpa.utils.get_keyword_defaults(plotobj.prepare)
         cont_dict = sherpa.utils.get_keyword_defaults(plotobj.contour)
         for key in kwargs.keys():
-            if prepare_dict.has_key(key):
+            if key in prepare_dict:
                 prepare_dict[key] = kwargs[key]
-            if cont_dict.has_key(key):
+            if key in cont_dict:
                 cont_dict[key] = kwargs[key]
 
         if sherpa.utils.bool_cast(kwargs['replot']):
@@ -13913,9 +13928,9 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: how is sigma converted into delta_stat
     def reg_proj(self, par0, par1, id=None, otherids=None, replot=False,
-                 fast=True, min=None, max=None, nloop=(10, 10), delv=None, fac=4,
-                 log=(False, False), sigma=(1, 2, 3), levels=None, numcores=None,
-                 overplot=False):
+                 fast=True, min=None, max=None, nloop=(10, 10), delv=None,
+                 fac=4, log=(False, False), sigma=(1, 2, 3), levels=None,
+                 numcores=None, overplot=False):
         """Plot the statistic value as two parameters are varied.
 
         Create a confidence plot of the fit statistic as a function of
@@ -14042,8 +14057,8 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: how is sigma converted into delta_stat
     def reg_unc(self, par0, par1, id=None, otherids=None, replot=False,
                 min=None, max=None, nloop=(10, 10), delv=None, fac=4,
-                log=(False, False), sigma=(1, 2, 3), levels=None, numcores=None,
-                overplot=False):
+                log=(False, False), sigma=(1, 2, 3), levels=None,
+                numcores=None, overplot=False):
         """Plot the statistic value as two parameters are varied.
 
         Create a confidence plot of the fit statistic as a function of
@@ -14171,10 +14186,10 @@ class Session(NoNewAttributesAfterInit):
                        numcores=numcores, overplot=overplot)
 
     # Aliases
-    #interval_projection = int_proj
-    #interval_uncertainty = int_unc
-    #region_projection = reg_proj
-    #region_uncertainty = reg_unc
+    # interval_projection = int_proj
+    # interval_uncertainty = int_unc
+    # region_projection = reg_proj
+    # region_uncertainty = reg_unc
 
     ###########################################################################
     # Basic imaging
@@ -15587,4 +15602,3 @@ class Session(NoNewAttributesAfterInit):
 
         """
         return sherpa.image.Image.xpaset(arg, data)
-

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2344,7 +2344,7 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-NOTE: is ncols really 2 here? Does it make sense?
     def load_staterror(self, id, filename=None, ncols=2, *args, **kwargs):
-        """Load the statistical errors from a file.
+        """Load the statistical errors from an ASCII file.
 
         Read in a column or image from a file and use the values
         as the statistical errors for a data set. This over rides
@@ -2387,6 +2387,9 @@ class Session(NoNewAttributesAfterInit):
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
+        See `unpack_data` for a description of the supported
+        file format.
+
         Examples
         --------
 
@@ -2413,7 +2416,7 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-NOTE: is ncols really 2 here? Does it make sense?
     def load_syserror(self, id, filename=None, ncols=2, *args, **kwargs):
-        """Load the systematic errors from a file.
+        """Load the systematic errors from an ASCII file.
 
         Read in a column or image from a file and use the values
         as the systematic errors for a data set.
@@ -2453,6 +2456,9 @@ class Session(NoNewAttributesAfterInit):
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
+        See `unpack_data` for a description of the supported
+        file format.
+
         Examples
         --------
 
@@ -2480,7 +2486,7 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: does ncols make sense here? (have removed for now)
     def load_filter(self, id, filename=None, ignore=False, ncols=2,
                     *args, **kwargs):
-        """Load the filter array from a file and add to a data set.
+        """Load the filter array from an ASCII file and add to a data set.
 
         Parameters
         ----------
@@ -2519,6 +2525,9 @@ class Session(NoNewAttributesAfterInit):
         they are interpreted as the ``id`` and ``filename`` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
+
+        See `unpack_data` for a description of the supported
+        file format.
 
         Examples
         --------
@@ -3472,10 +3481,10 @@ class Session(NoNewAttributesAfterInit):
     def unpack_data(self, filename, ncols=2, colkeys=None,
                     dstype=sherpa.data.Data1D, sep=' ', comment='#',
                     require_floats=True):
-        """Create a sherpa data object from a file.
+        """Create a sherpa data object from an ASCII file.
 
-        The object returned by `unpack_data` can be used in a
-        `set_data` call.
+        This function is used to read in columns from an ASCII
+        file and convert them to a Sherpa data object.
 
         Parameters
         ----------
@@ -3520,7 +3529,32 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The file reading is performed by `sherpa.io.read_data`.
+
+        The file reading is performed by `sherpa.io.get_ascii_data`,
+        which reads in each line from the file, strips out any unsupported
+        characters (replacing them by the ``sep`` argument), skips
+        empty lines, and then identifies whether it is a comment or data
+        line.
+
+        The list of unsupported characters are: ``\t``, ``\n``,
+        ``\r``, comma, semi-colon, colon, space, and ``|``.
+
+        The last comment line before the data is used to define the
+        column names, splitting the line by the ``sep`` argument.
+        If there are no comment lines then the columns are named
+        starting at ``col1``, ``col2``, up to the number of columns.
+
+        Data lines are separated into columns - splitting by the
+        ``sep`` comment - and then converted to NumPy arrays.
+        If the ``require_floats`` argument is ``True`` then the
+        column will be converted to the `sherpa.utils.SherpaFloat`
+        type, with an error raised if this fails.
+
+        An error is raised if the number of columns per row
+        is not constant.
+
+        If the ``colkeys`` argument is used then a case-sensitive
+        match is used to determine what columns to return.
 
         Examples
         --------
@@ -3536,6 +3570,17 @@ class Session(NoNewAttributesAfterInit):
 
         >>> dat = unpack_data('src.dat', ncols=3)
 
+        Read in the X and Y columns from the file. The last line
+        before the data must contain the column names:
+
+        >>> dat = unpack_data('src.dat', colkeys=['X', 'Y'])
+
+        Read in a histogram:
+
+        >>> cols = ['XLO', 'XHI', 'Y']
+        >>> idat = unpack_data('hist.dat', colkeys=cols,
+                               dstype=ui.Data1DInt)
+
         """
         return self._read_data(sherpa.io.read_data, filename, ncols, colkeys,
                                sep, dstype, comment, require_floats)
@@ -3544,7 +3589,7 @@ class Session(NoNewAttributesAfterInit):
     def load_data(self, id, filename=None, ncols=2, colkeys=None,
                   dstype=sherpa.data.Data1D, sep=' ', comment='#',
                   require_floats=True):
-        """Load a data set from a file.
+        """Load a data set from an ASCII file.
 
         Parameters
         ----------
@@ -3592,6 +3637,9 @@ class Session(NoNewAttributesAfterInit):
         they are interpreted as the ``id`` and ``filename`` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
+
+        See `unpack_data` for a description of the supported
+        file format.
 
         Examples
         --------
@@ -3731,7 +3779,7 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
     def save_arrays(self, filename, args, fields=None, clobber=False, sep=' ',
                     comment='#', linebreak='\n', format='%g'):
-        """Write a list of arrays to a file.
+        """Write a list of arrays to an ASCII file.
 
         Parameters
         ----------
@@ -3773,11 +3821,11 @@ class Session(NoNewAttributesAfterInit):
 
         >>> x = get_indep()
         >>> y = get_dep()
-        >>> save_arrays('src.dat', [x,y])
+        >>> save_arrays('src.dat', [x, y])
 
         Use the column names "r" and "surbri" for the columns:
 
-        >>> save_arrays('prof.txt', [x,y], fields=["r", "surbri"],
+        >>> save_arrays('prof.txt', [x, y], fields=["r", "surbri"],
                         clobber=True)
 
         """
@@ -6248,7 +6296,7 @@ class Session(NoNewAttributesAfterInit):
     def load_table_model(self, modelname, filename, ncols=2, colkeys=None,
                          dstype=sherpa.data.Data1D, sep=' ', comment='#',
                          method=sherpa.utils.linear_interp):
-        """Load tabular data and use it as a model component.
+        """Load ASCII tabular data and use it as a model component.
 
         A table model is defined on a grid of points which is
         interpolated onto the independent axis of the data set. The
@@ -6267,14 +6315,17 @@ class Session(NoNewAttributesAfterInit):
            in the file). It should be 1 or 2.
         colkeys : array of str, optional
            An array of the column name to read in. The default is
-           ``None``.
+           ``None``, which uses the first ``ncols`` columns in the file.
+           The default column names are col followed by the column number,
+           so ``col1`` for the first column.
         dstype : data class to use, optional
            What type of data is to be used. Supported values include
            `Data1D` (the default) and `Data1DInt`.
         sep : str, optional
-           The separator character. The default is ``' '``.
+           The separator character for columns. The default is ``' '``.
         comment : str, optional
-           The comment character. The default is ``'#'``.
+           Lines starting with this string are ignored. The default
+           is ``'#'``.
         method : func
            The interpolation method to use to map the input data onto
            the coordinate grid of the data set. Linear,
@@ -6294,6 +6345,24 @@ class Session(NoNewAttributesAfterInit):
         Examples of interpolation schemes provided by `sherpa.utils`
         are: `linear_interp`, `nearest_interp`, `neville`, and
         `neville2d`.
+
+        See `unpack_data` for a description of the supported
+        file format.
+
+        When reading in two columns, the data will be re-ordered
+        so that the first column read in (the independent axis)
+        is numerically increasing.
+
+        If ``ncols=1``, only the model values (dependent axis) are
+        read in. In this case, the data set to which the model
+        is applied - via ``set_source`` - must have the same number
+        of data points as the model.
+
+        When used with an integrated data set (for example,
+        `Data1DInt`), then the first column of the table - the
+        independent axis - should be the left-edge of the bin,
+        and the second column is the integrated value for that
+        bin.
 
         Examples
         --------
@@ -6393,6 +6462,9 @@ class Session(NoNewAttributesAfterInit):
 
         There is no way using this interface to indicate that the
         model is for 1D or 2D data.
+
+        The format for the input file, and how to control what columns
+        to read, are described in the help for the `unpack_data` function.
 
         Examples
         --------


### PR DESCRIPTION
Release Notes
-------------

Improve the documentation for file I/O in `sherpa.ui`, including

* be explicit about ASCII support only (including remove mention of FITS support)
* add documentation for the support routines (e.g. those in `sherpa/io.py`) that actually do the I/O

Improve documentation for `load_table_model`, in particular the file support.

Fix unknown error classes in `sherpa.ui.utils`: these are in "hard to exercise" code paths (since there have been no reports about the unknown symbols).

There have been PEP8-related code changes.

Notes
-----

Ideally the fix for the unknown error classes would be in a separate PR but I don't have the time to rework this.