### PR TITLE
fix #262 list_data_ids() fails on py3 with mixed id types

### DIFF
--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1,0 +1,28 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from sherpa.ui.utils import Session
+
+
+# bug #262
+def test_list_ids():
+    session = Session()
+    session.load_arrays(1, [1, 2, 3], [1, 2, 3])
+    session.load_arrays("bar", [1, 2, 3], [1, 2, 3])
+    assert [1, "bar"] == session.list_data_ids()

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -18,11 +18,14 @@
 #
 
 from sherpa.ui.utils import Session
+from numpy.testing import assert_array_equal
 
 
 # bug #262
 def test_list_ids():
     session = Session()
     session.load_arrays(1, [1, 2, 3], [1, 2, 3])
-    session.load_arrays("bar", [1, 2, 3], [1, 2, 3])
-    assert [1, "bar"] == session.list_data_ids()
+    session.load_arrays("1", [1, 2, 3], [4, 5, 6])
+    assert [1, "1"] == session.list_data_ids()
+    assert_array_equal([4, 5, 6], session.get_data('1').get_dep())
+    assert_array_equal([1, 2, 3], session.get_data(1).get_dep())

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -26,6 +26,8 @@ def test_list_ids():
     session = Session()
     session.load_arrays(1, [1, 2, 3], [1, 2, 3])
     session.load_arrays("1", [1, 2, 3], [4, 5, 6])
-    assert [1, "1"] == session.list_data_ids()
+
+    # order of 1 and "1" is not determined
+    assert {1, "1"} == set(session.list_data_ids())
     assert_array_equal([4, 5, 6], session.get_data('1').get_dep())
     assert_array_equal([1, 2, 3], session.get_data(1).get_dep())

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2251,7 +2251,7 @@ class Session(NoNewAttributesAfterInit):
         # TODO3: I have left the explicit copy in (the "[:]" suffix)
         # when converting to Python 3, but it is probably unnescessary
         keys = list(self._data.keys())[:]
-        keys.sort()
+        keys.sort(key=str)  # always sort by string value.
         return keys
 
     def get_data(self, id=None):


### PR DESCRIPTION
Fix #262 

# Release Note
Sherpa was sorting the list of dataset IDs in a non-python3 compliant fashion, which resulted in issues when using strings and integers together as dataset IDs. This has now been fixed.