### PR TITLE
Fix #265 (ChIPS tests need the sherpa-test-data directory)

### DIFF
--- a/sherpa/astro/ui/tests/test_chips_unit.py
+++ b/sherpa/astro/ui/tests/test_chips_unit.py
@@ -17,7 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import pytest
-from sherpa.utils import requires_fits
+from sherpa.utils import requires_data, requires_fits
 from six.moves import reload_module
 
 
@@ -57,6 +57,7 @@ def clean_up(request, ui):
     request.addfinalizer(fin)
 
 
+@requires_data
 @requires_fits
 @pytest.fixture(autouse=True)
 def load_data(ui, make_data_path):
@@ -102,6 +103,3 @@ def test_plot(call, args, chips, ui):
     function = getattr(ui, "plot_"+call)
     function(*args)
     assert_chips_called(chips)
-
-
-

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -132,11 +132,17 @@ def make_data_path():
 
     Returns
     -------
-    make_data_path : func A function that accepts a list of path elements to be joined with the base data dir path
+    make_data_path : func
+        A function that accepts a list of path elements to be joined with
+        the base data dir path. This function exits with a RuntimeError
+        if the data directory is None, pointing out the requires_data
+        decorator is needed.
     """
     path = SherpaTestCase.datadir
 
     def wrapped(arg):
+        if path is None:
+            raise RuntimeError("Test needs the requires_data decorator")
         return os.path.join(path, arg)
 
     return wrapped


### PR DESCRIPTION
The ChIPS tests are skipped when the sherpa-test-data directory is not available.