### PR TITLE
Fix bug #177 - tests failing with numpy-mkl 1.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       python: "2.7"
       sudo: required
       dist: trusty
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 MKL=nomkl
+      python: "2.7"
+      sudo: required
+      dist: trusty
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "2.7"
       sudo: required
@@ -45,7 +49,6 @@ matrix:
 env:  FITS="astropy" INSTALL_TYPE=install TEST=smoke MATPLOTLIBVER=1.5
 
 before_install:
-  - export MKL="nomkl"
   - export LIBGFORTRANVER="1.0"
   - export SHERPA_CHANNEL=https://conda.anaconda.org/sherpa
   - export MINICONDA=/home/travis/miniconda
@@ -54,11 +57,11 @@ before_install:
   - ./miniconda.sh -b -p $MINICONDA
   - export PATH=$MINICONDA/bin:$PATH
   - conda update --yes conda
-  - if [ -n "${FITS}" ]; then conda install --yes -c ${SHERPA_CHANNEL} ${FITS} $MKL; fi
+  - if [ -n "${FITS}" ]; then conda install --yes -c ${SHERPA_CHANNEL} ${FITS} ${MKL}; fi
   - if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
   - if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
   - echo ${MATPLOTLIB} ${NUMPY} ${FITS}
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} $MKL libgfortran=$LIBGFORTRANVER
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER
   - conda config --add channels ${SHERPA_CHANNEL}
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -207,9 +207,8 @@ class test_utils(SherpaTestCase):
         ncpus = multiprocessing.cpu_count()
 
         numtasks = 8
-        vals = numpy.array([1, 2, 3])
         f = numpy.sum
-        iterable = [vals] * numtasks
+        iterable = [numpy.arange(1, 2+2*i) for i in range(numtasks)]
 
         result = map(f, iterable)
         result = numpy.asarray(result)

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -18,6 +18,7 @@
 #
 
 import numpy
+import multiprocessing
 from numpy.testing import assert_allclose, assert_equal
 
 from sherpa import utils
@@ -202,25 +203,12 @@ class test_utils(SherpaTestCase):
                 val = utils.neville2d(xx, yy, x, y, fval)
                 self.assertTrue(utils.Knuth_close(answer, val, tol))
 
-    # TODO: have a skip-if-no-parallel-support?
     def test_parallel_map(self):
+        ncpus = multiprocessing.cpu_count()
 
-        ncpus = 1
-        try:
-            import multiprocessing
-            ncpus = multiprocessing.cpu_count()
-            Pool = multiprocessing.Pool
-        except:
-            return
-
-        # TODO: would it be better to use a test that is both
-        #       deterministic (i.e. does not use random values)
-        #       and not sensitive to numerical noise here?
-        #
         numtasks = 8
-        size = (64, 64)
-        vals = numpy.random.rand(*size)
-        f = numpy.linalg.eigvals
+        vals = numpy.array([1, 2, 3])
+        f = numpy.sum
         iterable = [vals] * numtasks
 
         result = map(f, iterable)
@@ -228,17 +216,7 @@ class test_utils(SherpaTestCase):
 
         pararesult = utils.parallel_map(f, iterable, ncpus)
 
-        pool = Pool(ncpus)
-        poolresult = pool.map(f, iterable)
-
-        # Using conda on Linux, using an equality test worked
-        # with numpy 1.10.2, but with the upgrade to 1.10.4 (which pulled
-        # in mkl) the check was changed to a tolerance.
-        #
-        # assert_equal(result, numpy.asarray(pararesult))
-        # assert_equal(result, numpy.asarray(poolresult))
-        assert_allclose(result, numpy.asarray(pararesult))
-        assert_allclose(result, numpy.asarray(poolresult))
+        assert_equal(result, numpy.asarray(pararesult))
 
 
 if __name__ == '__main__':

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,8 +18,12 @@
 #
 
 import numpy
-from sherpa.utils import *
-from sherpa.utils import SherpaFloat
+from numpy.testing import assert_allclose, assert_equal
+
+from sherpa import utils
+from sherpa.utils import SherpaTest, SherpaTestCase, SherpaFloat, \
+    NoNewAttributesAfterInit
+
 
 class test_utils(SherpaTestCase):
 
@@ -71,9 +75,9 @@ class test_utils(SherpaTestCase):
 
         # Basic usage
         for meth in (c.m, c.cm, c.sm):
-            m = export_method(meth)
+            m = utils.export_method(meth)
             self.assertEqual(m.__name__, meth.__name__)
-            self.assert_(m.__doc__ is not None)
+            self.assertTrue(m.__doc__ is not None)
             self.assertEqual(m.__doc__, meth.__doc__)
             self.assertEqual(m(3), 6)
             self.assertEqual(m(3, 7), 21)
@@ -87,107 +91,118 @@ class test_utils(SherpaTestCase):
                              meth.__name__)
 
         # Non-method argument
-        def f(x):  return 2*x
-        self.assert_(export_method(f) is f)
+        def f(x):
+            return 2 * x
+        self.assertTrue(utils.export_method(f) is f)
 
         # Name and module name
-        m = export_method(c.m, 'foo', 'bar')
+        m = utils.export_method(c.m, 'foo', 'bar')
         self.assertEqual(m.__name__, 'foo')
         self.assertEqual(m.__module__, 'bar')
         self.assertEqual(m(3), 6)
         self.assertEqual(m(3, 7), 21)
 
     def test_get_keyword_names(self):
-        self.assertEqual(get_keyword_names(self.f1), [])
+        self.assertEqual(utils.get_keyword_names(self.f1), [])
         l = ['b', 'c', 'd', 'e']
-        self.assertEqual(get_keyword_names(self.f2), l)
-        self.assertEqual(get_keyword_names(self.f2, 2), l[2:])
+        self.assertEqual(utils.get_keyword_names(self.f2), l)
+        self.assertEqual(utils.get_keyword_names(self.f2, 2), l[2:])
 
     def test_get_keyword_defaults(self):
-        self.assertEqual(get_keyword_defaults(self.f1), {})
-        d = {'b':1, 'c':2, 'd':3, 'e':4}
-        self.assertEqual(get_keyword_defaults(self.f2), d)
+        self.assertEqual(utils.get_keyword_defaults(self.f1), {})
+        d = {'b': 1, 'c': 2, 'd': 3, 'e': 4}
+        self.assertEqual(utils.get_keyword_defaults(self.f2), d)
         del d['b']
         del d['c']
-        self.assertEqual(get_keyword_defaults(self.f2, 2), d)
+        self.assertEqual(utils.get_keyword_defaults(self.f2, 2), d)
 
     def test_print_fields(self):
         names = ['a', 'bb', 'ccc']
         vals = {'a': 3, 'bb': 'Ham', 'ccc': numpy.array([1.0, 2.0, 3.0])}
-        self.assertEqual(print_fields(names, vals),
+        self.assertEqual(utils.print_fields(names, vals),
                          'a   = 3\nbb  = Ham\nccc = Float64[3]')
 
     def test_calc_total_error(self):
-        stat = numpy.array([1,2])
-        sys = numpy.array([3,4])
-        self.assert_(calc_total_error(None, None) is None)
-        self.assert_(calc_total_error(stat, None) is stat)
-        self.assert_(calc_total_error(None, sys) is sys)
-        self.assert_(numpy.all(calc_total_error(stat, sys) ==
-                               numpy.sqrt(stat*stat + sys*sys)))
+        stat = numpy.array([1, 2])
+        sys = numpy.array([3, 4])
+
+        self.assertEqual(utils.calc_total_error(None, None), None)
+        assert_equal(utils.calc_total_error(stat, None), stat)
+        assert_equal(utils.calc_total_error(None, sys), sys)
+
+        # Unlike the above tests, only look for equivalence within
+        # a tolerance, since the numbers are manipulated rather than
+        # copied in this case (although the equation should be the same
+        # so the old approach of using equality should actually be okay
+        # here).
+        ans = numpy.sqrt(stat * stat + sys * sys)
+        assert_allclose(utils.calc_total_error(stat, sys), ans)
 
     def test_poisson_noise(self):
-        out = poisson_noise(1000)
-        self.assert_(type(out) is SherpaFloat)
-        self.assert_(out > 0.0)
+        out = utils.poisson_noise(1000)
+        self.assertEqual(type(out), SherpaFloat)
+        self.assertGreater(out, 0.0)
 
         for x in (-1000, 0):
-            out = poisson_noise(x)
-            self.assert_(type(out) is SherpaFloat)
-            self.assert_(out == 0.0)
+            out = utils.poisson_noise(x)
+            self.assertEqual(type(out), SherpaFloat)
+            self.assertEqual(out, 0.0)
 
-        out = poisson_noise([1001, 1002, 0.0, 1003, -1004])
-        self.assert_(type(out) is numpy.ndarray)
-        self.assert_(out.dtype.type is SherpaFloat)
-        self.assert_(numpy.all(numpy.flatnonzero(out > 0.0) ==
-                               numpy.array([0, 1, 3])))
+        out = utils.poisson_noise([1001, 1002, 0.0, 1003, -1004])
+        self.assertEqual(type(out), numpy.ndarray)
+        self.assertEqual(out.dtype.type, SherpaFloat)
+        ans = numpy.flatnonzero(out > 0.0)
+        assert_equal(ans, numpy.array([0, 1, 3]))
 
-        self.assertRaises(ValueError, poisson_noise, 'ham')
-        self.assertRaises(TypeError, poisson_noise, [1, 2, 'ham'])
+        self.assertRaises(ValueError, utils.poisson_noise, 'ham')
+        self.assertRaises(TypeError, utils.poisson_noise, [1, 2, 'ham'])
 
-
-    def test_neville( self ):
+    def test_neville(self):
         func = numpy.exp
         tol = 1.0e-6
         num = 10
+        # TODO: can we not just use vectorized code here?
         x = []
         y = []
-        for ii in xrange( num ):
-            x.append( ii / float( num ) )
-            y.append( func( x[ ii ] ) )
-        xx = numpy.array( x )
-        yy = numpy.array( y )
-        for ii in xrange( num ):
-            tmp = 1.01 * ( ii/ float( num ) )
-            answer = func( tmp )
-            val = neville( tmp, xx, yy )
-            self.assert_( Knuth_close( answer, val, tol ) )
+        for ii in xrange(num):
+            x.append(ii / float(num))
+            y.append(func(x[ii]))
+        xx = numpy.array(x)
+        yy = numpy.array(y)
+        for ii in xrange(num):
+            tmp = 1.01 * (ii / float(num))
+            answer = func(tmp)
+            val = utils.neville(tmp, xx, yy)
+            self.assertTrue(utils.Knuth_close(answer, val, tol))
 
-    def test_neville2d( self ):
+    def test_neville2d(self):
         funcx = numpy.sin
         funcy = numpy.exp
         nrow = 10
         ncol = 10
         tol = 1.0e-4
-        x = numpy.zeros( (nrow,) )
-        y = numpy.zeros( (ncol,) )
-        fval = numpy.empty( ( nrow, ncol ) )
+        # TODO: As with test_neville; can this not be simplified with
+        # vectorized code
+        x = numpy.zeros((nrow, ))
+        y = numpy.zeros((ncol, ))
+        fval = numpy.empty((nrow, ncol))
         row_tmp = numpy.pi / nrow
-        col_tmp = 1.0 / float( ncol )
-        for row in xrange( nrow ):
-            x[ row ] = ( row + 1.0 ) * row_tmp
-            for col in xrange( ncol ):
-                y[ col ] = ( col + 1.0 ) / float( ncol )
-                fval[ row ][ col ] = funcx( x[ row ] ) * funcy( y[ col ] )
+        # col_tmp = 1.0 / float(ncol)
+        for row in xrange(nrow):
+            x[row] = (row + 1.0) * row_tmp
+            for col in xrange(ncol):
+                y[col] = (col + 1.0) / float(ncol)
+                fval[row][col] = funcx(x[row]) * funcy(y[col])
 
-        for row in xrange( ncol ):
-            xx = ( -0.1 + ( row + 1.0 ) / float( nrow ) ) * numpy.pi
-            for col in xrange( 4 ):
-                yy = -0.1 +( col + 1.0 )/ float( ncol )
-                answer = funcx( xx ) * funcy( yy )
-                val = neville2d( xx, yy, x, y, fval )
-                self.assert_( Knuth_close( answer, val, tol ) )
+        for row in xrange(ncol):
+            xx = (-0.1 + (row + 1.0) / float(nrow)) * numpy.pi
+            for col in xrange(4):
+                yy = -0.1 + (col + 1.0) / float(ncol)
+                answer = funcx(xx) * funcy(yy)
+                val = utils.neville2d(xx, yy, x, y, fval)
+                self.assertTrue(utils.Knuth_close(answer, val, tol))
 
+    # TODO: have a skip-if-no-parallel-support?
     def test_parallel_map(self):
 
         ncpus = 1
@@ -198,25 +213,34 @@ class test_utils(SherpaTestCase):
         except:
             return
 
+        # TODO: would it be better to use a test that is both
+        #       deterministic (i.e. does not use random values)
+        #       and not sensitive to numerical noise here?
+        #
         numtasks = 8
-        size = (64,64)
+        size = (64, 64)
         vals = numpy.random.rand(*size)
         f = numpy.linalg.eigvals
-        iterable = [vals]*numtasks
+        iterable = [vals] * numtasks
 
         result = map(f, iterable)
+        result = numpy.asarray(result)
 
-        pararesult = parallel_map(f, iterable, ncpus)
+        pararesult = utils.parallel_map(f, iterable, ncpus)
 
         pool = Pool(ncpus)
         poolresult = pool.map(f, iterable)
 
-        self.assert_((numpy.asarray(result) == numpy.asarray(pararesult)).all())
-        self.assert_((numpy.asarray(result) == numpy.asarray(poolresult)).all())
-
+        # Using conda on Linux, using an equality test worked
+        # with numpy 1.10.2, but with the upgrade to 1.10.4 (which pulled
+        # in mkl) the check was changed to a tolerance.
+        #
+        # assert_equal(result, numpy.asarray(pararesult))
+        # assert_equal(result, numpy.asarray(poolresult))
+        assert_allclose(result, numpy.asarray(pararesult))
+        assert_allclose(result, numpy.asarray(poolresult))
 
 
 if __name__ == '__main__':
 
-    import sherpa.utils as utils
     SherpaTest(utils).test()


### PR DESCRIPTION
Release Notes
-------------

Update the tests to support numpy 1.10.4 with the Intel Math Kernel Library (mkl), as provided by anaconda.

Notes
------

This updates several tests to check for numeric equivalence using a
tolerance rather than absolute equality. There have also been PEP8
changes, and updates to use more-recent unittest methods (e.g.
assertTrue rather than assert_ and assertGreater).

Several tests should probably be re-written to use vectorized routines
rather than iterating over elements, but that is outside the scope of
this fix.

The problem test could be re-written to use a different numerical
operation, which could remove the need for a tolerance check, but I
felt that was also out-of-scope here.