### PR TITLE
Bug #149 filter grouping

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -877,13 +877,7 @@ class DataPHA(Data1DInt):
 
         self.grouping, self.quality = group_func(*args, **kwargs)
 
-        # for fixing bug #149. Find the last group. If it's bad quality,
-        # remove it from the grouped view. This could be fixed in
-        # the grouping library; instead of assigning quality=2 to unfilled
-        # groups, just ignore them completely from the grouped view.
-        # last_bad_group_index = numpy.where(self.grouping == 1)[0][-1]
-        # if self.quality[last_bad_group_index] == 2:
-        #     self.grouping[last_bad_group_index:] = 0
+        # Ignore bad groups automatically (for bug #149)
         self._ignore_bad_groups()
 
         self.group()

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -317,12 +317,13 @@ class test_threads(SherpaTestCase):
     # As of CIAO 4.5, can filter on channel number, even when
     # data are grouped! Test results should exactly match CIAO 4.4
     # fit results in grouped/fit.py
+    # jbudynk [sherpa 4.8.1]: fit results updated to fix bug #149.
     def test_grouped_ciao4_5(self):
         self.run_thread('grouped_ciao4.5')
-        self.assertEqualWithinTol(ui.get_fit_results().statval, 18.8316, 1e-4)
-        self.assertEqual(ui.get_fit_results().numpoints, 46)
-        self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.83906, 1e-4)
-        self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000301258, 1e-4)
+        self.assertEqualWithinTol(ui.get_fit_results().statval, 18.5383, 1e-4)
+        self.assertEqual(ui.get_fit_results().numpoints, 45)
+        self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.81842, 1e-4)
+        self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000298156, 1e-4)
 
     @requires_fits
     @requires_xspec

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -320,10 +320,10 @@ class test_threads(SherpaTestCase):
     # jbudynk [sherpa 4.8.1]: fit results updated to fix bug #149.
     def test_grouped_ciao4_5(self):
         self.run_thread('grouped_ciao4.5')
-        self.assertEqualWithinTol(ui.get_fit_results().statval, 18.5383, 1e-4)
-        self.assertEqual(ui.get_fit_results().numpoints, 45)
-        self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.81842, 1e-4)
-        self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000298156, 1e-4)
+        self.assertEqualWithinTol(ui.get_fit_results().statval, 18.8316, 1e-4)
+        self.assertEqual(ui.get_fit_results().numpoints, 46)
+        self.assertEqualWithinTol(self.locals['aa'].gamma.val, 1.83906, 1e-4)
+        self.assertEqualWithinTol(self.locals['aa'].ampl.val, 0.000301258, 1e-4)
 
     @requires_fits
     @requires_xspec

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -243,6 +243,7 @@ class test_grouping(SherpaTestCase):
 
     # test for when the last bin after grouping is less than the number
     # specified for group_counts()
+    # TODO: get rid of this test??
     @requires_data
     @requires_fits
     def test_group_counts_ignore_bad(self):
@@ -255,11 +256,12 @@ class test_grouping(SherpaTestCase):
         # control array. We expect the last bin to have less than 16 counts.
         # TODO: is this true? Or should unfilled groups be removed from the
         # grouped array?
+        # control array. All bins should have at least 16 counts
         new_y = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
                 22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
                 20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
                 17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
-                16.0, 9.0]
+                16.0]
 
         # The last bin is less than 16, and so should have a bad group quality
         group_quality = numpy.zeros(1024)
@@ -269,11 +271,6 @@ class test_grouping(SherpaTestCase):
 
         # before ignoring the bad data
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
-
-        # ignore bad data (with group quality=2) should remove the last bin
-        # with value 9
-        data.ignore_bad()
-        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y[:-1])
 
     # issue 149
     # set a filter to the data before grouping it.
@@ -330,16 +327,9 @@ class test_grouping(SherpaTestCase):
         # TODO: is this true? Or should unfilled groups be removed from the
         # grouped array?
         grouped = [19, 18, 16, 21, 18, 19, 16, 17, 17, 19, 16, 16, 17, 16,
-                   17, 16, 17, 16, 16, 16, 17, 16, 16, 16, 16, 3]
+                   17, 16, 17, 16, 16, 16, 17, 16, 16, 16, 16]
 
         numpy.testing.assert_array_equal(data.get_dep(filter=True), grouped)
-
-        # ignore any bad groups
-        data.ignore_bad()
-
-        # the last element in the grouped array should be masked
-        numpy.testing.assert_array_equal(data.get_dep(filter=True),
-                                         grouped[:-1])
 
     def test_group_bins_simple(self):
 
@@ -395,9 +385,9 @@ class test_grouping(SherpaTestCase):
         data.group_snr(5, errorCol=errs)
 
         # control x and y arrays.
-        new_x = numpy.arange(start=1, stop=101, step=7)
+        new_x = numpy.arange(start=1, stop=101, step=7)[:-1]
         new_y = numpy.ones(new_x.size) * 7
-        new_y[new_y.size-1] = 2 # 2 bins left over after grouping
+        # new_y[new_y.size-1] = 2 # 2 bins left over after grouping
 
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
         # TODO: uncomment when I figure out how to get the x data
@@ -407,7 +397,7 @@ class test_grouping(SherpaTestCase):
         data.ungroup()
         data.group_snr(5)
 
-        new_y = [26, 26, 26, 22]
+        new_y = [26, 26, 26]
 
         # there should be 10 bins with y=10
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
@@ -420,7 +410,7 @@ class test_grouping(SherpaTestCase):
         data.group_adapt_snr(17)
 
         # expected grouped array
-        new_y = [169.0, 365.0, 579.0, 819.0, 457.0, 359.0, 15.0]
+        new_y = [365.0, 579.0, 819.0, 457.0, 359.0]
 
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
 
@@ -432,7 +422,7 @@ class test_grouping(SherpaTestCase):
         data.group_adapt(700)
 
         # expected grouped array
-        new_y = [315.0, 798.0, 819.0, 816.0, 15.0]
+        new_y = [798.0, 819.0, 816.0]
 
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -21,6 +21,7 @@ import numpy
 from sherpa.astro.data import DataPHA
 from sherpa.utils import SherpaTestCase, requires_data, requires_fits
 from sherpa.astro.io import read_pha
+import unittest
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -223,7 +224,7 @@ class test_grouping(SherpaTestCase):
             logger.setLevel(self.loggingLevel)
 
     # issue 149
-    def test_grouping_simple(self):
+    def test_group_counts_simple(self):
 
         x = numpy.arange(start=1, stop=161, step=1)
         y = numpy.ones(x.size)
@@ -237,12 +238,11 @@ class test_grouping(SherpaTestCase):
         # test that the data is grouped correctly
         numpy.testing.assert_array_equal(dataset.get_dep(filter=True), newy)
 
-    # issue 149
     # test for when the last bin after grouping is less than the number
     # specified for group_counts()
     @requires_data
     @requires_fits
-    def test_group_counts_issue149(self):
+    def test_group_counts_ignore_bad1(self):
 
         # load a real dataset to test
         data = read_pha(self.pha3c273)
@@ -268,6 +268,25 @@ class test_grouping(SherpaTestCase):
         # with value 9
         data.ignore_bad()
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y[:-1])
+
+    # issue 149
+    # set a filter to the data before grouping it using data from bug 149
+    # NOTE: we expect this test to fail until issue #149 is resolved.
+    @requires_fits
+    @requires_data
+    def test_group_counts_issue149(self):
+        data = read_pha(self.specfit_dataset, use_errors=True)
+
+        #filter and group data
+        data.notice(0.5, 7.0)
+        data.group_counts(16)
+
+        # the expected grouped counts after filtering
+        new_y = [19, 18, 16, 21, 18, 19, 16, 17, 19, 16, 16, 17, 16, 17,
+                 16, 17, 16, 16, 16, 17, 16, 16, 16, 16, 16, 16, 16]
+
+        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
+
 
     def test_group_bins_simple(self):
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -21,7 +21,6 @@ import numpy
 from sherpa.astro.data import DataPHA
 from sherpa.utils import SherpaTestCase, requires_data, requires_fits
 from sherpa.astro.io import read_pha
-import unittest
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -294,52 +293,6 @@ class test_grouping(SherpaTestCase):
                    16., 16., 16.]
 
         numpy.testing.assert_array_equal(data.get_dep(filter=True), grouped)
-
-    # set quality flags and a filter to the data before grouping it.
-    # NOTE: we expect this test to fail until we fix properly handle grouping
-    # and quality flags, and until issue #149 is resolved.
-    @requires_fits
-    @requires_data
-    def test_grouping_with_previous_quality_flags(self):
-
-        data = read_pha(self.specfit_dataset1, use_errors=True)
-
-        # set the data quality arrays
-        # use OGIP standards (0=good, 1=bad from data redux pipeline, 2=bad from
-        # software, 5=bad from user)
-        quality = numpy.zeros(len(data.channel))
-        quality[:30] = 5
-        quality[301:350] = 5
-        quality[350:] = 1
-
-        data.quality = quality
-
-        # filter data
-        data.notice(0.5, 7.0)
-
-        # ignore bad data points
-        data.ignore_bad()
-
-        # group_counts() removes the filter before rebinning
-        # but re-applies the filter afterwards
-        data.group_counts(16)
-
-        # the expected grouped counts
-        # note that the last element in the array is an unfilled group that
-        # should have a bad group quality value
-        # TODO: is this true? Or should unfilled groups be removed from the
-        # grouped array?
-        grouped = [19, 18, 16, 21, 18, 19, 16, 17, 17, 19, 16, 16, 17, 16,
-                   17, 16, 17, 16, 16, 16, 17, 16, 16, 16, 16, 3]
-
-        numpy.testing.assert_array_equal(data.get_dep(filter=True), grouped)
-
-        # ignore any bad groups
-        data.ignore_bad()
-
-        # the last element in the grouped array should be masked
-        numpy.testing.assert_array_equal(data.get_dep(filter=True),
-                                         grouped[:-1])
 
     def test_group_bins_simple(self):
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -375,7 +375,7 @@ class test_grouping(SherpaTestCase):
         new_x = numpy.arange(start=1, stop=1025, step=16)
         new_y = numpy.ones(64) * 16
 
-        # there should be 10 bins with y=10
+        # there should be 64 bins with y=16
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
         # TODO: uncomment when I figure out how to get the x data
         # numpy.testing.assert_array_equal(data.get_indep(filter=True), new_x)
@@ -433,6 +433,41 @@ class test_grouping(SherpaTestCase):
 
         # expected grouped array
         new_y = [315.0, 798.0, 819.0, 816.0, 15.0]
+
+        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
+
+    def test_group_filter_keep_good_bins(self):
+        # if a filter is set to the data, make sure all the grouped data inside
+        # the filter is still shown when calling "get_dep(filter=True)"
+
+        # make a straight line from x=1 to x=1024
+        x = numpy.arange(start=1, stop=1025, step=1)
+        y = numpy.ones(x.size)
+        data = DataPHA("dataset", x, y)
+
+        # group so each bin is 16 channels wide
+        data.group_width(16)
+
+        # set a filter to include 16 - 1008
+        data.notice(15, 1008)
+
+        # control x and y arrays. There should be 62 groups
+        new_x = numpy.arange(start=16, stop=1008, step=16)
+        new_y = numpy.ones(new_x.size) * 16
+
+        # there should be 64 bins with y=16
+        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
+
+        # cleanup
+        data.ungroup()
+
+        # set a filter to include the whole dataset *before* grouping
+        data.notice(0, 2000)
+        data.group_width(16)
+
+        # control x and y arrays. There should be 64 groups
+        new_x = numpy.arange(start=1, stop=1025, step=16)
+        new_y = numpy.ones(64) * 16
 
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -21,10 +21,10 @@ import numpy
 from sherpa.astro.data import DataPHA
 from sherpa.utils import SherpaTestCase, requires_data, requires_fits
 from sherpa.astro.io import read_pha
-import unittest
 
 import logging
 logger = logging.getLogger('sherpa')
+
 
 class test_filter_energy_grid(SherpaTestCase):
 
@@ -72,21 +72,19 @@ class test_filter_energy_grid(SherpaTestCase):
         logger.setLevel(self.old_level)
 
     def test_notice(self):
-        #clear mask
+        # clear mask
         self.pha.notice()        
         self.pha.notice(0.0, 6.0)
-        #self.assertEqual(self._notice, self.pha.mask)
+        # self.assertEqual(self._notice, self.pha.mask)
         assert (self._notice == numpy.asarray(self.pha.mask)).all()
 
-
     def test_ignore(self):
-        #clear mask
+        # clear mask
         self.pha.notice()
         self.pha.ignore(0.0, 1.0)
         self.pha.ignore(3.0, 15.0)
-        #self.assertEqual(self._ignore, self.pha.mask)
+        # self.assertEqual(self._ignore, self.pha.mask)
         assert (self._ignore == numpy.asarray(self.pha.mask)).all()
-
 
 
 class test_filter_energy_grid_reversed(SherpaTestCase):
@@ -184,32 +182,31 @@ class test_filter_energy_grid_reversed(SherpaTestCase):
         0.34669766,  0.34418666,  0.33912122,  0.33720407,  0.33505177,
         0.33279634,  0.33081138,  0.32847831,  0.32592943], numpy.float)
 
-
     def setUp(self):
-        #self.old_level = logger.getEffectiveLevel()
-        #logger.setLevel(logging.ERROR)
+        # self.old_level = logger.getEffectiveLevel()
+        # logger.setLevel(logging.ERROR)
         self.pha = DataPHA('', numpy.arange(204, dtype=float)+1.,
                            numpy.zeros(204),
                            bin_lo=self._emin, bin_hi=self._emax)
         self.pha.units="energy"
 
     def tearDown(self):
-        #logger.setLevel(self.old_level)
+        # logger.setLevel(self.old_level)
         pass
 
     def test_notice(self):
-        #clear mask
+        # clear mask
         self.pha.notice()
         self.pha.notice(4., 8.3)
         assert (self._notice == numpy.asarray(self.pha.mask)).all()
 
-
     def test_ignore(self):
-        #clear mask
+        # clear mask
         self.pha.notice()
         self.pha.ignore(10.3, 13.8)
         self.pha.ignore(4.6, 6.2)
         assert (self._ignore == numpy.asarray(self.pha.mask)).all()
+
 
 class test_grouping(SherpaTestCase):
 
@@ -274,7 +271,6 @@ class test_grouping(SherpaTestCase):
 
     # issue 149
     # set a filter to the data before grouping it.
-    # NOTE: we expect this test to fail until issue #149 is resolved.
     @requires_fits
     @requires_data
     def test_group_counts_issue149(self):
@@ -294,7 +290,7 @@ class test_grouping(SherpaTestCase):
 
     # set quality flags and a filter to the data before grouping it.
     # NOTE: we expect this test to fail until we fix properly handle grouping
-    # and quality flags, and until issue #149 is resolved.
+    # and quality flags.
     @requires_fits
     @requires_data
     def test_grouping_with_previous_quality_flags(self):
@@ -322,10 +318,6 @@ class test_grouping(SherpaTestCase):
         data.group_counts(16)
 
         # the expected grouped counts
-        # note that the last element in the array is an unfilled group that
-        # should have a bad group quality value
-        # TODO: is this true? Or should unfilled groups be removed from the
-        # grouped array?
         grouped = [19, 18, 16, 21, 18, 19, 16, 17, 17, 19, 16, 16, 17, 16,
                    17, 16, 17, 16, 16, 16, 17, 16, 16, 16, 16]
 
@@ -486,7 +478,7 @@ class test_filter_wave_grid(SherpaTestCase):
 
     def test_notice(self):
         self.pha.units = 'wavelength'
-        #clear mask
+        # clear mask
         self.pha.notice()
         self.pha.notice(100.0, 225.0)
         numpy.testing.assert_array_equal(self._notice, numpy.asarray(
@@ -494,7 +486,7 @@ class test_filter_wave_grid(SherpaTestCase):
 
     def test_ignore(self):
         self.pha.units = 'wavelength'
-        #clear mask
+        # clear mask
         self.pha.notice()
         self.pha.ignore(30.01, 225.0)
         self.pha.ignore(0.1, 6.0)

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -250,16 +250,19 @@ class test_grouping(SherpaTestCase):
         data.group_counts(16)
 
         # control array. We expect the last bin to have less than 16 counts.
+        # TODO: is this true? Or should unfilled groups be removed from the
+        # grouped array?
         new_y = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
                 22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
                 20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
                 17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
                 16.0, 9.0]
 
-        # The last bin is less than 16, and so should have group quality = 2
-        quality = numpy.zeros(1024)
-        quality[957:] = 2
-        numpy.testing.assert_array_equal(data.quality, quality)
+        # The last bin is less than 16, and so should have a bad group quality
+        group_quality = numpy.zeros(1024)
+        group_quality[957] = 2
+        # TODO: decide how we will store bad group qualities, or if we will
+        # store them at all. See TODO above.
 
         # before ignoring the bad data
         numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
@@ -301,6 +304,8 @@ class test_grouping(SherpaTestCase):
         # the expected grouped counts
         # note that the last element in the array is an unfilled group that
         # should have a bad group quality value
+        # TODO: is this true? Or should unfilled groups be removed from the
+        # grouped array?
         grouped = [19, 18, 16, 21, 18, 19, 16, 17, 17, 19, 16, 16, 17, 16,
                    17, 16, 17, 16, 16, 16, 17, 16, 16, 16, 16, 3]
 
@@ -312,7 +317,6 @@ class test_grouping(SherpaTestCase):
         # the last element in the grouped array should be masked
         numpy.testing.assert_array_equal(data.get_dep(filter=True),
                                          grouped[:-1])
-
 
     def test_group_bins_simple(self):
 

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,10 +29,10 @@ logger = logging.getLogger('sherpa')
 class test_filter_energy_grid(SherpaTestCase):
 
     _notice = numpy.ones(46, dtype=bool)
-    _notice[44:46]=False
+    _notice[44:46] = False
 
     _ignore = numpy.zeros(46, dtype=bool)
-    _ignore[14:33]=True
+    _ignore[14:33] = True
 
     _emin = numpy.array([
         1.46000006e-03,   2.48199999e-01,   3.06600004e-01,   4.67200011e-01,
@@ -65,7 +65,7 @@ class test_filter_energy_grid(SherpaTestCase):
         logger.setLevel(logging.ERROR)
         self.pha = DataPHA('', numpy.arange(46, dtype=float)+1.,
                            numpy.zeros(46),
-                           bin_lo = self._emin, bin_hi = self._emax )
+                           bin_lo=self._emin, bin_hi=self._emax )
         self.pha.units="energy"
 
     def tearDown(self):
@@ -76,7 +76,7 @@ class test_filter_energy_grid(SherpaTestCase):
         self.pha.notice()        
         self.pha.notice(0.0, 6.0)
         #self.assertEqual(self._notice, self.pha.mask)
-        assert (self._notice==numpy.asarray(self.pha.mask)).all()
+        assert (self._notice == numpy.asarray(self.pha.mask)).all()
 
 
     def test_ignore(self):
@@ -85,18 +85,18 @@ class test_filter_energy_grid(SherpaTestCase):
         self.pha.ignore(0.0, 1.0)
         self.pha.ignore(3.0, 15.0)
         #self.assertEqual(self._ignore, self.pha.mask)
-        assert (self._ignore==numpy.asarray(self.pha.mask)).all()
+        assert (self._ignore == numpy.asarray(self.pha.mask)).all()
 
 
 
 class test_filter_energy_grid_reversed(SherpaTestCase):
 
     _notice = numpy.zeros(204, dtype=bool)
-    _notice[0:42]=True
+    _notice[0:42] = True
 
     _ignore = numpy.ones(204, dtype=bool)
-    _ignore[66:70]=False
-    _ignore[0:17]=False
+    _ignore[66:70] = False
+    _ignore[0:17] = False
 
     _emin = numpy.array([
         2.39196181,  2.35973215,  2.34076023,  2.30973101,  2.2884388 ,
@@ -190,7 +190,7 @@ class test_filter_energy_grid_reversed(SherpaTestCase):
         #logger.setLevel(logging.ERROR)
         self.pha = DataPHA('', numpy.arange(204, dtype=float)+1.,
                            numpy.zeros(204),
-                           bin_lo = self._emin, bin_hi = self._emax )
+                           bin_lo=self._emin, bin_hi=self._emax)
         self.pha.units="energy"
 
     def tearDown(self):
@@ -201,7 +201,7 @@ class test_filter_energy_grid_reversed(SherpaTestCase):
         #clear mask
         self.pha.notice()
         self.pha.notice(4., 8.3)
-        assert (self._notice==numpy.asarray(self.pha.mask)).all()
+        assert (self._notice == numpy.asarray(self.pha.mask)).all()
 
 
     def test_ignore(self):
@@ -209,7 +209,7 @@ class test_filter_energy_grid_reversed(SherpaTestCase):
         self.pha.notice()
         self.pha.ignore(10.3, 13.8)
         self.pha.ignore(4.6, 6.2)
-        assert (self._ignore==numpy.asarray(self.pha.mask)).all()
+        assert (self._ignore == numpy.asarray(self.pha.mask)).all()
 
 class test_grouping(SherpaTestCase):
 
@@ -219,7 +219,7 @@ class test_grouping(SherpaTestCase):
         self.pha3c273 = self.make_path('3c273.pi')
         self.specfit_dataset1 = self.make_path(
             'acisf00308_000N001_r0044_pha3.fits')
-        self.specfit_dataset2 =  self.make_path(
+        self.specfit_dataset2 = self.make_path(
             'acisf01878_000N001_r0100_pha3.fits')
         self.adapt_dataset = self.make_path('dmgroup_pha1.fits')
 
@@ -227,7 +227,6 @@ class test_grouping(SherpaTestCase):
         if hasattr(self, 'loggingLevel'):
             logger.setLevel(self.loggingLevel)
 
-    # issue 149
     def test_group_counts_simple(self):
 
         x = numpy.arange(start=1, stop=161, step=1)
@@ -441,10 +440,10 @@ class test_grouping(SherpaTestCase):
 class test_filter_wave_grid(SherpaTestCase):
 
     _notice = numpy.ones(16384, dtype=bool)
-    _notice[8465:16384]=False
+    _notice[8465:16384] = False
 
     _ignore = numpy.zeros(16384, dtype=bool)
-    _ignore[14064:15984]=True
+    _ignore[14064:15984] = True
 
     _emin = numpy.arange(205.7875, 0.9875, -0.0125)
 
@@ -455,7 +454,7 @@ class test_filter_wave_grid(SherpaTestCase):
         logger.setLevel(logging.ERROR)
         self.pha = DataPHA('', numpy.arange(16384, dtype=float)+1,
                            numpy.zeros(16384),
-                           bin_lo = self._emin, bin_hi = self._emax )
+                           bin_lo=self._emin, bin_hi=self._emax )
 
     def tearDown(self):
         logger.setLevel(self.old_level)
@@ -465,15 +464,17 @@ class test_filter_wave_grid(SherpaTestCase):
         #clear mask
         self.pha.notice()
         self.pha.notice(100.0, 225.0)
-        assert (self._notice==numpy.asarray(self.pha.mask)).all()
+        numpy.testing.assert_array_equal(self._notice, numpy.asarray(
+            self.pha.mask))
 
     def test_ignore(self):
         self.pha.units = 'wavelength'
         #clear mask
         self.pha.notice()
         self.pha.ignore(30.01, 225.0)
-        self.pha.ignore(0.1, 6.0)        
-        assert (self._ignore==numpy.asarray(self.pha.mask)).all()
+        self.pha.ignore(0.1, 6.0)
+        numpy.testing.assert_array_equal(self._ignore, numpy.asarray(
+            self.pha.mask))
 
 
 if __name__ == '__main__':

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -151,6 +151,58 @@ class test_more_ui(SherpaTestCase):
         ui.group_counts('3c273', 15)
 
 
+class test_grouping(SherpaTestCase):
+    def setUp(self):
+        self.pha3c273 = self.make_path('3c273.pi')
+
+    # issue 149
+    def test_grouping_simple(self):
+
+        x = numpy.arange(start=1, stop=161, step=1)
+        y = numpy.ones(x.size)
+        ui.load_arrays(0, x, y, ui.DataPHA)
+        ui.group_counts(0,16)
+
+        # control arrays
+        newx = numpy.arange(start=1, stop=161, step=16)
+        newy = numpy.zeros(newx.size)+16
+
+        # test that the data is grouped correctly
+        numpy.testing.assert_array_equal(ui.get_data(0).to_fit()[0], newy)
+
+    # issue 149
+    # test for when the last bin after grouping is less than the number
+    # specified for group_counts()
+    @requires_data
+    @requires_fits
+    def test_group_counts_issue149(self):
+
+        # load a real dataset to test
+        ui.load_pha(1, self.pha3c273)
+        ui.ungroup(1)
+        ui.group_counts(1, 16)
+
+        # control array. We expect the last bin to have less than 16 counts.
+        newy = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
+                22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
+                20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
+                17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
+                16.0, 9.0]
+
+        # The last bin is less than 16, and so should have group quality = 2
+        quality = numpy.zeros(1024)
+        quality[957:] = 2
+        numpy.testing.assert_array_equal(ui.get_data(1).quality, quality)
+
+        # before ignoring the bad data
+        numpy.testing.assert_array_equal(ui.get_data(1).to_fit()[0], newy)
+
+        # ignore bad data (with group quality=2) should remove the last bin
+        # with value 9
+        ui.ignore_bad(1)
+        numpy.testing.assert_array_equal(ui.get_data(1).to_fit()[0], newy[:-1])
+
+
 @requires_data
 @requires_fits
 class test_image_12578(SherpaTestCase):

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -31,8 +31,6 @@ from sherpa.utils import requires_data, requires_fits, requires_group
 from sherpa.astro import ui
 from sherpa.data import Data1D
 from sherpa.astro.data import DataPHA
-from sherpa.astro.ui.utils import Session
-from sherpa.astro.io import read_pha
 
 import logging
 logger = logging.getLogger("sherpa")
@@ -151,94 +149,6 @@ class test_more_ui(SherpaTestCase):
         ui.notice_id('3c273', 0.3, 2)
         ui.group_counts('3c273', 30)
         ui.group_counts('3c273', 15)
-
-
-class test_grouping(SherpaTestCase):
-    def setUp(self):
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-        self.pha3c273 = self.make_path('3c273.pi')
-        self.specfit_dataset = self.make_path('acisf00308_000N001_r0044_pha3.fits')
-
-    def tearDown(self):
-        if hasattr(self, 'loggingLevel'):
-            logger.setLevel(self.loggingLevel)
-
-    # issue 149
-    def test_grouping_simple(self):
-
-        x = numpy.arange(start=1, stop=161, step=1)
-        y = numpy.ones(x.size)
-        dataset = DataPHA("dataset", x, y)
-        dataset.group_counts(16)
-
-        # control arrays
-        newx = numpy.arange(start=1, stop=161, step=16)
-        newy = numpy.zeros(newx.size)+16
-
-        # test that the data is grouped correctly
-        numpy.testing.assert_array_equal(dataset.get_dep(filter=True), newy)
-
-    # issue 149
-    # test for when the last bin after grouping is less than the number
-    # specified for group_counts()
-    @requires_data
-    @requires_fits
-    def test_group_counts_issue149(self):
-
-        # load a real dataset to test
-        data = read_pha(self.pha3c273)
-        data.ungroup()
-        data.group_counts(16)
-
-        # control array. We expect the last bin to have less than 16 counts.
-        new_y = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
-                22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
-                20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
-                17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
-                16.0, 9.0]
-
-        # The last bin is less than 16, and so should have group quality = 2
-        quality = numpy.zeros(1024)
-        quality[957:] = 2
-        numpy.testing.assert_array_equal(data.quality, quality)
-
-        # before ignoring the bad data
-        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
-
-        # ignore bad data (with group quality=2) should remove the last bin
-        # with value 9
-        data.ignore_bad()
-        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y[:-1])
-
-
-class test_group_bins(SherpaTestCase):
-
-    def setUp(self):
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-
-    def tearDown(self):
-        if hasattr(self, 'loggingLevel'):
-            logger.setLevel(self.loggingLevel)
-
-    def test_group_bins_simple(self):
-
-        # make a straight line from x=1 to x=101
-        x = numpy.arange(start=1, stop=101, step=1)
-        y = numpy.ones(100)
-        data = DataPHA("dataset", x, y)
-
-        # group into 10 bins
-        data.group_bins(0, 10)
-
-        # control x and y arrays
-        new_x = numpy.arange(start=1, stop=101, step=10)
-        new_y = numpy.ones(10) * 10
-
-        # there should be 10 bins with y=10
-        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
-        numpy.testing.assert_array_equal(data.get_indep(filter=True), new_x)
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -31,6 +31,8 @@ from sherpa.utils import requires_data, requires_fits, requires_group
 from sherpa.astro import ui
 from sherpa.data import Data1D
 from sherpa.astro.data import DataPHA
+from sherpa.astro.ui.utils import Session
+from sherpa.astro.io import read_pha
 
 import logging
 logger = logging.getLogger("sherpa")
@@ -153,22 +155,29 @@ class test_more_ui(SherpaTestCase):
 
 class test_grouping(SherpaTestCase):
     def setUp(self):
+        self._old_logger_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
         self.pha3c273 = self.make_path('3c273.pi')
+        self.specfit_dataset = self.make_path('acisf00308_000N001_r0044_pha3.fits')
+
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
 
     # issue 149
     def test_grouping_simple(self):
 
         x = numpy.arange(start=1, stop=161, step=1)
         y = numpy.ones(x.size)
-        ui.load_arrays(0, x, y, ui.DataPHA)
-        ui.group_counts(0,16)
+        dataset = DataPHA("dataset", x, y)
+        dataset.group_counts(16)
 
         # control arrays
         newx = numpy.arange(start=1, stop=161, step=16)
         newy = numpy.zeros(newx.size)+16
 
         # test that the data is grouped correctly
-        numpy.testing.assert_array_equal(ui.get_data(0).to_fit()[0], newy)
+        numpy.testing.assert_array_equal(dataset.get_dep(filter=True), newy)
 
     # issue 149
     # test for when the last bin after grouping is less than the number
@@ -178,12 +187,12 @@ class test_grouping(SherpaTestCase):
     def test_group_counts_issue149(self):
 
         # load a real dataset to test
-        ui.load_pha(1, self.pha3c273)
-        ui.ungroup(1)
-        ui.group_counts(1, 16)
+        data = read_pha(self.pha3c273)
+        data.ungroup()
+        data.group_counts(16)
 
         # control array. We expect the last bin to have less than 16 counts.
-        newy = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
+        new_y = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
                 22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
                 20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
                 17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
@@ -192,15 +201,44 @@ class test_grouping(SherpaTestCase):
         # The last bin is less than 16, and so should have group quality = 2
         quality = numpy.zeros(1024)
         quality[957:] = 2
-        numpy.testing.assert_array_equal(ui.get_data(1).quality, quality)
+        numpy.testing.assert_array_equal(data.quality, quality)
 
         # before ignoring the bad data
-        numpy.testing.assert_array_equal(ui.get_data(1).to_fit()[0], newy)
+        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
 
         # ignore bad data (with group quality=2) should remove the last bin
         # with value 9
-        ui.ignore_bad(1)
-        numpy.testing.assert_array_equal(ui.get_data(1).to_fit()[0], newy[:-1])
+        data.ignore_bad()
+        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y[:-1])
+
+
+class test_group_bins(SherpaTestCase):
+
+    def setUp(self):
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
+
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
+
+    def test_group_bins_simple(self):
+
+        # make a straight line from x=1 to x=101
+        x = numpy.arange(start=1, stop=101, step=1)
+        y = numpy.ones(100)
+        data = DataPHA("dataset", x, y)
+
+        # group into 10 bins
+        data.group_bins(0, 10)
+
+        # control x and y arrays
+        new_x = numpy.arange(start=1, stop=101, step=10)
+        new_y = numpy.ones(10) * 10
+
+        # there should be 10 bins with y=10
+        numpy.testing.assert_array_equal(data.get_dep(filter=True), new_y)
+        numpy.testing.assert_array_equal(data.get_indep(filter=True), new_x)
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -150,7 +150,8 @@ class test_more_ui(SherpaTestCase):
         ui.group_counts('3c273', 30)
         ui.group_counts('3c273', 15)
 
-
+@requires_data
+@requires_fits
 class test_grouping_ui(SherpaTestCase):
     def setUp(self):
         self.data = self.make_path('3c273.pi')
@@ -175,20 +176,14 @@ class test_grouping_ui(SherpaTestCase):
         ui.group_counts('src', 16)
         ui.group_counts('src', 10, bkg_id=1)
 
-        print ui.get_data('src').to_fit()[0]
-        # print ui.get_dep('src').to_fit()[0]
-        print ui.get_bkg('src').get_dep(filter=True)
-
-        # TODO: Should unfilled groups be removed from the grouped array?
-        # the last element (9) should be removed if unfilled (bad group quality)
-        # groups are not included in the output grouped array.
         # grouped source data
         src_grouped = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
                 22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
                 20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
                 17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
-                16.0, 9.0]
+                16.0]
         # grouped background data
+        # TODO: is this expected?
         bkg_grouped = [10, 10, 10, 10, 10, 11, 10, 10, 10, 10, 10, 10, 10,
                        10, 10, 10, 10, 45]
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -151,6 +151,53 @@ class test_more_ui(SherpaTestCase):
         ui.group_counts('3c273', 15)
 
 
+class test_grouping_ui(SherpaTestCase):
+    def setUp(self):
+        self.data = self.make_path('3c273.pi')
+        self.bkg = self.make_path('3c273_bg.pi')
+        self.loggingLevel = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
+        ui.clean()
+
+    def tearDown(self):
+        if hasattr(self, 'loggingLevel'):
+            logger.setLevel(self.loggingLevel)
+
+    def test_group_background_indep(self):
+        ui.load_pha('src', self.data)
+        ui.ungroup('src')
+        ui.load_pha('background', self.bkg)
+
+        # set bkg as background to src
+        ui.set_bkg('src', ui.get_data('background'), bkg_id=1)
+
+        # group the data and bkg separately
+        ui.group_counts('src', 16)
+        ui.group_counts('src', 10, bkg_id=1)
+
+        print ui.get_data('src').to_fit()[0]
+        # print ui.get_dep('src').to_fit()[0]
+        print ui.get_bkg('src').get_dep(filter=True)
+
+        # TODO: Should unfilled groups be removed from the grouped array?
+        # the last element (9) should be removed if unfilled (bad group quality)
+        # groups are not included in the output grouped array.
+        # grouped source data
+        src_grouped = [17.0, 16.0, 17.0, 16.0, 18.0, 21.0, 17.0, 23.0, 18.0, 21.0,
+                22.0, 21.0, 19.0, 21.0, 17.0, 17.0, 17.0, 17.0, 21.0, 17.0,
+                20.0, 17.0, 18.0, 17.0, 18.0, 17.0, 16.0, 16.0, 17.0, 17.0,
+                17.0, 16.0, 16.0, 17.0, 17.0, 16.0, 17.0, 16.0, 17.0, 16.0,
+                16.0, 9.0]
+        # grouped background data
+        bkg_grouped = [10, 10, 10, 10, 10, 11, 10, 10, 10, 10, 10, 10, 10,
+                       10, 10, 10, 10, 45]
+
+        # check results
+        numpy.testing.assert_array_equal(ui.get_data('src').to_fit()[0],
+                                         src_grouped)
+        numpy.testing.assert_array_equal(ui.get_bkg('src').get_dep(filter=True),
+                                         bkg_grouped)
+
 @requires_data
 @requires_fits
 class test_image_12578(SherpaTestCase):

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -24,6 +24,7 @@ Tools for creating, storing, inspecting, and manipulating data sets
 from six.moves import zip as izip
 import sys
 import inspect
+import operator
 import numpy
 from sherpa.utils.err import DataErr, NotImplementedErr
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
@@ -135,14 +136,23 @@ class BaseData(NoNewAttributesAfterInit):
     def notice(self, mins, maxes, axislist, ignore=False):
 
         ignore = bool_cast(ignore)
-        if( str in [type(min) for min in mins] ):
+        if str in [type(min) for min in mins]:
             raise DataErr('typecheck', 'lower bound')
-        elif( str in [type(max) for max in maxes] ):
+        elif str in [type(max) for max in maxes]:
             raise DataErr('typecheck', 'upper bound')
-        elif( str in [type(axis) for axis in axislist] ):
+        elif str in [type(axis) for axis in axislist]:
             raise DataErr('typecheck', 'grid')
 
-        mask = filter_bins(mins, maxes, axislist)
+        # If the data is grouped,
+        try:
+            if self.grouped:
+                mask = filter_bins(mins, maxes, axislist, gt_operator=operator.gt)
+            else:
+                # use default filtering
+                mask = filter_bins(mins, maxes, axislist)
+        except AssertionError:
+            # isn't a PHA dataset. Use default filtering
+            mask = filter_bins(mins, maxes, axislist)
 
         if mask is None:
             self.mask = not ignore

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -150,7 +150,7 @@ class BaseData(NoNewAttributesAfterInit):
             else:
                 # use default filtering
                 mask = filter_bins(mins, maxes, axislist)
-        except AssertionError:
+        except AttributeError:
             # isn't a PHA dataset. Use default filtering
             mask = filter_bins(mins, maxes, axislist)
 

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -143,16 +143,7 @@ class BaseData(NoNewAttributesAfterInit):
         elif str in [type(axis) for axis in axislist]:
             raise DataErr('typecheck', 'grid')
 
-        # If the data is grouped,
-        try:
-            if self.grouped:
-                mask = filter_bins(mins, maxes, axislist, gt_operator=operator.gt)
-            else:
-                # use default filtering
-                mask = filter_bins(mins, maxes, axislist)
-        except AttributeError:
-            # isn't a PHA dataset. Use default filtering
-            mask = filter_bins(mins, maxes, axislist)
+        mask = filter_bins(mins, maxes, axislist)
 
         if mask is None:
             self.mask = not ignore

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -376,7 +376,7 @@ namespace sherpa { namespace astro { namespace utils {
       // include channels where grouping == 0 so the filter will catch large
       // energy bins
       if( group[ ii ] >= 0 )
-	pick_pts.push_back( ii );
+	    pick_pts.push_back( ii );
     pick_pts.push_back( len_group );
 
     npy_intp dim = npy_intp( pick_pts.size( ) - 1 );
@@ -388,11 +388,11 @@ namespace sherpa { namespace astro { namespace utils {
       IndexType stop = pick_pts[ ii + 1 ];
       
       if ( stop > len_data )
-	return EXIT_FAILURE;
+	    return EXIT_FAILURE;
 
       if ( func == "_make_groups" ) {
-	grouped[ ii ] = data[0] + (SherpaFloat) ii;
-	continue;
+	    grouped[ ii ] = data[0] + (SherpaFloat) ii;
+	    continue;
       }
       
       funcs[func]( data, start, stop, val );

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -382,7 +382,7 @@ def requires_pylab(test_function):
 eps = numpy.finfo(numpy.float32).eps
 
 
-def filter_bins(mins, maxes, axislist, gt_operator=operator.ge):
+def filter_bins(mins, maxes, axislist):
     mask = None
 
     for lo, hi, axis in izip(mins, maxes, axislist):
@@ -401,7 +401,7 @@ def filter_bins(mins, maxes, axislist, gt_operator=operator.ge):
         else:
             # axismask = (lo <= axis) & (axis <= hi)
             axismask = (sao_fcmp(lo, axis, eps) <= 0) & \
-                       (gt_operator(sao_fcmp(hi, axis, eps), 0))
+                       (sao_fcmp(hi, axis, eps) >= 0)
 
         if mask is None:
             mask = axismask

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -382,7 +382,7 @@ def requires_pylab(test_function):
 eps = numpy.finfo(numpy.float32).eps
 
 
-def filter_bins(mins, maxes, axislist):
+def filter_bins(mins, maxes, axislist, gt_operator=operator.ge):
     mask = None
 
     for lo, hi, axis in izip(mins, maxes, axislist):
@@ -401,7 +401,7 @@ def filter_bins(mins, maxes, axislist):
         else:
             # axismask = (lo <= axis) & (axis <= hi)
             axismask = (sao_fcmp(lo, axis, eps) <= 0) & \
-                       (sao_fcmp(hi, axis, eps) >= 0)
+                       (gt_operator(sao_fcmp(hi, axis, eps), 0))
 
         if mask is None:
             mask = axismask


### PR DESCRIPTION
# Release Note

Fixes bug #149. If a dataset is filtered and then grouped with `group_counts(grpnum)`, the last bin in the grouped array, while less than `grpnum`, is included in the array. The sherpa documentation states that `group_counts(grpnum)` will group the dataset counts so that each bin contains at least `grpnum` counts.

This fix ensures that each bin in a grouped dataset upholds to the given user condition, be it enough counts, SNR, etc.

A number of simple grouping tests for each grouping method (`group_snr(), group_adapt(), etc.`) have also been added.
# Status

This bug is fixed in the sense that the steps in #149 result in the expected output. However, this fix only works for datasets that have been filtered before being grouped. We still need to discuss and fix what happens to unfilled bins in grouped datasets. 

Currently, if no filters have been applied to the dataset, the data is simply grouped by the external grplib functions, which by default leave the last unfilled bin in the grouped dataset. The unfilled groups are given a quality of 2; the user can ignore the unfilled group with `ignore_bad()`.

For now, I've put the PR on hold because one test, `sherpa/astro/tests/test_data.py::test_grouping::test_grouping_with_previous_quality_flags()`, will fail until we decide how to handle grouping, filtering, and quality flags. I can set this test to fail if we do not want to tackle this issue in this PR.

Note that a number of fitting tests are failing because the grouping logic has changed, which affects the fit results as the groups are different.
# Description

This bug is part of a bigger issue on grouping, filtering, and quality flags. We need to decide what the behavior of grouping should be when a bin is left unfilled - must it never be added to the grouped array in the external grplib code? Should sherpa handle ignoring unfilled bins internally? Should we make the user ignore the unfilled groups themselves? And so on.
