### PR TITLE
Apply noticed channels to backscale ratio array in WStat

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -523,7 +523,10 @@ class IterFit(NoNewAttributesAfterInit):
                 exposure_time[2 * index + 1] = bkg.exposure
                 ratio = vectorize_backscale_ratio(bkg.backscal,
                                                   mydata.backscal,
-                                                  data_size[index])
+                                                  len(mydata.channel))
+                noticed_channels = array(mydata.get_noticed_channels(),
+                                         dtype=int)  
+                ratio = ratio[noticed_channels-1]
                 backscale_ratio = append(backscale_ratio, ratio)
             else:
                 return result

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -197,6 +197,9 @@ class test_stats(SherpaTestCase):
         self.data = read_pha(pha_fname)
         self.data.notice(0.5, 7.0)
 
+        # hard-code number of channels
+        self.data.backscal = self.data.backscal * numpy.ones(1024)
+         
         bkg_fname = self.make_path("9774_bg.pi")
         self.bkg = read_pha(bkg_fname)
 


### PR DESCRIPTION
Fix #248
# Release Note

Sherpa now handles the case of the background scaling factor not being provided as a header keyword but as an array in `wstat`. Noticed channels are now properly applied to the backscale ratio array.
# Notes

We should provide more thorough and isolated tests for `wstat` and other statistics, which is captured in #238. This work is however out of the scope of this PR.
