### PR TITLE
Add model documentation (#217)

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -540,6 +540,9 @@ class LineBroad(ArithmeticModel):
         return _modelfcts.linebroad(*args, **kwargs)
 
 
+# DOC-NOTE: for some reason the division in the equation in the notes
+#           section confuses sphinx (it thinks it is a section title).
+#
 class Lorentz1D(ArithmeticModel):
     """One-dimensional normalized Lorentz model function.
 

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -1,5 +1,6 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+# coding: utf-8
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -28,11 +29,54 @@ import sherpa.astro.models._modelfcts
 __all__ = ('Atten', 'BBody', 'BBodyFreq', 'Beta1D', 'BPL1D', 'Dered', 'Edge',
            'LineBroad', 'Lorentz1D', 'NormBeta1D', 'Schechter',
            'Beta2D', 'DeVaucouleurs2D', 'HubbleReynolds', 'Lorentz2D',
-           'JDPileup', 'MultiResponseSumModel', 'Sersic2D', 'Disk2D', 
+           'JDPileup', 'MultiResponseSumModel', 'Sersic2D', 'Disk2D',
            'Shell2D')
 
 
 class Atten(ArithmeticModel):
+    """Model the attenuation by the Inter-Stellar Medium (ISM).
+
+    This model calculates the transmission of the interstellar medium
+    using the description of the ISM absorption of [1]_. It includes
+    neutral He autoionization features. Between 1.2398 and 43.655
+    Angstroms (i.e. in the 0.28-10 keV range) the model also accounts
+    for metals as described in [2]_. It should only be used when the
+    independent axis has units of Angstroms.
+
+    Attributes
+    ----------
+    hcol
+        The column density of HI in atoms cm^-2.
+    heiRatio
+        The ratio of the HeI to HI column densities.
+    heiiRatio
+        The ratio of the HeII to HI column densities.
+
+    Notes
+    -----
+    The code uses the best available photoionization cross-sections to
+    date from the atomic data literature and combines them in an
+    arbitrary mixture of the three ionic species: HI, HeI, and HeII.
+
+    This model provided courtesy of Pat Jelinsky.
+
+    The grid version is evaluated by numerically intgerating the
+    function over each bin using a non-adaptive Gauss-Kronrod scheme
+    suited for smooth functions [3]_, falling over to a simple
+    trapezoid scheme if this fails.
+
+    References
+    ----------
+
+    .. [1] Rumph, Bowyer, & Vennes 1994, AJ 107, 2108
+           http://adsabs.harvard.edu/abs/1994AJ....107.2108R
+
+    .. [2] Morrison & McCammon 1983, ApJ 270, 119
+           http://adsabs.harvard.edu/abs/1983ApJ...270..119M
+
+    .. [3] https://www.gnu.org/software/gsl/manual/html_node/QNG-non_002dadaptive-Gauss_002dKronrod-integration.html
+
+    """
 
     def __init__(self, name='atten'):
         self.hcol = Parameter(name, 'hcol', 1e+20, 1e+17, 1e+24, tinyval)
@@ -49,6 +93,52 @@ class Atten(ArithmeticModel):
 
 
 class BBody(ArithmeticModel):
+    """A one-dimensional Blackbody model.
+
+    This model can be used when the independent axis is in energy
+    or wavelength space.
+
+    Attributes
+    ----------
+    space
+        This parameter is not fit (``alwaysfrozen`` is set), and
+        should be set to either 0, when the independent axis is
+        energy with units of keV, or 1 when the axis is wavelength
+        with units of Angstrom.
+    kT
+        The temperature if the blackbody, in keV.
+    ampl
+        The amplitude of the blackbody component.
+
+    See Also
+    --------
+    BBodyFreq
+
+    Notes
+    -----
+    The blackbody emission is calculated as a function of energy using
+    the expression::
+
+        f(E) = ampl * E^2 / (exp(E / kT) - 1)
+
+    where E is the photon energy, and kT is the blackbody temperature
+    (both in keV). The amplitude, ampl, is related to the ratio of
+    source radius to distance by::
+
+        ampl = (2 * pi / (c^2 * h^3)) (R / d)^2
+             = 9.884 x 10^31 (R / d)^2
+
+    with Planck's constant (h) specified in keV-s and the speed of
+    light (c) specified in cm/s, and with R and d representing the
+    radius of, and distance to, the source respectively.
+
+    There are two conditions when the above equation is not used:
+
+    - if E/kt < 10^-4 then f(E) = ampl * E * kT
+
+    - if E/kT > 60, f(E) = 0.
+
+    """
 
     def __init__(self, name='bbody'):
         self.space = Parameter(name, 'space', 0, 0, 1, 0, 1,
@@ -82,6 +172,33 @@ class BBody(ArithmeticModel):
 
 
 class BBodyFreq(ArithmeticModel):
+    """A one-dimensional Blackbody model (frequency).
+
+    This model can be used when the independent axis is in frequency
+    space.
+
+    Attributes
+    ----------
+    T
+        The temperature if the blackbody, in Kelvin.
+    ampl
+        The amplitude of the blackbody component.
+
+    See Also
+    --------
+    BBody
+
+    Notes
+    -----
+    The blackbody emission is calculated as a function of frequency
+    (v) using Wien's law (hv >> kT):
+
+
+        f(v) = ampl * 2 * h * v^3 * exp(-h * v / (k * T)) / c^2
+
+    where T is the blackbody temperature in Kelvin, h is Planck's
+    constant, k is Boltzmann's constant, and c the speed of light.
+    """
 
     def __init__(self, name='bbodyfreq'):
         self.T = Parameter(name, 'T', 1e+06, 1000, 1e+10, 1000, 1e+10)
@@ -113,6 +230,44 @@ class BBodyFreq(ArithmeticModel):
 
 
 class Beta1D(ArithmeticModel):
+    """One-dimensional beta model function.
+
+    The beta model is a Lorentz model with a varying power law.
+
+    Attributes
+    ----------
+    r0
+        The core radius.
+    beta
+        This parameter controls the slope of the profile at large
+        radii.
+    xpos
+        The reference point of the profile. This is frozen by default.
+    ampl
+        The amplitude refers to the maximum value of the model, at
+        x = xpos.
+
+    See Also
+    --------
+    Beta2D, Lorentz1D, NormBeta1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * (1 + ((x - xpos) / r0)^2)^(0.5 - 3 * beta)
+
+    The grid version is evaluated by numerically intgerating the
+    function over each bin using a non-adaptive Gauss-Kronrod scheme
+    suited for smooth functions [1]_, falling over to a simple
+    trapezoid scheme if this fails.
+
+    References
+    ----------
+
+    .. [1] https://www.gnu.org/software/gsl/manual/html_node/QNG-non_002dadaptive-Gauss_002dKronrod-integration.html
+
+    """
 
     def __init__(self, name='beta1d'):
         self.r0 = Parameter(name, 'r0', 1, tinyval, hard_min=tinyval)
@@ -146,6 +301,38 @@ class Beta1D(ArithmeticModel):
 
 
 class BPL1D(ArithmeticModel):
+    """One-dimensional broken power-law function.
+
+    Attributes
+    ----------
+    gamma1
+       The slope of the power law below the break point.
+    gamma2
+       The slope of the power law above the break point.
+    eb
+       The position of the break point.
+    ref
+       The reference position for the amplitude.
+    ampl
+       The amplitude, defined with respect to the reference position.
+
+    See Also
+    --------
+    Beta1D, Lorentz1D, NormBeta1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * (x / ref)^(-gamma1)   x <= eb
+
+             = ampl' * (x / ref)^(-gamma2)  otherwise
+
+       ampl' = ampl (eb / ref)^(gamma2 - gamma1)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='bpl1d'):
         self.gamma1 = Parameter(name, 'gamma1', 0, -10, 10)
@@ -174,7 +361,58 @@ class BPL1D(ArithmeticModel):
         return _modelfcts.bpl1d(*args, **kwargs)
 
 
+# TODO: what are the units of the independent axis: Angstrom?
+
 class Dered(ArithmeticModel):
+    """A de-reddening model.
+
+    The integrate flag of this model should be set to False when
+    used with an integrated grid.
+
+    Attributes
+    ----------
+    rv
+        The ratio of total to selective extinction.
+    nhgal
+        The absorbing column density of H_gal in units of 10^20 cm^-2.
+
+    Notes
+    -----
+    This dereddening model uses the analytic formula for the mean
+    extension law described in [1]_::
+
+        A(lambda) = E(B-V) * (a * rv + b)
+                  = 1.086 tau(lambda)
+
+    where tau(lambda) is the wavelength-dependent optical depth::
+
+        I(lambda) = I(0) * exp(-tau(lambda))
+
+    and a and b are computed using wavelength-dependent formulae,
+    which are not reproduced here, for the wavelength range 1000
+    Angstroms to 3.3 microns. The relationship between the color
+    excess and the column density (nhgal) is [2]_::
+
+        E(B-V) = nhgal / 58.0
+
+    where the units of nhgal is 10^20 cm^-2. The value of the ratio
+    of total to selective extinction, rv, is initially set to 3.1, the
+    standard value for the diffuse ISM. The final model form is::
+
+        I(lambda) = I(0) exp(-nhgal * (a * ev + b) / (58.0 * 1.086)
+
+    This model provided courtesy of Karl Forster.
+
+    References
+    ----------
+
+    .. [1] Cardelli, Clayton, & Mathis 1989, ApJ 345, 245
+           http://adsabs.harvard.edu/abs/1989ApJ...345..245C
+
+    .. [2] Bohlin, Savage, & Drake 1978, ApJ 224, 132
+           http://adsabs.harvard.edu/abs/1978ApJ...224..132B
+
+    """
 
     def __init__(self, name='dered'):
         self.rv = Parameter(name, 'rv', 10, 1e-10, 1000, tinyval)
@@ -188,6 +426,40 @@ class Dered(ArithmeticModel):
 
 
 class Edge(ArithmeticModel):
+    """Photoabsorption edge model.
+
+    This model can be used when the independent axis is in energy
+    or wavelength space.
+
+    Attributes
+    ----------
+    space
+        This parameter is not fit (``alwaysfrozen`` is set), and
+        should be set to either 0, when the independent axis is
+        energy with units of keV, or 1 when the axis is wavelength
+        with units of Angstrom.
+    thresh
+        The edge position (in energy or wavelength units matching
+        the data grid).
+    abs
+        The absorption coefficient.
+
+    Notes
+    -----
+    A phenomenological photoabsorption edge model as a function of
+    energy::
+
+        f(x) = exp(-abs * (x / thresh)^-3)   if x >= thresh
+
+             = 1.0                           otherwise
+
+    or, as a function of wavelength::
+
+        f(x) = exp(-abs * (x / thresh)^3)    if x <= thresh
+
+             = 1.0                           otherwise
+
+    """
 
     def __init__(self, name='edge'):
         self.space = Parameter(name, 'space', 0, 0, 1, 0, 1,
@@ -203,7 +475,35 @@ class Edge(ArithmeticModel):
         return _modelfcts.edge(*args, **kwargs)
 
 
+# DOC-NOTE:
+#    The equation is different to the ahelp file, but matches the code
+#
+# DOC-TODO:
+#    add note about integrated version
+#    convince myself that it is doing something useful.
+#
+
 class LineBroad(ArithmeticModel):
+    """A one-dimensional line-broadening profile.
+
+    Attributes
+    ----------
+    ampl
+        The amplitude of the line.
+    rest
+        The rest wavelength.
+    vsini
+        The rotation velocity (v sin(i)), in km/s.
+
+    Notes
+    -----
+    The model is::
+
+        f(lambda) = 2 * ampl * c * sqrt(x) / (pi * rest * vsini)
+
+                x = 1 - ((lambda - rest) * c / (rest * vsini))^2
+
+    """
 
     def __init__(self, name='linebroad'):
         self.ampl = Parameter(name, 'ampl', 1, 0, hard_min=0)
@@ -241,6 +541,34 @@ class LineBroad(ArithmeticModel):
 
 
 class Lorentz1D(ArithmeticModel):
+    """One-dimensional normalized Lorentz model function.
+
+    Attributes
+    ----------
+    fwhm
+        The full-width half maximum of the line.
+    pos
+        The center of the line.
+    ampl
+        The amplitude refers to the integral of the model.
+
+    See Also
+    --------
+    Beta1D, NormBeta1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) =                A * fwhm
+               --------------------------------------
+               2 * pi * (0.25 * fwhm^2 + (x - pos)^2)
+
+           A = ampl / integral f(x) dx
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='lorentz1d'):
         self.fwhm = Parameter(name, 'fwhm', 10, 0, hard_min=0)
@@ -278,6 +606,45 @@ class Lorentz1D(ArithmeticModel):
 
 
 class NormBeta1D(ArithmeticModel):
+    """One-dimensional normalized beta model function.
+
+    This is the same model as the ``Beta1D`` model but with a
+    different slope parameter and normalisation.
+
+    Attributes
+    ----------
+    pos
+        The center of the line.
+    w
+        The line width.
+    alpha
+        The slope of the profile at large radii.
+    ampl
+        The amplitude refers to the integral of the model.
+
+    See Also
+    --------
+    Beta1D, Lorentz1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = A * (1 + ((x - pos) / w)^2)^(-alpha)
+
+           A = ampl / integral f(x) dx
+
+    The grid version is evaluated by numerically intgerating the
+    function over each bin using a non-adaptive Gauss-Kronrod scheme
+    suited for smooth functions [1]_, falling over to a simple
+    trapezoid scheme if this fails.
+
+    References
+    ----------
+
+    .. [1] https://www.gnu.org/software/gsl/manual/html_node/QNG-non_002dadaptive-Gauss_002dKronrod-integration.html
+
+    """
 
     def __init__(self, name='normbeta1d'):
         self.pos = Parameter(name, 'pos', 0)
@@ -311,6 +678,33 @@ class NormBeta1D(ArithmeticModel):
 
 
 class Schechter(ArithmeticModel):
+    """One-dimensional Schecter model function.
+
+    This model is for integrated data grids only.
+
+    Attributes
+    ----------
+    alpha
+        The slope of the power-law component.
+    ref
+        The reference position, which controls the switch from the
+        power-law to the exponential.
+    norm
+        The normalisation of the model.
+
+    Notes
+    -----
+    The functional form of the model for grids is::
+
+        f(xlo,xhi) = norm * (xlo / ref)^alpha
+                          * exp(-xlo / ref)
+                          * (xhi - xlo) / ref
+
+    and for points the model is::
+
+        f(x) = 0
+
+    """
 
     def __init__(self, name='schechter'):
         self.alpha = Parameter(name, 'alpha', 10)
@@ -331,6 +725,61 @@ class Schechter(ArithmeticModel):
 
 
 class Beta2D(ArithmeticModel):
+    """Two-dimensional beta model function.
+
+    The beta model is a Lorentz model with a varying power law.
+
+    Attributes
+    ----------
+    r0
+        The core radius.
+    xpos
+        The center of the model on the x0 axis.
+    ypos
+        The center of the model on the x1 axis.
+    ellip
+        The ellipticity of the model.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+    alpha
+        This parameter controls the slope of the profile at large
+        radii.
+
+    See Also
+    --------
+    Beta1D, DeVaucouleurs2D, HubbleReynolds, Lorentz2D, Sersic2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl * (1 + r(x0,x1)^2)^(-alpha)
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+                     -------------------------------------------
+                                  r0^2 * (1-ellip)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+
+    The grid version is evaluated by adaptive multidimensional
+    integration scheme on hypercubes using cubature rules, based
+    on code from HIntLib ([1]_) and GSL ([2]_).
+
+    References
+    ----------
+
+    .. [1] HIntLib - High-dimensional Integration Library
+           http://mint.sbg.ac.at/HIntLib/
+
+    .. [2] GSL - GNU Scientific Library
+           http://www.gnu.org/software/gsl/
+
+    """
 
     def __init__(self, name='beta2d'):
         self.r0 = Parameter(name, 'r0', 10, tinyval, hard_min=tinyval)
@@ -370,6 +819,51 @@ class Beta2D(ArithmeticModel):
 
 
 class DeVaucouleurs2D(ArithmeticModel):
+    """Two-dimensional de Vaucouleurs model.
+
+    This is a formulation of the R^(1/4) law introduced by [1]_. It
+    is a special case of the ``Sersic2D`` model with ``n=4``,
+    as described in [2]_, [3]_, and [4]_.
+
+    Attributes
+    ----------
+    r0
+        The core radius.
+    xpos
+        The center of the model on the x0 axis.
+    ypos
+        The center of the model on the x1 axis.
+    ellip
+        The ellipticity of the model.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+
+    See Also
+    --------
+    Beta2D, HubbleReynolds, Lorentz2D, Sersic2D
+
+    Notes
+    -----
+    The model used is the same as the ``Sersic2D`` model with ``n=4``.
+
+    References
+    ----------
+
+    .. [1] de Vaucouleurs G., 1948, Ann. d’Astroph. 11, 247
+           http://adsabs.harvard.edu/abs/1948AnAp...11..247D
+
+    .. [2] http://ned.ipac.caltech.edu/level5/March05/Graham/Graham2.html
+
+    .. [3] Graham, A. & Driver, S., 2005, PASA, 22, 118
+           http://adsabs.harvard.edu/abs/2005PASA...22..118G
+
+    .. [4] Ciotti, L. & Bertin, G., A&A, 1999, 352, 447-451
+           http://adsabs.harvard.edu/abs/1999A%26A...352..447C
+
+    """
 
     def __init__(self, name='devaucouleurs2d'):
         self.r0 = Parameter(name, 'r0', 10, 0, hard_min=0)
@@ -407,6 +901,57 @@ class DeVaucouleurs2D(ArithmeticModel):
 
 
 class HubbleReynolds(ArithmeticModel):
+    """Two-dimensional Hubble-Reynolds model.
+
+    Attributes
+    ----------
+    r0
+        The core radius.
+    xpos
+        The center of the model on the x0 axis.
+    ypos
+        The center of the model on the x1 axis.
+    ellip
+        The ellipticity of the model.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+
+    See Also
+    --------
+    Beta2D, DeVaucouleurs2D, Lorentz2D, Sersic2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl / (1 + r(x0,x1))^2
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+                     -------------------------------------------
+                                  r0^2 * (1-ellip)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+
+    The grid version is evaluated by adaptive multidimensional
+    integration scheme on hypercubes using cubature rules, based
+    on code from HIntLib ([1]_) and GSL ([2]_).
+
+    References
+    ----------
+
+    .. [1] HIntLib - High-dimensional Integration Library
+           http://mint.sbg.ac.at/HIntLib/
+
+    .. [2] GSL - GNU Scientific Library
+           http://www.gnu.org/software/gsl/
+
+    """
+
 
     def __init__(self, name='hubblereynolds'):
         self.r0 = Parameter(name, 'r0', 10, 0, hard_min=0)
@@ -444,6 +989,45 @@ class HubbleReynolds(ArithmeticModel):
 
 
 class Lorentz2D(ArithmeticModel):
+    """Two-dimensional un-normalised Lorentz function.
+
+    Attributes
+    ----------
+    fwhm
+        The full-width half maximum.
+    xpos
+        The center of the model on the x0 axis.
+    ypos
+        The center of the model on the x1 axis.
+    ellip
+        The ellipticity of the model.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+
+    See Also
+    --------
+    Beta1D, DeVaucouleurs2D, HubbleReynolds, Lorentz1D, Sersic2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl / (1 + 4 * r(x0,x1)^2)
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+                     -------------------------------------------
+                                 fwhm^2 * (1-ellip)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='lorentz2d'):
         self.fwhm = Parameter(name, 'fwhm', 10, tinyval, hard_min=tinyval)
@@ -480,6 +1064,62 @@ class Lorentz2D(ArithmeticModel):
 
 
 class JDPileup(ArithmeticModel):
+    """A CCD pileup model for the ACIS detectors on Chandra.
+
+    This model is based on the work by John Davis ([1]_). It is
+    intended only for modeling the pileup in one-dimensional spectra
+    obtained in imaging mode (i.e. no grating data), but can be used
+    with the zeroth-order spectrum of a grating data set.
+
+    Attributes
+    ----------
+    alpha
+        The alpha parameter parameterizes "grade migration" in the
+        detector and represents the fraction of piled-up events that
+        result in a good grade.
+    g0
+        The probabilty of assigning a grade of zero. This should
+        remain frozen.
+    f
+        The fraction of flux falling into the pileup region. This
+        should remain frozen.
+    n
+        The number of detection cells. This parameter can not be fit.
+    ftime
+        The frame time in seconds (as given by the ``EXPTIME``
+        keyword of the event file). This parameter can not be fit.
+    fracexp
+        The fractional exposure that the source experienced while
+        dithering on the chip (as given by the ``FRACEXPO`` keyword
+        in the ARF file). This parameter can not be fit.
+    nterms
+        The maximum number of photons considered for pileup in a
+        single readout frame. This should not be changed from its
+        default value of 30. This parameter can not be fit.
+
+    Notes
+    -----
+    As the pileup model is inherently non-linear, it is strongly
+    advised that multiple optimization methods are used to thoroughly
+    investigate the search space for the model.
+
+    The alpha parameter should vary with photon energy and detector
+    position, but for simplicity it is treated as independent of
+    energy and location.
+
+    An example of using this model to fit a Chandra spectrum is
+    provided in [2]_.
+
+    References
+    ----------
+
+    .. [1] Davis, J, 2001, ApJ, 562, 575-582.
+           http://adsabs.harvard.edu/abs/2001ApJ...562..575D
+
+    .. [2] "Using A Pileup Model",
+           http://cxc.harvard.edu/sherpa/threads/pileup/
+
+    """
 
     def __init__(self, name='jdpileup'):
         self.alpha = Parameter(name, 'alpha', 0.5, 0, 1, 0, 1)
@@ -539,6 +1179,73 @@ class MultiResponseSumModel(ArithmeticModel):
     pass
 
 class Sersic2D(ArithmeticModel):
+    """Two-dimensional Sersic model.
+
+    This is a generalization of the ``DeVaucouleurs2D`` model,
+    in which the exponent ``n`` can vary ([1]_, [2]_, and [3]_).
+
+    Attributes
+    ----------
+    r0
+        The core radius.
+    xpos
+        The center of the model on the x0 axis.
+    ypos
+        The center of the model on the x1 axis.
+    ellip
+        The ellipticity of the model.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+    n
+        The Sersic index (n=4 replicates the ``DeVaucouleurs2D``
+        model).
+
+    See Also
+    --------
+    Beta2D, DeVaucouleurs2D, HubbleReynolds, Lorentz2D
+
+    Notes
+    -----
+    The functional form of the model for points is can be
+    expressed as the following::
+
+        f(x0,x1) = ampl * exp(-b(n) * (r(x0,x1)^(1/n) - 1))
+
+            b(n) = 2 * n - 1 / 3 + 4 / (405 * n) + 46 / (25515 * n^2)
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+                     -------------------------------------------
+                                  r0^2 * (1-ellip)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+
+    The grid version is evaluated by adaptive multidimensional
+    integration scheme on hypercubes using cubature rules, based
+    on code from HIntLib ([4]_) and GSL ([5]_).
+
+    References
+    ----------
+
+    .. [1] http://ned.ipac.caltech.edu/level5/March05/Graham/Graham2.html
+
+    .. [2] Graham, A. & Driver, S., 2005, PASA, 22, 118
+           http://adsabs.harvard.edu/abs/2005PASA...22..118G
+
+    .. [3] Ciotti, L. & Bertin, G., A&A, 1999, 352, 447-451
+           http://adsabs.harvard.edu/abs/1999A%26A...352..447C
+
+    .. [4] HIntLib - High-dimensional Integration Library
+           http://mint.sbg.ac.at/HIntLib/
+
+    .. [5] GSL - GNU Scientific Library
+           http://www.gnu.org/software/gsl/
+
+    """
 
     def __init__(self, name='sersic2d'):
         self.r0 = Parameter(name, 'r0', 10, 0, hard_min=0)
@@ -575,11 +1282,41 @@ class Sersic2D(ArithmeticModel):
         kwargs['integrate']=bool_cast(self.integrate)
         return _modelfcts.sersic(*args, **kwargs)
 
-### disk2d and shell2d models 
+### disk2d and shell2d models
 ### Contributed by Christoph Deil of the HESS project
 ### Added to CIAO 4.6 for Dec. 2013 release SMD
 
 class Disk2D(ArithmeticModel):
+    """Two-dimensional uniform disk model.
+
+    Attributes
+    ----------
+    xpos
+        The center of the disk on the x0 axis.
+    ypos
+        The center of the disk on the x1 axis.
+    ampl
+        The amplitude of the signal within the disk.
+    r0
+        The radius of the disk.
+
+    See Also
+    --------
+    Shell2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl  if (x0 - xpos)^2 + (x1 - ypos)^2 <= r0^2
+
+                 = 0     otherwise
+
+    For grids, the x0lo,x1lo values are used in the above equation.
+
+    This model was provided by Christoph Deil.
+    """
+
     def __init__(self, name='disk2d'):
         self.xpos = Parameter(name, 'xpos', 0) # p[0]
         self.ypos = Parameter(name, 'ypos', 0) # p[1]
@@ -594,7 +1331,45 @@ class Disk2D(ArithmeticModel):
         # Return ampl when r2 <= r0 else return 0
         return numpy.select([r2 <= p[3] ** 2], [p[2]])
 
+# DOC-NOTE: TODO finish the functional form description
+
 class Shell2D(ArithmeticModel):
+    """A homogenous spherical 3D shell projected onto 2D.
+
+    Attributes
+    ----------
+    xpos
+        The center of the shell on the x0 axis.
+    ypos
+        The center of the shell on the x1 axis.
+    ampl
+        The amplitude.
+    r0
+        The line-of-sight distance.
+    width
+        The width of the shell.
+
+    See Also
+    --------
+    Disk2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl * r(x0,x1)
+
+                 = 0     otherwise
+
+        r(x0,x1) = ?
+
+    For grids, the x0lo,x1lo values are used in the above equation.
+
+    It is not correct for very large shells on the sky.
+
+    This model was provided by Christoph Deil.
+    """
+
     def __init__(self, name='shell2d'):
         self.xpos = Parameter(name, 'xpos', 0) # p[0]
         self.ypos = Parameter(name, 'ypos', 0) # p[1]

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -596,9 +596,10 @@ class BrokenPowerlaw(ArithmeticModel):
 # Cardelli, Clayton, and Mathis
 # (ApJ, 1989, vol 345, pp 245)
 class CCM(ArithmeticModel):
-    """The Cardelli, Clayton, and Mathis extinction curve.
+    """Galactic extinction: the Cardelli, Clayton, and Mathis model.
 
-    The extinction is calculated using the formula from [1]_.
+    The interstellar extinction is calculated using the formula
+    from [1]_.
 
     Attributes
     ----------
@@ -606,6 +607,10 @@ class CCM(ArithmeticModel):
         E(B-V)
     r
         R_v
+
+    See Also
+    --------
+    FM, LMC, Seaton, SM, SMC, XGAL
 
     Notes
     -----
@@ -999,7 +1004,43 @@ class XGal(ArithmeticModel):
 # See Fitzpatrick and Massa (ApJ, 1988, vol. 328, p. 734)
 
 class FM(ArithmeticModel):
-    """Extinction curve for UV spectra below 3200 A (Fitzpatrick and Massa 1988)"""
+    """UV extinction curve: Fitzpatrick and Massa 1988.
+
+    The UV extinction is calculated using [1]_.
+
+    Attributes
+    ----------
+    ebv
+        E(B-V)
+    x0
+        Position of the Drude bump.
+    width
+        Width of the Drude bump.
+    c1
+        The intercept of the linear term.
+    c2
+        The slope of the linear term.
+    c3
+        Normalization of the Drude bump.
+    c4
+        Normalization of the FUV curvature.
+
+    See Also
+    --------
+    CCM, LMC, Seaton, SM, SMC, XGAL
+
+    Notes
+    -----
+    When evaluated on a binned grid, the lower-edges of the bins are
+    used for the calculation.
+
+    References
+    ----------
+
+    .. [1] Fitzpatrick and Massa 1988
+           http://adsabs.harvard.edu/abs/1988ApJ...328..734F
+
+    """
 
     def __init__(self, name='fm'):
         self.ebv = Parameter(name, 'ebv', 0.5)  # E(B-V)
@@ -1068,7 +1109,33 @@ class LMC(ArithmeticModel):
 # This model computes the galactic interstellar extinction function
 # from Savage & Mathis (1979, ARA&A, 17, 73-111)
 class SM(ArithmeticModel):
-    """Galactic interstellar extinction function from Savage & Mathis (1979, ARA&A, 17, 73-111)"""
+    """Galactic extinction: the Savage & Mathis model.
+
+    The interstellar extinction is calculated using the formula
+    from [1]_.
+
+    Attributes
+    ----------
+    ebv
+        E(B-V)
+
+    See Also
+    --------
+    CCM, FM, LMC, Seaton, SMC, XGAL
+
+    Notes
+    -----
+    When evaluated on a binned grid, the lower-edges of the bins are
+    used for the calculation.
+
+    References
+    ----------
+
+    .. [1] Savage & Mathis,1979, ARA&A, 17, 73-111
+           http://adsabs.harvard.edu/abs/1979ARA%26A..17...73S
+
+    """
+
     def __init__(self, name='sm'):
         self.ebv = Parameter(name, 'ebv', 0.5)
 
@@ -1153,7 +1220,55 @@ class SMC(ArithmeticModel):
 # 10000 < lambda		    extrapolate linearly in 1/lambda
 
 class Seaton(ArithmeticModel):
-    """Seaton's interstellar extinction function (1979 MNRAS)"""
+    """Galactic extinction: the Seaton model from Synphot.
+
+    The interstellar extinction is calculated using the formula
+    from [1]_ as implemented in STSCI's Synphot program [2]_.
+    The supported wavelength range is 1000 to 10000 Angstroms, and
+    the Notes section describes the changes from [1]_.
+
+    Attributes
+    ----------
+    ebv
+        E(B-V)
+
+    See Also
+    --------
+    CCM, FM, LMC, SM, SMC, XGAL
+
+    Notes
+    -----
+    The formulae are based on an adopted value of R=3.20.
+
+    For wavelengths above 3704 Angstrom, the function interpolates
+    linearly in 1/lambda in table 3 [1]_. For wavelengths below this,
+    the formulae from table 2 [1]_ are used (see also [3]_, corrected
+    to R=3.2).  The formulae match at the endpoints of their
+    respective intervals. There is a mismatch of 0.009 mag/ebmv at
+    nu=2.7 (lambda=3704 Angstrom). Seaton's tabulated value of 1.44
+    mag at 1/lambda = 1.1 may be in error; 1.64 seems more consistent
+    with his other values.
+
+    For wavelengths below 1000 Angstrom, a constant value equal to
+    the value at 1000 Angstrom is used. For wavelengths above 10000
+    Angstroms a linear extrapolation (in 1/lambda) is used.
+
+    When evaluated on a binned grid, the lower-edges of the bins are
+    used for the calculation.
+
+    References
+    ----------
+
+    .. [1] Seaton, M. J. 1979, MNRAS, 187, 73
+           http://adsabs.harvard.edu/abs/1979MNRAS.187P..73S
+
+    .. [2] http://www.stsci.edu/institute/software_hardware/stsdas/synphot
+
+    .. [3] Nandy et al., 1975, A&A, 44, 195-203.
+           http://adsabs.harvard.edu/abs/1975A%26A....44..195N
+
+    """
+
     def __init__(self, name='seaton'):
         self.ebv = Parameter(name, 'ebv', 0.5)
 

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -690,7 +690,7 @@ class BlackBody(ArithmeticModel):
 
     See Also
     --------
-    Bremstrahlung
+    Bremsstrahlung
 
     Notes
     -----
@@ -763,7 +763,7 @@ class Bremsstrahlung(ArithmeticModel):
 
     See Also
     --------
-    Blackbody
+    BlackBody
 
     Notes
     -----

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -17,6 +17,20 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""
+Optical models intended for SED Analysis
+
+The models match those used by the SpecView application [1]_,
+and are intended for un-binned one-dimensional data sets defined
+on a wavelength grid, with units of Angstroms.
+
+References
+----------
+
+.. [1] http://www.stsci.edu/institute/software_hardware/specview/
+
+"""
+
 from six.moves import xrange
 import numpy
 from sherpa.models.parameter import Parameter, tinyval
@@ -73,6 +87,33 @@ def _extinct_interp(xtable, etable, x):
 # This model sets in edge (in Angstroms) beyond which absorption
 # is a significant feature to the spectrum or SED.
 class AbsorptionEdge(ArithmeticModel):
+    """Optical model of an absorption edge.
+
+    This model is intended to be used to modify another model (e.g.
+    by multiplying the two together). It is for use when the
+    independent axis is in wavelength units (e.g. Angstrom).
+
+    Attributes
+    ----------
+    egdew
+        The location of the edge. Above this value the model is
+        set to 1.
+    tau
+        The optical depth of the edge.
+    index
+        The exponent used for the relative distance from the edge.
+        It is a hidden parameter, with a value fixed at 3.
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = exp(-tau * (x / index)^3)   for x <= edgew
+
+             = 1                           otherwise
+
+    and for integrated data sets the low-edge of the grid is used.
+    """
 
     def __init__(self, name='absorptionedge'):
         self.edgew = Parameter(name, 'edgew', 5000., tinyval, frozen=True, units='angstroms')
@@ -100,6 +141,29 @@ class AbsorptionEdge(ArithmeticModel):
 
 # This model is an accretion disk continuum function.
 class AccretionDisk(ArithmeticModel):
+    """A model of emission due to an accretion disk.
+
+    It is for use when the independent axis is in Angstroms.
+
+    Attributes
+    ----------
+    ref
+        The reference wavelength, in Angstroms.
+    beta
+    ampl
+        The amplitude of the disk.
+    norm
+        The normalization value for the position. It is a hidden
+        parameter, with a value fixed at 20000.
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * (x / norm)^(-beta) * exp(-ref / x)
+
+    and for integrated data sets the low-edge of the grid is used.
+    """
 
     def __init__(self, name='accretiondisk'):
 

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -1360,7 +1360,34 @@ class EmissionVoigt(ArithmeticModel):
 # This model computes the extragalactic extinction function of
 # Calzetti, Kinney and Storchi-Bergmann, 1994, ApJ, 429, 582
 class XGal(ArithmeticModel):
-    """Extragalactic extinction function of Calzetti, Kinney and Storchi-Bergmann"""
+    """Extragalactic extinction: Calzetti, Kinney and Storchi-Bergmann
+
+    The extragalactic extinction is calculated using the formula
+    from [1]_. This model is intended to be used to modify another
+    model (e.g. by multiplying the two together). It is for use when
+    the independent axis is in Angstrom.
+
+    Attributes
+    ----------
+    ebv
+        E(B-V)
+
+    See Also
+    --------
+    CCM, FM, LMC, Seaton, SM, SMC
+
+    Notes
+    -----
+    When evaluated on a binned grid, the lower-edges of the bins are
+    used for the calculation.
+
+    References
+    ----------
+
+    .. [1] Calzetti, Kinney, Storchi-Bergmann, 1994, ApJ, 429, 582
+           http://adsabs.harvard.edu/abs/1994ApJ...429..582C
+
+    """
 
     def __init__(self, name='xgal'):
         self.ebv = Parameter(name, 'ebv', 0.5)
@@ -1462,7 +1489,34 @@ class FM(ArithmeticModel):
 # This model computes the extinction curve using the
 #  LMC extinction curve from Howarth 1983 MNRAS, 203, 301
 class LMC(ArithmeticModel):
-    """Howarth's LMC extinction curve (Howarth 1983 MNRAS, 203, 301)"""
+    """LMC extinction: the Howarth model.
+
+    The interstellar extinction is calculated using the formula
+    from [1]_. This model is intended to be used to modify another
+    model (e.g. by multiplying the two together). It is for use when
+    the independent axis is in Angstrom.
+
+    Attributes
+    ----------
+    ebv
+        E(B-V)
+
+    See Also
+    --------
+    CCM, FM, Seaton, SM, SMC, XGAL
+
+    Notes
+    -----
+    When evaluated on a binned grid, the lower-edges of the bins are
+    used for the calculation.
+
+    References
+    ----------
+
+    .. [1] Howarth 1983 MNRAS, 203, 301
+           http://adsabs.harvard.edu/abs/1983MNRAS.203..301H
+
+    """
 
     def __init__(self, name='lmc'):
         self.ebv = Parameter(name, 'ebv', 0.5)
@@ -1523,7 +1577,7 @@ class SM(ArithmeticModel):
     References
     ----------
 
-    .. [1] Savage & Mathis,1979, ARA&A, 17, 73-111
+    .. [1] Savage & Mathis, 1979, ARA&A, 17, 73-111
            http://adsabs.harvard.edu/abs/1979ARA%26A..17...73S
 
     """
@@ -1557,7 +1611,35 @@ class SM(ArithmeticModel):
 # This model computes the SMC extinction function of
 # Prevot et al. 1984, A&A, 132, 389-392
 class SMC(ArithmeticModel):
-    """Prevot et.al. 1984 extinction curve for the SMC"""
+    """SMC extinction: the Prevot et al. 1984 model.
+
+    The interstellar extinction is calculated using the formula
+    from [1]_. This model is intended to be used to modify another
+    model (e.g. by multiplying the two together). It is for use when
+    the independent axis is in Angstrom.
+
+    Attributes
+    ----------
+    ebv
+        E(B-V)
+
+    See Also
+    --------
+    CCM, FM, LMC, Seaton, SM, XGAL
+
+    Notes
+    -----
+    When evaluated on a binned grid, the lower-edges of the bins are
+    used for the calculation.
+
+    References
+    ----------
+
+    .. [1] Prevot et al. 1984, A&A, 132, 389-392
+           http://adsabs.harvard.edu/abs/1984A%26A...132..389P
+
+    """
+
     def __init__(self, name='smc'):
         self.ebv = Parameter(name, 'ebv', 0.5)
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -548,7 +548,57 @@ class XSbbodyrad(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.norm))
 
 
+# DOC-NOTE: the XSPEC documentation has a different parameter order to
+#           the code.
 class XSbexrav(XSAdditiveModel):
+    """The XSPEC bexrav model: reflected e-folded broken power law, neutral medium
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Gamma1
+        The power-law index of the first power-law component.
+    breakE
+        The break energy, in keV.
+    Gamma2
+        The power-law index of the second power-law component.
+    foldE
+        The e-folding energy (Ec) in keV. If zero there is no cut off.
+    rel_refl
+        The reflection scaling parameter (a value of 1 for an
+        isotropic source above the disk).
+    cosIncl
+        The cosine of the inclination angle.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbexriv
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the BEXRAV_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBexrav.html
+
+    """
 
     _calc =  _xspec.C_xsbexrav
 
@@ -572,6 +622,58 @@ class XSbexrav(XSAdditiveModel):
 
 
 class XSbexriv(XSAdditiveModel):
+    """The XSPEC bexriv model: reflected e-folded broken power law, ionized medium
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Gamma1
+        The power-law index of the first power-law component.
+    breakE
+        The break energy, in keV.
+    Gamma2
+        The power-law index of the second power-law component.
+    foldE
+        The e-folding energy (Ec) in keV. If zero there is no cut off.
+    rel_refl
+        The reflection scaling parameter (a value of 1 for an
+        isotropic source above the disk).
+    redshift
+        The redshift of the source.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    cosIncl
+        The cosine of the inclination angle.
+    T_disk
+        The disk temperature in K.
+    xi
+        The disk inoization parameter: see [1]_ for an explanation.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbexrav
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the BEXRIV_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBexriv.html
+
+    """
 
     _calc =  _xspec.C_xsbexriv
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -699,6 +699,33 @@ class XSbexriv(XSAdditiveModel):
 
 
 class XSbknpower(XSAdditiveModel):
+    """The XSPEC bknpower model: broken power law.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndx1
+        The power law photon index for energies less than BreakE.
+    BreakE
+        The break energy, in keV.
+    PhoIndx2
+        The power law photon index for energies greater than BreakE.
+    norm
+        The normalization of the model. See [1]_ for details, as its
+        meaning depends on whether the "POW_EMIN" or "POW_EMAX"
+        keywords have been set with ``set_xsxset``.
+
+    See Also
+    --------
+    XSbkn2pow, XSpowerlaw, XSzpowerlw
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBknpower.html
+
+    """
 
     _calc =  _xspec.C_brokenPowerLaw
 
@@ -716,6 +743,38 @@ class XSbknpower(XSAdditiveModel):
 
 
 class XSbkn2pow(XSAdditiveModel):
+    """The XSPEC bkn2pow model: broken power law with two breaks.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndx1
+        The power law photon index for energies less than BreakE1.
+    BreakE1
+        The first break energy, in keV.
+    PhoIndx2
+        The power law photon index for energies greater than BreakE1
+        but less than BreakE2.
+    BreakE2
+        The second break energy, in keV.
+    PhoIndx3
+        The power law photon index for energies greater than BreakE2.
+    norm
+        The normalization of the model. See [1]_ for details, as its
+        meaning depends on whether the "POW_EMIN" or "POW_EMAX"
+        keywords have been set with ``set_xsxset``.
+
+    See Also
+    --------
+    XSbknpower, XSpowerlaw, XSzpowerlw
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBkn2pow.html
+
+    """
 
     _calc =  _xspec.C_broken2PowerLaw
 
@@ -1721,6 +1780,29 @@ class XSplcabs(XSAdditiveModel):
 
 
 class XSpowerlaw(XSAdditiveModel):
+    """The XSPEC powerlaw model: power law photon spectrum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndx
+        The power law photon index.
+    norm
+        The normalization of the model. See [1]_ for details, as its
+        meaning depends on whether the "POW_EMIN" or "POW_EMAX"
+        keywords have been set with ``set_xsxset``.
+
+    See Also
+    --------
+    XSbknpower, XSbkn2pow, XSzpowerlw
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPowerlaw.html
+
+    """
 
     _calc =  _xspec.C_powerLaw
 
@@ -2494,6 +2576,31 @@ class XSzgauss(XSAdditiveModel):
 
 
 class XSzpowerlw(XSAdditiveModel):
+    """The XSPEC zpowerlw model: redshifted power law photon spectrum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndx
+        The power law photon index.
+    redshift
+        The redshift.
+    norm
+        The normalization of the model. See [1]_ for details, as its
+        meaning depends on whether the "POW_EMIN" or "POW_EMAX"
+        keywords have been set with ``set_xsxset``.
+
+    See Also
+    --------
+    XSbknpower, XSbkn2pow, XSpowerlaw
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPowerlaw.html
+
+    """
 
     _calc =  _xspec.C_zpowerLaw
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -5742,6 +5742,10 @@ class XSredden(XSMultiplicativeModel):
     EBV
         The value of E(B-v) for the line of sight to the source.
 
+    See Also
+    --------
+    XSzredden
+
     References
     ----------
 
@@ -5905,7 +5909,6 @@ class XSswind1(XSMultiplicativeModel):
     .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSwind1.html
 
     """
-
 
     _calc =  _xspec.swind1
 
@@ -6279,6 +6282,45 @@ class XSwndabs(XSMultiplicativeModel):
 
 
 class XSxion(XSMultiplicativeModel):
+    """The XSPEC xion model: reflected spectrum of photo-ionized accretion disk/ring.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    height
+        The height of the source above the disk (in Schwarzschild radii).
+    lxld
+        The ratio of the X-ray source luminosity to that of the disk.
+    rate
+        The accretion rate (in Eddington units).
+    cosAng
+        The cosine of the inclination angle (1 is face on).
+    inner
+        The inner radius of the disk (in Schwarzschild radii).
+    outer
+        The er radius of the disk (in Schwarzschild radii).
+    index
+        The photon index of the source.
+    redshift
+        The redshift of the absorber.
+    Feabun
+        The Fe abundance relative to Solar: see [1]_ for more details.
+    E_cut
+        The exponential high energy cut-off energy for the source.
+    Ref_type
+        See [1]_ for details.
+    Ref_smear
+        See [1]_ for details.
+    Geometry
+        See [1]_ for details.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelXion.html
+
+    """
 
     _calc =  _xspec.xsxirf
 
@@ -6300,6 +6342,28 @@ class XSxion(XSMultiplicativeModel):
 
 
 class XSzdust(XSMultiplicativeModel):
+    """The XSPEC zdust model: extinction by dust grains.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    method
+        The model to use: 1 is Milky Way, 2 is LMC, 3 is SMC.
+        This parameter can not be thawed.
+    EBV
+        The color excess, E(B-V).
+    Rv
+        The ratio of total to selective extinction.
+    redshift
+        The redshift of the absorber.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZdust.html
+
+    """
 
     _calc =  _xspec.mszdst
 
@@ -6455,6 +6519,27 @@ class XSzphabs(XSMultiplicativeModel):
 
 
 class XSzxipcf(XSMultiplicativeModel):
+    """The XSPEC zxipcf model: partial covering absorption by partially ionized material.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The column density, in units of 10^22 cm^2.
+    logxi
+        The log of xi: see [1]_ for more details.
+    CvrFract
+        The covering fraction.
+    redshift
+        The redshift of the source.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZxipcf.html
+
+    """
 
     _calc =  _xspec.zxipcf
 
@@ -6467,6 +6552,27 @@ class XSzxipcf(XSMultiplicativeModel):
 
 
 class XSzredden(XSMultiplicativeModel):
+    """The XSPEC zredden model: redshifted version of redden.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    EBV
+        The value of E(B-v) for the line of sight to the source.
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSredden
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZredden.html
+
+    """
 
     _calc =  _xspec.xszcrd
 
@@ -6477,6 +6583,27 @@ class XSzredden(XSMultiplicativeModel):
 
 
 class XSzsmdust(XSMultiplicativeModel):
+    """The XSPEC zsmdust model: extinction by dust grains in starburst galaxies.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    EBV
+        The value of E(B-v) for the line of sight to the source.
+    ExtIndex
+        The spectral index of the extinction curve.
+    Rv
+        The ratio of total to selective extinction.
+    redshift
+        The redshift of the absorber.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZsmdust.html
+
+    """
 
     _calc =  _xspec.msldst
 
@@ -6579,6 +6706,29 @@ class XSzvarabs(XSMultiplicativeModel):
 
 
 class XSzvfeabs(XSMultiplicativeModel):
+    """The XSPEC zvfeabs model: photoelectric absorption with free Fe edge energy.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    metals
+        The abundance relative to solar.
+    FEabun
+        The iron abundance relative to solar.
+    FEKedge
+        The Fe K edge energy, in keV.
+    redshift
+        The redshift of the absorber.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZvfeabs.html
+
+    """
 
     _calc =  _xspec.xszvfe
 
@@ -7231,6 +7381,28 @@ class XSvvapec(XSAdditiveModel):
 
 
 class XSzigm(XSMultiplicativeModel):
+    """The XSPEC zigm model: UV/Optical attenuation by the intergalactic medium.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    redshift
+        The redshift of the absorber.
+        This parameter can not be thawed.
+    model
+        The model to use: 0 is Madau, 1 is Meiksin.
+        This parameter can not be thawed.
+    lyman_limit
+        Should photoelectric absorption be included (1), or not (0).
+        This parameter can not be thawed.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZigm.html
+
+    """
 
     _calc = _xspec.zigm
 
@@ -7877,6 +8049,27 @@ class XSlyman(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.nHeI, self.b, self.redshift, self.ZA))
 
 class XSzbabs(XSMultiplicativeModel):
+    """The XSPEC lyman model: Voigt absorption profiles for H I or He II Lyman series.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The H column density, in 10^22 atoms/cm^2.
+    nHeI
+        The He I column density, in 10^22 atoms/cm^2.
+    nHeI
+        The He II column density, in 10^22 atoms/cm^2.
+    redshift
+        The redshift of the absorber.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZbabs.html
+
+    """
 
     _calc =  _xspec.xszbabs
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2078,6 +2078,42 @@ class XSgnei(XSAdditiveModel):
 
 
 class XSgrad(XSAdditiveModel):
+    """The XSPEC grad model: accretion disk, Schwarzschild black hole.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    D
+        The distance to the source in kpc.
+    i
+        The disk inclination angle, in degrees. A face-on disk has
+        i=0.
+    Mass
+        The mass of the central object, in solar masses.
+    Mdot
+        The mass accretion rate in units of 10^18 g/s.
+    TclTef
+        The spectral hardening factor, Tcol/Teff. See [1]_ for more
+        details.
+    refflag
+        A flag to control the relativistic effects: if positive then
+        a relativistic calculation is used; if zero or negative then
+        a Newtonian calculation is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model. It should be fixed to 1.
+
+    See Also
+    --------
+    XSkerbb
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGrad.html
+
+    """
 
     _calc =  _xspec.grad
 
@@ -2093,6 +2129,27 @@ class XSgrad(XSAdditiveModel):
 
 
 class XSgrbm(XSAdditiveModel):
+    """The XSPEC grbm model: gamma-ray burst continuum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    alpha
+        The first powerlaw index.
+    beta
+        The second powerlaw index.
+    temp
+        The characteristic energy, in keV.
+    norm
+        The normalization of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGrbm.html
+
+    """
 
     _calc =  _xspec.xsgrbm
 
@@ -2105,6 +2162,55 @@ class XSgrbm(XSAdditiveModel):
 
 
 class XSkerrbb(XSAdditiveModel):
+    """The XSPEC kerrbb model: multi-temperature blackbody model for thin accretion disk around a Kerr black hole.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    eta
+        The ratio of the disk power produced by a torque at the disk
+        inner boundary to the disk power arising from accretion. See
+        [1]_ for more details.
+    a
+        The specific angular momentum of the black hole in units of the
+        black hole mass M (when G=c=1). It should be in the range [0, 1).
+    i
+        The disk inclination angle, in degrees. A face-on disk has
+        i=0. It must be less than or equal to 85 degrees.
+    Mbh
+        The mass of the black hole, in solar masses.
+    Mdd
+        The "effective" mass accretion rate in units of 10^18 g/s.
+        See [1]_ for more details.
+    Dbh
+        The distance from the observer to the black hole, in units of kpc.
+    hd
+        The spectral hardening factor, Tcol/Teff. See [1]_ for more
+        details.
+    rflag
+        A flag to switch on or off the effect of self irradiation:
+        when greater than zero the self irradition is included,
+        otherwise it is not. This parameter can not be thawed.
+    lflag
+        A flag to switch on or off the effect of limb darkening:
+        when greater than zero the disk emission is assumed to be
+        limb darkened, otherwise it is isotropic.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model. It should be fixed to 1
+        if the inclination, mass, and distance are frozen.
+
+    See Also
+    --------
+    XSgrad
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKerrbb.html
+
+    """
 
     _calc =  _xspec.C_kerrbb
 
@@ -2123,6 +2229,42 @@ class XSkerrbb(XSAdditiveModel):
 
 
 class XSkerrd(XSAdditiveModel):
+    """The XSPEC kerrd model: optically thick accretion disk around a Kerr black hole.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    distance
+        The distance, in units of kpc.
+    TcollTeff
+        The spectral hardening factor, Tcol/Teff. See [1]_ for more
+        details.
+    M
+        The mass of the central object, in solar masses.
+    Mdot
+        The mass accretion rate in units of 10^18 g/s.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+    Rin
+        The inner radius, in units of GM/c^2. The last stable orbit
+        is 1.235.
+    Rout
+        The outer radius, in units of GM/c^2.
+    norm
+        The normalization of the model. It should be fixed to 1.
+
+    See Also
+    --------
+    XSlaor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKerrd.html
+
+    """
 
     _calc =  _xspec.C_kerrdisk
 
@@ -2139,6 +2281,47 @@ class XSkerrd(XSAdditiveModel):
 
 
 class XSkerrdisk(XSAdditiveModel):
+    """The XSPEC kerrdisk model: accretion disk line emission with BH spin as free parameter.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    lineE
+        The rest-frame line energy, in keV.
+    Index1
+        The emissivity index for the inner disk.
+    Index2
+        The emissivity index for the outer disk.
+    r_brg
+        The break radius separating the inner and outer portions of the
+        disk, in gravitational radii.
+    a
+        The dimensionless black hole spin.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+    Rinms
+        The inner radius of the disk, in units of the radius of
+        marginal stability.
+    Routms
+        The outer radius of the disk, in units of the radius of
+        marginal stability.
+    z
+        The redshift of the source.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSdiskline, XSlaor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKerrdisk.html
+
+    """
 
     _calc =  _xspec.spin
 
@@ -2162,6 +2345,36 @@ class XSkerrdisk(XSAdditiveModel):
 
 
 class XSlaor(XSAdditiveModel):
+    """The XSPEC laor model: accretion disk, black hole emission line.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    lineE
+        The rest-frame line energy, in keV.
+    Index
+        The power law dependence of emissivity (scales as R^-Index).
+    RinG
+        The inner radius, in units of GM/c^2.
+    RoutG
+        The outer radius, in units of GM/c^2.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSlaor2
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLaor.html
+
+    """
 
     _calc =  _xspec.C_xslaor
 
@@ -2181,6 +2394,40 @@ class XSlaor(XSAdditiveModel):
 
 
 class XSlaor2(XSAdditiveModel):
+    """The XSPEC laor2 model: accretion disk with broken-power law emissivity profile, black hole emission line.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    lineE
+        The rest-frame line energy, in keV.
+    Index
+        The power law dependence of emissivity (scales as R^-Index).
+    RinG
+        The inner radius, in units of GM/c^2.
+    RoutG
+        The outer radius, in units of GM/c^2.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+    Rbreak
+        The radius at which the emissivity power-law index changes.
+    Index1
+        The emissivity power-law index for r>Rbreak.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSlaor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLaor2.html
+
+    """
 
     _calc =  _xspec.C_laor2
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1545,7 +1545,7 @@ class XScutoffpl(XSAdditiveModel):
 
     Attributes
     ----------
-    PhoIndx
+    PhoIndex
         The power law photon index.
     HighECut
         The e-folding energy of the exponential rolloff, in keV.
@@ -1919,7 +1919,7 @@ class XSequil(XSAdditiveModel):
 
     See Also
     --------
-    XSnei, XSgnei, XSvequil
+    XSnei, XSgnei, XSpshock, XSvequil
 
     References
     ----------
@@ -3170,7 +3170,7 @@ class XSpegpwrlw(XSAdditiveModel):
 
     Attributes
     ----------
-    PhoIndx
+    PhoIndex
         The power law photon index.
     eMin
         The lower peg for the normalization, in keV.
@@ -3331,6 +3331,44 @@ class XSpexriv(XSAdditiveModel):
 
 
 class XSplcabs(XSAdditiveModel):
+    """The XSPEC plcabs model: powerlaw observed through dense, cold matter.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The column density, in units of 10^22 cm^-2.
+    nMax
+        The maximum number of scatterings. This parameter can not be
+        thawed.
+    FeAbun
+        The iron abundance.
+    FeKedge
+        The energy of the Fe K edge, in keV.
+    PhoIndex
+        The power law photon index.
+    HighECut
+        The high-energy cut-off threshold energy, in keV.
+    foldE
+        The high-energy cut-off e-folding energy, in keV.
+    acrit
+        The critical albedo for switching to elastic scattering. See
+        [1]_ for more details.
+    FAST
+        If set to a value above 1, use a mean energy shift instead of
+        integration. This parameter can not be thawed.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPlcabs.html
+
+    """
 
     _calc =  _xspec.xsp1tr
 
@@ -3356,7 +3394,7 @@ class XSpowerlaw(XSAdditiveModel):
 
     Attributes
     ----------
-    PhoIndx
+    PhoIndex
         The power law photon index.
     norm
         The normalization of the model. See [1]_ for details, as its
@@ -3383,6 +3421,21 @@ class XSpowerlaw(XSAdditiveModel):
 
 
 class XSposm(XSAdditiveModel):
+    """The XSPEC posm model: positronium continuum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPosm.html
+
+    """
 
     _calc =  _xspec.xsposm
 
@@ -3392,6 +3445,39 @@ class XSposm(XSAdditiveModel):
 
 
 class XSpshock(XSAdditiveModel):
+    """The XSPEC pshock model: plane-parallel shocked plasma, constant temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    Tau_l
+        The lower limit on the ionization timescale, in s/cm^3.
+    Tau_u
+        The upper limit on the ionization timescale, in s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSvpshock, XSvvpshock
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPshock.html
+
+    """
 
     _calc =  _xspec.C_pshock
 
@@ -4260,6 +4346,41 @@ class XSvvnpshock(XSAdditiveModel):
 
 
 class XSvpshock(XSAdditiveModel):
+    """The XSPEC vpshock model: plane-parallel shocked plasma, constant temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element in solar units.
+    Tau_l
+        The lower limit on the ionization timescale, in s/cm^3.
+    Tau_u
+        The upper limit on the ionization timescale, in s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSpshock, XSvvpshock
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPshock.html
+
+    """
 
     _calc =  _xspec.C_vpshock
 
@@ -4286,6 +4407,42 @@ class XSvpshock(XSAdditiveModel):
 
 
 class XSvvpshock(XSAdditiveModel):
+    """The XSPEC vvpshock model: plane-parallel shocked plasma, constant temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element, with respect to Solar.
+    Tau_l
+        The lower limit on the ionization timescale, in s/cm^3.
+    Tau_u
+        The upper limit on the ionization timescale, in s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSpshock, XSvpshock
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPshock.html
+
+    """
 
     _calc =  _xspec.C_vvpshock
 
@@ -4539,7 +4696,7 @@ class XSzpowerlw(XSAdditiveModel):
 
     Attributes
     ----------
-    PhoIndx
+    PhoIndex
         The power law photon index.
     redshift
         The redshift.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1302,6 +1302,32 @@ class XScflow(XSAdditiveModel):
 
 
 class XScompbb(XSAdditiveModel):
+    """The XSPEC compbb model: Comptonization, black body.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The blackbody temperature, in keV.
+    kTe
+        The electron temperature of the hot plasma, in keV.
+    tau
+        The optical depth of the plasma.
+    norm
+        The model normalization: it is the same definition as
+        used for the ``XSbbodyrad`` model.
+
+    See Also
+    --------
+    XSbbodyrad
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCompbb.html
+
+    """
 
     _calc =  _xspec.compbb
 
@@ -1314,6 +1340,25 @@ class XScompbb(XSAdditiveModel):
 
 
 class XScompLS(XSAdditiveModel):
+    """The XSPEC compLS model: Comptonization, Lamb & Sanford.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The blackbody temperature, in keV.
+    tau
+        The optical depth of the plasma.
+    norm
+        The model normalization.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCompls.html
+
+    """
 
     _calc =  _xspec.compls
 
@@ -1324,7 +1369,73 @@ class XScompLS(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.tau, self.norm))
 
 
+# DOC-NOTE: The XSPEC documentation for a number of parameters suggest
+#           that they can be negative, but the model.dat limits suggest
+#           otherwise (e.g. ktbb and tau_y).
+#
 class XScompPS(XSAdditiveModel):
+    """The XSPEC compPS model: Comptonization, Poutanen & Svenson.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kTe
+        The electron temperature in keV.
+    EleIndex
+        The electron power-law index.
+    Gmin
+        The minimum Lorentz factor gamma.
+    GMax
+        The maximum Lorentz factor gamma: see [1]_ for more details.
+    kTbb
+        The temperature of the soft photons, in keV.
+    tauy
+        The vertical optical depth of the corona: see [1]_ for more
+        details.
+    geom
+        The geometry to use; see [1]_ for more details.
+    HRcyl
+        The value of H/R, when a cylinder geometry is used (|geom| = 2).
+    cosIncl
+        The cosine of the inclination angle.
+    cov_frac
+        The covering fraction of the cold clouds (only used when
+        |geom| < 4).
+    rel_refl
+        The amount of reflection (Omega / (2 pi))
+    Fe_ab_re
+        The iron abundance, in units of solar.
+    Me_ab
+        The abundance of heavy elements, in units of solar.
+    xi
+        The disk ionization parameter.
+    Tdisk
+        The disk temperature for reflection, in K.
+    Betor10
+        The reflection emissivity law: see [1]_ for more details.1
+    Rin
+        The inner radius of the disk in Schwarzschild units.
+    Rout
+        The outer radius of the disk in Schwarzschild units.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model.
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the COMPPS_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCompps.html
+
+    """
 
     _calc =  _xspec.C_xscompps
 
@@ -1353,6 +1464,25 @@ class XScompPS(XSAdditiveModel):
 
 
 class XScompST(XSAdditiveModel):
+    """The XSPEC compST model: Comptonization, Sunyaev & Titarchuk.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature, in keV.
+    tau
+        The optical depth of the plasma.
+    norm
+        The model normalization: see [1]_ for more details.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCompst.html
+
+    """
 
     _calc =  _xspec.compst
 
@@ -1363,7 +1493,37 @@ class XScompST(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.tau, self.norm))
 
 
+# DOC NOTE: the approx parameter is described in XSPEC as being allowed
+#           to be negative, but the limits do not permit this.
+#
 class XScompTT(XSAdditiveModel):
+    """The XSPEC compTT model: Comptonization, Titarchuk.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    redshift
+        The redshift of the source.
+    T0
+        The input soft photon (Wien) temperature in keV.
+    kT
+        The plasma temperature, in keV.
+    taup
+        The plasma optical depth.
+    approx
+        The geometry setting: a value less than or equal to 1 is a
+        disk, above 1 it is a sphere. See [1]_ for more details on
+        how this parameter affects the model. It must remain frozen.
+    norm
+        The normalization of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelComptt.html
+
+    """
 
     _calc =  _xspec.xstitg
 
@@ -4030,6 +4190,44 @@ class XSzagauss(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.Redshift, self.norm))
 
 class XScompmag(XSAdditiveModel):
+    """The XSPEC compmag model: Thermal and bulk Comptonization for cylindrical accretion onto the polar cap of a magnetized neutron star.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kTbb
+        The seed blackbody temperature, in keV.
+    kTe
+        The electron temperature of the accretion column, in keV.
+    tau
+        The vertical optical depth of the accretion column, with
+        electron cross-section equal to 10^-3 of the Thomson cross-section.
+    eta
+        The index of the velocity profile when the accretion velocity
+        increases towards the neutron star (valid when betaflag is 1).
+    beta0
+        The terminal velocity of the accreting matter at the neutron star
+        surface (valid when betaflag is 1).
+    r0
+        The radius of the accretion column in units of the neutron star
+        Schwarzschild radius.
+    A
+        The albedo at the surface of the neutron star.
+    betaflag
+        A flag for setting the velocity profile of the accretion
+        column, described at [1]_. It has values of 1 or 2 and can
+        not be thawed.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCompmag.html
+
+    """
 
     _calc =  _xspec.xscompmag
 
@@ -4046,6 +4244,39 @@ class XScompmag(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kTbb, self.kTe, self.tau, self.eta, self.beta0, self.r0, self.A, self.betaflag, self.norm))
 
 class XScomptb(XSAdditiveModel):
+    """The XSPEC comptb model: Thermal and bulk Comptonization of a seed blackbody-like spectrum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kTs
+        The temperature of the seed photons, in keV.
+    gamma
+        The index of the seed photon spectrum.
+    alpha
+        The energy index of the Comptonization spectrum.
+    delta
+        The bulk parameter, efficiency of bulk over thermal
+        Comptonization.
+    kTe
+        The temperature of the electrons, in keV.
+    log_A
+        The log of the illuminating factor parameter (A).
+    norm
+        The normalization of the seed photon spectrum: it is the
+        same definition as used for the ``XSbbody`` model.
+
+    See Also
+    --------
+    XSbbody
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelComptb.html
+
+    """
 
     _calc =  _xspec.xscomptb
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -551,7 +551,7 @@ class XSbbodyrad(XSAdditiveModel):
 # DOC-NOTE: the XSPEC documentation has a different parameter order to
 #           the code.
 class XSbexrav(XSAdditiveModel):
-    """The XSPEC bexrav model: reflected e-folded broken power law, neutral medium
+    """The XSPEC bexrav model: reflected e-folded broken power law, neutral medium.
 
     The model is described at [1]_.
 
@@ -622,7 +622,7 @@ class XSbexrav(XSAdditiveModel):
 
 
 class XSbexriv(XSAdditiveModel):
-    """The XSPEC bexriv model: reflected e-folded broken power law, ionized medium
+    """The XSPEC bexriv model: reflected e-folded broken power law, ionized medium.
 
     The model is described at [1]_.
 
@@ -3202,6 +3202,51 @@ class XSpegpwrlw(XSAdditiveModel):
 
 
 class XSpexrav(XSAdditiveModel):
+    """The XSPEC pexrav model: reflected powerlaw, neutral medium.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndex
+        The first power-law photon index.
+    foldE
+        The cut-off energy (E_c) in keV. Set to 0 for no cut off.
+    rel_refl
+        The reflection scaling parameter (a value between 0 and 1
+        for an isotropic source above the disk, less than 0 for no
+        reflected component).
+    redshift
+        The redshift of the source.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    cosIncl
+        The cosine of the inclination angle in degrees.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSpexriv, XSpexmon
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the PEXRAV_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPexrav.html
+
+    """
 
     _calc =  _xspec.C_xspexrav
 
@@ -3218,6 +3263,55 @@ class XSpexrav(XSAdditiveModel):
 
 
 class XSpexriv(XSAdditiveModel):
+    """The XSPEC pexrav model: reflected powerlaw, neutral medium.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndex
+        The first power-law photon index.
+    foldE
+        The cut-off energy (E_c) in keV. Set to 0 for no cut off.
+    rel_refl
+        The reflection scaling parameter (a value between 0 and 1
+        for an isotropic source above the disk, less than 0 for no
+        reflected component).
+    redshift
+        The redshift of the source.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    cosIncl
+        The cosine of the inclination angle in degrees.
+    T_disk
+        The disk temperature in K.
+    xi
+        The disk ionization parameter: see [1]_ for more details.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSpexrav, XSpexmon
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the PEXRIV_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPexriv.html
+
+    """
 
     _calc =  _xspec.C_xspexriv
 
@@ -5972,7 +6066,49 @@ class XSoptxagnf(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.Redshift, self.norm))
 
 
+# DOC-NOTE: the parameter order in the XSPEC documentation is very different
+#           to the model.dat file. Or, rel_refl is actually labelled as scale
+#           and foldE as Ec.
+#
 class XSpexmon(XSAdditiveModel):
+    """The XSPEC pexmon model: neutral Compton reflection with self-consistent Fe and Ni lines.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndex
+        The power-law photon index.
+    foldE
+        The cut-off energy (E_c) in keV. Set to 0 for no cut off.
+    rel_refl
+        The reflection scaling parameter (a value of 1 for an
+        isotropic source above the disk, less than 0 for no direct
+        component).
+    redshift
+        The redshift of the source.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    Incl
+        The inclination angle in degrees.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSpexrav, XSpexriv
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPexmon.html
+
+    """
 
     _calc = _xspec.pexmon
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3790,6 +3790,43 @@ class XSsedov(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.Abundanc, self.Tau, self.redshift, self.norm))
 
 class XSsirf(XSAdditiveModel):
+    """The XSPEC sirf model: self-irradiated funnel.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    tin
+        The inner temperature (at the inner, inside-the-funnel
+        photosphere), in keV.
+    rin
+        The inner (inner, inside-the-fulle photosphere) radius in
+        "spherisation radius" units (see [1]_ for details).
+    rout
+        The outer photosphere radius in "spherisation radius" units
+    theta
+        The half-opening angle of the cone, in degrees.
+    incl
+        The inclination angle of the funnel, in degrees. Affects mainly
+        self-occultation and relativistic boost effects.
+    valpha
+        The velocity law exponent.
+    gamma
+        The adiabatic index. It affects the inner, hotter parts of the
+        flow, therefore we set is to 4/3 by default.
+    mdot
+        The mass ejection rate in Eddington (critical) units.
+    irrad
+        The number of iterations for irradiation.
+    norm
+        The normalization of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSirf.html
+
+    """
 
     _calc =  _xspec.C_sirf
 
@@ -3809,6 +3846,30 @@ class XSsirf(XSAdditiveModel):
                                               self.irrad, self.norm))
 
 class XSsrcut(XSAdditiveModel):
+    """The XSPEC srcut model: synchrotron spectrum, cutoff power law.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    alpha
+        The radio spectral index.
+    breakfreq
+        The break frequency: approximately the frequency at which the
+        flux has dropped by a factor of 10 from a straight power law.
+    norm
+        The 1 Ghz flux in Jy.
+
+    See Also
+    --------
+    XSsresc
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSrcut.html
+
+    """
 
     _calc =  _xspec.srcut
 
@@ -3820,6 +3881,31 @@ class XSsrcut(XSAdditiveModel):
 
 
 class XSsresc(XSAdditiveModel):
+    """The XSPEC sresc model: synchrotron spectrum, cut off by particle escape.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    alpha
+        The radio spectral index.
+    breakfreq
+        The break frequency: approximately the frequency at which the
+        flux has dropped by a factor of 6 from a straight power law.
+        See [1]_ for more details.
+    norm
+        The 1 Ghz flux in Jy.
+
+    See Also
+    --------
+    XSsrcut
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSresc.html
+
+    """
 
     _calc =  _xspec.sresc
 
@@ -3831,6 +3917,29 @@ class XSsresc(XSAdditiveModel):
 
 
 class XSstep(XSAdditiveModel):
+    """The XSPEC step model: step function convolved with gaussian.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Energy
+        The start energy, in keV.
+    Sigma
+        The gaussian sigma, in keV.
+    norm
+        The step amplitude.
+
+    See Also
+    --------
+    XSgaussian
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelStep.html
+
+    """
 
     _calc =  _xspec.xsstep
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -4019,6 +4019,85 @@ class XScplinear(XSAdditiveModel):
 
 
 class XSeqpair(XSAdditiveModel):
+    """The XSPEC eqpair model: Paolo Coppi's hybrid (thermal/non-thermal) hot plasma emission models.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    l_hl_s
+        The ratio of the hard to soft compactness, l_h / l_s.
+    l_bb
+        The soft photon compactness.
+    kT_bb
+        The temperature of the blackbody if greater than 0.
+        When less than zero then the absolute value is used as
+        the T_max parameter of the ``XSdispkpn`` model. The units
+        are in eV.
+    l_ntl_h
+        The fraction of power supplied to energetic particles which
+        goes into accelerating non-thermal particles, l_nt / l_h.
+    tau_p
+        The Thomson scattering depth.
+    radius
+        The size of the scattering region in cm.
+    g_min
+        The minimum Lorentz factor of the pairs.
+    g_max
+        The maximum Lorentz factor of the pairs.
+    G_inj
+        If less than zero then the non-thermal spectrum is assumed
+        mono-energetic at g_max, otherwise a power law is used from
+        g_min to g_max.
+    pairinj
+        If zero then accelerated particles are electrons from thermal
+        pool. If one then accelerated particles are electrons and
+        positrons.
+    cosIncl
+        The cosine of the inclination angle of the reflecting material
+        to the line of sight.
+    Refl
+        The fraction of the scattering region's emission intercepted
+        by reflecting material.
+    Fe_abund
+        The iron abundance with respect to solar.
+    AbHe
+        The abundance of the other metals with respect to solar.
+    T_disk
+        The temperature of the reflecting disk, in K.
+    xi
+        The ionization parameter of the reflector.
+    Beta
+        The power-law index with radius of disk reflection
+        emissivity.
+    Rin
+        The inner radius of the reflecting material, in units of
+        GM/c^2.
+    Rout
+        The outer radius of the reflecting material, in units of
+        GM/c^2.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the mode: see [1]_ for more details.
+
+    See Also
+    --------
+    XScompth, XSeqtherm
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEqpair.html
+
+    """
 
     _calc = _xspec.C_xseqpair
 
@@ -4048,6 +4127,85 @@ class XSeqpair(XSAdditiveModel):
 
 
 class XSeqtherm(XSAdditiveModel):
+    """The XSPEC eqtherm model: Paolo Coppi's hybrid (thermal/non-thermal) hot plasma emission models.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    l_hl_s
+        The ratio of the hard to soft compactness, l_h / l_s.
+    l_bb
+        The soft photon compactness.
+    kT_bb
+        The temperature of the blackbody if greater than 0.
+        When less than zero then the absolute value is used as
+        the T_max parameter of the ``XSdispkpn`` model. The units
+        are in eV.
+    l_ntl_h
+        The fraction of power supplied to energetic particles which
+        goes into accelerating non-thermal particles, l_nt / l_h.
+    tau_p
+        The Thomson scattering depth.
+    radius
+        The size of the scattering region in cm.
+    g_min
+        The minimum Lorentz factor of the pairs.
+    g_max
+        The maximum Lorentz factor of the pairs.
+    G_inj
+        If less than zero then the non-thermal spectrum is assumed
+        mono-energetic at g_max, otherwise a power law is used from
+        g_min to g_max.
+    pairinj
+        If zero then accelerated particles are electrons from thermal
+        pool. If one then accelerated particles are electrons and
+        positrons.
+    cosIncl
+        The cosine of the inclination angle of the reflecting material
+        to the line of sight.
+    Refl
+        The fraction of the scattering region's emission intercepted
+        by reflecting material.
+    Fe_abund
+        The iron abundance with respect to solar.
+    AbHe
+        The abundance of the other metals with respect to solar.
+    T_disk
+        The temperature of the reflecting disk, in K.
+    xi
+        The ionization parameter of the reflector.
+    Beta
+        The power-law index with radius of disk reflection
+        emissivity.
+    Rin
+        The inner radius of the reflecting material, in units of
+        GM/c^2.
+    Rout
+        The outer radius of the reflecting material, in units of
+        GM/c^2.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the mode: see [1]_ for more details.
+
+    See Also
+    --------
+    XScompth, XSeqpair
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEqpair.html
+
+    """
 
     _calc = _xspec.C_xseqth
 
@@ -4077,6 +4235,85 @@ class XSeqtherm(XSAdditiveModel):
 
 
 class XScompth(XSAdditiveModel):
+    """The XSPEC compth model: Paolo Coppi's hybrid (thermal/non-thermal) hot plasma emission models.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    l_hl_s
+        The ratio of the hard to soft compactness, l_h / l_s.
+    l_bb
+        The soft photon compactness.
+    kT_bb
+        The temperature of the blackbody if greater than 0.
+        When less than zero then the absolute value is used as
+        the T_max parameter of the ``XSdispkpn`` model. The units
+        are in eV.
+    l_ntl_h
+        The fraction of power supplied to energetic particles which
+        goes into accelerating non-thermal particles, l_nt / l_h.
+    tau_p
+        The Thomson scattering depth.
+    radius
+        The size of the scattering region in cm.
+    g_min
+        The minimum Lorentz factor of the pairs.
+    g_max
+        The maximum Lorentz factor of the pairs.
+    G_inj
+        If less than zero then the non-thermal spectrum is assumed
+        mono-energetic at g_max, otherwise a power law is used from
+        g_min to g_max.
+    pairinj
+        If zero then accelerated particles are electrons from thermal
+        pool. If one then accelerated particles are electrons and
+        positrons.
+    cosIncl
+        The cosine of the inclination angle of the reflecting material
+        to the line of sight.
+    Refl
+        The fraction of the scattering region's emission intercepted
+        by reflecting material.
+    Fe_abund
+        The iron abundance with respect to solar.
+    AbHe
+        The abundance of the other metals with respect to solar.
+    T_disk
+        The temperature of the reflecting disk, in K.
+    xi
+        The ionization parameter of the reflector.
+    Beta
+        The power-law index with radius of disk reflection
+        emissivity.
+    Rin
+        The inner radius of the reflecting material, in units of
+        GM/c^2.
+    Rout
+        The outer radius of the reflecting material, in units of
+        GM/c^2.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the mode: see [1]_ for more details.
+
+    See Also
+    --------
+    XSeqpair, XSeqtherm
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEqpair.html
+
+    """
 
     _calc = _xspec.C_xscompth
 
@@ -4304,6 +4541,29 @@ class XSvgadem(XSAdditiveModel):
 
 
 class XSeplogpar(XSAdditiveModel):
+    """The XSPEC eplogpar model: log-parabolic blazar model with nu-Fnu normalization.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Ep
+        The peak energy, in keV, of the nu-Fnu curve.
+    beta
+        The curvature term.
+    norm
+        The flux in nu-Fnu units at the energy Ep.
+
+    See Also
+    --------
+    XSlogpar
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEplogpar.html
+
+    """
 
     _calc = _xspec.eplogpar
 
@@ -4315,6 +4575,31 @@ class XSeplogpar(XSAdditiveModel):
 
 
 class XSlogpar(XSAdditiveModel):
+    """The XSPEC logpar model: log-parabolic blazar model.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    alpha
+        The slope at the pivot energy.
+    beta
+        The curvature term.
+    pivotE
+        The pivot energy, in keV.
+    norm
+        The normalization of the mode: see [1]_ for more details.
+
+    See Also
+    --------
+    XSeplogpar
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLogpar.html
+
+    """
 
     _calc = _xspec.logpar
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2752,6 +2752,43 @@ class XSvvrnei(XSAdditiveModel):
 
 
 class XSnpshock(XSAdditiveModel):
+    """The XSPEC npshock model: shocked plasma, plane parallel, separate ion, electron temperatures.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT_a
+        The mean shock temperature, in keV.
+    kT_b
+        The electron temperature immediately behind the shock
+        front, in keV. See [1]_ for a discussion of the behavior
+        of kT_a and kT_b.
+    Abundanc
+        The metal abundance, as defined by the
+        ``set_xsabund`` function.
+    Tau_l
+        The lower limit on the ionization timescale in s/cm^3.
+    Tau_u
+        The upper limit on the ionization timescale in s/cm^3.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSvnpshock, XSvvnpshock
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNpshock.html
+
+    """
 
     _calc =  _xspec.C_npshock
 
@@ -3707,6 +3744,45 @@ class XSvvnei(XSAdditiveModel):
 
 
 class XSvnpshock(XSAdditiveModel):
+    """The XSPEC vnpshock model: shocked plasma, plane parallel, separate ion, electron temperatures.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT_a
+        The mean shock temperature, in keV.
+    kT_b
+        The electron temperature immediately behind the shock
+        front, in keV. See [1]_ for a discussion of the behavior
+        of kT_a and kT_b.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element, with respect to Solar.
+    Tau_l
+        The lower limit on the ionization timescale in s/cm^3.
+    Tau_u
+        The upper limit on the ionization timescale in s/cm^3.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSnpshock, XSvvnpshock
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNpshock.html
+
+    """
 
     _calc =  _xspec.C_vnpshock
 
@@ -3734,6 +3810,46 @@ class XSvnpshock(XSAdditiveModel):
 
 
 class XSvvnpshock(XSAdditiveModel):
+    """The XSPEC vvnpshock model: shocked plasma, plane parallel, separate ion, electron temperatures.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT_a
+        The mean shock temperature, in keV.
+    kT_b
+        The electron temperature immediately behind the shock
+        front, in keV. See [1]_ for a discussion of the behavior
+        of kT_a and kT_b.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element, with respect to Solar.
+    Tau_l
+        The lower limit on the ionization timescale in s/cm^3.
+    Tau_u
+        The upper limit on the ionization timescale in s/cm^3.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSnpshock, XSvnpshock
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNpshock.html
+
+    """
 
     _calc =  _xspec.C_vvnpshock
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3492,6 +3492,33 @@ class XSpshock(XSAdditiveModel):
 
 
 class XSraymond(XSAdditiveModel):
+    """The XSPEC raymond model: emission, hot diffuse gas, Raymond-Smith.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSvraymond
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRaymond.html
+
+    """
 
     _calc =  _xspec.xsrays
 
@@ -3504,6 +3531,25 @@ class XSraymond(XSAdditiveModel):
 
 
 class XSredge(XSAdditiveModel):
+    """The XSPEC redge model: emission, recombination edge.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    edge
+        The threshold energy, in keV.
+    kT
+        The plasma temperature, in keV.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRedge.html
+
+    """
 
     _calc =  _xspec.xredge
 
@@ -4486,6 +4532,32 @@ class XSvvpshock(XSAdditiveModel):
 
 
 class XSvraymond(XSAdditiveModel):
+    """The XSPEC vraymond model: emission, hot diffuse gas, Raymond-Smith.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSraymond
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRaymond.html
+
+    """
 
     _calc =  _xspec.xsvrys
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1050,6 +1050,29 @@ class XSezdiskbb(XSAdditiveModel):
 
 
 class XSgaussian(XSAdditiveModel):
+    """The XSPEC gaussian model: gaussian line profile.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line energy, in keV.
+    Sigma
+        The line width, in keV. A value of zero means a delta function.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSagauss, XSzagauss, XSzgauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGaussian.html
+
+    """
 
     _calc =  _xspec.xsgaul
 
@@ -2259,6 +2282,31 @@ class XSzbremss(XSAdditiveModel):
 
 
 class XSzgauss(XSAdditiveModel):
+    """The XSPEC gaussian model: gaussian line profile.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line energy, in keV.
+    Sigma
+        The line width, in keV. A value of zero means a delta function.
+    redshift
+        The redshift of the line.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSagauss, XSgaussian, XSzagauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGaussian.html
+
+    """
 
     _calc =  _xspec.C_xszgau
 
@@ -3316,6 +3364,29 @@ class XSpexmon(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.foldE, self.rel_refl, self.redshift, self.abund, self.Fe_abund, self.Incl, self.norm))
 
 class XSagauss(XSAdditiveModel):
+    """The XSPEC agauss model: gaussian line profile in wavelength space.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line wavelength, in Angstrom.
+    Sigma
+        The line width, in Angstrom. A value of zero means a delta function.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSgaussian, XSzagauss, XSzgauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelAgauss.html
+
+    """
 
     _calc =  _xspec.C_agauss
 
@@ -3326,6 +3397,31 @@ class XSagauss(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.norm))
 
 class XSzagauss(XSAdditiveModel):
+    """The XSPEC zagauss model: gaussian line profile in wavelength space.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line wavelength, in Angstrom.
+    Sigma
+        The line width, in Angstrom. A value of zero means a delta function.
+    Redshift
+        The redshift of the line.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSagauss, XSgaussian, XSzgauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelAgauss.html
+
+    """
 
     _calc =  _xspec.C_zagauss
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1897,6 +1897,35 @@ class XSdiskpn(XSAdditiveModel):
 
 
 class XSequil(XSAdditiveModel):
+    """The XSPEC equil model: collisional plasma, ionization equilibrium.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSnei, XSgnei, XSvequil
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEquil.html
+
+    """
 
     _calc =  _xspec.C_equil
 
@@ -1909,6 +1938,23 @@ class XSequil(XSAdditiveModel):
 
 
 class XSexpdec(XSAdditiveModel):
+    """The XSPEC expdec model: exponential decay.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    factor
+        The exponential factor.
+    norm
+        The normalization of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelExpdec.html
+
+    """
 
     _calc =  _xspec.xsxpdec
 
@@ -1919,6 +1965,23 @@ class XSexpdec(XSAdditiveModel):
 
 
 class XSezdiskbb(XSAdditiveModel):
+    """The XSPEC ezdiskbb model: multiple blackbody disk model with zero-torque inner boundary.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    T_max
+        The maximum temperature in the disk, in keV.
+    norm
+        The normalization of the model: see [1]_ for more details.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEzdiskbb.html
+
+    """
 
     _calc =  _xspec.ezdiskbb
 
@@ -1968,6 +2031,39 @@ class XSgaussian(XSAdditiveModel):
 
 
 class XSgnei(XSAdditiveModel):
+    """The XSPEC gnei model: collisional plasma, non-equilibrium, temperature evolution.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    Tau
+        The inoization timescale in units of s/cm^3.
+    kT_ave
+        The ionization timescale averaged plasma temperature in keV.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSnei, XSvgnei, XSvvgnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGnei.html
+
+    """
 
     _calc =  _xspec.C_gnei
 
@@ -2163,6 +2259,37 @@ class XSmkcflow(XSAdditiveModel):
 
 
 class XSnei(XSAdditiveModel):
+    """The XSPEC nei model: collisional plasma, non-equilibrium, constant temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    Tau
+        The inoization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSgnei, XSvnei, XSvvnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNei.html
+
+    """
 
     _calc =  _xspec.C_nei
 
@@ -2716,6 +2843,34 @@ class XSvbremss(XSAdditiveModel):
 
 
 class XSvequil(XSAdditiveModel):
+    """The XSPEC vequil model: collisional plasma, ionization equilibrium.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element in solar units.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEquil.html
+
+    """
 
     _calc =  _xspec.C_vequil
 
@@ -2739,6 +2894,41 @@ class XSvequil(XSAdditiveModel):
 
 
 class XSvgnei(XSAdditiveModel):
+    """The XSPEC gnei model: collisional plasma, non-equilibrium, temperature evolution.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element, with respect to Solar.
+    Tau
+        The inoization timescale in units of s/cm^3.
+    kT_ave
+        The ionization timescale averaged plasma temperature in keV.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSgnei, XSvnei, XSvvgnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGnei.html
+
+    """
 
     _calc =  _xspec.C_vgnei
 
@@ -2765,6 +2955,42 @@ class XSvgnei(XSAdditiveModel):
 
 
 class XSvvgnei(XSAdditiveModel):
+    """The XSPEC gnei model: collisional plasma, non-equilibrium, temperature evolution.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element, with respect to Solar.
+    Tau
+        The inoization timescale in units of s/cm^3.
+    kT_ave
+        The ionization timescale averaged plasma temperature in keV.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSgnei, XSvgnei, XSvvnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGnei.html
+
+    """
 
     _calc =  _xspec.C_vvgnei
 
@@ -2887,6 +3113,39 @@ class XSvmcflow(XSAdditiveModel):
 
 
 class XSvnei(XSAdditiveModel):
+    """The XSPEC vnei model: collisional plasma, non-equilibrium, constant temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element, with respect to Solar.
+    Tau
+        The inoization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSgnei, XSnei, XSvvnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNei.html
+
+    """
 
     _calc =  _xspec.C_vnei
 
@@ -2912,6 +3171,40 @@ class XSvnei(XSAdditiveModel):
 
 
 class XSvvnei(XSAdditiveModel):
+    """The XSPEC vvnei model: collisional plasma, non-equilibrium, constant temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element, with respect to Solar.
+    Tau
+        The inoization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSequil, XSgnei, XSnei, XSvnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNei.html
+
+    """
 
     _calc =  _xspec.C_vvnei
 
@@ -4498,6 +4791,46 @@ class XSzigm(XSMultiplicativeModel):
 
 
 class XSgadem(XSAdditiveModel):
+    """The XSPEC gadem model: plasma emission, multi-temperature with gaussian distribution of emission measure.
+
+    The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
+    functions change and return the current settings for the relative
+    abundances of the metals. See the ``XSapec`` documentation for settings
+    relevant to the APEC model (i.e. when ``switch=2``).
+
+    Attributes
+    ----------
+    Tmean
+        The mean temperature for the gaussian emission measure
+        distribution, in keV.
+    Tsigma
+        The sigma of the temperature distribution for the gaussian
+        emission measure, in keV.
+    nH
+        H density, in cm^-3.
+    abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    Redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XSapec, XSvgadem
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGadem.html
+
+    """
 
     _calc = _xspec.C_gaussDem
 
@@ -4513,6 +4846,45 @@ class XSgadem(XSAdditiveModel):
 
 
 class XSvgadem(XSAdditiveModel):
+    """The XSPEC gadem model: plasma emission, multi-temperature with gaussian distribution of emission measure.
+
+    The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
+    functions change and return the current settings for the relative
+    abundances of the metals. See the ``XSapec`` documentation for settings
+    relevant to the APEC model (i.e. when ``switch=2``).
+
+    Attributes
+    ----------
+    Tmean
+        The mean temperature for the gaussian emission measure
+        distribution, in keV.
+    Tsigma
+        The sigma of the temperature distribution for the gaussian
+        emission measure, in keV.
+    nH
+        H density, in cm^-3.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element in solar units.
+    Redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XSapec, XSgadem
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGadem.html
+
+    """
 
     _calc = _xspec.C_vgaussDem
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1396,12 +1396,13 @@ class XScompPS(XSAdditiveModel):
     geom
         The geometry to use; see [1]_ for more details.
     HRcyl
-        The value of H/R, when a cylinder geometry is used (|geom| = 2).
+        The value of H/R, when a cylinder geometry is used
+        (abs(geom) = 2).
     cosIncl
         The cosine of the inclination angle.
     cov_frac
         The covering fraction of the cold clouds (only used when
-        |geom| < 4).
+        abs(geom) < 4).
     rel_refl
         The amount of reflection (Omega / (2 pi))
     Fe_ab_re

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -5379,7 +5379,7 @@ class XSedge(XSMultiplicativeModel):
 
     See Also
     --------
-    XSzedge
+    XSsmedge, XSzedge
 
     References
     ----------
@@ -5571,6 +5571,25 @@ class XShrefl(XSMultiplicativeModel):
 
 
 class XSnotch(XSMultiplicativeModel):
+    """The XSPEC notch model: absorption line, notch.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line energy, in keV.
+    Width
+        The line width, in keV.
+    CvrFract
+        The covering fraction.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNotch.html
+
+    """
 
     _calc =  _xspec.xsntch
 
@@ -5586,6 +5605,27 @@ class XSnotch(XSMultiplicativeModel):
 
 
 class XSpcfabs(XSMultiplicativeModel):
+    """The XSPEC pcfabs model: partial covering fraction absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    CvrFract
+        The covering fraction.
+
+    See Also
+    --------
+    XSphabs, XSpwab, XSzpcfabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPcfabs.html
+
+    """
 
     _calc =  _xspec.xsabsp
 
@@ -5596,6 +5636,31 @@ class XSpcfabs(XSMultiplicativeModel):
 
 
 class XSphabs(XSMultiplicativeModel):
+    """The XSPEC phabs model: photoelectric absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+
+    See Also
+    --------
+    XSvphabs, XSzphabs, XSzvphabs
+
+    Notes
+    -----
+    The `set_xsxsect` function changes the cross sections used by this
+    model. The `set_xsabund` function changes the relative abundances of
+    the elements.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPhabs.html
+
+    """
 
     _calc = _xspec.xsphab
 
@@ -5605,6 +5670,23 @@ class XSphabs(XSMultiplicativeModel):
 
 
 class XSplabs(XSMultiplicativeModel):
+    """The XSPEC plabs model: power law absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    index
+        The power-law index.
+    coef
+        The normalization.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPlabs.html
+
+    """
 
     _calc =  _xspec.xsplab
 
@@ -5615,6 +5697,31 @@ class XSplabs(XSMultiplicativeModel):
 
 
 class XSpwab(XSMultiplicativeModel):
+    """The XSPEC pwab model: power-law distribution of neutral absorbers.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nHmin
+        The minimum equivalent hydrogen column (in units of
+        10^22 atoms/cm^2).
+    nHmax
+        The maximum equivalent hydrogen column (in units of
+        10^22 atoms/cm^2).
+    beta
+        The power law index for the covering fraction.
+
+    See Also
+    --------
+    XSpcfabs, XSwabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPwab.html
+
+    """
 
     _calc =  _xspec.C_xspwab
 
@@ -5626,6 +5733,21 @@ class XSpwab(XSMultiplicativeModel):
 
 
 class XSredden(XSMultiplicativeModel):
+    """The XSPEC redden model: interstellar extinction.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    EBV
+        The value of E(B-v) for the line of sight to the source.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRedden.html
+
+    """
 
     _calc =  _xspec.xscred
 
@@ -5635,6 +5757,31 @@ class XSredden(XSMultiplicativeModel):
 
 
 class XSsmedge(XSMultiplicativeModel):
+    """The XSPEC smedge model: smeared edge.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    edgeE
+        The threshold edge, in keV.
+    MaxTau
+        The maximum absorption factor at the threshold.
+    index
+        The index for photo-electric cross-section.
+    width
+        The smearing width, in keV.
+
+    See Also
+    --------
+    XSedge, XSzedge
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSmedge.html
+
+    """
 
     _calc =  _xspec.xssmdg
 
@@ -5647,6 +5794,23 @@ class XSsmedge(XSMultiplicativeModel):
 
 
 class XSspexpcut(XSMultiplicativeModel):
+    """The XSPEC spexpcut model: super-exponential cutoff absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Ecut
+        The e-folding energy for the absorption, in keV.
+    alpha
+        The exponent index: see [1]_ for more details.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSpexpcut.html
+
+    """
 
     _calc =  _xspec.C_superExpCutoff
 
@@ -5657,6 +5821,31 @@ class XSspexpcut(XSMultiplicativeModel):
 
 
 class XSspline(XSMultiplicativeModel):
+    """The XSPEC spline model: spline modification.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Estart
+        The start x value (energy), in keV.
+    YStart
+        The start y value.
+    Yend
+        The end y value.
+    YPstart
+        The start dy/dx value.
+    YPEnd
+        The end dy/dx value.
+    Eend
+        The end x value (energy), in keV.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSpline.html
+
+    """
 
     _calc =  _xspec.xsspln
 
@@ -5671,6 +5860,21 @@ class XSspline(XSMultiplicativeModel):
 
 
 class XSSSS_ice(XSMultiplicativeModel):
+    """The XSPEC sss_ice model: Einstein SSS ice absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    clumps
+        The ice thickness parameter.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSssice.html
+
+    """
 
     _calc =  _xspec.xssssi
 
@@ -5680,6 +5884,28 @@ class XSSSS_ice(XSMultiplicativeModel):
 
 
 class XSswind1(XSMultiplicativeModel):
+    """The XSPEC swind1 model: absorption by partially ionized material with large velocity shear.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    column
+        The column density, in units of 10^22 cm^2.
+    logxi
+        The log of xi: see [1]_ for more details.
+    sigma
+        The gaussian sigma for velocity smearing (v/c).
+    redshift
+        The redshift of the source.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSwind1.html
+
+    """
+
 
     _calc =  _xspec.swind1
 
@@ -5692,6 +5918,30 @@ class XSswind1(XSMultiplicativeModel):
 
 
 class XSTBabs(XSMultiplicativeModel):
+    """The XSPEC TBabs model: ISM grain absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+
+    See Also
+    --------
+    XSTBgrain, XSTBvarabs, XSzTBabs
+
+    Notes
+    -----
+    The `set_xsabund` function changes the relative abundances of
+    the elements, in particular the "wilm" setting.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelTbabs.html
+
+    """
 
     _calc =  _xspec.C_tbabs
 
@@ -5701,6 +5951,41 @@ class XSTBabs(XSMultiplicativeModel):
 
 
 class XSTBgrain(XSMultiplicativeModel):
+    """The XSPEC TBgrain model: ISM grain absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    h2
+        The equivalent molecular hydrogen column (in units of
+         10^22 atoms/cm^2).
+    rho
+        The grain density, in g/cm^3.
+    amin
+        The minimum grain size, in micro-meters.
+    amax
+        The maximum grain size, in micro-meters.
+    PL
+        The power-law index of grain sizes.
+
+    See Also
+    --------
+    XSTBabs, XSTBvarabs, XSzTBabs
+
+    Notes
+    -----
+    The `set_xsabund` function changes the relative abundances of
+    the elements, in particular the "wilm" setting.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelTbabs.html
+
+    """
 
     _calc =  _xspec.C_tbgrain
 
@@ -5715,6 +6000,48 @@ class XSTBgrain(XSMultiplicativeModel):
 
 
 class XSTBvarabs(XSMultiplicativeModel):
+    """The XSPEC TBvarabs model: ISM grain absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Cl, Ar, Ca, Cr, Fe, Co, Ni
+        The abundance of the element in solar units.
+    H2
+        The equivalent molecular hydrogen column (in units of
+         10^22 atoms/cm^2).
+    rho
+        The grain density, in g/cm^3.
+    amin
+        The minimum grain size, in micro-meters.
+    amax
+        The maximum grain size, in micro-meters.
+    PL
+        The power-law index of grain sizes.
+    H_dep, He_dep, C_dep, N_dep, O_dep, Ne_dep, Na_dep, Mg_dep, Al_dep,
+    Si_dep, S_dep, Cl_dep, Ar_dep, Ca_dep, Cr_dep, Fe_dep, Co_dep, Ni_dep
+        The grain depletion fraction of the element.
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSTBabs, XSTBgrain, XSzTBabs
+
+    Notes
+    -----
+    The `set_xsabund` function changes the relative abundances of
+    the elements, in particular the "wilm" setting.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelTbabs.html
+
+    """
 
     _calc =  _xspec.C_tbvabs
 
@@ -5765,6 +6092,21 @@ class XSTBvarabs(XSMultiplicativeModel):
 
 
 class XSuvred(XSMultiplicativeModel):
+    """The XSPEC uvred model: interstellar extinction, Seaton Law.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    EBV
+        The value of E(B-v) for the line of sight to the source.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelUvred.html
+
+    """
 
     _calc =  _xspec.xsred
 
@@ -5774,6 +6116,31 @@ class XSuvred(XSMultiplicativeModel):
 
 
 class XSvarabs(XSMultiplicativeModel):
+    """The XSPEC varabs model: photoelectric absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    H, He, C, N, O, Ne, Na, Mg, Al, Si, S, Cl, Ar, Ca, Cr, Fe, Co, Ni
+        See [1]_ for a description of the units.
+
+    See Also
+    --------
+    XSvphabs, XSzvarabs
+
+    Notes
+    -----
+    The `set_xsxsect` function changes the cross sections used by this
+    model. The `set_xsabund` function changes the relative abundances of
+    the elements.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVarabs.html
+
+    """
 
     _calc =  _xspec.xsabsv
 
@@ -5800,6 +6167,33 @@ class XSvarabs(XSMultiplicativeModel):
 
 
 class XSvphabs(XSMultiplicativeModel):
+    """The XSPEC vphabs model: photoelectric absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Cl, Ar, Ca, Cr, Fe, Co, Ni
+        The abundance of the element in solar units.
+
+    See Also
+    --------
+    XSphabs, XSvarabs, XSzphabs, XSzvphabs
+
+    Notes
+    -----
+    The `set_xsxsect` function changes the cross sections used by this
+    model. The `set_xsabund` function changes the relative abundances of
+    the elements.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPhabs.html
+
+    """
 
     _calc =  _xspec.xsvphb
 
@@ -5826,6 +6220,25 @@ class XSvphabs(XSMultiplicativeModel):
 
 
 class XSwabs(XSMultiplicativeModel):
+    """The XSPEC wabs model: photoelectric absorption, Wisconsin cross-sections.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+
+    See Also
+    --------
+    XSzwabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWabs.html
+
+    """
 
     _calc =  _xspec.xsabsw
 
@@ -5835,6 +6248,27 @@ class XSwabs(XSMultiplicativeModel):
 
 
 class XSwndabs(XSMultiplicativeModel):
+    """The XSPEC wndabs model: photo-electric absorption, warm absorber.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    WindowE
+        The window energy, in keV.
+
+    See Also
+    --------
+    XSzwndabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWndabs.html
+
+    """
 
     _calc =  _xspec.xswnab
 
@@ -5950,6 +6384,29 @@ class XSzhighect(XSMultiplicativeModel):
 
 
 class XSzpcfabs(XSMultiplicativeModel):
+    """The XSPEC zpcfabs model: partial covering fraction absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    CvrFract
+        The covering fraction.
+    redshift
+        The redshift.
+
+    See Also
+    --------
+    XSpcfabs, XSphabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPcfabs.html
+
+    """
 
     _calc =  _xspec.xszabp
 
@@ -5961,6 +6418,33 @@ class XSzpcfabs(XSMultiplicativeModel):
 
 
 class XSzphabs(XSMultiplicativeModel):
+    """The XSPEC zphabs model: photoelectric absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSphabs, XSvphabs, XSzvphabs
+
+    Notes
+    -----
+    The `set_xsxsect` function changes the cross sections used by this
+    model. The `set_xsabund` function changes the relative abundances of
+    the elements.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPhabs.html
+
+    """
 
     _calc = _xspec.xszphb
 
@@ -6005,6 +6489,32 @@ class XSzsmdust(XSMultiplicativeModel):
 
 
 class XSzTBabs(XSMultiplicativeModel):
+    """The XSPEC zTBabs model: ISM grain absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSTBabs, XSTBgrain, XSTBvarabs
+
+    Notes
+    -----
+    The `set_xsabund` function changes the relative abundances of
+    the elements, in particular the "wilm" setting.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelTbabs.html
+
+    """
 
     _calc =  _xspec.C_ztbabs
 
@@ -6015,6 +6525,33 @@ class XSzTBabs(XSMultiplicativeModel):
 
 
 class XSzvarabs(XSMultiplicativeModel):
+    """The XSPEC zvarabs model: photoelectric absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    H, He, C, N, O, Ne, Na, Mg, Al, Si, S, Cl, Ar, Ca, Cr, Fe, Co, Ni
+        See [1]_ for a description of the units.
+    redshift
+        The redshift of the absorber
+
+    See Also
+    --------
+    XSvarabs, XSzvphabs
+
+    Notes
+    -----
+    The `set_xsxsect` function changes the cross sections used by this
+    model. The `set_xsabund` function changes the relative abundances of
+    the elements.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVarabs.html
+
+    """
 
     _calc =  _xspec.xszvab
 
@@ -6055,6 +6592,35 @@ class XSzvfeabs(XSMultiplicativeModel):
 
 
 class XSzvphabs(XSMultiplicativeModel):
+    """The XSPEC vphabs model: photoelectric absorption.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Cl, Ar, Ca, Cr, Fe, Co, Ni
+        The abundance of the element in solar units.
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSphabs, XSvphabs, XSzphabs
+
+    Notes
+    -----
+    The `set_xsxsect` function changes the cross sections used by this
+    model. The `set_xsabund` function changes the relative abundances of
+    the elements.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPhabs.html
+
+    """
 
     _calc =  _xspec.xszvph
 
@@ -6082,6 +6648,27 @@ class XSzvphabs(XSMultiplicativeModel):
 
 
 class XSzwabs(XSMultiplicativeModel):
+    """The XSPEC zwabs model: photoelectric absorption, Wisconsin cross-sections.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSwabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWabs.html
+
+    """
 
     _calc =  _xspec.xszabs
 
@@ -6092,6 +6679,29 @@ class XSzwabs(XSMultiplicativeModel):
 
 
 class XSzwndabs(XSMultiplicativeModel):
+    """The XSPEC zwndabs model: photo-electric absorption, warm absorber.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The equivalent hydrogen column (in units of 10^22 atoms/cm^2).
+    WindowE
+        The window energy, in keV.
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSwndabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWndabs.html
+
+    """
 
     _calc =  _xspec.xszwnb
 
@@ -7208,7 +7818,7 @@ class XSheilin(XSMultiplicativeModel):
         The He I column density, in 10^22 atoms/cm^2.
     b
         The b value, in km/s.
-    redshidt
+    redshift
         The redshift of the absorber.
 
     See Also

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -393,7 +393,7 @@ class XSMultiplicativeModel(XSModel):
 
 
 class XSapec(XSAdditiveModel):
-    """The XSPEC apec model.
+    """The XSPEC apec model: APEC emission spectrum.
 
     The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
     functions change and return the current settings for the relative
@@ -414,11 +414,11 @@ class XSapec(XSAdditiveModel):
         The redshift of the plasma.
     norm
         The normalization of the model: see [1]_ for an explanation
-        for the units.
+        of the units.
 
     See Also
     --------
-    XSvapec, XSvvapec, XSbapec, XSbvapec, XSbvvapec
+    XSbapec, XSbvapec, XSbvvapec, XSvapec, XSvvapec
 
     References
     ----------
@@ -438,6 +438,40 @@ class XSapec(XSAdditiveModel):
 
 
 class XSbapec(XSAdditiveModel):
+    """The XSPEC bapec model: velocity broadened APEC thermal plasma model.
+
+    The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
+    functions change and return the current settings for the relative
+    abundances of the metals. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keywords "APECROOT" and "APEC_TRACE_ABUND".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function and the "APEC_TRACE_ABUND" xset
+        keyword.
+    Redshift
+        The redshift of the plasma.
+    Velocity
+        The gaussian sigma of the velocity broadening, in km/s.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSbvapec, XSbvvapec, XSvapec, XSvvapec
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBapec.html
+
+    """
 
     _calc =  _xspec.xsbape
 
@@ -578,6 +612,35 @@ class XSbremss(XSAdditiveModel):
 
 
 class XSbvapec(XSAdditiveModel):
+    """The XSPEC bvapec model: velocity broadened APEC thermal plasma model.
+
+    The model is described at [1]_, with ``XSbapec`` describing how
+    it is implemented in Sherpa.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    He, C, N, O, Ne, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element in solar units.
+    Redshift
+        The redshift of the plasma.
+    Velocity
+        The gaussian sigma of the velocity broadening, in km/s.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSbapec, XSbvvapec, XSvapec, XSvvapec
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBapec.html
+
+    """
 
     _calc =  _xspec.xsbvpe
 
@@ -1642,7 +1705,7 @@ class XSstep(XSAdditiveModel):
 
 
 class XSvapec(XSAdditiveModel):
-    """The XSPEC vapec model.
+    """The XSPEC vapec model: APEC emission spectrum.
 
     The model is described at [1]_, with ``XSapec`` describing how
     it is implemented in Sherpa.
@@ -1657,11 +1720,11 @@ class XSvapec(XSAdditiveModel):
         The redshift of the plasma.
     norm
         The normalization of the model: see [1]_ for an explanation
-        for the units.
+        of the units.
 
     See Also
     --------
-    XSapec, XSvvapec, XSbapec, XSbvapec, XSbvvapec
+    XSapec, XSbapec, XSbvapec, XSbvvapec, XSvvapec
 
     References
     ----------
@@ -2975,6 +3038,36 @@ class XScompth(XSAdditiveModel):
 
 
 class XSbvvapec(XSAdditiveModel):
+    """The XSPEC bvvapec model: velocity broadened APEC thermal plasma model.
+
+    The model is described at [1]_, with ``XSbapec`` describing how
+    it is implemented in Sherpa.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element in solar units.
+    Redshift
+        The redshift of the plasma.
+    Velocity
+        The gaussian sigma of the velocity broadening, in km/s.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSbapec, XSbvapec, XSvapec, XSvvapec
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBapec.html
+
+    """
 
     _calc = _xspec.xsbvvp
 
@@ -3017,7 +3110,7 @@ class XSbvvapec(XSAdditiveModel):
 
 
 class XSvvapec(XSAdditiveModel):
-    """The XSPEC vvapec model.
+    """The XSPEC vvapec model: APEC emission spectrum.
 
     The model is described at [1]_, with ``XSapec`` describing how
     it is implemented in Sherpa.
@@ -3033,11 +3126,11 @@ class XSvvapec(XSAdditiveModel):
         The redshift of the plasma.
     norm
         The normalization of the model: see [1]_ for an explanation
-        for the units.
+        of the units.
 
     See Also
     --------
-    XSapec, XSvapec, XSbapec, XSbvapec, XSbvvapec
+    XSapec, XSbapec, XSbvapec, XSbvvapec, XSvapec
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1280,7 +1280,7 @@ class XScflow(XSAdditiveModel):
 
     See Also
     --------
-    XScevmkl
+    XScevmkl, XSmkcflow
 
     References
     ----------
@@ -2007,7 +2007,7 @@ class XSgaussian(XSAdditiveModel):
 
     See Also
     --------
-    XSagauss, XSzagauss, XSzgauss
+    XSagauss, XSlorentz, XSzagauss, XSzgauss
 
     References
     ----------
@@ -2449,6 +2449,29 @@ class XSlaor2(XSAdditiveModel):
 
 
 class XSlorentz(XSAdditiveModel):
+    """The XSPEC lorentz model: lorentz line profile.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line energy, in keV.
+    Width
+        The FWHM of the line, in keV.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSgaussian
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLorentz.html
+
+    """
 
     _calc =  _xspec.xslorz
 
@@ -2465,6 +2488,35 @@ class XSlorentz(XSAdditiveModel):
 
 
 class XSmeka(XSAdditiveModel):
+    """The XSPEC meka model: emission, hot diffuse gas (Mewe-Gronenschild).
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    nH
+        H density, in cm^-3.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSvmeka
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelMeka.html
+
+    """
 
     _calc =  _xspec.xsmeka
 
@@ -2478,6 +2530,40 @@ class XSmeka(XSAdditiveModel):
 
 
 class XSmekal(XSAdditiveModel):
+    """The XSPEC mekal model: emission, hot diffuse gas (Mewe-Kaastra-Liedahl).
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    nH
+        H density, in cm^-3.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSvmekal
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelMekal.html
+
+    """
 
     _calc =  _xspec.xsmekl
 
@@ -2492,6 +2578,39 @@ class XSmekal(XSAdditiveModel):
 
 
 class XSmkcflow(XSAdditiveModel):
+    """The XSPEC mkcflow model: cooling flow, mekal.
+
+    The model is described at [1]_. The results of this model depend
+    on the cosmology settings set with ``set_xscosmo``.
+
+    Attributes
+    ----------
+    lowT
+        The minimum temperature, in keV.
+    highT
+        The maxmimum temperature, in keV.
+    Abundanc
+        The abundance relative to Solar, as set by ``set_xsabund``.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The mass accretion rate (solar mass per year).
+
+    See Also
+    --------
+    XSapec, XScflow, XScevmkl, XSvmcflow
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelMkcflow.html
+
+    """
 
     _calc =  _xspec.C_xsmkcf
 
@@ -3280,6 +3399,34 @@ class XSvvgnei(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.kT_ave, self.redshift, self.norm))
 
 class XSvmeka(XSAdditiveModel):
+    """The XSPEC vmeka model: emission, hot diffuse gas (Mewe-Gronenschild).
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    nH
+        H density, in cm^-3.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSmeka
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelMeka.html
+
+    """
 
     _calc =  _xspec.xsvmek
 
@@ -3306,6 +3453,39 @@ class XSvmeka(XSAdditiveModel):
 
 
 class XSvmekal(XSAdditiveModel):
+    """The XSPEC vmekal model: emission, hot diffuse gas (Mewe-Kaastra-Liedahl).
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    nH
+        H density, in cm^-3.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSvmekal
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelMekal.html
+
+    """
 
     _calc =  _xspec.xsvmkl
 
@@ -3333,6 +3513,39 @@ class XSvmekal(XSAdditiveModel):
 
 
 class XSvmcflow(XSAdditiveModel):
+    """The XSPEC vmcflow model: cooling flow, mekal.
+
+    The model is described at [1]_. The results of this model depend
+    on the cosmology settings set with ``set_xscosmo``.
+
+    Attributes
+    ----------
+    lowT
+        The minimum temperature, in keV.
+    highT
+        The maxmimum temperature, in keV.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The mass accretion rate (solar mass per year).
+
+    See Also
+    --------
+    XSapec, XScflow, XScevmkl, XSmkcflow
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelMkcflow.html
+
+    """
 
     _calc =  _xspec.C_xsvmcf
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -718,7 +718,7 @@ class XSbknpower(XSAdditiveModel):
 
     See Also
     --------
-    XSbkn2pow, XSpowerlaw, XSzpowerlw
+    XSbkn2pow, XScutoffpl, XSpowerlaw, XSzpowerlw
 
     References
     ----------
@@ -767,7 +767,7 @@ class XSbkn2pow(XSAdditiveModel):
 
     See Also
     --------
-    XSbknpower, XSpowerlaw, XSzpowerlw
+    XSbknpower, XScutoffpl, XSpowerlaw, XSzpowerlw
 
     References
     ----------
@@ -1413,7 +1413,7 @@ class XScompPS(XSAdditiveModel):
     Tdisk
         The disk temperature for reflection, in K.
     Betor10
-        The reflection emissivity law: see [1]_ for more details.1
+        The reflection emissivity law: see [1]_ for more details.
     Rin
         The inner radius of the disk in Schwarzschild units.
     Rout
@@ -1493,7 +1493,7 @@ class XScompST(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.tau, self.norm))
 
 
-# DOC NOTE: the approx parameter is described in XSPEC as being allowed
+# DOC-NOTE: the approx parameter is described in XSPEC as being allowed
 #           to be negative, but the limits do not permit this.
 #
 class XScompTT(XSAdditiveModel):
@@ -1538,6 +1538,31 @@ class XScompTT(XSAdditiveModel):
 
 
 class XScutoffpl(XSAdditiveModel):
+    """The XSPEC cutoffpl model: power law, high energy exponential cutoff.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndx
+        The power law photon index.
+    HighECut
+        The e-folding energy of the exponential rolloff, in keV.
+    norm
+        The normalization of the model. See [1]_ for details, as its
+        meaning depends on whether the "POW_EMIN" or "POW_EMAX"
+        keywords have been set with ``set_xsxset``.
+
+    See Also
+    --------
+    XSbknpower, XSbkn2pow, XSpowerlaw, XSzpowerlw
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCutoffpl.html
+
+    """
 
     _calc =  _xspec.C_cutoffPowerLaw
 
@@ -1549,6 +1574,32 @@ class XScutoffpl(XSAdditiveModel):
 
 
 class XSdisk(XSAdditiveModel):
+    """The XSPEC disk model: accretion disk, black body.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    accrate
+        The accretion rate, in Eddington luminosities.
+    NSmass
+        The central mass, in solar mass units.
+    Rinn
+        The inner disk radius in gravitational units (three
+        Schwarzschild radii).
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    See Also
+    --------
+    XSdiskbb, XSdiskm, XSdisko
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDisk.html
+
+    """
 
     _calc =  _xspec.disk
 
@@ -1561,6 +1612,49 @@ class XSdisk(XSAdditiveModel):
 
 
 class XSdiskir(XSAdditiveModel):
+    """The XSPEC diskir model: Irradiated inner and outer disk.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT_disk
+        The temperature of the innermost part of the unilluminated
+        disk, in keV.
+    Gamma
+        The asymptotic power-law photon index.
+    kT_e
+        The electron temperature (high-energy rollover) in keV.
+    LcLd
+        The ratio of the luminosity in the Compton tail to that of
+        the unilluminated disk.
+    fin
+        The fraction of luminosity in the Compton tail which is
+        thermalized in the inner disk. Generally fix at 0.1 as
+        appropriate for an albedo of 0.3 and solid angle of 0.3.
+    rirr
+        The radius of the Compton illuminated disk in terms of the
+        inner disk radius.
+    fout
+        The fraction of bolometric flux which is thermalized in the
+        outer disk.
+    logrout
+        The log (base 10) of the outer disk radius in terms of the
+        inner disk radius.
+    norm
+        The model normalization: it is the same definition as
+        used for the ``XSdiskbb`` model.
+
+    See Also
+    --------
+    XSdiskbb
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDiskir.html
+
+    """
 
     _calc =  _xspec.diskir
 
@@ -1578,6 +1672,27 @@ class XSdiskir(XSAdditiveModel):
 
 
 class XSdiskbb(XSAdditiveModel):
+    """The XSPEC disk model: accretion disk, multi-black body components.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Tin
+        The temperature at the inner disk radius, in keV.
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    See Also
+    --------
+    XSdiskpbb, XSdiskpn
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDiskbb.html
+
+    """
 
     _calc =  _xspec.xsdskb
 
@@ -1588,6 +1703,31 @@ class XSdiskbb(XSAdditiveModel):
 
 
 class XSdiskline(XSAdditiveModel):
+    """The XSPEC diskline model: accretion disk line emission, relativistic.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line energy in keV.
+    Betor10
+        The power law dependence of emissivity: see [1]_ for more details.
+    RinM
+        The inner radius, in units of GM^2/c.
+    RoutM
+        The outer radius, in units of GM^2/c.
+    Incl
+        The inclination, in degrees.
+    norm
+        The model normalization in photon/cm^2/s.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDiskline.html
+
+    """
 
     _calc =  _xspec.xsdili
 
@@ -1607,6 +1747,34 @@ class XSdiskline(XSAdditiveModel):
 
 
 class XSdiskm(XSAdditiveModel):
+    """The XSPEC diskm model: accretion disk with gas pressure viscosity.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    NSmass
+        The accretion rate, in Eddington luminosities.
+    NSmass
+        The central mass, in solar mass units.
+    Rinn
+        The inner disk radius in gravitational units (three
+        Schwarzschild radii).
+    alpha
+        The viscosity.
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    See Also
+    --------
+    XSdisk, XSdisko
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDiskm.html
+
+    """
 
     _calc =  _xspec.diskm
 
@@ -1620,6 +1788,34 @@ class XSdiskm(XSAdditiveModel):
 
 
 class XSdisko(XSAdditiveModel):
+    """The XSPEC disko model: accretion disk, inner, radiation pressure viscosity.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    NSmass
+        The accretion rate, in Eddington luminosities.
+    NSmass
+        The central mass, in solar mass units.
+    Rinn
+        The inner disk radius in gravitational units (three
+        Schwarzschild radii).
+    alpha
+        The viscosity.
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    See Also
+    --------
+    XSdisk, XSdiskm
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDisko.html
+
+    """
 
     _calc =  _xspec.disko
 
@@ -1633,6 +1829,29 @@ class XSdisko(XSAdditiveModel):
 
 
 class XSdiskpbb(XSAdditiveModel):
+    """The XSPEC diskpbb model: accretion disk, power-law dependence for T(r).
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Tin
+        The temperature at the inner disk radius, in keV.
+    p
+        The exponent of the radial dependence of the disk temperature.
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    See Also
+    --------
+    XSdiskbb, XSdiskpn
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDiskpbb.html
+
+    """
 
     _calc =  _xspec.diskpbb
 
@@ -1644,6 +1863,29 @@ class XSdiskpbb(XSAdditiveModel):
 
 
 class XSdiskpn(XSAdditiveModel):
+    """The XSPEC diskpn model: accretion disk, black hole, black body.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    T_max
+        The maximum temperature in the disk, in keV.
+    R_in
+        The inner disk radius, in units of Rg (GM/c^2).
+    norm
+        The normalization of the model: see [1]_ for details.
+
+    See Also
+    --------
+    XSdiskbb, XSdiskpbb
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDiskpn.html
+
+    """
 
     _calc =  _xspec.xsdiskpn
 
@@ -2227,7 +2469,7 @@ class XSpowerlaw(XSAdditiveModel):
 
     See Also
     --------
-    XSbknpower, XSbkn2pow, XSzpowerlw
+    XSbknpower, XSbkn2pow, XScutoffpl, XSzpowerlw
 
     References
     ----------
@@ -3073,7 +3315,7 @@ class XSzpowerlw(XSAdditiveModel):
 
     See Also
     --------
-    XSbknpower, XSbkn2pow, XSpowerlaw
+    XSbknpower, XSbkn2pow, XScutoffpl, XSpowerlaw
 
     References
     ----------
@@ -3727,6 +3969,27 @@ class XSzwndabs(XSMultiplicativeModel):
 
 
 class XScplinear(XSAdditiveModel):
+    """The XSPEC cplinear model: a non-physical piecewise-linear model for low count background spectra.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    energy00, energy01, energy02, energy03, energy04, energy05,
+    energy06, energy07, energy08, energy09
+        Energy in keV.
+    log_rate01, log_rate02, log_rate03, log_rate04, log_rate05,
+    log_rate06, log_rate07, log_rate08, log_rate09
+        Log of the rate.
+    norm
+        The normalization of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCplinear.html
+
+    """
 
     _calc = _xspec.C_cplinear
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -795,6 +795,28 @@ class XSbkn2pow(XSAdditiveModel):
 
 
 class XSbmc(XSAdditiveModel):
+    """The XSPEC bmc model: Comptonization by relativistic matter.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the thermal photon source in keV.
+    alpha
+        The energy spectral index.
+    logA
+        The log of the A parameter: see [1]_ for more details.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBmc.html
+
+    """
 
     _calc =  _xspec.xsbmc
 
@@ -807,6 +829,28 @@ class XSbmc(XSAdditiveModel):
 
 
 class XSbremss(XSAdditiveModel):
+    """The XSPEC bremss model: thermal bremsstrahlung.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The plasma temperature in keV.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSvbremss, XSzbremss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBremss.html
+
+    """
 
     _calc =  _xspec.xsbrms
 
@@ -871,6 +915,38 @@ class XSbvapec(XSAdditiveModel):
 
 
 class XSc6mekl(XSAdditiveModel):
+    """The XSPEC c6mekl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
+        Chebyshev polynomial coefficients.
+    nH
+        H density, in cm^-3.
+    abundanc
+        The abundance relative to Solar, as set by ``set_xsabund``.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XSc6pmekl, XSc6pvmkl, XSc6vmekl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelC6mekl.html
+
+    """
 
     _calc =  _xspec.c6mekl
 
@@ -890,6 +966,39 @@ class XSc6mekl(XSAdditiveModel):
 
 
 class XSc6pmekl(XSAdditiveModel):
+    """The XSPEC c6pmekl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
+
+    The model is described at [1]_. It differs from ``XSc6mekl`` by
+    by using the exponential of the 6th order Chebyshev polynomial.
+
+    Attributes
+    ----------
+    CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
+        Chebyshev polynomial coefficients.
+    nH
+        H density, in cm^-3.
+    abundanc
+        The abundance relative to Solar, as set by ``set_xsabund``.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XSc6mekl, XSc6pvmkl, XSc6vmekl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelC6mekl.html
+
+    """
 
     _calc =  _xspec.c6pmekl
 
@@ -909,6 +1018,39 @@ class XSc6pmekl(XSAdditiveModel):
 
 
 class XSc6pvmkl(XSAdditiveModel):
+    """The XSPEC c6pvmkl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
+
+    The model is described at [1]_. It differs from ``XSc6vmekl`` by
+    by using the exponential of the 6th order Chebyshev polynomial.
+
+    Attributes
+    ----------
+    CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
+        Chebyshev polynomial coefficients.
+    nH
+        H density, in cm^-3.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XSc6mekl, XSc6pmekl, XSc6vmekl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelC6mekl.html
+
+    """
 
     _calc =  _xspec.c6pvmkl
 
@@ -941,6 +1083,38 @@ class XSc6pvmkl(XSAdditiveModel):
 
 
 class XSc6vmekl(XSAdditiveModel):
+    """The XSPEC c6vmekl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
+        Chebyshev polynomial coefficients.
+    nH
+        H density, in cm^-3.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XSc6mekl, XSc6pmekl, XSc6pvmkl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelC6mekl.html
+
+    """
 
     _calc =  _xspec.c6vmekl
 
@@ -973,6 +1147,40 @@ class XSc6vmekl(XSAdditiveModel):
 
 
 class XScemekl(XSAdditiveModel):
+    """The XSPEC cemekl model: plasma emission, multi-temperature using mekal.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    alpha
+        The power-law index of the emissivity function.
+    Tmax
+        The maxmimum temperature, in keV.
+    nH
+        H density, in cm^-3.
+    abundanc
+        The abundance relative to Solar, as set by ``set_xsabund``.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XScevmkl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCemekl.html
+
+    """
 
     _calc =  _xspec.cemekl
 
@@ -988,6 +1196,40 @@ class XScemekl(XSAdditiveModel):
 
 
 class XScevmkl(XSAdditiveModel):
+    """The XSPEC cevmkl model: plasma emission, multi-temperature using mekal.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    alpha
+        The power-law index of the emissivity function.
+    Tmax
+        The maxmimum temperature, in keV.
+    nH
+        H density, in cm^-3.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance relative to Solar.
+    redshift
+        The redshift of the plasma.
+    switch
+        If 0, the mekal code is run to evaluate the model; if 1
+        then interpolation of the mekal data is used; if 2 then
+        interpolation of APEC data is used. See [1]_ for more details.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model.
+
+    See Also
+    --------
+    XScemekl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCemekl.html
+
+    """
 
     _calc =  _xspec.C_cemVMekal
 
@@ -1016,6 +1258,36 @@ class XScevmkl(XSAdditiveModel):
 
 
 class XScflow(XSAdditiveModel):
+    """The XSPEC cflow model: cooling flow.
+
+    The model is described at [1]_. The results of this model depend
+    on the cosmology settings set with ``set_xscosmo``.
+
+    Attributes
+    ----------
+    slope
+        The power-law index of the emissivity function.
+    lowT
+        The minimum temperature, in keV.
+    highT
+        The maxmimum temperature, in keV.
+    Abundanc
+        The abundance relative to Solar, as set by ``set_xsabund``.
+    redshift
+        The redshift of the plasma.
+    norm
+        The mass accretion rate (solar mass per year).
+
+    See Also
+    --------
+    XScevmkl
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCflow.html
+
+    """
 
     _calc =  _xspec.C_xscflw
 
@@ -2007,6 +2279,30 @@ class XSvapec(XSAdditiveModel):
 
 
 class XSvbremss(XSAdditiveModel):
+    """The XSPEC vbremss model: thermal bremsstrahlung.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The plasma temperature in keV.
+    HeH
+        The ratio n(He) / n(H).
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbremss, XSzbremss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBremss.html
+
+    """
 
     _calc =  _xspec.xsbrmv
 
@@ -2523,6 +2819,30 @@ class XSzbbody(XSAdditiveModel):
 
 
 class XSzbremss(XSAdditiveModel):
+    """The XSPEC zbremss model: thermal bremsstrahlung.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The plasma temperature in keV.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbremss, XSvbremss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBremss.html
+
+    """
 
     _calc =  _xspec.xszbrm
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -485,6 +485,28 @@ class XSbapec(XSAdditiveModel):
 
 
 class XSbbody(XSAdditiveModel):
+    """The XSPEC bbody model: blackbody spectrum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the object, in keV.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbbodyrad, XSzbbody
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBbody.html
+
+    """
 
     _calc =  _xspec.xsblbd
 
@@ -495,6 +517,28 @@ class XSbbody(XSAdditiveModel):
 
 
 class XSbbodyrad(XSAdditiveModel):
+    """The XSPEC bbodyrad model: blackbody spectrum, area normalized.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the object, in keV.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbbody, XSzbbody
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBbodyrad.html
+
+    """
 
     _calc =  _xspec.xsbbrd
 
@@ -2260,6 +2304,30 @@ class XSvvsedov(XSAdditiveModel):
 
 
 class XSzbbody(XSAdditiveModel):
+    """The XSPEC zbbody model: blackbody spectrum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    kT
+        The temperature of the object, in keV.
+    redshift
+        The redshift of the object.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSbbody, XSbbodyrad
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBbody.html
+
+    """
 
     _calc =  _xspec.xszbod
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3043,6 +3043,62 @@ class XSnsx(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
 
 class XSnteea(XSAdditiveModel):
+    """The XSPEC nteea model: non-thermal pair plasma.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    l_nth
+        The nonthermal electron compactness.
+    l_bb
+        The blackbody compactness.
+    f_refl
+        The scaling factor for reflection. This is 1 for an isotropic
+        source above the disk.
+    kT_bb
+        The blackbody temperature in eV.
+    g_max
+        The maximum Lorentz factor.
+    l_th
+        The thermal compactness. Set to 0 for a pure nonthermal plasma.
+    tau_p
+        The Thomson optical depth of ionization electrons.
+    G_inj
+        The electron injection index (0 for monoenergetic injection).
+    g_min
+        The minimum Lorentz factor of the power law injection (not used
+        for monoenergetic injection).
+    g_0
+        The minimum Lorentz factor for nonthermal reprocessing, in the
+        range (1, g_min].
+    radius
+        The radius in cm (for Coulomb/bremsstrahlung only).
+    pair_esc
+        The pair escape rate in c.
+    cosIncl
+        The cosine of the inclination angle.
+    Fe_abund
+        The iron abundance relative to that set by the ``set_xsabund``
+        function.
+    redshift
+        The redshift of the source.
+    norm
+        The normalization of the model: see [1]_ for more details.
+
+    Notes
+    -----
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the NTEEA_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNteea.html
+
+    """
 
     _calc =  _xspec.C_xsnteea
 
@@ -3067,6 +3123,32 @@ class XSnteea(XSAdditiveModel):
 
 
 class XSnthComp(XSAdditiveModel):
+    """The XSPEC nthComp model: Thermally comptonized continuum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Gamma
+        The asymptotic power-law photon index.
+    kT_e
+        The electron temperature (high-energy rollover) in keV.
+    kT_bb
+        The seed photon temperature (low-energy rollover) in keV.
+    inp_type
+        The seed photon source: when 0 use a blackbody, when 1 use
+        a disk-blackbody.
+    redshift
+        The redshift.
+    norm
+        The normalization of the model: see [1]_ for more details.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNthcomp.html
+
+    """
 
     _calc =  _xspec.C_nthcomp
 
@@ -3081,6 +3163,33 @@ class XSnthComp(XSAdditiveModel):
 
 
 class XSpegpwrlw(XSAdditiveModel):
+    """The XSPEC pegpwrlw model: power law, pegged normalization.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndx
+        The power law photon index.
+    eMin
+        The lower peg for the normalization, in keV.
+    eMax
+        The upper peg for the normalization, in keV.
+    norm
+        The flux, in units of 10^-12 erg/cm^2/s, over the range
+        eMin to eMax. If eMin=eMax then it is the flux in
+        micro-Jy at eMin.
+
+    See Also
+    --------
+    XSbknpower, XSbkn2pow, XScutoffpl, XSpowerlaw, XSzpowerlw
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPegpwrlw.html
+
+    """
 
     _calc =  _xspec.xspegp
 
@@ -3161,7 +3270,7 @@ class XSpowerlaw(XSAdditiveModel):
 
     See Also
     --------
-    XSbknpower, XSbkn2pow, XScutoffpl, XSzpowerlw
+    XSbknpower, XSbkn2pow, XScutoffpl, XSpegpwrlw, XSzpowerlw
 
     References
     ----------
@@ -5110,7 +5219,7 @@ class XSeqpair(XSAdditiveModel):
     redshift
         The redshift of the source.
     norm
-        The normalization of the mode: see [1]_ for more details.
+        The normalization of the model: see [1]_ for more details.
 
     See Also
     --------
@@ -5218,7 +5327,7 @@ class XSeqtherm(XSAdditiveModel):
     redshift
         The redshift of the source.
     norm
-        The normalization of the mode: see [1]_ for more details.
+        The normalization of the model: see [1]_ for more details.
 
     See Also
     --------
@@ -5326,7 +5435,7 @@ class XScompth(XSAdditiveModel):
     redshift
         The redshift of the source.
     norm
-        The normalization of the mode: see [1]_ for more details.
+        The normalization of the model: see [1]_ for more details.
 
     See Also
     --------
@@ -5698,7 +5807,7 @@ class XSlogpar(XSAdditiveModel):
     pivotE
         The pivot energy, in keV.
     norm
-        The normalization of the mode: see [1]_ for more details.
+        The normalization of the model: see [1]_ for more details.
 
     See Also
     --------
@@ -5722,6 +5831,59 @@ class XSlogpar(XSAdditiveModel):
 
 
 class XSoptxagn(XSAdditiveModel):
+    """The XSPEC optxagn model: Colour temperature corrected disc and energetically coupled Comptonisation model for AGN.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    mass
+        The black hole mass in solar masses.
+    dist
+        The comoving (proper) distance in Mpc.
+    logLLEdd
+        The Eddington ratio.
+    astar
+        The dimensionless black hole spin.
+    rcor
+        The coronal radius in Rg=GM/c^2. See [1]_ for more details.
+    logrout
+        The log of the outer radius of the disk in units of Rg. See
+        [1]_ for more details.
+    kT_e
+        The electron temperature for the soft Comptonisation component
+        (soft excess), in keV.
+    tau
+        The optical depth of the soft Comptonisation component. If this
+        parameter is negative then only the soft Compton component is used.
+    Gamma
+        The spectral index of the hard Comptonisation component
+        ('power law') which has temperature fixed to 100 keV.
+    fpl
+        The fraction of the power below rcor which is emitted in the hard
+        comptonisation component. If this parameter is negative then only
+        the hard Compton component is used.
+    fcol
+        The colour temperature correction to apply to the disc blackbody
+        emission for radii below rcor with effective temperature > tscat.
+    tscat
+        The effective temperature limit, in K, used in the colour
+        temperature correction.
+    Redshift
+        The redshift.
+    norm
+        The normalization of the model. It must be frozen.
+
+    See Also
+    --------
+    XSOptxagnf
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelOptxagn.html
+
+    """
 
     _calc = _xspec.optxagn
 
@@ -5744,6 +5906,53 @@ class XSoptxagn(XSAdditiveModel):
 
 
 class XSoptxagnf(XSAdditiveModel):
+    """The XSPEC optxagn model: Colour temperature corrected disc and energetically coupled Comptonisation model for AGN.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    mass
+        The black hole mass in solar masses.
+    dist
+        The comoving (proper) distance in Mpc.
+    logLLEdd
+        The Eddington ratio.
+    astar
+        The dimensionless black hole spin.
+    rcor
+        The coronal radius in Rg=GM/c^2. See [1]_ for more details.
+    logrout
+        The log of the outer radius of the disk in units of Rg. See
+        [1]_ for more details.
+    kT_e
+        The electron temperature for the soft Comptonisation component
+        (soft excess), in keV.
+    tau
+        The optical depth of the soft Comptonisation component. If this
+        parameter is negative then only the soft Compton component is used.
+    Gamma
+        The spectral index of the hard Comptonisation component
+        ('power law') which has temperature fixed to 100 keV.
+    fpl
+        The fraction of the power below rcor which is emitted in the hard
+        comptonisation component. If this parameter is negative then only
+        the hard Compton component is used.
+    Redshift
+        The redshift.
+    norm
+        The normalization of the model. It must be frozen.
+
+    See Also
+    --------
+    XSOptxagn
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelOptxagn.html
+
+    """
 
     _calc = _xspec.optxagnf
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -5171,6 +5171,32 @@ class XSzpowerlw(XSAdditiveModel):
 
 
 class XSabsori(XSMultiplicativeModel):
+    """The XSPEC absori model: ionized absorber.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndex
+        The power-law photon index.
+    nH
+        The Hydrogen column, in units of 10^22 cm^-2.
+    Temp_abs
+        The absorber temperature, in K.
+    xi
+        The absorber ionization state. See [1]_ for more details.
+    redshift
+        The redshift of the absorber.
+    Fe_abund
+        The iron abundance with respect to solar, as set by the
+        ``set_xsabund`` function.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelAbsori.html
+
+    """
 
     _calc =  _xspec.C_xsabsori
 
@@ -5185,6 +5211,34 @@ class XSabsori(XSMultiplicativeModel):
 
 
 class XSacisabs(XSMultiplicativeModel):
+    """The XSPEC acisabs model: Chandra ACIS q.e. decay.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Tdays
+        Days between Chandra launch and ACIS observation.
+    norm
+    tauinf
+        Slope of linear quantum efficiency decay.
+    tefold
+        Offset of linear quantum efficiency decay.
+    nC
+        Number of carbon atoms in hydrocarbon.
+    nH
+        Number of hydrogen atoms in hydrocarbon.
+    nO
+        Number of oxygen atoms in hydrocarbon.
+    nN
+        Number of nitrogen atoms in hydrocarbon.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelAcisabs.html
+
+    """
 
     _calc =  _xspec.acisabs
 
@@ -5201,6 +5255,21 @@ class XSacisabs(XSMultiplicativeModel):
 
 
 class XSconstant(XSMultiplicativeModel):
+    """The XSPEC constant model: energy-independent factor.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    factor
+        The value of the model.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelConstant.html
+
+    """
 
     _calc =  _xspec.xscnst
 
@@ -5210,6 +5279,21 @@ class XSconstant(XSMultiplicativeModel):
 
 
 class XScabs(XSMultiplicativeModel):
+    """The XSPEC cabs model: Optically-thin Compton scattering.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nH
+        The Hydrogen column, in units of 10^22 cm^-2.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCabs.html
+
+    """
 
     _calc =  _xspec.xscabs
 
@@ -5219,6 +5303,29 @@ class XScabs(XSMultiplicativeModel):
 
 
 class XScyclabs(XSMultiplicativeModel):
+    """The XSPEC cyclabs model: absorption line, cyclotron.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Depth0
+        The depth of the fundamental.
+    E0
+        The cyclotron energy, in keV.
+    Width0
+        The width of the fundamental, in keV.
+    Depth2
+        The depth of the second harmonic.
+    Width2
+        The width of the second harmonic, in keV.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCyclabs.html
+
+    """
 
     _calc =  _xspec.xscycl
 
@@ -5232,6 +5339,23 @@ class XScyclabs(XSMultiplicativeModel):
 
 
 class XSdust(XSMultiplicativeModel):
+    """The XSPEC dust model: dust scattering.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Frac
+        The scattering fraction at 1 keV.
+    Halosz
+        The size of the halo at 1 keV in units of the detector beamsize.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelDust.html
+
+    """
 
     _calc =  _xspec.xsdust
 
@@ -5242,6 +5366,27 @@ class XSdust(XSMultiplicativeModel):
 
 
 class XSedge(XSMultiplicativeModel):
+    """The XSPEC edge model: absorption edge.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    edgeE
+        The threshold edge, in keV.
+    MaxTau
+        The absorption depth at the threshold.
+
+    See Also
+    --------
+    XSzedge
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEdge.html
+
+    """
 
     _calc =  _xspec.xsedge
 
@@ -5252,6 +5397,21 @@ class XSedge(XSMultiplicativeModel):
 
 
 class XSexpabs(XSMultiplicativeModel):
+    """The XSPEC expabs model: exponential roll-off at low E.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LowECut
+        The e-folding energy for the absorption, in keV.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelExpabs.html
+
+    """
 
     _calc =  _xspec.xsabsc
 
@@ -5261,6 +5421,25 @@ class XSexpabs(XSMultiplicativeModel):
 
 
 class XSexpfac(XSMultiplicativeModel):
+    """The XSPEC expfac model: exponential modification.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Ampl
+        The amplitude of the effect.
+    Factor
+        The exponential factor.
+    StartE
+        The start energy of the modification, in keV.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelExpfac.html
+
+    """
 
     _calc =  _xspec.xsexp
 
@@ -5272,6 +5451,26 @@ class XSexpfac(XSMultiplicativeModel):
 
 
 class XSgabs(XSMultiplicativeModel):
+    """The XSPEC gabs model: gaussian absorption line.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LineE
+        The line energy, in keV.
+    Sigma
+        The line width (sigma), in keV.
+    Tau
+        The line depth. The optical depth at the line center is
+        Tau / (sqrt(2 pi) * Sigma).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGabs.html
+
+    """
 
     _calc =  _xspec.C_gaussianAbsorptionLine
 
@@ -5287,6 +5486,27 @@ class XSgabs(XSMultiplicativeModel):
 
 
 class XShighecut(XSMultiplicativeModel):
+    """The XSPEC highecut model: high-energy cutoff.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    cutoffE
+        The cut-off energy, in keV.
+    foldE
+        The e-folding energy, in keV.
+
+    See Also
+    --------
+    XSzhighect
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelHighecut.html
+
+    """
 
     _calc =  _xspec.xshecu
 
@@ -5301,6 +5521,40 @@ class XShighecut(XSMultiplicativeModel):
 
 
 class XShrefl(XSMultiplicativeModel):
+    """The XSPEC hrefl model: reflection model.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    thetamin
+        The minimum angle, in degrees, between source photons incident
+        on the slab and the slab normal.
+    thetamax
+        The maximum angle, in degrees, between source photons incident
+        on the slab and the slab normal.
+    thetamobs
+        The angle, in degrees, between the observer's line of sight and
+        the slab normal.
+    Feabun
+        The iron abundance relative to solar.
+    FeKedge
+        The iron K edge energy, in keV.
+    Escfrac
+        The fraction of the direct flux seen by the observer: see [1]_
+        for more details.
+    covfac
+        The normalization of the reflected continuum: see [1]_ for more
+        details.
+    redshift
+        The redshift.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelHrefl.html
+
+    """
 
     _calc =  _xspec.xshrfl
 
@@ -5624,6 +5878,29 @@ class XSzdust(XSMultiplicativeModel):
 
 
 class XSzedge(XSMultiplicativeModel):
+    """The XSPEC edge model: absorption edge.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    edgeE
+        The threshold edge, in keV.
+    MaxTau
+        The absorption depth at the threshold.
+    redshift
+        The redshift of the edge.
+
+    See Also
+    --------
+    XSedge
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelEdge.html
+
+    """
 
     _calc =  _xspec.xszedg
 
@@ -5635,6 +5912,29 @@ class XSzedge(XSMultiplicativeModel):
 
 
 class XSzhighect(XSMultiplicativeModel):
+    """The XSPEC highecut model: high-energy cutoff.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    cutoffE
+        The cut-off energy, in keV.
+    foldE
+        The e-folding energy, in keV.
+    redshift
+        The redshift.
+
+    See Also
+    --------
+    XShighecut
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelHighecut.html
+
+    """
 
     _calc =  _xspec.xszhcu
 
@@ -6898,6 +7198,29 @@ class XScomptb(XSAdditiveModel):
 
 
 class XSheilin(XSMultiplicativeModel):
+    """The XSPEC heilin model: Voigt absorption profiles for He I series.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nHeI
+        The He I column density, in 10^22 atoms/cm^2.
+    b
+        The b value, in km/s.
+    redshidt
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSlyman
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelHeilin.html
+
+    """
 
     _calc =  _xspec.xsphei
 
@@ -6908,6 +7231,31 @@ class XSheilin(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.nHei, self.b, self.redshift))
 
 class XSlyman(XSMultiplicativeModel):
+    """The XSPEC lyman model: Voigt absorption profiles for H I or He II Lyman series.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nHeI
+        The H I or He II column density, in 10^22 atoms/cm^2.
+    b
+        The b value, in km/s.
+    redshift
+        The redshift of the absorber.
+    ZA
+        The atomic number of the species being calculated.
+
+    See Also
+    --------
+    XSheilin
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLyman.html
+
+    """
 
     _calc =  _xspec.xslyman
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2804,6 +2804,35 @@ class XSnpshock(XSAdditiveModel):
 
 
 class XSnsa(XSAdditiveModel):
+    """The XSPEC nsa model: neutron star atmosphere.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LogT_eff
+        The log of Teff, the unredshifted effective temperature.
+    M_ns
+        The neutron star gravitational mass, in units of the solar mass.
+    R_ns
+        The neutron star radius, in km.
+    MagField
+        The neutron star magnetic field strength, in Gauss. It must be
+        fixed at one of 0, 1e12, or 1e13 G.
+    norm
+        The normalization is 1/D^2, where D is the distance to the
+        neutron star in pc.
+
+    See Also
+    --------
+    XSnsagrav
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNsa.html
+
+    """
 
     _calc =  _xspec.nsa
 
@@ -2817,6 +2846,32 @@ class XSnsa(XSAdditiveModel):
 
 
 class XSnsagrav(XSAdditiveModel):
+    """The XSPEC nsagrav model: NS H atmosphere model for different g.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LogT_eff
+        The log of Teff, the unredshifted effective temperature.
+    NSmass
+        The neutron star gravitational mass, in units of the solar mass.
+    NSrad
+        The "true" neutron star radius, in km.
+    norm
+        The normalization is 1/D^2, where D is the distance to the
+        neutron star in pc.
+
+    See Also
+    --------
+    XSnsa
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNsagrav.html
+
+    """
 
     _calc =  _xspec.nsagrav
 
@@ -2829,6 +2884,29 @@ class XSnsagrav(XSAdditiveModel):
 
 
 class XSnsatmos(XSAdditiveModel):
+    """The XSPEC nsatmos model: NS Hydrogen Atmosphere model with electron conduction and self-irradiation.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LogT_eff
+        The log of Teff, the unredshifted effective temperature.
+    M_ns
+        The neutron star gravitational mass, in units of the solar mass.
+    R_ns
+        The "true" neutron star radius, in km.
+    dist
+        The distance to the neutron star, in kpc.
+    norm
+        The fraction of the neutron star surface emitting.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNsatmos.html
+
+    """
 
     _calc =  _xspec.nsatmos
 
@@ -2842,6 +2920,32 @@ class XSnsatmos(XSAdditiveModel):
 
 
 class XSnsmax(XSAdditiveModel):
+    """The XSPEC nsmax model: Neutron Star Magnetic Atmosphere.
+
+    The model is described at [1]_. It has been superceeded by
+    ``XSnsmaxg``.
+
+    Attributes
+    ----------
+    LogTeff
+        The log of Teff, the unredshifted surface effective temperature.
+    redshift
+        This is 1 + zg, the gravitational redshift.
+    specfile
+        Which model to use: see [1]_ for more details.
+    norm
+        The normalization of the model: see [1]_ for more details.
+
+    See Also
+    --------
+    XSnsmaxg
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNsmax.html
+
+    """
 
     _calc =  _xspec.nsmax
 
@@ -2854,6 +2958,35 @@ class XSnsmax(XSAdditiveModel):
 
 
 class XSnsmaxg(XSAdditiveModel):
+    """The XSPEC nsmaxg model: neutron star with a magnetic atmosphere.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LogTeff
+        The log of Teff, the unredshifted surface effective temperature.
+    M_ns
+        The neutron star gravitational mass, in units of the solar mass.
+    R_ns
+        The neutron star radius, in km.
+    dist
+        The distance to the neutron star, in kpc.
+    specfile
+        Which model to use: see [1]_ for more details.
+    norm
+        The normalization: see [1]_ for more details.
+
+    See Also
+    --------
+    XSnsmax, XSnsx
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNsmaxg.html
+
+    """
 
     _calc =  _xspec.nsmaxg
 
@@ -2868,6 +3001,35 @@ class XSnsmaxg(XSAdditiveModel):
 
 
 class XSnsx(XSAdditiveModel):
+    """The XSPEC nsx model: neutron star with a non-magnetic atmosphere.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    LogTeff
+        The log of Teff, the unredshifted surface effective temperature.
+    M_ns
+        The neutron star gravitational mass, in units of the solar mass.
+    R_ns
+        The neutron star radius, in km.
+    dist
+        The distance to the neutron star, in kpc.
+    specfile
+        Which model to use: see [1]_ for more details.
+    norm
+        The normalization: see [1]_ for more details.
+
+    See Also
+    --------
+    XSnsmaxg
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNsx.html
+
+    """
 
     _calc =  _xspec.nsx
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -652,7 +652,7 @@ class XSbexriv(XSAdditiveModel):
     T_disk
         The disk temperature in K.
     xi
-        The disk inoization parameter: see [1]_ for an explanation.
+        The disk ionization parameter: see [1]_ for an explanation.
     norm
         The normalization of the model: see [1]_ for an explanation
         of the units.
@@ -2046,7 +2046,7 @@ class XSgnei(XSAdditiveModel):
         The metal abundance of the plasma, as defined by the
         ``set_xsabund`` function.
     Tau
-        The inoization timescale in units of s/cm^3.
+        The ionization timescale in units of s/cm^3.
     kT_ave
         The ionization timescale averaged plasma temperature in keV.
     redshift
@@ -2640,7 +2640,7 @@ class XSnei(XSAdditiveModel):
         The metal abundance of the plasma, as defined by the
         ``set_xsabund`` function.
     Tau
-        The inoization timescale in units of s/cm^3.
+        The ionization timescale in units of s/cm^3.
     redshift
         The redshift of the plasma.
     norm
@@ -2670,6 +2670,39 @@ class XSnei(XSAdditiveModel):
 
 
 class XSrnei(XSAdditiveModel):
+    """The XSPEC rnei model: non-equilibrium recombining collisional plasma.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    kT_init
+        The initial temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    Tau
+        The ionization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSnei, XSgnei, XSvrnei, XSvvrnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRnei.html
+
+    """
 
     _calc =  _xspec.C_rnei
 
@@ -2684,6 +2717,41 @@ class XSrnei(XSAdditiveModel):
 
 
 class XSvrnei(XSAdditiveModel):
+    """The XSPEC vrnei model: non-equilibrium recombining collisional plasma.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    kT_init
+        The initial temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element, with respect to Solar.
+    Tau
+        The ionization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSrnei, XSvvrnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRnei.html
+
+    """
 
     _calc =  _xspec.C_vrnei
 
@@ -2710,6 +2778,42 @@ class XSvrnei(XSAdditiveModel):
 
 
 class XSvvrnei(XSAdditiveModel):
+    """The XSPEC vvrnei model: non-equilibrium recombining collisional plasma.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    kT_init
+        The initial temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element, with respect to Solar.
+    Tau
+        The ionization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSrnei, XSvrnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRnei.html
+
+    """
 
     _calc =  _xspec.C_vvrnei
 
@@ -2782,7 +2886,7 @@ class XSnpshock(XSAdditiveModel):
 
     See Also
     --------
-    XSequil, XSvnpshock, XSvvnpshock
+    XSequil, XSsedov, XSvnpshock, XSvvnpshock
 
     References
     ----------
@@ -3264,7 +3368,7 @@ class XSpexrav(XSAdditiveModel):
 
 
 class XSpexriv(XSAdditiveModel):
-    """The XSPEC pexrav model: reflected powerlaw, neutral medium.
+    """The XSPEC pexriv model: reflected powerlaw, neutral medium.
 
     The model is described at [1]_.
 
@@ -3566,6 +3670,56 @@ class XSredge(XSAdditiveModel):
 
 
 class XSrefsch(XSAdditiveModel):
+    """The XSPEC refsch model: reflected power law from ionized accretion disk.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    PhoIndex
+        The power-law photon index.
+    foldE
+        The cut-off energy (E_c) in keV. Set to 0 for no cut off.
+    rel_refl
+        The reflection scaling parameter (a value between 0 and 1
+        for an isotropic source above the disk, less than 0 for no
+        direct component).
+    redshift
+        The redshift of the source.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    Incl
+        The inclination angle in degrees.
+    T_disk
+        The disk temperature in K.
+    xi
+        The disk ionization parameter: see [1]_ for more details.
+    Betor10
+        The power law dependence of emissivity: see [1]_ for more details.
+    Rin
+        The inner radius, in units of GM^2/c.
+    Rout
+        The outer radius, in units of GM^2/c.
+    accuracy
+        The internal model accuracy: points of spectrum per energy decade.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSdiskline, XSpexriv
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRefsch.html
+
+    """
 
     _calc =  _xspec.xsrefsch
 
@@ -3588,6 +3742,41 @@ class XSrefsch(XSAdditiveModel):
 
 
 class XSsedov(XSAdditiveModel):
+    """The XSPEC sedov model: sedov model, separate ion/electron temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT_a
+        The mean shock temperature, in keV.
+    kT_b
+        The electron temperature immediately behind the shock
+        front, in keV. See [1]_ for a discussion of the behavior
+        of kT_a and kT_b.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function.
+    Tau
+        The ionization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSpshock, XSvsedov, XSvvsedov
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSedov.html
+
+    """
 
     _calc =  _xspec.C_sedov
 
@@ -3811,7 +4000,7 @@ class XSvgnei(XSAdditiveModel):
     He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
         The abundance of the element, with respect to Solar.
     Tau
-        The inoization timescale in units of s/cm^3.
+        The ionization timescale in units of s/cm^3.
     kT_ave
         The ionization timescale averaged plasma temperature in keV.
     redshift
@@ -3873,7 +4062,7 @@ class XSvvgnei(XSAdditiveModel):
     K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
         The abundance of the element, with respect to Solar.
     Tau
-        The inoization timescale in units of s/cm^3.
+        The ionization timescale in units of s/cm^3.
     kT_ave
         The ionization timescale averaged plasma temperature in keV.
     redshift
@@ -4124,7 +4313,7 @@ class XSvnei(XSAdditiveModel):
     He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
         The abundance of the element, with respect to Solar.
     Tau
-        The inoization timescale in units of s/cm^3.
+        The ionization timescale in units of s/cm^3.
     redshift
         The redshift of the plasma.
     norm
@@ -4183,7 +4372,7 @@ class XSvvnei(XSAdditiveModel):
     K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
         The abundance of the element, with respect to Solar.
     Tau
-        The inoization timescale in units of s/cm^3.
+        The ionization timescale in units of s/cm^3.
     redshift
         The redshift of the plasma.
     norm
@@ -4581,6 +4770,43 @@ class XSvraymond(XSAdditiveModel):
 
 
 class XSvsedov(XSAdditiveModel):
+    """The XSPEC vsedov model: sedov model, separate ion/electron temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT_a
+        The mean shock temperature, in keV.
+    kT_b
+        The electron temperature immediately behind the shock
+        front, in keV. See [1]_ for a discussion of the behavior
+        of kT_a and kT_b.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element, with respect to Solar.
+    Tau
+        The ionization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSsedov, XSvvsedov
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSedov.html
+
+    """
 
     _calc =  _xspec.C_vsedov
 
@@ -4607,6 +4833,44 @@ class XSvsedov(XSAdditiveModel):
 
 
 class XSvvsedov(XSAdditiveModel):
+    """The XSPEC vvsedov model: sedov model, separate ion/electron temperature.
+
+    The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keyword "NEIVERS".
+
+    Attributes
+    ----------
+    kT_a
+        The mean shock temperature, in keV.
+    kT_b
+        The electron temperature immediately behind the shock
+        front, in keV. See [1]_ for a discussion of the behavior
+        of kT_a and kT_b.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element, with respect to Solar.
+    Tau
+        The ionization timescale in units of s/cm^3.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSsedov, XSvsedov
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSedov.html
+
+    """
 
     _calc =  _xspec.C_vvsedov
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -820,6 +820,7 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 static PyMethodDef XSpecMethods[] = {
   { (char*)"get_xsversion", (PyCFunction)get_version, METH_NOARGS,
     (char*) "get_xsversion()\n\n"
+            "Return the version of the X-Spec model library in use.\n"
             RETURNSDOC
             "version : str\n"
             "   The version of the X-Spec model library used\n"
@@ -831,6 +832,7 @@ static PyMethodDef XSpecMethods[] = {
 
   { (char*)"get_xschatter", (PyCFunction)get_chatter, METH_NOARGS,
     (char*) "get_xschatter()\n\n"
+            "Return the chatter level used by X-Spec.\n"
             RETURNSDOC
             "chatter : int\n"
             "   The chatter setting used by the X-Spec routines.\n"
@@ -840,22 +842,23 @@ static PyMethodDef XSpecMethods[] = {
             ">>> get_xschatter()\n0\n\n"},
   { (char*)"set_xschatter", (PyCFunction)set_chatter, METH_VARARGS,
     (char*) "set_xschatter(level)\n\n"
+            "Set the chatter level used by X-Spec.\n\n"
             "Set the chatter setting used by the X-Spec routines\n"
             "for determining what information gets printed to the\n"
-            "screen. It is equivalent to the X-Spec `chatter`\n"
+            "screen. It is equivalent to the X-Spec ``chatter``\n"
             "command [1]_.\n"
             PARAMETERSDOC
             "level : int\n"
-            "   The higher the `level`, the more screen output will\n"
-            "   be created by X-Spec routines. A value of `0` hides\n"
-            "   most information while `25` will generate a lot of\n"
+            "   The higher the value of ``level``, the more screen output will\n"
+            "   be created by X-Spec routines. A value of ``0`` hides\n"
+            "   most information while ``25`` will generate a lot of\n"
             "   debug output.\n"
             SEEALSODOC
             "get_xschatter : Return the X-Spec chatter setting.\n"
             NOTESDOC
-            "The default `chatter` setting used by Sherpa is `0`, which\n"
+            "The default chatter setting used by Sherpa is ``0``, which\n"
             "is lower than - so, creates less screen output - the\n"
-            "default value used by X-Spec (`10`).\n\n"
+            "default value used by X-Spec (``10``).\n\n"
             "There is no way to change the X-Spec \"log chatter\"\n"
             "setting.\n"
             REFERENCESDOC "\n"
@@ -869,7 +872,7 @@ static PyMethodDef XSpecMethods[] = {
 
   { (char*)"get_xsabund", (PyCFunction)get_abund, METH_VARARGS,
     (char*) "get_xsabund(element=None)\n\n"
-            "Return the X-Spec abundance setting or elemental abundance.\n\n"
+            "Return the X-Spec abundance setting or elemental abundance.\n"
             PARAMETERSDOC
             "element : str, optional\n"
             "   When not given, the abundance table name is returned.\n"
@@ -880,17 +883,17 @@ static PyMethodDef XSpecMethods[] = {
             "   'Cu', 'Zn'. Case is important.\n"
             RETURNSDOC
             "val : str or float\n"
-            "   When `element` is `None`, the abundance table name is\n"
+            "   When ``element`` is ``None``, the abundance table name is\n"
             "   returned (see `set_xsabund`); the string 'file' is\n"
             "   used when the abundances were read from a file. A\n"
             "   numeric value is returned when an element name is\n"
             "   given. This value is the elemental abundance relative\n"
-            "   to `H`.\n"
+            "   to H.\n"
             SEEALSODOC
             "set_xsabund : Set the X-Spec abundance table.\n"
             EXAMPLESDOC "\n"
             "Return the current abundance setting, which in this case\n"
-            "is `angr`, the default value for X-Spec:\n\n"
+            "is 'angr', the default value for X-Spec:\n\n"
             ">>> get_xsabund()\n'angr'\n\n"
             "The `set_xsabund` function has been used to read in the\n"
             "abundances from a file, so the routine now returns the\n"
@@ -900,9 +903,10 @@ static PyMethodDef XSpecMethods[] = {
             ">>> get_xsabund('He')\n0.09769999980926514\n\n"},
   { (char*)"set_xsabund", (PyCFunction)set_abund, METH_VARARGS,
     (char*) "set_xsabund(abundance)\n\n"
+            "Set the elemental abundances used by X-Spec models.\n\n"
             "Set the abundance table used in the X-Spec plasma emission and\n"
             "photoelectric absorption models. It is equivalent to the X-Spec\n"
-            "`abund` command [1]_.\n"
+            "``abund`` command [1]_.\n"
             PARAMETERSDOC
             "abundance : str\n"
             "   A file name, format described below, or one of the\n"
@@ -913,15 +917,15 @@ static PyMethodDef XSpecMethods[] = {
             "set_xschatter : Control the screen output of X-Spec functions and models.\n"
             NOTESDOC
             "The pre-defined abundance tables are:\n\n"
-            " - `angr`, from [2]_\n"
-            " - `aspl`, from [3]_\n"
-            " - `feld`, from [4]_, except for elements not listed which\n"
-            "   are given `grsa` abundances\n"
-            " - `aneb`, from [5]_\n"
-            " - `grsa`, from [6]_\n"
-            " - `wilm`, from [7]_, except for elements not listed which\n"
+            " - 'angr', from [2]_\n"
+            " - 'aspl', from [3]_\n"
+            " - 'feld', from [4]_, except for elements not listed which\n"
+            "   are given 'grsa' abundances\n"
+            " - 'aneb', from [5]_\n"
+            " - 'grsa', from [6]_\n"
+            " - 'wilm', from [7]_, except for elements not listed which\n"
             "   are given zero abundance\n"
-            " - `lodd`, from [8]_\n\n"
+            " - 'lodd', from [8]_\n\n"
             "The values for these tables are given at [1]_.\n\n"
             "Data files should be in ASCII format, containing a single\n"
             "numeric (floating-point) column of the abundance values,\n"
@@ -959,10 +963,10 @@ static PyMethodDef XSpecMethods[] = {
 
   { (char*)"set_xscosmo", (PyCFunction)set_cosmo, METH_VARARGS,
     (char*) "set_xscosmo(h0, q0, l0)\n\n"
+            "Set the cosmological parameters used by X-Spec models.\n\n"
             "Set the cosmological parameters (H_0, q_0, lambda_0) used\n"
-            "by X-Spec.\n It is equivalent to the X-Spec\n"
-            "`cosmo` command [1]_. The default values are:\n"
-            "h0=70, q0=0, l0=0.73\n"
+            "by X-Spec. It is equivalent to the X-Spec ``cosmo``\n"
+            "command [1]_. The default values are h0=70, q0=0, and l0=0.73\n"
             PARAMETERSDOC
             "h0 : number\n"
             "   The Hubble constant in km/s/Mpc.\n"
@@ -986,7 +990,7 @@ static PyMethodDef XSpecMethods[] = {
     (char*) "get_xscosmo()\n\n"
             "Return the X-Spec cosmology settings.\n"
             RETURNSDOC
-            "(h0,q0,l0) :\n"
+            "(h0,q0,l0)\n"
             "   The Hubble constant, in km/s/Mpc, the deceleration\n"
             "   parameter, and the cosmological constant.\n"
             SEEALSODOC
@@ -996,7 +1000,7 @@ static PyMethodDef XSpecMethods[] = {
 
   { (char*)"get_xsxsect", (PyCFunction)get_cross, METH_NOARGS,
     (char*) "get_xsxsect()\n\n"
-            "Return the name of the X-Spec photoelectric absorption\n"
+            "Return the name of the X-Spec photoelectric absorption "
             "cross-sections setting.\n"
             RETURNSDOC
             "val : str\n"
@@ -1010,14 +1014,14 @@ static PyMethodDef XSpecMethods[] = {
     (char*) "set_xsxsect(name)\n\n"
             "Set the X-Spec photoelectric absorption cross-sections\n"
             "setting, which changes the cross-sections used by all\n"
-            "X-Spec absorption models *except* for `xswabs`. It is\n"
-            "equivalent to the X-Spec `xsect` command [1]_.\n"
+            "X-Spec absorption models *except* for `XSwabs`. It is\n"
+            "equivalent to the X-Spec ``xsect`` command [1]_.\n"
             PARAMETERSDOC
             "name : { 'bcmc', 'obcm', 'vern' }\n"
             "   The options are: 'bcmc' from [2]_ with a new\n"
             "   He cross-section based on [3]_; 'obcm' which is,\n"
             "   the same as 'bcmc', but with the He cross-section\n"
-            "   from [2]_, or 'vern' [4_].\n"
+            "   from [2]_, or 'vern' [4]_.\n"
             SEEALSODOC
             "get_xsxsect : Return the name of the X-Spec photoelectric absorption cross-sections.\n"
             "get_xsversion : Return the version of X-Spec used by this module.\n"
@@ -1043,8 +1047,9 @@ static PyMethodDef XSpecMethods[] = {
 
   { (char*)"set_xsxset", (PyCFunction)set_xset, METH_VARARGS,
     (char*) "set_xsxset(name, value)\n\n"
+            "Set an X-Spec XSET variable to a value.\n\n"
             "Set variables used by X-Spec models. It is equivalent to the\n"
-            "X-Spec `xset` command [1]_, but only for setting the model\n"
+            "X-Spec ``xset`` command [1]_, but only for setting the model\n"
             "database settings. See `set_xsabund`, `set_xscosmo`, and\n"
             "`set_xsxsect` for the other settings.\n"
             PARAMETERSDOC
@@ -1081,7 +1086,7 @@ static PyMethodDef XSpecMethods[] = {
             ">>> set_xsxset('POW_EMAX', '2.0')\n\n"},
   { (char*)"get_xsxset", (PyCFunction)get_xset, METH_VARARGS,
     (char*) "get_xsxset(name)\n\n"
-            "Return the X-Spec model setting.\n\n"
+            "Return the value of an X-Spec XSET variable.\n\n"
             PARAMETERSDOC
             "name : str\n"
             "   The name of the setting. There is no check that\n"
@@ -1092,7 +1097,7 @@ static PyMethodDef XSpecMethods[] = {
             "   or the empty string, if not set.\n"
             SEEALSODOC
             "set_xsxset : Set a X-Spec model setting.\n"
-            NOTESDOC "\n"
+            NOTESDOC
             "Due to the way X-Spec model settings work, `get_xsxset`\n"
             "will only return a value if it has previously been set\n"
             "with a call to `set_xsxset`. There is no way to retrive\n"

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1000,6 +1000,7 @@ static PyMethodDef XSpecMethods[] = {
 
   { (char*)"get_xsxsect", (PyCFunction)get_cross, METH_NOARGS,
     (char*) "get_xsxsect()\n\n"
+            "Return the cross sections used by X-Spec models.\n\n"
             "Return the name of the X-Spec photoelectric absorption "
             "cross-sections setting.\n"
             RETURNSDOC
@@ -1012,6 +1013,7 @@ static PyMethodDef XSpecMethods[] = {
             ">>> get_xsxsect()\n'bcmc'\n\n"},
   { (char*)"set_xsxsect", (PyCFunction)set_cross, METH_VARARGS,
     (char*) "set_xsxsect(name)\n\n"
+            "Set the cross sections used by X-Spec models.\n\n"
             "Set the X-Spec photoelectric absorption cross-sections\n"
             "setting, which changes the cross-sections used by all\n"
             "X-Spec absorption models *except* for `XSwabs`. It is\n"

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -153,8 +153,11 @@ class Cos(ArithmeticModel):
     Attributes
     ----------
     period
+        The period of the cosine, in units of the independent axis.
     offset
+        The offset (related to the phase) of the cosine.
     ampl
+        The amplitude of the cosine.
 
     See Also
     --------
@@ -249,8 +252,11 @@ class Erf(ArithmeticModel):
     Attributes
     ----------
     ampl
+        The amplitude of the model.
     offset
+        The offset of the model.
     sigma
+        The scaling factor.
 
     See Also
     --------
@@ -297,8 +303,11 @@ class Erfc(ArithmeticModel):
     Attributes
     ----------
     ampl
+        The amplitude of the model.
     offset
+        The offset of the model.
     sigma
+        The scaling factor.
 
     See Also
     --------
@@ -345,8 +354,11 @@ class Exp(ArithmeticModel):
     Attributes
     ----------
     offset
+        The offset of the model.
     coeff
+        The scaling factor.
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -381,8 +393,11 @@ class Exp10(ArithmeticModel):
     Attributes
     ----------
     offset
+        The offset of the model.
     coeff
+        The scaling factor.
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -420,6 +435,7 @@ class Gauss1D(ArithmeticModel):
         The Full-Width Half Maximum of the gaussian. It is related to
         the sigma value by: FWHM = sqrt(8 * log(2)) * sigma.
     pos
+        The center of the gaussian.
     ampl
         The amplitude refers to the maximum peak of the model.
 
@@ -503,8 +519,11 @@ class Log(ArithmeticModel):
     Attributes
     ----------
     offset
+        The offset of the model.
     coeff
+        The scaling factor.
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -539,8 +558,11 @@ class Log10(ArithmeticModel):
     Attributes
     ----------
     offset
+        The offset of the model.
     coeff
+        The scaling factor.
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -581,6 +603,7 @@ class LogParabola(ArithmeticModel):
     c2
         The curvature of the parabola (beta).
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -629,6 +652,7 @@ class NormGauss1D(ArithmeticModel):
         The Full-Width Half Maximum of the gaussian. It is related to
         the sigma value by: FWHM = sqrt(8 * log(2)) * sigma.
     pos
+        The center of the gaussian.
     ampl
         The amplitude refers to the integral of the model over the
         range -infinity to infinity.
@@ -692,7 +716,9 @@ class Poisson(ArithmeticModel):
     Attributes
     ----------
     mean
+        The mean of the first distribution.
     ampl
+        The amplitude of the model.
 
     Notes
     -----
@@ -849,14 +875,18 @@ class Polynom1D(ArithmeticModel):
 class PowLaw1D(ArithmeticModel):
     """One-dimensional power-law function.
 
+    It is assumed that the independent axis is positive at all points.
+
     Attributes
     ----------
     gamma
+        The photon index of the power law.
     ref
         As the reference point is degenerate with the amplitude, the
         ``alwaysfrozen`` attribute of the reference point is set so
         that it can not be varied during a fit.
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -942,8 +972,11 @@ class Sin(ArithmeticModel):
     Attributes
     ----------
     period
+        The period of the sine, in units of the independent axis.
     offset
+        The offset (related to the phase) of the sine.
     ampl
+        The amplitude of the sine.
 
     See Also
     --------
@@ -982,7 +1015,9 @@ class Sqrt(ArithmeticModel):
     Attributes
     ----------
     offset
+        The offset of the model.
     ampl
+        The amplitude of the model.
 
     See Also
     --------
@@ -1115,8 +1150,11 @@ class Tan(ArithmeticModel):
     Attributes
     ----------
     period
+        The period of the tangent, in units of the independent axis.
     offset
+        The offset (related to the phase) of the tangent.
     ampl
+        The amplitude of the tangent.
 
     See Also
     --------
@@ -1616,14 +1654,23 @@ class Polynom2D(ArithmeticModel):
     Attributes
     ----------
     c
+        The constant term.
     cy1
+        The coefficient for the x1 term.
     cy2
+        The coefficient for the x1^2 term.
     cx1
+        The coefficient for the x0 term.
     cx1y1
+        The coefficient for the x0 x1 term.
     cx1y2
+        The coefficient for the x0 x1^2 term.
     cx2
+        The coefficient for the x0^2 term.
     cx2y1
+        The coefficient for the x0^2 x1 term.
     cx2y2
+        The coefficient for the x0^2 x1^2 term.
 
     See Also
     --------

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -43,6 +43,42 @@ DBL_EPSILON = numpy.finfo(numpy.float).eps
 
 
 class Box1D(ArithmeticModel):
+    """One-dimensional box function.
+
+    The model is flat between ``xlow`` and ``xhi`` (both limits are
+    inclusive), where it is set to the ``ampl`` parameter. Outside
+    this range the model is zero.
+
+    Attributes
+    ----------
+    xlow
+        The lower edge of the box.
+    xhi
+        The upper edge of the box.
+    ampl
+        The amplitude of the box.
+
+    See Also
+    --------
+    Box2D, Const1D, Delta1D, StepLo1D, StepHi1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl if xlow <= x <= xhi
+             = 0       otherwise
+
+    and for an integrated grid it is::
+
+        f(lo,hi) = ampl         if lo >= xlow and hi <= xhi
+                 = 0            if hi <= xlow or lo >= xhi
+                 = ampl * g     where g is the fraction of lo,hi
+                                that falls within xlo,xhi
+
+    This behavior is different to how the amplitude is handled in
+    other models, such as ``Const1D``.
+    """
 
     def __init__(self, name='box1d'):
         self.xlow = Parameter(name, 'xlow', 0)
@@ -64,6 +100,28 @@ class Box1D(ArithmeticModel):
 
 
 class Const1D(ArithmeticModel):
+    """A constant model for one-dimensional data.
+
+    Attributes
+    ----------
+    c0
+        The amplitude of the model.
+
+    See Also
+    --------
+    Box1D, Const2D, Delta1D, Scale1D, StepLo1D, StepHi1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl
+
+    and for an integrated grid it is::
+
+        f(xlo,xhi) = ampl * (xhi - xlo)
+
+    """
 
     def __init__(self, name='const1d'):
         self.c0 = Parameter(name, 'c0', 1)
@@ -90,6 +148,27 @@ class Const1D(ArithmeticModel):
 
 
 class Cos(ArithmeticModel):
+    """One-dimensional cosine function.
+
+    Attributes
+    ----------
+    period
+    offset
+    ampl
+
+    See Also
+    --------
+    Sin, Tan
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * cos (2 * pi * (x - offset) / period)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='cos'):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
@@ -109,6 +188,37 @@ class Cos(ArithmeticModel):
 
 
 class Delta1D(ArithmeticModel):
+    """One-dimensional delta function.
+
+    The model is only defined at a single point (or bin for integrated
+    grids).
+
+    Attributes
+    ----------
+    pos
+        The position of the signal.
+    ampl
+        The amplitude.
+
+    See Also
+    --------
+    Box1D, Const1D, Delta2D, StepLo1D, StepHi1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl if x == pos
+             = 0       otherwise
+
+    and for an integrated grid it is::
+
+        f(lo,hi) = ampl         if lo <= pos <= hi
+                 = 0            otherwise
+
+    This behavior is different to how the amplitude is handled in
+    other models, such as ``Const1D``.
+    """
 
     def __init__(self, name='delta1d'):
         self.pos = Parameter(name, 'pos', 0)
@@ -134,6 +244,35 @@ class Delta1D(ArithmeticModel):
 
 
 class Erf(ArithmeticModel):
+    """One-dimensional error function [1]_.
+
+    Attributes
+    ----------
+    ampl
+    offset
+    sigma
+
+    See Also
+    --------
+    Erfc
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * erf((x - offset) / sigma)
+
+        erf(y) = (2 / sqrt(pi)) Int_0^y exp(-t^2) dt
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+
+    References
+    ----------
+
+    .. [1] http://mathworld.wolfram.com/Erf.html
+
+    """
 
     def __init__(self, name='erf'):
         self.ampl = Parameter(name, 'ampl', 1, 0)
@@ -153,6 +292,35 @@ class Erf(ArithmeticModel):
 
 
 class Erfc(ArithmeticModel):
+    """One-dimensional complementary error function [1]_.
+
+    Attributes
+    ----------
+    ampl
+    offset
+    sigma
+
+    See Also
+    --------
+    Erf
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * erfc((x - offset) / sigma)
+
+        erfc(y) = (2 / sqrt(pi)) Int_y^infinity exp(-t^2) dt
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+
+    References
+    ----------
+
+    .. [1] http://mathworld.wolfram.com/Erfc.html
+
+    """
 
     def __init__(self, name='erfc'):
         self.ampl = Parameter(name, 'ampl', 1, 0)
@@ -172,6 +340,27 @@ class Erfc(ArithmeticModel):
 
 
 class Exp(ArithmeticModel):
+    """One-dimensional exponential function.
+
+    Attributes
+    ----------
+    offset
+    coeff
+    ampl
+
+    See Also
+    --------
+    Exp10, Log, Log10, LogParabola, Sqrt
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * exp(coeff * (x - offset))
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='exp'):
         self.offset = Parameter(name, 'offset', 0)
@@ -187,6 +376,27 @@ class Exp(ArithmeticModel):
 
 
 class Exp10(ArithmeticModel):
+    """One-dimensional exponential function, base 10.
+
+    Attributes
+    ----------
+    offset
+    coeff
+    ampl
+
+    See Also
+    --------
+    Exp, Log, Log10, LogParabola, Sqrt
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * 10^(coeff * (x - offset))
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='exp10'):
         self.offset = Parameter(name, 'offset', 0)
@@ -202,6 +412,64 @@ class Exp10(ArithmeticModel):
 
 
 class Gauss1D(ArithmeticModel):
+    """One-dimensional gaussian function.
+
+    Attributes
+    ----------
+    fwhm
+        The Full-Width Half Maximum of the gaussian. It is related to
+        the sigma value by: FWHM = sqrt(8 * log(2)) * sigma.
+    pos
+    ampl
+        The amplitude refers to the maximum peak of the model.
+
+    See Also
+    --------
+    Gauss2D, NormGauss1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * exp(-4 * log(2) * (x - pos)^2 / fwhm^2)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+
+    Examples
+    --------
+
+    Compare the gaussian and normalized gaussian models:
+
+    >>> m1 = sherpa.models.basic.Gauss1D()
+    >>> m2 = sherpa.models.basic.NormGauss1D()
+    >>> m1.pos, m2.pos = 10, 10
+    >>> m1.ampl, m2.ampl = 10, 10
+    >>> m1.fwhm, m2.fwhm = 5, 5
+    >>> m1(10)
+    10.0
+    >>> m2(10)
+    1.8788745573993026
+    >>> m1.fwhm, m2.fwhm = 1, 1
+    >>> m1(10)
+    10.0
+    >>> m2(10)
+    9.394372786996513
+
+    The normalised version will sum to the amplitude when given
+    an integrated grid - i.e. both low and high edges rather than
+    points - that covers all the signal (and with a bin size a lot
+    smaller than the FWHM):
+
+    >>> m1.fwhm, m2.fwhm = 12.2, 12.2
+    >>> grid = np.arange(-90, 110, 0.01)
+    >>> glo, ghi = grid[:-1], grid[1:]
+    >>> m1(glo, ghi).sum()
+    129.86497637060958
+    >>> m2(glo, ghi).sum()
+    10.000000000000002
+
+    """
 
     def __init__(self, name='gauss1d'):
         self.fwhm = Parameter(name, 'fwhm', 10, tinyval, hard_min=tinyval)
@@ -230,6 +498,27 @@ class Gauss1D(ArithmeticModel):
 
 
 class Log(ArithmeticModel):
+    """One-dimensional natural logarithm function.
+
+    Attributes
+    ----------
+    offset
+    coeff
+    ampl
+
+    See Also
+    --------
+    Exp, Exp10, Log10, LogParabola, Sqrt
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * log (coeff * (x - offset))
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='log'):
         self.offset = Parameter(name, 'offset', 0)
@@ -245,6 +534,27 @@ class Log(ArithmeticModel):
 
 
 class Log10(ArithmeticModel):
+    """One-dimensional logarithm function, base 10.
+
+    Attributes
+    ----------
+    offset
+    coeff
+    ampl
+
+    See Also
+    --------
+    Exp, Exp10, Log, LogParabola, Sqrt
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * log_10 (coeff * (x - offset))
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='log10'):
         self.offset = Parameter(name, 'offset', 0)
@@ -260,6 +570,39 @@ class Log10(ArithmeticModel):
 
 
 class LogParabola(ArithmeticModel):
+    """One-dimensional log-parabolic function.
+
+    Attributes
+    ----------
+    ref
+        The reference point for the normalization.
+    c1
+        The power-law index (gamma).
+    c2
+        The curvature of the parabola (beta).
+    ampl
+
+    See Also
+    --------
+    Exp, Exp10, Log, Log10, Sqrt
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * (x / ref) ^ (-c1 - c2 * log_10 (x / ref))
+
+    The grid version is evaluated by numerically intgerating the
+    function over each bin using a non-adaptive Gauss-Kronrod scheme
+    suited for smooth functions [1]_, falling over to a simple
+    trapezoid scheme if this fails.
+
+    References
+    ----------
+
+    .. [1] https://www.gnu.org/software/gsl/manual/html_node/QNG-non_002dadaptive-Gauss_002dKronrod-integration.html
+
+    """
 
     def __init__(self, name='logparabola'):
         self.ref = Parameter(name, 'ref', 1, alwaysfrozen=True)
@@ -278,6 +621,34 @@ class LogParabola(ArithmeticModel):
 _gfactor = numpy.sqrt(numpy.pi/(4*numpy.log(2)))
 
 class NormGauss1D(ArithmeticModel):
+    """One-dimensional normalised gaussian function.
+
+    Attributes
+    ----------
+    fwhm
+        The Full-Width Half Maximum of the gaussian. It is related to
+        the sigma value by: FWHM = sqrt(8 * log(2)) * sigma.
+    pos
+    ampl
+        The amplitude refers to the integral of the model over the
+        range -infinity to infinity.
+
+
+    See Also
+    --------
+    Gauss1D, NormGauss2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * exp(-4 * log(2) * (x - pos)^2 / fwhm^2)
+               ----------------------------------------------
+                       sqrt(pi / (4 * log(2))) * fwhm
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='normgauss1d'):
         self.fwhm = Parameter(name, 'fwhm', 10, tinyval, hard_min=tinyval)
@@ -312,6 +683,34 @@ class NormGauss1D(ArithmeticModel):
 
 
 class Poisson(ArithmeticModel):
+    """One-dimensional Poisson function.
+
+    A model expressing the ratio of two Poisson distributions of mean
+    mu, one for which the random variable is x, and the other for
+    which the random variable is equal to mu itself.
+
+    Attributes
+    ----------
+    mean
+    ampl
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * mean! exp((x - mean) * log(mean)) / x!
+
+    The grid version is evaluated by numerically intgerating the
+    function over each bin using a non-adaptive Gauss-Kronrod scheme
+    suited for smooth functions [1]_, falling over to a simple
+    trapezoid scheme if this fails.
+
+    References
+    ----------
+
+    .. [1] https://www.gnu.org/software/gsl/manual/html_node/QNG-non_002dadaptive-Gauss_002dKronrod-integration.html
+
+    """
 
     def __init__(self, name='poisson'):
         self.mean = Parameter(name, 'mean', 1, 1e-05, hard_min=tinyval)
@@ -331,6 +730,50 @@ class Poisson(ArithmeticModel):
 
 
 class Polynom1D(ArithmeticModel):
+    """One-dimensional polynomial function.
+
+    The maximum order of the polynomial is 8. The default setting has
+    all parameters frozen except for ``c0``, which means that the
+    model acts as a constant.
+
+    Attributes
+    ----------
+    c0
+        The constant term.
+    c1
+        The amplitude of the (x-offset) term.
+    c2
+        The amplitude of the (x-offset)^2 term.
+    c3
+        The amplitude of the (x-offset)^3 term.
+    c4
+        The amplitude of the (x-offset)^4 term.
+    c5
+        The amplitude of the (x-offset)^5 term.
+    c6
+        The amplitude of the (x-offset)^6 term.
+    c7
+        The amplitude of the (x-offset)^7 term.
+    c8
+        The amplitude of the (x-offset)^8 term.
+    offset
+        There is a degeneracy between ``c0`` and ``offset``, so it
+        is recommended that at least one of these remains frozen.
+
+
+    See Also
+    --------
+    PowLaw1D, Polynom2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = sum_(i=0)^(i=8) c_i * (x - offset)^i
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='polynom1d'):
         pars = []
@@ -404,6 +847,30 @@ class Polynom1D(ArithmeticModel):
 
 
 class PowLaw1D(ArithmeticModel):
+    """One-dimensional power-law function.
+
+    Attributes
+    ----------
+    gamma
+    ref
+        As the reference point is degenerate with the amplitude, the
+        ``alwaysfrozen`` attribute of the reference point is set so
+        that it can not be varied during a fit.
+    ampl
+
+    See Also
+    --------
+    Polynom1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * (x / ref)^(-gamma)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='powlaw1d'):
         self.gamma = Parameter(name, 'gamma', 1, -10, 10)
@@ -436,6 +903,33 @@ class PowLaw1D(ArithmeticModel):
 
 
 class Scale1D(Const1D):
+    """A constant model for one-dimensional data.
+
+    This is a specialized form of the ``Const1D`` model where the
+    ``integrate`` flag is turned off.
+
+    Attributes
+    ----------
+    c0
+        The amplitude of the model.
+
+    See Also
+    --------
+    Box1D, Const1D, Delta1D, Scale2D, StepLo1D, StepHi1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl
+
+    and for an integrated grid it is::
+
+        f(xlo,xhi) = ampl * (xhi - xlo)
+
+    This later case will only be used if the ``integrate``
+    attribute is set to ``True``.
+    """
 
     def __init__(self, name='scale1d'):
         Const1D.__init__(self, name)
@@ -443,6 +937,27 @@ class Scale1D(Const1D):
 
 
 class Sin(ArithmeticModel):
+    """One-dimensional sine function.
+
+    Attributes
+    ----------
+    period
+    offset
+    ampl
+
+    See Also
+    --------
+    Cos, Tan
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * sin (2 * pi * (x - offset) / period)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='sin'):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
@@ -462,6 +977,26 @@ class Sin(ArithmeticModel):
 
 
 class Sqrt(ArithmeticModel):
+    """One-dimensional square root function.
+
+    Attributes
+    ----------
+    offset
+    ampl
+
+    See Also
+    --------
+    Exp, Exp10, Log, Log10, LogParabola
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * sqrt (x - offset)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='sqrt'):
         self.offset = Parameter(name, 'offset', 0)
@@ -475,6 +1010,36 @@ class Sqrt(ArithmeticModel):
 
 
 class StepHi1D(ArithmeticModel):
+    """One-dimensional step function.
+
+    The model is flat above ``xcut``, where it is set to the ``ampl``
+    parameter, and zero below this.
+
+    Attributes
+    ----------
+    xcut
+        The position of the step.
+    ampl
+        The amplitude of the step.
+
+    See Also
+    --------
+    Box1D, Const1D, Delta1D, StepLo1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl if x >= xcut
+             = 0       otherwise
+
+    and for an integrated grid it is::
+
+        f(xlo,xhi) = ampl * (xhi - xlo)  if xlo >= xcut
+                   = ampl * (xhi - xcut) if xlo < xcut and xhi >= xcut
+                   = 0                   if xhi < xcut
+
+    """
 
     def __init__(self, name='stephi1d'):
         self.xcut = Parameter(name, 'xcut', 0)
@@ -495,6 +1060,36 @@ class StepHi1D(ArithmeticModel):
 
 
 class StepLo1D(ArithmeticModel):
+    """One-dimensional step function.
+
+    The model is flat below ``xcut``, where it is set to the ``ampl``
+    parameter, and zero above this.
+
+    Attributes
+    ----------
+    xcut
+        The position of the step.
+    ampl
+        The amplitude of the step.
+
+    See Also
+    --------
+    Box1D, Const1D, Delta1D, StepHi1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl if x <= xcut
+             = 0       otherwise
+
+    and for an integrated grid it is::
+
+        f(xlo,xhi) = ampl * (xhi - xlo)  if xhi <= xcut
+                   = ampl * (xcut - xlo) if xlo <= xcut and xhi > xcut
+                   = 0                   if xlo > xcut
+
+    """
 
     def __init__(self, name='steplo1d'):
         self.xcut = Parameter(name, 'xcut', 0)
@@ -515,6 +1110,27 @@ class StepLo1D(ArithmeticModel):
 
 
 class Tan(ArithmeticModel):
+    """One-dimensional tan function.
+
+    Attributes
+    ----------
+    period
+    offset
+    ampl
+
+    See Also
+    --------
+    Cos, Sin
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x) = ampl * tan (2 * pi * (x - offset) / period)
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='tan'):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
@@ -535,6 +1151,47 @@ class Tan(ArithmeticModel):
 
 
 class Box2D(ArithmeticModel):
+    """Two-dimensional box function.
+
+    The model is flat between the limits, where it is set to the
+    ``ampl`` parameter. Outside this range the model is zero.
+
+    Attributes
+    ----------
+    xlow
+        The lower edge of the box (``x0`` axis).
+    xhi
+        The upper edge of the box (``x0`` axis).
+    ylow
+        The lower edge of the box (``x1`` axis).
+    yhi
+        The upper edge of the box (``x1`` axis).
+    ampl
+        The amplitude of the box.
+
+    See Also
+    --------
+    Box1D, Const2D, Delta2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl if xlow <= x0 <= xhi
+                           ylow <= x1 <= yhi
+                 = 0       otherwise
+
+    and for an integrated grid it is::
+
+        f(x0lo,x0hi,x1lo,x1hi)
+                 = 0            if x0hi <= xlow or x0lo >= xhi
+                                or x1hi <= ylow or x1lo >= yhi
+                 = ampl * g     where g is the fraction of the pixel
+                                that falls within the region
+
+    This behavior is different to how the amplitude is handled in
+    other models, such as ``Const2D``.
+    """
 
     def __init__(self, name='box2d'):
         self.xlow = Parameter(name, 'xlow', 0)
@@ -565,6 +1222,29 @@ class Box2D(ArithmeticModel):
 
 
 class Const2D(Const1D):
+    """A constant model for two-dimensional data.
+
+    Attributes
+    ----------
+    c0
+        The amplitude of the model.
+
+    See Also
+    --------
+    Box2D, Const1D, Delta2D, Scale2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0, x1) = ampl
+
+    and for an integrated grid it is::
+
+        f(x0lo, x1lo, x0hi, x1hi = ampl * (x0hi - x0lo)
+                                        * (x1hi - x1lo)
+
+    """
 
     def __init__(self, name='const2d'):
         Const1D.__init__(self, name)
@@ -576,6 +1256,34 @@ class Const2D(Const1D):
 
 
 class Scale2D(Const2D):
+    """A constant model for two-dimensional data.
+
+    This is a specialized form of the ``Const2D`` model where the
+    ``integrate`` flag is turned off.
+
+    Attributes
+    ----------
+    c0
+        The amplitude of the model.
+
+    See Also
+    --------
+    Box2D, Const2D, Delta2D, Scale1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0, x1) = ampl
+
+    and for an integrated grid it is::
+
+        f(x0lo, x1lo, x0hi, x1hi) = ampl * (x0hi - x0lo)
+                                         * (x1hi - x1lo)
+
+    This later case will only be used if the ``integrate``
+    attribute is set to ``True``.
+    """
 
     def __init__(self, name='scale2d'):
         Const2D.__init__(self, name)
@@ -584,6 +1292,40 @@ class Scale2D(Const2D):
 
 
 class Delta2D(ArithmeticModel):
+    """Two-dimensional delta function.
+
+    The model is only defined at a single point (or bin for integrated
+    grids).
+
+    Attributes
+    ----------
+    xpos
+        The coordinate of the signal on the x0 axis.
+    ypos
+        The coordinate of the signal on the x1 axis.
+    ampl
+        The amplitude.
+
+    See Also
+    --------
+    Box2D, Const2D, Delta1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0, x1) = ampl if x0 == xpos and x1 == ypos
+             = 0         otherwise
+
+    and for an integrated grid it is::
+
+        f(x0lo, x1lo, x0hi, x1hi) = ampl if x0lo <= xpos <= x0hi
+                                            x1lo <= ypos <= x1hi
+                                  = 0    otherwise
+
+    This behavior is different to how the amplitude is handled in
+    other models, such as ``Const2D``.
+    """
 
     def __init__(self, name='delta2d'):
         self.xpos = Parameter(name, 'xpos', 0)
@@ -612,6 +1354,58 @@ class Delta2D(ArithmeticModel):
         return _modelfcts.delta2d(*args, **kwargs)
 
 class Gauss2D(ArithmeticModel):
+    """Two-dimensional gaussian function.
+
+    Attributes
+    ----------
+    fwhm
+        The Full-Width Half Maximum of the gaussian along the major
+        axis. It is related to the sigma value by:
+        FWHM = sqrt(8 * log(2)) * sigma.
+    xpos
+        The center of the gaussian on the x0 axis.
+    ypos
+        The center of the gaussian on the x1 axis.
+    ellip
+        The ellipticity of the gaussian.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+
+    See Also
+    --------
+    Gauss1D, NormGauss2D, SigmaGauss2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl * exp(-4 * log(2) * r(x0,x1)^2 / fwhm^2)
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+                     -------------------------------------------
+                                     (1-ellip)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+
+    The grid version is evaluated by adaptive multidimensional
+    integration scheme on hypercubes using cubature rules, based
+    on code from HIntLib ([1]_) and GSL ([2]_).
+
+    References
+    ----------
+
+    .. [1] HIntLib - High-dimensional Integration Library
+           http://mint.sbg.ac.at/HIntLib/
+
+    .. [2] GSL - GNU Scientific Library
+           http://www.gnu.org/software/gsl/
+
+    """
 
     def __init__(self, name='gauss2d'):
         self.fwhm = Parameter(name, 'fwhm', 10, tinyval, hard_min=tinyval)
@@ -647,6 +1441,58 @@ class Gauss2D(ArithmeticModel):
         return _modelfcts.gauss2d(*args, **kwargs)
 
 class SigmaGauss2D(Gauss2D):
+    """Two-dimensional gaussian function (varying sigma).
+
+    Attributes
+    ----------
+    sigma_a
+        The sigma of the gaussian along the major axis.
+    sigma_b
+        The sigma of the gaussian along the minor axis.
+    xpos
+        The center of the gaussian on the x0 axis.
+    ypos
+        The center of the gaussian on the x1 axis.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the maximum peak of the model.
+
+    See Also
+    --------
+    Gauss2D, NormGauss2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = ampl * exp(-r(x0,x1)^2 / 2)
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 + yoff(x0,x1)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+                      ---------------------------------------------------
+                                            sigma_a
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+                      ---------------------------------------------------
+                                            sigma_b
+
+    The grid version is evaluated by adaptive multidimensional
+    integration scheme on hypercubes using cubature rules, based
+    on code from HIntLib ([1]_) and GSL ([2]_).
+
+    References
+    ----------
+
+    .. [1] HIntLib - High-dimensional Integration Library
+           http://mint.sbg.ac.at/HIntLib/
+
+    .. [2] GSL - GNU Scientific Library
+           http://www.gnu.org/software/gsl/
+
+    """
 
     def __init__(self, name='sigmagauss2d'):
         self.sigma_a = Parameter(name, 'sigma_a', 10, tinyval, hard_min=tinyval)
@@ -668,6 +1514,61 @@ class SigmaGauss2D(Gauss2D):
 
 
 class NormGauss2D(ArithmeticModel):
+    """Two-dimensional normalised gaussian function.
+
+    Attributes
+    ----------
+    fwhm
+        The Full-Width Half Maximum of the gaussian along the major
+        axis. It is related to the sigma value by:
+        FWHM = sqrt(8 * log(2)) * sigma.
+    xpos
+        The center of the gaussian on the x0 axis.
+    ypos
+        The center of the gaussian on the x1 axis.
+    ellip
+        The ellipticity of the gaussian.
+    theta
+        The angle of the major axis. It is in radians, measured
+        counter-clockwise from the X0 axis (i.e. the line X1=0).
+    ampl
+        The amplitude refers to the integral of the model over the
+        range -infinity to infinity for both axes.
+
+    See Also
+    --------
+    Gauss2D, NormGauss1D, SigmaGauss2D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x0,x1) = 4 * log(2) * ampl * exp(-4 * log(2) * r(x0,x1)^2 / fwhm^2)
+                   ----------------------------------------------------------
+                           pi * fwhm * fwhm * sqrt(1 - ellip * ellip)
+
+        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+                     -------------------------------------------
+                                     (1-ellip)^2
+
+        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+
+    The grid version is evaluated by adaptive multidimensional
+    integration scheme on hypercubes using cubature rules, based
+    on code from HIntLib ([1]_) and GSL ([2]_).
+
+    References
+    ----------
+
+    .. [1] HIntLib - High-dimensional Integration Library
+           http://mint.sbg.ac.at/HIntLib/
+
+    .. [2] GSL - GNU Scientific Library
+           http://www.gnu.org/software/gsl/
+
+    """
 
     def __init__(self, name='normgauss2d'):
         self.fwhm = Parameter(name, 'fwhm', 10, tinyval, hard_min=tinyval)
@@ -710,6 +1611,40 @@ class NormGauss2D(ArithmeticModel):
 
 
 class Polynom2D(ArithmeticModel):
+    """Two-dimensional polynomial function.
+
+    The maximum order of the polynomial is 2.
+
+    Attributes
+    ----------
+    c
+    cy1
+    cy2
+    cx1
+    cx1y1
+    cx1y2
+    cx2
+    cx2y1
+    cx2y2
+
+    See Also
+    --------
+    Polynom1D
+
+    Notes
+    -----
+    The functional form of the model for points is::
+
+        f(x,x1) = c + cx1 * x0 + cx2 * x0^2 +
+                      cy1 * x1 + cy2 * x1^2 +
+                      cx1y1 * x0 * x1 +
+                      cx1y2 * x0 * x1^2 +
+                      cx2y1 * x0^2 * x1 +
+                      cx2y2 * x0^2 * x1^2
+
+    and for an integrated grid it is the integral of this over
+    the bin.
+    """
 
     def __init__(self, name='polynom2d'):
         self.c = Parameter(name, 'c', 1)
@@ -842,6 +1777,11 @@ class TableModel(ArithmeticModel):
                        (len(self.__y), len(x0)))
 
 class UserModel(ArithmeticModel):
+    """Support for user-supplied models.
+
+    The class is used by sherpa.ui.load_user_model and
+    sherpa.astro.ui.load_user_model.
+    """
     def __init__(self, name='usermodel', pars=None):
         # these attributes should remain somewhat private
         # as not to conflict with user defined parameter names

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -730,7 +730,7 @@ class Poisson(ArithmeticModel):
 
 
 class Polynom1D(ArithmeticModel):
-    """One-dimensional polynomial function.
+    """One-dimensional polynomial function of order 8.
 
     The maximum order of the polynomial is 8. The default setting has
     all parameters frozen except for ``c0``, which means that the

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1382,11 +1382,11 @@ class Gauss2D(ArithmeticModel):
     -----
     The functional form of the model for points is::
 
-        f(x0,x1) = ampl * exp(-4 * log(2) * r(x0,x1)^2 / fwhm^2)
+        f(x0,x1) = ampl * exp(-4 * log(2) * r(x0,x1)^2)
 
         r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
                      -------------------------------------------
-                                     (1-ellip)^2
+                                fwhm^2 * (1-ellip)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 
@@ -1470,14 +1470,12 @@ class SigmaGauss2D(Gauss2D):
         f(x0,x1) = ampl * exp(-r(x0,x1)^2 / 2)
 
         r(x0,x1)^2 = xoff(x0,x1)^2 + yoff(x0,x1)^2
+                     -------------   -------------
+                       sigma_a^2       sigma_b^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
-                      ---------------------------------------------------
-                                            sigma_a
 
         yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
-                      ---------------------------------------------------
-                                            sigma_b
 
     The grid version is evaluated by adaptive multidimensional
     integration scheme on hypercubes using cubature rules, based
@@ -1543,13 +1541,13 @@ class NormGauss2D(ArithmeticModel):
     -----
     The functional form of the model for points is::
 
-        f(x0,x1) = 4 * log(2) * ampl * exp(-4 * log(2) * r(x0,x1)^2 / fwhm^2)
-                   ----------------------------------------------------------
-                           pi * fwhm * fwhm * sqrt(1 - ellip * ellip)
+        f(x0,x1) = 4 * log(2) * ampl * exp(-4 * log(2) * r(x0,x1)^2)
+                   -------------------------------------------------
+                       pi * fwhm * fwhm * sqrt(1 - ellip * ellip)
 
         r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
                      -------------------------------------------
-                                     (1-ellip)^2
+                                 fwhm^2 * (1-ellip)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 


### PR DESCRIPTION
Fix #217.

# Status

The PR is ready for review.

#  Release notes

Integrate existing model documentation (from external sources and the CIAO ahelp documentation system) into the model classes.

# Notes

The aim is to make this a documentation-only change, but there may be some inadvertent changes in code sections due to stripping out extra white space.

I am not planning in this PR to add documentation to some of the more "hidden" classes (at least for those people using the `sherpa.ui` or `sherpa.astro.ui` interface): e.g. the "instrument" models like `PSFModel`, `ARFModel`, `RSPModel`.