### PR TITLE
Add GPLV3+ badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/sherpa/sherpa.svg?branch=master)](https://travis-ci.org/sherpa/sherpa)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
+[![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**


### PR DESCRIPTION
# Release notes

Add a license "badge" to indicate the license of Sherpa (GPLv3+) to the top of the README file, in the same style as the test status and Zenodo badges.

# Discussion

This information is already part of the document, but it makes it easier to find at a glance.