### PR TITLE
update Zenodo DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
 [![Build Status](https://travis-ci.org/sherpa/sherpa.svg?branch=master)](https://travis-ci.org/sherpa/sherpa)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 
-**Previous Releases DOIs**
-
-4.8.0: [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.45243.svg)](http://dx.doi.org/10.5281/zenodo.45243)
-
-
-
-
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
 
 - [Sherpa](#sherpa)
+- [License](#license)
 - [How To Install Sherpa](#how-to-install-sherpa)
   - [Binary installation](#binary-installation)
     - [1a. Anaconda](#1a-anaconda)
@@ -55,6 +49,16 @@ What can you do with Sherpa?
 
 A [Quick Start Tutorial](http://nbviewer.ipython.org/github/sherpa/sherpa/tree/master/docs/SherpaQuickStart.ipynb)
 is included in the `docs` folder and can be opened with an `ipython notebook`.
+
+License
+=======
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version. A copy of the GNU General Public License can be found in the
+`LICENSE` file provided with the source code, or from the
+[Free Software Foundation](http://www.gnu.org/licenses/).
 
 How To Install Sherpa
 =====================
@@ -507,11 +511,14 @@ about these options.
 History
 =======
 
-Sherpa is developed by the
-[Chandra X-ray Observatory](http://chandra.harvard.edu/) to provide
-fitting and modelling capabilities to the
-[CIAO](http://cxc.harvard.edu/ciao/) analysis package. It has been
-released onto
-[GitHub](https://github.com/sherpa/sherpa) under the
-GNU General Public Licence, version 3 for users to extend (whether
-to other areas of Astronomy or in other domains).
+Sherpa is developed by the [Chandra X-ray
+Observatory](http://chandra.harvard.edu/) to provide fitting and modelling
+capabilities to the [CIAO](http://cxc.harvard.edu/ciao/) analysis package. It
+has been released onto [GitHub](https://github.com/sherpa/sherpa) for users to
+extend (whether to other areas of Astronomy or in other domains).
+
+Previous releases
+-----------------
+
+4.8.0: 27 January 2016 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.45243.svg)](http://dx.doi.org/10.5281/zenodo.45243)
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
   - [XSPEC](#xspec)
   - [Other customization options](#other-customization-options)
 - [History](#history)
-
+  - [Previous releases](#previous-releases)
+  
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 [![Build Status](https://travis-ci.org/sherpa/sherpa.svg?branch=master)](https://travis-ci.org/sherpa/sherpa)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 
+**Previous Releases DOIs**
+
+4.8.0: [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.45243.svg)](http://dx.doi.org/10.5281/zenodo.45243)
+
+
+
+
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
 


### PR DESCRIPTION
# Description

This PR adds a Zenodo DOI badge for 4.8.0 previous release. The DOI badge that was already present automatically points to the latest release. Probably because of caching issues the images look the same, but I checked that they point to different pages.

I am not really sure this is a good idea, so I didn't play too much with the formatting and location. Maybe instead of adding a badge we should list the DOIs in the CITATION file?