### PR TITLE
make the travis logs less verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
     fi
 
 install:
-  - python setup.py $INSTALL_TYPE
+    - python setup.py $INSTALL_TYPE &> install.log
 
 script:
   - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x"; fi


### PR DESCRIPTION
This PR should make the travis log less verbose and avoid hitting the log size limits of Travis.

There are far better solutions (including not relying on Travis any more ;-) ), so that the logs can be recovered if the builds fail, but I can't explore them right now and we need the builds to pass.