### PR TITLE
fix #277 - parallel_map not working on py3 with numcores=1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
     fi
 
 install:
-  - python setup.py $INSTALL_TYPE
+    - python setup.py $INSTALL_TYPE &> install.log
 
 script:
   - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x"; fi

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -46,7 +46,7 @@ from sherpa.utils._psf import extract_kernel, normalize, set_origin, \
 
 from sherpa import get_config
 from six.moves.configparser import ConfigParser, NoSectionError
-from six.moves import xrange
+from six.moves import xrange, map
 
 import logging
 warning = logging.getLogger("sherpa").warning
@@ -1704,7 +1704,7 @@ def worker(f, ii, chunk, out_q, err_q, lock):
         return
 
     # output the result and task ID to output queue
-    out_q.put((ii, vals))
+    out_q.put((ii, list(vals)))
 
 
 def run_tasks(procs, err_q, out_q, num):
@@ -1763,7 +1763,7 @@ def parallel_map(function, sequence, numcores=None):
     size = len(sequence)
 
     if not _multi or size == 1 or (numcores is not None and numcores < 2):
-        return map(function, sequence)
+        return list(map(function, sequence))
 
     if numcores is None:
         numcores = _ncpus

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -17,6 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import pytest
 import numpy
 import multiprocessing
 from numpy.testing import assert_allclose, assert_equal
@@ -263,9 +264,9 @@ class test_utils(SherpaTestCase):
                 val = utils.neville2d(xx, yy, x, y, fval)
                 self.assertTrue(utils.Knuth_close(answer, val, tol))
 
-    def test_parallel_map(self):
-        ncpus = multiprocessing.cpu_count()
 
+@pytest.mark.parametrize("num_tasks", [1, 3, 100])
+def test_parallel_map(num_tasks):
         numtasks = 8
         f = numpy.sum
         iterable = [numpy.arange(1, 2+2*i) for i in range(numtasks)]
@@ -273,6 +274,6 @@ class test_utils(SherpaTestCase):
         result = list(map(f, iterable))
         result = numpy.asarray(result)
 
-        pararesult = utils.parallel_map(f, iterable, ncpus)
+        pararesult = utils.parallel_map(f, iterable, num_tasks)
 
         assert_equal(result, numpy.asarray(pararesult))


### PR DESCRIPTION
Fix #277.

# Release Note
The `utils` function `parallel_map` failed on Python 3 when called with `numcores=1`, i.e. on systems with only one processor/core. This has been fixed.

# Description
Note that the tests have been changed to make them fail (with the fix removed) on all platforms, whatever the number of cores. So, when testing I made sure I would see the 1-core test fail on a system where the old test would pass and then, with the fix back in place, I made sure the test passes again.