### PR TITLE
make sure background is taken into account in calc_stat_info

### DIFF
--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -309,3 +309,11 @@ class test_stats(SherpaTestCase):
         ui.set_stat('chi2datavar')
         err = ui.get_staterror()
         numpy.testing.assert_allclose(err, numpy.sqrt(xy), rtol=1e-7, atol=1e-7)
+
+    def test_wstat_calc_stat_info(self):
+        ui.load_pha("stat", self.make_path("3c273.pi"))
+        ui.set_source("stat", ui.powlaw1d.p1)
+        ui.set_stat("wstat")
+        p1 = ui.get_model_component("p1")
+        ui.fit("stat")
+        ui.get_stat_info()


### PR DESCRIPTION
This PR fixes #147.

# Release Note
`calc_stat_info` call failed when `wstat` was selected, as the background was not taken into account. This issue has now been fixed.

# Notes
I did some minor refactoring, but I really dislike the `isinstance` usage. If stats need info from the `Fit` objects, then we should provide a reference to these object at least at the method level (if not in the constructor) and remove the `isinstance` procedural dispatching. However, this deeper refactoring is more risky, might break the established API, and should be independent of just fixing the bug.