### PR TITLE
fix docstring for levmar tolerance

### DIFF
--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -372,8 +372,8 @@ class LevMar(OptMethod):
        free parameters.
     epsfcn : number
        This is used in determining a suitable step length for the
-       forward-difference approximation; default is FLT_EPSILON ~ 1.19209289551e-07,
-       where DBL_EPSILON is the smallest number
+       forward-difference approximation; default is FLT_EPSILON
+       ~ 1.19209289551e-07, where FLT_EPSILON is the smallest number
        x such that `1.0 != 1.0 + x`. This approximation assumes that
        the relative errors in the functions are of the order of
        `epsfcn`. If `epsfcn` is less than the machine precision, it is

--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -348,21 +348,21 @@ class LevMar(OptMethod):
     ----------
     ftol : number
        The function tolerance to terminate the search for the minimum;
-       the default is sqrt(DBL_EPSILON) ~ 1.19209289551e-07, where
-       DBL_EPSILON is the smallest number x such that `1.0 != 1.0 +
+       the default is FLT_EPSILON ~ 1.19209289551e-07, where
+       FLT_EPSILON is the smallest number x such that `1.0 != 1.0 +
        x`. The conditions are satisfied when both the actual and
        predicted relative reductions in the sum of squares are, at
        most, ftol.
     xtol : number
        The relative error desired in the approximate solution; default
-       is sqrt( DBL_EPSILON ) ~ 1.19209289551e-07, where DBL_EPSILON
+       is FLT_EPSILON ~ 1.19209289551e-07, where FLT_EPSILON
        is the smallest number x such that `1.0 != 1.0 + x`. The
        conditions are satisfied when the relative error between two
        consecutive iterates is, at most, `xtol`.
     gtol : number
        The orthogonality desired between the function vector and the
-       columns of the jacobian; default is sqrt( DBL_EPSILON ) ~
-       1.19209289551e-07, where DBL_EPSILON is the smallest number x
+       columns of the jacobian; default is FLT_EPSILON ~
+       1.19209289551e-07, where FLT_EPSILON is the smallest number x
        such that `1.0 != 1.0 + x`. The conditions are satisfied when
        the cosine of the angle between fvec and any column of the
        jacobian is, at most, `gtol` in absolute value.
@@ -372,8 +372,8 @@ class LevMar(OptMethod):
        free parameters.
     epsfcn : number
        This is used in determining a suitable step length for the
-       forward-difference approximation; default is sqrt( DBL_EPSILON
-       ) ~ 1.19209289551e-07, where DBL_EPSILON is the smallest number
+       forward-difference approximation; default is FLT_EPSILON ~ 1.19209289551e-07,
+       where DBL_EPSILON is the smallest number
        x such that `1.0 != 1.0 + x`. This approximation assumes that
        the relative errors in the functions are of the order of
        `epsfcn`. If `epsfcn` is less than the machine precision, it is


### PR DESCRIPTION
Fix #128.

# Release Note

The documentation string for the Levenberg-Marquardt optimization function now correctly states that the parameter default values are equal to the single precision epsilon, rather than the square root of the double precision epsilon.