### PR TITLE
remove nosetuptools travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,6 @@ before_install:
   - if [ ${TEST} == smoke ];
      then git submodule deinit -f .;
     fi
-  - if [ -n "${NOSETUPTOOLS}" ]; then conda remove --yes setuptools; fi
-
 
 install:
   - python setup.py $INSTALL_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ matrix:
       python: "2.7"
       sudo: required
       dist: trusty
-    - env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
-      python: "2.7"
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5
       python: "2.7"
     - env: FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
@@ -50,7 +48,7 @@ matrix:
   allow_failures:
     - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
 
-env:  INSTALL_TYPE=install TEST=smoke NOSETUPTOOLS="true" MATPLOTLIBVER=1.5
+env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
 
 before_install:
   - export LIBGFORTRANVER="1.0"


### PR DESCRIPTION
This PR removes a travis build that is not required anymore (the purpose of the build was to test CIAO support, but CIAO now includes setuptools), and that is actually erroring on travis.