### PR TITLE
add some docs about other fortran compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ There are two ways to download the source code:
 
  - directly from GitHub as a git repository
 
+**NOTE:** it is possible to build Sherpa with `fortran` compilers other than
+`gfortran`. While this is not supported, [PR #202](https://github.com/sherpa/sherpa/pull/202/files)
+shows how this can been accomplished with `g95` on `OS X` in a specific setup.
+Similar changes are probably required for other compilers or setups.
+Since the `fortran` code is compiled by `numpy`'s [`f2py`](http://docs.scipy.org/doc/numpy-dev/f2py/distutils.html)
+you might want to check their documentation for details.
+
 ### 2a. Extract the source tarball
 
 If you donwloaded the Sherpa source tarball, you can extract it by:

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ There are two ways to download the source code:
 `gfortran`. While this is not supported, [PR #202](https://github.com/sherpa/sherpa/pull/202/files)
 shows how this can been accomplished with `g95` on `OS X` in a specific setup.
 Similar changes are probably required for other compilers or setups.
-Since the `fortran` code is compiled by `numpy`'s [`f2py`](http://docs.scipy.org/doc/numpy-dev/f2py/distutils.html)
-you might want to check their documentation for details.
+The `fortran` extensions are compiled by
+[`f2py` via `numpy.distutils`](http://docs.scipy.org/doc/numpy-1.11.0/f2py/distutils.html).
 
 ### 2a. Extract the source tarball
 


### PR DESCRIPTION
Fix #5.

# Release Note
Added documentation regarding support of different `fortran` compilers. While we only officially support `gfortran`, we have an example on how to patch Sherpa's `setup.py` to use a different compiler with a platform-dependent configuration.