### PR TITLE
fix for wstat issues #227 #248

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -574,10 +574,6 @@ class IterFit(NoNewAttributesAfterInit):
                 bkg_backscal = _to_array(bkg.backscal)
                 ratio = bkg_backscal / src_backscal
 
-                print("*** sizes")
-                print("*** bkg   = {}".format(npts))
-                print("*** ratio = {}".format(ratio.size))
-
                 backscale_ratio = append(backscale_ratio, ratio)
             else:
                 return result

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -548,7 +548,14 @@ class IterFit(NoNewAttributesAfterInit):
                 #       "up" and "down" components). It looks like it
                 #       only uses the first element.
                 bkg = mydata.get_background(mydata.background_ids[0])
-                tmp_bkg_dep = bkg.get_dep(True)
+
+                # This uses the grouping applied to the background
+                # data set, but we need to apply the source grouping
+                # to it.
+                #
+                # tmp_bkg_dep = bkg.get_dep(True)
+                tmp_bkg_dep = mydata.apply_filter(bkg.get_dep(False),
+                                                  groupfunc=np.sum)
 
                 npts = tmp_bkg_dep.size
                 data_size.append(npts)
@@ -566,6 +573,10 @@ class IterFit(NoNewAttributesAfterInit):
                 src_backscal = _to_array(mydata.backscal)
                 bkg_backscal = _to_array(bkg.backscal)
                 ratio = bkg_backscal / src_backscal
+
+                print("*** sizes")
+                print("*** bkg   = {}".format(npts))
+                print("*** ratio = {}".format(ratio.size))
 
                 backscale_ratio = append(backscale_ratio, ratio)
             else:

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -504,14 +504,22 @@ class IterFit(NoNewAttributesAfterInit):
                 src = src_backscal
             return bkg / src
 
-        result = {'bkg': None, 'backscale_ratio': None, 'data_size': None,
+        result = {'bkg': None, 'backscale_ratio': None,
                   'exposure_time': None}
-        bkg_dep = []
-        data_size = None
+
+        # It looks like the sizes need to be filled up,
+        # even if the background data is not filled in (i.e if return
+        # is called in the middle of the loop through self.data.datasets
+        # below).
+        #
+        result['data_size'] = np.asarray([d.get_dep(True).size
+                                          for d in self.data.datasets],
+                                         dtype=np.int)
+
         exposure_time = None
         backscale_ratio = []
+        bkg_dep = []
 
-        data_size = []
         exposure_time = []
         for mydata in self.data.datasets:
             if hasattr(mydata, 'response_ids') and \
@@ -557,9 +565,6 @@ class IterFit(NoNewAttributesAfterInit):
                 tmp_bkg_dep = mydata.apply_filter(bkg.get_dep(False),
                                                   groupfunc=np.sum)
 
-                npts = tmp_bkg_dep.size
-                data_size.append(npts)
-
                 bkg_dep = append(bkg_dep, tmp_bkg_dep)
 
                 exposure_time.extend([mydata.exposure, bkg.exposure])
@@ -580,7 +585,6 @@ class IterFit(NoNewAttributesAfterInit):
 
         result['bkg'] = bkg_dep
         result['backscale_ratio'] = backscale_ratio
-        result['data_size'] = np.asarray(data_size, dtype=np.int)
         result['exposure_time'] = np.asarray(exposure_time)
         return result
 

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -37,8 +37,8 @@ from sherpa.data import DataSimulFit
 from sherpa.estmethods import Covariance, EstNewMin
 from sherpa.models import SimulFitModel
 from sherpa.optmethods import LevMar, NelderMead
-from sherpa.stats import Chi2, Chi2Gehrels, Cash, CStat, Chi2ModVar, LeastSq, \
-    Likelihood, WStat, UserStat
+from sherpa.stats import Chi2, Chi2Gehrels, Cash, CStat, Chi2ModVar, \
+    LeastSq, Likelihood, WStat, UserStat
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info

--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -177,7 +177,16 @@ class test_wstat_single_scalar(SherpaTestCase):
 @requires_data
 @requires_fits
 class test_wstat_two_scalar(SherpaTestCase):
-    """Two PHA files with a scalar backscal value"""
+    """Two PHA files with a scalar backscal value.
+
+    Although two PHA files are used, there are three data sets.
+    Two of the data sets are the same file (9774) but grouped
+    differently: one where the background grouping from group_counts
+    is overwritten (the work around mentiond for issue #227),
+    and one where this is not done, to see if #227 has been
+    "fixed" (at least with regard to calculating the statistic
+    value).
+    """
 
     def setUp(self):
 
@@ -251,7 +260,7 @@ class test_wstat_two_scalar(SherpaTestCase):
         stat = ui.calc_stat(idval)
         self.assertAlmostEqual(expected, stat, places=7)
 
-    def _check_stat2(self, expected):
+    def _check_stat_all(self, expected):
         """Is calc_stat() == expected?"""
 
         stat = ui.calc_stat()
@@ -265,7 +274,7 @@ class test_wstat_two_scalar(SherpaTestCase):
         exp2 = 401.75572944361613
         self._check_stat(1, 46, exp1)
         self._check_stat(2, 148, exp2)
-        self._check_stat2(exp1 + exp2)
+        self._check_stat_all(exp1 + exp2)
 
     def test_wstat_grouped_filtered(self):
         self._filter_data()
@@ -276,7 +285,7 @@ class test_wstat_two_scalar(SherpaTestCase):
         exp2 = 127.35556915677182
         self._check_stat(1, 35, exp1)
         self._check_stat(2, 120, exp2)
-        self._check_stat2(exp1 + exp2)
+        self._check_stat_all(exp1 + exp2)
 
     def test_wstat_ungrouped_all(self):
         ui.ungroup(1)
@@ -288,7 +297,7 @@ class test_wstat_two_scalar(SherpaTestCase):
         exp2 = 880.8442022201893
         self._check_stat(1, 1024, exp1)
         self._check_stat(2, 1024, exp2)
-        self._check_stat2(exp1 + exp2)
+        self._check_stat_all(exp1 + exp2)
 
     def test_wstat_ungrouped_filtered(self):
         ui.ungroup(1)
@@ -301,7 +310,7 @@ class test_wstat_two_scalar(SherpaTestCase):
         exp2 = 397.4089421041855
         self._check_stat(1, 375, exp1)
         self._check_stat(2, 375, exp2)
-        self._check_stat2(exp1 + exp2)
+        self._check_stat_all(exp1 + exp2)
 
 
 @requires_data

--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -386,7 +386,6 @@ class test_wstat_group_counts(SherpaTestCase):
         stat = ui.calc_stat(idval)
         self.assertAlmostEqual(expected, stat, places=7)
 
-    @expectedFailure
     def test_wstat_grouped_all(self):
 
         # Used git commit 770359b5004374b969ebb63c173f293419397b4c
@@ -394,7 +393,6 @@ class test_wstat_group_counts(SherpaTestCase):
         expval = 401.75572944361613
         self._check_stat(1, 148, expval)
 
-    @expectedFailure
     def test_wstat_grouped_filtered(self):
         self._filter_data()
 

--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -72,14 +72,14 @@
 #     Actually, DougBurke believes this is due to the behavior
 #     of group_counts, which we already work around below,
 #     search for "Note: this is related to issue 227".
+#     and in fact this issue may have been fixed by the same
+#     code that is used to get all these tests to pass.
 #
 
 import numpy as np
 
 from sherpa.utils import SherpaTestCase, requires_data, requires_fits
 from sherpa.astro import ui
-
-from unittest import expectedFailure
 
 import logging
 
@@ -482,14 +482,12 @@ class test_wstat_single_array(SherpaTestCase):
         stat = ui.calc_stat()
         self.assertAlmostEqual(expected, stat, places=7)
 
-    @expectedFailure
     def test_wstat_grouped_all(self):
 
         # Used git commit 770359b5004374b969ebb63c173f293419397b4c
         # to create the oracle value, on a linux 64-bit machine.
         self._check_stat(46, 71.21845954979574)
 
-    @expectedFailure
     def test_wstat_grouped_filtered(self):
         self._filter_data()
 
@@ -504,7 +502,6 @@ class test_wstat_single_array(SherpaTestCase):
         # to create the oracle value, on a linux 64-bit machine.
         self._check_stat(1024, 663.0160968458746)
 
-    @expectedFailure
     def test_wstat_ungrouped_filtered(self):
         ui.ungroup()
         self._filter_data()


### PR DESCRIPTION
**EDITED TO ADD** my preferred approach to fixing this problem is in PR #287 - which changes how data is passed from the fit to the stat object.
# Summary

Support a variety of data options when using the `wstat` statistic, including grouped or ungrouped data, filtered or unfiltered data, and scalar or vector backscale arrays. This includes #227 and #248.

I am not 100% convinced this is the approach to take - since it "forces" the background data to match the grouping of the source data set. This is arguably the right thing to do for `wstat`, but it may not be for other statistics, and the routine where this is being calculated is meant to be somewhat general (as far as I can tell).

There is also the possibility that the code does not correctly support datasets with multiple background datasets, but this is outside the scope of this PR (i.e. if it is broken here, it is broken in `master`).

This PR is intended for review and discussion. I am not convinced it will be accepted, but the code changes are fairly small.
