### PR TITLE
Generalize calc_stat API + example of how to have several datasets with different fit statistics

### DIFF
--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -26,14 +26,48 @@ from sherpa.utils import requires_data, requires_xspec, requires_fits
 from sherpa.utils import SherpaTestCase
 from sherpa.data import Data1D
 
-from sherpa.models import PowLaw1D
+from sherpa.models import PowLaw1D, SimulFitModel
+from sherpa.data import DataSimulFit
 from sherpa.fit import Fit
-from sherpa.stats import Cash, UserStat, WStat
+from sherpa.stats import Stat, Cash, LeastSq, UserStat, WStat, \
+    CStat, LeastSq, Chi2Gehrels, Chi2ConstVar, Chi2ModVar, Chi2XspecVar, \
+    Chi2DataVar
 from sherpa.optmethods import LevMar, NelderMead
 from sherpa.utils.err import StatErr
 from sherpa.astro import ui
 import logging
 logger = logging.getLogger("sherpa")
+
+
+class MySimulStat(UserStat):
+    def __init__(self, name='mysimulstat'):
+        UserStat.__init__(self, name)
+
+    @staticmethod
+    def mycal_staterror(data):
+        return numpy.ones_like(data)
+
+    @staticmethod
+    def my_simulstat(data, model, staterror, *args, **kwargs):
+        data_size = kwargs['extra_args']['data_size']
+        data1 = data[:data_size[0]]
+        data2 = data[data_size[0]:]
+        model1 = model[:data_size[0]]
+        model2 = model[data_size[0]:]
+        staterror1 = staterror[:data_size[0]]
+        staterror2 = staterror[data_size[0]:]
+        mystat1 = Chi2DataVar()
+        mystat2 = Chi2DataVar()
+        stat1, fvec1 = mystat1.calc_stat(data1, model1, staterror1)
+        stat2, fvec2 = mystat2.calc_stat(data2, model2, staterror2)
+        fvec = numpy.power((data - model) / staterror, 2)
+        stat = numpy.sum(fvec)
+        # print stat1 + stat2 - stat
+        return (stat, fvec)
+        return (stat1 + stat2, numpy.append(fvec1, fvec2))
+
+    calc_stat = my_simulstat
+    calc_staterror = mycal_staterror
 
 
 class MyCashWithBkg(UserStat):
@@ -46,9 +80,9 @@ class MyCashWithBkg(UserStat):
         return None
 
     @staticmethod
-    def cash_withbkg(data, model, staterror=None, syserror=None, weight=None,
-                     bkg=None):
+    def cash_withbkg(data, model, staterror, *args, **kwargs):
         fvec = model - (data * numpy.log(model))
+        weight = kwargs.get('weight')
         if weight is not None:
             fvec = fvec * weight
         return 2.0 * sum(fvec), fvec
@@ -67,8 +101,7 @@ class MyChiWithBkg(UserStat):
         return numpy.ones_like(data)
 
     @staticmethod
-    def chi_withbkg(data, model, staterror=None, syserror=None, weight=None,
-                    bkg=None):
+    def chi_withbkg(data, model, staterror, *args, **kwargs):
         fvec = ((data - model) / staterror)**2
         stat = fvec.sum()
         return (stat, fvec)
@@ -87,9 +120,9 @@ class MyCashNoBkg(UserStat):
         return None
 
     @staticmethod
-    def cash_nobkg(data, model, staterror=None, syserror=None,
-                   weight=None):
+    def cash_nobkg(data, model, staterror, *args, **kwargs):
         fvec = model - (data * numpy.log(model))
+        weight = kwargs.get('weight')
         if weight is not None:
             fvec = fvec * weight
         return 2.0 * sum(fvec), fvec
@@ -108,7 +141,7 @@ class MyChiNoBkg(UserStat):
         return numpy.ones_like(data)
 
     @staticmethod
-    def chi_nobkg(data, model, staterror=None, syserror=None, weight=None):
+    def chi_nobkg(data, model, staterror, *args, **kwargs):
         fvec = ((data - model) / staterror)**2
         stat = fvec.sum()
         return (stat, fvec)
@@ -122,6 +155,83 @@ class MyChiNoBkg(UserStat):
 @requires_data
 class test_stats(SherpaTestCase):
 
+    _fit_simul_datavarstat_results_bench = {
+        'succeeded': 1,
+        'numpoints': 18,
+        'dof': 15,
+        'istatval': 1218.11457171,
+        'statval': 204.883073969,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [65647.539439194588, 2.1440354994101929, 13955.023665227312])
+        }
+
+    _fit_chi2xspecvar_results_bench = {
+        'succeeded': 1,
+        'numpoints': 446,
+        'dof': 443,
+        'istatval': 3488.58436522,
+        'statval': 1167.11621982,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [4717.3082876288863, 1.785895698907098, 39702.914274813716])
+        }
+
+    _fit_chi2modvar_results_bench = {
+        'succeeded': 1,
+        'numpoints': 446,
+        'dof': 443,
+        'istatval': 98751.1141165,
+        'statval': 951.052518517,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [6323.954237402093, 1.5898717247339578, 25049.100925267721])
+        }
+
+    _fit_chi2constvar_results_bench = {
+        'succeeded': 1,
+        'numpoints': 446,
+        'dof': 443,
+        'istatval': 11078.2610904,
+        'statval': 1658.30318937,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [5408.2022582955542, 1.2222311487955908, 4612.0008873213301])
+        }
+
+    _fit_chi2gehrels_results_bench = {
+        'succeeded': 1,
+        'numpoints': 446,
+        'dof': 443,
+        'istatval': 2295.18738409,
+        'statval': 590.888903039,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [5077.8010218337085, 1.592875823400443, 19067.111802328174])
+        }
+
+    _fit_leastsq_results_bench = {
+        'succeeded': 1,
+        'numpoints': 446,
+        'dof': 443,
+        'istatval': 100275.650273,
+        'statval': 15010.2465747,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [5408.4207593703177, 1.2222288063374338, 4611.9525063414185])
+        }
+
+    _fit_cstat_results_bench = {
+        'succeeded': 1,
+        'numpoints': 446,
+        'dof': 443,
+        'istatval': 16859.677457,
+        'statval': 1173.95573689,
+        'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
+        'parvals': numpy.array(
+            [5886.0660236942495, 1.6556198746259132, 30098.968589487202])
+        }
+
     _fit_mycash_results_bench = {
         'succeeded': 1,
         'numpoints': 446,
@@ -131,7 +241,7 @@ class test_stats(SherpaTestCase):
         'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
         'parvals': numpy.array(
             [5886.0660236942495, 1.6556198746259132, 30098.968589487202])
-    }
+        }
 
     _fit_mycashnobkg_results_bench = {
         'succeeded': 1,
@@ -142,7 +252,7 @@ class test_stats(SherpaTestCase):
         'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
         'parvals': numpy.array(
             [5886.0660236942495, 1.6556198746259132, 30098.968589487202])
-    }
+        }
 
     _fit_mychi_results_bench = {
         'succeeded': 1,
@@ -153,7 +263,7 @@ class test_stats(SherpaTestCase):
         'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
         'parvals': numpy.array(
             [65.215835020062741, 1.2149346471169165, 4454.4695930173866])
-    }
+        }
 
     _fit_mycashnobkg_results_bench = {
         'succeeded': 1,
@@ -164,7 +274,7 @@ class test_stats(SherpaTestCase):
         'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
         'parvals': numpy.array(
             [295.11120384933781, 0.69990055680397523, 20.998971817852862])
-    }
+        }
 
     _fit_mychinobkg_results_bench = {
         'succeeded': 1,
@@ -175,7 +285,7 @@ class test_stats(SherpaTestCase):
         'parnames': ('abs1.nH', 'abs1.gamma', 'abs1.ampl'),
         'parvals': numpy.array(
             [346.51084808235697, 0.24721168701021015, 7.9993714921823997])
-    }
+        }
 
     _fit_wstat_results_bench = {
         'succeeded': 1,
@@ -191,8 +301,8 @@ class test_stats(SherpaTestCase):
     def setUp(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        from sherpa.astro.xspec import XSphabs
         from sherpa.astro.io import read_pha
+        from sherpa.astro.xspec import XSphabs
 
         pha_fname = self.make_path("9774.pi")
         self.data = read_pha(pha_fname)
@@ -205,28 +315,64 @@ class test_stats(SherpaTestCase):
         p1 = PowLaw1D('p1')
         self.model = abs1 + p1
 
+        self.model_mult = abs1 * p1
+        pi2278 = self.make_path("pi2278.fits")
+        pi2286 = self.make_path("pi2286.fits")
+        self.data_pi2278 = read_pha(pi2278)
+        self.data_pi2286 = read_pha(pi2286)
+
     def tearDown(self):
         if hasattr(self, "_old_logger_level"):
             logger.setLevel(self._old_logger_level)
 
-    def compare_results(self, arg1, arg2):
+    def compare_results(self, arg1, arg2, tol1=1.0e-6, tol2=1.0e-3):
 
         for key in ["succeeded", "numpoints", "dof"]:
             assert arg1[key] == int(getattr(arg2, key))
 
         for key in ["istatval", "statval"]:
             assert numpy.allclose(float(arg1[key]), float(getattr(arg2, key)),
-                                  1.e-6, 1.e-6)
+                                  tol1, tol1)
 
         for key in ["parvals"]:
             try:
                 assert numpy.allclose(arg1[key], getattr(arg2, key),
-                                      1.e-3, 1.e-3)
+                                      tol2, tol2)
             except AssertionError:
                 print('parvals bench: ', arg1[key])
                 print('parvals fit:   ', getattr(arg2, key))
                 print('results', arg2)
                 raise
+
+    def test_chi2xspecvar_stat(self):
+        fit = Fit(self.data, self.model, Chi2XspecVar(), NelderMead())
+        results = fit.fit()
+        self.compare_results(self._fit_chi2xspecvar_results_bench, results)
+
+    def test_chi2modvar_stat(self):
+        fit = Fit(self.data, self.model, Chi2ModVar(), NelderMead())
+        results = fit.fit()
+        self.compare_results(self._fit_chi2modvar_results_bench, results)
+
+    def test_chi2constvar_stat(self):
+        fit = Fit(self.data, self.model, Chi2ConstVar(), NelderMead())
+        results = fit.fit()
+        self.compare_results(self._fit_chi2constvar_results_bench, results)
+
+    def test_chi2gehrels_stat(self):
+        fit = Fit(self.data, self.model, Chi2Gehrels(), NelderMead())
+        results = fit.fit()
+        self.compare_results(self._fit_chi2gehrels_results_bench, results)
+
+    def test_leastsq_stat(self):
+        fit = Fit(self.data, self.model, LeastSq(), NelderMead())
+        results = fit.fit()
+        self.compare_results(self._fit_leastsq_results_bench, results)
+
+    def test_cstat_stat(self):
+        fit = Fit(self.data, self.model, CStat(), NelderMead())
+        results = fit.fit()
+        self.compare_results(self._fit_cstat_results_bench, results)
 
     def test_cash_stat(self):
         fit = Fit(self.data, self.model, Cash(), NelderMead())
@@ -253,7 +399,8 @@ class test_stats(SherpaTestCase):
         data = self.bkg
         fit = Fit(data, self.model, MyChiNoBkg(), LevMar())
         results = fit.fit()
-        self.compare_results(self._fit_mychinobkg_results_bench, results)
+        self.compare_results(self._fit_mychinobkg_results_bench, results,
+                             tol1=1.0e-5)
 
     def test_mycash_datahasbkg_modelhasnobkg(self):
         fit = Fit(self.data, self.model, MyCashNoBkg(), NelderMead())
@@ -275,7 +422,8 @@ class test_stats(SherpaTestCase):
         data = self.bkg
         fit = Fit(data, self.model, MyChiWithBkg(), LevMar())
         results = fit.fit()
-        self.compare_results(self._fit_mychinobkg_results_bench, results)
+        self.compare_results(self._fit_mychinobkg_results_bench, results,
+                             tol1=1.0e-5)
 
     def test_wstat(self):
         fit = Fit(self.data, self.model, WStat(), NelderMead())
@@ -309,12 +457,50 @@ class test_stats(SherpaTestCase):
         ui.load_arrays(1, xy, xy, Data1D)
         ui.set_stat('chi2datavar')
         err = ui.get_staterror()
-        numpy.testing.assert_allclose(err, numpy.sqrt(xy), rtol=1e-7, atol=1e-7)
+        numpy.testing.assert_allclose(err, numpy.sqrt(xy),
+                                      rtol=1e-7, atol=1e-7)
 
+    def test_get_stat_info(self):
+        fname_3c273 = self.make_path("3c273.pi")
+        ui.load_pha(fname_3c273)
+        src = ui.xspowerlaw.pl
+        ui.set_source(src)
+        ui.guess('pl')
+        ui.set_stat('wstat')
+        stat_info = ui.get_stat_info()[0]
+        assert stat_info.dof == 44
+        assert stat_info.numpoints == 46
+
+    def test_mysimul_stat_fit(self):
+        data1 = self.data_pi2278
+        data2 = self.data_pi2286
+        model1 = self.model_mult
+        model2 = self.model_mult
+        data = DataSimulFit(name='data1data2', datasets=[data1, data2])
+        model = SimulFitModel(name='model1model2', parts=[model1, model2])
+        fit = Fit(data=data, model=model, stat=MySimulStat(),
+                  method=NelderMead())
+        result = fit.fit()
+        self.compare_results(self._fit_simul_datavarstat_results_bench,
+                             result)
+
+    def test_simul_stat_fit(self):
+        data1 = self.data_pi2278
+        data2 = self.data_pi2286
+        model1 = self.model_mult
+        model2 = self.model_mult
+        data = DataSimulFit(name='data1data2', datasets=[data1, data2])
+        model = SimulFitModel(name='model1model2', parts=[model1, model2])
+        fit = Fit(data=data, model=model, stat=MyChiNoBkg(),
+                  method=NelderMead())
+        result = fit.fit()
+        self.compare_results(self._fit_simul_datavarstat_results_bench,
+                             result)
+
+    # bug #147
     def test_wstat_calc_stat_info(self):
         ui.load_pha("stat", self.make_path("3c273.pi"))
         ui.set_source("stat", ui.powlaw1d.p1)
         ui.set_stat("wstat")
-        p1 = ui.get_model_component("p1")
         ui.fit("stat")
         ui.get_stat_info()

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -100,8 +100,7 @@ __all__ = ('NoNewAttributesAfterInit', 'SherpaTestCase',
            'pad_bounding_box', 'parallel_map', 'param_apply_limits',
            'parse_expr', 'poisson_noise', 'print_fields', 'rebin',
            'sao_arange', 'sao_fcmp', 'set_origin', 'sum_intervals', 'zeroin',
-           'multinormal_pdf', 'multit_pdf', 'get_error_estimates', 'quantile',
-           'get_valid_args')
+           'multinormal_pdf', 'multit_pdf', 'get_error_estimates', 'quantile')
 
 _guess_ampl_scale = 1.e+3
 
@@ -2913,15 +2912,6 @@ def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
 
     except (ZeroDivisionError, OutOfBoundErr):
         return [[xb, fb], [[xa, fa], [xc, fc]], nfev[0]]
-
-
-def get_valid_args(func):
-    valid_args = func.__code__.co_varnames[:func.__code__.co_argcount]
-    # number of keyword arguments
-    kwargs_length = len(func.__defaults__) if func.__defaults__ else 0
-    # because kwargs are last
-    valid_kwargs = valid_args[-kwargs_length:] if kwargs_length else []
-    return valid_kwargs
 
 
 def public(f):


### PR DESCRIPTION
When I was asked to pass the bkg data to the UserStat, I made a mistake by

making the code backwards compatible.  Then when I had to add WStat to Sherpa,
things went from bad to very bad.  After all, WStat needs the exposure time and
backscale ratio.  Not to mention the size of the data sets if one is to use it
for fitting simultaneous data sets (different data sets could have different
exposure time and/or backscale ratios).

The old classes for the Stats are not very easily extensible; Moreover, The
changes should also enable the user to do simultaneous fit using different
statistics for different data set.