### PR TITLE
Protect XPA command to avoid shell confusion.

### DIFF
--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2006-2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2006-2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -264,7 +264,8 @@ def xpaget(cmd, template=_DefTemplate, doRaise = True):
     Raises RuntimeError or issues a warning (depending on doRaise)
     if anything is written to stderr.
     """
-    fullCmd = 'xpaget %s %s' % (template, cmd,)
+    # Would be better to make a sequence rather than have to quote arguments
+    fullCmd = 'xpaget %s "%s"' % (template, cmd,)
 
     p = _Popen(
             args = fullCmd,
@@ -312,10 +313,11 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate, doRaise = True)
     Raises RuntimeError or issues a warning (depending on doRaise)
     if anything is written to stdout or stderr.
     """
+    # Would be better to make a sequence rather than have to quote arguments
     if data or dataFunc:
-        fullCmd = 'xpaset %s %s' % (template, cmd)
+        fullCmd = 'xpaset %s "%s"' % (template, cmd)
     else:
-        fullCmd = 'xpaset -p %s %s' % (template, cmd)
+        fullCmd = 'xpaset -p %s "%s"' % (template, cmd)
 
     p = _Popen(
             args = fullCmd,
@@ -402,7 +404,7 @@ def _splitDict(inDict, keys):
     for key in keys:
         if inDict.has_key(key):
             outDict[key] = inDict.pop(key)
-    return outDict	
+    return outDict
 
 
 class DS9Win:
@@ -439,7 +441,7 @@ class DS9Win:
 
         _Popen(
                 args = ('ds9', '-title', self.template, '-port', "0"),
-                cwd = None, 
+                cwd = None,
         )
 
         startTime = time.time()
@@ -550,7 +552,7 @@ class DS9Win:
 # (apparently due to a bug in ds9) and because it wasn't very useful
 #	def showBinFile(self, fname, **kargs):
 #		"""Display a binary file in ds9.
-#		
+#
 #		The following keyword arguments are used to specify the array:
 #		- xdim		# of points along x
 #		- ydim		# of points along y
@@ -558,7 +560,7 @@ class DS9Win:
 #		- zdim		# of points along z
 #		- bitpix	number of bits/pixel; negative if floating
 #		- arch	one of bigendian or littleendian (intel)
-#		
+#
 #		The remaining keywords are extras treated as described
 #		in the module comment.
 #
@@ -573,7 +575,7 @@ class DS9Win:
 #		filePathPlusInfo = _expandPath(fname, arrInfo)
 #
 #		self.xpaset(cmd='file array "%s"' % (filePathPlusInfo,))
-#		
+#
 #		for keyValue in kargs.iteritems():
 #			self.xpaset(cmd=' '.join(keyValue))
 

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -134,17 +134,17 @@ History:
 2008-05-28 Stephen Doe  Always raise exception on error (doRaise=True always)
 2008-11-25 Stephen Doe  Search PATH for access to application, rather than shell out to use 'which' -- PATH sometimes not correctly inherited by shell via Popen, for csh on some Mac, Solaris machines.
 """
-__all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
 
-import numpy as num
+import numpy as np
 import os
 import sys
-import platform
-import socket
 import time
 import warnings
 import subprocess
 from sherpa.utils.err import RuntimeErr, TypeErr
+
+__all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
+
 
 def _addToPATH(newPath):
     """Add newPath to the PATH environment variable.
@@ -161,6 +161,7 @@ def _addToPATH(newPath):
         pathStr = newPath
     os.environ["PATH"] = pathStr
 
+
 def _findUnixApp(appName):
     """Search PATH to find first directory that has the application.
     Return the path if found.
@@ -169,18 +170,18 @@ def _findUnixApp(appName):
     try:
         appPath = ''
         for path in os.environ['PATH'].split(':'):
-            if (os.access(path + '/' + appName, os.X_OK) == True):
+            if os.access(path + '/' + appName, os.X_OK):
                 appPath = path
                 break
 
-        if (appPath == '' or
-            not appPath.startswith("/")):
+        if appPath == '' or not appPath.startswith("/"):
             raise RuntimeErr('notonpath', appName)
 
     except:
         raise
 
     return appPath
+
 
 def _findDS9AndXPA():
     """Locate ds9 and xpa, and add to PATH if not already there.
@@ -245,10 +246,11 @@ if errStr:
 _ArrayKeys = ("dim", "dims", "xdim", "ydim", "zdim", "bitpix", "skip", "arch")
 _DefTemplate = "sherpa"
 
-_OpenCheckInterval = 0.2 # seconds
-_MaxOpenTime = 60.0 # seconds
+_OpenCheckInterval = 0.2  # seconds
+_MaxOpenTime = 60.0  # seconds
 
-def xpaget(cmd, template=_DefTemplate, doRaise = True):
+
+def xpaget(cmd, template=_DefTemplate, doRaise=True):
     """Executes a simple xpaget command:
             xpaset -p <template> <cmd>
     returning the reply.
@@ -268,11 +270,11 @@ def xpaget(cmd, template=_DefTemplate, doRaise = True):
     fullCmd = 'xpaget %s "%s"' % (template, cmd,)
 
     p = _Popen(
-            args = fullCmd,
-            shell = True,
-            stdin = subprocess.PIPE,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
+        args=fullCmd,
+        shell=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     try:
         p.stdin.close()
@@ -289,7 +291,8 @@ def xpaget(cmd, template=_DefTemplate, doRaise = True):
         p.stderr.close()
 
 
-def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate, doRaise = True):
+def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate,
+           doRaise=True):
     """Executes a simple xpaset command:
             xpaset -p <template> <cmd>
     or else feeds data to:
@@ -320,11 +323,11 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate, doRaise = True)
         fullCmd = 'xpaset -p %s "%s"' % (template, cmd)
 
     p = _Popen(
-            args = fullCmd,
-            shell = True,
-            stdin = subprocess.PIPE,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.STDOUT,
+        args=fullCmd,
+        shell=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
     try:
         if dataFunc:
@@ -343,7 +346,7 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate, doRaise = True)
             else:
                 warnings.warn(fullErrMsg)
     finally:
-        p.stdin.close() # redundant
+        p.stdin.close()  # redundant
         p.stdout.close()
 
 
@@ -355,20 +358,22 @@ def _computeCnvDict():
     """
 
     cnvDict = {
-            num.int8: num.int16,
-            num.uint16: num.int32,
-            num.uint32: num.float32,	# ds9 can't handle 64 bit integer data
-            num.int64: num.float64,
+        np.int8: np.int16,
+        np.uint16: np.int32,
+        np.uint32: np.float32,  # ds9 can't handle 64 bit integer data
+        np.int64: np.float64,
     }
 
-    if hasattr(num, "uint64="):
-        cnvDict[num.uint64] = num.float64
+    # TODO: should this check for 'uint64' since 'uint64=' is not a
+    #       valid attribute name
+    if hasattr(np, "uint64="):
+        cnvDict[np.uint64] = np.float64
 
     return cnvDict
 
 _CnvDict = _computeCnvDict()
-_FloatTypes = (num.float32, num.float64)
-_ComplexTypes = (num.complex64, num.complex128)
+_FloatTypes = (np.float32, np.float64)
+_ComplexTypes = (np.complex64, np.complex128)
 
 
 def _expandPath(fname, extraArgs=""):
@@ -402,7 +407,7 @@ def _splitDict(inDict, keys):
     """
     outDict = {}
     for key in keys:
-        if inDict.has_key(key):
+        if key in inDict:
             outDict[key] = inDict.pop(key)
     return outDict
 
@@ -421,10 +426,9 @@ class DS9Win:
                     Note: doOpen always raises RuntimeError on failure!
     """
     def __init__(self,
-            template=_DefTemplate,
-            doOpen = True,
-            doRaise = True
-    ):
+                 template=_DefTemplate,
+                 doOpen=True,
+                 doRaise=True):
         self.template = str(template)
         self.doRaise = bool(doRaise)
         self.alreadyOpen = self.isOpen()
@@ -440,8 +444,8 @@ class DS9Win:
             return
 
         _Popen(
-                args = ('ds9', '-title', self.template, '-port', "0"),
-                cwd = None,
+            args=('ds9', '-title', self.template, '-port', "0"),
+            cwd=None,
         )
 
         startTime = time.time()
@@ -485,20 +489,21 @@ class DS9Win:
         Raises RuntimeError if ds9 is not running or returns an error message.
         """
         if not hasattr(arr, "dtype") or not hasattr(arr, "astype"):
-            arr = num.array(arr)
+            arr = np.array(arr)
 
-        if num.iscomplexobj(arr):
+        if np.iscomplexobj(arr):
             raise TypeErr('nocomplex')
 
         ndim = arr.ndim
         if ndim not in (2, 3):
             raise RuntimeErr('only2d3d')
-        dimNames = ["z", "y", "x"][3-ndim:]
+
+        dimNames = ["z", "y", "x"][3 - ndim:]
 
         # if necessary, convert array type
         cnvType = _CnvDict.get(arr.dtype.type)
         if cnvType:
-#			print "converting array from %s to %s" % (arr.type(), cnvType)
+            # print "converting array from %s to %s" % (arr.type(), cnvType)
             arr = arr.astype(cnvType)
 
         # determine byte order of array
@@ -519,7 +524,7 @@ class DS9Win:
         # compute bits/pix; ds9 uses negative values for floating values
         bitsPerPix = arr.itemsize * 8
 
-        #if num.issubclass_(arr.dtype.type, float):
+        # if np.issubclass_(arr.dtype.type, float):
         if arr.dtype.type in _FloatTypes:
             # array is float; use negative value
             bitsPerPix = -bitsPerPix
@@ -535,14 +540,14 @@ class DS9Win:
             arryDict["%sdim" % axis] = size
 
         arryDict["bitpix"] = bitsPerPix
-        if (isBigendian):
+        if isBigendian:
             arryDict["arch"] = 'bigendian'
         else:
             arryDict["arch"] = 'littleendian'
 
         self.xpaset(
-                cmd = 'array [%s]' % (_formatOptions(arryDict),),
-                dataFunc = arr.tofile,
+            cmd='array [%s]' % (_formatOptions(arryDict),),
+            dataFunc=arr.tofile,
         )
 
         for keyValue in kargs.iteritems():
@@ -611,11 +616,10 @@ class DS9Win:
         Raises RuntimeError if anything is written to stderr.
         """
         return xpaget(
-                cmd = cmd,
-                template = self.template,
-                doRaise = self.doRaise,
+            cmd=cmd,
+            template=self.template,
+            doRaise=self.doRaise,
         )
-
 
     def xpaset(self, cmd, data=None, dataFunc=None):
         """Executes a simple xpaset command:
@@ -634,11 +638,11 @@ class DS9Win:
         Raises RuntimeError if anything is written to stdout or stderr.
         """
         return xpaset(
-                cmd = cmd,
-                data = data,
-                dataFunc = dataFunc,
-                template = self.template,
-                doRaise = self.doRaise,
+            cmd=cmd,
+            data=data,
+            dataFunc=dataFunc,
+            template=self.template,
+            doRaise=self.doRaise,
         )
 
 if __name__ == "__main__":

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -17,7 +17,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
 import numpy
 # from numpy.testing import assert_allclose
 
@@ -25,19 +24,22 @@ import tempfile
 
 import os
 import sherpa
-from sherpa.image import *
+from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
+    ResidImage
+
 from sherpa.utils import SherpaTestCase, requires_ds9
+
 
 # Create a 10x10 array for the tests.
 class Data(object):
     def __init__(self):
         self.name = None
-        self.y = numpy.arange(0,(10*10)/2,0.5)
-        self.y = self.y.reshape(10,10)
+        self.y = numpy.arange(0, (10 * 10) / 2, 0.5)
+        self.y = self.y.reshape(10, 10)
         self.eqpos = None
         self.sky = None
 
-    def get_img(self,model=None):
+    def get_img(self, model=None):
         if model is not None:
             return (self.y, self.y)
         else:
@@ -45,25 +47,29 @@ class Data(object):
 
 data = Data()
 
+
 def get_arr_from_imager(im):
     # DS9 returns data as unordered string
     # Turn it into a 10x10 array
     data_out = im.xpaget("data image 1 1 10 10 yes")
     data_out = data_out.split()
-    data_out = numpy.array(data_out).reshape(10,10)
+    data_out = numpy.array(data_out).reshape(10, 10)
     data_out = numpy.float_(data_out)
     return data_out
+
 
 # TODO: use numpy.testing.assert_allclose (or related) so that a
 #       per-pixel check can be done, rather than an aggregated one.
 #       Hmmm, apparently the test is doing something different than
 #       I think it is, as the values aren't an exact match. So what
-#       exactly is get_arr_from_imager returning?
+#       exactly is get_arr_from_imager returning? Is it just a
+#       Fortran/C axis difference?
 
 @requires_ds9
 class test_image(SherpaTestCase):
     def test_ds9(self):
-        im = sherpa.image.ds9_backend.DS9.DS9Win(sherpa.image.ds9_backend.DS9._DefTemplate, False)
+        ctor = sherpa.image.ds9_backend.DS9.DS9Win
+        im = ctor(sherpa.image.ds9_backend.DS9._DefTemplate, False)
         im.doOpen()
         im.showArray(data.y)
         data_out = get_arr_from_imager(im)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -21,6 +21,8 @@ import unittest
 import numpy
 # from numpy.testing import assert_allclose
 
+import tempfile
+
 import os
 import sherpa
 from sherpa.image import *
@@ -117,24 +119,22 @@ class test_image(SherpaTestCase):
 
         """
 
-        ofile = 'x'
-        already_exists = os.path.exists(ofile)
-        if not already_exists:
-            try:
-                open(ofile, 'w').write('')
-            except IOError:
-                # assume it's a permission-denied error
-                unittest.skip('Unable to write to the current directory')
-                return
-
+        origdir = os.getcwd()
+        dname = tempfile.mkdtemp()
         try:
+            os.chdir(dname)
+
+            ofile = 'x'
+            open(ofile, 'w').write('')
+
             im = Image()
             im.image(data.y)
             data_out = get_arr_from_imager(im)
 
         finally:
-            if not already_exists:
-                os.unlink('x')
+            os.unlink(ofile)
+            os.chdir(origdir)
+            os.rmdir(dname)
 
         im.xpaset("quit")
 

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -17,8 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import numpy
-# from numpy.testing import assert_allclose
+import numpy as np
+from numpy.testing import assert_allclose
 
 import tempfile
 
@@ -34,7 +34,7 @@ from sherpa.utils import SherpaTestCase, requires_ds9
 class Data(object):
     def __init__(self):
         self.name = None
-        self.y = numpy.arange(0, (10 * 10) / 2, 0.5)
+        self.y = np.arange(0, (10 * 10) / 2, 0.5)
         self.y = self.y.reshape(10, 10)
         self.eqpos = None
         self.sky = None
@@ -48,22 +48,53 @@ class Data(object):
 data = Data()
 
 
-def get_arr_from_imager(im):
-    # DS9 returns data as unordered string
-    # Turn it into a 10x10 array
-    data_out = im.xpaget("data image 1 1 10 10 yes")
-    data_out = data_out.split()
-    data_out = numpy.array(data_out).reshape(10, 10)
-    data_out = numpy.float_(data_out)
-    return data_out
+# The order returned by the xpaget call below is neither C or Fortran
+# style. For instance,
+#
+# >>> y = np.asarray([1,2,3,10,20,30]).reshape(2,3)
+# >>> im = Image()
+# >>> im.image(y)
+# >>> got = im.xpaget("data image 1 1 3 2 yes")
+# >>> got
+# '3\n20\n30\n1\n2\n10\n'
+# >>> im.xpaget("data image 1 1 3 2 no")
+# '3,1 = 3\n2,2 = 20\n3,2 = 30\n1,1 = 1\n2,1 = 2\n1,2 = 10\n'
+#
+def get_arr_from_imager(im, yexp):
+    """Return data from image object, using the yexp value for shape/type"""
+
+    assert yexp.ndim == 2
+
+    (ny, nx) = yexp.shape
+    dtype = yexp.dtype.type
+
+    def proc(s):
+        """Convert 'i,j = z' to a tuple (i, j, z)"""
+        # no error checking
+        toks = s.split('=')
+        z = dtype(toks[1])
+        toks = toks[0].split(',')
+        i = int(toks[0])
+        j = int(toks[1])
+        return (i, j, z)
+
+    # There is almost-certainly a better way to do this, but for
+    # now be explicit (the array sizes are not expected to be large,
+    # so it doesn't need to be efficient).
+    out = np.zeros((ny, nx), dtype=dtype)
+    d = im.xpaget("data image 1 1 {} {} no".format(nx, ny))
+    for l in d.split('\n'):
+        if l.strip() == '':
+            continue
+        i, j, z = proc(l)
+        out[j - 1, i - 1] = z
+
+    return out
 
 
-# TODO: use numpy.testing.assert_allclose (or related) so that a
-#       per-pixel check can be done, rather than an aggregated one.
-#       Hmmm, apparently the test is doing something different than
-#       I think it is, as the values aren't an exact match. So what
-#       exactly is get_arr_from_imager returning? Is it just a
-#       Fortran/C axis difference?
+_atol = 0.0
+_rtol = 1.0e-6
+
 
 @requires_ds9
 class test_image(SherpaTestCase):
@@ -72,57 +103,60 @@ class test_image(SherpaTestCase):
         im = ctor(sherpa.image.ds9_backend.DS9._DefTemplate, False)
         im.doOpen()
         im.showArray(data.y)
-        data_out = get_arr_from_imager(im)
+        data_out = get_arr_from_imager(im, data.y)
         im.xpaset("quit")
-        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+        assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
     def test_image(self):
         im = Image()
         im.image(data.y)
-        data_out = get_arr_from_imager(im)
+        data_out = get_arr_from_imager(im, data.y)
         im.xpaset("quit")
-        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+        assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
     def test_data_image(self):
         im = DataImage()
         im.prepare_image(data)
         im.image()
-        data_out = get_arr_from_imager(im)
+        data_out = get_arr_from_imager(im, data.y)
         im.xpaset("quit")
-        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+        assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
     def test_model_image(self):
         im = ModelImage()
         im.prepare_image(data, 1)
         im.image()
-        data_out = get_arr_from_imager(im)
+        data_out = get_arr_from_imager(im, data.y)
         im.xpaset("quit")
-        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+        assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
     def test_ratio_image(self):
         im = RatioImage()
         im.prepare_image(data, 1)
         im.image()
-        data_out = get_arr_from_imager(im)
+        data_out = get_arr_from_imager(im, data.y)
         im.xpaset("quit")
-        # The sum is 99, because the first model pixel
-        # will be zero, and therefore the ratio function
+        # All values but the first will be 1, because the first
+        # model pixel will be zero, and therefore the ratio function
         # reassigns the ratio there to be one.
-        self.assertEqualWithinTol(data_out.sum(), 99.0, 1e-4)
+        expval = np.ones(data.y.shape)
+        expval[0, 0] = 0
+        assert_allclose(expval, data_out, atol=_atol, rtol=_rtol)
 
     def test_resid_image(self):
         im = ResidImage()
         im.prepare_image(data, 1)
         im.image()
-        data_out = get_arr_from_imager(im)
+        data_out = get_arr_from_imager(im, data.y)
         im.xpaset("quit")
-        self.assertEqualWithinTol(data_out.sum(), 0.0, 1e-4)
+        # Return value is all zeros
+        assert_allclose(data.y * 0, data_out, atol=_atol, rtol=_rtol)
 
     def test_connection_with_x_file(self):
         """Check that the connection works even if there is a
         file called x (this checks that the xpaset call is properly
-        escaped).
-
+        escaped when 'xpaset sherpa [BITPIX=..,x=..,y=..,]' is
+        called.
         """
 
         origdir = os.getcwd()
@@ -135,7 +169,7 @@ class test_image(SherpaTestCase):
 
             im = Image()
             im.image(data.y)
-            data_out = get_arr_from_imager(im)
+            data_out = get_arr_from_imager(im, data.y)
 
         finally:
             os.unlink(ofile)
@@ -144,5 +178,4 @@ class test_image(SherpaTestCase):
 
         im.xpaset("quit")
 
-        # assert_allclose(data.y, data_out, atol=0.0, rtol=1e-6)
-        self.assertEqualWithinTol((data.y - data_out).sum(), 0.0, 1e-4)
+        assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -30,12 +30,17 @@ from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
 from sherpa.utils import SherpaTestCase, requires_ds9
 
 
-# Create a 10x10 array for the tests.
+# Create a rectangular array for the tests just to ensure that
+# there are no issues with Fortran/C order.
+#
+_ny = 10
+_nx = 13
+
+
 class Data(object):
     def __init__(self):
         self.name = None
-        self.y = np.arange(0, (10 * 10) / 2, 0.5)
-        self.y = self.y.reshape(10, 10)
+        self.y = np.arange(0, _ny * _nx).reshape(_ny, _nx) / 2.0
         self.eqpos = None
         self.sky = None
 


### PR DESCRIPTION
# Release Notes

Fix the problem where if the working directory contained a file called `x` or `y` then the `sherpa.astro.ui.image_data()` function would fail with the message

     DS9Err: Could not display image

A test has been added to check this case, as well as a general clean up to slightly improve
the testing. The code has been updated for PEP8 fixes.

# Details

This fix is to avoid `sherpa.astro.ui.image_data()` from failing when
the working directory contains a file called `x` or `y` (and possibly
other combinations). It is a limited fix; ideally the code should be
updated to take better advantage of the `subprocess` module (e.g.
using a sequence rather than a string for the arguments, so that
there is no need to "protect" arguments).

Is there any reason why the XPA communication can not be done with https://github.com/ericmandel/pyds9 ?