### PR TITLE
fix 275, string representation of data classes under py3

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -107,7 +107,7 @@ class DataARF(Data1DInt):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x != 'header'), self._fields)
+            self._fields = tuple(filter((lambda x: x != 'header'), self._fields))
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
@@ -181,7 +181,7 @@ class DataRMF(Data1DInt):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x != 'header'), self._fields)
+            self._fields = tuple(filter((lambda x: x != 'header'), self._fields))
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
@@ -401,7 +401,7 @@ class DataPHA(Data1DInt):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x != 'header'), self._fields)
+            self._fields = tuple(filter((lambda x: x != 'header'), self._fields))
             ss = BaseData.__str__(self)
         finally:
             self._fields = old
@@ -1814,7 +1814,7 @@ class DataIMG(Data2D):
         old = self._fields
         ss = old
         try:
-            self._fields = filter((lambda x: x != 'header'), self._fields)
+            self._fields = tuple(filter((lambda x: x != 'header'), self._fields))
             ss = BaseData.__str__(self)
         finally:
             self._fields = old

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -20,7 +20,7 @@
 import numpy
 from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import DataPHA
-from sherpa.utils import SherpaTestCase
+from sherpa.utils import SherpaTestCase, requires_fits
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -250,6 +250,7 @@ class test_filter_wave_grid(SherpaTestCase):
 
 
 # It would be nice to add some unit testing here, but it's not trivial and time doesn't allow.
+@requires_fits
 def test_bug_275(make_data_path):
     session = Session()
     session.load_data(make_data_path('3c273.pi'))

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -18,6 +18,7 @@
 #
 
 import numpy
+from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import DataPHA
 from sherpa.utils import SherpaTestCase
 
@@ -248,8 +249,14 @@ class test_filter_wave_grid(SherpaTestCase):
         assert (self._ignore==numpy.asarray(self.pha.mask)).all()
 
 
-if __name__ == '__main__':
+# It would be nice to add some unit testing here, but it's not trivial and time doesn't allow.
+def test_bug_275(make_data_path):
+    session = Session()
+    session.load_data(make_data_path('3c273.pi'))
+    str(session.get_data())
+    str(session.get_rmf())
+    str(session.get_arf())
 
-    from sherpa.utils import SherpaTest
-    import sherpa.astro
-    SherpaTest(sherpa.astro).test()
+    session.load_data(make_data_path('img.fits'))
+    str(session.get_data())
+

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -22,7 +22,7 @@ import pytest
 import os
 import sys
 import re
-from sherpa.utils import SherpaTestCase
+from sherpa.utils import SherpaTestCase, requires_data
 
 from six.moves import reload_module
 
@@ -125,6 +125,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="session")
+@requires_data
 def make_data_path():
     """
     Fixture for tests requiring the test data dir. It returns a function that can be used to make paths by using


### PR DESCRIPTION
Fix #275.

# Release Note
Data classes `DataPHA`, `DataARF`, `DataRMF`, `DataIMG`, and `DataIMGInt` in `sherpa.astro.data` would throw an exception if users tried to print them as strings, under Python 3. This has been fixed.