### PR TITLE
Update copyright year to include 2016.

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/clean.py
+++ b/helpers/clean.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/deps/__init__.py
+++ b/helpers/deps/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/install.py
+++ b/helpers/install.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/sdist.py
+++ b/helpers/sdist.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-# 
-#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2014, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-# Copyright (C) 2014  Smithsonian Astrophysical Observatory
+# Copyright (C) 2014, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 #
-# Copyright (C) 2015  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/datastack/plot_backend/__init__.py
+++ b/sherpa/astro/datastack/plot_backend/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-# Copyright (C) 2015  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/datastack/utils.py
+++ b/sherpa/astro/datastack/utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-# Copyright (C) 2015  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/io/meta.py
+++ b/sherpa/astro/io/meta.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/models/tests/test_models.py
+++ b/sherpa/astro/models/tests/test_models.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -134,7 +134,7 @@ class AbsorptionGaussian(ArithmeticModel):
 
     def __init__(self, name='absorptiongaussian'):
 
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, 
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
         self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
         self.ewidth = Parameter(name, 'ewidth', 1.)
@@ -173,7 +173,7 @@ class AbsorptionLorentz(ArithmeticModel):
 
     def __init__(self, name='absorptionlorentz'):
 
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, 
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
         self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
         self.ewidth = Parameter(name, 'ewidth', 1.)
@@ -239,7 +239,7 @@ class OpticalGaussian(ArithmeticModel):
 
     def __init__(self, name='opticalgaussian'):
 
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, 
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
         self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
         self.tau = Parameter(name, 'tau', 0.5)
@@ -363,7 +363,7 @@ class BlackBody(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.temperature))
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         c1 = 1.438786e8
@@ -382,7 +382,7 @@ class BlackBody(ArithmeticModel):
             denon = numpy.zeros_like(x)
             denon[x0] = numpy.power(x[x0], 5)
             argmin_slice = numpy.where(arg < self._argmin)[0]
-            if (len(argmin_slice) > 0): 
+            if (len(argmin_slice) > 0):
                 denon[argmin_slice] *= arg[argmin_slice] * (1.0 + 0.5 * arg[argmin_slice])
             arg = numpy.where(arg > self._argmax, self._argmax, arg)
 
@@ -405,7 +405,7 @@ class Bremsstrahlung(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.temperature))
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         if 0.0 == p[0]:
@@ -428,7 +428,7 @@ class BrokenPowerlaw(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.index1, self.index2))
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -451,7 +451,7 @@ class CCM(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.ebv, self.r))
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.zeros_like(x)
@@ -520,7 +520,7 @@ class LogAbsorption(ArithmeticModel):
 
     def __init__(self, name='logabsorption'):
 
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, 
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
         self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
         self.tau = Parameter(name, 'tau', 0.5)
@@ -592,7 +592,7 @@ class LogEmission(ArithmeticModel):
         fmax = (arg - 1.0) * p[2] / p[1] / 2.0
 
         if (p[3] == 1.0):
-            return numpy.where(x >= p[1], fmax * numpy.power((x / p[1]), -arg), fmax * numpy.power((x / p[1]), arg)) 
+            return numpy.where(x >= p[1], fmax * numpy.power((x / p[1]), -arg), fmax * numpy.power((x / p[1]), arg))
 
         arg1 = 0.69314718 / numpy.log (1.0 + p[3] * p[0] / 2.9979e5 / 2.0)
         fmax = (arg - 1.0) * p[2] / p[1] / (1.0 + (arg - 1.0) / (arg1 - 1.0))
@@ -618,7 +618,7 @@ class Polynomial(ArithmeticModel):
         pars.append(self.offset)
         ArithmeticModel.__init__(self, name, pars)
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.zeros_like(x)
@@ -640,7 +640,7 @@ class Powerlaw(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.index))
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -665,7 +665,7 @@ class Recombination(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.temperature, self.fwhm))
 
-    #@modelCacher1d 
+    #@modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -743,7 +743,7 @@ class FM(ArithmeticModel):
     def __init__(self, name='fm'):
         self.ebv = Parameter(name, 'ebv', 0.5)  # E(B-V)
         self.x0 = Parameter(name, 'x0', 4.6)    # Position of Drude bump
-        self.width = Parameter(name, 'width', 0.06) # Width of Drude bump 
+        self.width = Parameter(name, 'width', 0.06) # Width of Drude bump
         self.c1 = Parameter(name, 'c1', 0.2)
         self.c2 = Parameter(name, 'c2', 0.1)
         self.c3 = Parameter(name, 'c3', 0.02)

--- a/sherpa/astro/optical/tests/test_optical.py
+++ b/sherpa/astro/optical/tests/test_optical.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,6 +1,6 @@
 from __future__ import division
 #
-#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/sim/fullbayes.py
+++ b/sherpa/astro/sim/fullbayes.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,7 +37,7 @@ class FullBayes(PragBayes):
     def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
              priors=(), originalscale=True, scale=1, sigma_m=False, p_M=.5,
              simarf=None, p_M_arf=.5, sigma_arf=0.1):
-        # nsubiters is missing from init() to indicate that nubiters=1 for 
+        # nsubiters is missing from init() to indicate that nubiters=1 for
         # full bayes
 
         if isinstance(simarf, PCA1DAdd):
@@ -46,7 +46,7 @@ class FullBayes(PragBayes):
             self.simarf = ARFSIMFactory()(simarf)
 
         if not isinstance(self.simarf, PCA1DAdd):
-            raise TypeError("Simulation ARF must be PCA for FullBayes" + 
+            raise TypeError("Simulation ARF must be PCA for FullBayes" +
                             " not %s" % type(self.simarf).__name__)
 
         self.accept_arfs = [0]
@@ -130,7 +130,7 @@ class FullBayes(PragBayes):
 
 
     def perturb_arf(self, current_params, current_stat):
-        if self.simarf is not None:         
+        if self.simarf is not None:
 
             # add deviations starting with original ARF for each iter
             for specresp, arf, arf_dict in zip(self.backup_arfs, self.arfs, self.arf_dicts):

--- a/sherpa/astro/sim/pragbayes.py
+++ b/sherpa/astro/sim/pragbayes.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -62,7 +62,7 @@ class ARFSIMFactory(object):
         elif emethod is not None and emethod.startswith('SIM1DADD'):
             bias      = cols[2]['BIAS']
             component = cols[3]['COMPONENT']
-            simcomp   = cols[3]['SIMCOMP'] 
+            simcomp   = cols[3]['SIMCOMP']
             return SIM1DAdd(bias, component, simcomp)
 
         raise TypeError("Unknown simulation ARF '%s'" % filename)
@@ -223,7 +223,7 @@ class WalkWithSubIters(Walk):
 
                 # Assume proposal is rejected by default
                 proposals[jump] = current_params
-                stats[jump]  = current_stat            
+                stats[jump]  = current_stat
 
                 for jj in xrange(nsubiter):
 
@@ -262,7 +262,7 @@ class WalkWithSubIters(Walk):
                         self._sampler.reject()
                         acceptflag[jump] = False
 
-                        # If acceptance fails do we start back at the last accepted 
+                        # If acceptance fails do we start back at the last accepted
                         # iteration or the last accepted subiteration?
                         current_params = proposals[ii]
                         current_stat   = stats[ii]
@@ -303,7 +303,7 @@ class PragBayes(MetropolisMH):
              simarf=None, nsubiters=10):
 
         # Note that nsubiters is used as a dummy parameter to indicate the default
-        # value.  See the function WalkWithSubIters.__call__() 
+        # value.  See the function WalkWithSubIters.__call__()
 
         if isinstance(simarf, (PCA1DAdd, SIM1DAdd)):
             self.simarf = simarf
@@ -346,7 +346,7 @@ class PragBayes(MetropolisMH):
         """ MH jumping rule """
 
         # The current proposal is ignored here.
-        # MH jumps from the current best-fit parameter values using the 
+        # MH jumps from the current best-fit parameter values using the
         # covariance scale from the sub-iteration fit
 
         # If the ARF is updated then sigma will be None, then

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/utils/tests/test_astro_utils.py
+++ b/sherpa/astro/utils/tests/test_astro_utils.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2008  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2008, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,7 +36,7 @@ class test_utils(SherpaTestCase):
         self.assertTrue( is_in(self.long, 100, 200) )
 
         # hi case
-        self.assertTrue( is_in(self.long, 50, 1024) ) 
+        self.assertTrue( is_in(self.long, 50, 1024) )
 
         # 'hidden' lo case
         self.assertTrue( is_in(self.long, 250, 2000) )

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2008, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2008, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -394,7 +394,7 @@ class Data(BaseData):
 
     def get_yerr(self, filter=False, staterrfunc=None):
         "Return errors in dependent axis in N-D view of dependent variable"
-        return self.get_error(filter, staterrfunc) 
+        return self.get_error(filter, staterrfunc)
 
     def get_ylabel(self, yfunc=None):
         "Return label for dependent axis in N-D view of dependent variable"
@@ -473,7 +473,7 @@ class DataSimulFit(Data):
 
         return numpy.concatenate(total_model)
 
-    def to_fit(self, staterrfunc=None):        
+    def to_fit(self, staterrfunc=None):
         total_dep = []
         total_staterror = []
         total_syserror = []

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/estmethods/src/estwrappers.cc
+++ b/sherpa/estmethods/src/estwrappers.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/include/sherpa/integration.hh
+++ b/sherpa/include/sherpa/integration.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/logposterior.py
+++ b/sherpa/logposterior.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2009, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-# 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -34,7 +34,7 @@ warning = logging.getLogger(__name__).warning
 __all__ = ('Box1D', 'Const1D', 'Cos', 'Delta1D', 'Erf', 'Erfc', 'Exp', 'Exp10',
            'Gauss1D', 'Log', 'Log10', 'LogParabola', 'NormGauss1D', 'Poisson',
            'Polynom1D', 'PowLaw1D', 'Scale1D', 'Sin', 'Sqrt', 'StepHi1D',
-           'StepLo1D', 'Tan', 'Box2D', 'Const2D', 'Delta2D', 'Gauss2D', 
+           'StepLo1D', 'Tan', 'Box2D', 'Const2D', 'Delta2D', 'Gauss2D',
            'SigmaGauss2D',
            'NormGauss2D', 'Polynom2D', 'Scale2D', 'UserModel', 'TableModel',
            'Integrate1D')
@@ -424,7 +424,7 @@ class PowLaw1D(ArithmeticModel):
         kwargs['integrate']=bool_cast(self.integrate)
         if kwargs['integrate']:
             # avoid numerical issues with C pow() function close to zero,
-            # 0.0 +- ~1.e-14.  PowLaw1D integrated has multiple calls to 
+            # 0.0 +- ~1.e-14.  PowLaw1D integrated has multiple calls to
             # pow(X, 1.0 - gamma).  So gamma values close to 1.0 +- 1.e-10
             # should be be 1.0 to avoid errors propagating in the calculated
             # model.

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-# 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -572,7 +572,7 @@ class NestedModel(CompositeModel, ArithmeticModel):
 
     def calc(self, p, *args, **kwargs):
         nouter = len(self.outer.pars)
-        return self.outer.calc(p[:nouter], 
+        return self.outer.calc(p[:nouter],
                                self.inner.calc(p[nouter:], *args, **kwargs),
                                *self.otherargs, **self.otherkwargs)
 

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-# 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,7 +37,7 @@ def create_template_model(modelname, names, parvals, templates, template_interpo
 
     `modelname`  - name of the template model.
 
-    `names`      - list of strings that define the order of the 
+    `names`      - list of strings that define the order of the
                    named parameters.
 
     `parvals`    - 2-D ndarray of parameter vectors, index corresponds
@@ -53,7 +53,7 @@ def create_template_model(modelname, names, parvals, templates, template_interpo
 
     """
     # Create a list of parameters from input
-    pars = []   
+    pars = []
     for ii, name in enumerate(names):
         minimum = min(parvals[:,ii])
         maximum = max(parvals[:,ii])
@@ -141,7 +141,7 @@ class TemplateModel(ArithmeticModel):
             self.__dict__[par.name] = par
 
         for ii, parval in enumerate(parvals):
-            self.index[tuple(parval)] = templates[ii]        
+            self.index[tuple(parval)] = templates[ii]
 
         ArithmeticModel.__init__(self, name, pars)
         self.is_discrete = True

--- a/sherpa/models/tests/test_basic.py
+++ b/sherpa/models/tests/test_basic.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -47,7 +47,7 @@ class test_basic(SherpaTestCase):
             if isinstance(m, basic.TableModel):
                 m.load(x,x)
             if isinstance(m, basic.UserModel):
-                m.calc = userfunc 
+                m.calc = userfunc
             self.assertEqual(type(m).__name__.lower(), m.name)
             count += 1
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -99,13 +99,13 @@ def _narrow_limits( myrange, xxx, debug ):
         myxmin = numpy.asarray(list(map(lambda xx: xx - range * numpy.abs(xx), x)), numpy.float_)
         if debug:
             print()
-            print('raise_min_limit: myxmin=%s' % myxmin)    
+            print('raise_min_limit: myxmin=%s' % myxmin)
             print('raise_min_limit: x=%s' % x)
         below = numpy.flatnonzero(myxmin < xmin)
         if below.size > 0:
             myxmin[below] = xmin[below]
         if debug:
-            print('raise_min_limit: myxmin=%s' % myxmin)    
+            print('raise_min_limit: myxmin=%s' % myxmin)
             print('raise_min_limit: x=%s' % x)
             print()
         return myxmin
@@ -115,13 +115,13 @@ def _narrow_limits( myrange, xxx, debug ):
         if debug:
             print()
             print('lower_max_limit: x=%s' % x)
-            print('lower_max_limit: myxmax=%s' % myxmax)    
+            print('lower_max_limit: myxmax=%s' % myxmax)
         above = numpy.flatnonzero(myxmax > xmax)
         if above.size > 0:
             myxmax[above] = xmax[above]
         if debug:
             print('lower_max_limit: x=%s' % x)
-            print('lower_max_limit: myxmax=%s' % myxmax)    
+            print('lower_max_limit: myxmax=%s' % myxmax)
             print()
         return myxmax
 
@@ -131,7 +131,7 @@ def _narrow_limits( myrange, xxx, debug ):
 
     if False != debug:
         print('narrow_limits: xmin=%s' % xmin)
-        print('narrow_limits: x=%s' % x)        
+        print('narrow_limits: x=%s' % x)
         print('narrow_limits: xmax=%s' % xmax)
     myxmin = raise_min_limit( myrange, xmin, x, debug=False )
     myxmax = lower_max_limit( myrange, x, xmax, debug=False )
@@ -139,7 +139,7 @@ def _narrow_limits( myrange, xxx, debug ):
     if False != debug:
         print('range = %d' % myrange)
         print('narrow_limits: myxmin=%s' % myxmin)
-        print('narrow_limits: x=%s' % x)        
+        print('narrow_limits: x=%s' % x)
         print('narrow_limits: myxmax=%s\n' % myxmax)
 
     double_check_limits( x, myxmin, myxmax )
@@ -468,7 +468,7 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
 
 
 #
-# Nelder Mead 
+# Nelder Mead
 #
 def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
           nloop=1, iquad=1, simp=None, verbose=-1):
@@ -487,7 +487,7 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
 
     orig_fcn = stat_cb0
     def stat_cb0(x_new):
-        if _outside_limits(x_new, xmin, xmax) or _my_is_nan(x_new):        
+        if _outside_limits(x_new, xmin, xmax) or _my_is_nan(x_new):
             return FUNC_MAX
         return orig_fcn(x_new)
 
@@ -519,7 +519,7 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
 # Monte Carlo
 #
 def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
-               seed=74815, population_size=None, xprob=0.9, 
+               seed=74815, population_size=None, xprob=0.9,
                weighting_factor=0.8):
 
     def stat_cb0( pars ):
@@ -562,7 +562,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         mymaxfev = min( maxfev_per_iter, maxfev )
         if all( x == 0.0 ):
             mystep = list(map(lambda fubar: 1.2 + fubar, x))
-        else: 
+        else:
             mystep = list(map(lambda fubar: 1.2 * fubar, x))
         result = neldermead( myfcn, x, xmin, xmax, maxfev=mymaxfev, ftol=ftol,
                              finalsimplex=9, step=mystep )
@@ -587,7 +587,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
                                                    result[4].get('nfev')))
         ############################## nmDifEvo ##############################
 
-        ofval = FUNC_MAX        
+        ofval = FUNC_MAX
         while nfev < maxfev:
 
             xmin, xmax = _narrow_limits( factor, [x,xmin,xmax], debug=False )
@@ -627,7 +627,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     if nfev < maxfev:
         if all( x == 0.0 ):
             mystep = list(map(lambda fubar: 1.2 + fubar, x))
-        else: 
+        else:
             mystep = list(map(lambda fubar: 1.2 * fubar, x))
         result = neldermead(fcn, x, xmin, xmax,
                             maxfev=min(512*len(x), maxfev - nfev),
@@ -653,7 +653,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
 
 
 #
-# Nelder Mead 
+# Nelder Mead
 #
 def neldermead( fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
                 initsimplex=0, finalsimplex=9, step=None, iquad=1,
@@ -688,7 +688,7 @@ def neldermead( fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
             finalsimplex = [ 2 ]
         elif 2 == finalsimplex:
             finalsimplex = [ 0, 0 ]
-        elif 3 == finalsimplex:            
+        elif 3 == finalsimplex:
             finalsimplex = [ 0, 1 ]
         elif 4 == finalsimplex:
             finalsimplex = [ 0, 1, 0 ]
@@ -701,15 +701,15 @@ def neldermead( fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
         elif 8 == finalsimplex:
             finalsimplex = [ 1, 2, 0 ]
         elif 9 == finalsimplex:
-            finalsimplex = [ 0, 1, 1 ]            
+            finalsimplex = [ 0, 1, 1 ]
         elif 10 == finalsimplex:
-            finalsimplex = [ 0, 2, 1 ]            
+            finalsimplex = [ 0, 2, 1 ]
         elif 11 == finalsimplex:
-            finalsimplex = [ 1, 1, 1 ]                        
+            finalsimplex = [ 1, 1, 1 ]
         elif 12 == finalsimplex:
-            finalsimplex = [ 1, 2, 1 ]            
+            finalsimplex = [ 1, 2, 1 ]
         elif 13 == finalsimplex:
-            finalsimplex = [ 2, 1, 1 ]            
+            finalsimplex = [ 2, 1, 1 ]
         else:
             finalsimplex = [ 2, 2, 2 ]
     elif ( False == numpy.isscalar(finalsimplex) and

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/plot/chips_backend.py
+++ b/sherpa/plot/chips_backend.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -364,7 +364,7 @@ def init():
 def begin():
     global _initialized
 
-    chips.lock()    
+    chips.lock()
     chips.advanced.open_undo_buffer()
     if _initialized is False:
         try:

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/sim/simulate.py
+++ b/sherpa/sim/simulate.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -86,7 +86,7 @@ class LikelihoodRatioResults(NoNewAttributesAfterInit):
         return '<Likelihood ratio results instance>'
 
 
-    def __str__(self):      
+    def __str__(self):
         samples = self.samples
         if self.samples is not None:
             samples = numpy.array2string(self.samples, separator=',', precision=4, suppress_small=False)
@@ -177,7 +177,7 @@ class LikelihoodRatioTest(NoNewAttributesAfterInit):
         # Fake using poisson_noise with null
         fake = poisson_noise(nullfit.data.eval_model(nullfit.model))
 
-                # Set faked data for both nullfit and altfit 
+                # Set faked data for both nullfit and altfit
         nullfit.data.set_dep(fake)
 
         # Start the faked fit at initial null best-fit values
@@ -201,7 +201,7 @@ class LikelihoodRatioTest(NoNewAttributesAfterInit):
         debug("alt model")
         debug(str(altfit.model))
 
-        # Set alt model and fit   
+        # Set alt model and fit
         altfr = altfit.fit()
         debug(altfr.format())
 

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
-# 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -49,7 +49,7 @@ class test_sim(SherpaTestCase):
         'nfev': 93,
         'statval': 8483.0287367571564,
         'parnames': ['p1.gamma', 'p1.ampl', 'g1.fwhm',
-                     'g1.pos', 'g1.ampl'], 
+                     'g1.pos', 'g1.ampl'],
         'parvals': numpy.array(
             [1.0701938169914813,
              9.1826254677279469,
@@ -84,7 +84,7 @@ class test_sim(SherpaTestCase):
         p1 = PowLaw1D('p1')
         p1.gamma.set(1.0, -10, 10, frozen=False)
         p1.ampl.set(1.0, 0.0, _max, frozen=False)
-        p1.ref.set(1.0, -_max, _max, frozen=True)      
+        p1.ref.set(1.0, -_max, _max, frozen=True)
         model = p1 + g1
 
         method = LevMar()
@@ -128,7 +128,7 @@ class test_sim(SherpaTestCase):
         multivariate_t(self.mu, self.cov, self.dof, self.num)
 
     def test_cauchy(self):
-        multivariate_cauchy(self.mu, self.cov, self.num)       
+        multivariate_cauchy(self.mu, self.cov, self.num)
 
     def test_parameter_scale_vector(self):
         ps = ParameterScaleVector()

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -524,14 +524,14 @@ class UserStat(Stat):
 
 class WStat(Likelihood):
     """Maximum likelihood function including background (XSPEC style).
-    
+
     This is equivalent to the XSpec implementation of the
     W statistic for CStat [1]_, and includes the background data in
     the fit statistic. If a model is being fit to the background then
     the CStat statistic should be used.
 
     The following description is taken from [1]_.
-    
+
     Suppose that each bin in the background spectrum is given its own
     parameter so that the background model is b_i = f_i. A standard fit
     for all these parameters would be impractical; however there is an
@@ -539,7 +539,7 @@ class WStat(Likelihood):
     variables which can be derived by using the fact that the derivative
     of the likelihood (L) will be zero at the best fit. Solving for the
     f_i and substituting gives the profile likelihood::
-    
+
       W = 2 sum_(i=1)^N t_s m_i + (t_s + t_b) f_i -
           S_i ln(t_s m_i + t_s f_i) - B_i ln(t_b f_i) -
           S_i (1- ln(S_i)) - B_i (1 - ln(B_i))
@@ -549,7 +549,7 @@ class WStat(Likelihood):
       f_i = (S_i + B_i - (t_s + t_b) m_i + d_i) / (2 (t_s + t_b))
       d_i = sqrt([(t_s + t_b) m_i - S_i - B_i]^2 +
                  4(t_s + t_b) B_i m_i)
-                 
+
     If any bin has S_i and/or B_i zero then its contribution to W (W_i)
     is calculated as a special case. So, if S_i is zero then::
 

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/tests/test_stack.py
+++ b/sherpa/tests/test_stack.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/src/_psf.cc
+++ b/sherpa/utils/src/_psf.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/src/integration.cc
+++ b/sherpa/utils/src/integration.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/tests/test_err.py
+++ b/sherpa/utils/tests/test_err.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2013  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2013, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -24,14 +24,14 @@ from sherpa.utils.err import ModelErr
 class test_err(SherpaTestCase):
 
     def test_NewSherpaErr(self):
-        class OldSherpaErr( Exception ): 
-            "Old class for all Sherpa exceptions" 
-            def __init__( self, dict, key, *args ): 
-                if key in dict: 
-                    errmsg = dict[ key ] % args 
-                else: 
-                    errmsg = "unknown key '%s'" % key 
-                Exception.__init__(self, errmsg) 
+        class OldSherpaErr( Exception ):
+            "Old class for all Sherpa exceptions"
+            def __init__( self, dict, key, *args ):
+                if key in dict:
+                    errmsg = dict[ key ] % args
+                else:
+                    errmsg = "unknown key '%s'" % key
+                Exception.__init__(self, errmsg)
 
         dict = {'simple':'simple message', 'arg':'argument: %s'}
 
@@ -53,7 +53,7 @@ class test_err(SherpaTestCase):
         self.assertEqual('My Error', str(err))
 
         # Test #5: verify the user provided example, which exercises a derived class
-        err = ModelErr("Unable to frobnicate model %s" % 'modelname') 
+        err = ModelErr("Unable to frobnicate model %s" % 'modelname')
         self.assertEqual('Unable to frobnicate model modelname', str(err))
 
 

--- a/sherpa/utils/tests/test_integration.py
+++ b/sherpa/utils/tests/test_integration.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/tests/test_root.py
+++ b/sherpa/utils/tests/test_root.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -1,20 +1,20 @@
 #
-#  copyright (c) 2016  smithsonian astrophysical observatory
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
 #
 #
-#  this program is free software; you can redistribute it and/or modify
-#  it under the terms of the gnu general public license as published by
-#  the free software foundation; either version 3 of the license, or
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  this program is distributed in the hope that it will be useful,
-#  but without any warranty; without even the implied warranty of
-#  merchantability or fitness for a particular purpose.  see the
-#  gnu general public license for more details.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
 #
-#  you should have received a copy of the gnu general public license along
-#  with this program; if not, write to the free software foundation, inc.,
-#  51 franklin street, fifth floor, boston, ma 02110-1301 usa.
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import pytest
 import numpy


### PR DESCRIPTION
This also changes the case of one of the copyright statements. Note that
files in extern/ are not changed in this commit, and there is no
copyright statement or license in sherpa/include/capsulethunk.h
(I assume it's the same as the Python version).