### PR TITLE
Avoid numpy 1.10.4 in Travis builds (work around for #177)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ before_install:
      then git submodule deinit -f .;
     fi
   - if [ -n "${NOSETUPTOOLS}" ]; then conda remove --yes setuptools; fi
+  - conda install 'numpy < 1.10.4'  # TEMPORARY work around #177
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
      then git submodule deinit -f .;
     fi
   - if [ -n "${NOSETUPTOOLS}" ]; then conda remove --yes setuptools; fi
-  - conda install 'numpy < 1.10.4'  # TEMPORARY work around #177
+  - conda install --yes 'numpy < 1.10.4'  # TEMPORARY work around #177
 
 
 install:


### PR DESCRIPTION
This is an attempt to avoid numpy 1.10.4 in the Travis builds to avoid
triggering #177. It is not a sensible long-term solution.