### PR TITLE
DO NOTE MERGE - tweak g95 configuration to work for CIAO's OSXM builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ except:
         "Could not import setuptools.\n"
         "This might lead to an incomplete installation\n"
     )
+
+import platform
+
 from numpy.distutils.core import setup
 
 from helpers.extensions import static_ext_modules
@@ -129,5 +132,12 @@ meta = dict(name='sherpa',
                 'Topic :: Scientific/Engineering :: Physics'
                 ],
             )
+
+if platform.system() == 'Darwin':
+       from numpy.distutils.fcompiler.g95 import G95FCompiler
+       G95FCompiler.executables['linker_so'] = ["gcc","-undefined dynamic_lookup -bundle"]
+       G95FCompiler.get_libraries = lambda s: ['f95',]
+       G95FCompiler.get_library_dirs = lambda s : ['/opt/local/lib',]
+
 
 setup(**meta)


### PR DESCRIPTION
# Description

This change allows to tweak the g95 compiler options so that Sherpa can be built in CIAO with `g95` i.s.o. `gfortran`.

For now this is a test. I don't like the way paths and library names are hard coded. If the test works I'll try and rework the PR so that the options can be configured from the command line or by tweaking the `setup.cfg` file.

This seems also related to #5, as options could be provided to support compilers other than `gfortran`.
