### PR TITLE
Fix #92 - issue a more meaningful warning when FITS backends are not available

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -50,7 +50,14 @@ if io_opt.startswith('pycrates') or io_opt.startswith('crates'):
 elif io_opt.startswith('pyfits'):
     io_opt = 'pyfits_backend'
 
-backend = __import__(io_opt, globals(), locals(), [])
+try:
+    backend = __import__(io_opt, globals(), locals(), [])
+except ImportError:
+    raise ImportError("""Cannot import selected FITS I/O backend {}.
+    If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
+    If you are using Standalone Sherpa, please install astropy (pyfits should also work, but it's deprecated)."""
+                      .format(io_opt))
+
 warning = logging.getLogger(__name__).warning
 info    = logging.getLogger(__name__).info
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -44,7 +44,8 @@ import tempfile
 import numpy
 from numpy.testing import assert_array_equal
 
-from sherpa.utils import SherpaTest, SherpaTestCase, requires_data, requires_xspec, _has_package_from_list
+from sherpa.utils import SherpaTest, SherpaTestCase
+from sherpa.utils import requires_data, requires_xspec, _has_package_from_list, requires_fits
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
 
@@ -1058,6 +1059,7 @@ class test_ui(SherpaTestCase):
 
     @requires_data
     @requires_xspec
+    @requires_fits
     def test_canonical_pha_basic(self):
 
         _, canonical = self._setup_pha_basic()
@@ -1065,6 +1067,7 @@ class test_ui(SherpaTestCase):
 
     @requires_data
     @requires_xspec
+    @requires_fits
     def test_restore_pha_basic(self):
         "Can the state be evaluated?"
 
@@ -1089,6 +1092,7 @@ class test_ui(SherpaTestCase):
 
     @requires_data
     @requires_xspec
+    @requires_fits
     def test_canonical_pha_grouped(self):
 
         _, _, canonical = self._setup_pha_grouped()
@@ -1096,6 +1100,7 @@ class test_ui(SherpaTestCase):
 
     @requires_data
     @requires_xspec
+    @requires_fits
     def test_restore_pha_grouped(self):
         "Can the state be evaluated?"
 
@@ -1128,6 +1133,7 @@ class test_ui(SherpaTestCase):
 
     @requires_data
     @requires_xspec
+    @requires_fits
     def test_canonical_pha_back(self):
 
         _, _, canonical = self._setup_pha_back()
@@ -1135,6 +1141,7 @@ class test_ui(SherpaTestCase):
 
     @requires_data
     @requires_xspec
+    @requires_fits
     def test_restore_pha_back(self):
         "Can the state be evaluated?"
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -308,6 +308,7 @@ class test_xspec(SherpaTestCase):
                             err_msg=emsg + "energy to wavelength")
 
     @requires_data
+    @requires_fits
     def test_tablemodel_checks_input_length(self):
 
         # see test_table_model for more information on the table
@@ -326,6 +327,7 @@ class test_xspec(SherpaTestCase):
         self.assertRaises(TypeError, mdl, [0.1, 0.2], [0.2, 0.3, 0.4])
 
     @requires_data
+    @requires_fits
     def test_xspec_tablemodel(self):
         # Just test one table model; use the same scheme as
         # test_xspec_models_noncontiguous().
@@ -364,6 +366,7 @@ class test_xspec(SherpaTestCase):
                         err_msg=emsg + "two args")
 
     @requires_data
+    @requires_fits
     def test_xspec_tablemodel_noncontiguous2(self):
 
         ui.load_table_model('tmod',


### PR DESCRIPTION
I don't think this is worth a release note anymore, but just in case
# Release Note
Fix #92: a more meaningful message is given to the user when `sherpa.astro.io` is imported directly and no fits backends are available.

# Notes
Some tests would fail if no FITS backends were present. This PR also fixes this situation by adding the proper `@requires_fits` decorator to tests that were missing it.

# Testing
I would be more comfortable using `mock` and/or `pytest` for writing a test that ensure that the warning is issued. On the other hand, since tests should run just fine when no backends are installed, we may also want to create a new travis build. This is probably overkill in this case, but I am happy to do it if people feels this should be done. Note that in order to be meaningful, it should be a full build including xspec.