### PR TITLE
Allow XSPEC 12.8.2q builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ matrix:
       python: "2.7"
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
+  allow_failures:
+    - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
 
 env:  INSTALL_TYPE=install TEST=smoke NOSETUPTOOLS="true" MATPLOTLIBVER=1.5
 


### PR DESCRIPTION
# Release Notes

There is no change to the Sherpa code base here. It is only to the `.travis.yml` file.

This PR allows the XSPEC version 12.8.2q test on Travis-CI to fail but the run still be considered a success. This is because there are known memory issues with this version of XSPEC (and that have been fixed in 12.9.0) that appear to cause random failures for the 12.8.2 build.

# Other notes

An alternative to this PR is to remove the 12.8.2q build from the matrix and just make 12.9.0 the minimum supported XSPEC version.

@olaurino had mentioned this as a possible change, and after reviewing a recent PR which was flagged as a faillure due to this issue (i.e. re-running the 12.8.2 XSPEC test made it pass) I decided to put in this PR.