### PR TITLE
Remove the TraceCalls class.

### DIFF
--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -99,7 +99,7 @@ __all__ = ('NoNewAttributesAfterInit', 'SherpaTest', 'SherpaTestCase',
            'parse_expr', 'poisson_noise', 'print_fields', 'rebin',
            'sao_arange', 'sao_fcmp', 'set_origin', 'sum_intervals', 'zeroin',
            'multinormal_pdf', 'multit_pdf', 'get_error_estimates', 'quantile',
-           'TraceCalls','get_valid_args')
+           'get_valid_args')
 
 _guess_ampl_scale = 1.e+3
 
@@ -114,42 +114,6 @@ _guess_ampl_scale = 1.e+3
 SherpaInt = numpy.intp
 SherpaUInt = numpy.uintp
 SherpaFloat = numpy.float_
-
-###############################################################################
-
-
-class TraceCalls(object):
-    """ Use as a decorator on functions that should be traced. Several
-        functions can be decorated - they will all be indented according
-        to their call depth.
-    """
-    def __init__(self, stream=sys.stdout, indent_step=2, show_ret=False):
-        self.stream = stream
-        self.indent_step = indent_step
-        self.show_ret = show_ret
-
-        # This is a class attribute since we want to share the indentation
-        # level between different traced functions, in case they call
-        # each other.
-        TraceCalls.cur_indent = 0
-
-    def __call__(self, fn):
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            indent = ' ' * TraceCalls.cur_indent
-            argstr = ', '.join(
-                [repr(a) for a in args] +
-                ["%s=%s" % (a, repr(b)) for a, b in kwargs.items()])
-            self.stream.write('%s%s(%s)\n' % (indent, fn.__name__, argstr))
-
-            TraceCalls.cur_indent += self.indent_step
-            ret = fn(*args, **kwargs)
-            TraceCalls.cur_indent -= self.indent_step
-
-            if self.show_ret:
-                self.stream.write('%s--> %s\n' % (indent, ret))
-            return ret
-        return wrapper
 
 ###############################################################################
 


### PR DESCRIPTION
The sherpa.utils.TraceCalls class is not used in Sherpa and so has
been removed. Was it part of the loggable prototype work that was
removed in PR #100? See changeset 4ba7b8985d8bc3ec2f86fa15c5c0785959501222