### PR TITLE
opt out of mkl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
   - if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
   - echo ${MATPLOTLIB} ${NUMPY} ${FITS}
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY}
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} nomkl
   - conda config --add channels ${SHERPA_CHANNEL}
   - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];


### PR DESCRIPTION
Workaround #177.

This PR opts out of the new default `mkl` feature in conda packages for `numpy` and related packages. This works around #177, but it does not fix it. A proper fix would make sure that tests pass both with and without `mkl`. In this sense #178 (plus probably adding at least one more travis build) is the way to go eventually.

With respect to #180, this PR does not pins the `numpy` version: it just makes sure `nomkl` is selected as a feature in the conda environment.

See https://www.continuum.io/blog/developer-blog/anaconda-25-release-now-mkl-optimizations