### PR TITLE
Update the release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@
 Sherpa
 ======
 
-Sherpa is a modeling and fitting application for Python. It contains a powerful language for combining simple models
-into complex expressions that can be fit to the data using a variety of statistics and optimization methods.
-It is easily extensible to include user models, statistics, and optimization methods.
-It provides a high-level User Interface for interactive data-analysis work,
-such as within an IPython notebook, and it can also be used as a library
-component, providing fitting and modeling capabilities to an application.
+Sherpa is a modeling and fitting application for Python. It contains a
+powerful language for combining simple models into complex expressions
+that can be fit to the data using a variety of statistics and
+optimization methods.  It is easily extensible to include user models,
+statistics, and optimization methods.  It provides a high-level User
+Interface for interactive data-analysis work, such as within an
+IPython notebook, and it can also be used as a library component,
+providing fitting and modeling capabilities to an application.
 
 What can you do with Sherpa?
 
@@ -54,11 +56,12 @@ How To Install Sherpa
 
 Sherpa can be installed from a binary distribution or built from sources.
 
-The binary distribution is suited for people wanting to have Sherpa up and
-running as soon as possible in its standard form.
+The binary distribution is suited for people wanting to have Sherpa up
+and running as soon as possible in its standard form.
 
-Source installation is available for platforms incompatible with the binary
-builds, or for users wanting to customize the way Sherpa is built and installed.
+Source installation is available for platforms incompatible with the
+binary builds, or for users wanting to customize the way Sherpa is
+built and installed.
 
 If you are in doubt about which installation to perform, you should try
 with the Conda installation (sections [1a](#1a-anaconda) and [1b](#1b-starting-from-scratch)).
@@ -95,8 +98,8 @@ Anaconda-powered environment, not the full Anaconda distribution.
 
 ### 1a. Anaconda
 
-If you have Anaconda already installed on your system you can use it to seamlessly
-install Sherpa.
+If you have Anaconda already installed on your system you can use it
+to seamlessly install Sherpa.
 
 First you need to add the Sherpa channel to your configuration,
 and then install Sherpa:
@@ -111,9 +114,9 @@ To test that your installation works, just type:
 Note that by default `sherpa_test` only runs a small number of tests.
 
 Starting with release 4.8.1 we are also releasing the test data files
-that are required to run the entire Sherpa test suite. Given the relatively
-large footprint of these datafiles we distribute `sherpatest`
-as a separate `conda` package.
+that are required to run the entire Sherpa test suite. Given the
+relatively large footprint of these datafiles we distribute
+`sherpatest` as a separate `conda` package.
 
 In order to install `sherpatest` just run:
 
@@ -293,6 +296,7 @@ an `OK` message.
 is not installed `sherpa_test` will try to install it.
 
 ### 2e. Development mode
+
 If you plan to edit the Sherpa code, it is more convenient
 to work in development mode rather than using the `install` command.
 
@@ -325,6 +329,7 @@ The same issue may occur if you installed both the Sherpa binaries
 and build Sherpa from sources in the same environment.
 
 ### 2f. Download Test Data
+
 The `sherpa_test` and `python setup.py test` commands only execute
 a small number of tests to ensure that your installation of Sherpa
 is functional. The full test suite requires data files that are

--- a/README.md
+++ b/README.md
@@ -6,14 +6,19 @@
 
 - [Sherpa](#sherpa)
 - [How To Install Sherpa](#how-to-install-sherpa)
-  - [Binary installation](#binary-installation)
+  - [Binary installation using Anaconda](#binary-installation)
     - [1a. Anaconda](#1a-anaconda)
     - [1b. Starting from scratch](#1b-starting-from-scratch)
+    - [1c. Other packages](#1c-other-packages)
   - [Source Build](#source-build)
     - [2a. Extract the source tarball](#2a-extract-the-source-tarball)
     - [2b. Get the code from the GitHub repository](#2b-get-the-code-from-the-github-repository)
     - [2c. Build Sherpa](#2c-build-sherpa)
     - [2d. Testing the build](#2d-testing-the-build)
+    - [2e. Development mode](#2e-development-mode)
+  - [Testing Sherpa](#test)
+    - [3a. Binary installation](#3a-binary-installation)
+    - [3b. Built from source](#3b-built-from-source)
 - [Custom source build](#custom-source-build)
   - [FFTW library](#fftw-library)
   - [XSPEC](#xspec)
@@ -66,7 +71,6 @@ built and installed.
 If you are in doubt about which installation to perform, you should try
 with the Conda installation (sections [1a](#1a-anaconda) and [1b](#1b-starting-from-scratch)).
 
-
 1. Binary installation (Anaconda)
 
 2. Source build (from a source tarball or the GitHub repository)
@@ -81,8 +85,8 @@ Source builds can be customized, for instance:
 These and other customization options are descibed below.
 
 
-Binary installation
--------------------
+Binary installation using Anaconda
+----------------------------------
 
 If you already have Anaconda installed on your system, you can just follow the
 easy steps in section [1a](#1a-anaconda).
@@ -106,25 +110,6 @@ and then install Sherpa:
 
     $ conda config --add channels https://conda.anaconda.org/sherpa
     $ conda install sherpa
-
-To test that your installation works, just type:
-
-    $ sherpa_test
-
-Note that by default `sherpa_test` only runs a small number of tests.
-
-Starting with release 4.8.1 we are also releasing the test data files
-that are required to run the entire Sherpa test suite. Given the
-relatively large footprint of these datafiles we distribute
-`sherpatest` as a separate `conda` package.
-
-In order to install `sherpatest` just run:
-
-    $ conda install sherpatest
-    
-Then run `sherpa_test` as usual.
-
-Some tests may also be skipped if you don't have `astropy` installed.
 
 To update Sherpa:
 
@@ -158,7 +143,7 @@ Decide where you are going to install Miniconda, e.g.:
     $ setenv MINICONDA /home/miniconda # TCSH
 
 Run the Miniconda installer. It is assumed that you have read and agree with
-the [Miniconda EULA](http://docs.continuum.io/anaconda/eula.html)
+the [Miniconda End User License Agreement (EULA)](http://docs.continuum.io/anaconda/eula.html)
 
     $ bash <Miniconda file you downloaded> -b -p $MINICONDA # BASH AND TCSH
 
@@ -193,6 +178,15 @@ Sherpa environment.
 BASH users will be reminded that they are running in the Sherpa environment
 by pre-pending the string (sherpa) to their BASH prompt.
 
+When you are done working with Sherpa you can either close the terminal
+window you were working with, or you can deactivate the Sherpa environment and
+restore your default environment:
+
+    $ source deactivate # BASH
+    $ setenv $PATH $OLDPATH # TCSH
+
+### 1c. Other packages
+
 You can start using Sherpa by starting a Python shell, or you can install
 `ipython` and use it as a more convenient shell. We recommend that you also install
 `ipython-notebook` and `matplotlib` so that you can use the nice `ipython` notebook
@@ -201,27 +195,6 @@ Sherpa. We also recommend that you install `astropy` for enabling FITS I/O
 (Sherpa will look for `pyfits` if `astropy` is not present).
 
     $ conda install ipython-notebook matplotlib astropy
-
-When you are done working with Sherpa you can either close the terminal
-window you were working with, or you can deactivate the Sherpa environment and
-restore your default environment:
-
-    $ source deactivate # BASH
-    $ setenv $PATH $OLDPATH # TCSH
-
-Please remember that you need to activate the Sherpa environment every time
-you want to work with it. After the installation, the following commands are
-necessary to run Sherpa:
-
-    $ source activate sherpa # BASH
-    $ setenv OLDPATH $PATH; setenv PATH ${MINICONDA}/envs/sherpa/bin:${PATH} #TCSH
-    ... Run your favourite Python shell ....
-
-When you are done and you want to go back to your environment, close the
-terminal or deactivate the Sherpa environment.
-
-    $ source deactivate sherpa # BASH  
-    $ setenv $PATH $OLDPATH
 
 
 Source Build
@@ -266,10 +239,10 @@ You can clone the Sherpa repository with:
     $ git clone https://github.com/sherpa/sherpa
     $ cd sherpa
 
-The most stable code is available through the 4.8.1 tag. The main development
-code, which is unstable, is available in the `master` branch. New features
-and bug fixes or other, even less
-stable versions of the code may be available in other branches.
+The most stable code is available through the 4.8.1 tag. The main
+development code, which is unstable, is available in the `master`
+branch. New features and bug fixes or other, even less stable versions
+of the code may be available in other branches.
 
 ### 2c. Build Sherpa
 
@@ -286,11 +259,10 @@ To test that your installation of Sherpa is working, type:
 which will run a small test suite (the script may not be in your path,
 depending on where the installation step chose to install Sherpa).
 
-Note that the test may report several `SKIPPED` lines.
-These messages are expected - as some of the
-tests require optional packages to be installed alongside
-Sherpa. These warnings may be ignored, as long as the test ends with
-an `OK` message.
+Note that the test may report several `SKIPPED` lines.  These messages
+are expected - as some of the tests require optional packages to be
+installed alongside Sherpa. These warnings may be ignored, as long as
+the test ends with an `OK` message.
 
 **NOTE:** the `sherpa_test` command requires `pytest` to run. If `pytest`
 is not installed `sherpa_test` will try to install it.
@@ -308,11 +280,12 @@ command rather than the `sherpa_test` script:
 
     $ python setup.py test
 
-The `test` command is a wrapper that calls `pytest` under the hood.
+The `test` command is a wrapper that calls `pytest` under the hood,
+and includes the `develop` command.
 
-You can pass additional arguments to `pytest` with `-a` or `--pytest-args`.
-For instance,
-you can run a single test, i.e. a single test method, with:
+You can pass additional arguments to `pytest` with the `-a` or
+`--pytest-args` arguments.  As an example, a single test can be run
+using the syntax:
 
     $ python setup.py test -a sherpa/astro/datastack/tests/test_datastack.py::test_load::test_case3
 
@@ -320,39 +293,58 @@ you can run a single test, i.e. a single test method, with:
 Python environment you end up with two competing installations of Sherpa
 which result in unexpected behavior. If this happens, simply run
 `pip uninstall sherpa` as many times as necessary, until you get an
-error message as no more Sherpa installations are available
-and then install Sherpa again.
+error message that no more Sherpa installations are available. At this
+point you can re-install Sherpa.
 
-Also note that the `test` command executes `develop`.
+The same issue may occur if you installed both the Sherpa binaries and
+build Sherpa from sources in the same environment.
 
-The same issue may occur if you installed both the Sherpa binaries
-and build Sherpa from sources in the same environment.
 
-### 2f. Download Test Data
+Testing Sherpa
+--------------
 
-The `sherpa_test` and `python setup.py test` commands only execute
-a small number of tests to ensure that your installation of Sherpa
-is functional. The full test suite requires data files that are
-not included in the Sherpa distribution by default.
+To test that your installation works, just type:
 
-If you want you can download such data files and run the whole test suite.
+    $ sherpa_test
 
-Since this is mostly useful when developing for Sherpa, the instructions
-below assume that you are using `git` and that you are located in the
-top directory:
+The number of tests run by `sherpa_test` depends on what Python
+packages are installed (for example, `astropy` and `matplotlib`), on
+external software (are DS9 and the XPA toolset installed), and whether
+the external Sherpa test data set is installed.
+
+The external Sherpa test data is large, and mostly useful when
+developing Sherpa. The download method depends on how Sherpa
+was installed.
+
+### 3a. Binary installation
+
+Starting with release 4.8.1, the external test data files can be
+installed from the Sherpa conda channel by saying:
+
+    $ conda install sherpatest
+
+At this point, `sherpa_test` will pick up the data and so run more
+tests.
+
+### 3b. Built from source
+
+At the top level of the Sherpa distribution, used to [build
+Sherpa](#2c-build-sherpa), use the following commands to add the test
+data set inti the `sherpa-test-data/` directory (this assumes that the
+source code was installed with `git` and not unpacked from a tarball):
 
     $ git submodule init
     $ git submodule update
 
-This will install the data files under `sherpa-test-data`.
+At this point, the data will be picked up automatically by either of
+the following commands:
 
-The data will be picked up automatically by `python setup.py test`.
+    $ sherpa_test
+    $ python setup.py test
 
-The data files are included in a standard Python package with its
+The data files are also available as a standard Python package with its
 own [`git` repository](https://github.com/sherpa/sherpa-test-data).
 
-You can download and install the `sherpatest` package as usual
-if you are not using `git`.
 
 Custom source build
 ===================
@@ -423,12 +415,12 @@ used, but the full path should be in your own copy of the file):
 
         xspec_lib_dirs=$HEADAS/lib
         xspec_libraries=XSFunctions XSModel XSUtil XS wcs-4.20
-        cfitsio_libraries=cfitsio_3.37
-        ccfits_libraries=CCfits_2.4
+        cfitsio_libraries=cfitsio_3.38
+        ccfits_libraries=CCfits_2.5
 
     The environment variable `$HEADAS` should be expanded out, and the
     version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
-    may need to be changed.
+    may need to be changed, depending on the version of XSPEC.
 
  2. Use the model-only build of XSPEC, which will also require
     building the
@@ -437,7 +429,7 @@ used, but the full path should be in your own copy of the file):
     and
     [WCSLIB](http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/)
     libraries (it is not clear if version 5 is supported, since
-    XSPEC 12.8.2 uses version 4.20). If all the libraries are installed
+    XSPEC 12.9.0 uses version 4.20). If all the libraries are installed
     into the same location ($HEADAS/lib), then a similar set up to the
     full XSPEC build is used
 
@@ -459,16 +451,22 @@ used, but the full path should be in your own copy of the file):
         xspec_lib_dirs=$ASCDS_INSTALL/ots/lib
         xspec_libraries=XSFunctions XSModel XSUtil XS
 
-In all cases, the same version of `gfortran` should be used to
-build Sherpa and XSPEC, to avoid possible incompatabilities.
+    **NOTE** Although this is possible, it is srtongly recommended
+    that either of the first two approaches is used instead. There
+    have been issues seen using the CIAO binaries on certain OS-X
+    systems.
+
+In all cases, the same version of `gfortran` should be used to build
+Sherpa and XSPEC, in order to avoid possible incompatabilities.
 
 If there are problems building, or using, the module, then the other
 options may need to be set - in particular the `gfortran_lib_dirs` and
 `gfortran_libraries` settings.
 
-The XSpec module is designed for use with XSpec version 12.8.2e. It
-can be used with other versions - either patches to 12.8.2 or
-different versions - but there may be build or user issues.
+The XSpec module is designed for use with XSpec versions 12.9.0 and
+12.8.2, although 12.9.0 is the preferred version. Using with other
+versions may lead to build problems or incomplete support for the
+XSPEC models.
 
 In order for the module to work, the `HEADAS` environment variable has
 to be set in the shell from which the Python session is started.  For
@@ -483,7 +481,7 @@ such as:
 
     >>> from sherpa.astro import xspec
     >>> xspec.get_xsversion()
-    '12.8.2e'
+    '12.9.0m'
 
 Other customization options
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - [Sherpa](#sherpa)
 - [How To Install Sherpa](#how-to-install-sherpa)
-  - [Binary installation using Anaconda](#binary-installation)
+  - [Binary installation using Anaconda](#binary-installation-using-anaconda)
     - [1a. Anaconda](#1a-anaconda)
     - [1b. Starting from scratch](#1b-starting-from-scratch)
     - [1c. Other packages](#1c-other-packages)
@@ -16,7 +16,7 @@
     - [2c. Build Sherpa](#2c-build-sherpa)
     - [2d. Testing the build](#2d-testing-the-build)
     - [2e. Development mode](#2e-development-mode)
-  - [Testing Sherpa](#test)
+  - [Testing Sherpa](#testing-sherpa)
     - [3a. Binary installation](#3a-binary-installation)
     - [3b. Built from source](#3b-built-from-source)
 - [Custom source build](#custom-source-build)

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -9,6 +9,7 @@ for newer versions of the dependency, along with some feature enhancements,
 bug fixes and additional, more accurate tests.
 
 The newly supported dependencies:
+
   - matplotlib v1.5
   - numpy 1.10 (with and without mkl support)
   - xspec v12.9.0i (when building from source)
@@ -20,7 +21,7 @@ Mode details below (infrastructure changes are not shown):
 #102: fix issues when writing out FITS files using the `save_pha` and
 `save_table` commands when using the `astropy`/`pyfits` backend (bug #46).
 Fix for when the notice2d_id, notice2d_image, and the ignore version functions
-are called with an invalid identifier (i.e. an identifier that i snot an integer
+are called with an invalid identifier (i.e. an identifier that is not an integer
 or string value). The error is now an ArgumentTypeErr with the message "'ids'
 must be an identifier or list of identifiers". It was a NameError with the
 message "global name '_argument_type_error' is not defined".
@@ -52,6 +53,7 @@ changed were, when the new symbols are availble, to:
 #137: upgrade CIAO region library to v4.8
 
 #138: improve and fix issues in `save_all` function.
+
  - added a new argument to `save_all`: if `outfile` is `None` then the `outfh`
    argument is used 
    to define the output handle (the argument can be any file-like argument, such


### PR DESCRIPTION
Re-order and re-word the installation instructions - in particular the test section - and adjust the version numbers given in the XSPEC installation section, as well as point out the known problems with the "build using CIAO binaries" approach.

Several other minor clean ups, including changing the alignment to better match an 80-column width, for those people reading directly rather than a rendered version.

Ideally the binary section would split out the "how to use a virtual environment" from the miniconda installation section (as it is relevant for both `1a` and `1b`) but I did not want to try that now.