### PR TITLE
add safety condition for datadir discovery override

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = -rs --verbose --ignore=setup.py
-norecursedirs = .git build dist tmp*
+addopts = -rs --verbose --ignore=setup.py --ignore=test_requirements.txt
+norecursedirs = .git build dist tmp* .eggs

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -82,6 +82,7 @@ def pytest_configure(config):
     """
     try:
         path = config.getoption(TEST_DATA_OPTION)
-        SherpaTestCase.datadir = path
+        if (path):
+            SherpaTestCase.datadir = path
     except ValueError:  # option not defined from command line, no-op
         pass

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -82,7 +82,7 @@ def pytest_configure(config):
     """
     try:
         path = config.getoption(TEST_DATA_OPTION)
-        if (path):
+        if path:
             SherpaTestCase.datadir = path
     except ValueError:  # option not defined from command line, no-op
         pass


### PR DESCRIPTION
# Description
This PR adds a safety condition to make sure the test data directory is not set to `None` by `pytest` when no `--test-data` command line option is provided.

There are also minor changes to `pytest.ini` to:
  * avoid `test_requirements.txt` from being collected
  * workaround a possible issue reported by @DougBurke when installing `pytest-cov` (packages in `.eggs` are ignored during test discovery).

# Notes
It looks like the order in which the configuration of `pytest` and the collection of tests may be different when using plugins.

As reported by @DougBurke, running `python setup.py test` on commit 95047e results in tests requiring the test data being skipped, even if the `git` submodule is correctly initialized.

Travis builds, on the other hand, seemed unaffected.

It turns out the difference is in whether the coverage plugin was used or not. If one uses the plugin, e.g.  `python setup.py test -a "--cov sherpa --cov-report term"` (which is what Travis does) then the issue is gone, and tests requiring external data are not skipped any more.

So, it looks like the order in which the `pytest` configuration is run (i.e. when the optional `--test-data` command line argument is read), and the tests are collected (i.e. when the `requires_*` annotations are evaluated) depends on whether the coverage plugin is included or not, or by other conditions triggered by the coverage command line.