### PR TITLE
use matplotlib 1.4 for pyfits build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       python: "2.7"
       sudo: required
       dist: trusty
-    - env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
+    - env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
       python: "2.7"
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5
       python: "2.7"


### PR DESCRIPTION
This PR fixes a conflict in the `pyfits` travis build. The `pyfits` conda binary pins the `numpy` dependency to 1.8. A conflict arise later on when trying to install `matplotlib` 1.5.

A number of PRs are currently failing for this reason. PRs should be rebase on top of master when this is merged, which should happen as soon as the Travis builds are green.