### PR TITLE
Avoid use of inspect.getargspec in Python3

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -37,8 +37,7 @@ known_warnings = {
         [
             r"unorderable dtypes.*",
             r"Non-string object detected for the array ordering.*",
-            r"using a non-integer number instead of an integer will result in an error in the future",
-            r"inspect.getargspec\(\) is deprecated"
+            r"using a non-integer number instead of an integer will result in an error in the future"
         ],
     UserWarning:
         [

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -288,10 +288,23 @@ class Sampler(object):
 
     def __init__(self):
 
-        # get the initial keyword argument defaults
-        argspec = inspect.getargspec(self.init)
-        first = len(argspec[0]) - len(argspec[3])
-        self._opts = dict(izip(argspec[0][first:], argspec[3][0:]))
+        # get the initial keyword argument defaults;
+        # it looks like inspect.getargspec is not being removed
+        # in Python 3.6, but use the signature function if it is
+        # available to avoid possible warnings.
+        try:
+            sig = inspect.signature(self.init)
+            opts = [(p.name, p.default)
+                    for p in sig.parameters.values()
+                    if p.kind == p.POSITIONAL_OR_KEYWORD and
+                    p.default != p.empty]
+
+        except AttributeError:
+            argspec = inspect.getargspec(self.init)
+            first = len(argspec[0]) - len(argspec[3])
+            opts = izip(argspec[0][first:], argspec[3][0:])
+
+        self._opts = dict(opts)
         self.walk = None
 
     def init(self):


### PR DESCRIPTION
Finish off the replacement of `inspect.getargspec` by `inspect.signature`. The check for the deprecation warning has also been removed (since it should not be needed now).

I considered changing `sherpa.sim.mh` to use functionality from `sherpa.utils` rather than re-write it, but decided to keep the module "clean" of imports from sherpa for now.