### PR TITLE
Travis changes for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+# leaving this as 2.7 for the pyfits test, as I am not sure if that works
+# with Python 3.5
 python:
   - "2.7"
 
@@ -17,41 +19,46 @@ addons:
       - flex
       - bison
 
-# We use matrix include so that xspec builds (which are more complicated and long) are started first
+# We use matrix include so that xspec builds (which are more complicated
+# and long) are started first
+#
+# The first run is the Python 2.7 run, the rest are python 3.5
 matrix:
   fast_finish: true
   include:
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=smoke MATPLOTLIBVER=1.5
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "2.7"
+      sudo: required
+      dist: trusty
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=smoke MATPLOTLIBVER=1.5
+      python: "3.5"
       sudo: required
       dist: trusty
     - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "2.7"
+      python: "3.5"
       sudo: required
       dist: trusty
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 MKL=nomkl
-      python: "2.7"
+      python: "3.5"
       sudo: required
       dist: trusty
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "3.5"
       sudo: required
       dist: trusty
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "2.7"
-      sudo: required
-      dist: trusty
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5
-      python: "2.7"
+      python: "3.5"
     - env: FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "2.7"
+      python: "3.5"
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.4 NUMPYVER=1.9
-      python: "2.7"
+      python: "3.5"
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
-      python: "2.7"
+      python: "3.5"
   allow_failures:
     - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
+      python: "2.7"
 
+# is this a python 2.7 or 3.5 run?
 env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ addons:
 
 # We use matrix include so that xspec builds (which are more complicated and long) are started first
 matrix:
-  allow_failures:
-      - python: "3.5"
   fast_finish: true
   include:
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=smoke MATPLOTLIBVER=1.5

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -134,7 +134,7 @@ def smoke(verbosity=0, require_failure=False, fits=None, xspec=False):
 def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False):
     from optparse import OptionParser
     parser = OptionParser()
-    parser.add_option("-v", "--verbosity", dest="verbosity",
+    parser.add_option("-v", "--verbosity", dest="verbosity", type=int,
                       help="verbosity level")
     parser.add_option("-0", "--require-failure", dest="require_failure", action="store_true",
                       help="require smoke test to fail (for debugging)")

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -46,7 +46,12 @@ known_warnings = {
         [
             r"unorderable dtypes.*",
             r"Non-string object detected for the array ordering.*",
-            r"using a non-integer number instead of an integer will result in an error in the future"
+            r"using a non-integer number instead of an integer will result in an error in the future",
+            # the following is needed for "old" versions of astropy
+            # (e.g. version 1.0.4), as newer versions (and the Sherpa
+            # code base) should not use inspect.getargspec
+            r"inspect.getargspec() is deprecated, use inspect.signature() instead"
+
         ],
     UserWarning:
         [

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -50,7 +50,7 @@ known_warnings = {
             # the following is needed for "old" versions of astropy
             # (e.g. version 1.0.4), as newer versions (and the Sherpa
             # code base) should not use inspect.getargspec
-            r"inspect.getargspec() is deprecated, use inspect.signature() instead"
+            r"inspect.getargspec\(\) is deprecated"
 
         ],
     UserWarning:


### PR DESCRIPTION
# Summary

Python 3.5 builds must now pass for the overall tests to pass. The versions have been swapped, so that there's now only one Python 2.7 run (testing everything) and all the other runs use Python 3.5.
# Discussion

The first commit should be done, now we have merged the Python 3 support to master (this removes the "AllowFailures" rule for Python 3.5). The second commit swaps the 2.7 and 3.5 builds (_except_ for the pyfits test) since the idea is that for the standalone build we are better off testing the various options with 3.5 rather than 2.7. A 2.7 run is needed, which tests as much as possible, to make sure changes are suitable for CIAO. 
