### PR TITLE
WIP: Add a python=3.6 build option on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,9 @@ matrix:
       python: "2.7"
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "3.6-dev"
+      # matplotlib is not available for python 3.6 just yet (early Jan 2017)
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule NUMPYVER=1.10
+      python: "3.6"
       sudo: required
       dist: trusty
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
       # matplotlib is not available for python 3.6 just yet (early Jan 2017)
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule NUMPYVER=1.10
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule NUMPYVER=1.11
       python: "3.6"
       sudo: required
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "nightly"
+      python: "3.6-dev"
       sudo: required
       dist: trusty
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ before_install:
     fi
 
 install:
-  - python setup.py $INSTALL_TYPE
+    - python setup.py $INSTALL_TYPE &> install.log
 
 script:
   - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,10 @@ matrix:
       python: "2.7"
   allow_failures:
     - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
+      python: "nightly"
+      sudo: required
+      dist: trusty
 
 env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,12 @@ matrix:
       python: "2.7"
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
-  allow_failures:
-    - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
       python: "nightly"
       sudo: required
       dist: trusty
+  allow_failures:
+    - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
 
 env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
 


### PR DESCRIPTION
Python 3.6 is now close to release, so test out the nightly branch which is
hopefully close to this release: see
https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against
for more details.

I picked the Python 3.5 test as the one to copy, and marked it as
allowed-to-fail, as this is intended to be informational since we do
not claim Python 3.6 support yet.
