### PR TITLE
add docstrings to smoke test classes and functions

### DIFF
--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -32,19 +32,26 @@ logger = logging.getLogger("sherpa")
 
 def run(verbosity=0, require_failure=False, fits=None, xspec=False):
     """
-    Run the smoke tests, i.e. a small set of tests designed to verify that the installation does not have
+    Run the smoke tests.
+
+    A smoke test is a small set of tests designed to verify that the installation does not have
     any obvious issues.
 
     Parameters
     ----------
-    verbosity non-negative int. Set verbosity level: the higher the level, the more verbose the test. This
-    parameter is passed to the unittest TextTestRunner class.
-    require_failure boolean. For debugging purposes, the test may be required to always fail.
-    fits basesting. The string representing the FITS backend module to require. If the module cannot be imported,
-    the smoke test will fail. However, the other tests will keep running, although they may be skipped if they
-    require the FITS backend.
-    xspec boolean. Whether the xspec module is required. If the xspec module cannot be imported, the smoke test will
-    fail. However, the other tests will keep running, although they may be skipped if they require xspec.
+    verbosity : non-negative int
+        Set verbosity level: the higher the level, the more verbose the test. This
+        parameter is passed to the unittest TextTestRunner class.
+        require_failure boolean. For debugging purposes, the test may be required to always fail.
+
+    fits : basestring
+        The string representing the FITS backend module to require. If the module cannot be imported,
+        the smoke test will fail. However, the other tests will keep running, although they may be skipped if they
+        require the FITS backend.
+
+    xspec : boolean
+        Whether the xspec module is required. If the xspec module cannot be imported, the smoke test will
+        fail. However, the other tests will keep running, although they may be skipped if they require xspec.
 
     Returns
     -------
@@ -77,6 +84,8 @@ def run(verbosity=0, require_failure=False, fits=None, xspec=False):
 
 class SmokeTest(unittest.TestCase):
     """
+    Smoke test test case.
+
     Historically, CIAO software has been accompanied by "smoke tests", tests that are shipped with the
     main code distribution and that can be run to assess whether the software was properly installed.
 
@@ -126,7 +135,9 @@ class SmokeTest(unittest.TestCase):
     @requires_fits
     def test_fits_io(self):
         """
-        Test that basic FITS I/O functions work, which means that the FITS backend can be used to perform basic
+        Test that basic FITS I/O functions work.
+
+        This test ensures that the FITS backend can be used to perform basic
         I/O functions.
         """
         ui.load_pha(self.fits)
@@ -136,7 +147,10 @@ class SmokeTest(unittest.TestCase):
     @requires_xspec
     def test_xspec(self):
         """
-        Perform a very simple fit with an xspec model, and check that the results make sense.
+        Perform a very simple fit with an xspec model.
+
+        Also check that the results make sense.
+
         This test proves that the xspec extension properly works, and that there are no obvious building, linking, or
         environment issues that would prevent the xspec model from running.
         """
@@ -152,7 +166,9 @@ class SmokeTest(unittest.TestCase):
 
     def test_failure(self):
         """
-        This is a debug test that always fails. It may be used to check that error conditions upstream are correctly
+        This is a debug test that always fails.
+
+        It may be used to check that error conditions upstream are correctly
         handled by scripts calling the Smoke Test. Whether or not this test is run depends on the option passed to the
         run function in this module.
         """
@@ -161,6 +177,8 @@ class SmokeTest(unittest.TestCase):
 
 class SmokeTestSuite(unittest.TestSuite):
     """
+    Smoke test suite.
+
     At this point the Smoke Test is comprised of a single unittest test case. However, it may be extended in the future,
     so we set up a test suite.
 

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -31,6 +31,25 @@ logger = logging.getLogger("sherpa")
 
 
 def run(verbosity=0, require_failure=False, fits=None, xspec=False):
+    """
+    Run the smoke tests, i.e. a small set of tests designed to verify that the installation does not have
+    any obvious issues.
+
+    Parameters
+    ----------
+    verbosity non-negative int. Set verbosity level: the higher the level, the more verbose the test. This
+    parameter is passed to the unittest TextTestRunner class.
+    require_failure boolean. For debugging purposes, the test may be required to always fail.
+    fits basesting. The string representing the FITS backend module to require. If the module cannot be imported,
+    the smoke test will fail. However, the other tests will keep running, although they may be skipped if they
+    require the FITS backend.
+    xspec boolean. Whether the xspec module is required. If the xspec module cannot be imported, the smoke test will
+    fail. However, the other tests will keep running, although they may be skipped if they require xspec.
+
+    Returns
+    -------
+    The function will exit with a non-zero exit status if any errors are detected.
+    """
     test_suite = SmokeTestSuite(require_failure=require_failure)
     runner = unittest.TextTestRunner(verbosity=verbosity)
     result = runner.run(test_suite)
@@ -57,6 +76,24 @@ def run(verbosity=0, require_failure=False, fits=None, xspec=False):
 
 
 class SmokeTest(unittest.TestCase):
+    """
+    Historically, CIAO software has been accompanied by "smoke tests", tests that are shipped with the
+    main code distribution and that can be run to assess whether the software was properly installed.
+
+    The Smoke Test is not a full tests suite, but simply tries to detect obvious failures that signal an
+    improper setup.
+
+    This class implements the Smoke Test as a standalone unittest test case. This means that there are no
+    external dependencies required for the Smoke Test to run, and the only data files it may use are shipped
+    with the main distribution as well.
+
+    It is also run as part fo the full Sherpa tests suite.
+
+    Some methods require external dependencies. If such dependencies are not found the tests are skipped.
+
+    There is more logic (see the run method in this module) that checks the requirements are actually installed
+    and fails the Smoke Test if they are not.
+    """
     def setUp(self):
         self._old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
@@ -73,6 +110,9 @@ class SmokeTest(unittest.TestCase):
             logger.setLevel(self._old_level)
 
     def test_fit(self):
+        """
+        Perform a very simple fit with built-in models, and check that the results make sense.
+        """
         ui.load_arrays(1, self.x, self.y)
         ui.set_source("polynom1d.p")
         ui.thaw("p.c1")
@@ -85,12 +125,21 @@ class SmokeTest(unittest.TestCase):
 
     @requires_fits
     def test_fits_io(self):
+        """
+        Test that basic FITS I/O functions work, which means that the FITS backend can be used to perform basic
+        I/O functions.
+        """
         ui.load_pha(self.fits)
         with NamedTemporaryFile() as f:
             ui.save_pha(f.name, ascii=False, clobber=True)
 
     @requires_xspec
     def test_xspec(self):
+        """
+        Perform a very simple fit with an xspec model, and check that the results make sense.
+        This test proves that the xspec extension properly works, and that there are no obvious building, linking, or
+        environment issues that would prevent the xspec model from running.
+        """
         ui.load_arrays(1, self.x, self.y)
         ui.set_source("xspowerlaw.p")
         ui.set_method("moncar")
@@ -102,14 +151,36 @@ class SmokeTest(unittest.TestCase):
         assert_almost_equal(observed, expected)
 
     def test_failure(self):
+        """
+        This is a debug test that always fails. It may be used to check that error conditions upstream are correctly
+        handled by scripts calling the Smoke Test. Whether or not this test is run depends on the option passed to the
+        run function in this module.
+        """
         self.fail("Requested to fail")
 
 
 class SmokeTestSuite(unittest.TestSuite):
+    """
+    At this point the Smoke Test is comprised of a single unittest test case. However, it may be extended in the future,
+    so we set up a test suite.
+
+    Also, the suite disables the always-failing debugging test depending on the options with which the Smoke Test
+    is running.
+    """
+
+    # classes in the suite
     test_classes = (SmokeTest,)
+
+    # tests that always fail
     failure_methods = ('test_failure',)
 
     def __init__(self, *args, **kwargs):
+        """
+        The init method passes all the arguments along to the unittest.TestSuite init method.
+
+        It also accepts a "require_failure" keyword argument used to decide whether the debugging test method must
+        fail.
+        """
         self.require_failure = kwargs.pop("require_failure", False)
         unittest.TestSuite.__init__(self, *args, **kwargs)
 
@@ -119,6 +190,9 @@ class SmokeTestSuite(unittest.TestSuite):
         self._set_skips()
 
     def _set_skips(self):
+        """
+        Make sure the test method that always fails is skipped, unless "require_failure" is set to True.
+        """
         if not self.require_failure:
             for case in self:
                 for test in case:


### PR DESCRIPTION
Address #212
 
# Description
This PR adds some docstrings to #210, to explain the purpose and extent of the smoke test.

We may want to add a commit to change the README, but it may not be worth providing users with too many testing options. We might just leave the current `sherpa_test` documentation unchanged and do not advertise the Smoke Test option explicitly to standalone users, which do not have the limitations of the CIAO users (e.g. no mock, no pytest).