### PR TITLE
Add aliases for parameter names so to support new xspec names (fix #74)

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -858,7 +858,7 @@ class DeVaucouleurs2D(ArithmeticModel):
     References
     ----------
 
-    .. [1] de Vaucouleurs G., 1948, Ann. d’Astroph. 11, 247
+    .. [1] de Vaucouleurs G., 1948, Ann. d'Astroph. 11, 247
            http://adsabs.harvard.edu/abs/1948AnAp...11..247D
 
     .. [2] http://ned.ipac.caltech.edu/level5/March05/Graham/Graham2.html

--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -37,11 +37,8 @@ class test_sim(SherpaTestCase):
     @requires_fits
     @requires_xspec
     def setUp(self):
-        try:
-            from sherpa.astro.io import read_pha
-            from sherpa.astro.xspec import XSwabs, XSpowerlaw
-        except:
-            return
+        from sherpa.astro.io import read_pha
+        from sherpa.astro.xspec import XSwabs, XSpowerlaw
         # self.startdir = os.getcwd()
         self.old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.CRITICAL)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1181,7 +1181,7 @@ class XSc6pvmkl(XSAdditiveModel):
     by using the exponential of the 6th order Chebyshev polynomial.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1258,7 +1258,7 @@ class XSc6vmekl(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1335,7 +1335,7 @@ class XScemekl(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1397,7 +1397,7 @@ class XScevmkl(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1588,7 +1588,7 @@ class XScompPS(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``tauy`` and ``HRcyl`` will be removed in the next release as
+              ``tauy`` and ``HRcyl`` might be removed in future releases as
               they have been replaced by ``tau_y`` and ``HovR_cyl``
               respectively, to match the XSPEC naming convention.
 
@@ -1801,7 +1801,7 @@ class XSdisk(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``NSmass`` will be removed in the next release as it has been
+              ``NSmass`` might be removed in future releases as it has been
               replaced by ``CenMass``, to match the XSPEC naming convention.
 
     Attributes
@@ -1852,7 +1852,7 @@ class XSdiskir(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``LcLd`` will be removed in the next release as it has been
+              ``LcLd`` might be removed in future releases as it has been
               replaced by ``LcovrLd``, to match the XSPEC naming convention.
 
     Attributes
@@ -1956,7 +1956,7 @@ class XSdiskline(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinM`` and ``RoutM`` will be removed in the next release as
+              ``RinM`` and ``RoutM`` might be removed in future releases as
               they have been replaced by ``Rin_M`` and ``Rout_M``
               respectively, to match the XSPEC naming convention.
 
@@ -2166,7 +2166,7 @@ class XSequil(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` will be removed in the next release as it has been
+              ``kT_ave`` might be removed in future releases as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
@@ -2358,7 +2358,7 @@ class XSgrad(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``TclTef`` will be removed in the next release as it has been
+              ``TclTef`` might be removed in future releases as it has been
               replaced by ``TclovTef``, to match the XSPEC naming convention.
 
     Attributes
@@ -2422,7 +2422,7 @@ class XSgrbm(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``temp`` will be removed in the next release as it has been
+              ``temp`` might be removed in future releases as it has been
               replaced by ``tem``, to match the XSPEC naming convention.
 
     Attributes
@@ -2535,7 +2535,7 @@ class XSkerrd(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``TcolTeff`` will be removed in the next release as it has been
+              ``TcolTeff`` might be removed in future releases as it has been
               replaced by ``TcoloTeff``, to match the XSPEC naming convention.
 
     Attributes
@@ -2682,7 +2682,7 @@ class XSlaor(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinG`` and ``RoutG`` will be removed in the next release as
+              ``RinG`` and ``RoutG`` might be removed in future releases as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
 
@@ -2745,7 +2745,7 @@ class XSlaor2(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinG`` and ``RoutG`` will be removed in the next release as
+              ``RinG`` and ``RoutG`` might be removed in future releases as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
 
@@ -2853,7 +2853,7 @@ class XSmeka(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -2957,7 +2957,7 @@ class XSmkcflow(XSAdditiveModel):
     on the cosmology settings set with ``set_xscosmo``.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -3416,7 +3416,7 @@ class XSnsmax(XSAdditiveModel):
     ``XSnsmaxg``.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` will be removed in the next release as it has been
+              ``specfile`` might be removed in future releases as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
@@ -3466,7 +3466,7 @@ class XSnsmaxg(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` will be removed in the next release as it has been
+              ``specfile`` might be removed in future releases as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
@@ -3522,7 +3522,7 @@ class XSnsx(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` will be removed in the next release as it has been
+              ``specfile`` might be removed in future releases as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
@@ -3864,7 +3864,7 @@ class XSplcabs(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``nmax`` and ``FAST`` will be removed in the next release as
+              ``nmax`` and ``FAST`` might be removed in future releases as
               they have been replaced by ``_nmax`` and ``_FAST``
               respectively, to match the XSPEC naming convention.
 
@@ -4289,7 +4289,7 @@ class XSsrcut(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``breakfreq`` will be removed in the next release as it has
+              ``breakfreq`` might be removed in future releases as it has
               been replaced by ``break_``, to match the XSPEC naming
               convention.
 
@@ -4464,7 +4464,7 @@ class XSvbremss(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``HeH`` will be removed in the next release as it has been
+              ``HeH`` might be removed in future releases as it has been
               replaced by ``HeovrH``, to match the XSPEC naming convention.
 
     Attributes
@@ -4514,7 +4514,7 @@ class XSvequil(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` will be removed in the next release as it has been
+              ``kT_ave`` might be removed in future releases as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
@@ -4569,7 +4569,7 @@ class XSvgnei(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` will be removed in the next release as it has been
+              ``kT_ave`` might be removed in future releases as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
@@ -4728,7 +4728,7 @@ class XSvmeka(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -4856,7 +4856,7 @@ class XSvmcflow(XSAdditiveModel):
     on the cosmology settings set with ``set_xscosmo``.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -5973,7 +5973,7 @@ class XSgabs(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``Tau`` will be removed in the next release as it has been
+              ``Tau`` might be removed in future releases as it has been
               replaced by ``Strength``, to match the XSPEC namin
               convention.
 
@@ -6269,7 +6269,7 @@ class XSredden(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -6437,7 +6437,7 @@ class XSswind1(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logxi`` will be removed in the next release as it has been
+              ``logxi`` might be removed in future releases as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
     Attributes
@@ -6657,7 +6657,7 @@ class XSuvred(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -6857,7 +6857,7 @@ class XSxion(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``lxld`` will be removed in the next release as it has been
+              ``lxld`` might be removed in future releases as it has been
               replaced by ``lxovrld``, to match the XSPEC naming convention.
 
     Attributes
@@ -6930,7 +6930,7 @@ class XSzdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``method`` and ``EBV`` will be removed in the next release as
+              ``method`` and ``EBV`` might be removed in future releases as
               they have been replaced by ``_method`` and ``E_BmV``
               respectively, to match the XSPEC naming convention.
 
@@ -7122,7 +7122,7 @@ class XSzxipcf(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logxi`` will be removed in the next release as it has been
+              ``logxi`` might be removed in future releases as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
     Attributes
@@ -7168,7 +7168,7 @@ class XSzredden(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -7212,7 +7212,7 @@ class XSzsmdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -7826,7 +7826,7 @@ class XScompth(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``AbHe`` will be removed in the next release as it has been
+              ``AbHe`` might be removed in future releases as it has been
               replaced by ``Ab_met``, to match the XSPEC naming convention.
 
     Attributes
@@ -8298,7 +8298,7 @@ class XSlogpar(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``pivotE`` will be removed in the next release as it has been
+              ``pivotE`` might be removed in future releases as it has been
               replaced by ``_pivotE``, to match the XSPEC naming convention.
 
     Attributes
@@ -8348,7 +8348,7 @@ class XSoptxagn(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logLLEdd`` will be removed in the next release as it has
+              ``logLLEdd`` might be removed in future releases as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
 
@@ -8437,7 +8437,7 @@ class XSoptxagnf(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logLLEdd`` will be removed in the next release as it has
+              ``logLLEdd`` might be removed in future releases as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
 
@@ -8746,7 +8746,7 @@ class XSheilin(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift`` will be removed in the next release as it has
+              ``redshift`` might be removed in future releases as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
 
@@ -8845,7 +8845,7 @@ class XSzbabs(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift`` will be removed in the next release as it has
+              ``redshift`` might be removed in future releases as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -7817,25 +7817,28 @@ class XSeqtherm(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
 
+# It is not obvious from the XSPEC documentation what theta, showbb,
+# and RefOn are.
+#
 class XScompth(XSAdditiveModel):
     """The XSPEC compth model: Paolo Coppi's hybrid (thermal/non-thermal) hot plasma emission models.
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``AbHe`` will be removed in the next release as it has been
+              replaced by ``Ab_met``, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    l_hl_s
-        The ratio of the hard to soft compactness, l_h / l_s.
-    l_bb
-        The soft photon compactness.
+    theta
+    showbb
     kT_bb
         The temperature of the blackbody if greater than 0.
         When less than zero then the absolute value is used as
         the T_max parameter of the ``XSdispkpn`` model. The units
         are in eV.
-    l_ntl_h
-        The fraction of power supplied to energetic particles which
-        goes into accelerating non-thermal particles, l_nt / l_h.
+    RefOn
     tau_p
         The Thomson scattering depth.
     radius
@@ -7890,6 +7893,10 @@ class XScompth(XSAdditiveModel):
     the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
+
+    In Sherpa 4.9.0 the ``AbHe`` parameter has been renamed to
+    ``Ab_met``. It can still be accessed using ``AbHe`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -7870,13 +7870,6 @@ class XSzigm(XSMultiplicativeModel):
     lyman_limit
         Should photoelectric absorption be included (1), or not (0).
         This parameter can not be thawed.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 all the parameters have been renamed so that they
-    start with an underscore character. They can still be accessed using
-    the old names for the time being, but these attributes have been
-    deprecated.
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -919,9 +919,11 @@ class XSbmc(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
-              ``logA`` may be removed in future releases as it has been
-              replaced by ``log_A``, to match the XSPEC naming convention.
+    .. note:: Deprecated in Sherpa 4.10.0
+
+       The ``logA`` parameter has been renamed ``log_A`` to match the
+       XSPEC definition. The name ``logA`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -934,12 +936,6 @@ class XSbmc(XSAdditiveModel):
     norm
         The normalization of the model: see [1]_ for an explanation
         of the units.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``logA`` parameter has been renamed to ``log_A``.
-    It can still be accessed using ``logA`` for the time being, but this
-    attribute name has been deprecated.
 
     References
     ----------
@@ -1528,9 +1524,11 @@ class XScompPS(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``tauy`` and ``HRcyl`` might be removed in future releases as
-              they have been replaced by ``tau_y`` and ``HovR_cyl``
-              respectively, to match the XSPEC naming convention.
+
+       The ``tauy`` and ``HRcyl`` parameters have been renamed to ``tau_y``
+       and ``HovR_cyl`` respectively to match the XSPEC definition. The names
+       ``tauy`` and ``HRcyl`` can still be used to access the parameters, but
+       they will be removed in a future release.
 
     Attributes
     ----------
@@ -1584,10 +1582,6 @@ class XScompPS(XSAdditiveModel):
     the ``set_xsxset`` function to set the value of the COMPPS_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
-
-    In Sherpa 4.10.0 ``tauy`` has been renamed to ``tau_y`` and
-    ``HRcyl`` to ``HovR_cyl``. They can still be accessed using the old
-    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -1739,8 +1733,11 @@ class XSdisk(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``NSmass`` might be removed in future releases as it has been
-              replaced by ``CenMass``, to match the XSPEC naming convention.
+
+       The ``NSmass`` parameter has been renamed to ``CenMass`` to match
+       the XSPEC definition. The name ``NSmass`` can still be used to
+       access the parameter, but this name will be removed in a future
+       release.
 
     Attributes
     ----------
@@ -1757,12 +1754,6 @@ class XSdisk(XSAdditiveModel):
     See Also
     --------
     XSdiskbb, XSdiskm, XSdisko
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``NSmass`` parameter has been renamed to
-    ``CenMass``. It can still be accessed using ``NSMass`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1788,8 +1779,10 @@ class XSdiskir(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``LcLd`` might be removed in future releases as it has been
-              replaced by ``LcovrLd``, to match the XSPEC naming convention.
+
+       The ``LcLd`` parameter has been renamed ``LcovrLd`` to match the
+       XSPEC definition. The name ``LcLd`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -1823,12 +1816,6 @@ class XSdiskir(XSAdditiveModel):
     See Also
     --------
     XSdiskbb
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``LcLd`` parameter has been renamed to
-    ``LcovrLd``. It can still be accessed using ``LcLd`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1890,9 +1877,11 @@ class XSdiskline(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinM`` and ``RoutM`` might be removed in future releases as
-              they have been replaced by ``Rin_M`` and ``Rout_M``
-              respectively, to match the XSPEC naming convention.
+
+       The ``RinM`` and ``RoutM`` parameters have been renamed ``Rin_M``
+       and ``Rout_M`` respectively to match the XSPEC definition. The names
+       ``RinM`` and ``RoutM`` can still be used to access the parameters,
+       but they will be removed in a future release.
 
     Attributes
     ----------
@@ -1908,12 +1897,6 @@ class XSdiskline(XSAdditiveModel):
         The inclination, in degrees.
     norm
         The model normalization in photon/cm^2/s.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 ``RinM`` has been renamed to ``Rin_M`` and
-    ``RoutM`` to ``Rout_M``. They can still be accessed using the old
-    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -2097,10 +2080,6 @@ class XSequil(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` might be removed in future releases as it has been
-              replaced by ``meankT``, to match the XSPEC naming convention.
-
     Attributes
     ----------
     kT
@@ -2235,6 +2214,12 @@ class XSgnei(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
+    .. note:: Deprecated in Sherpa 4.10.0
+
+       The ``kT_ave`` parameter has been renamed ``meanKT`` to match the
+       XSPEC definition. The name ``kT_ave`` can still be used to access
+       the parameter, but this name will be removed in a future release.
+
     Attributes
     ----------
     kT
@@ -2255,12 +2240,6 @@ class XSgnei(XSAdditiveModel):
     See Also
     --------
     XSequil, XSnei, XSvgnei, XSvvgnei
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
-    ``meankT``. It can still be accessed using ``kT_ave`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2288,8 +2267,10 @@ class XSgrad(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``TclTef`` might be removed in future releases as it has been
-              replaced by ``TclovTef``, to match the XSPEC naming convention.
+
+       The ``TclTef`` parameter has been renamed ``TclovTef`` to match the
+       XSPEC definition. The name ``logA`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -2316,12 +2297,6 @@ class XSgrad(XSAdditiveModel):
     See Also
     --------
     XSkerbb
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``TclTef`` parameter has been renamed to
-    ``TclovTef``. It can still be accessed using ``TclTef`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2350,8 +2325,10 @@ class XSgrbm(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``temp`` might be removed in future releases as it has been
-              replaced by ``tem``, to match the XSPEC naming convention.
+
+       The ``temp`` parameter has been renamed ``tem`` to match the
+       XSPEC definition. The name ``temp`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -2363,12 +2340,6 @@ class XSgrbm(XSAdditiveModel):
         The characteristic energy, in keV.
     norm
         The normalization of the model.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``temp`` parameter has been renamed to
-    ``tem``. It can still be accessed using ``temp`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2461,8 +2432,10 @@ class XSkerrd(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``TcolTeff`` might be removed in future releases as it has been
-              replaced by ``TcoloTeff``, to match the XSPEC naming convention.
+
+       The ``TcolTeff`` parameter has been renamed ``TcoloTeff`` to match the
+       XSPEC definition. The name ``TcolTeff`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -2489,12 +2462,6 @@ class XSkerrd(XSAdditiveModel):
     See Also
     --------
     XSlaor
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``TcolTeff`` parameter has been renamed to
-    ``TcoloTeff``. It can still be accessed using ``TcolTeff`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2524,10 +2491,12 @@ class XSkerrdisk(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``r_brg``, ``Rinms``, and ``Routms`` will be removed in the
-              next release as they have been replaced by ``r_br_g``,
-              ``Rin_ms``, and ``Rout_ms`` respectively, to match the XSPEC
-              naming convention.
+
+       The ``r_brg``, ``Rinms``, and ``Routms`` parameters have been
+       renamed to ``r_br_g``, ``Rin_ms``, and ``Rout_ms`` respectively
+       to match the XSPEC definition. The names ``r_brg``, ``Rinms``,
+       and ``Routms`` can still be used to access the parameters, but
+       they will be removed in a future release.
 
     Attributes
     ----------
@@ -2559,13 +2528,6 @@ class XSkerrdisk(XSAdditiveModel):
     See Also
     --------
     XSdiskline, XSlaor
-
-    Notes
-    -----
-    In Sherpa 4.10.0 ``r_brg`` has been renamed to ``r_br_g``, ``Rinms``
-    to ``Rin_ms``, and ``Routms`` to ``Rout_ms``. They can still be
-    accessed using the old names for the time being, but these attributes
-    have been deprecated.
 
     References
     ----------
@@ -2602,9 +2564,11 @@ class XSlaor(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinG`` and ``RoutG`` might be removed in future releases as
-              they have been replaced by ``Rin_G`` and ``Rout_G``
-              respectively, to match the XSPEC naming convention.
+
+       The ``RinG`` and ``RoutG`` parameters have been renamed to
+       ``Rin_G`` and ``Rout_G`` respectively to match the XSPEC definition.
+       The names ``RinG`` and ``RoutG`` can still be used to access the
+       parameters, but they will be removed in a future release.
 
     Attributes
     ----------
@@ -2625,12 +2589,6 @@ class XSlaor(XSAdditiveModel):
     See Also
     --------
     XSlaor2
-
-    Notes
-    -----
-    In Sherpa 4.10.0 ``RinG`` has been renamed to ``Rin_G`` and
-    ``RoutG`` to ``Rout_G``. They can still be accessed using the old
-    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -2663,9 +2621,11 @@ class XSlaor2(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinG`` and ``RoutG`` might be removed in future releases as
-              they have been replaced by ``Rin_G`` and ``Rout_G``
-              respectively, to match the XSPEC naming convention.
+
+       The ``RinG`` and ``RoutG`` parameters have been renamed to
+       ``Rin_G`` and ``Rout_G`` respectively to match the XSPEC definition.
+       The names ``RinG`` and ``RoutG`` can still be used to access the
+       parameters, but they will be removed in a future release.
 
     Attributes
     ----------
@@ -2690,12 +2650,6 @@ class XSlaor2(XSAdditiveModel):
     See Also
     --------
     XSlaor
-
-    Notes
-    -----
-    In Sherpa 4.10.0 ``RinG`` has been renamed to ``Rin_G`` and
-    ``RoutG`` to ``Rout_G``. They can still be accessed using the old
-    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -4135,9 +4089,10 @@ class XSsrcut(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``breakfreq`` might be removed in future releases as it has
-              been replaced by ``break_``, to match the XSPEC naming
-              convention.
+
+       The ``breakfreq`` parameter has been renamed ``break_`` to match the
+       XSPEC definition. The name ``breakfreq`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -4152,12 +4107,6 @@ class XSsrcut(XSAdditiveModel):
     See Also
     --------
     XSsresc
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``breakfreq`` parameter has been renamed to
-    ``break_``. It can still be accessed using ``breakfreq`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4308,8 +4257,10 @@ class XSvbremss(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``HeH`` might be removed in future releases as it has been
-              replaced by ``HeovrH``, to match the XSPEC naming convention.
+
+       The ``HeH`` parameter has been renamed ``HeovrH`` to match the
+       XSPEC definition. The name ``HeH`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -4324,12 +4275,6 @@ class XSvbremss(XSAdditiveModel):
     See Also
     --------
     XSbremss, XSzbremss
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``HeH`` parameter has been renamed to
-    ``HeovrH``. It can still be accessed using ``HeH`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4354,10 +4299,6 @@ class XSvequil(XSAdditiveModel):
     The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` might be removed in future releases as it has been
-              replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -4411,8 +4352,10 @@ class XSvgnei(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` might be removed in future releases as it has been
-              replaced by ``meankT``, to match the XSPEC naming convention.
+
+       The ``kT_ave`` parameter has been renamed ``meanKT`` to match the
+       XSPEC definition. The name ``kT_ave`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -4436,12 +4379,6 @@ class XSvgnei(XSAdditiveModel):
     See Also
     --------
     XSequil, XSgnei, XSvnei, XSvvgnei
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
-    ``meankT``. It can still be accessed using ``kT_ave`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4482,6 +4419,12 @@ class XSvvgnei(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
+    .. note:: Deprecated in Sherpa 4.10.0
+
+       The ``kT_ave`` parameter has been renamed ``meanKT`` to match the
+       XSPEC definition. The name ``kT_ave`` can still be used to access
+       the parameter, but this name will be removed in a future release.
+
     Attributes
     ----------
     kT
@@ -4505,12 +4448,6 @@ class XSvvgnei(XSAdditiveModel):
     See Also
     --------
     XSequil, XSgnei, XSvgnei, XSvvnei
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
-    ``meankT``. It can still be accessed using ``kT_ave`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -5791,9 +5728,10 @@ class XSgabs(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``Tau`` might be removed in future releases as it has been
-              replaced by ``Strength``, to match the XSPEC namin
-              convention.
+
+       The ``Tau`` parameter has been renamed ``Strength`` to match the
+       XSPEC definition. The name ``Tau`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -5803,13 +5741,7 @@ class XSgabs(XSMultiplicativeModel):
         The line width (sigma), in keV.
     Strength
         The line depth. The optical depth at the line center is
-        Tau / (sqrt(2 pi) * Sigma).
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``Tau`` parameter has been renamed to
-    ``Strength``. It can still be accessed using ``Tau`` for the time
-    being, but this attribute has been deprecated.
+        Strength / (sqrt(2 pi) * Sigma).
 
     References
     ----------
@@ -6085,8 +6017,10 @@ class XSredden(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` might be removed in future releases as it has been
-              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
+       The ``EBV`` parameter has been renamed ``E_BmV`` to match the
+       XSPEC definition. The name ``EBV`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -6096,12 +6030,6 @@ class XSredden(XSMultiplicativeModel):
     See Also
     --------
     XSzredden
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
-    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6251,8 +6179,10 @@ class XSswind1(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logxi`` might be removed in future releases as it has been
-              replaced by ``log_xi``, to match the XSPEC naming convention.
+
+       The ``logxi`` parameter has been renamed ``log_xi`` to match the
+       XSPEC definition. The name ``logxi`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -6264,12 +6194,6 @@ class XSswind1(XSMultiplicativeModel):
         The gaussian sigma for velocity smearing (v/c).
     redshift
         The redshift of the source.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``logxi`` parameter has been renamed to
-    ``log_xi``. It can still be accessed using ``logxi`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6469,19 +6393,15 @@ class XSuvred(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` might be removed in future releases as it has been
-              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
+       The ``EBV`` parameter has been renamed ``E_BmV`` to match the
+       XSPEC definition. The name ``EBV`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
     E_BmV
         The value of E(B-v) for the line of sight to the source.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
-    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6667,8 +6587,10 @@ class XSxion(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``lxld`` might be removed in future releases as it has been
-              replaced by ``lxovrld``, to match the XSPEC naming convention.
+
+       The ``lxld`` parameter has been renamed ``lxovrld`` to match the
+       XSPEC definition. The name ``lxld`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -6698,12 +6620,6 @@ class XSxion(XSMultiplicativeModel):
         See [1]_ for details.
     Geometry
         See [1]_ for details.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``lxld`` parameter has been renamed to
-    ``lxovrld``. It can still be accessed using ``lxld`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6738,8 +6654,10 @@ class XSzdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` might be removed in future releases as
-              it has been replaced by ``E_BmV`` to match the XSPEC naming convention.
+
+       The ``EBV`` parameter has been renamed ``E_BmV`` to match the
+       XSPEC definition. The name ``EBV`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -6752,13 +6670,6 @@ class XSzdust(XSMultiplicativeModel):
         The ratio of total to selective extinction.
     redshift
         The redshift of the absorber.
-
-    Notes
-    -----
-    In Sherpa 4.10.0
-    ``EBV`` has been renamed to ``E_BmV``. It can still be accessed using the old
-    names for the time being, but these attributes have been deprecated.
-
 
     References
     ----------
@@ -6927,8 +6838,10 @@ class XSzxipcf(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logxi`` might be removed in future releases as it has been
-              replaced by ``log_xi``, to match the XSPEC naming convention.
+
+       The ``logxi`` parameter has been renamed ``log_xi`` to match the
+       XSPEC definition. The name ``logxi`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -6940,12 +6853,6 @@ class XSzxipcf(XSMultiplicativeModel):
         The covering fraction.
     redshift
         The redshift of the source.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``logxi`` parameter has been renamed to
-    ``log_xi``. It can still be accessed using ``logxi`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6971,8 +6878,10 @@ class XSzredden(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` might be removed in future releases as it has been
-              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
+       The ``EBV`` parameter has been renamed ``E_BmV`` to match the
+       XSPEC definition. The name ``EBV`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -6984,12 +6893,6 @@ class XSzredden(XSMultiplicativeModel):
     See Also
     --------
     XSredden
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
-    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -7013,8 +6916,10 @@ class XSzsmdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` might be removed in future releases as it has been
-              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
+       The ``EBV`` parameter has been renamed ``E_BmV`` to match the
+       XSPEC definition. The name ``EBV`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -7026,12 +6931,6 @@ class XSzsmdust(XSMultiplicativeModel):
         The ratio of total to selective extinction.
     redshift
         The redshift of the absorber.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
-    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -7363,10 +7262,12 @@ class XSeqpair(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
-              next release as they have been replaced by ``l_hovl_s``,
-              ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
-              naming convention.
+
+       The ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` parameters have been
+       renamed to ``l_hovl_s``, ``l_ntol_h``, and ``Ab_met`` respectively
+       to match the XSPEC definition. The names ``l_hl_s``, ``l_ntl_h``,
+       and ``AbHe`` can still be used to access the parameters, but
+       they will be removed in a future release.
 
     Attributes
     ----------
@@ -7437,11 +7338,6 @@ class XSeqpair(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.10.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
-    ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
-    be accessed using the old names for the time being, but these attributes
-    have been deprecated.
-
     References
     ----------
 
@@ -7483,10 +7379,12 @@ class XSeqtherm(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
-              next release as they have been replaced by ``l_hovl_s``,
-              ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
-              naming convention.
+
+       The ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` parameters have been
+       renamed to ``l_hovl_s``, ``l_ntol_h``, and ``Ab_met`` respectively
+       to match the XSPEC definition. The names ``l_hl_s``, ``l_ntl_h``,
+       and ``AbHe`` can still be used to access the parameters, but
+       they will be removed in a future release.
 
     Attributes
     ----------
@@ -7557,11 +7455,6 @@ class XSeqtherm(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.10.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
-    ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
-    be accessed using the old names for the time being, but these attributes
-    have been deprecated.
-
     References
     ----------
 
@@ -7606,8 +7499,10 @@ class XScompth(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``AbHe`` might be removed in future releases as it has been
-              replaced by ``Ab_met``, to match the XSPEC naming convention.
+
+       The ``AbHe`` parameter has been renamed ``Ab_met`` to match the
+       XSPEC definition. The name ``AbHe`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -7673,10 +7568,6 @@ class XScompth(XSAdditiveModel):
     the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
-
-    In Sherpa 4.10.0 the ``AbHe`` parameter has been renamed to
-    ``Ab_met``. It can still be accessed using ``AbHe`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -8096,9 +7987,11 @@ class XSoptxagn(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logLLEdd`` might be removed in future releases as it has
-              been replaced by ``logLoLedd``, to match the XSPEC naming
-              convention.
+
+       The ``logLLEdd`` parameter has been renamed ``logLoLedd`` to match
+       the XSPEC definition. The name ``logLLEdd`` can still be used to
+       access the parameter, but this name will be removed in a future
+       release.
 
     Attributes
     ----------
@@ -8143,12 +8036,6 @@ class XSoptxagn(XSAdditiveModel):
     --------
     XSOptxagnf
 
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``logLLEdd`` parameter has been renamed to
-    ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
-    time being, but this attribute has been deprecated.
-
     References
     ----------
 
@@ -8183,9 +8070,11 @@ class XSoptxagnf(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logLLEdd`` might be removed in future releases as it has
-              been replaced by ``logLoLedd``, to match the XSPEC naming
-              convention.
+
+       The ``logLLEdd`` parameter has been renamed ``logLoLedd`` to match
+       the XSPEC definition. The name ``logLLEdd`` can still be used to
+       access the parameter, but this name will be removed in a future
+       release.
 
     Attributes
     ----------
@@ -8223,12 +8112,6 @@ class XSoptxagnf(XSAdditiveModel):
     See Also
     --------
     XSOptxagn
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``logLLEdd`` parameter has been renamed to
-    ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
-    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -8490,9 +8373,10 @@ class XSheilin(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift`` might be removed in future releases as it has
-              been replaced by ``z``, to match the XSPEC naming
-              convention.
+
+       The ``redshift`` parameter has been renamed ``z`` to match the
+       XSPEC definition. The name ``redshift`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -8506,12 +8390,6 @@ class XSheilin(XSMultiplicativeModel):
     See Also
     --------
     XSlyman
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``redshift`` parameter has been renamed to
-    ``z``. It can still be accessed using ``redshift`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -8536,9 +8414,11 @@ class XSlyman(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``nHeI`` and ``redshift`` will be removed in the next
-              release as they have been replaced by ``n`` and ``z``
-              respectively, to match the XSPEC naming convention.
+
+       The ``nHeI`` and ``redshift`` parameters have been renamed to
+       ``n`` and ``z`` respectively to match the XSPEC definition. The
+       names ``nHeI`` and ``redshift`` can still be used to access the
+       parameters, but they will be removed in a future release.
 
     Attributes
     ----------
@@ -8554,12 +8434,6 @@ class XSlyman(XSMultiplicativeModel):
     See Also
     --------
     XSheilin
-
-    Notes
-    -----
-    In Sherpa 4.10.0 ``nHeI`` has been renamed to ``n`` and ``redshift``
-    to ``z``. They can still be accessed using the old names for the
-    time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -8584,9 +8458,10 @@ class XSzbabs(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift`` might be removed in future releases as it has
-              been replaced by ``z``, to match the XSPEC naming
-              convention.
+
+       The ``redshift`` parameter has been renamed ``z`` to match the
+       XSPEC definition. The name ``redshift`` can still be used to access
+       the parameter, but this name will be removed in a future release.
 
     Attributes
     ----------
@@ -8598,12 +8473,6 @@ class XSzbabs(XSMultiplicativeModel):
         The He II column density, in 10^22 atoms/cm^2.
     z
         The redshift of the absorber.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``redshift`` parameter has been renamed to
-    ``z``. It can still be accessed using ``redshift`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -953,9 +953,8 @@ class XSbmc(XSAdditiveModel):
     def __init__(self, name='bmc'):
         self.kT = Parameter(name, 'kT', 1., 1.e-2, 100., 0.0, hugeval, 'keV')
         self.alpha = Parameter(name, 'alpha', 1., 1.e-2, 4.0, 0.0, hugeval)
-        self.log_A = Parameter(name, 'log_A', 0.0, -6.0, 6.0, -hugeval, hugeval)
+        self.log_A = Parameter(name, 'log_A', 0.0, -6.0, 6.0, -hugeval, hugeval, aliases=["logA"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        self._renamedpars = [('logA', 'log_A')]
         XSAdditiveModel.__init__(self, name, (self.kT, self.alpha, self.log_A, self.norm))
 
 
@@ -1101,10 +1100,8 @@ class XSc6mekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
@@ -1166,10 +1163,8 @@ class XSc6pmekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
@@ -1244,10 +1239,8 @@ class XSc6pvmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -1321,10 +1314,8 @@ class XSc6vmekl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -1383,10 +1374,8 @@ class XScemekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
@@ -1458,10 +1447,8 @@ class XScevmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -1664,9 +1651,9 @@ class XScompPS(XSAdditiveModel):
         self.Gmin = Parameter(name, 'Gmin', -1., -1., 10., -hugeval, hugeval, frozen=True)
         self.Gmax = Parameter(name, 'Gmax', 1.e3, 10., 1.e4, 0.0, hugeval, frozen=True)
         self.kTbb = Parameter(name, 'kTbb', 0.1, 0.001, 10., 0.0, hugeval, 'keV', True)
-        self.tau_y = Parameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.0, hugeval)
+        self.tau_y = Parameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.0, hugeval, aliases=["tauy"])
         self.geom = Parameter(name, 'geom', 0.0, -5.0, 4.0, -hugeval, hugeval, frozen=True)
-        self.HovR_cyl = Parameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.0, hugeval, frozen=True)
+        self.HovR_cyl = Parameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.0, hugeval, frozen=True, aliases=["HRcyl"])
         self.cosIncl = Parameter(name, 'cosIncl', 0.5, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.cov_frac = Parameter(name, 'cov_frac', 1.0, 0.0, 1.0, 0.0, hugeval, frozen=True)
         self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e4, 0.0, hugeval, frozen=True)
@@ -1679,8 +1666,6 @@ class XScompPS(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'Rs', True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('tauy', 'tau_y'), ('HRcyl', 'HovR_cyl')]
 
         XSAdditiveModel.__init__(self, name, (self.kTe, self.EleIndex, self.Gmin, self.Gmax, self.kTbb, self.tau_y, self.geom, self.HovR_cyl, self.cosIncl, self.cov_frac, self.rel_refl, self.Fe_ab_re, self.Me_ab, self.xi, self.Tdisk, self.Betor10, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -1837,11 +1822,9 @@ class XSdisk(XSAdditiveModel):
 
     def __init__(self, name='disk'):
         self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 0.0, hugeval)
-        self.CenMass = Parameter(name, 'CenMass', 1.4, .4, 10., 0.0, hugeval, units='Msun', frozen=True)
+        self.CenMass = Parameter(name, 'CenMass', 1.4, .4, 10., 0.0, hugeval, units='Msun', frozen=True, aliases=["NSmass"])
         self.Rinn = Parameter(name, 'Rinn', 1.03, 1.01, 1.03, 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('NSmass', 'CenMass')]
 
         XSAdditiveModel.__init__(self, name, (self.accrate, self.CenMass, self.Rinn, self.norm))
 
@@ -1907,14 +1890,12 @@ class XSdiskir(XSAdditiveModel):
         self.kT_disk = Parameter(name, 'kT_disk', 1.0, 0.01, 5., 0.0, hugeval, 'keV')
         self.Gamma = Parameter(name, 'Gamma', 1.7, 1.001, 5., 0.0, hugeval)
         self.kT_e = Parameter(name, 'kT_e', 100., 5., 1.e3, 0.0, hugeval, 'keV')
-        self.LcovrLd = Parameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, hugeval)
+        self.LcovrLd = Parameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, hugeval, aliases=["LcLd"])
         self.fin = Parameter(name, 'fin', 1.e-1, 0.0, 1., 0.0, hugeval, frozen=True)
         self.rirr = Parameter(name, 'rirr', 1.2, 1.0001, 10., 1.0001, hugeval)
         self.fout = Parameter(name, 'fout', 1.e-4, 0.0, 1.e-1, 0.0, hugeval)
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('LcLd', 'LcovrLd')]
 
         XSAdditiveModel.__init__(self, name, (self.kT_disk, self.Gamma, self.kT_e, self.LcovrLd, self.fin, self.rirr, self.fout, self.logrout, self.norm))
 
@@ -1993,12 +1974,10 @@ class XSdiskline(XSAdditiveModel):
     def __init__(self, name='diskline'):
         self.LineE = Parameter(name, 'LineE', 6.7, 0., 100., 0.0, hugeval, 'keV')
         self.Betor10 = Parameter(name, 'Betor10', -2., -10., 20., -hugeval, hugeval, frozen=True)
-        self.Rin_M = Parameter(name, 'Rin_M', 10., 6., 1000., 0.0, hugeval, frozen=True)
-        self.Rout_M = Parameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, hugeval, frozen=True)
+        self.Rin_M = Parameter(name, 'Rin_M', 10., 6., 1000., 0.0, hugeval, frozen=True, aliases=["RinM"])
+        self.Rout_M = Parameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, hugeval, frozen=True, aliases=["RoutM"])
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('RinM', 'Rin_M'), ('RoutM', 'Rout_M')]
 
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Betor10, self.Rin_M, self.Rout_M, self.Incl, self.norm))
 
@@ -2343,11 +2322,9 @@ class XSgnei(XSAdditiveModel):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 0.0, hugeval, 's/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV', aliases=["kT_ave"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('kT_ave', 'meankT')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau, self.meankT, self.redshift, self.norm))
 
@@ -2407,11 +2384,9 @@ class XSgrad(XSAdditiveModel):
         self.i = Parameter(name, 'i', 0.0, 0.0, 90.0, 0.0, hugeval, 'deg', True)
         self.Mass = Parameter(name, 'Mass', 1.0, 0.0, 100.0, 0.0, hugeval, 'solar')
         self.Mdot = Parameter(name, 'Mdot', 1.0, 0.0, 100.0, 0.0, hugeval, '1e18')
-        self.TclovTef = Parameter(name, 'TclovTef', 1.7, 1.0, 10.0, 0.0, hugeval, frozen=True)
+        self.TclovTef = Parameter(name, 'TclovTef', 1.7, 1.0, 10.0, 0.0, hugeval, frozen=True, aliases=["TclTef"])
         self.refflag = Parameter(name, 'refflag', 1.0, -1.0, 1.0, -hugeval, hugeval, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('TclTef', 'TclovTef')]
 
         XSAdditiveModel.__init__(self, name, (self.D, self.i, self.Mass, self.Mdot, self.TclovTef, self.refflag, self.norm))
 
@@ -2454,10 +2429,8 @@ class XSgrbm(XSAdditiveModel):
     def __init__(self, name='grbm'):
         self.alpha = Parameter(name, 'alpha', -1., -3., +2., -hugeval, hugeval)
         self.beta = Parameter(name, 'beta', -2., -5., +2., -hugeval, hugeval)
-        self.tem = Parameter(name, 'tem', +300., +50., +1000., 0.0, hugeval, 'keV')
+        self.tem = Parameter(name, 'tem', +300., +50., +1000., 0.0, hugeval, 'keV', aliases=["temp"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('temp', 'tem')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.tem, self.norm))
 
@@ -2581,15 +2554,13 @@ class XSkerrd(XSAdditiveModel):
 
     def __init__(self, name='kerrd'):
         self.distance = Parameter(name, 'distance', 1., 0.01, 1000., 0.0, hugeval, 'kpc', True)
-        self.TcoloTeff = Parameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 0.0, hugeval, frozen=True)
+        self.TcoloTeff = Parameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 0.0, hugeval, frozen=True, aliases=["TcolTeff"])
         self.M = Parameter(name, 'M', 1.0, 0.1, 100., 0.0, hugeval, 'solar')
         self.Mdot = Parameter(name, 'Mdot', 1.0, 0.01, 100., 0.0, hugeval, '1e18')
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.Rin = Parameter(name, 'Rin', 1.235, 1.235, 100., 0.0, hugeval, 'Rg', True)
         self.Rout = Parameter(name, 'Rout', 1e5, 1e4, 1e8, 0.0, hugeval, 'Rg', True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('TcolTeff', 'TcoloTeff')]
 
         XSAdditiveModel.__init__(self, name, (self.distance, self.TcoloTeff, self.M, self.Mdot, self.Incl, self.Rin, self.Rout, self.norm))
 
@@ -2656,17 +2627,13 @@ class XSkerrdisk(XSAdditiveModel):
         self.lineE = Parameter(name, 'lineE', 6.4, 0.1, 100., 0.0, hugeval, 'keV')
         self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -hugeval, hugeval, frozen=True)
         self.Index2 = Parameter(name, 'Index2', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.r_br_g = Parameter(name, 'r_br_g', 6.0, 1.0, 400., 0.0, hugeval, frozen=True)
+        self.r_br_g = Parameter(name, 'r_br_g', 6.0, 1.0, 400., 0.0, hugeval, frozen=True, aliases=["r_brg"])
         self.a = Parameter(name, 'a', 0.998, 0.0, 0.998, 0.0, hugeval)
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
-        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, 1.0, 400., 0.0, hugeval, frozen=True)
-        self.Rout_ms = Parameter(name, 'Rout_ms', 400., 1.0, 400., 0.0, hugeval, frozen=True)
+        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, 1.0, 400., 0.0, hugeval, frozen=True, aliases=["Rinms"])
+        self.Rout_ms = Parameter(name, 'Rout_ms', 400., 1.0, 400., 0.0, hugeval, frozen=True, aliases=["Routms"])
         self.z = Parameter(name, 'z', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('r_brg', 'r_br_g'),
-                             ('Rinms', 'Rin_ms'),
-                             ('Routms', 'Rout_ms')]
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index1, self.Index2, self.r_br_g, self.a, self.Incl, self.Rin_ms, self.Rout_ms, self.z, self.norm))
 
@@ -2724,12 +2691,10 @@ class XSlaor(XSAdditiveModel):
     def __init__(self, name='laor'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
         self.Index = Parameter(name, 'Index', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
-        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True, aliases=["RinG"])
+        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True, aliases=[""])
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('RinG', 'Rin_G'), ('RoutG', 'Rout_G')]
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.norm))
 
@@ -2791,14 +2756,12 @@ class XSlaor2(XSAdditiveModel):
     def __init__(self, name='laor2'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
         self.Index = Parameter(name, 'Index', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
-        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True, aliases=["RinG"])
+        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True, aliases=["RoutG"])
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.Rbreak = Parameter(name, 'Rbreak', 20., 1.235, 400., 0.0, hugeval, frozen=True)
         self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('RinG', 'Rin_G'), ('RoutG', 'Rout_G')]
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.Rbreak, self.Index1, self.norm))
 
@@ -2942,10 +2905,8 @@ class XSmekal(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 0.0, hugeval, 'cm-3', True)
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self._switch, self.norm))
 
@@ -3002,10 +2963,8 @@ class XSmkcflow(XSAdditiveModel):
         self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self._switch, self.norm))
 
@@ -3452,10 +3411,8 @@ class XSnsmax(XSAdditiveModel):
     def __init__(self, name='nsmax'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.8, 0.0, hugeval, 'K')
         self.redshift = Parameter(name, 'redshift', 0.1, 0.0, 1.5, 0.0, 2.0)
-        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('specfile', '_specfile')]
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self._specfile, self.norm))
 
@@ -3508,10 +3465,8 @@ class XSnsmaxg(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('specfile', '_specfile')]
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
 
@@ -3564,10 +3519,8 @@ class XSnsx(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self._specfile = Parameter(name, '_specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('specfile', '_specfile')]
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
 
@@ -3913,18 +3866,16 @@ class XSplcabs(XSAdditiveModel):
 
     def __init__(self, name='plcabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
-        self._nmax = Parameter(name, '_nmax', 1, alwaysfrozen=True)
+        self._nmax = Parameter(name, '_nmax', 1, alwaysfrozen=True, aliases=["nmax"])
         self.FeAbun = Parameter(name, 'FeAbun', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.FeKedge = Parameter(name, 'FeKedge', 7.11, 7., 10., 0.0, hugeval, 'KeV', True)
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -2., 9., -hugeval, hugeval)
         self.HighECut = Parameter(name, 'HighECut', 25., 1., 50., 0.0, 90., 'keV', True)
         self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 0.0, hugeval, frozen=True)
         self.acrit = Parameter(name, 'acrit', 1., 0.0, 1.0, 0.0, hugeval, frozen=True)
-        self._FAST = Parameter(name, '_FAST', 0, alwaysfrozen=True)
+        self._FAST = Parameter(name, '_FAST', 0, alwaysfrozen=True, aliases=["FAST"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('nmax', '_nmax'), ('FAST', '_FAST')]
 
         XSAdditiveModel.__init__(self, name, (self.nH, self._nmax, self.FeAbun, self.FeKedge, self.PhoIndex, self.HighECut, self.foldE, self.acrit, self._FAST, self.redshift, self.norm))
 
@@ -4324,10 +4275,8 @@ class XSsrcut(XSAdditiveModel):
 
     def __init__(self, name='srcut'):
         self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 0.0, hugeval)
-        self.break_ = Parameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 0.0, hugeval, 'Hz')
+        self.break_ = Parameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 0.0, hugeval, 'Hz', aliases=["breakfreq"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('breakfreq', 'break_')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.break_, self.norm))
 
@@ -4498,10 +4447,8 @@ class XSvbremss(XSAdditiveModel):
 
     def __init__(self, name='vbremss'):
         self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 0.0, hugeval, 'keV')
-        self.HeovrH = Parameter(name, 'HeovrH', 1.0, 0., 100., 0.0, hugeval)
+        self.HeovrH = Parameter(name, 'HeovrH', 1.0, 0., 100., 0.0, hugeval, aliases=["HeH"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('HeH', 'HeovrH')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.HeovrH, self.norm))
 
@@ -4626,11 +4573,9 @@ class XSvgnei(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 0.0, hugeval, 's/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV', aliases=["kT_ave"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('kT_ave', 'meankT')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.meankT, self.redshift, self.norm))
 
@@ -4714,12 +4659,10 @@ class XSvvgnei(XSAdditiveModel):
         self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 10000.0, frozen=True)
         self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 10000.0, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, 'keV', aliases=["kT_ave"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('kT_ave', 'meankT')]
-
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
+
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.meankT, self.redshift, self.norm))
 
 class XSvmeka(XSAdditiveModel):
@@ -4841,10 +4784,8 @@ class XSvmekal(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -4914,10 +4855,8 @@ class XSvmcflow(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -6005,9 +5944,7 @@ class XSgabs(XSMultiplicativeModel):
     def __init__(self, name='gabs'):
         self.LineE = Parameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, hugeval, 'keV')
         self.Sigma = Parameter(name, 'Sigma', 0.01, 0., 10., 0.0, hugeval, 'keV')
-        self.Strength = Parameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, hugeval)
-
-        self._renamedpars = [('Tau', 'Strength')]
+        self.Strength = Parameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, hugeval, aliases=["Tau"])
 
         XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Sigma, self.Strength))
 
@@ -6297,9 +6234,7 @@ class XSredden(XSMultiplicativeModel):
     _calc = _xspec.xscred
 
     def __init__(self, name='redden'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval, aliases=["EBV"])
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
@@ -6468,11 +6403,9 @@ class XSswind1(XSMultiplicativeModel):
 
     def __init__(self, name='swind1'):
         self.column = Parameter(name, 'column', 6., 3., 50., 0.0, hugeval)
-        self.log_xi = Parameter(name, 'log_xi', 2.5, 2.1, 4.1, 0.0, hugeval)
+        self.log_xi = Parameter(name, 'log_xi', 2.5, 2.1, 4.1, 0.0, hugeval, aliases=["logxi"])
         self.sigma = Parameter(name, 'sigma', 0.1, 0., .5, 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('logxi', 'log_xi')]
 
         XSMultiplicativeModel.__init__(self, name, (self.column, self.log_xi, self.sigma, self.redshift))
 
@@ -6681,9 +6614,7 @@ class XSuvred(XSMultiplicativeModel):
     _calc = _xspec.xsred
 
     def __init__(self, name='uvred'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval, aliases=["EBV"])
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
@@ -6906,7 +6837,7 @@ class XSxion(XSMultiplicativeModel):
 
     def __init__(self, name='xion'):
         self.height = Parameter(name, 'height', 5., 0.0, 1.e2, 0.0, hugeval, 'r_s')
-        self.lxovrld = Parameter(name, 'lxovrld', 0.3, 0.02, 100, 0.0, hugeval)
+        self.lxovrld = Parameter(name, 'lxovrld', 0.3, 0.02, 100, 0.0, hugeval, aliases=["lxld"])
         self.rate = Parameter(name, 'rate', 0.05, 1.e-3, 1., 0.0, hugeval)
         self.cosAng = Parameter(name, 'cosAng', 0.9, 0., 1., 0.0, hugeval)
         self.inner = Parameter(name, 'inner', 3., 2., 1.e3, 0.0, hugeval, 'r_s')
@@ -6918,8 +6849,6 @@ class XSxion(XSMultiplicativeModel):
         self.Ref_type = Parameter(name, 'Ref_type', 1., 1., 3., 0.0, hugeval, frozen=True)
         self.Rel_smear = Parameter(name, 'Rel_smear', 4., 1., 4., 0.0, hugeval, frozen=True)
         self.Geometry = Parameter(name, 'Geometry', 1., 1., 4., 0.0, hugeval, frozen=True)
-
-        self._renamedpars = [('lxld', 'lxovrld')]
 
         XSMultiplicativeModel.__init__(self, name, (self.height, self.lxovrld, self.rate, self.cosAng, self.inner, self.outer, self.index, self.redshift, self.Feabun, self.E_cut, self.Ref_type, self.Rel_smear, self.Geometry))
 
@@ -6963,12 +6892,10 @@ class XSzdust(XSMultiplicativeModel):
     _calc = _xspec.mszdst
 
     def __init__(self, name='zdust'):
-        self._method = Parameter(name, '_method', 1, 1, 3, 1, 3, alwaysfrozen=True)
-        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval)
+        self._method = Parameter(name, '_method', 1, 1, 3, 1, 3, alwaysfrozen=True, aliases=["method"])
+        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval, aliases=["EBV"])
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
-
-        self._renamedpars = [('method', '_method'), ('EBV', 'E_BmV')]
 
         XSMultiplicativeModel.__init__(self, name, (self._method, self.E_BmV, self.Rv, self.redshift))
 
@@ -7153,11 +7080,9 @@ class XSzxipcf(XSMultiplicativeModel):
 
     def __init__(self, name='zxipcf'):
         self.Nh = Parameter(name, 'Nh', 10, 0.05, 500, 0.0, hugeval, '10^22 atoms / cm^2')
-        self.log_xi = Parameter(name, 'log_xi', 3, -3, 6, -hugeval, hugeval)
+        self.log_xi = Parameter(name, 'log_xi', 3, -3, 6, -hugeval, hugeval, aliases=["logxi"])
         self.CvrFract = Parameter(name, 'CvrFract', 0.5, 0., 1., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('logxi', 'log_xi')]
 
         XSMultiplicativeModel.__init__(self, name, (self.Nh, self.log_xi, self.CvrFract, self.redshift))
 
@@ -7198,10 +7123,8 @@ class XSzredden(XSMultiplicativeModel):
     _calc = _xspec.xszcrd
 
     def __init__(self, name='zredden'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval, aliases=["EBV"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.redshift))
 
@@ -7242,12 +7165,10 @@ class XSzsmdust(XSMultiplicativeModel):
     _calc = _xspec.msldst
 
     def __init__(self, name='zsmdust'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval, aliases=["EBV"])
         self.ExtIndex = Parameter(name, 'ExtIndex', 1.0, -10.0, 10., -hugeval, hugeval)
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.ExtIndex, self.Rv, self.redshift))
 
@@ -7539,16 +7460,16 @@ class XScplinear(XSAdditiveModel):
     _calc = _xspec.C_cplinear
 
     def __init__(self, name='cplinear'):
-        self._energy00 = Parameter(name, '_energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy01 = Parameter(name, '_energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy02 = Parameter(name, '_energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy03 = Parameter(name, '_energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy04 = Parameter(name, '_energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy05 = Parameter(name, '_energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy06 = Parameter(name, '_energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy07 = Parameter(name, '_energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy08 = Parameter(name, '_energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy09 = Parameter(name, '_energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy00 = Parameter(name, '_energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy00"])
+        self._energy01 = Parameter(name, '_energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy01"])
+        self._energy02 = Parameter(name, '_energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy02"])
+        self._energy03 = Parameter(name, '_energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy03"])
+        self._energy04 = Parameter(name, '_energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy04"])
+        self._energy05 = Parameter(name, '_energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy05"])
+        self._energy06 = Parameter(name, '_energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy06"])
+        self._energy07 = Parameter(name, '_energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy07"])
+        self._energy08 = Parameter(name, '_energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy08"])
+        self._energy09 = Parameter(name, '_energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy09"])
         self.log_rate00 = Parameter(name, 'log_rate00', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate01 = Parameter(name, 'log_rate01', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate02 = Parameter(name, 'log_rate02', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
@@ -7560,11 +7481,6 @@ class XScplinear(XSAdditiveModel):
         self.log_rate08 = Parameter(name, 'log_rate08', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate09 = Parameter(name, 'log_rate09', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [(n, '_' + n) for n in
-                             ['energy{:02d}'.format(i)
-                              for i in range(10)]
-                             ]
 
         XSAdditiveModel.__init__(self, name, (self._energy00, self._energy01, self._energy02, self._energy03, self._energy04, self._energy05, self._energy06, self._energy07, self._energy08, self._energy09, self.log_rate00, self.log_rate01, self.log_rate02, self.log_rate03, self.log_rate04, self.log_rate05, self.log_rate06, self.log_rate07, self.log_rate08, self.log_rate09, self.norm))
 
@@ -7664,10 +7580,10 @@ class XSeqpair(XSAdditiveModel):
     _calc = _xspec.C_xseqpair
 
     def __init__(self, name='eqpair'):
-        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
+        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval, aliases=["l_hl_s"])
         self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, hugeval)
         self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 0.0, hugeval, 'eV', True)
-        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval)
+        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval, aliases=["l_ntl_h"])
         self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 0.0, hugeval, frozen=True)
         self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 0.0, hugeval, 'cm', True)
         self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 0.0, hugeval, frozen=True)
@@ -7677,7 +7593,7 @@ class XSeqpair(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True, aliases=["AbHe"])
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7685,10 +7601,6 @@ class XSeqpair(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('l_hl_s', 'l_hovl_s'),
-                             ('l_ntl_h', 'l_ntol_h'),
-                             ('AbHe', 'Ab_met')]
 
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -7788,10 +7700,10 @@ class XSeqtherm(XSAdditiveModel):
     _calc = _xspec.C_xseqth
 
     def __init__(self, name='eqtherm'):
-        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
+        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval, aliases=["l_hl_s"])
         self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, hugeval)
         self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 0.0, hugeval, 'eV', True)
-        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval)
+        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval, aliases=["l_ntl_h"])
         self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 0.0, hugeval, frozen=True)
         self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 0.0, hugeval, 'cm', True)
         self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 0.0, hugeval, frozen=True)
@@ -7801,7 +7713,7 @@ class XSeqtherm(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True, aliases=["AbHe"])
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7809,10 +7721,6 @@ class XSeqtherm(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('l_hl_s', 'l_hovl_s'),
-                             ('l_ntl_h', 'l_ntol_h'),
-                             ('AbHe', 'Ab_met')]
 
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -7921,7 +7829,7 @@ class XScompth(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True, aliases=["AbHe"])
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7929,8 +7837,6 @@ class XScompth(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('AbHe', 'Ab_met')]
 
         XSAdditiveModel.__init__(self, name, (self.theta, self.showbb, self.kT_bb, self.RefOn, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -8116,13 +8022,9 @@ class XSzigm(XSMultiplicativeModel):
     _calc = _xspec.zigm
 
     def __init__(self, name='zigm'):
-        self._redshift = Parameter(name, '_redshift', 0.0, alwaysfrozen=True)
-        self._model = Parameter(name, '_model', 0, 0, 1, 0, 1, alwaysfrozen=True)
-        self._lyman_limit = Parameter(name, '_lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True)
-
-        self._renamedpars = [('redshift', '_redshift'),
-                             ('model', '_model'),
-                             ('lyman_limit', '_lyman_limit')]
+        self._redshift = Parameter(name, '_redshift', 0.0, alwaysfrozen=True, aliases=["redshift"])
+        self._model = Parameter(name, '_model', 0, 0, 1, 0, 1, alwaysfrozen=True, aliases=["model"])
+        self._lyman_limit = Parameter(name, '_lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["lyman_limit"])
 
         XSMultiplicativeModel.__init__(self, name, (self._redshift, self._model, self._lyman_limit))
 
@@ -8180,10 +8082,8 @@ class XSgadem(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift, self._switch, self.norm))
 
@@ -8250,10 +8150,8 @@ class XSvgadem(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self._switch, self.norm))
 
@@ -8334,10 +8232,8 @@ class XSlogpar(XSAdditiveModel):
     def __init__(self, name='logpar'):
         self.alpha = Parameter(name, 'alpha', 1.5, 0., 4., 0.0, hugeval)
         self.beta = Parameter(name, 'beta', 0.2, -4., 4., -hugeval, hugeval)
-        self._pivotE = Parameter(name, '_pivotE', 1.0, units='keV', alwaysfrozen=True)
+        self._pivotE = Parameter(name, '_pivotE', 1.0, units='keV', alwaysfrozen=True, aliases=["pivotE"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('pivotE', '_pivotE')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self._pivotE, self.norm))
 
@@ -8413,7 +8309,7 @@ class XSoptxagn(XSAdditiveModel):
     def __init__(self, name='optxagn'):
         self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 0.0, hugeval, 'solar', True)
         self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.0, hugeval, 'Mpc', True)
-        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval)
+        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval, aliases=["logLLEdd"])
         self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, hugeval, frozen=True)
         self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 0.0, hugeval, 'rg')
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval, frozen=True)
@@ -8425,8 +8321,6 @@ class XSoptxagn(XSAdditiveModel):
         self.tscat = Parameter(name, 'tscat', 1.e5, 1e4, 1e5, 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
-
-        self._renamedpars = [('logLLEdd', 'logLoLedd')]
 
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.fcol, self.tscat, self.Redshift, self.norm))
 
@@ -8496,7 +8390,7 @@ class XSoptxagnf(XSAdditiveModel):
     def __init__(self, name='optxagnf'):
         self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 0.0, hugeval, 'solar', True)
         self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.0, hugeval, 'Mpc', True)
-        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval)
+        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval, aliases=["logLLEdd"])
         self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, hugeval, frozen=True)
         self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 0.0, hugeval, 'rg')
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval, frozen=True)
@@ -8506,8 +8400,6 @@ class XSoptxagnf(XSAdditiveModel):
         self.fpl = Parameter(name, 'fpl', 1.e-4, 0.0, 1., 0.0, hugeval)
         self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
-
-        self._renamedpars = [('logLLEdd', 'logLoLedd')]
 
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.Redshift, self.norm))
 
@@ -8781,9 +8673,7 @@ class XSheilin(XSMultiplicativeModel):
     def __init__(self, name='heilin'):
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
-
-        self._renamedpars = [('redshift', 'z')]
+        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
 
         # TODO: correct self.nHei to self.nHeI
         XSMultiplicativeModel.__init__(self, name, (self.nHei, self.b, self.z))
@@ -8829,13 +8719,10 @@ class XSlyman(XSMultiplicativeModel):
     _calc = _xspec.xslyman
 
     def __init__(self, name='lyman'):
-        self.n = Parameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
+        self.n = Parameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2', aliases=["nHeI"])
         self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
+        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
         self.ZA = Parameter(name, 'ZA', 1.0, 1.0, 2.0, 1.0, 2.0)
-
-        self._renamedpars = [('nHeI', 'n'),
-                             ('redshift', 'z')]
 
         XSMultiplicativeModel.__init__(self, name, (self.n, self.b, self.z, self.ZA))
 
@@ -8879,9 +8766,7 @@ class XSzbabs(XSMultiplicativeModel):
         self.nH = Parameter(name, 'nH', 1.e-4, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.nHeII = Parameter(name, 'nHeII', 1.e-6, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
-        self.z = Parameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6)
-
-        self._renamedpars = [('redshift', 'z')]
+        self.z = Parameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6, aliases=["redshift"])
 
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.nHeI, self.nHeII, self.z))
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1050,8 +1050,8 @@ class XSc6mekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
-              ``switch`` will be removed in the next release as it has been
+    .. note:: Deprecated in Sherpa 4.10.0
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1078,7 +1078,7 @@ class XSc6mekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1115,8 +1115,8 @@ class XSc6pmekl(XSAdditiveModel):
     The model is described at [1]_. It differs from ``XSc6mekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
 
-    .. note:: Deprecated in Sherpa 4.9.0
-              ``switch`` will be removed in the next release as it has been
+    .. note:: Deprecated in Sherpa 4.10.0
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1143,7 +1143,7 @@ class XSc6pmekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1180,7 +1180,7 @@ class XSc6pvmkl(XSAdditiveModel):
     The model is described at [1]_. It differs from ``XSc6vmekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1208,7 +1208,7 @@ class XSc6pvmkl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1257,7 +1257,7 @@ class XSc6vmekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1285,7 +1285,7 @@ class XSc6vmekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1334,7 +1334,7 @@ class XScemekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1364,7 +1364,7 @@ class XScemekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1396,7 +1396,7 @@ class XScevmkl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1426,7 +1426,7 @@ class XScevmkl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1587,7 +1587,7 @@ class XScompPS(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``tauy`` and ``HRcyl`` will be removed in the next release as
               they have been replaced by ``tau_y`` and ``HovR_cyl``
               respectively, to match the XSPEC naming convention.
@@ -1645,7 +1645,7 @@ class XScompPS(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 ``tauy`` has been renamed to ``tau_y`` and
+    In Sherpa 4.10.0 ``tauy`` has been renamed to ``tau_y`` and
     ``HRcyl`` to ``HovR_cyl``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -1800,7 +1800,7 @@ class XSdisk(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``NSmass`` will be removed in the next release as it has been
               replaced by ``CenMass``, to match the XSPEC naming convention.
 
@@ -1822,7 +1822,7 @@ class XSdisk(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``NSmass`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``NSmass`` parameter has been renamed to
     ``CenMass``. It can still be accessed using ``NSMass`` for the time
     being, but this attribute has been deprecated.
 
@@ -1851,7 +1851,7 @@ class XSdiskir(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``LcLd`` will be removed in the next release as it has been
               replaced by ``LcovrLd``, to match the XSPEC naming convention.
 
@@ -1890,7 +1890,7 @@ class XSdiskir(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``LcLd`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``LcLd`` parameter has been renamed to
     ``LcovrLd``. It can still be accessed using ``LcLd`` for the time
     being, but this attribute has been deprecated.
 
@@ -1955,7 +1955,7 @@ class XSdiskline(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``RinM`` and ``RoutM`` will be removed in the next release as
               they have been replaced by ``Rin_M`` and ``Rout_M``
               respectively, to match the XSPEC naming convention.
@@ -1977,7 +1977,7 @@ class XSdiskline(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``RinM`` has been renamed to ``Rin_M`` and
+    In Sherpa 4.10.0 ``RinM`` has been renamed to ``Rin_M`` and
     ``RoutM`` to ``Rout_M``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -2165,7 +2165,7 @@ class XSequil(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``kT_ave`` will be removed in the next release as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
@@ -2326,7 +2326,7 @@ class XSgnei(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
     ``meankT``. It can still be accessed using ``kT_ave`` for the time
     being, but this attribute has been deprecated.
 
@@ -2357,7 +2357,7 @@ class XSgrad(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``TclTef`` will be removed in the next release as it has been
               replaced by ``TclovTef``, to match the XSPEC naming convention.
 
@@ -2389,7 +2389,7 @@ class XSgrad(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``TclTef`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``TclTef`` parameter has been renamed to
     ``TclovTef``. It can still be accessed using ``TclTef`` for the time
     being, but this attribute has been deprecated.
 
@@ -2421,7 +2421,7 @@ class XSgrbm(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``temp`` will be removed in the next release as it has been
               replaced by ``tem``, to match the XSPEC naming convention.
 
@@ -2438,7 +2438,7 @@ class XSgrbm(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``temp`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``temp`` parameter has been renamed to
     ``tem``. It can still be accessed using ``temp`` for the time
     being, but this attribute has been deprecated.
 
@@ -2534,7 +2534,7 @@ class XSkerrd(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``TcolTeff`` will be removed in the next release as it has been
               replaced by ``TcoloTeff``, to match the XSPEC naming convention.
 
@@ -2566,7 +2566,7 @@ class XSkerrd(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``TcolTeff`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``TcolTeff`` parameter has been renamed to
     ``TcoloTeff``. It can still be accessed using ``TcolTeff`` for the time
     being, but this attribute has been deprecated.
 
@@ -2599,7 +2599,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``r_brg``, ``Rinms``, and ``Routms`` will be removed in the
               next release as they have been replaced by ``r_br_g``,
               ``Rin_ms``, and ``Rout_ms`` respectively, to match the XSPEC
@@ -2638,7 +2638,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``r_brg`` has been renamed to ``r_br_g``, ``Rinms``
+    In Sherpa 4.10.0 ``r_brg`` has been renamed to ``r_br_g``, ``Rinms``
     to ``Rin_ms``, and ``Routms`` to ``Rout_ms``. They can still be
     accessed using the old names for the time being, but these attributes
     have been deprecated.
@@ -2681,7 +2681,7 @@ class XSlaor(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``RinG`` and ``RoutG`` will be removed in the next release as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
@@ -2708,7 +2708,7 @@ class XSlaor(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``RinG`` has been renamed to ``Rin_G`` and
+    In Sherpa 4.10.0 ``RinG`` has been renamed to ``Rin_G`` and
     ``RoutG`` to ``Rout_G``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -2744,7 +2744,7 @@ class XSlaor2(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``RinG`` and ``RoutG`` will be removed in the next release as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
@@ -2775,7 +2775,7 @@ class XSlaor2(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``RinG`` has been renamed to ``Rin_G`` and
+    In Sherpa 4.10.0 ``RinG`` has been renamed to ``Rin_G`` and
     ``RoutG`` to ``Rout_G``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -2852,7 +2852,7 @@ class XSmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -2924,7 +2924,7 @@ class XSmekal(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -2956,7 +2956,7 @@ class XSmkcflow(XSAdditiveModel):
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -2984,7 +2984,7 @@ class XSmkcflow(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -3415,7 +3415,7 @@ class XSnsmax(XSAdditiveModel):
     The model is described at [1]_. It has been superceeded by
     ``XSnsmaxg``.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``specfile`` will be removed in the next release as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
@@ -3436,7 +3436,7 @@ class XSnsmax(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
     ``_specfile``. It can still be accessed using ``specfile`` for the
     time being, but this attribute has been deprecated.
 
@@ -3465,7 +3465,7 @@ class XSnsmaxg(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``specfile`` will be removed in the next release as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
@@ -3490,7 +3490,7 @@ class XSnsmaxg(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
     ``_specfile``. It can still be accessed using ``specfile`` for the
     time being, but this attribute has been deprecated.
 
@@ -3521,7 +3521,7 @@ class XSnsx(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``specfile`` will be removed in the next release as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
@@ -3546,7 +3546,7 @@ class XSnsx(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
     ``_specfile``. It can still be accessed using ``specfile`` for the
     time being, but this attribute has been deprecated.
 
@@ -3863,7 +3863,7 @@ class XSplcabs(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``nmax`` and ``FAST`` will be removed in the next release as
               they have been replaced by ``_nmax`` and ``_FAST``
               respectively, to match the XSPEC naming convention.
@@ -3898,7 +3898,7 @@ class XSplcabs(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``nmax`` has been renamed to ``_nmax`` and
+    In Sherpa 4.10.0 ``nmax`` has been renamed to ``_nmax`` and
     ``FAST`` to ``_FAST``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -4288,7 +4288,7 @@ class XSsrcut(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``breakfreq`` will be removed in the next release as it has
               been replaced by ``break_``, to match the XSPEC naming
               convention.
@@ -4309,7 +4309,7 @@ class XSsrcut(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``breakfreq`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``breakfreq`` parameter has been renamed to
     ``break_``. It can still be accessed using ``breakfreq`` for the time
     being, but this attribute has been deprecated.
 
@@ -4463,7 +4463,7 @@ class XSvbremss(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``HeH`` will be removed in the next release as it has been
               replaced by ``HeovrH``, to match the XSPEC naming convention.
 
@@ -4483,7 +4483,7 @@ class XSvbremss(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``HeH`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``HeH`` parameter has been renamed to
     ``HeovrH``. It can still be accessed using ``HeH`` for the time
     being, but this attribute has been deprecated.
 
@@ -4513,7 +4513,7 @@ class XSvequil(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``kT_ave`` will be removed in the next release as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
@@ -4568,7 +4568,7 @@ class XSvgnei(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``kT_ave`` will be removed in the next release as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
@@ -4597,7 +4597,7 @@ class XSvgnei(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
     ``meankT``. It can still be accessed using ``kT_ave`` for the time
     being, but this attribute has been deprecated.
 
@@ -4668,7 +4668,7 @@ class XSvvgnei(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
     ``meankT``. It can still be accessed using ``kT_ave`` for the time
     being, but this attribute has been deprecated.
 
@@ -4727,7 +4727,7 @@ class XSvmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -4810,7 +4810,7 @@ class XSvmekal(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -4855,7 +4855,7 @@ class XSvmcflow(XSAdditiveModel):
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -4883,7 +4883,7 @@ class XSvmcflow(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -5972,7 +5972,7 @@ class XSgabs(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``Tau`` will be removed in the next release as it has been
               replaced by ``Strength``, to match the XSPEC namin
               convention.
@@ -5989,7 +5989,7 @@ class XSgabs(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``Tau`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``Tau`` parameter has been renamed to
     ``Strength``. It can still be accessed using ``Tau`` for the time
     being, but this attribute has been deprecated.
 
@@ -6268,7 +6268,7 @@ class XSredden(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -6283,7 +6283,7 @@ class XSredden(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -6436,7 +6436,7 @@ class XSswind1(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logxi`` will be removed in the next release as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
@@ -6453,7 +6453,7 @@ class XSswind1(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logxi`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logxi`` parameter has been renamed to
     ``log_xi``. It can still be accessed using ``logxi`` for the time
     being, but this attribute has been deprecated.
 
@@ -6656,7 +6656,7 @@ class XSuvred(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -6667,7 +6667,7 @@ class XSuvred(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -6856,7 +6856,7 @@ class XSxion(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``lxld`` will be removed in the next release as it has been
               replaced by ``lxovrld``, to match the XSPEC naming convention.
 
@@ -6891,7 +6891,7 @@ class XSxion(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``lxld`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``lxld`` parameter has been renamed to
     ``lxovrld``. It can still be accessed using ``lxld`` for the time
     being, but this attribute has been deprecated.
 
@@ -6929,7 +6929,7 @@ class XSzdust(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``method`` and ``EBV`` will be removed in the next release as
               they have been replaced by ``_method`` and ``E_BmV``
               respectively, to match the XSPEC naming convention.
@@ -6948,7 +6948,7 @@ class XSzdust(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``method`` has been renamed to ``_method`` and
+    In Sherpa 4.10.0 ``method`` has been renamed to ``_method`` and
     ``EBV`` to ``E_BmV``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -7121,7 +7121,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logxi`` will be removed in the next release as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
@@ -7138,7 +7138,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logxi`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logxi`` parameter has been renamed to
     ``log_xi``. It can still be accessed using ``logxi`` for the time
     being, but this attribute has been deprecated.
 
@@ -7167,7 +7167,7 @@ class XSzredden(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -7184,7 +7184,7 @@ class XSzredden(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -7211,7 +7211,7 @@ class XSzsmdust(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -7228,7 +7228,7 @@ class XSzsmdust(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -7507,7 +7507,7 @@ class XScplinear(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               The ``energy01`` to ``energy09`` attributes will be removed in
               the next release as they has been replaced by ``_energy01``
               to ``_energy09``, to match the XSPEC naming convention.
@@ -7525,7 +7525,7 @@ class XScplinear(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``energy01`` to ``energy09`` attributes have been
+    In Sherpa 4.10.0 the ``energy01`` to ``energy09`` attributes have been
     renamed to ``_energy01`` to ``_energy09``. They can still be
     accessed using the old names, but they have been deprecated.
 
@@ -7574,7 +7574,7 @@ class XSeqpair(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
               next release as they have been replaced by ``l_hovl_s``,
               ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
@@ -7649,7 +7649,7 @@ class XSeqpair(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
+    In Sherpa 4.10.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
     ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
     be accessed using the old names for the time being, but these attributes
     have been deprecated.
@@ -7698,7 +7698,7 @@ class XSeqtherm(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
               next release as they have been replaced by ``l_hovl_s``,
               ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
@@ -7773,7 +7773,7 @@ class XSeqtherm(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
+    In Sherpa 4.10.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
     ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
     be accessed using the old names for the time being, but these attributes
     have been deprecated.
@@ -7825,7 +7825,7 @@ class XScompth(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``AbHe`` will be removed in the next release as it has been
               replaced by ``Ab_met``, to match the XSPEC naming convention.
 
@@ -7894,7 +7894,7 @@ class XScompth(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 the ``AbHe`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``AbHe`` parameter has been renamed to
     ``Ab_met``. It can still be accessed using ``AbHe`` for the time
     being, but this attribute has been deprecated.
 
@@ -8081,7 +8081,7 @@ class XSzigm(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``redshift``, ``model``, and ``lyman_limit`` will be removed
                in the next release as they have been replaced by
                ``_redshift``, ``_model``, and ``_lyman_limit``
@@ -8101,7 +8101,7 @@ class XSzigm(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 all the parameters have been renamed so that they
+    In Sherpa 4.10.0 all the parameters have been renamed so that they
     start with an underscore character. They can still be accessed using
     the old names for the time being, but these attributes have been
     deprecated.
@@ -8297,7 +8297,7 @@ class XSlogpar(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``pivotE`` will be removed in the next release as it has been
               replaced by ``_pivotE``, to match the XSPEC naming convention.
 
@@ -8318,7 +8318,7 @@ class XSlogpar(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``pivotE`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``pivotE`` parameter has been renamed to
     ``_pivotE``. It can still be accessed using ``pivotE`` for the time
     being, but this attribute has been deprecated.
 
@@ -8347,7 +8347,7 @@ class XSoptxagn(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logLLEdd`` will be removed in the next release as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
@@ -8397,7 +8397,7 @@ class XSoptxagn(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logLLEdd`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logLLEdd`` parameter has been renamed to
     ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
     time being, but this attribute has been deprecated.
 
@@ -8436,7 +8436,7 @@ class XSoptxagnf(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logLLEdd`` will be removed in the next release as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
@@ -8480,7 +8480,7 @@ class XSoptxagnf(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logLLEdd`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logLLEdd`` parameter has been renamed to
     ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
     time being, but this attribute has been deprecated.
 
@@ -8745,7 +8745,7 @@ class XSheilin(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``redshift`` will be removed in the next release as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
@@ -8765,7 +8765,7 @@ class XSheilin(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``redshift`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``redshift`` parameter has been renamed to
     ``z``. It can still be accessed using ``redshift`` for the time
     being, but this attribute has been deprecated.
 
@@ -8793,7 +8793,7 @@ class XSlyman(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``nHeI`` and ``redshift`` will be removed in the next
               release as they have been replaced by ``n`` and ``z``
               respectively, to match the XSPEC naming convention.
@@ -8815,7 +8815,7 @@ class XSlyman(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``nHeI`` has been renamed to ``n`` and ``redshift``
+    In Sherpa 4.10.0 ``nHeI`` has been renamed to ``n`` and ``redshift``
     to ``z``. They can still be accessed using the old names for the
     time being, but these attributes have been deprecated.
 
@@ -8844,7 +8844,7 @@ class XSzbabs(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``redshift`` will be removed in the next release as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
@@ -8862,7 +8862,7 @@ class XSzbabs(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``redshift`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``redshift`` parameter has been renamed to
     ``z``. It can still be accessed using ``redshift`` for the time
     being, but this attribute has been deprecated.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -943,9 +943,10 @@ class XSbmc(XSAdditiveModel):
     def __init__(self, name='bmc'):
         self.kT = Parameter(name, 'kT', 1., 1.e-2, 100., 0.0, hugeval, 'keV')
         self.alpha = Parameter(name, 'alpha', 1., 1.e-2, 4.0, 0.0, hugeval)
-        self.logA = Parameter(name, 'logA', 0.0, -6.0, 6.0, -hugeval, hugeval)
+        self.log_A = Parameter(name, 'log_A', 0.0, -6.0, 6.0, -hugeval, hugeval)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.alpha, self.logA, self.norm))
+        self._renamedpars = [('logA', 'log_A')]
+        XSAdditiveModel.__init__(self, name, (self.kT, self.alpha, self.log_A, self.norm))
 
 
 class XSbremss(XSAdditiveModel):
@@ -1080,9 +1081,12 @@ class XSc6mekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
 
 class XSc6pmekl(XSAdditiveModel):
@@ -1132,9 +1136,12 @@ class XSc6pmekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
 
 class XSc6pvmkl(XSAdditiveModel):
@@ -1197,9 +1204,12 @@ class XSc6pvmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
 
 class XSc6vmekl(XSAdditiveModel):
@@ -1261,9 +1271,12 @@ class XSc6vmekl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
 
 class XScemekl(XSAdditiveModel):
@@ -1310,9 +1323,12 @@ class XScemekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
 
 class XScevmkl(XSAdditiveModel):
@@ -1372,9 +1388,12 @@ class XScevmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
 
 class XScflow(XSAdditiveModel):
@@ -1566,9 +1585,9 @@ class XScompPS(XSAdditiveModel):
         self.Gmin = Parameter(name, 'Gmin', -1., -1., 10., -hugeval, hugeval, frozen=True)
         self.Gmax = Parameter(name, 'Gmax', 1.e3, 10., 1.e4, 0.0, hugeval, frozen=True)
         self.kTbb = Parameter(name, 'kTbb', 0.1, 0.001, 10., 0.0, hugeval, 'keV', True)
-        self.tauy = Parameter(name, 'tauy', 1.0, 0.05, 3.0, 0.0, hugeval)
+        self.tau_y = Parameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.0, hugeval)
         self.geom = Parameter(name, 'geom', 0.0, -5.0, 4.0, -hugeval, hugeval, frozen=True)
-        self.HRcyl = Parameter(name, 'HRcyl', 1.0, 0.5, 2.0, 0.0, hugeval, frozen=True)
+        self.HovR_cyl = Parameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.0, hugeval, frozen=True)
         self.cosIncl = Parameter(name, 'cosIncl', 0.5, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.cov_frac = Parameter(name, 'cov_frac', 1.0, 0.0, 1.0, 0.0, hugeval, frozen=True)
         self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e4, 0.0, hugeval, frozen=True)
@@ -1581,7 +1600,10 @@ class XScompPS(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'Rs', True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kTe, self.EleIndex, self.Gmin, self.Gmax, self.kTbb, self.tauy, self.geom, self.HRcyl, self.cosIncl, self.cov_frac, self.rel_refl, self.Fe_ab_re, self.Me_ab, self.xi, self.Tdisk, self.Betor10, self.Rin, self.Rout, self.redshift, self.norm))
+
+        self._renamedpars = [('tauy', 'tau_y'), ('HRcyl', 'HovR_cyl')]
+
+        XSAdditiveModel.__init__(self, name, (self.kTe, self.EleIndex, self.Gmin, self.Gmax, self.kTbb, self.tau_y, self.geom, self.HovR_cyl, self.cosIncl, self.cov_frac, self.rel_refl, self.Fe_ab_re, self.Me_ab, self.xi, self.Tdisk, self.Betor10, self.Rin, self.Rout, self.redshift, self.norm))
 
 
 class XScompST(XSAdditiveModel):
@@ -1726,10 +1748,13 @@ class XSdisk(XSAdditiveModel):
 
     def __init__(self, name='disk'):
         self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 0.0, hugeval)
-        self.NSmass = Parameter(name, 'NSmass', 1.4, .4, 10., 0.0, hugeval, units='Msun', frozen=True)
+        self.CenMass = Parameter(name, 'CenMass', 1.4, .4, 10., 0.0, hugeval, units='Msun', frozen=True)
         self.Rinn = Parameter(name, 'Rinn', 1.03, 1.01, 1.03, 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.accrate, self.NSmass, self.Rinn, self.norm))
+
+        self._renamedpars = [('NSmass', 'CenMass')]
+
+        XSAdditiveModel.__init__(self, name, (self.accrate, self.CenMass, self.Rinn, self.norm))
 
 
 class XSdiskir(XSAdditiveModel):
@@ -1783,13 +1808,16 @@ class XSdiskir(XSAdditiveModel):
         self.kT_disk = Parameter(name, 'kT_disk', 1.0, 0.01, 5., 0.0, hugeval, 'keV')
         self.Gamma = Parameter(name, 'Gamma', 1.7, 1.001, 5., 0.0, hugeval)
         self.kT_e = Parameter(name, 'kT_e', 100., 5., 1.e3, 0.0, hugeval, 'keV')
-        self.LcLd = Parameter(name, 'LcLd', 0.1, 0., 10., 0.0, hugeval)
+        self.LcovrLd = Parameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, hugeval)
         self.fin = Parameter(name, 'fin', 1.e-1, 0.0, 1., 0.0, hugeval, frozen=True)
         self.rirr = Parameter(name, 'rirr', 1.2, 1.0001, 10., 1.0001, hugeval)
         self.fout = Parameter(name, 'fout', 1.e-4, 0.0, 1.e-1, 0.0, hugeval)
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT_disk, self.Gamma, self.kT_e, self.LcLd, self.fin, self.rirr, self.fout, self.logrout, self.norm))
+
+        self._renamedpars = [('LcLd', 'LcovrLd')]
+
+        XSAdditiveModel.__init__(self, name, (self.kT_disk, self.Gamma, self.kT_e, self.LcovrLd, self.fin, self.rirr, self.fout, self.logrout, self.norm))
 
 
 class XSdiskbb(XSAdditiveModel):
@@ -1855,11 +1883,14 @@ class XSdiskline(XSAdditiveModel):
     def __init__(self, name='diskline'):
         self.LineE = Parameter(name, 'LineE', 6.7, 0., 100., 0.0, hugeval, 'keV')
         self.Betor10 = Parameter(name, 'Betor10', -2., -10., 20., -hugeval, hugeval, frozen=True)
-        self.RinM = Parameter(name, 'RinM', 10., 6., 1000., 0.0, hugeval, frozen=True)
-        self.RoutM = Parameter(name, 'RoutM', 1000., 0., 1000000., 0.0, hugeval, frozen=True)
+        self.Rin_M = Parameter(name, 'Rin_M', 10., 6., 1000., 0.0, hugeval, frozen=True)
+        self.Rout_M = Parameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, hugeval, frozen=True)
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.LineE, self.Betor10, self.RinM, self.RoutM, self.Incl, self.norm))
+
+        self._renamedpars = [('RinM', 'Rin_M'), ('RoutM', 'Rout_M')]
+
+        XSAdditiveModel.__init__(self, name, (self.LineE, self.Betor10, self.Rin_M, self.Rout_M, self.Incl, self.norm))
 
     def guess(self, dep, *args, **kwargs):
         XSAdditiveModel.guess(self, dep, *args, **kwargs)
@@ -2192,10 +2223,13 @@ class XSgnei(XSAdditiveModel):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 0.0, hugeval, 's/cm^3')
-        self.kT_ave = Parameter(name, 'kT_ave', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau, self.kT_ave, self.redshift, self.norm))
+
+        self._renamedpars = [('kT_ave', 'meankT')]
+
+        XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau, self.meankT, self.redshift, self.norm))
 
 
 class XSgrad(XSAdditiveModel):
@@ -2243,10 +2277,13 @@ class XSgrad(XSAdditiveModel):
         self.i = Parameter(name, 'i', 0.0, 0.0, 90.0, 0.0, hugeval, 'deg', True)
         self.Mass = Parameter(name, 'Mass', 1.0, 0.0, 100.0, 0.0, hugeval, 'solar')
         self.Mdot = Parameter(name, 'Mdot', 1.0, 0.0, 100.0, 0.0, hugeval, '1e18')
-        self.TclTef = Parameter(name, 'TclTef', 1.7, 1.0, 10.0, 0.0, hugeval, frozen=True)
+        self.TclovTef = Parameter(name, 'TclovTef', 1.7, 1.0, 10.0, 0.0, hugeval, frozen=True)
         self.refflag = Parameter(name, 'refflag', 1.0, -1.0, 1.0, -hugeval, hugeval, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.D, self.i, self.Mass, self.Mdot, self.TclTef, self.refflag, self.norm))
+
+        self._renamedpars = [('TclTef', 'TclovTef')]
+
+        XSAdditiveModel.__init__(self, name, (self.D, self.i, self.Mass, self.Mdot, self.TclovTef, self.refflag, self.norm))
 
 
 class XSgrbm(XSAdditiveModel):
@@ -2277,9 +2314,12 @@ class XSgrbm(XSAdditiveModel):
     def __init__(self, name='grbm'):
         self.alpha = Parameter(name, 'alpha', -1., -3., +2., -hugeval, hugeval)
         self.beta = Parameter(name, 'beta', -2., -5., +2., -hugeval, hugeval)
-        self.temp = Parameter(name, 'temp', +300., +50., +1000., 0.0, hugeval, 'keV')
+        self.tem = Parameter(name, 'tem', +300., +50., +1000., 0.0, hugeval, 'keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.temp, self.norm))
+
+        self._renamedpars = [('temp', 'tem')]
+
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.tem, self.norm))
 
 
 class XSkerrbb(XSAdditiveModel):
@@ -2391,14 +2431,17 @@ class XSkerrd(XSAdditiveModel):
 
     def __init__(self, name='kerrd'):
         self.distance = Parameter(name, 'distance', 1., 0.01, 1000., 0.0, hugeval, 'kpc', True)
-        self.TcolTeff = Parameter(name, 'TcolTeff', 1.5, 1.0, 2.0, 0.0, hugeval, frozen=True)
+        self.TcoloTeff = Parameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 0.0, hugeval, frozen=True)
         self.M = Parameter(name, 'M', 1.0, 0.1, 100., 0.0, hugeval, 'solar')
         self.Mdot = Parameter(name, 'Mdot', 1.0, 0.01, 100., 0.0, hugeval, '1e18')
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.Rin = Parameter(name, 'Rin', 1.235, 1.235, 100., 0.0, hugeval, 'Rg', True)
         self.Rout = Parameter(name, 'Rout', 1e5, 1e4, 1e8, 0.0, hugeval, 'Rg', True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.distance, self.TcolTeff, self.M, self.Mdot, self.Incl, self.Rin, self.Rout, self.norm))
+
+        self._renamedpars = [('TcolTeff', 'TcoloTeff')]
+
+        XSAdditiveModel.__init__(self, name, (self.distance, self.TcoloTeff, self.M, self.Mdot, self.Incl, self.Rin, self.Rout, self.norm))
 
 
 class XSkerrdisk(XSAdditiveModel):
@@ -2450,14 +2493,19 @@ class XSkerrdisk(XSAdditiveModel):
         self.lineE = Parameter(name, 'lineE', 6.4, 0.1, 100., 0.0, hugeval, 'keV')
         self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -hugeval, hugeval, frozen=True)
         self.Index2 = Parameter(name, 'Index2', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.r_brg = Parameter(name, 'r_brg', 6.0, 1.0, 400., 0.0, hugeval, frozen=True)
+        self.r_br_g = Parameter(name, 'r_br_g', 6.0, 1.0, 400., 0.0, hugeval, frozen=True)
         self.a = Parameter(name, 'a', 0.998, 0.0, 0.998, 0.0, hugeval)
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
-        self.Rinms = Parameter(name, 'Rinms', 1.0, 1.0, 400., 0.0, hugeval, frozen=True)
-        self.Routms = Parameter(name, 'Routms', 400., 1.0, 400., 0.0, hugeval, frozen=True)
+        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, 1.0, 400., 0.0, hugeval, frozen=True)
+        self.Rout_ms = Parameter(name, 'Rout_ms', 400., 1.0, 400., 0.0, hugeval, frozen=True)
         self.z = Parameter(name, 'z', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.lineE, self.Index1, self.Index2, self.r_brg, self.a, self.Incl, self.Rinms, self.Routms, self.z, self.norm))
+
+        self._renamedpars = [('r_brg', 'r_br_g'),
+                             ('Rinms', 'Rin_ms'),
+                             ('Routms', 'Rout_ms')]
+
+        XSAdditiveModel.__init__(self, name, (self.lineE, self.Index1, self.Index2, self.r_br_g, self.a, self.Incl, self.Rin_ms, self.Rout_ms, self.z, self.norm))
 
     def guess(self, dep, *args, **kwargs):
         XSAdditiveModel.guess(self, dep, *args, **kwargs)
@@ -2502,11 +2550,14 @@ class XSlaor(XSAdditiveModel):
     def __init__(self, name='laor'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
         self.Index = Parameter(name, 'Index', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.RinG = Parameter(name, 'RinG', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
-        self.RoutG = Parameter(name, 'RoutG', 400., 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True)
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.RinG, self.RoutG, self.Incl, self.norm))
+
+        self._renamedpars = [('RinG', 'Rin_G'), ('RoutG', 'Rout_G')]
+
+        XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.norm))
 
     def guess(self, dep, *args, **kwargs):
         XSAdditiveModel.guess(self, dep, *args, **kwargs)
@@ -2555,13 +2606,16 @@ class XSlaor2(XSAdditiveModel):
     def __init__(self, name='laor2'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
         self.Index = Parameter(name, 'Index', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.RinG = Parameter(name, 'RinG', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
-        self.RoutG = Parameter(name, 'RoutG', 400., 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True)
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.Rbreak = Parameter(name, 'Rbreak', 20., 1.235, 400., 0.0, hugeval, frozen=True)
         self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.RinG, self.RoutG, self.Incl, self.Rbreak, self.Index1, self.norm))
+
+        self._renamedpars = [('RinG', 'Rin_G'), ('RoutG', 'Rout_G')]
+
+        XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.Rbreak, self.Index1, self.norm))
 
     def guess(self, dep, *args, **kwargs):
         XSAdditiveModel.guess(self, dep, *args, **kwargs)
@@ -2693,9 +2747,12 @@ class XSmekal(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 0.0, hugeval, 'cm-3', True)
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self._switch, self.norm))
 
 
 class XSmkcflow(XSAdditiveModel):
@@ -2740,9 +2797,12 @@ class XSmkcflow(XSAdditiveModel):
         self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self._switch, self.norm))
 
 
 class XSnei(XSAdditiveModel):
@@ -3177,9 +3237,12 @@ class XSnsmax(XSAdditiveModel):
     def __init__(self, name='nsmax'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.8, 0.0, hugeval, 'K')
         self.redshift = Parameter(name, 'redshift', 0.1, 0.0, 1.5, 0.0, 2.0)
-        self.specfile = Parameter(name, 'specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self.specfile, self.norm))
+
+        self._renamedpars = [('specfile', '_specfile')]
+
+        XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self._specfile, self.norm))
 
 
 class XSnsmaxg(XSAdditiveModel):
@@ -3220,9 +3283,12 @@ class XSnsmaxg(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self.specfile = Parameter(name, 'specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
+
+        self._renamedpars = [('specfile', '_specfile')]
+
+        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
 
 
 class XSnsx(XSAdditiveModel):
@@ -3263,9 +3329,12 @@ class XSnsx(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self.specfile = Parameter(name, 'specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
+
+        self._renamedpars = [('specfile', '_specfile')]
+
+        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
 
 class XSnteea(XSAdditiveModel):
     """The XSPEC nteea model: non-thermal pair plasma.
@@ -3598,17 +3667,20 @@ class XSplcabs(XSAdditiveModel):
 
     def __init__(self, name='plcabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
-        self.nmax = Parameter(name, 'nmax', 1, alwaysfrozen=True)
+        self._nmax = Parameter(name, '_nmax', 1, alwaysfrozen=True)
         self.FeAbun = Parameter(name, 'FeAbun', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.FeKedge = Parameter(name, 'FeKedge', 7.11, 7., 10., 0.0, hugeval, 'KeV', True)
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -2., 9., -hugeval, hugeval)
         self.HighECut = Parameter(name, 'HighECut', 25., 1., 50., 0.0, 90., 'keV', True)
         self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 0.0, hugeval, frozen=True)
         self.acrit = Parameter(name, 'acrit', 1., 0.0, 1.0, 0.0, hugeval, frozen=True)
-        self.FAST = Parameter(name, 'FAST', 0, alwaysfrozen=True)
+        self._FAST = Parameter(name, '_FAST', 0, alwaysfrozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.nH, self.nmax, self.FeAbun, self.FeKedge, self.PhoIndex, self.HighECut, self.foldE, self.acrit, self.FAST, self.redshift, self.norm))
+
+        self._renamedpars = [('nmax', '_nmax'), ('FAST', '_FAST')]
+
+        XSAdditiveModel.__init__(self, name, (self.nH, self._nmax, self.FeAbun, self.FeKedge, self.PhoIndex, self.HighECut, self.foldE, self.acrit, self._FAST, self.redshift, self.norm))
 
 
 class XSpowerlaw(XSAdditiveModel):
@@ -3995,9 +4067,12 @@ class XSsrcut(XSAdditiveModel):
 
     def __init__(self, name='srcut'):
         self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 0.0, hugeval)
-        self.breakfreq = Parameter(name, 'breakfreq', 2.42E17, 1.E15, 1.E19, 0.0, hugeval, 'Hz')
+        self.break_ = Parameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 0.0, hugeval, 'Hz')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.breakfreq, self.norm))
+
+        self._renamedpars = [('breakfreq', 'break_')]
+
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.break_, self.norm))
 
 
 class XSsresc(XSAdditiveModel):
@@ -4156,9 +4231,12 @@ class XSvbremss(XSAdditiveModel):
 
     def __init__(self, name='vbremss'):
         self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 0.0, hugeval, 'keV')
-        self.HeH = Parameter(name, 'HeH', 1.0, 0., 100., 0.0, hugeval)
+        self.HeovrH = Parameter(name, 'HeovrH', 1.0, 0., 100., 0.0, hugeval)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.HeH, self.norm))
+
+        self._renamedpars = [('HeH', 'HeovrH')]
+
+        XSAdditiveModel.__init__(self, name, (self.kT, self.HeovrH, self.norm))
 
 
 class XSvequil(XSAdditiveModel):
@@ -4267,10 +4345,13 @@ class XSvgnei(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 0.0, hugeval, 's/cm^3')
-        self.kT_ave = Parameter(name, 'kT_ave', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.kT_ave, self.redshift, self.norm))
+
+        self._renamedpars = [('kT_ave', 'meankT')]
+
+        XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.meankT, self.redshift, self.norm))
 
 
 class XSvvgnei(XSAdditiveModel):
@@ -4346,10 +4427,13 @@ class XSvvgnei(XSAdditiveModel):
         self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 10000.0, frozen=True)
         self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 10000.0, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.kT_ave = Parameter(name, 'kT_ave', 1.0, 0.0808, 79.9, 0.0808, 79.9, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, 'keV')
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
+
+        self._renamedpars = [('kT_ave', 'meankT')]
+
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.kT_ave, self.redshift, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.meankT, self.redshift, self.norm))
 
 class XSvmeka(XSAdditiveModel):
     """The XSPEC vmeka model: emission, hot diffuse gas (Mewe-Gronenschild).
@@ -4460,9 +4544,12 @@ class XSvmekal(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
 
 class XSvmcflow(XSAdditiveModel):
@@ -4520,9 +4607,12 @@ class XSvmcflow(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
 
 class XSvnei(XSAdditiveModel):
@@ -5597,8 +5687,11 @@ class XSgabs(XSMultiplicativeModel):
     def __init__(self, name='gabs'):
         self.LineE = Parameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, hugeval, 'keV')
         self.Sigma = Parameter(name, 'Sigma', 0.01, 0., 10., 0.0, hugeval, 'keV')
-        self.Tau = Parameter(name, 'Tau', 1.0, 0., 1.e6, 0.0, hugeval)
-        XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Sigma, self.Tau))
+        self.Strength = Parameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, hugeval)
+
+        self._renamedpars = [('Tau', 'Strength')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Sigma, self.Strength))
 
     def guess(self, dep, *args, **kwargs):
         pos = get_xspec_position(dep, *args)
@@ -5876,8 +5969,11 @@ class XSredden(XSMultiplicativeModel):
     _calc = _xspec.xscred
 
     def __init__(self, name='redden'):
-        self.EBV = Parameter(name, 'EBV', 0.05, 0., 10., 0.0, hugeval)
-        XSMultiplicativeModel.__init__(self, name, (self.EBV,))
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
+
+        self._renamedpars = [('EBV', 'E_BmV')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
 
 class XSsmedge(XSMultiplicativeModel):
@@ -6034,10 +6130,13 @@ class XSswind1(XSMultiplicativeModel):
 
     def __init__(self, name='swind1'):
         self.column = Parameter(name, 'column', 6., 3., 50., 0.0, hugeval)
-        self.logxi = Parameter(name, 'logxi', 2.5, 2.1, 4.1, 0.0, hugeval)
+        self.log_xi = Parameter(name, 'log_xi', 2.5, 2.1, 4.1, 0.0, hugeval)
         self.sigma = Parameter(name, 'sigma', 0.1, 0., .5, 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        XSMultiplicativeModel.__init__(self, name, (self.column, self.logxi, self.sigma, self.redshift))
+
+        self._renamedpars = [('logxi', 'log_xi')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.column, self.log_xi, self.sigma, self.redshift))
 
 
 class XSTBabs(XSMultiplicativeModel):
@@ -6234,8 +6333,11 @@ class XSuvred(XSMultiplicativeModel):
     _calc = _xspec.xsred
 
     def __init__(self, name='uvred'):
-        self.EBV = Parameter(name, 'EBV', 0.05, 0., 10., 0.0, hugeval)
-        XSMultiplicativeModel.__init__(self, name, (self.EBV,))
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
+
+        self._renamedpars = [('EBV', 'E_BmV')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
 
 class XSvarabs(XSMultiplicativeModel):
@@ -6446,7 +6548,7 @@ class XSxion(XSMultiplicativeModel):
 
     def __init__(self, name='xion'):
         self.height = Parameter(name, 'height', 5., 0.0, 1.e2, 0.0, hugeval, 'r_s')
-        self.lxld = Parameter(name, 'lxld', 0.3, 0.02, 100, 0.0, hugeval)
+        self.lxovrld = Parameter(name, 'lxovrld', 0.3, 0.02, 100, 0.0, hugeval)
         self.rate = Parameter(name, 'rate', 0.05, 1.e-3, 1., 0.0, hugeval)
         self.cosAng = Parameter(name, 'cosAng', 0.9, 0., 1., 0.0, hugeval)
         self.inner = Parameter(name, 'inner', 3., 2., 1.e3, 0.0, hugeval, 'r_s')
@@ -6458,7 +6560,10 @@ class XSxion(XSMultiplicativeModel):
         self.Ref_type = Parameter(name, 'Ref_type', 1., 1., 3., 0.0, hugeval, frozen=True)
         self.Rel_smear = Parameter(name, 'Rel_smear', 4., 1., 4., 0.0, hugeval, frozen=True)
         self.Geometry = Parameter(name, 'Geometry', 1., 1., 4., 0.0, hugeval, frozen=True)
-        XSMultiplicativeModel.__init__(self, name, (self.height, self.lxld, self.rate, self.cosAng, self.inner, self.outer, self.index, self.redshift, self.Feabun, self.E_cut, self.Ref_type, self.Rel_smear, self.Geometry))
+
+        self._renamedpars = [('lxld', 'lxovrld')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.height, self.lxovrld, self.rate, self.cosAng, self.inner, self.outer, self.index, self.redshift, self.Feabun, self.E_cut, self.Ref_type, self.Rel_smear, self.Geometry))
 
 
 class XSzdust(XSMultiplicativeModel):
@@ -6488,11 +6593,14 @@ class XSzdust(XSMultiplicativeModel):
     _calc = _xspec.mszdst
 
     def __init__(self, name='zdust'):
-        self.method = Parameter(name, 'method', 1, 1, 3, 1, 3, alwaysfrozen=True)
-        self.EBV = Parameter(name, 'EBV', 0.1, 0.0, 100., 0.0, hugeval)
+        self._method = Parameter(name, '_method', 1, 1, 3, 1, 3, alwaysfrozen=True)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval)
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
-        XSMultiplicativeModel.__init__(self, name, (self.method, self.EBV, self.Rv, self.redshift))
+
+        self._renamedpars = [('method', '_method'), ('EBV', 'E_BmV')]
+
+        XSMultiplicativeModel.__init__(self, name, (self._method, self.E_BmV, self.Rv, self.redshift))
 
 
 class XSzedge(XSMultiplicativeModel):
@@ -6665,10 +6773,13 @@ class XSzxipcf(XSMultiplicativeModel):
 
     def __init__(self, name='zxipcf'):
         self.Nh = Parameter(name, 'Nh', 10, 0.05, 500, 0.0, hugeval, '10^22 atoms / cm^2')
-        self.logxi = Parameter(name, 'logxi', 3, -3, 6, -hugeval, hugeval)
+        self.log_xi = Parameter(name, 'log_xi', 3, -3, 6, -hugeval, hugeval)
         self.CvrFract = Parameter(name, 'CvrFract', 0.5, 0., 1., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        XSMultiplicativeModel.__init__(self, name, (self.Nh, self.logxi, self.CvrFract, self.redshift))
+
+        self._renamedpars = [('logxi', 'log_xi')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.Nh, self.log_xi, self.CvrFract, self.redshift))
 
 
 class XSzredden(XSMultiplicativeModel):
@@ -6697,9 +6808,12 @@ class XSzredden(XSMultiplicativeModel):
     _calc = _xspec.xszcrd
 
     def __init__(self, name='zredden'):
-        self.EBV = Parameter(name, 'EBV', 0.05, 0., 10., 0.0, hugeval)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        XSMultiplicativeModel.__init__(self, name, (self.EBV, self.redshift))
+
+        self._renamedpars = [('EBV', 'E_BmV')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.redshift))
 
 
 class XSzsmdust(XSMultiplicativeModel):
@@ -6728,11 +6842,14 @@ class XSzsmdust(XSMultiplicativeModel):
     _calc = _xspec.msldst
 
     def __init__(self, name='zsmdust'):
-        self.EBV = Parameter(name, 'EBV', 0.1, 0.0, 100., 0.0, hugeval)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval)
         self.ExtIndex = Parameter(name, 'ExtIndex', 1.0, -10.0, 10., -hugeval, hugeval)
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
-        XSMultiplicativeModel.__init__(self, name, (self.EBV, self.ExtIndex, self.Rv, self.redshift))
+
+        self._renamedpars = [('EBV', 'E_BmV')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.ExtIndex, self.Rv, self.redshift))
 
 
 class XSzTBabs(XSMultiplicativeModel):
@@ -7011,16 +7128,16 @@ class XScplinear(XSAdditiveModel):
     _calc = _xspec.C_cplinear
 
     def __init__(self, name='cplinear'):
-        self.energy00 = Parameter(name, 'energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy01 = Parameter(name, 'energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy02 = Parameter(name, 'energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy03 = Parameter(name, 'energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy04 = Parameter(name, 'energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy05 = Parameter(name, 'energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy06 = Parameter(name, 'energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy07 = Parameter(name, 'energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy08 = Parameter(name, 'energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self.energy09 = Parameter(name, 'energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy00 = Parameter(name, '_energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy01 = Parameter(name, '_energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy02 = Parameter(name, '_energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy03 = Parameter(name, '_energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy04 = Parameter(name, '_energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy05 = Parameter(name, '_energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy06 = Parameter(name, '_energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy07 = Parameter(name, '_energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy08 = Parameter(name, '_energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy09 = Parameter(name, '_energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
         self.log_rate00 = Parameter(name, 'log_rate00', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate01 = Parameter(name, 'log_rate01', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate02 = Parameter(name, 'log_rate02', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
@@ -7032,7 +7149,13 @@ class XScplinear(XSAdditiveModel):
         self.log_rate08 = Parameter(name, 'log_rate08', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate09 = Parameter(name, 'log_rate09', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.energy00, self.energy01, self.energy02, self.energy03, self.energy04, self.energy05, self.energy06, self.energy07, self.energy08, self.energy09, self.log_rate00, self.log_rate01, self.log_rate02, self.log_rate03, self.log_rate04, self.log_rate05, self.log_rate06, self.log_rate07, self.log_rate08, self.log_rate09, self.norm))
+
+        self._renamedpars = [(n, '_' + n) for n in
+                             ['energy{:02d}'.format(i)
+                              for i in range(10)]
+                             ]
+
+        XSAdditiveModel.__init__(self, name, (self._energy00, self._energy01, self._energy02, self._energy03, self._energy04, self._energy05, self._energy06, self._energy07, self._energy08, self._energy09, self.log_rate00, self.log_rate01, self.log_rate02, self.log_rate03, self.log_rate04, self.log_rate05, self.log_rate06, self.log_rate07, self.log_rate08, self.log_rate09, self.norm))
 
 
 class XSeqpair(XSAdditiveModel):
@@ -7119,10 +7242,10 @@ class XSeqpair(XSAdditiveModel):
     _calc = _xspec.C_xseqpair
 
     def __init__(self, name='eqpair'):
-        self.l_hl_s = Parameter(name, 'l_hl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
+        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
         self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, hugeval)
         self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 0.0, hugeval, 'eV', True)
-        self.l_ntl_h = Parameter(name, 'l_ntl_h', 0.5, 0., 0.9999, 0.0, hugeval)
+        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval)
         self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 0.0, hugeval, frozen=True)
         self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 0.0, hugeval, 'cm', True)
         self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 0.0, hugeval, frozen=True)
@@ -7132,7 +7255,7 @@ class XSeqpair(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.AbHe = Parameter(name, 'AbHe', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7140,7 +7263,12 @@ class XSeqpair(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.l_hl_s, self.l_bb, self.kT_bb, self.l_ntl_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.AbHe, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
+
+        self._renamedpars = [('l_hl_s', 'l_hovl_s'),
+                             ('l_ntl_h', 'l_ntol_h'),
+                             ('AbHe', 'Ab_met')]
+
+        XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
 
 class XSeqtherm(XSAdditiveModel):
@@ -7227,10 +7355,10 @@ class XSeqtherm(XSAdditiveModel):
     _calc = _xspec.C_xseqth
 
     def __init__(self, name='eqtherm'):
-        self.l_hl_s = Parameter(name, 'l_hl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
+        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
         self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, hugeval)
         self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 0.0, hugeval, 'eV', True)
-        self.l_ntl_h = Parameter(name, 'l_ntl_h', 0.5, 0., 0.9999, 0.0, hugeval)
+        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval)
         self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 0.0, hugeval, frozen=True)
         self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 0.0, hugeval, 'cm', True)
         self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 0.0, hugeval, frozen=True)
@@ -7240,7 +7368,7 @@ class XSeqtherm(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.AbHe = Parameter(name, 'AbHe', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7248,7 +7376,12 @@ class XSeqtherm(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.l_hl_s, self.l_bb, self.kT_bb, self.l_ntl_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.AbHe, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
+
+        self._renamedpars = [('l_hl_s', 'l_hovl_s'),
+                             ('l_ntl_h', 'l_ntol_h'),
+                             ('AbHe', 'Ab_met')]
+
+        XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
 
 class XScompth(XSAdditiveModel):
@@ -7348,7 +7481,7 @@ class XScompth(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.AbHe = Parameter(name, 'AbHe', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7356,7 +7489,10 @@ class XScompth(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.theta, self.showbb, self.kT_bb, self.RefOn, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.AbHe, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
+
+        self._renamedpars = [('AbHe', 'Ab_met')]
+
+        XSAdditiveModel.__init__(self, name, (self.theta, self.showbb, self.kT_bb, self.RefOn, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
 
 class XSbvvapec(XSAdditiveModel):
@@ -7527,10 +7663,15 @@ class XSzigm(XSMultiplicativeModel):
     _calc = _xspec.zigm
 
     def __init__(self, name='zigm'):
-        self.redshift = Parameter(name, 'redshift', 0.0, alwaysfrozen=True)
-        self.model = Parameter(name, 'model', 0, 0, 1, 0, 1, alwaysfrozen=True)
-        self.lyman_limit = Parameter(name, 'lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True)
-        XSMultiplicativeModel.__init__(self, name, (self.redshift, self.model, self.lyman_limit))
+        self._redshift = Parameter(name, '_redshift', 0.0, alwaysfrozen=True)
+        self._model = Parameter(name, '_model', 0, 0, 1, 0, 1, alwaysfrozen=True)
+        self._lyman_limit = Parameter(name, '_lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True)
+
+        self._renamedpars = [('redshift', '_redshift'),
+                             ('model', '_model'),
+                             ('lyman_limit', '_lyman_limit')]
+
+        XSMultiplicativeModel.__init__(self, name, (self._redshift, self._model, self._lyman_limit))
 
 
 ## Here are the seven new additive models from XSPEC 12.7.1
@@ -7586,9 +7727,12 @@ class XSgadem(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift, self._switch, self.norm))
 
 
 class XSvgadem(XSAdditiveModel):
@@ -7653,9 +7797,12 @@ class XSvgadem(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self.switch = Parameter(name, 'switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self.switch, self.norm))
+
+        self._renamedpars = [('switch', '_switch')]
+
+        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self._switch, self.norm))
 
 
 class XSeplogpar(XSAdditiveModel):
@@ -7724,9 +7871,12 @@ class XSlogpar(XSAdditiveModel):
     def __init__(self, name='logpar'):
         self.alpha = Parameter(name, 'alpha', 1.5, 0., 4., 0.0, hugeval)
         self.beta = Parameter(name, 'beta', 0.2, -4., 4., -hugeval, hugeval)
-        self.pivotE = Parameter(name, 'pivotE', 1.0, units='keV', alwaysfrozen=True)
+        self._pivotE = Parameter(name, '_pivotE', 1.0, units='keV', alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.pivotE, self.norm))
+
+        self._renamedpars = [('pivotE', '_pivotE')]
+
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self._pivotE, self.norm))
 
 
 class XSoptxagn(XSAdditiveModel):
@@ -7789,7 +7939,7 @@ class XSoptxagn(XSAdditiveModel):
     def __init__(self, name='optxagn'):
         self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 0.0, hugeval, 'solar', True)
         self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.0, hugeval, 'Mpc', True)
-        self.logLLEdd = Parameter(name, 'logLLEdd', -1., -10., 2, -hugeval, hugeval)
+        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval)
         self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, hugeval, frozen=True)
         self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 0.0, hugeval, 'rg')
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval, frozen=True)
@@ -7801,7 +7951,10 @@ class XSoptxagn(XSAdditiveModel):
         self.tscat = Parameter(name, 'tscat', 1.e5, 1e4, 1e5, 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
-        XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.fcol, self.tscat, self.Redshift, self.norm))
+
+        self._renamedpars = [('logLLEdd', 'logLoLedd')]
+
+        XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.fcol, self.tscat, self.Redshift, self.norm))
 
 
 class XSoptxagnf(XSAdditiveModel):
@@ -7858,7 +8011,7 @@ class XSoptxagnf(XSAdditiveModel):
     def __init__(self, name='optxagnf'):
         self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 0.0, hugeval, 'solar', True)
         self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.0, hugeval, 'Mpc', True)
-        self.logLLEdd = Parameter(name, 'logLLEdd', -1., -10., 2, -hugeval, hugeval)
+        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval)
         self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, hugeval, frozen=True)
         self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 0.0, hugeval, 'rg')
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval, frozen=True)
@@ -7868,7 +8021,10 @@ class XSoptxagnf(XSAdditiveModel):
         self.fpl = Parameter(name, 'fpl', 1.e-4, 0.0, 1., 0.0, hugeval)
         self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
-        XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.Redshift, self.norm))
+
+        self._renamedpars = [('logLLEdd', 'logLoLedd')]
+
+        XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.Redshift, self.norm))
 
 
 # DOC-NOTE: the parameter order in the XSPEC documentation is very different
@@ -8129,8 +8285,12 @@ class XSheilin(XSMultiplicativeModel):
     def __init__(self, name='heilin'):
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.redshift = Parameter(name, 'redshift', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
-        XSMultiplicativeModel.__init__(self, name, (self.nHei, self.b, self.redshift))
+        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
+
+        self._renamedpars = [('redshift', 'z')]
+
+        # TODO: correct self.nHei to self.nHeI
+        XSMultiplicativeModel.__init__(self, name, (self.nHei, self.b, self.z))
 
 class XSlyman(XSMultiplicativeModel):
     """The XSPEC lyman model: Voigt absorption profiles for H I or He II Lyman series.
@@ -8162,11 +8322,15 @@ class XSlyman(XSMultiplicativeModel):
     _calc = _xspec.xslyman
 
     def __init__(self, name='lyman'):
-        self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
+        self.n = Parameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.redshift = Parameter(name, 'redshift', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
+        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
         self.ZA = Parameter(name, 'ZA', 1.0, 1.0, 2.0, 1.0, 2.0)
-        XSMultiplicativeModel.__init__(self, name, (self.nHeI, self.b, self.redshift, self.ZA))
+
+        self._renamedpars = [('nHeI', 'n'),
+                             ('redshift', 'z')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.n, self.b, self.z, self.ZA))
 
 class XSzbabs(XSMultiplicativeModel):
     """The XSPEC lyman model: Voigt absorption profiles for H I or He II Lyman series.
@@ -8197,8 +8361,11 @@ class XSzbabs(XSMultiplicativeModel):
         self.nH = Parameter(name, 'nH', 1.e-4, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.nHeII = Parameter(name, 'nHeII', 1.e-6, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
-        self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 1.0e5, 0.0, 1.0e6)
-        XSMultiplicativeModel.__init__(self, name, (self.nH, self.nHeI, self.nHeII, self.redshift))
+        self.z = Parameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6)
+
+        self._renamedpars = [('redshift', 'z')]
+
+        XSMultiplicativeModel.__init__(self, name, (self.nH, self.nHeI, self.nHeII, self.z))
 
 # Add model classes to __all__
 __all__ += tuple(n for n in globals() if n.startswith('XS'))

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -919,17 +919,27 @@ class XSbmc(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``logA`` will be removed in the next release as it has been
+              replaced by ``log_A``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kT
         The temperature of the thermal photon source in keV.
     alpha
         The energy spectral index.
-    logA
+    log_A
         The log of the A parameter: see [1]_ for more details.
     norm
         The normalization of the model: see [1]_ for an explanation
         of the units.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``logA`` parameter has been renamed to ``log_A``.
+    It can still be accessed using ``log_A`` for the time being, but this
+    attribute has been deprecated.
 
     References
     ----------
@@ -1040,6 +1050,10 @@ class XSc6mekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
@@ -1050,7 +1064,7 @@ class XSc6mekl(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1061,6 +1075,12 @@ class XSc6mekl(XSAdditiveModel):
     See Also
     --------
     XSc6pmekl, XSc6pvmkl, XSc6vmekl
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1095,6 +1115,10 @@ class XSc6pmekl(XSAdditiveModel):
     The model is described at [1]_. It differs from ``XSc6mekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
@@ -1105,7 +1129,7 @@ class XSc6pmekl(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1116,6 +1140,12 @@ class XSc6pmekl(XSAdditiveModel):
     See Also
     --------
     XSc6mekl, XSc6pvmkl, XSc6vmekl
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1150,6 +1180,10 @@ class XSc6pvmkl(XSAdditiveModel):
     The model is described at [1]_. It differs from ``XSc6vmekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
@@ -1160,7 +1194,7 @@ class XSc6pvmkl(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1171,6 +1205,12 @@ class XSc6pvmkl(XSAdditiveModel):
     See Also
     --------
     XSc6mekl, XSc6pmekl, XSc6vmekl
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1217,6 +1257,10 @@ class XSc6vmekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
@@ -1227,7 +1271,7 @@ class XSc6vmekl(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1238,6 +1282,12 @@ class XSc6vmekl(XSAdditiveModel):
     See Also
     --------
     XSc6mekl, XSc6pmekl, XSc6pvmkl
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1284,6 +1334,10 @@ class XScemekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     alpha
@@ -1296,7 +1350,7 @@ class XScemekl(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1307,6 +1361,12 @@ class XScemekl(XSAdditiveModel):
     See Also
     --------
     XScevmkl
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1336,6 +1396,10 @@ class XScevmkl(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     alpha
@@ -1348,7 +1412,7 @@ class XScevmkl(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1359,6 +1423,12 @@ class XScevmkl(XSAdditiveModel):
     See Also
     --------
     XScemekl
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1517,6 +1587,11 @@ class XScompPS(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``tauy`` and ``HRcyl`` will be removed in the next release as
+              they have been replaced by ``tau_y`` and ``HovR_cyl``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kTe
@@ -1529,12 +1604,12 @@ class XScompPS(XSAdditiveModel):
         The maximum Lorentz factor gamma: see [1]_ for more details.
     kTbb
         The temperature of the soft photons, in keV.
-    tauy
+    tau_y
         The vertical optical depth of the corona: see [1]_ for more
         details.
     geom
         The geometry to use; see [1]_ for more details.
-    HRcyl
+    HovR_cyl
         The value of H/R, when a cylinder geometry is used
         (abs(geom) = 2).
     cosIncl
@@ -1569,6 +1644,10 @@ class XScompPS(XSAdditiveModel):
     the ``set_xsxset`` function to set the value of the COMPPS_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
+
+    In Sherpa 4.9.0 ``tauy`` has been renamed to ``tau_y`` and
+    ``HRcyl`` to ``HovR_cyl``. They can still be accessed using the old
+    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -1721,11 +1800,15 @@ class XSdisk(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``NSmass`` will be removed in the next release as it has been
+              replaced by ``CenMass``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     accrate
         The accretion rate, in Eddington luminosities.
-    NSmass
+    CenMass
         The central mass, in solar mass units.
     Rinn
         The inner disk radius in gravitational units (three
@@ -1736,6 +1819,12 @@ class XSdisk(XSAdditiveModel):
     See Also
     --------
     XSdiskbb, XSdiskm, XSdisko
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``NSmass`` parameter has been renamed to
+    ``CenMass``. It can still be accessed using ``NSMass`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1762,6 +1851,10 @@ class XSdiskir(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``LcLd`` will be removed in the next release as it has been
+              replaced by ``LcovrLd``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kT_disk
@@ -1771,7 +1864,7 @@ class XSdiskir(XSAdditiveModel):
         The asymptotic power-law photon index.
     kT_e
         The electron temperature (high-energy rollover) in keV.
-    LcLd
+    LcovrLd
         The ratio of the luminosity in the Compton tail to that of
         the unilluminated disk.
     fin
@@ -1794,6 +1887,12 @@ class XSdiskir(XSAdditiveModel):
     See Also
     --------
     XSdiskbb
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``LcLd`` parameter has been renamed to
+    ``LcovrLd``. It can still be accessed using ``LcLd`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1856,20 +1955,31 @@ class XSdiskline(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``RinM`` and ``RoutM`` will be removed in the next release as
+              they have been replaced by ``Rin_M`` and ``Rout_M``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
     LineE
         The line energy in keV.
     Betor10
         The power law dependence of emissivity: see [1]_ for more details.
-    RinM
+    Rin_M
         The inner radius, in units of GM^2/c.
-    RoutM
+    Rout_M
         The outer radius, in units of GM^2/c.
     Incl
         The inclination, in degrees.
     norm
         The model normalization in photon/cm^2/s.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``RinM`` has been renamed to ``Rin_M`` and
+    ``RoutM`` to ``Rout_M``. They can still be accessed using the old
+    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -2055,6 +2165,10 @@ class XSequil(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``kT_ave`` will be removed in the next release as it has been
+              replaced by ``meankT``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kT
@@ -2198,7 +2312,7 @@ class XSgnei(XSAdditiveModel):
         ``set_xsabund`` function.
     Tau
         The ionization timescale in units of s/cm^3.
-    kT_ave
+    meankT
         The ionization timescale averaged plasma temperature in keV.
     redshift
         The redshift of the plasma.
@@ -2209,6 +2323,12 @@ class XSgnei(XSAdditiveModel):
     See Also
     --------
     XSequil, XSnei, XSvgnei, XSvvgnei
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    ``meankT``. It can still be accessed using ``kT_ave`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2237,6 +2357,10 @@ class XSgrad(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``TclTef`` will be removed in the next release as it has been
+              replaced by ``TclovTef``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     D
@@ -2248,7 +2372,7 @@ class XSgrad(XSAdditiveModel):
         The mass of the central object, in solar masses.
     Mdot
         The mass accretion rate in units of 10^18 g/s.
-    TclTef
+    TclovTef
         The spectral hardening factor, Tcol/Teff. See [1]_ for more
         details.
     refflag
@@ -2262,6 +2386,12 @@ class XSgrad(XSAdditiveModel):
     See Also
     --------
     XSkerbb
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``TclTef`` parameter has been renamed to
+    ``TclovTef``. It can still be accessed using ``TclTef`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2291,16 +2421,26 @@ class XSgrbm(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``temp`` will be removed in the next release as it has been
+              replaced by ``tem``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     alpha
         The first powerlaw index.
     beta
         The second powerlaw index.
-    temp
+    tem
         The characteristic energy, in keV.
     norm
         The normalization of the model.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``temp`` parameter has been renamed to
+    ``tem``. It can still be accessed using ``temp`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2394,11 +2534,15 @@ class XSkerrd(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``TcolTeff`` will be removed in the next release as it has been
+              replaced by ``TcoloTeff``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     distance
         The distance, in units of kpc.
-    TcollTeff
+    TcoloTeff
         The spectral hardening factor, Tcol/Teff. See [1]_ for more
         details.
     M
@@ -2419,6 +2563,12 @@ class XSkerrd(XSAdditiveModel):
     See Also
     --------
     XSlaor
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``TcolTeff`` parameter has been renamed to
+    ``TcoloTeff``. It can still be accessed using ``TcolTeff`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2449,6 +2599,12 @@ class XSkerrdisk(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``r_brg``, ``Rinms``, and ``Routms`` will be removed in the
+              next release as they have been replaced by ``r_br_g``,
+              ``Rin_ms``, and ``Rout_ms`` respectively, to match the XSPEC
+              naming convention.
+
     Attributes
     ----------
     lineE
@@ -2457,7 +2613,7 @@ class XSkerrdisk(XSAdditiveModel):
         The emissivity index for the inner disk.
     Index2
         The emissivity index for the outer disk.
-    r_brg
+    r_br_g
         The break radius separating the inner and outer portions of the
         disk, in gravitational radii.
     a
@@ -2465,10 +2621,10 @@ class XSkerrdisk(XSAdditiveModel):
     Incl
         The disk inclination angle, in degrees. A face-on disk has
         Incl=0.
-    Rinms
+    Rin_ms
         The inner radius of the disk, in units of the radius of
         marginal stability.
-    Routms
+    Rout_ms
         The outer radius of the disk, in units of the radius of
         marginal stability.
     z
@@ -2479,6 +2635,13 @@ class XSkerrdisk(XSAdditiveModel):
     See Also
     --------
     XSdiskline, XSlaor
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``r_brg`` has been renamed to ``r_br_g``, ``Rinms``
+    to ``Rin_ms``, and ``Routms`` to ``Rout_ms``. They can still be
+    accessed using the old names for the time being, but these attributes
+    have been deprecated.
 
     References
     ----------
@@ -2518,15 +2681,20 @@ class XSlaor(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``RinG`` and ``RoutG`` will be removed in the next release as
+              they have been replaced by ``Rin_G`` and ``Rout_G``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
     lineE
         The rest-frame line energy, in keV.
     Index
         The power law dependence of emissivity (scales as R^-Index).
-    RinG
+    Rin_G
         The inner radius, in units of GM/c^2.
-    RoutG
+    Rout_G
         The outer radius, in units of GM/c^2.
     Incl
         The disk inclination angle, in degrees. A face-on disk has
@@ -2537,6 +2705,12 @@ class XSlaor(XSAdditiveModel):
     See Also
     --------
     XSlaor2
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``RinG`` has been renamed to ``Rin_G`` and
+    ``RoutG`` to ``Rout_G``. They can still be accessed using the old
+    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -2570,15 +2744,20 @@ class XSlaor2(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``RinG`` and ``RoutG`` will be removed in the next release as
+              they have been replaced by ``Rin_G`` and ``Rout_G``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
     lineE
         The rest-frame line energy, in keV.
     Index
         The power law dependence of emissivity (scales as R^-Index).
-    RinG
+    Rin_G
         The inner radius, in units of GM/c^2.
-    RoutG
+    Rout_G
         The outer radius, in units of GM/c^2.
     Incl
         The disk inclination angle, in degrees. A face-on disk has
@@ -2593,6 +2772,12 @@ class XSlaor2(XSAdditiveModel):
     See Also
     --------
     XSlaor
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``RinG`` has been renamed to ``Rin_G`` and
+    ``RoutG`` to ``Rout_G``. They can still be accessed using the old
+    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -2667,6 +2852,10 @@ class XSmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kT
@@ -2720,7 +2909,7 @@ class XSmekal(XSAdditiveModel):
         ``set_xsabund`` function.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -2732,6 +2921,12 @@ class XSmekal(XSAdditiveModel):
     See Also
     --------
     XSapec, XSvmekal
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2761,6 +2956,10 @@ class XSmkcflow(XSAdditiveModel):
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     lowT
@@ -2771,7 +2970,7 @@ class XSmkcflow(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -2782,6 +2981,12 @@ class XSmkcflow(XSAdditiveModel):
     See Also
     --------
     XSapec, XScflow, XScevmkl, XSvmcflow
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3210,13 +3415,17 @@ class XSnsmax(XSAdditiveModel):
     The model is described at [1]_. It has been superceeded by
     ``XSnsmaxg``.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``specfile`` will be removed in the next release as it has been
+              replaced by ``_specfile``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     LogTeff
         The log of Teff, the unredshifted surface effective temperature.
     redshift
         This is 1 + zg, the gravitational redshift.
-    specfile
+    _specfile
         Which model to use: see [1]_ for more details.
     norm
         The normalization of the model: see [1]_ for more details.
@@ -3224,6 +3433,12 @@ class XSnsmax(XSAdditiveModel):
     See Also
     --------
     XSnsmaxg
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    ``_specfile``. It can still be accessed using ``specfile`` for the
+    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3250,6 +3465,10 @@ class XSnsmaxg(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``specfile`` will be removed in the next release as it has been
+              replaced by ``_specfile``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     LogTeff
@@ -3260,7 +3479,7 @@ class XSnsmaxg(XSAdditiveModel):
         The neutron star radius, in km.
     dist
         The distance to the neutron star, in kpc.
-    specfile
+    _specfile
         Which model to use: see [1]_ for more details.
     norm
         The normalization: see [1]_ for more details.
@@ -3268,6 +3487,12 @@ class XSnsmaxg(XSAdditiveModel):
     See Also
     --------
     XSnsmax, XSnsx
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    ``_specfile``. It can still be accessed using ``specfile`` for the
+    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3296,6 +3521,10 @@ class XSnsx(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``specfile`` will be removed in the next release as it has been
+              replaced by ``_specfile``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     LogTeff
@@ -3306,7 +3535,7 @@ class XSnsx(XSAdditiveModel):
         The neutron star radius, in km.
     dist
         The distance to the neutron star, in kpc.
-    specfile
+    _specfile
         Which model to use: see [1]_ for more details.
     norm
         The normalization: see [1]_ for more details.
@@ -3314,6 +3543,12 @@ class XSnsx(XSAdditiveModel):
     See Also
     --------
     XSnsmaxg
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    ``_specfile``. It can still be accessed using ``specfile`` for the
+    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3628,11 +3863,16 @@ class XSplcabs(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``nmax`` and ``FAST`` will be removed in the next release as
+              they have been replaced by ``_nmax`` and ``_FAST``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
     nH
         The column density, in units of 10^22 cm^-2.
-    nMax
+    _nmax
         The maximum number of scatterings. This parameter can not be
         thawed.
     FeAbun
@@ -3648,13 +3888,19 @@ class XSplcabs(XSAdditiveModel):
     acrit
         The critical albedo for switching to elastic scattering. See
         [1]_ for more details.
-    FAST
+    _FAST
         If set to a value above 1, use a mean energy shift instead of
         integration. This parameter can not be thawed.
     redshift
         The redshift of the source.
     norm
         The normalization of the model.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``nmax`` has been renamed to ``_nmax`` and
+    ``FAST`` to ``_FAST``. They can still be accessed using the old
+    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -4042,11 +4288,16 @@ class XSsrcut(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``breakfreq`` will be removed in the next release as it has
+              been replaced by ``break_``, to match the XSPEC naming
+              convention.
+
     Attributes
     ----------
     alpha
         The radio spectral index.
-    breakfreq
+    break_
         The break frequency: approximately the frequency at which the
         flux has dropped by a factor of 10 from a straight power law.
     norm
@@ -4055,6 +4306,12 @@ class XSsrcut(XSAdditiveModel):
     See Also
     --------
     XSsresc
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``breakfreq`` parameter has been renamed to
+    ``break_``. It can still be accessed using ``breakfreq`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4206,11 +4463,15 @@ class XSvbremss(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``HeH`` will be removed in the next release as it has been
+              replaced by ``HeovrH``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kT
         The plasma temperature in keV.
-    HeH
+    HeovrH
         The ratio n(He) / n(H).
     norm
         The normalization of the model: see [1]_ for an explanation
@@ -4219,6 +4480,12 @@ class XSvbremss(XSAdditiveModel):
     See Also
     --------
     XSbremss, XSzbremss
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``HeH`` parameter has been renamed to
+    ``HeovrH``. It can still be accessed using ``HeH`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4245,6 +4512,10 @@ class XSvequil(XSAdditiveModel):
     The model is described at [1]_. The ``set_xsxset`` and ``get_xsxset``
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
+
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``kT_ave`` will be removed in the next release as it has been
+              replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -4297,6 +4568,10 @@ class XSvgnei(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``kT_ave`` will be removed in the next release as it has been
+              replaced by ``meankT``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     kT
@@ -4308,7 +4583,7 @@ class XSvgnei(XSAdditiveModel):
         The abundance of the element, with respect to Solar.
     Tau
         The ionization timescale in units of s/cm^3.
-    kT_ave
+    meankT
         The ionization timescale averaged plasma temperature in keV.
     redshift
         The redshift of the plasma.
@@ -4319,6 +4594,12 @@ class XSvgnei(XSAdditiveModel):
     See Also
     --------
     XSequil, XSgnei, XSvnei, XSvvgnei
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    ``meankT``. It can still be accessed using ``kT_ave`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4373,7 +4654,7 @@ class XSvvgnei(XSAdditiveModel):
         The abundance of the element, with respect to Solar.
     Tau
         The ionization timescale in units of s/cm^3.
-    kT_ave
+    meankT
         The ionization timescale averaged plasma temperature in keV.
     redshift
         The redshift of the plasma.
@@ -4384,6 +4665,12 @@ class XSvvgnei(XSAdditiveModel):
     See Also
     --------
     XSequil, XSgnei, XSvgnei, XSvvnei
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    ``meankT``. It can still be accessed using ``kT_ave`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4439,6 +4726,10 @@ class XSvmeka(XSAdditiveModel):
     """The XSPEC vmeka model: emission, hot diffuse gas (Mewe-Gronenschild).
 
     The model is described at [1]_.
+
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -4504,7 +4795,7 @@ class XSvmekal(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -4516,6 +4807,12 @@ class XSvmekal(XSAdditiveModel):
     See Also
     --------
     XSapec, XSvmekal
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4558,6 +4855,10 @@ class XSvmcflow(XSAdditiveModel):
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``switch`` will be removed in the next release as it has been
+              replaced by ``_switch``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     lowT
@@ -4568,7 +4869,7 @@ class XSvmcflow(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    switch
+    _switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -4579,6 +4880,12 @@ class XSvmcflow(XSAdditiveModel):
     See Also
     --------
     XSapec, XScflow, XScevmkl, XSmkcflow
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    ``_switch``. It can still be accessed using ``switch`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -5665,15 +5972,26 @@ class XSgabs(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``Tau`` will be removed in the next release as it has been
+              replaced by ``Strength``, to match the XSPEC namin
+              convention.
+
     Attributes
     ----------
     LineE
         The line energy, in keV.
     Sigma
         The line width (sigma), in keV.
-    Tau
+    Strength
         The line depth. The optical depth at the line center is
         Tau / (sqrt(2 pi) * Sigma).
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``Tau`` parameter has been renamed to
+    ``Strength``. It can still be accessed using ``Tau`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -5950,14 +6268,24 @@ class XSredden(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``EBV`` will be removed in the next release as it has been
+              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    EBV
+    E_BmV
         The value of E(B-v) for the line of sight to the source.
 
     See Also
     --------
     XSzredden
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6108,16 +6436,26 @@ class XSswind1(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``logxi`` will be removed in the next release as it has been
+              replaced by ``log_xi``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     column
         The column density, in units of 10^22 cm^2.
-    logxi
+    log_xi
         The log of xi: see [1]_ for more details.
     sigma
         The gaussian sigma for velocity smearing (v/c).
     redshift
         The redshift of the source.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``logxi`` parameter has been renamed to
+    ``log_xi``. It can still be accessed using ``logxi`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6318,10 +6656,20 @@ class XSuvred(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``EBV`` will be removed in the next release as it has been
+              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    EBV
+    E_BmV
         The value of E(B-v) for the line of sight to the source.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6508,11 +6856,15 @@ class XSxion(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``lxld`` will be removed in the next release as it has been
+              replaced by ``lxovrld``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     height
         The height of the source above the disk (in Schwarzschild radii).
-    lxld
+    lxovrld
         The ratio of the X-ray source luminosity to that of the disk.
     rate
         The accretion rate (in Eddington units).
@@ -6536,6 +6888,12 @@ class XSxion(XSMultiplicativeModel):
         See [1]_ for details.
     Geometry
         See [1]_ for details.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``lxld`` parameter has been renamed to
+    ``lxovrld``. It can still be accessed using ``lxld`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6571,17 +6929,29 @@ class XSzdust(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``method`` and ``EBV`` will be removed in the next release as
+              they have been replaced by ``_method`` and ``E_BmV``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    method
+    _method
         The model to use: 1 is Milky Way, 2 is LMC, 3 is SMC.
         This parameter can not be thawed.
-    EBV
+    E_BmV
         The color excess, E(B-V).
     Rv
         The ratio of total to selective extinction.
     redshift
         The redshift of the absorber.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``method`` has been renamed to ``_method`` and
+    ``EBV`` to ``E_BmV``. They can still be accessed using the old
+    names for the time being, but these attributes have been deprecated.
+
 
     References
     ----------
@@ -6751,16 +7121,26 @@ class XSzxipcf(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``logxi`` will be removed in the next release as it has been
+              replaced by ``log_xi``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     nH
         The column density, in units of 10^22 cm^2.
-    logxi
+    log_xi
         The log of xi: see [1]_ for more details.
     CvrFract
         The covering fraction.
     redshift
         The redshift of the source.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``logxi`` parameter has been renamed to
+    ``log_xi``. It can still be accessed using ``logxi`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6787,9 +7167,13 @@ class XSzredden(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``EBV`` will be removed in the next release as it has been
+              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    EBV
+    E_BmV
         The value of E(B-v) for the line of sight to the source.
     redshift
         The redshift of the absorber.
@@ -6797,6 +7181,12 @@ class XSzredden(XSMultiplicativeModel):
     See Also
     --------
     XSredden
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -6821,9 +7211,13 @@ class XSzsmdust(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``EBV`` will be removed in the next release as it has been
+              replaced by ``E_BmV``, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    EBV
+    E_BmV
         The value of E(B-v) for the line of sight to the source.
     ExtIndex
         The spectral index of the extinction curve.
@@ -6831,6 +7225,12 @@ class XSzsmdust(XSMultiplicativeModel):
         The ratio of total to selective extinction.
     redshift
         The redshift of the absorber.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    ``E_Bmv``. It can still be accessed using ``EBV`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -7107,16 +7507,27 @@ class XScplinear(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              The ``energy01`` to ``energy09`` attributes will be removed in
+              the next release as they has been replaced by ``_energy01``
+              to ``_energy09``, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    energy00, energy01, energy02, energy03, energy04, energy05,
-    energy06, energy07, energy08, energy09
+    _energy00, _energy01, _energy02, _energy03, _energy04, _energy05,
+    _energy06, _energy07, _energy08, _energy09
         Energy in keV.
     log_rate01, log_rate02, log_rate03, log_rate04, log_rate05,
     log_rate06, log_rate07, log_rate08, log_rate09
         Log of the rate.
     norm
         The normalization of the model.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``energy01`` to ``energy09`` attributes have been
+    renamed to ``_energy01`` to ``_energy09``. They can still be
+    accessed using the old names, but they have been deprecated.
 
     References
     ----------
@@ -7163,9 +7574,15 @@ class XSeqpair(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
+              next release as they have been replaced by ``l_hovl_s``,
+              ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
+              naming convention.
+
     Attributes
     ----------
-    l_hl_s
+    l_hovl_s
         The ratio of the hard to soft compactness, l_h / l_s.
     l_bb
         The soft photon compactness.
@@ -7174,7 +7591,7 @@ class XSeqpair(XSAdditiveModel):
         When less than zero then the absolute value is used as
         the T_max parameter of the ``XSdispkpn`` model. The units
         are in eV.
-    l_ntl_h
+    l_ntol_h
         The fraction of power supplied to energetic particles which
         goes into accelerating non-thermal particles, l_nt / l_h.
     tau_p
@@ -7201,7 +7618,7 @@ class XSeqpair(XSAdditiveModel):
         by reflecting material.
     Fe_abund
         The iron abundance with respect to solar.
-    AbHe
+    Ab_met
         The abundance of the other metals with respect to solar.
     T_disk
         The temperature of the reflecting disk, in K.
@@ -7231,6 +7648,11 @@ class XSeqpair(XSAdditiveModel):
     the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
+
+    In Sherpa 4.9.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
+    ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
+    be accessed using the old names for the time being, but these attributes
+    have been deprecated.
 
     References
     ----------
@@ -7276,9 +7698,15 @@ class XSeqtherm(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
+              next release as they have been replaced by ``l_hovl_s``,
+              ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
+              naming convention.
+
     Attributes
     ----------
-    l_hl_s
+    l_hovl_s
         The ratio of the hard to soft compactness, l_h / l_s.
     l_bb
         The soft photon compactness.
@@ -7287,7 +7715,7 @@ class XSeqtherm(XSAdditiveModel):
         When less than zero then the absolute value is used as
         the T_max parameter of the ``XSdispkpn`` model. The units
         are in eV.
-    l_ntl_h
+    l_ntol_h
         The fraction of power supplied to energetic particles which
         goes into accelerating non-thermal particles, l_nt / l_h.
     tau_p
@@ -7314,7 +7742,7 @@ class XSeqtherm(XSAdditiveModel):
         by reflecting material.
     Fe_abund
         The iron abundance with respect to solar.
-    AbHe
+    Ab_met
         The abundance of the other metals with respect to solar.
     T_disk
         The temperature of the reflecting disk, in K.
@@ -7344,6 +7772,11 @@ class XSeqtherm(XSAdditiveModel):
     the ``set_xsxset`` function to set the value of the EQPAIR_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
+
+    In Sherpa 4.9.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
+    ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
+    be accessed using the old names for the time being, but these attributes
+    have been deprecated.
 
     References
     ----------
@@ -7427,7 +7860,7 @@ class XScompth(XSAdditiveModel):
         by reflecting material.
     Fe_abund
         The iron abundance with respect to solar.
-    AbHe
+    Ab_met
         The abundance of the other metals with respect to solar.
     T_disk
         The temperature of the reflecting disk, in K.
@@ -7641,17 +8074,30 @@ class XSzigm(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``redshift``, ``model``, and ``lyman_limit`` will be removed
+               in the next release as they have been replaced by
+               ``_redshift``, ``_model``, and ``_lyman_limit``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    redshift
+    _redshift
         The redshift of the absorber.
         This parameter can not be thawed.
-    model
+    _model
         The model to use: 0 is Madau, 1 is Meiksin.
         This parameter can not be thawed.
-    lyman_limit
+    _lyman_limit
         Should photoelectric absorption be included (1), or not (0).
         This parameter can not be thawed.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 all the parameters have been renamed so that they
+    start with an underscore character. They can still be accessed using
+    the old names for the time being, but these attributes have been
+    deprecated.
 
     References
     ----------
@@ -7683,7 +8129,7 @@ class XSgadem(XSAdditiveModel):
     The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
     functions change and return the current settings for the relative
     abundances of the metals. See the ``XSapec`` documentation for settings
-    relevant to the APEC model (i.e. when ``switch=2``).
+    relevant to the APEC model (i.e. when ``_switch=2``).
 
     Attributes
     ----------
@@ -7741,7 +8187,7 @@ class XSvgadem(XSAdditiveModel):
     The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
     functions change and return the current settings for the relative
     abundances of the metals. See the ``XSapec`` documentation for settings
-    relevant to the APEC model (i.e. when ``switch=2``).
+    relevant to the APEC model (i.e. when ``_switch=2``).
 
     Attributes
     ----------
@@ -7844,13 +8290,17 @@ class XSlogpar(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``pivotE`` will be removed in the next release as it has been
+              replaced by ``_pivotE``, to match the XSPEC naming convention.
+
     Attributes
     ----------
     alpha
         The slope at the pivot energy.
     beta
         The curvature term.
-    pivotE
+    _pivotE
         The pivot energy, in keV.
     norm
         The normalization of the model: see [1]_ for more details.
@@ -7858,6 +8308,12 @@ class XSlogpar(XSAdditiveModel):
     See Also
     --------
     XSeplogpar
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``pivotE`` parameter has been renamed to
+    ``_pivotE``. It can still be accessed using ``pivotE`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -7884,13 +8340,18 @@ class XSoptxagn(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``logLLEdd`` will be removed in the next release as it has
+              been replaced by ``logLoLedd``, to match the XSPEC naming
+              convention.
+
     Attributes
     ----------
     mass
         The black hole mass in solar masses.
     dist
         The comoving (proper) distance in Mpc.
-    logLLEdd
+    logLoLEdd
         The Eddington ratio.
     astar
         The dimensionless black hole spin.
@@ -7927,6 +8388,12 @@ class XSoptxagn(XSAdditiveModel):
     --------
     XSOptxagnf
 
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``logLLEdd`` parameter has been renamed to
+    ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
+    time being, but this attribute has been deprecated.
+
     References
     ----------
 
@@ -7962,13 +8429,18 @@ class XSoptxagnf(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``logLLEdd`` will be removed in the next release as it has
+              been replaced by ``logLoLedd``, to match the XSPEC naming
+              convention.
+
     Attributes
     ----------
     mass
         The black hole mass in solar masses.
     dist
         The comoving (proper) distance in Mpc.
-    logLLEdd
+    logLoLEdd
         The Eddington ratio.
     astar
         The dimensionless black hole spin.
@@ -7998,6 +8470,12 @@ class XSoptxagnf(XSAdditiveModel):
     See Also
     --------
     XSOptxagn
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``logLLEdd`` parameter has been renamed to
+    ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
+    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -8260,18 +8738,29 @@ class XSheilin(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``redshift`` will be removed in the next release as it has
+              been replaced by ``z``, to match the XSPEC naming
+              convention.
+
     Attributes
     ----------
     nHeI
         The He I column density, in 10^22 atoms/cm^2.
     b
         The b value, in km/s.
-    redshift
+    z
         The redshift of the absorber.
 
     See Also
     --------
     XSlyman
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``redshift`` parameter has been renamed to
+    ``z``. It can still be accessed using ``redshift`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -8297,13 +8786,18 @@ class XSlyman(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``nHeI`` and ``redshift`` will be removed in the next
+              release as they have been replaced by ``n`` and ``z``
+              respectively, to match the XSPEC naming convention.
+
     Attributes
     ----------
-    nHeI
+    n
         The H I or He II column density, in 10^22 atoms/cm^2.
     b
         The b value, in km/s.
-    redshift
+    z
         The redshift of the absorber.
     ZA
         The atomic number of the species being calculated.
@@ -8311,6 +8805,12 @@ class XSlyman(XSMultiplicativeModel):
     See Also
     --------
     XSheilin
+
+    Notes
+    -----
+    In Sherpa 4.9.0 ``nHeI`` has been renamed to ``n`` and ``redshift``
+    to ``z``. They can still be accessed using the old names for the
+    time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -8337,6 +8837,11 @@ class XSzbabs(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
+    .. note:: Deprecated in Sherpa 4.9.0
+              ``redshift`` will be removed in the next release as it has
+              been replaced by ``z``, to match the XSPEC naming
+              convention.
+
     Attributes
     ----------
     nH
@@ -8345,8 +8850,14 @@ class XSzbabs(XSMultiplicativeModel):
         The He I column density, in 10^22 atoms/cm^2.
     nHeI
         The He II column density, in 10^22 atoms/cm^2.
-    redshift
+    z
         The redshift of the absorber.
+
+    Notes
+    -----
+    In Sherpa 4.9.0 the ``redshift`` parameter has been renamed to
+    ``z``. It can still be accessed using ``redshift`` for the time
+    being, but this attribute has been deprecated.
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1100,7 +1100,7 @@ class XSc6mekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
@@ -1163,7 +1163,7 @@ class XSc6pmekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
@@ -1239,7 +1239,7 @@ class XSc6pvmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
@@ -1314,7 +1314,7 @@ class XSc6vmekl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
@@ -1374,7 +1374,7 @@ class XScemekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
@@ -1447,7 +1447,7 @@ class XScevmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
@@ -2905,7 +2905,7 @@ class XSmekal(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 0.0, hugeval, 'cm-3', True)
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self._switch, self.norm))
@@ -2963,7 +2963,7 @@ class XSmkcflow(XSAdditiveModel):
         self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self._switch, self.norm))
@@ -4784,7 +4784,7 @@ class XSvmekal(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
@@ -4855,7 +4855,7 @@ class XSvmcflow(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
@@ -8082,7 +8082,7 @@ class XSgadem(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift, self._switch, self.norm))
@@ -8150,7 +8150,7 @@ class XSvgadem(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
+        self.switch = Parameter(name, 'switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self._switch, self.norm))

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3411,7 +3411,7 @@ class XSnsmax(XSAdditiveModel):
     def __init__(self, name='nsmax'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.8, 0.0, hugeval, 'K')
         self.redshift = Parameter(name, 'redshift', 0.1, 0.0, 1.5, 0.0, 2.0)
-        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
+        self.specfile = Parameter(name, 'specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self._specfile, self.norm))
@@ -3465,7 +3465,7 @@ class XSnsmaxg(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
+        self.specfile = Parameter(name, 'specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
@@ -3519,7 +3519,7 @@ class XSnsx(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self._specfile = Parameter(name, '_specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
+        self.specfile = Parameter(name, 'specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
@@ -3866,14 +3866,14 @@ class XSplcabs(XSAdditiveModel):
 
     def __init__(self, name='plcabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
-        self._nmax = Parameter(name, '_nmax', 1, alwaysfrozen=True, aliases=["nmax"])
+        self.nmax = Parameter(name, 'nmax', 1, alwaysfrozen=True)
         self.FeAbun = Parameter(name, 'FeAbun', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.FeKedge = Parameter(name, 'FeKedge', 7.11, 7., 10., 0.0, hugeval, 'KeV', True)
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -2., 9., -hugeval, hugeval)
         self.HighECut = Parameter(name, 'HighECut', 25., 1., 50., 0.0, 90., 'keV', True)
         self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 0.0, hugeval, frozen=True)
         self.acrit = Parameter(name, 'acrit', 1., 0.0, 1.0, 0.0, hugeval, frozen=True)
-        self._FAST = Parameter(name, '_FAST', 0, alwaysfrozen=True, aliases=["FAST"])
+        self.FAST = Parameter(name, 'FAST', 0, alwaysfrozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
@@ -6892,7 +6892,7 @@ class XSzdust(XSMultiplicativeModel):
     _calc = _xspec.mszdst
 
     def __init__(self, name='zdust'):
-        self._method = Parameter(name, '_method', 1, 1, 3, 1, 3, alwaysfrozen=True, aliases=["method"])
+        self.method = Parameter(name, 'method', 1, 1, 3, 1, 3, alwaysfrozen=True)
         self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval, aliases=["EBV"])
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
@@ -7460,16 +7460,16 @@ class XScplinear(XSAdditiveModel):
     _calc = _xspec.C_cplinear
 
     def __init__(self, name='cplinear'):
-        self._energy00 = Parameter(name, '_energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy00"])
-        self._energy01 = Parameter(name, '_energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy01"])
-        self._energy02 = Parameter(name, '_energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy02"])
-        self._energy03 = Parameter(name, '_energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy03"])
-        self._energy04 = Parameter(name, '_energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy04"])
-        self._energy05 = Parameter(name, '_energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy05"])
-        self._energy06 = Parameter(name, '_energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy06"])
-        self._energy07 = Parameter(name, '_energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy07"])
-        self._energy08 = Parameter(name, '_energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy08"])
-        self._energy09 = Parameter(name, '_energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy09"])
+        self.energy00 = Parameter(name, 'energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy01 = Parameter(name, 'energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy02 = Parameter(name, 'energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy03 = Parameter(name, 'energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy04 = Parameter(name, 'energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy05 = Parameter(name, 'energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy06 = Parameter(name, 'energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy07 = Parameter(name, 'energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy08 = Parameter(name, 'energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self.energy09 = Parameter(name, 'energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
         self.log_rate00 = Parameter(name, 'log_rate00', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate01 = Parameter(name, 'log_rate01', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate02 = Parameter(name, 'log_rate02', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
@@ -8022,9 +8022,9 @@ class XSzigm(XSMultiplicativeModel):
     _calc = _xspec.zigm
 
     def __init__(self, name='zigm'):
-        self._redshift = Parameter(name, '_redshift', 0.0, alwaysfrozen=True, aliases=["redshift"])
-        self._model = Parameter(name, '_model', 0, 0, 1, 0, 1, alwaysfrozen=True, aliases=["model"])
-        self._lyman_limit = Parameter(name, '_lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["lyman_limit"])
+        self.redshift = Parameter(name, 'redshift', 0.0, alwaysfrozen=True)
+        self.model = Parameter(name, 'model', 0, 0, 1, 0, 1, alwaysfrozen=True)
+        self.lyman_limit = Parameter(name, 'lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self._redshift, self._model, self._lyman_limit))
 
@@ -8232,7 +8232,7 @@ class XSlogpar(XSAdditiveModel):
     def __init__(self, name='logpar'):
         self.alpha = Parameter(name, 'alpha', 1.5, 0., 4., 0.0, hugeval)
         self.beta = Parameter(name, 'beta', 0.2, -4., 4., -hugeval, hugeval)
-        self._pivotE = Parameter(name, '_pivotE', 1.0, units='keV', alwaysfrozen=True, aliases=["pivotE"])
+        self.pivotE = Parameter(name, 'pivotE', 1.0, units='keV', alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self._pivotE, self.norm))

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -920,7 +920,7 @@ class XSbmc(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.9.0
-              ``logA`` will be removed in the next release as it has been
+              ``logA`` may be removed in future releases as it has been
               replaced by ``log_A``, to match the XSPEC naming convention.
 
     Attributes
@@ -937,9 +937,9 @@ class XSbmc(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logA`` parameter has been renamed to ``log_A``.
-    It can still be accessed using ``log_A`` for the time being, but this
-    attribute has been deprecated.
+    In Sherpa 4.10.0 the ``logA`` parameter has been renamed to ``log_A``.
+    It can still be accessed using ``logA`` for the time being, but this
+    attribute name has been deprecated.
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1049,10 +1049,6 @@ class XSc6mekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
-
     Attributes
     ----------
     CPcoef1, CPcoef2, CPcoef3, CPcoef4, CPcoef5, CPcoef6
@@ -1063,7 +1059,7 @@ class XSc6mekl(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1074,12 +1070,6 @@ class XSc6mekl(XSAdditiveModel):
     See Also
     --------
     XSc6pmekl, XSc6pvmkl, XSc6vmekl
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1103,7 +1093,9 @@ class XSc6mekl(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
+                                              self.CPcoef6, self.nH, self.abundanc, self.redshift, self.switch,
+                                              self.norm))
 
 
 class XSc6pmekl(XSAdditiveModel):
@@ -1111,10 +1103,6 @@ class XSc6pmekl(XSAdditiveModel):
 
     The model is described at [1]_. It differs from ``XSc6mekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -1126,7 +1114,7 @@ class XSc6pmekl(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1137,12 +1125,6 @@ class XSc6pmekl(XSAdditiveModel):
     See Also
     --------
     XSc6mekl, XSc6pvmkl, XSc6vmekl
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1166,7 +1148,9 @@ class XSc6pmekl(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
+                                              self.CPcoef6, self.nH, self.abundanc, self.redshift, self.switch,
+                                              self.norm))
 
 
 class XSc6pvmkl(XSAdditiveModel):
@@ -1174,10 +1158,6 @@ class XSc6pvmkl(XSAdditiveModel):
 
     The model is described at [1]_. It differs from ``XSc6vmekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -1189,7 +1169,7 @@ class XSc6pvmkl(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1200,12 +1180,6 @@ class XSc6pvmkl(XSAdditiveModel):
     See Also
     --------
     XSc6mekl, XSc6pmekl, XSc6vmekl
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1242,17 +1216,16 @@ class XSc6pvmkl(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
+                                              self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na,
+                                              self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni,
+                                              self.redshift, self.switch, self.norm))
 
 
 class XSc6vmekl(XSAdditiveModel):
     """The XSPEC c6vmekl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
 
     The model is described at [1]_.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -1264,7 +1237,7 @@ class XSc6vmekl(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1275,12 +1248,6 @@ class XSc6vmekl(XSAdditiveModel):
     See Also
     --------
     XSc6mekl, XSc6pmekl, XSc6pvmkl
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1317,17 +1284,16 @@ class XSc6vmekl(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
+                                              self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na,
+                                              self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni,
+                                              self.redshift, self.switch, self.norm))
 
 
 class XScemekl(XSAdditiveModel):
     """The XSPEC cemekl model: plasma emission, multi-temperature using mekal.
 
     The model is described at [1]_.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -1341,7 +1307,7 @@ class XScemekl(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1352,12 +1318,6 @@ class XScemekl(XSAdditiveModel):
     See Also
     --------
     XScevmkl
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1377,17 +1337,14 @@ class XScemekl(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift,
+                                              self.switch, self.norm))
 
 
 class XScevmkl(XSAdditiveModel):
     """The XSPEC cevmkl model: plasma emission, multi-temperature using mekal.
 
     The model is described at [1]_.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -1401,7 +1358,7 @@ class XScevmkl(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -1412,12 +1369,6 @@ class XScevmkl(XSAdditiveModel):
     See Also
     --------
     XScemekl
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -1450,7 +1401,9 @@ class XScevmkl(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne,
+                                              self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe,
+                                              self.Ni, self.redshift, self.switch, self.norm))
 
 
 class XScflow(XSAdditiveModel):
@@ -2815,10 +2768,6 @@ class XSmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
-
     Attributes
     ----------
     kT
@@ -2872,7 +2821,7 @@ class XSmekal(XSAdditiveModel):
         ``set_xsabund`` function.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -2884,12 +2833,6 @@ class XSmekal(XSAdditiveModel):
     See Also
     --------
     XSapec, XSvmekal
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2908,7 +2851,7 @@ class XSmekal(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self.switch, self.norm))
 
 
 class XSmkcflow(XSAdditiveModel):
@@ -2916,10 +2859,6 @@ class XSmkcflow(XSAdditiveModel):
 
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -2931,7 +2870,7 @@ class XSmkcflow(XSAdditiveModel):
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -2942,12 +2881,6 @@ class XSmkcflow(XSAdditiveModel):
     See Also
     --------
     XSapec, XScflow, XScevmkl, XSvmcflow
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -2966,7 +2899,8 @@ class XSmkcflow(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self.switch,
+                                              self.norm))
 
 
 class XSnei(XSAdditiveModel):
@@ -3374,17 +3308,13 @@ class XSnsmax(XSAdditiveModel):
     The model is described at [1]_. It has been superceeded by
     ``XSnsmaxg``.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` might be removed in future releases as it has been
-              replaced by ``_specfile``, to match the XSPEC naming convention.
-
     Attributes
     ----------
     LogTeff
         The log of Teff, the unredshifted surface effective temperature.
     redshift
         This is 1 + zg, the gravitational redshift.
-    _specfile
+    specfile
         Which model to use: see [1]_ for more details.
     norm
         The normalization of the model: see [1]_ for more details.
@@ -3392,12 +3322,6 @@ class XSnsmax(XSAdditiveModel):
     See Also
     --------
     XSnsmaxg
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
-    ``_specfile``. It can still be accessed using ``specfile`` for the
-    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3414,17 +3338,13 @@ class XSnsmax(XSAdditiveModel):
         self.specfile = Parameter(name, 'specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self._specfile, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self.specfile, self.norm))
 
 
 class XSnsmaxg(XSAdditiveModel):
     """The XSPEC nsmaxg model: neutron star with a magnetic atmosphere.
 
     The model is described at [1]_.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` might be removed in future releases as it has been
-              replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -3436,7 +3356,7 @@ class XSnsmaxg(XSAdditiveModel):
         The neutron star radius, in km.
     dist
         The distance to the neutron star, in kpc.
-    _specfile
+    specfile
         Which model to use: see [1]_ for more details.
     norm
         The normalization: see [1]_ for more details.
@@ -3444,12 +3364,6 @@ class XSnsmaxg(XSAdditiveModel):
     See Also
     --------
     XSnsmax, XSnsx
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
-    ``_specfile``. It can still be accessed using ``specfile`` for the
-    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3468,17 +3382,13 @@ class XSnsmaxg(XSAdditiveModel):
         self.specfile = Parameter(name, 'specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
 
 
 class XSnsx(XSAdditiveModel):
     """The XSPEC nsx model: neutron star with a non-magnetic atmosphere.
 
     The model is described at [1]_.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` might be removed in future releases as it has been
-              replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -3490,7 +3400,7 @@ class XSnsx(XSAdditiveModel):
         The neutron star radius, in km.
     dist
         The distance to the neutron star, in kpc.
-    _specfile
+    specfile
         Which model to use: see [1]_ for more details.
     norm
         The normalization: see [1]_ for more details.
@@ -3498,12 +3408,6 @@ class XSnsx(XSAdditiveModel):
     See Also
     --------
     XSnsmaxg
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
-    ``_specfile``. It can still be accessed using ``specfile`` for the
-    time being, but this attribute has been deprecated.
 
     References
     ----------
@@ -3522,7 +3426,7 @@ class XSnsx(XSAdditiveModel):
         self.specfile = Parameter(name, 'specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
 
 class XSnteea(XSAdditiveModel):
     """The XSPEC nteea model: non-thermal pair plasma.
@@ -3816,16 +3720,11 @@ class XSplcabs(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``nmax`` and ``FAST`` might be removed in future releases as
-              they have been replaced by ``_nmax`` and ``_FAST``
-              respectively, to match the XSPEC naming convention.
-
     Attributes
     ----------
     nH
         The column density, in units of 10^22 cm^-2.
-    _nmax
+    nmax
         The maximum number of scatterings. This parameter can not be
         thawed.
     FeAbun
@@ -3841,19 +3740,13 @@ class XSplcabs(XSAdditiveModel):
     acrit
         The critical albedo for switching to elastic scattering. See
         [1]_ for more details.
-    _FAST
+    FAST
         If set to a value above 1, use a mean energy shift instead of
         integration. This parameter can not be thawed.
     redshift
         The redshift of the source.
     norm
         The normalization of the model.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 ``nmax`` has been renamed to ``_nmax`` and
-    ``FAST`` to ``_FAST``. They can still be accessed using the old
-    names for the time being, but these attributes have been deprecated.
 
     References
     ----------
@@ -3877,7 +3770,9 @@ class XSplcabs(XSAdditiveModel):
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.nH, self._nmax, self.FeAbun, self.FeKedge, self.PhoIndex, self.HighECut, self.foldE, self.acrit, self._FAST, self.redshift, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.nH, self.nmax, self.FeAbun, self.FeKedge, self.PhoIndex,
+                                              self.HighECut, self.foldE, self.acrit, self.FAST, self.redshift,
+                                              self.norm))
 
 
 class XSpowerlaw(XSAdditiveModel):
@@ -4670,10 +4565,6 @@ class XSvmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
-
     Attributes
     ----------
     kT
@@ -4738,7 +4629,7 @@ class XSvmekal(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -4750,12 +4641,6 @@ class XSvmekal(XSAdditiveModel):
     See Also
     --------
     XSapec, XSvmekal
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4787,7 +4672,9 @@ class XSvmekal(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na,
+                                              self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni,
+                                              self.redshift, self.switch, self.norm))
 
 
 class XSvmcflow(XSAdditiveModel):
@@ -4795,10 +4682,6 @@ class XSvmcflow(XSAdditiveModel):
 
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
-
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` might be removed in future releases as it has been
-              replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
     ----------
@@ -4810,7 +4693,7 @@ class XSvmcflow(XSAdditiveModel):
         The abundance relative to Solar.
     redshift
         The redshift of the plasma.
-    _switch
+    switch
         If 0, the mekal code is run to evaluate the model; if 1
         then interpolation of the mekal data is used; if 2 then
         interpolation of APEC data is used. See [1]_ for more details.
@@ -4821,12 +4704,6 @@ class XSvmcflow(XSAdditiveModel):
     See Also
     --------
     XSapec, XScflow, XScevmkl, XSmkcflow
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
-    ``_switch``. It can still be accessed using ``switch`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -4858,7 +4735,9 @@ class XSvmcflow(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na,
+                                              self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni,
+                                              self.redshift, self.switch, self.norm))
 
 
 class XSvnei(XSAdditiveModel):
@@ -6859,13 +6738,12 @@ class XSzdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``method`` and ``EBV`` might be removed in future releases as
-              they have been replaced by ``_method`` and ``E_BmV``
-              respectively, to match the XSPEC naming convention.
+              ``EBV`` might be removed in future releases as
+              it has been replaced by ``E_BmV`` to match the XSPEC naming convention.
 
     Attributes
     ----------
-    _method
+    method
         The model to use: 1 is Milky Way, 2 is LMC, 3 is SMC.
         This parameter can not be thawed.
     E_BmV
@@ -6877,8 +6755,8 @@ class XSzdust(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.10.0 ``method`` has been renamed to ``_method`` and
-    ``EBV`` to ``E_BmV``. They can still be accessed using the old
+    In Sherpa 4.10.0
+    ``EBV`` has been renamed to ``E_BmV``. It can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
 
@@ -6897,7 +6775,7 @@ class XSzdust(XSMultiplicativeModel):
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
 
-        XSMultiplicativeModel.__init__(self, name, (self._method, self.E_BmV, self.Rv, self.redshift))
+        XSMultiplicativeModel.__init__(self, name, (self.method, self.E_BmV, self.Rv, self.redshift))
 
 
 class XSzedge(XSMultiplicativeModel):
@@ -7428,27 +7306,16 @@ class XScplinear(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              The ``energy01`` to ``energy09`` attributes will be removed in
-              the next release as they has been replaced by ``_energy01``
-              to ``_energy09``, to match the XSPEC naming convention.
-
     Attributes
     ----------
-    _energy00, _energy01, _energy02, _energy03, _energy04, _energy05,
-    _energy06, _energy07, _energy08, _energy09
+    energy00, energy01, energy02, energy03, energy04, energy05,
+    energy06, energy07, energy08, energy09
         Energy in keV.
     log_rate01, log_rate02, log_rate03, log_rate04, log_rate05,
     log_rate06, log_rate07, log_rate08, log_rate09
         Log of the rate.
     norm
         The normalization of the model.
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``energy01`` to ``energy09`` attributes have been
-    renamed to ``_energy01`` to ``_energy09``. They can still be
-    accessed using the old names, but they have been deprecated.
 
     References
     ----------
@@ -7482,7 +7349,12 @@ class XScplinear(XSAdditiveModel):
         self.log_rate09 = Parameter(name, 'log_rate09', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self._energy00, self._energy01, self._energy02, self._energy03, self._energy04, self._energy05, self._energy06, self._energy07, self._energy08, self._energy09, self.log_rate00, self.log_rate01, self.log_rate02, self.log_rate03, self.log_rate04, self.log_rate05, self.log_rate06, self.log_rate07, self.log_rate08, self.log_rate09, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.energy00, self.energy01, self.energy02, self.energy03,
+                                              self.energy04, self.energy05, self.energy06, self.energy07,
+                                              self.energy08, self.energy09, self.log_rate00, self.log_rate01,
+                                              self.log_rate02, self.log_rate03, self.log_rate04, self.log_rate05,
+                                              self.log_rate06, self.log_rate07, self.log_rate08, self.log_rate09,
+                                              self.norm))
 
 
 class XSeqpair(XSAdditiveModel):
@@ -7987,21 +7859,15 @@ class XSzigm(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift``, ``model``, and ``lyman_limit`` will be removed
-               in the next release as they have been replaced by
-               ``_redshift``, ``_model``, and ``_lyman_limit``
-              respectively, to match the XSPEC naming convention.
-
     Attributes
     ----------
-    _redshift
+    redshift
         The redshift of the absorber.
         This parameter can not be thawed.
-    _model
+    model
         The model to use: 0 is Madau, 1 is Meiksin.
         This parameter can not be thawed.
-    _lyman_limit
+    lyman_limit
         Should photoelectric absorption be included (1), or not (0).
         This parameter can not be thawed.
 
@@ -8026,7 +7892,7 @@ class XSzigm(XSMultiplicativeModel):
         self.model = Parameter(name, 'model', 0, 0, 1, 0, 1, alwaysfrozen=True)
         self.lyman_limit = Parameter(name, 'lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True)
 
-        XSMultiplicativeModel.__init__(self, name, (self._redshift, self._model, self._lyman_limit))
+        XSMultiplicativeModel.__init__(self, name, (self.redshift, self.model, self.lyman_limit))
 
 
 ## Here are the seven new additive models from XSPEC 12.7.1
@@ -8038,7 +7904,7 @@ class XSgadem(XSAdditiveModel):
     The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
     functions change and return the current settings for the relative
     abundances of the metals. See the ``XSapec`` documentation for settings
-    relevant to the APEC model (i.e. when ``_switch=2``).
+    relevant to the APEC model (i.e. when ``switch=2``).
 
     Attributes
     ----------
@@ -8085,7 +7951,8 @@ class XSgadem(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift,
+                                              self.switch, self.norm))
 
 
 class XSvgadem(XSAdditiveModel):
@@ -8094,7 +7961,7 @@ class XSvgadem(XSAdditiveModel):
     The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
     functions change and return the current settings for the relative
     abundances of the metals. See the ``XSapec`` documentation for settings
-    relevant to the APEC model (i.e. when ``_switch=2``).
+    relevant to the APEC model (i.e. when ``switch=2``).
 
     Attributes
     ----------
@@ -8153,7 +8020,9 @@ class XSvgadem(XSAdditiveModel):
         self.switch = Parameter(name, 'switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self._switch, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O,
+                                              self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca,
+                                              self.Fe, self.Ni, self.Redshift, self.switch, self.norm))
 
 
 class XSeplogpar(XSAdditiveModel):
@@ -8195,17 +8064,13 @@ class XSlogpar(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.10.0
-              ``pivotE`` might be removed in future releases as it has been
-              replaced by ``_pivotE``, to match the XSPEC naming convention.
-
     Attributes
     ----------
     alpha
         The slope at the pivot energy.
     beta
         The curvature term.
-    _pivotE
+    pivotE
         The pivot energy, in keV.
     norm
         The normalization of the model: see [1]_ for more details.
@@ -8213,12 +8078,6 @@ class XSlogpar(XSAdditiveModel):
     See Also
     --------
     XSeplogpar
-
-    Notes
-    -----
-    In Sherpa 4.10.0 the ``pivotE`` parameter has been renamed to
-    ``_pivotE``. It can still be accessed using ``pivotE`` for the time
-    being, but this attribute has been deprecated.
 
     References
     ----------
@@ -8235,7 +8094,7 @@ class XSlogpar(XSAdditiveModel):
         self.pivotE = Parameter(name, 'pivotE', 1.0, units='keV', alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
-        XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self._pivotE, self.norm))
+        XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.pivotE, self.norm))
 
 
 class XSoptxagn(XSAdditiveModel):

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -57,6 +57,8 @@ known_warnings = {
             #  This does not have to do with Sherpa and is coming from some versions of
             #  jupyter_client
             r"metadata .* was set from the constructor.*",
+            r"Parameter name norm is deprecated for model RenamedPars, use ampl instead",
+            r"Parameter name NORM is deprecated for model ParameterCase, use ampl instead"
         ],
     UserWarning:
         [

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -57,8 +57,6 @@ known_warnings = {
             #  This does not have to do with Sherpa and is coming from some versions of
             #  jupyter_client
             r"metadata .* was set from the constructor.*",
-            r"Parameter name norm is deprecated for model RenamedPars, use ampl instead",
-            r"Parameter name NORM is deprecated for model ParameterCase, use ampl instead"
         ],
     UserWarning:
         [

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -87,6 +87,7 @@ class Model(NoNewAttributesAfterInit):
         self.type = self.__class__.__name__.lower()
         self.pars = tuple(pars)
         self.is_discrete = False
+        # Should this set up the _renamedpars attribute if not set?
         NoNewAttributesAfterInit.__init__(self)
 
     def __repr__(self):
@@ -123,14 +124,28 @@ class Model(NoNewAttributesAfterInit):
 
     # Make parameter access case insensitive
     def __getattr__(self, name):
-        par = None
-        for key in self.__dict__.keys():
-            if (type(key) == str):
-                if (name.lower() == key.lower()):
-                    par = self.__dict__.get(key)
-                    break
-        if (par is not None) and isinstance(par, Parameter):
-            return par
+        lname = name.lower()
+
+        for key in self.__dict__:
+            try:
+                kname = key.lower()
+            except AttributeError:
+                continue
+
+            if lname == kname:
+                val = self.__dict__.get(key)
+                if isinstance(val, Parameter):
+                    return val
+
+        # Some of the logic here should be cached - i.e. a mapping
+        # created from the old name to the parameter for the new
+        # name.
+        rpars = self.__dict__.get('_renamedpars')
+        if rpars is not None:
+            for (oname, nname) in rpars:
+                if oname.lower() == lname:
+                    return getattr(self, nname)
+
         # this must be AttributeError for 'getattr' to work
         raise AttributeError("'%s' object has no attribute '%s'" %
                              (type(self).__name__, name))

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -119,6 +119,11 @@ class Model(NoNewAttributesAfterInit):
 
         mdl.norm = 1.2e-3
 
+    Support is provided to allow parameter names to be changed,
+    while still providing access to the old name (as a deprecated
+    interface). This is handled by creating an array of (old name,
+    new name) pairs - where old and new names are strings - and storing
+    it in the ``_renamedpars`` attribute when initialising the model.
     """
 
     def __init__(self, name, pars=()):
@@ -164,8 +169,8 @@ class Model(NoNewAttributesAfterInit):
     def __iter__(self):
         return iter([self])
 
-    # Make parameter access case insensitive
     def __getattr__(self, name):
+        """Access to parameters is case insensitive."""
         lname = name.lower()
 
         def warn(oname, nname):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -206,12 +206,8 @@ class Model(NoNewAttributesAfterInit):
 
         else:
             for key in self.__dict__:
-                try:
-                    kname = key.lower()
-                except AttributeError:
-                    continue
 
-                if lname == kname:
+                if lname == key.lower():
                     val = self.__dict__.get(key)
                     if isinstance(val, Parameter):
                         return val

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -119,11 +119,6 @@ class Model(NoNewAttributesAfterInit):
 
         mdl.norm = 1.2e-3
 
-    Support is provided to allow parameter names to be changed,
-    while still providing access to the old name (as a deprecated
-    interface). This is handled by creating an array of (old name,
-    new name) pairs - where old and new names are strings - and storing
-    it in the ``_renamedpars`` attribute when initialising the model.
     """
 
     def __init__(self, name, pars=()):

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -242,7 +242,7 @@ class Parameter(NoNewAttributesAfterInit):
 
     def __init__(self, modelname, name, val, min=-hugeval, max=hugeval,
                  hard_min=-hugeval, hard_max=hugeval, units='',
-                 frozen=False, alwaysfrozen=False, hidden=False):
+                 frozen=False, alwaysfrozen=False, hidden=False, aliases=None):
         self.modelname = modelname
         self.name = name
         self.fullname = '%s.%s' % (modelname, name)
@@ -269,6 +269,8 @@ class Parameter(NoNewAttributesAfterInit):
         self.default_val = val
         self.link = None
         self._guessed = False
+
+        self.aliases = [a.lower() for a in aliases] if aliases is not None else []
 
         NoNewAttributesAfterInit.__init__(self)
 

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -17,6 +17,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""Support for model parameter values.
+"""
+
 import logging
 import numpy
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit
@@ -96,6 +99,33 @@ def _make_binop(op, opstr):
 
 
 class Parameter(NoNewAttributesAfterInit):
+    """Represent a model parameter.
+
+    Parameters
+    ----------
+    modelname : str
+        The name of the model component containing the parameter.
+    name : str
+        The name of the parameter. It should be considered to be
+        matched in a case-insensitive manner.
+    val : number
+        The default value for the parameter.
+    min, max, hard_min, hard_max: number, optional
+        The soft and hard limits for the parameter value.
+    units : str, optional
+        The units for the parameter value.
+    frozen : bool, optional
+        Does the parameter default to being frozen?
+    alwaysfrozen : bool, optional
+        If set then the parameter can never be thawed.
+    hidden : bool, optional
+        Should the parameter be included when displaying the model
+        contents?
+    aliases : None or list of str
+        If not None then alternative names for the parameter (these
+        are expected to be matched in a case-insensitive manner).
+
+    """
 
     #
     # Read-only properties
@@ -329,9 +359,21 @@ class Parameter(NoNewAttributesAfterInit):
     __pow__, __rpow__ = _make_binop(numpy.power, '**')
 
     def freeze(self):
+        """Set the `frozen` attribute for the parameter.
+
+        See Also
+        --------
+        thaw
+        """
         self.frozen = True
 
     def thaw(self):
+        """Unset the `frozen` attribute for the parameter.
+
+        See Also
+        --------
+        frozen
+        """
         self.frozen = False
 
     def unlink(self):
@@ -348,6 +390,7 @@ class Parameter(NoNewAttributesAfterInit):
 
     def set(self, val=None, min=None, max=None, frozen=None,
             default_val=None, default_min=None, default_max=None):
+        """Change a parameter setting."""
 
         if max is not None and max > self.max:
             self.max = max

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -30,12 +30,15 @@ __all__ = ('Parameter', 'CompositeParameter', 'ConstantParameter',
 
 
 # Default minimum and maximum magnitude for parameters
-#tinyval = 1.0e-120
-#hugeval = 1.0e+120
-tinyval = numpy.float(numpy.finfo(numpy.float32).tiny) # FLT_TINY
-hugeval = numpy.float(numpy.finfo(numpy.float32).max)  # FLT_MAX
-#tinyval = 1.0e-38
-#hugeval = 1.0e+38
+# tinyval = 1.0e-120
+# hugeval = 1.0e+120
+# tinyval = 1.0e-38
+# hugeval = 1.0e+38
+#
+# Use FLT_TINY and FLT_MAX
+tinyval = numpy.float(numpy.finfo(numpy.float32).tiny)
+hugeval = numpy.float(numpy.finfo(numpy.float32).max)
+
 
 def _make_set_limit(name):
     def _set_limit(self, val):
@@ -43,9 +46,12 @@ def _make_set_limit(name):
         # Ensure that we don't try to set any value that is outside
         # the hard parameter limits.
         if val < self._hard_min:
-            raise ParameterErr('edge', self.fullname, 'hard minimum', self._hard_min)
+            raise ParameterErr('edge', self.fullname,
+                               'hard minimum', self._hard_min)
         if val > self._hard_max:
-            raise ParameterErr('edge', self.fullname, 'hard maximum', self._hard_max)
+            raise ParameterErr('edge', self.fullname,
+                               'hard maximum', self._hard_max)
+
         # Ensure that we don't try to set a parameter range, such that
         # the minimum will be greater than the current parameter value,
         # or that the maximum will be less than the current parameter value.
@@ -59,30 +65,33 @@ def _make_set_limit(name):
         # Due to complaints about having to rewrite existing user scripts,
         # downgrade the ParameterErr issued here to mere warnings.  Also,
         # set the value to the appropriate soft limit.
-        if (hasattr(self, "_NoNewAttributesAfterInit__initialized") == True and
-            self._NoNewAttributesAfterInit__initialized == True):
-            if (name == "_min"):
-                if (val > self.val):
-                    self.val = val
-                    warning(('parameter %s less than new minimum; %s reset to %g') % (self.fullname, self.fullname, self.val))
-            if (name == "_max"):
-                if (val < self.val):
-                    self.val = val
-                    warning(('parameter %s greater than new maximum; %s reset to %g') % (self.fullname, self.fullname, self.val))
+        if hasattr(self, "_NoNewAttributesAfterInit__initialized") and \
+           self._NoNewAttributesAfterInit__initialized:
+            if name == "_min" and (val > self.val):
+                self.val = val
+                warning(('parameter %s less than new minimum; %s reset to %g') % (self.fullname, self.fullname, self.val))
+            if name == "_max" and (val < self.val):
+                self.val = val
+                warning(('parameter %s greater than new maximum; %s reset to %g') % (self.fullname, self.fullname, self.val))
 
         setattr(self, name, val)
+
     return _set_limit
+
 
 def _make_unop(op, opstr):
     def func(self):
         return UnaryOpParameter(self, op, opstr)
     return func
 
+
 def _make_binop(op, opstr):
     def func(self, rhs):
         return BinaryOpParameter(self, rhs, op, opstr)
+
     def rfunc(self, lhs):
         return BinaryOpParameter(lhs, self, op, opstr)
+
     return (func, rfunc)
 
 
@@ -113,7 +122,7 @@ class Parameter(NoNewAttributesAfterInit):
             return self.eval()
         if self.link is not None:
             return self.link.val
-        return self._val    
+        return self._val
 
     def _set_val(self, val):
         if isinstance(val, Parameter):
@@ -143,7 +152,7 @@ class Parameter(NoNewAttributesAfterInit):
             return self.eval()
         if self.link is not None:
             return self.link.default_val
-        return self._default_val    
+        return self._default_val
 
     def _set_default_val(self, default_val):
         if isinstance(default_val, Parameter):
@@ -196,6 +205,7 @@ class Parameter(NoNewAttributesAfterInit):
         if self.link is not None:
             return True
         return self._frozen
+
     def _set_frozen(self, val):
         val = bool(val)
         if self._alwaysfrozen and (not val):
@@ -209,6 +219,7 @@ class Parameter(NoNewAttributesAfterInit):
 
     def _get_link(self):
         return self._link
+
     def _set_link(self, link):
         if link is not None:
             if self._alwaysfrozen:
@@ -300,8 +311,8 @@ class Parameter(NoNewAttributesAfterInit):
                  'default_min = %s\n' +
                  'default_max = %s') %
                 (str(self.val), str(self.min), str(self.max), self.units,
-                 self.frozen, linkstr, str(self.default_val), str(self.default_min),
-                 str(self.default_max)))
+                 self.frozen, linkstr, str(self.default_val),
+                 str(self.default_min), str(self.default_max)))
 
     # Unary operations
     __neg__ = _make_unop(numpy.negative, '-')
@@ -335,7 +346,6 @@ class Parameter(NoNewAttributesAfterInit):
             self._guessed = False
         self._val = self.default_val
 
-
     def set(self, val=None, min=None, max=None, frozen=None,
             default_val=None, default_min=None, default_max=None):
 
@@ -344,12 +354,10 @@ class Parameter(NoNewAttributesAfterInit):
         if default_max is not None and default_max > self.default_max:
             self.default_max = default_max
 
-
         if min is not None and min < self.min:
             self.min = min
         if default_min is not None and default_min < self.default_min:
             self.default_min = default_min
-
 
         if val is not None:
             self.val = val
@@ -429,7 +437,7 @@ class BinaryOpParameter(CompositeParameter):
     def wrapobj(obj):
         if isinstance(obj, Parameter):
             return obj
-        return ConstantParameter(obj) 
+        return ConstantParameter(obj)
 
     def __init__(self, lhs, rhs, op, opstr):
         self.lhs = self.wrapobj(lhs)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,17 +21,17 @@ import logging
 import operator
 import numpy
 import warnings
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.testing import SherpaTestCase
 from sherpa.utils.err import ModelErr
-from sherpa.models.model import *
-from sherpa.models.model import ArithmeticModel
+from sherpa.models.model import ArithmeticModel, ArithmeticConstantModel, \
+    BinaryOpModel, FilterModel, NestedModel, UnaryOpModel
 from sherpa.models.parameter import Parameter, tinyval
 from sherpa.models.basic import Sin, Const1D
 
 
 def my_sin(pars, x):
     return (pars[2].val *
-            numpy.sin(2.0*numpy.pi * (x - pars[1].val) / pars[0].val))
+            numpy.sin(2.0 * numpy.pi * (x - pars[1].val) / pars[0].val))
 
 
 class test_model(SherpaTestCase):
@@ -143,7 +143,7 @@ class test_composite_model(SherpaTestCase):
                operator.floordiv, operator.truediv, operator.mod,
                operator.pow]
 
-        if hasattr(operator, 'div'): # Python 2
+        if hasattr(operator, 'div'):  # Python 2
             ops.append(operator.div)
 
         for op in ops:
@@ -156,7 +156,7 @@ class test_composite_model(SherpaTestCase):
         cmplx = (3 * self.m + self.m2) / (self.m ** 3.2)
         m = self.m(self.x)
         m2 = self.m2(self.x)
-        self.assertEqual(cmplx(self.x), (3*m + m2) / (m ** 3.2))
+        self.assertEqual(cmplx(self.x), (3 * m + m2) / (m ** 3.2))
 
     def test_filter(self):
         m = self.s[::2]
@@ -174,7 +174,8 @@ class test_composite_model(SherpaTestCase):
 # the Sin model (which lets the tests be re-used).
 #
 class RenamedPars(Sin):
-    # The only reason I am extending Sin is to inherit the method implementations
+    # The only reason I am extending Sin is to inherit the method
+    # implementations
 
     def __init__(self, name='renamedpars'):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -173,10 +173,14 @@ class test_composite_model(SherpaTestCase):
 # the Sin model (which lets the tests be re-used).
 #
 class RenamedPars(Sin):
+    # The only reason I am extending Sin is to inherit the method implementations
 
     def __init__(self, name='renamedpars'):
-        self._renamedpars = [('norm', 'ampl')]
-        Sin.__init__(self, name)
+        self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
+        self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
+        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=['norm'])
+        ArithmeticModel.__init__(self, name,
+                                 (self.period, self.offset, self.ampl))
 
 
 class test_model_renamed(test_model):
@@ -227,8 +231,7 @@ class ParameterCase(ArithmeticModel):
     def __init__(self, name='parametercase'):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
         self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
-        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0)
-        self._renamedpars = [('NORM', 'ampl')]
+        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
 
         with warnings.catch_warnings(record=True) as warn:
             pars = (self.perioD, self.oFFSEt, self.NORM)
@@ -245,7 +248,7 @@ class ParameterCase(ArithmeticModel):
         return self._basemodel.calc(*args, **kwargs)
 
 
-def validate_warning(warning_capturer, parameter_name="NORM", model_name="ParameterCase"):
+def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase"):
     assert 1 == len(warning_capturer)
     warning = warning_capturer[-1]
     assert issubclass(warning.category, DeprecationWarning)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -190,17 +190,19 @@ class test_model_renamed(test_model):
 
     def test_getpar_rename(self):
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             for par in (self.m.norm, self.m.NorM, self.m.NOrm):
                 self.assertIs(par, self.m.pars[2])
             if self.__class__ == test_model_renamed:
-                validate_warning(warn, "norm", "RenamedPars")
+                validate_warning(warn, "norm", "RenamedPars", num=3)
             else:
-                validate_warning(warn)
+                validate_warning(warn, num=3)
 
     def test_setpar_rename(self):
         self.m.ampl = 1
         self.assertNotEqual(self.m.ampl.val, 12.0)
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             self.m.norm = 12
             if (self.__class__ == test_model_renamed):
                 validate_warning(warn, "norm", "RenamedPars")
@@ -210,6 +212,7 @@ class test_model_renamed(test_model):
         self.assertEqual(self.m.ampl.val, 12.0)
 
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             self.m.NoRM = 18
             if self.__class__ == test_model_renamed:
                 validate_warning(warn, "norm", "RenamedPars")
@@ -234,6 +237,7 @@ class ParameterCase(ArithmeticModel):
         self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
 
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             pars = (self.perioD, self.oFFSEt, self.NORM)
             validate_warning(warn)
 
@@ -248,14 +252,14 @@ class ParameterCase(ArithmeticModel):
         return self._basemodel.calc(*args, **kwargs)
 
 
-def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase"):
-    assert 1 == len(warning_capturer)
-    warning = warning_capturer[-1]
-    assert issubclass(warning.category, DeprecationWarning)
-    expected_warning_message = 'Parameter name {} is deprecated for model {}, use ampl instead'.format(
-        parameter_name, model_name
-    )
-    assert expected_warning_message == str(warning.message)
+def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase", num=1):
+    assert num == len(warning_capturer)
+    for warning in warning_capturer:
+        assert issubclass(warning.category, DeprecationWarning)
+        expected_warning_message = 'Parameter name {} is deprecated for model {}, use ampl instead'.format(
+            parameter_name, model_name
+        )
+        assert expected_warning_message == str(warning.message)
 
 
 class test_model_parametercase_instance(test_model_renamed):

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -210,8 +210,8 @@ class ParameterCase(ArithmeticModel):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
         self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
         self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0)
-        pars = (self.perioD, self.oFFSEt, self.AMPL)
         self._renamedpars = [('NORM', 'ampl')]
+        pars = (self.perioD, self.oFFSEt, self.NORM)
 
         self._basemodel = Sin()
 
@@ -232,3 +232,4 @@ class test_model_parametercase_instance(test_model_renamed):
 
     def test_name(self):
         self.assertEqual(self.m.name, 'parametercase')
+        self.assertEqual(self.m.NORM.name, 'ampl')

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -38,6 +38,7 @@ class test_model(SherpaTestCase):
 
     def setUp(self):
         self.m = Sin('m')
+        self.expected_names = ['period', 'offset', 'ampl']
 
     def test_name(self):
         self.assertEqual(self.m.name, 'm')
@@ -51,7 +52,7 @@ class test_model(SherpaTestCase):
 
     def test_par_names(self):
         self.assertEqual([p.name for p in self.m.pars],
-                         ['period', 'offset', 'ampl'])
+                         self.expected_names)
 
     def test_getpar(self):
         for par in (self.m.period, self.m.PerioD, self.m.PERIod):
@@ -186,6 +187,7 @@ class RenamedPars(Sin):
 class test_model_renamed(test_model):
 
     def setUp(self):
+        test_model.setUp(self)
         self.m = RenamedPars('m')
 
     def test_getpar_rename(self):
@@ -194,7 +196,7 @@ class test_model_renamed(test_model):
             for par in (self.m.norm, self.m.NorM, self.m.NOrm):
                 self.assertIs(par, self.m.pars[2])
             if self.__class__ == test_model_renamed:
-                validate_warning(warn, "norm", "RenamedPars", num=3)
+                validate_warning(warn, "norm", "RenamedPars", "ampl", num=3)
             else:
                 validate_warning(warn, num=3)
 
@@ -205,7 +207,7 @@ class test_model_renamed(test_model):
             warnings.simplefilter("always", DeprecationWarning)
             self.m.norm = 12
             if (self.__class__ == test_model_renamed):
-                validate_warning(warn, "norm", "RenamedPars")
+                validate_warning(warn, "norm", "RenamedPars", "ampl")
             else:
                 validate_warning(warn)
 
@@ -215,7 +217,7 @@ class test_model_renamed(test_model):
             warnings.simplefilter("always", DeprecationWarning)
             self.m.NoRM = 18
             if self.__class__ == test_model_renamed:
-                validate_warning(warn, "norm", "RenamedPars")
+                validate_warning(warn, "norm", "RenamedPars", "ampl")
             else:
                 validate_warning(warn)
 
@@ -232,9 +234,9 @@ class ParameterCase(ArithmeticModel):
     """Re-implemenent Sin model so can copy tests"""
 
     def __init__(self, name='parametercase'):
-        self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
-        self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
-        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
+        self.period = Parameter(name, 'Period', 1, 1e-10, 10, tinyval)
+        self.offset = Parameter(name, 'Offset', 0, 0, hard_min=0)
+        self.ampl = Parameter(name, 'Ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
 
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always", DeprecationWarning)
@@ -252,12 +254,12 @@ class ParameterCase(ArithmeticModel):
         return self._basemodel.calc(*args, **kwargs)
 
 
-def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase", num=1):
+def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase", actual_name="Ampl", num=1):
     assert num == len(warning_capturer)
     for warning in warning_capturer:
         assert issubclass(warning.category, DeprecationWarning)
-        expected_warning_message = 'Parameter name {} is deprecated for model {}, use ampl instead'.format(
-            parameter_name, model_name
+        expected_warning_message = 'Parameter name {} is deprecated for model {}, use {} instead'.format(
+            parameter_name, model_name, actual_name
         )
         assert expected_warning_message == str(warning.message)
 
@@ -266,6 +268,7 @@ class test_model_parametercase_instance(test_model_renamed):
 
     def setUp(self):
         self.m = ParameterCase()
+        self.expected_names = ['Period', 'Offset', 'Ampl']
 
     def test_name(self):
         self.assertEqual(self.m.name, 'parametercase')


### PR DESCRIPTION
# Release Note

The XSPEC models have been updated to use parameter names that match the new XSPEC naming scheme introduced in XSPEC 12.9.0. The old parameter name can still be used as aliases for the new name, but are deprecated and will be removed in a next major release. Note this allows any models to define aliases for their parameters.

# Details

The approach is not specific to the XSPEC models, but they are the only ones which need it at this time.

- [X] validate proof of concept
- [X] add tests for proof of concept
- [X] add deprecation warning
- [X] add tests to check that deprecation warning is created when expected
- [X] implement for XSPEC models
- [X] validate new XSPEC parameter names against latest release (compared against XSPEC `12.9.0o`).
- [X] add documentation to models to describe old parameter names
- [X] add documentation to model class describing approach
- [X] validate in end-user testing: interactive environment, including `save_all`
- [X] validate in end-user testing: script

# Issues

The warning message - since it uses the Python `DeprecationWarning` system - does not display to users by default. I thought it would appear, but I haven't seen it from some quick testing. I wonder if sherpa (in CIAO) should adjust the warnings status (or maybe if you import `sherpa.astro.ui`, but I'm a bit more concerned about that approach).

# Example

The XSbmc model has a parameter called `logA` in Sherpa 4.8 but it has been renamed to `log_A`; as shown below, both can be used (and `.logA` is essentially an alias for `.log_A`):

```
>>> from sherpa.astro import ui
>>> ui.xsbmc.mdl
<XSbmc model instance 'xsbmc.mdl'>
>>> print(mdl)
xsbmc.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.kT       thawed            1         0.01          100        keV
   mdl.alpha    thawed            1         0.01            4           
   mdl.log_A    thawed            0           -6            6           
   mdl.norm     thawed            1            0        1e+24           
>>> mdl.log_a.val
0.0
>>> mdl.log_a = 1.1
>>> mdl.log_a.val
1.1000000000000001
>>> mdl.loga
<Parameter 'log_A' of model 'mdl'>
>>> mdl.loga.val
1.1000000000000001
>>> mdl.loga = 2
>>> mdl.log_a.val
2.0
>>> print(mdl)
xsbmc.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.kT       thawed            1         0.01          100        keV
   mdl.alpha    thawed            1         0.01            4           
   mdl.log_A    thawed            2           -6            6           
   mdl.norm     thawed            1            0        1e+24           
```

If you turn up the warnings you see a `DeprecationWarning`:

```
>>> from sherpa.astro import ui
>>> import warnings
>>> warnings.filterwarnings('once')
>>> ui.xsbmc.mdl
<XSbmc model instance 'xsbmc.mdl'>
>>> print(mdl)
xsbmc.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.kT       thawed            1         0.01          100        keV
   mdl.alpha    thawed            1         0.01            4           
   mdl.log_A    thawed            0           -6            6           
   mdl.norm     thawed            1            0        1e+24           
>>> mdl.loga = 2
sherpa/models/model.py:180: DeprecationWarning: Parameter name logA is deprecated for model XSbmc, use log_A instead
  warnings.warn(wmsg, DeprecationWarning)
>>> mdl.loga = 2
>>>
```
