### PR TITLE
rewrite sherpa.stats.Stat.calc_stat and simplify sherpa.fit.Fit (fix #227 #248 #289 #292).

### DIFF
--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -458,6 +458,41 @@ class Data(BaseData):
 
 
 class DataSimulFit(Data):
+    """Store multiple data sets.
+
+    This class lets multiple data sets be treated as a single
+    dataset by concatenation. That is, if two data sets have lengths
+    n1 and n2 then they can be considered as a single data set of
+    length n1 + n2.
+
+    Parameters
+    ----------
+    name : str
+        The name for the collection of data.
+    datasets : sequence of Data objects
+        The datasets to be stored; there must be at least one. They are
+        assumed to behave as sherpa.data.Data objects, but there is no
+        check for this condition.
+
+    Attributes
+    ----------
+    datasets : sequence of Data
+
+    See Also
+    --------
+    sherpa.models.model.SimulFitModel
+
+    Examples
+    --------
+
+    >>> d1 = Data1D('d1', [1, 2, 3], [10, 12, 15])
+    >>> d2 = Data1D('d2', [1, 2, 5, 7], [4, 15, 9, 24])
+    >>> dall = DataSimulFit('comb', (d1, d2))
+    >>> yvals, _, _ = dall.to_fit()
+    >>> print(yvals)
+    [10 12 15  4 15  9 24]
+
+    """
 
     def __init__(self, name, datasets):
         if len(datasets) == 0:

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -41,13 +41,6 @@ info = logging.getLogger(__name__).info
 __all__ = ('FitResults', 'ErrorEstResults', 'Fit')
 
 
-# def get_valid_args(func):
-#     valid_args = func.func_code.co_varnames[:func.func_code.co_argcount]
-#     kwargs_length = len(func.func_defaults)  # number of keyword arguments
-#     valid_kwargs = valid_args[-kwargs_length:]  # because kwargs are last
-#     return valid_kwargs
-
-
 def evaluates_model(func):
     """
     Fit object decorator that runs model startup() and teardown()
@@ -352,10 +345,11 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         self.parmins = ()
         self.parmaxes = ()
         self.nfits = 0
-        success = True
+        # The success flag is currently unused
+        # success = True
         for i in range(len(parlist)):
-            if results[2][i] != est_success:
-                success = False
+            # if results[2][i] != est_success:
+            #     success = False
             if (results[2][i] == est_hardmin or
                     results[2][i] == est_hardminmax):
                 self.parmins = self.parmins + (None,)
@@ -733,11 +727,6 @@ class IterFit(NoNewAttributesAfterInit):
         if grow < 0:
             raise SherpaErr("'grow' factor must be zero or greater")
 
-        # Keep record of current and previous statistics
-        #
-        # In this algorithm however, they do not seem to be used
-        # previous_stat = float32(finfo(float32).max)
-        # current_stat = statfunc(pars)[0]
         nfev = 0
         iters = 0
 
@@ -753,7 +742,13 @@ class IterFit(NoNewAttributesAfterInit):
             else:
                 mask_original.append(array(d.mask))
 
+        # QUS: why is teardown being called now when the model can be
+        #      evaluated multiple times in the following loop?
+        #      Note that after the loop  self.model.startup
+        #      is called, so either I [DJB] or the code has them the
+        #      wrong way around
         self.model.teardown()
+
         final_fit_results = None
         rejected = True
         try:
@@ -841,6 +836,8 @@ class IterFit(NoNewAttributesAfterInit):
 
         self._dep, self._staterror, self._syserror = self.data.to_fit(
             self.stat.calc_staterror)
+
+        # QUS: shouldn't this be teardown, not startup?
         self.model.startup()
 
         # N.B. -- If sigma-rejection in Sherpa 3.4 succeeded,
@@ -1020,9 +1017,7 @@ class Fit(NoNewAttributesAfterInit):
 
         """
 
-        # TODO: does this need to be updated due to changes in _calc_stat?
-        #       also, this logic would be better in the stat class
-        #       than here
+        # TODO: This logic would be better in the stat class than here
         #
         stat, fvec = self._calc_stat()
         model = self.data.eval_model_to_fit(self.model)

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -988,26 +988,9 @@ class Fit(NoNewAttributesAfterInit):
             The overall statistic value and the "per-bin" value.
         """
 
-        # Casting into simultaneous objects is not great (and should
-        # be done in __init__ if we are going to do this).
-        #
-        # Note that, because of Fit.simulfit, we can not assume that
-        # self.data and self.model are single (i.e. not simultaneous)
-        # objects.
-        #
-        if isinstance(self.data, DataSimulFit):
-            data = self.data
-        else:
-            data = DataSimulFit('simulfit data', (self.data,))
-
-        if isinstance(self.model, SimulFitModel):
-            model = self.model
-        else:
-            model = SimulFitModel('simulfit model', (self.model,))
-
         # TODO: is there anything missing here that
         #       self._iterfit.get_extra_args calculates?
-        return self.stat.calc_stat_from_data(data, model)
+        return self.stat.calc_stat_from_data(self.data, self.model)
 
     def calc_stat(self):
         """Calculate the statistic value.
@@ -1055,24 +1038,7 @@ class Fit(NoNewAttributesAfterInit):
         if not hasattr(self.stat, 'calc_chisqr'):
             return None
 
-        # Casting into simultaneous objects is not great (and should
-        # be done in __init__ if we are going to do this).
-        #
-        # Note that, because of Fit.simulfit, we can not assume that
-        # self.data and self.model are single (i.e. not simultaneous)
-        # objects.
-        #
-        if isinstance(self.data, DataSimulFit):
-            data = self.data
-        else:
-            data = DataSimulFit('simulfit data', (self.data,))
-
-        if isinstance(self.model, SimulFitModel):
-            model = self.model
-        else:
-            model = SimulFitModel('simulfit model', (self.model,))
-
-        return self.stat.calc_chisqr(data, model)
+        return self.stat.calc_chisqr(self.data, self.model)
 
     def calc_stat_info(self):
         """Calculate the statistic value and related information.

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -459,7 +459,7 @@ class IterFit(NoNewAttributesAfterInit):
         # Data set attributes needed to store fitting values between
         # calls to fit
         self._dep = None
-        self.extra_args = None
+        # self.extra_args = None
         self._staterror = None
         self._syserror = None
         self._nfev = 0
@@ -482,62 +482,6 @@ class IterFit(NoNewAttributesAfterInit):
     def _sig_handler(self, signum, frame):
         raise KeyboardInterrupt()
 
-    def get_extra_args(self, dep):
-        """get the bkg data for wstat and the user defined statistics"""
-
-        def vectorize_backscale_ratio(bkg_backscal, src_backscal, num):
-            '''return the ratio of bkg_backscal/src_backscal as a numpy
-            array of length n. bkg_backscal and/or src_backscal can be
-            either a floating point number or a numpy array'''
-            if hasattr(bkg_backscal, '__iter__') is False and \
-                    hasattr(src_backscal, '__iter__') is False:
-                # both backscal are floating point numbers, generate arrays
-                bkg = bkg_backscal * ones(num)
-                src = src_backscal
-            else:
-                # at least one of the backscals is a numpy array
-                bkg = bkg_backscal
-                src = src_backscal
-            return bkg / src
-
-        result = {'bkg': None, 'backscale_ratio': None, 'data_size': None,
-                  'exposure_time': None}
-        bkg_dep = []
-        data_size = None
-        exposure_time = None
-        backscale_ratio = []
-
-        len_datasets = len(self.data.datasets)
-        data_size = zeros(len_datasets, dtype=int)
-        exposure_time = zeros(2 * len_datasets)
-        for index in xrange(len_datasets):
-            mydata = self.data.datasets[index]
-            data_size[index] = mydata.get_dep(True).size
-        result['data_size'] = data_size
-        for index in xrange(len_datasets):
-            mydata = self.data.datasets[index]
-            if hasattr(mydata, 'response_ids') and \
-                    hasattr(mydata, 'background_ids') and \
-                    len(mydata.response_ids) and len(mydata.background_ids):
-                bkg = mydata.get_background(mydata.background_ids[0])
-                tmp_bkg_dep = bkg.get_dep(True)
-                # data_size[index] = tmp_bkg_dep.size
-                bkg_dep = append(bkg_dep, tmp_bkg_dep)
-                exposure_time[2 * index] = mydata.exposure
-                exposure_time[2 * index + 1] = bkg.exposure
-                ratio = vectorize_backscale_ratio(bkg.backscal,
-                                                  mydata.backscal,
-                                                  data_size[index])
-                backscale_ratio = append(backscale_ratio, ratio)
-            else:
-                return result
-
-        result['bkg'] = bkg_dep
-        result['backscale_ratio'] = backscale_ratio
-        # result['data_size'] = data_size
-        result['exposure_time'] = exposure_time
-        return result
-
     def _get_callback(self, outfile=None, clobber=False):
         if len(self.model.thawedpars) == 0:
             # raise FitError('model has no thawed parameters')
@@ -552,7 +496,7 @@ class IterFit(NoNewAttributesAfterInit):
         self._dep, self._staterror, self._syserror = self.data.to_fit(
             self.stat.calc_staterror)
 
-        self.extra_args = self.get_extra_args(self._dep)
+        # self.extra_args = self.get_extra_args(self._dep)
         self._nfev = 0
         if outfile is not None:
             if os.path.isfile(outfile) and not clobber:

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -569,10 +569,19 @@ class IterFit(NoNewAttributesAfterInit):
             # linked parameters
 
             self.model.thawedpars = pars
-            model = self.data.eval_model_to_fit(self.model)
-            stat = self.stat.calc_stat(self._dep, model, self._staterror,
-                                       syserror=self._syserror,
-                                       extra_args=self.extra_args)
+
+            # model = self.data.eval_model_to_fit(self.model)
+            # stat = self.stat.calc_stat(self._dep, model, self._staterror,
+            #                            syserror=self._syserror,
+            #                            extra_args=self.extra_args)
+
+            # TODO: does this work for iterated statistics - e.g.
+            #       sigmarej or primini?
+            #       It's not clear what is going along with ._dep and
+            #       ._stat/syserror
+            #
+            stat = self.stat.calc_stat(self.data, self.model)
+
             if self._file is not None:
                 vals = ['%5e %5e' % (self._nfev, stat[0])]
                 vals.extend(['%5e' % val for val in self.model.thawedpars])
@@ -990,7 +999,7 @@ class Fit(NoNewAttributesAfterInit):
 
         # TODO: is there anything missing here that
         #       self._iterfit.get_extra_args calculates?
-        return self.stat.calc_stat_from_data(self.data, self.model)
+        return self.stat.calc_stat(self.data, self.model)
 
     def calc_stat(self):
         """Calculate the statistic value.

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1093,8 +1093,11 @@ class Fit(NoNewAttributesAfterInit):
     def fit(self, outfile=None, clobber=False):
         dep, staterror, syserror = self.data.to_fit(self.stat.calc_staterror)
 
-        # TODO: add tests to check this happens before it can be removed,
-        #       as it should be handled by the calc_stat routine
+        # TODO: This test may already be handled by data.to_fit(),
+        #       which raises DataErr('notmask'), although I have not
+        #       investigated if it is possible to pass that check
+        #       but fail the following.
+        #
         if not iterable(dep) or len(dep) == 0:
             # raise FitError('no noticed bins found in data set')
             raise FitErr('nobins')

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -24,8 +24,7 @@ import logging
 import os
 import signal
 from numpy import arange, array, abs, iterable, sqrt, where, \
-    ones_like, isnan, isinf, float, float32, finfo, nan, any, zeros, append, \
-    int, ones
+    ones_like, isnan, isinf, float, float32, finfo, nan, any, int
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, igamc, \
     bool_cast, is_in, is_iterable, list_to_open_interval, sao_fcmp
 from sherpa.utils.err import FitErr, EstErr, SherpaErr
@@ -33,8 +32,8 @@ from sherpa.data import DataSimulFit
 from sherpa.estmethods import Covariance, EstNewMin
 from sherpa.models import SimulFitModel
 from sherpa.optmethods import LevMar, NelderMead
-from sherpa.stats import Chi2, Chi2Gehrels, Cash, CStat, Chi2ModVar, LeastSq, \
-    Likelihood, WStat, UserStat
+from sherpa.stats import Chi2, Chi2Gehrels, Cash, CStat, Chi2ModVar, \
+    LeastSq, Likelihood, WStat
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info
@@ -66,7 +65,6 @@ def evaluates_model(func):
 
 
 class StatInfoResults(NoNewAttributesAfterInit):
-
     """A summary of the current statistic value for
     one or more data sets.
 
@@ -126,12 +124,12 @@ class StatInfoResults(NoNewAttributesAfterInit):
 
     def format(self):
         s = ''
-        if (self.ids is not None and self.bkg_ids is None):
+        if self.ids is not None and self.bkg_ids is None:
             if len(self.ids) == 1:
                 s = 'Dataset               = %s\n' % str(self.ids[0])
             else:
                 s = 'Datasets              = %s\n' % str(self.ids).strip("()")
-        elif (self.ids is not None and self.bkg_ids is not None):
+        elif self.ids is not None and self.bkg_ids is not None:
             s = 'Background %s in Dataset = %s\n' % (str(self.bkg_ids[0]),
                                                      str(self.ids[0]))
         s += 'Statistic             = %s\n' % self.statname
@@ -146,7 +144,6 @@ class StatInfoResults(NoNewAttributesAfterInit):
 
 
 class FitResults(NoNewAttributesAfterInit):
-
     """A summary of the fit results.
 
     Attributes
@@ -237,8 +234,8 @@ class FitResults(NoNewAttributesAfterInit):
         if isinstance(fit.stat, Chi2) and not isinstance(fit.stat, LeastSq):
             isSimulFit = isinstance(fit.data, DataSimulFit)
             if isSimulFit:
-                is_error_set = [
-                    d.staterror is not None for d in fit.data.datasets]
+                is_error_set = [d.staterror is not None
+                                for d in fit.data.datasets]
                 if all(is_error_set):
                     statname = 'chi2'
             elif fit.data.staterror is not None:
@@ -265,13 +262,13 @@ class FitResults(NoNewAttributesAfterInit):
 
     def format(self):
         s = ''
-        if (self.datasets is not None):
+        if self.datasets is not None:
             if len(self.datasets) == 1:
                 s = 'Dataset               = %s\n' % str(self.datasets[0])
             else:
                 s = 'Datasets              = %s\n' % str(
                     self.datasets).strip("()")
-        if (self.itermethodname is not None and self.itermethodname != 'none'):
+        if self.itermethodname is not None and self.itermethodname != 'none':
             s += 'Iterative Fit Method  = %s\n' % self.itermethodname.capitalize()
         s += 'Method                = %s\n' % self.methodname
         s += 'Statistic             = %s\n' % self.statname
@@ -293,7 +290,8 @@ class FitResults(NoNewAttributesAfterInit):
             for name, val in izip(self.parnames, self.parvals):
                 s += '\n   %-12s   %-12g' % (name, val)
         else:
-            for name, val, covarerr in izip(self.parnames, self.parvals, self.covarerr):
+            for name, val, covarerr in izip(self.parnames, self.parvals,
+                                            self.covarerr):
                 s += '\n   %-12s   %-12g +/- %-12g' % (name, val, covarerr)
 
         if self.param_warnings != "":
@@ -309,10 +307,11 @@ class ErrorEstResults(NoNewAttributesAfterInit):
                'parmaxes', 'nfits')
 
     def __init__(self, fit, results, parlist=None):
-        if (parlist is None):
+        if parlist is None:
             parlist = [p for p in fit.model.pars if not p.frozen]
 
-        from sherpa.estmethods import est_success, est_hardmin, est_hardmax, est_hardminmax
+        from sherpa.estmethods import est_success, est_hardmin, \
+            est_hardmax, est_hardminmax
 
         warning_hmin = "hard minimum hit for parameter "
         warning_hmax = "hard maximum hit for parameter "
@@ -330,7 +329,7 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         self.nfits = 0
         success = True
         for i in range(len(parlist)):
-            if (results[2][i] != est_success):
+            if results[2][i] != est_success:
                 success = False
             if (results[2][i] == est_hardmin or
                     results[2][i] == est_hardminmax):
@@ -365,14 +364,14 @@ class ErrorEstResults(NoNewAttributesAfterInit):
 
     def format(self):
         s = ""
-        if (self.datasets is not None):
+        if self.datasets is not None:
             if len(self.datasets) == 1:
                 s = 'Dataset               = %s\n' % str(self.datasets[0])
             else:
                 s = 'Datasets              = %s\n' % str(
                     self.datasets).strip("()")
         s += 'Confidence Method     = %s\n' % self.methodname
-        if (self.iterfitname is not None or self.iterfitname != 'none'):
+        if self.iterfitname is not None or self.iterfitname != 'none':
             s += 'Iterative Fit Method  = %s\n' % self.iterfitname.capitalize()
         s += 'Fitting Method        = %s\n' % self.fitname
         s += 'Statistic             = %s\n' % self.statname
@@ -391,14 +390,14 @@ class ErrorEstResults(NoNewAttributesAfterInit):
                 if is_iterable(lower):
                     str += ' '
                     str += list_to_open_interval(lower)
-                elif (lower is None):
+                elif lower is None:
                     str += lowstr % '-----'
                 else:
                     str += lownum % lower
                 if is_iterable(upper):
                     str += '  '
                     str += list_to_open_interval(upper)
-                elif (upper is None):
+                elif upper is None:
                     str += highstr % '-----'
                 else:
                     str += highnum % upper
@@ -449,10 +448,10 @@ class IterFit(NoNewAttributesAfterInit):
         # models into the objects needed for simultaneous fitting,
         # if they are not already in such objects.
         self.data = data
-        if (type(data) is not DataSimulFit):
+        if type(data) is not DataSimulFit:
             self.data = DataSimulFit('simulfit data', (data,))
         self.model = model
-        if (type(model) is not SimulFitModel):
+        if type(model) is not SimulFitModel:
             self.model = SimulFitModel('simulfit model', (model,))
         self.stat = stat
         self.method = method
@@ -469,7 +468,7 @@ class IterFit(NoNewAttributesAfterInit):
         self.iterate = False
         self.funcs = {'primini': self.primini, 'sigmarej': self.sigmarej}
         self.current_func = None
-        if (itermethod_opts['name'] != 'none'):
+        if itermethod_opts['name'] != 'none':
             self.current_func = self.funcs[itermethod_opts['name']]
             self.iterate = True
 
@@ -484,7 +483,6 @@ class IterFit(NoNewAttributesAfterInit):
 
     def _get_callback(self, outfile=None, clobber=False):
         if len(self.model.thawedpars) == 0:
-            # raise FitError('model has no thawed parameters')
             raise FitErr('nothawedpar')
 
         # support Sherpa use with SAMP
@@ -499,8 +497,7 @@ class IterFit(NoNewAttributesAfterInit):
         # self.extra_args = self.get_extra_args(self._dep)
         self._nfev = 0
         if outfile is not None:
-            if os.path.isfile(outfile) and not clobber:
-                # raise FitError("'%s' exists, and clobber==False" % outfile)
+            if not clobber and os.path.isfile(outfile):
                 raise FitErr('noclobererr', outfile)
             self._file = open(outfile, 'w')
             names = ['# nfev statistic']
@@ -513,17 +510,6 @@ class IterFit(NoNewAttributesAfterInit):
             # linked parameters
 
             self.model.thawedpars = pars
-
-            # model = self.data.eval_model_to_fit(self.model)
-            # stat = self.stat.calc_stat(self._dep, model, self._staterror,
-            #                            syserror=self._syserror,
-            #                            extra_args=self.extra_args)
-
-            # TODO: does this work for iterated statistics - e.g.
-            #       sigmarej or primini?
-            #       It's not clear what is going along with ._dep and
-            #       ._stat/syserror
-            #
             stat = self.stat.calc_stat(self.data, self.model)
 
             if self._file is not None:
@@ -591,12 +577,11 @@ class IterFit(NoNewAttributesAfterInit):
         # Get tolerance, max number of iterations from the
         # dictionary for Primini's method
         tol = self.itermethod_opts['tol']
-        if (type(tol) != int and
-                type(tol) != float):
+        if type(tol) != int and type(tol) != float:
             raise SherpaErr(
                 "'tol' value for Primini's method must be a number")
         maxiters = self.itermethod_opts['maxiters']
-        if (type(maxiters) != int):
+        if type(maxiters) != int:
             raise SherpaErr(
                 "'maxiters' value for Primini's method must be an integer")
 
@@ -626,8 +611,8 @@ class IterFit(NoNewAttributesAfterInit):
         # agree to within tolerance.
         final_fit_results = None
         try:
-            while (sao_fcmp(previous_stat, current_stat, tol) != 0 and
-                   iters < maxiters):
+            while (iters < maxiters and
+                   sao_fcmp(previous_stat, current_stat, tol) != 0):
                 final_fit_results = self.method.fit(statfunc,
                                                     self.model.thawedpars,
                                                     parmins, parmaxes,
@@ -694,39 +679,40 @@ class IterFit(NoNewAttributesAfterInit):
         # to include with rejected data point).
 
         maxiters = self.itermethod_opts['maxiters']
-        if (type(maxiters) != int):
+        if type(maxiters) != int:
             raise SherpaErr(
                 "'maxiters' value for sigma rejection method must be an integer")
-        if (maxiters < 1):
+        if maxiters < 1:
             raise SherpaErr("'maxiters' must be one or greater")
 
         hrej = self.itermethod_opts['hrej']
-        if (type(hrej) != int and
-                type(hrej) != float):
+        if type(hrej) != int and type(hrej) != float:
             raise SherpaErr(
                 "'hrej' value for sigma rejection method must be a number")
-        if (not (hrej > 0)):
+        if hrej <= 0:
             raise SherpaErr("'hrej' must be greater than zero")
 
         lrej = self.itermethod_opts['lrej']
         # FIXME: [OL] There are more reliable ways of checking if an object
         # is (not) a number.
-        if (type(lrej) != int and type(lrej) != float):
+        if type(lrej) != int and type(lrej) != float:
             raise SherpaErr(
                 "'lrej' value for sigma rejection method must be a number")
         if lrej <= 0:
             raise SherpaErr("'lrej' must be greater than zero")
 
         grow = self.itermethod_opts['grow']
-        if (type(grow) != int):
+        if type(grow) != int:
             raise SherpaErr(
                 "'grow' value for sigma rejection method must be an integer")
-        if (grow < 0):
+        if grow < 0:
             raise SherpaErr("'grow' factor must be zero or greater")
 
         # Keep record of current and previous statistics
-        previous_stat = float32(finfo(float32).max)
-        current_stat = statfunc(pars)[0]
+        #
+        # In this algorithm however, they do not seem to be used
+        # previous_stat = float32(finfo(float32).max)
+        # current_stat = statfunc(pars)[0]
         nfev = 0
         iters = 0
 
@@ -736,7 +722,7 @@ class IterFit(NoNewAttributesAfterInit):
         for d in self.data.datasets:
             # If there's no filter, create a filter that is
             # all True
-            if (iterable(d.mask) != True):
+            if not iterable(d.mask):
                 mask_original.append(d.mask)
                 d.mask = ones_like(array(d.get_dep(False), dtype=bool))
             else:
@@ -746,7 +732,7 @@ class IterFit(NoNewAttributesAfterInit):
         final_fit_results = None
         rejected = True
         try:
-            while (rejected and iters < maxiters):
+            while rejected and iters < maxiters:
                 # Update stored y, staterror and syserror values
                 # from data, so callback function will work properly
                 self._dep, self._staterror, self._syserror = self.data.to_fit(
@@ -776,19 +762,17 @@ class IterFit(NoNewAttributesAfterInit):
                     j = 0
                     kmin = 0
                     for i in xrange(0, ressize):
-                        while (newmask[j] == False and
-                               j < filsize):
+                        while newmask[j] is False and j < filsize:
                             j = j + 1
-                        if (j >= filsize):
+                        if j >= filsize:
                             break
-                        if (residuals[i] <= -lrej or
-                                residuals[i] >= hrej):
+                        if residuals[i] <= -lrej or residuals[i] >= hrej:
                             rejected = True
                             kmin = j - grow
-                            if (kmin < 0):
+                            if kmin < 0:
                                 kmin = 0
                             kmax = j + grow
-                            if (kmax >= filsize):
+                            if kmax >= filsize:
                                 kmax = filsize - 1
                             for k in xrange(kmin, kmax + 1):
                                 newmask[k] = False
@@ -797,20 +781,19 @@ class IterFit(NoNewAttributesAfterInit):
                         # If we've masked out *all* data,
                         # immediately raise fit error, clean up
                         # on way out.
-                        if (any(newmask) == False):
+                        if any(newmask) is False:
                             raise FitErr('nobins')
                         d.mask = newmask
 
                 # For data sets with backgrounds, correct that
                 # backgrounds have masks that match their sources
                 for d in self.data.datasets:
-                    if (hasattr(d, "background_ids") == True and
-                            hasattr(d, "get_background") == True):
+                    if (hasattr(d, "background_ids") and
+                            hasattr(d, "get_background")):
                         for bid in d.background_ids:
                             b = d.get_background(bid)
-                            if (iterable(b.mask) == True and
-                                    iterable(d.mask) == True):
-                                if (len(b.mask) == len(d.mask)):
+                            if iterable(b.mask) and iterable(d.mask):
+                                if len(b.mask) == len(d.mask):
                                     b.mask = d.mask
 
                 # teardown model, get ready for next iteration
@@ -848,7 +831,8 @@ class IterFit(NoNewAttributesAfterInit):
         # Return results from sigma rejection
         return final_fit_results
 
-    def fit(self, statfunc, pars, parmins, parmaxes, statargs=(), statkwargs=None):
+    def fit(self, statfunc, pars, parmins, parmaxes,
+            statargs=(), statkwargs=None):
         if statkwargs is None:
             statkwargs = {}
         if not self.iterate:
@@ -909,7 +893,8 @@ class Fit(NoNewAttributesAfterInit):
         self.__dict__.update(state)
 
         if '_iterfit' not in state:
-            self.__dict__['_iterfit'] = IterFit(self.data, self.model, self.stat, self.method,
+            self.__dict__['_iterfit'] = IterFit(self.data, self.model,
+                                                self.stat, self.method,
                                                 {'name': 'none'})
 
     def __str__(self):
@@ -1032,8 +1017,8 @@ class Fit(NoNewAttributesAfterInit):
         if isinstance(self.stat, Chi2) and not isinstance(self.stat, LeastSq):
             isSimulFit = isinstance(self.data, DataSimulFit)
             if isSimulFit:
-                is_error_set = [
-                    d.staterror is not None for d in self.data.datasets]
+                is_error_set = [d.staterror is not None
+                                for d in self.data.datasets]
                 if all(is_error_set):
                     name = 'chi2'
             elif self.data.staterror is not None:
@@ -1052,15 +1037,12 @@ class Fit(NoNewAttributesAfterInit):
         #       but fail the following.
         #
         if not iterable(dep) or len(dep) == 0:
-            # raise FitError('no noticed bins found in data set')
             raise FitErr('nobins')
 
         if ((iterable(staterror) and 0.0 in staterror) and
                 isinstance(self.stat, Chi2) and
                 type(self.stat) != Chi2 and
                 type(self.stat) != Chi2ModVar):
-            # raise FitError('zeros found in uncertainties, consider using' +
-            #               ' calculated uncertainties')
             raise FitErr('binhas0')
 
         init_stat = self.calc_stat()
@@ -1133,7 +1115,7 @@ class Fit(NoNewAttributesAfterInit):
             return (current_pars, current_parmins, current_parmaxes)
 
         def thaw_par(i):
-            if (i < 0):
+            if i < 0:
                 pass
             else:
                 self.model.pars[self.thaw_indices[i]].frozen = False
@@ -1146,7 +1128,7 @@ class Fit(NoNewAttributesAfterInit):
         # Call from a parameter estimation method, to report
         # that limits for a given parameter have been found
         def report_progress(i, lower, upper):
-            if (i < 0):
+            if i < 0:
                 pass
             else:
                 name = self.model.pars[self.thaw_indices[i]].fullname
@@ -1164,17 +1146,14 @@ class Fit(NoNewAttributesAfterInit):
         # more than 3, don't bother calling method to estimate
         # parameter limits.
 
-        if (type(self.stat) is LeastSq):
-            # raise FitError('cannot estimate confidence limits with ' +
-            #               type(self.stat).__name__)
+        if type(self.stat) is LeastSq:
             raise EstErr('noerr4least2', type(self.stat).__name__)
 
-        if (type(self.stat) is not Cash):
+        if type(self.stat) is not Cash:
             dep, staterror, syserror = self.data.to_fit(
                 self.stat.calc_staterror)
 
             if not iterable(dep) or len(dep) == 0:
-                #raise FitError('no noticed bins found in data set')
                 raise FitErr('nobins')
 
             # For chi-squared and C-stat, reduced statistic is
@@ -1184,14 +1163,11 @@ class Fit(NoNewAttributesAfterInit):
             # Degress of freedom are number of data bins included
             # in fit, minus the number of thawed parameters.
             dof = len(dep) - len(self.model.thawedpars)
-            if (dof < 1):
-                #raise FitError('degrees of freedom are zero or lower')
+            if dof < 1:
                 raise EstErr('nodegfreedom')
 
             if (hasattr(self.estmethod, "max_rstat") and
                     (self.calc_stat() / dof) > self.estmethod.max_rstat):
-                # raise FitError('reduced statistic larger than ' +
-                #               str(self.estmethod.max_rstat))
                 raise EstErr('rstat>max', str(self.estmethod.max_rstat))
 
         # If statistic is chi-squared, change fitting method to
@@ -1211,13 +1187,13 @@ class Fit(NoNewAttributesAfterInit):
         if (hasattr(self.estmethod, "fast") and
                 bool_cast(self.estmethod.fast) and
                 methoddict is not None):
-            if (isinstance(self.stat, Likelihood)):
-                if (type(self.method) is not NelderMead):
+            if isinstance(self.stat, Likelihood):
+                if type(self.method) is not NelderMead:
                     self.method = methoddict['neldermead']
                     warning("Setting optimization to " + self.method.name
                             + " for confidence limit search")
             else:
-                if (type(self.method) is not LevMar):
+                if type(self.method) is not LevMar:
                     self.method = methoddict['levmar']
                     warning("Setting optimization to " + self.method.name
                             + " for confidence limit search")
@@ -1233,7 +1209,7 @@ class Fit(NoNewAttributesAfterInit):
 
         # If restricted to soft_limits, only send soft limits to
         # method, and do not reset model limits
-        if (bool_cast(self.estmethod.soft_limits) is True):
+        if bool_cast(self.estmethod.soft_limits):
             starthardmins = self.model.thawedparmins
             starthardmaxs = self.model.thawedparmaxes
         else:
@@ -1277,7 +1253,7 @@ class Fit(NoNewAttributesAfterInit):
         output = None
         results = None
         oldremin = -1.0
-        if (hasattr(self.estmethod, "remin")):
+        if hasattr(self.estmethod, "remin"):
             oldremin = self.estmethod.remin
         try:
             output = self.estmethod.compute(self._iterfit._get_callback(),
@@ -1301,7 +1277,7 @@ class Fit(NoNewAttributesAfterInit):
                 self.model.thawedparmins = startsoftmins
                 self.model.thawedparmaxes = startsoftmaxs
                 self.method = oldmethod
-                if (hasattr(self.estmethod, "remin")):
+                if hasattr(self.estmethod, "remin"):
                     self.estmethod.remin = -1.0
                 warning("Maximum number of reminimizations reached")
 
@@ -1318,8 +1294,8 @@ class Fit(NoNewAttributesAfterInit):
             self.model.thawedparmaxes = startsoftmaxs
             results = self.fit()
             self.refits = self.refits + 1
-            warning(
-                "New minimum statistic found while computing confidence limits")
+            warning("New minimum statistic found while computing " +
+                    "confidence limits")
             warning("New best-fit parameters:\n" + results.format())
 
             # Now, recompute errors for new best-fit parameters
@@ -1327,7 +1303,7 @@ class Fit(NoNewAttributesAfterInit):
             self.model.thawedparmins = startsoftmins
             self.model.thawedparmaxes = startsoftmaxs
             self.method = oldmethod
-            if (hasattr(self.estmethod, "remin")):
+            if hasattr(self.estmethod, "remin"):
                 self.estmethod.remin = oldremin
             return results
         except:
@@ -1338,7 +1314,7 @@ class Fit(NoNewAttributesAfterInit):
             self.model.thawedparmins = startsoftmins
             self.model.thawedparmaxes = startsoftmaxs
             self.method = oldmethod
-            if (hasattr(self.estmethod, "remin")):
+            if hasattr(self.estmethod, "remin"):
                 self.estmethod.remin = oldremin
             raise
 
@@ -1350,7 +1326,7 @@ class Fit(NoNewAttributesAfterInit):
         self.model.thawedparmaxes = startsoftmaxs
         results = ErrorEstResults(self, output, parlist)
         self.method = oldmethod
-        if (hasattr(self.estmethod, "remin")):
+        if hasattr(self.estmethod, "remin"):
             self.estmethod.remin = oldremin
 
         return results

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1126,6 +1126,9 @@ class Fit(NoNewAttributesAfterInit):
     @evaluates_model
     def fit(self, outfile=None, clobber=False):
         dep, staterror, syserror = self.data.to_fit(self.stat.calc_staterror)
+
+        # TODO: add tests to check this happens before it can be removed,
+        #       as it should be handled by the calc_stat routine
         if not iterable(dep) or len(dep) == 0:
             # raise FitError('no noticed bins found in data set')
             raise FitErr('nobins')
@@ -1137,12 +1140,6 @@ class Fit(NoNewAttributesAfterInit):
             # raise FitError('zeros found in uncertainties, consider using' +
             #               ' calculated uncertainties')
             raise FitErr('binhas0')
-
-        if (getattr(self.data, 'subtracted', False) and
-                isinstance(self.stat, Likelihood)):
-            # raise FitError('%s statistics cannot be used with background'
-            #               % self.stat.name + ' subtracted data')
-            raise FitErr('statnotforbackgsub', self.stat.name)
 
         init_stat = self.calc_stat()
         # output = self.method.fit ...

--- a/sherpa/include/sherpa/stats.hh
+++ b/sherpa/include/sherpa/stats.hh
@@ -36,11 +36,11 @@ namespace sherpa { namespace stats {
   //
   template <typename ArrayType, typename ConstArrayType, typename DataType,
 	    typename IndexType>
-  inline int calc_cstat_stat2( IndexType num, const ConstArrayType& yraw,
-                               const ConstArrayType& model,
-                               const ConstArrayType& weight,
-                               ArrayType& fvec, DataType& stat,
-                               DataType& trunc_value ) {
+  inline int calc_cstat_stat( IndexType num, const ConstArrayType& yraw,
+                              const ConstArrayType& model,
+                              const ConstArrayType& weight,
+                              ArrayType& fvec, DataType& stat,
+                              DataType& trunc_value ) {
 
     DataType mymodel;
     for ( IndexType ii = num - 1; ii >= 0; --ii ) {
@@ -86,10 +86,10 @@ namespace sherpa { namespace stats {
   //
   template <typename ArrayType, typename ConstArrayType, typename DataType,
 	    typename IndexType>
-  inline int calc_cash_stat2( IndexType num, const ConstArrayType& yraw,
-                              const ConstArrayType& model,
-                              const ConstArrayType& weight, ArrayType& fvec,
-                              DataType& stat, DataType& trunc_value ) {
+  inline int calc_cash_stat( IndexType num, const ConstArrayType& yraw,
+                             const ConstArrayType& model,
+                             const ConstArrayType& weight, ArrayType& fvec,
+                             DataType& stat, DataType& trunc_value ) {
 
     DataType mymodel, d;
     for ( IndexType ii = num - 1; ii >= 0; --ii ) {
@@ -120,8 +120,8 @@ namespace sherpa { namespace stats {
 
     {
       DataType junkcstat;
-      return calc_cstat_stat2( num, yraw, model, weight, fvec,
-                               junkcstat, trunc_value );
+      return calc_cstat_stat( num, yraw, model, weight, fvec,
+                              junkcstat, trunc_value );
     }
 
     return EXIT_SUCCESS;

--- a/sherpa/include/sherpa/stats.hh
+++ b/sherpa/include/sherpa/stats.hh
@@ -36,55 +36,6 @@ namespace sherpa { namespace stats {
   //
   template <typename ArrayType, typename ConstArrayType, typename DataType,
 	    typename IndexType>
-  inline int calc_cstat_stat( IndexType num, const ConstArrayType& yraw,
-                              const ConstArrayType& model,
-                              const ConstArrayType& error,
-                              const ConstArrayType& syserror,
-                              const ConstArrayType& weight,
-                              ArrayType& fvec, DataType& stat,
-                              DataType& trunc_value ) {
-
-    DataType mymodel;
-    for ( IndexType ii = num - 1; ii >= 0; --ii ) {
-
-      if ( model[ ii ] > 0.0) 
-	mymodel = model[ ii ];
-      else {
-	if (trunc_value > 0)
-	  mymodel = trunc_value;
-	else
-	  return EXIT_FAILURE;
-      }
-
-      if( yraw[ ii ] > 0.0 )
-	fvec[ ii ] = mymodel - yraw[ ii ] +
-	  yraw[ ii ] * ( std::log( yraw[ ii ] / mymodel ) );
-      else if ( yraw[ ii ] == 0.0 )
-	fvec[ ii ] = mymodel;
-      else
-	return EXIT_FAILURE;
-
-      // weight is not given in the following url
-      // https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
-      if ( weight )
-	fvec[ ii ] *= weight[ ii ];
-     
-    }
- 
-    stat = 2.0 *
-      sherpa::utils::kahan_sum< ArrayType, DataType, IndexType >( num, fvec );
-
-    DataType sqrt2 = std::sqrt( 2.0 );
-    for ( IndexType ii = num - 1; ii >= 0; --ii )
-      fvec[ ii ] = sqrt2 * std::sqrt( std::fabs(fvec[ii]) );
-
-    return EXIT_SUCCESS;
-
-  }
-
-
-  template <typename ArrayType, typename ConstArrayType, typename DataType,
-	    typename IndexType>
   inline int calc_cstat_stat2( IndexType num, const ConstArrayType& yraw,
                                const ConstArrayType& model,
                                const ConstArrayType& weight,
@@ -127,56 +78,6 @@ namespace sherpa { namespace stats {
 
     return EXIT_SUCCESS;
 
-  }
-
-
-  //
-  // fvec is needed for chi square and lmdif, it is not needed for Cash
-  //
-  template <typename ArrayType, typename ConstArrayType, typename DataType,
-	    typename IndexType>
-  inline int calc_cash_stat( IndexType num, const ConstArrayType& yraw,
-                             const ConstArrayType& model,
-                             const ConstArrayType& error,
-                             const ConstArrayType& syserror,
-                             const ConstArrayType& weight, ArrayType& fvec,
-                             DataType& stat, DataType& trunc_value ) {
-
-    DataType mymodel, d;
-    for ( IndexType ii = num - 1; ii >= 0; --ii ) {
-      
-      if ( model[ ii ] > 0.0) 
-	mymodel = model[ ii ];
-      else {
-	if (trunc_value > 0)
-	  mymodel = trunc_value;
-	else
-	  return EXIT_FAILURE;
-      }
-      
-      if ( 0.0 == yraw[ ii ] )
-      	d = mymodel;
-      else
-	d = mymodel - ( yraw[ ii ] * std::log( mymodel ) );
-      
-      if ( weight )
-	d *= weight[ ii ];
- 
-      fvec[ ii ] = d;
-
-    }
- 
-    stat = 2.0 *
-      sherpa::utils::kahan_sum< ArrayType, DataType, IndexType >( num, fvec );
-
-    {
-      DataType junkcstat;
-      return calc_cstat_stat( num, yraw, model, error, syserror, weight, fvec,
-			      junkcstat, trunc_value );
-    }
-
-    return EXIT_SUCCESS;
- 
   }
 
 

--- a/sherpa/include/sherpa/stats.hh
+++ b/sherpa/include/sherpa/stats.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -83,6 +83,53 @@ namespace sherpa { namespace stats {
   }
 
 
+  template <typename ArrayType, typename ConstArrayType, typename DataType,
+	    typename IndexType>
+  inline int calc_cstat_stat2( IndexType num, const ConstArrayType& yraw,
+                               const ConstArrayType& model,
+                               const ConstArrayType& weight,
+                               ArrayType& fvec, DataType& stat,
+                               DataType& trunc_value ) {
+
+    DataType mymodel;
+    for ( IndexType ii = num - 1; ii >= 0; --ii ) {
+
+      if ( model[ ii ] > 0.0) 
+	mymodel = model[ ii ];
+      else {
+	if (trunc_value > 0)
+	  mymodel = trunc_value;
+	else
+	  return EXIT_FAILURE;
+      }
+
+      if( yraw[ ii ] > 0.0 )
+	fvec[ ii ] = mymodel - yraw[ ii ] +
+	  yraw[ ii ] * ( std::log( yraw[ ii ] / mymodel ) );
+      else if ( yraw[ ii ] == 0.0 )
+	fvec[ ii ] = mymodel;
+      else
+	return EXIT_FAILURE;
+
+      // weight is not given in the following url
+      // https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
+      if ( weight )
+	fvec[ ii ] *= weight[ ii ];
+     
+    }
+ 
+    stat = 2.0 *
+      sherpa::utils::kahan_sum< ArrayType, DataType, IndexType >( num, fvec );
+
+    DataType sqrt2 = std::sqrt( 2.0 );
+    for ( IndexType ii = num - 1; ii >= 0; --ii )
+      fvec[ ii ] = sqrt2 * std::sqrt( std::fabs(fvec[ii]) );
+
+    return EXIT_SUCCESS;
+
+  }
+
+
   //
   // fvec is needed for chi square and lmdif, it is not needed for Cash
   //
@@ -126,6 +173,54 @@ namespace sherpa { namespace stats {
       DataType junkcstat;
       return calc_cstat_stat( num, yraw, model, error, syserror, weight, fvec,
 			      junkcstat, trunc_value );
+    }
+
+    return EXIT_SUCCESS;
+ 
+  }
+
+
+  //
+  // fvec is needed for chi square and lmdif, it is not needed for Cash
+  //
+  template <typename ArrayType, typename ConstArrayType, typename DataType,
+	    typename IndexType>
+  inline int calc_cash_stat2( IndexType num, const ConstArrayType& yraw,
+                              const ConstArrayType& model,
+                              const ConstArrayType& weight, ArrayType& fvec,
+                              DataType& stat, DataType& trunc_value ) {
+
+    DataType mymodel, d;
+    for ( IndexType ii = num - 1; ii >= 0; --ii ) {
+      
+      if ( model[ ii ] > 0.0) 
+	mymodel = model[ ii ];
+      else {
+	if (trunc_value > 0)
+	  mymodel = trunc_value;
+	else
+	  return EXIT_FAILURE;
+      }
+      
+      if ( 0.0 == yraw[ ii ] )
+      	d = mymodel;
+      else
+	d = mymodel - ( yraw[ ii ] * std::log( mymodel ) );
+      
+      if ( weight )
+	d *= weight[ ii ];
+ 
+      fvec[ ii ] = d;
+
+    }
+ 
+    stat = 2.0 *
+      sherpa::utils::kahan_sum< ArrayType, DataType, IndexType >( num, fvec );
+
+    {
+      DataType junkcstat;
+      return calc_cstat_stat2( num, yraw, model, weight, fvec,
+                               junkcstat, trunc_value );
     }
 
     return EXIT_SUCCESS;

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -312,6 +312,38 @@ class CompositeModel(Model):
 
 
 class SimulFitModel(CompositeModel):
+    """Store multiple models.
+
+    This class is for use with sherpa.data.DataSimulFit.
+
+    Parameters
+    ----------
+    name : str
+        The name for the collection of models.
+    parts : sequence of Model objects
+        The models.
+
+    Attributes
+    ----------
+    parts : sequence of Model
+
+    See Also
+    --------
+    sherpa.data.DataSimulFit
+
+    Examples
+    --------
+
+    >>> m1 = Polynom1D('m1')
+    >>> m2 = Gauss1D('g1')
+    >>> mall = SimulFitModel('comp', (m1, m1 + m2))
+
+    If dall is a DataSimulFit object then the model components
+    can be evaluated for the composite object using:
+
+    >>> ymdl = dall.eval_model_to_fit(mall)
+
+    """
 
     def __iter__(self):
         return iter(self.parts)

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -782,8 +782,10 @@ class WStat(Likelihood):
             #
             dummy = numpy.ones(dset.get_dep(False).size)
 
-            # Combine the BACKSCAL values by using the middle element
-            # of the group.
+            # Combine the BACKSCAL values (use the default _middle
+            # scheme as this is used elsewhere when combining
+            # BACKSCAL values; perhaps there should be an API call
+            # for this?).
             #
             src_backscal = dset.apply_filter(dset.backscal * dummy,
                                              groupfunc=dset._middle)

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -381,6 +381,33 @@ class Chi2(Stat):
                           None,  # TODO: weights
                           truncation_value)
 
+    def calc_chisqr(self, data, model):
+        """Return the chi-square value for each bin.
+
+        Parameters
+        ----------
+        data : a DataSimulFit instance
+            The data sets to use.
+        model : a SimulFitModel instance
+            The model expressions for each data set. It must match
+            the data parameter (the models are in the same order
+            as the data objects).
+
+        Returns
+        -------
+        chisqr : array of numbers
+            The per-bin chi-square values.
+
+        Notes
+        -----
+        Would it be a good idea to support "casting" a single data set
+        and model input into the relevant SimulFit instances, rather than
+        forcing the caller to?
+        """
+
+        _, fvec = self.calc_stat_from_data(data, model)
+        return fvec * fvec
+
 
 class LeastSq(Chi2):
     """Least Squared Statistic.

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -58,7 +58,7 @@ def get_syserror_weight_extra(dictionary):
 
 class Stat(NoNewAttributesAfterInit):
 
-    # Used by calc_stat_from_data.
+    # Used by calc_stat
     #
     _calc = None
 
@@ -199,10 +199,11 @@ class Stat(NoNewAttributesAfterInit):
     def calc_staterror(self, data):
         raise NotImplementedError
 
-    def calc_stat(self, data, model, staterror, *args, **kwargs):
-        raise NotImplementedError
+    # def calc_stat(self, data, model, staterror, *args, **kwargs):
+    #     raise NotImplementedError
 
-    def calc_stat_from_data(self, data, model):
+    # TODO: add *args, **kwargs?
+    def calc_stat(self, data, model):
         """Return the statistic value for the data and model.
 
         Parameters
@@ -264,7 +265,7 @@ class Likelihood(Stat):
         self._check_background_subtraction(data)
         return data, model
 
-    def calc_stat_from_data(self, data, model):
+    def calc_stat(self, data, model):
         data, model = self._validate_inputs(data, model)
         fitdata = data.to_fit(staterrfunc=self.calc_staterror)
         modeldata = data.eval_model_to_fit(model)
@@ -350,12 +351,6 @@ class Cash(Likelihood):
     def __init__(self, name='cash'):
         Likelihood.__init__(self, name)
 
-    @staticmethod
-    def calc_stat(data, model, staterror, *args, **kwargs):
-        syserror, weight, extra = get_syserror_weight_extra(kwargs)
-        return _statfcts.calc_cash_stat(data, model, staterror, syserror,
-                                        weight, truncation_value)
-
 
 class CStat(Likelihood):
     """Maximum likelihood function (XSPEC style).
@@ -428,12 +423,6 @@ class CStat(Likelihood):
     def __init__(self, name='cstat'):
         Likelihood.__init__(self, name)
 
-    @staticmethod
-    def calc_stat(data, model, staterror, *args, **kwargs):
-        syserror, weight, extra = get_syserror_weight_extra(kwargs)
-        return _statfcts.calc_cstat_stat(data, model, staterror, syserror,
-                                         weight, truncation_value)
-
 
 class Chi2(Stat):
     """Chi Squared statistic.
@@ -490,13 +479,13 @@ class Chi2(Stat):
     def calc_staterror(data):
         raise StatErr('chi2noerr')
 
-    @staticmethod
-    def calc_stat(data, model, staterror, *args, **kwargs):
-        syserror, weight, extra = get_syserror_weight_extra(kwargs)
-        return _statfcts.calc_chi2_stat(data, model, staterror,
-                                        syserror, weight, truncation_value)
+    #@staticmethod
+    #def calc_stat(data, model, staterror, *args, **kwargs):
+    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
+    #    return _statfcts.calc_chi2_stat(data, model, staterror,
+    #                                    syserror, weight, truncation_value)
 
-    def calc_stat_from_data(self, data, model):
+    def calc_stat(self, data, model):
         """TODO: should weights be an argument or taken from data?"""
 
         # TODO: HOW TO GET THE WEIGHTS?
@@ -526,14 +515,9 @@ class Chi2(Stat):
         chisqr : array of numbers
             The per-bin chi-square values.
 
-        Notes
-        -----
-        Would it be a good idea to support "casting" a single data set
-        and model input into the relevant SimulFit instances, rather than
-        forcing the caller to?
         """
 
-        _, fvec = self.calc_stat_from_data(data, model)
+        _, fvec = self.calc_stat(data, model)
         return fvec * fvec
 
 
@@ -554,11 +538,11 @@ class LeastSq(Chi2):
     def calc_staterror(data):
         return numpy.ones_like(data)
 
-    @staticmethod
-    def calc_stat(data, model, staterror, *args, **kwargs):
-        syserror, weight, extra = get_syserror_weight_extra(kwargs)
-        return _statfcts.calc_lsq_stat(data, model, staterror,
-                                       syserror, weight, truncation_value)
+    #@staticmethod
+    #def calc_stat(data, model, staterror, *args, **kwargs):
+    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
+    #    return _statfcts.calc_lsq_stat(data, model, staterror,
+    #                                   syserror, weight, truncation_value)
 
 
 class Chi2Gehrels(Chi2):
@@ -681,12 +665,12 @@ class Chi2ModVar(Chi2):
     def calc_staterror(data):
         return numpy.zeros_like(data)
 
-    @staticmethod
-    def calc_stat(data, model, staterror, *args, **kwargs):
-        syserror, weight, extra = get_syserror_weight_extra(kwargs)
-        return _statfcts.calc_chi2modvar_stat(data, model, staterror,
-                                              syserror, weight,
-                                              truncation_value)
+    #@staticmethod
+    #def calc_stat(data, model, staterror, *args, **kwargs):
+    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
+    #    return _statfcts.calc_chi2modvar_stat(data, model, staterror,
+    #                                          syserror, weight,
+    #                                          truncation_value)
 
 
 class Chi2XspecVar(Chi2):
@@ -756,9 +740,9 @@ class UserStat(Stat):
             raise StatErr('nostat', self.name, 'calc_staterror()')
         return self.errfunc(data)
 
-    def calc_stat(self, data, model, staterror, *args, **kwargs):
-        if not self._statfuncset:
-            raise StatErr('nostat', self.name, 'calc_stat()')
+    # def calc_stat(self, data, model, staterror, *args, **kwargs):
+    #     if not self._statfuncset:
+    #          raise StatErr('nostat', self.name, 'calc_stat()')
 
         # if bkg is None or bkg['bkg'] is None:
         #     return self.statfunc(data, model, staterror, syserror, weight)
@@ -766,8 +750,9 @@ class UserStat(Stat):
         #     return self.statfunc(data, model, staterror, syserror, weight,
         #                          bkg['bkg'])
 
-    def calc_stat_from_data(self, data, model, *args, **kwargs):
-        raise StatErr('nostat', self.name, 'calc_stat_from_data()')
+    # def calc_stat(self, data, model, *args, **kwargs):
+    def calc_stat(self, data, model):
+        raise StatErr('nostat', self.name, 'calc_stat()')
 
 
 class WStat(Likelihood):
@@ -837,21 +822,21 @@ class WStat(Likelihood):
     def __init__(self, name='wstat'):
         Likelihood.__init__(self, name)
 
-    @staticmethod
-    def calc_stat(data, model, staterror, *args, **kwargs):
+    #@staticmethod
+    #def calc_stat(data, model, staterror, *args, **kwargs):
+    #
+    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
+    #    if extra is None or extra['bkg'] is None:
+    #        raise StatErr('usecstat')
+    #
+    #    return _statfcts.calc_wstat_stat(data, model,
+    #                                     extra['data_size'],
+    #                                     extra['exposure_time'],
+    #                                     extra['bkg'],
+    #                                     extra['backscale_ratio'],
+    #                                     truncation_value)
 
-        syserror, weight, extra = get_syserror_weight_extra(kwargs)
-        if extra is None or extra['bkg'] is None:
-            raise StatErr('usecstat')
-
-        return _statfcts.calc_wstat_stat(data, model,
-                                         extra['data_size'],
-                                         extra['exposure_time'],
-                                         extra['bkg'],
-                                         extra['backscale_ratio'],
-                                         truncation_value)
-
-    def calc_stat_from_data(self, data, model):
+    def calc_stat(self, data, model):
 
         data, model = self._validate_inputs(data, model)
 

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -17,14 +17,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import absolute_import
+
 import warnings
 
 import numpy
 from sherpa.utils import NoNewAttributesAfterInit
 from sherpa.utils.err import FitErr, StatErr
-import sherpa.stats._statfcts
 from sherpa.data import DataSimulFit
 from sherpa.models import SimulFitModel
+
+from . import _statfcts
 
 from sherpa import get_config
 from six.moves.configparser import ConfigParser
@@ -346,7 +349,7 @@ class Cash(Likelihood):
 
     """
 
-    _calc = _statfcts.calc_cash_stat2
+    _calc = _statfcts.calc_cash_stat
 
     def __init__(self, name='cash'):
         Likelihood.__init__(self, name)
@@ -418,7 +421,7 @@ class CStat(Likelihood):
 
     """
 
-    _calc = _statfcts.calc_cstat_stat2
+    _calc = _statfcts.calc_cstat_stat
 
     def __init__(self, name='cstat'):
         Likelihood.__init__(self, name)

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -500,7 +500,7 @@ class Chi2(Stat):
         """TODO: should weights be an argument or taken from data?"""
 
         # TODO: HOW TO GET THE WEIGHTS?
-        self._validate_inputs(data, model)
+        data, model = self._validate_inputs(data, model)
         fitdata = data.to_fit(staterrfunc=self.calc_staterror)
         modeldata = data.eval_model_to_fit(model)
 

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -215,17 +215,14 @@ class Likelihood(Stat):
         """
 
         for dobj in data.datasets:
-            try:
-                if dobj.subtracted:
-                    # TODO:
-                    # Historically this has been a FitErr, but it
-                    # would make more sense to be a StatErr. This could
-                    # break people's code, so hold off for now
-                    # (October 2016).
-                    #
-                    raise FitErr('statnotforbackgsub', self.name)
-            except AttributeError:
-                pass
+            if getattr(dobj, 'subtracted', False):
+                # TODO:
+                # Historically this has been a FitErr, but it
+                # would make more sense to be a StatErr. This could
+                # break people's code, so hold off for now
+                # (October 2016).
+                #
+                raise FitErr('statnotforbackgsub', self.name)
 
     def _validate_inputs(self, data, model):
         self._check_background_subtraction(data)

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -52,13 +52,6 @@ if (bool(truncation_flag) is False or truncation_flag == "FALSE" or
     truncation_value = 1.0e-25
 
 
-def get_syserror_weight_extra(dictionary):
-    syserror = dictionary.get('syserror')
-    weight = dictionary.get('weight')
-    extra = dictionary.get('extra_args')
-    return syserror, weight, extra
-
-
 class Stat(NoNewAttributesAfterInit):
 
     # Used by calc_stat
@@ -199,11 +192,28 @@ class Stat(NoNewAttributesAfterInit):
         self._check_sizes_match(data, model)
         return data, model
 
+    # TODO:
+    #  - should this accept sherpa.data.Data input instead of
+    #    "raw" data (i.e. to match calc_stat)
+    #  - should this be moved out of the base Stat class since
+    #    isn't relevant for likelihood statistics?
+    #
     def calc_staterror(self, data):
-        raise NotImplementedError
+        """Return the statistic error values for the data.
 
-    # def calc_stat(self, data, model, staterror, *args, **kwargs):
-    #     raise NotImplementedError
+        Parameters
+        ----------
+        data : scalar or 1D array of numbers
+            The data values.
+
+        Returns
+        -------
+        staterror : scalar or array of numbers
+            The errors for the input data values (matches the data
+            argument).
+
+        """
+        raise NotImplementedError
 
     # TODO: add *args, **kwargs?
     def calc_stat(self, data, model):
@@ -482,14 +492,7 @@ class Chi2(Stat):
     def calc_staterror(data):
         raise StatErr('chi2noerr')
 
-    #@staticmethod
-    #def calc_stat(data, model, staterror, *args, **kwargs):
-    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
-    #    return _statfcts.calc_chi2_stat(data, model, staterror,
-    #                                    syserror, weight, truncation_value)
-
     def calc_stat(self, data, model):
-        """TODO: should weights be an argument or taken from data?"""
 
         # TODO: HOW TO GET THE WEIGHTS?
         data, model = self._validate_inputs(data, model)
@@ -540,12 +543,6 @@ class LeastSq(Chi2):
     @staticmethod
     def calc_staterror(data):
         return numpy.ones_like(data)
-
-    #@staticmethod
-    #def calc_stat(data, model, staterror, *args, **kwargs):
-    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
-    #    return _statfcts.calc_lsq_stat(data, model, staterror,
-    #                                   syserror, weight, truncation_value)
 
 
 class Chi2Gehrels(Chi2):
@@ -668,13 +665,6 @@ class Chi2ModVar(Chi2):
     def calc_staterror(data):
         return numpy.zeros_like(data)
 
-    #@staticmethod
-    #def calc_stat(data, model, staterror, *args, **kwargs):
-    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
-    #    return _statfcts.calc_chi2modvar_stat(data, model, staterror,
-    #                                          syserror, weight,
-    #                                          truncation_value)
-
 
 class Chi2XspecVar(Chi2):
     """Chi Squared with data variance (XSPEC style).
@@ -743,17 +733,6 @@ class UserStat(Stat):
             raise StatErr('nostat', self.name, 'calc_staterror()')
         return self.errfunc(data)
 
-    # def calc_stat(self, data, model, staterror, *args, **kwargs):
-    #     if not self._statfuncset:
-    #          raise StatErr('nostat', self.name, 'calc_stat()')
-
-        # if bkg is None or bkg['bkg'] is None:
-        #     return self.statfunc(data, model, staterror, syserror, weight)
-        # else:
-        #     return self.statfunc(data, model, staterror, syserror, weight,
-        #                          bkg['bkg'])
-
-    # def calc_stat(self, data, model, *args, **kwargs):
     def calc_stat(self, data, model):
         raise StatErr('nostat', self.name, 'calc_stat()')
 
@@ -824,20 +803,6 @@ class WStat(Likelihood):
 
     def __init__(self, name='wstat'):
         Likelihood.__init__(self, name)
-
-    #@staticmethod
-    #def calc_stat(data, model, staterror, *args, **kwargs):
-    #
-    #    syserror, weight, extra = get_syserror_weight_extra(kwargs)
-    #    if extra is None or extra['bkg'] is None:
-    #        raise StatErr('usecstat')
-    #
-    #    return _statfcts.calc_wstat_stat(data, model,
-    #                                     extra['data_size'],
-    #                                     extra['exposure_time'],
-    #                                     extra['bkg'],
-    #                                     extra['backscale_ratio'],
-    #                                     truncation_value)
 
     def calc_stat(self, data, model):
 

--- a/sherpa/stats/src/_statfcts.cc
+++ b/sherpa/stats/src/_statfcts.cc
@@ -36,8 +36,8 @@ static PyMethodDef StatFcts[] = {
   STATFCT( calc_chi2modvar_stat ),
   STATFCT( calc_lsq_stat ),
 
-  LKLHD_STATFCT( calc_cash_stat2 ),
-  LKLHD_STATFCT( calc_cstat_stat2 ),
+  LKLHD_STATFCT( calc_cash_stat ),
+  LKLHD_STATFCT( calc_cstat_stat ),
   WSTATFCT( calc_wstat_stat ),
 
   { NULL, NULL, 0, NULL }

--- a/sherpa/stats/src/_statfcts.cc
+++ b/sherpa/stats/src/_statfcts.cc
@@ -32,15 +32,13 @@ static PyMethodDef StatFcts[] = {
   STATERRFCT( calc_chi2datavar_errors ),
   STATERRFCT( calc_chi2xspecvar_errors ),
 
-  STATFCT( calc_cash_stat ),
-  STATFCT( calc_cstat_stat ),
   STATFCT( calc_chi2_stat ),
   STATFCT( calc_chi2modvar_stat ),
   STATFCT( calc_lsq_stat ),
-  WSTATFCT( calc_wstat_stat ),
 
   LKLHD_STATFCT( calc_cash_stat2 ),
   LKLHD_STATFCT( calc_cstat_stat2 ),
+  WSTATFCT( calc_wstat_stat ),
 
   { NULL, NULL, 0, NULL }
 

--- a/sherpa/stats/src/_statfcts.cc
+++ b/sherpa/stats/src/_statfcts.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -38,6 +38,9 @@ static PyMethodDef StatFcts[] = {
   STATFCT( calc_chi2modvar_stat ),
   STATFCT( calc_lsq_stat ),
   WSTATFCT( calc_wstat_stat ),
+
+  LKLHD_STATFCT( calc_cash_stat2 ),
+  LKLHD_STATFCT( calc_cstat_stat2 ),
 
   { NULL, NULL, 0, NULL }
 

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -18,8 +18,6 @@ from __future__ import print_function
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import os.path
-
 import numpy
 
 from sherpa.utils import requires_data, requires_xspec, requires_fits
@@ -29,9 +27,8 @@ from sherpa.data import Data1D
 from sherpa.models import PowLaw1D, SimulFitModel
 from sherpa.data import DataSimulFit
 from sherpa.fit import Fit
-from sherpa.stats import Stat, Cash, LeastSq, UserStat, WStat, \
-    CStat, LeastSq, Chi2Gehrels, Chi2ConstVar, Chi2ModVar, Chi2XspecVar, \
-    Chi2DataVar
+from sherpa.stats import Cash, CStat, WStat, LeastSq, UserStat, \
+    Chi2Gehrels, Chi2ConstVar, Chi2ModVar, Chi2XspecVar, Chi2DataVar
 from sherpa.optmethods import LevMar, NelderMead
 from sherpa.utils.err import StatErr
 from sherpa.astro import ui
@@ -417,11 +414,13 @@ class test_stats(SherpaTestCase):
             assert arg1[key] == int(getattr(arg2, key))
 
         for key in ["istatval", "statval"]:
-            numpy.testing.assert_allclose(float(arg1[key]), float(getattr(arg2, key)), tol)
+            numpy.testing.assert_allclose(float(arg1[key]),
+                                          float(getattr(arg2, key)), tol)
 
         for key in ["parvals"]:
             try:
-                numpy.testing.assert_allclose(arg1[key], getattr(arg2, key), tol)
+                numpy.testing.assert_allclose(arg1[key],
+                                              getattr(arg2, key), tol)
             except AssertionError:
                 print('parvals bench: ', arg1[key])
                 print('parvals fit:   ', getattr(arg2, key))

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -45,6 +45,7 @@ class MySimulStat(UserStat):
     def mycal_staterror(data):
         return numpy.ones_like(data)
 
+    """
     @staticmethod
     def my_simulstat(data, model, staterror, *args, **kwargs):
         data_size = kwargs['extra_args']['data_size']
@@ -63,14 +64,12 @@ class MySimulStat(UserStat):
         # print stat1 + stat2 - stat
         return (stat, fvec)
         return (stat1 + stat2, numpy.append(fvec1, fvec2))
+    """
 
-    calc_stat = my_simulstat
-    calc_staterror = mycal_staterror
-
-    # This is based on my_simulstat, but it's not 100% clear
+    # This is based on the original code, but it's not 100% clear
     # why some of the values are being calculated.
     #
-    def calc_stat_from_data(self, data, model, *args, **kwargs):
+    def my_simulstat(self, data, model, *args, **kwargs):
 
         tofit = data.to_fit(staterrfunc=self.calc_staterror)
         modeldata = data.eval_model_to_fit(model)
@@ -87,20 +86,18 @@ class MySimulStat(UserStat):
         # It is not clear what separating the data sets does
         # here, based on the original my_simulsat code.
         #
-        mystat = Chi2DataVar()
-        for dset, mexpr in zip(data.datasets, model.parts):
+        stats = [Chi2DataVar(), Chi2DataVar()]
+        for mystat, dset, mexpr in zip(stats, data.datasets, model.parts):
 
-            # At present calc_stat_from_data require SimulFit objects
-            sdata = DataSimulFit('temp', (dset,))
-            smdl = SimulFitModel('temp', (mexpr,))
-
-            thisstat, thisvec = mystat.calc_stat_from_data(sdata, smdl)
-
+            thisstat, thisvec = mystat.calc_stat(dset, mexpr)
             mstat += thisstat
             mfvec.append(thisvec)
 
         # return (mstat, numpy.concatenate(mfvec))
         return (stat, fvec)
+
+    calc_stat = my_simulstat
+    calc_staterror = mycal_staterror
 
 
 class MyCashWithBkg(UserStat):
@@ -112,6 +109,7 @@ class MyCashWithBkg(UserStat):
     def mycal_staterror(data):
         return None
 
+    """
     @staticmethod
     def cash_withbkg(data, model, staterror, *args, **kwargs):
         fvec = model - (data * numpy.log(model))
@@ -119,12 +117,10 @@ class MyCashWithBkg(UserStat):
         if weight is not None:
             fvec = fvec * weight
         return 2.0 * sum(fvec), fvec
-
-    calc_stat = cash_withbkg
-    calc_staterror = mycal_staterror
+    """
 
     @staticmethod
-    def calc_stat_from_data(data, model, *args, **kwargs):
+    def cash_withbkg(data, model, *args, **kwargs):
 
         tofit = data.to_fit(staterrfunc=None)
         modeldata = data.eval_model_to_fit(model)
@@ -136,6 +132,9 @@ class MyCashWithBkg(UserStat):
             fvec = fvec * weight
 
         return 2.0 * fvec.sum(), fvec
+
+    calc_stat = cash_withbkg
+    calc_staterror = mycal_staterror
 
 
 class MyChiWithBkg(UserStat):
@@ -147,16 +146,15 @@ class MyChiWithBkg(UserStat):
     def mycal_staterror(data):
         return numpy.ones_like(data)
 
+    """
     @staticmethod
     def chi_withbkg(data, model, staterror, *args, **kwargs):
         fvec = ((data - model) / staterror)**2
         stat = fvec.sum()
         return (stat, fvec)
+    """
 
-    calc_stat = chi_withbkg
-    calc_staterror = mycal_staterror
-
-    def calc_stat_from_data(self, data, model, *args, **kwargs):
+    def chi_withbkg(self, data, model, *args, **kwargs):
 
         tofit = data.to_fit(staterrfunc=self.calc_staterror)
         modeldata = data.eval_model_to_fit(model)
@@ -166,6 +164,9 @@ class MyChiWithBkg(UserStat):
 
         fvec = ((fitdata - modeldata) / staterror)**2
         return fvec.sum(), fvec
+
+    calc_stat = chi_withbkg
+    calc_staterror = mycal_staterror
 
 
 class MyCashNoBkg(UserStat):
@@ -177,6 +178,7 @@ class MyCashNoBkg(UserStat):
     def mycal_staterror(data):
         return None
 
+    """
     @staticmethod
     def cash_nobkg(data, model, staterror, *args, **kwargs):
         fvec = model - (data * numpy.log(model))
@@ -184,12 +186,10 @@ class MyCashNoBkg(UserStat):
         if weight is not None:
             fvec = fvec * weight
         return 2.0 * sum(fvec), fvec
-
-    calc_stat = cash_nobkg
-    calc_staterror = mycal_staterror
+    """
 
     @staticmethod
-    def calc_stat_from_data(data, model, *args, **kwargs):
+    def cash_nobkg(data, model, *args, **kwargs):
 
         tofit = data.to_fit(staterrfunc=None)
         modeldata = data.eval_model_to_fit(model)
@@ -202,6 +202,9 @@ class MyCashNoBkg(UserStat):
 
         return 2.0 * fvec.sum(), fvec
 
+    calc_stat = cash_nobkg
+    calc_staterror = mycal_staterror
+
 
 class MyChiNoBkg(UserStat):
 
@@ -212,16 +215,15 @@ class MyChiNoBkg(UserStat):
     def mycal_staterror(data):
         return numpy.ones_like(data)
 
+    """
     @staticmethod
     def chi_nobkg(data, model, staterror, *args, **kwargs):
         fvec = ((data - model) / staterror)**2
         stat = fvec.sum()
         return (stat, fvec)
+    """
 
-    calc_stat = chi_nobkg
-    calc_staterror = mycal_staterror
-
-    def calc_stat_from_data(self, data, model, *args, **kwargs):
+    def chi_nobkg(self, data, model, *args, **kwargs):
 
         tofit = data.to_fit(staterrfunc=self.calc_staterror)
         modeldata = data.eval_model_to_fit(model)
@@ -231,6 +233,9 @@ class MyChiNoBkg(UserStat):
 
         fvec = ((fitdata - modeldata) / staterror)**2
         return fvec.sum(), fvec
+
+    calc_stat = chi_nobkg
+    calc_staterror = mycal_staterror
 
 
 @requires_fits

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -157,12 +157,10 @@ def setup_multiple(usestat, usesys):
     """
 
     x, y = setup_single(usestat, usesys)
-
     data1 = x.datasets[0]
     model1 = y.parts[0]
 
     x, y = setup_single(usestat, usesys)
-
     data2 = x.datasets[0]
     data2.ignore(1, 3.5)
 
@@ -173,7 +171,6 @@ def setup_multiple(usestat, usesys):
 
     mdata = DataSimulFit('simul', (data1, data2))
     mmodel = SimulFitModel('simul', (model1, model1))
-
     return mdata, mmodel
 
 
@@ -197,12 +194,10 @@ def setup_multiple_1dint(stat, sys):
     """
 
     x, y = setup_single_1dint(stat, sys)
-
     data1 = x.datasets[0]
     model1 = y.parts[0]
 
     x, y = setup_single_1dint(stat, sys)
-
     # The bins cover (-10,-5), (-5,2), (3,4), (4,7)
     data2 = x.datasets[0]
     data2.ignore(2.5, 3.5)
@@ -213,7 +208,6 @@ def setup_multiple_1dint(stat, sys):
 
     mdata = DataSimulFit('simul', (data1, data2))
     mmodel = SimulFitModel('simul', (model1, model1))
-
     return mdata, mmodel
 
 
@@ -816,6 +810,15 @@ stat_pha_gehrels_ft = 0.989239848562
 stat_pha_gehrels_bg_ff = 1.43234664248
 stat_pha_gehrels_bg_ft = 1.03105762001
 
+# TODO: should the background subtraction actually raise an errror
+#       for the likelihood statistics?
+#
+stat_pha_cash = -299.771783393
+stat_pha_cash_bg = -297.366618448
+
+stat_pha_cstat = 1.75191290087
+stat_pha_cstat_bg = 1.8269289994
+
 
 # This is not as extensive as some of the earlier checks as the
 # assumption is that if it works for these variants it should be
@@ -853,9 +856,18 @@ stat_pha_gehrels_bg_ft = 1.03105762001
     (Chi2Gehrels, False, True, False, False, stat_pha_gehrels_ft),
     (Chi2Gehrels, False, True, True, False, stat_pha_gehrels_ft),
     (Chi2Gehrels, False, True, True, True, stat_pha_gehrels_bg_ft),
+
+    (Cash, True, True, False, False, stat_pha_cash),
+    (Cash, False, False, False, False, stat_pha_cash),
+    (Cash, False, False, True, True, stat_pha_cash_bg),
+
+    (CStat, True, True, False, False, stat_pha_cstat),
+    (CStat, False, False, False, False, stat_pha_cstat),
+    (CStat, False, False, True, True, stat_pha_cstat_bg),
+
 ])
-def test_stats_calc_stat_pha_chi2(stat, usestat, usesys,
-                                  havebg, usebg, expected):
+def test_stats_calc_stat_pha(stat, usestat, usesys,
+                             havebg, usebg, expected):
     """statistic calculates expected values: single PHA dataset"""
 
     data, model = setup_single_pha(usestat, usesys, background=havebg)

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1,0 +1,243 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Unit tests for changes to the stats module
+#
+# The chi-square tests are similar to those in
+# sherpa/tests/test_fit_unit.py
+
+import pytest
+import numpy as np
+
+from numpy.testing import assert_almost_equal, assert_equal
+
+from sherpa.data import Data1D, DataSimulFit
+from sherpa.models.model import SimulFitModel
+from sherpa.models.basic import Polynom1D
+from sherpa.utils.err import StatErr
+
+from sherpa.stats import LeastSq, Chi2, Chi2Gehrels, Chi2DataVar, \
+    Chi2ConstVar, Chi2ModVar, Chi2XspecVar, Cash, CStat, WStat, UserStat
+
+
+def setup_single(stat, sys):
+    """Return a single data set and model (as SimulFit objects).
+
+    Parameters
+    ----------
+    stat, sys : bool
+        Should statistical and systematic errors be explicitly set
+        (True) or taken from the statistic (False)?
+
+    Returns
+    -------
+    data, model
+        DataSimulFit and SimulFitModel objects.
+
+    """
+
+    x = np.asarray([-10, -5, 3, 4])
+    y = np.asarray([16.3, 2.4, 4.3, 5.6])
+    if stat:
+        # pick values close to sqrt(y)
+        staterr = np.asarray([4.0, 1.6, 2.1, 2.4])
+    else:
+        staterr = None
+    if sys:
+        syserr = 0.05 * y
+    else:
+        syserr = None
+
+    data = Data1D('tst1', x, y, staterror=staterr, syserror=syserr)
+
+    mdl = Polynom1D('mdl1')
+    mdl.c0 = 0
+    mdl.c2 = 0.2
+    mdl.offset = -1
+
+    return DataSimulFit('tst', (data,)), SimulFitModel('mdl', (mdl,))
+
+
+@pytest.mark.parametrize("stat", [Cash, CStat, WStat, UserStat])
+def test_stats_calc_chisqr_missing(stat):
+    """non chi-quare statistics do not have a calc_chisqr."""
+
+    statobj = stat()
+    assert not hasattr(statobj, 'calc_chisqr')
+
+
+@pytest.mark.parametrize("usesys", [True, False])
+def test_stats_calc_chisqr_chi2_nostat(usesys):
+    """chi-quare statistic with no staterror fails"""
+
+    data, models = setup_single(False, usesys)
+    statobj = Chi2()
+    with pytest.raises(StatErr):
+        statobj.calc_chisqr(data, models)
+
+
+# Numeric answers calculated using CIAO 4.8 (sherpa 4.8.0)
+# on a 64-bit Linux machine.
+#
+exp_delta = np.asarray([0.1, 0.8, 1.1, 0.6])
+exp_lsq = exp_delta * exp_delta
+
+exp_chi2_tt = np.asarray([0.00060009, 0.24860162, 0.27153028, 0.06166073])
+exp_chi2_tf = np.asarray([0.000625, 0.25, 0.27437642, 0.0625])
+
+exp_dvar_ft = np.asarray([0.00058948, 0.26507621, 0.27840252, 0.06339814])
+exp_dvar_ff = np.asarray([0.0006135, 0.26666667, 0.28139535, 0.06428571])
+
+exp_cvar_ft = np.asarray([0.00127972, 0.08933058, 0.16814371, 0.04980355])
+exp_cvar_ff = np.asarray([0.0013986, 0.08951049, 0.16923077, 0.05034965])
+
+exp_mvar_xt = np.asarray([0.00059297, 0.19910403, 0.37274064, 0.07088847])
+exp_mvar_xf = np.asarray([0.00061728, 0.2, 0.378125, 0.072])
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (Chi2, True, True, exp_chi2_tt),
+    (Chi2, True, False, exp_chi2_tf),
+    (LeastSq, True, True, exp_lsq),
+    (LeastSq, True, False, exp_lsq),
+    (LeastSq, False, True, exp_lsq),
+    (LeastSq, False, False, exp_lsq),
+    (Chi2Gehrels, True, True, exp_chi2_tt),
+    (Chi2DataVar, True, True, exp_chi2_tt),
+    (Chi2DataVar, True, False, exp_chi2_tf),
+    (Chi2DataVar, False, True, exp_dvar_ft),
+    (Chi2DataVar, False, False, exp_dvar_ff),
+    (Chi2XspecVar, True, True, exp_chi2_tt),
+    (Chi2XspecVar, True, False, exp_chi2_tf),
+    (Chi2XspecVar, False, True, exp_dvar_ft),
+    (Chi2XspecVar, False, False, exp_dvar_ff),
+    (Chi2ConstVar, True, True, exp_chi2_tt),
+    (Chi2ConstVar, True, False, exp_chi2_tf),
+    (Chi2ConstVar, False, True, exp_cvar_ft),
+    (Chi2ConstVar, False, False, exp_cvar_ff),
+    (Chi2ModVar, True, True, exp_mvar_xt),
+    (Chi2ModVar, True, False, exp_mvar_xf),
+    (Chi2ModVar, False, True, exp_mvar_xt),
+    (Chi2ModVar, False, False, exp_mvar_xf)
+])
+def test_stats_calc_chisqr(stat, usestat, usesys, expected):
+    """chi-quare statistics calculates expected values"""
+
+    data, models = setup_single(usestat, usesys)
+    statobj = stat()
+    answer = statobj.calc_chisqr(data, models)
+    assert_almost_equal(answer, expected)
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected1", [
+    (Chi2, True, True, exp_chi2_tt),
+    (Chi2, True, False, exp_chi2_tf),
+    (LeastSq, True, True, exp_lsq),
+    (LeastSq, True, False, exp_lsq),
+    (LeastSq, False, True, exp_lsq),
+    (LeastSq, False, False, exp_lsq),
+    (Chi2Gehrels, True, True, exp_chi2_tt),
+    (Chi2DataVar, True, True, exp_chi2_tt),
+    (Chi2DataVar, True, False, exp_chi2_tf),
+    (Chi2DataVar, False, True, exp_dvar_ft),
+    (Chi2DataVar, False, False, exp_dvar_ff),
+    (Chi2XspecVar, True, True, exp_chi2_tt),
+    (Chi2XspecVar, True, False, exp_chi2_tf),
+    (Chi2XspecVar, False, True, exp_dvar_ft),
+    (Chi2XspecVar, False, False, exp_dvar_ff),
+    (Chi2ConstVar, True, True, exp_chi2_tt),
+    (Chi2ConstVar, True, False, exp_chi2_tf),
+    # See test_stats_calc_chisqr_multi_cvar for the next two
+    # (Chi2ConstVar, False, True, exp_cvar_ft),
+    # (Chi2ConstVar, False, False, exp_cvar_ff),
+    (Chi2ModVar, True, True, exp_mvar_xt),
+    (Chi2ModVar, True, False, exp_mvar_xf),
+    (Chi2ModVar, False, True, exp_mvar_xt),
+    (Chi2ModVar, False, False, exp_mvar_xf)
+])
+def test_stats_calc_chisqr_multi(stat, usestat, usesys, expected1):
+    """chi-quare statistics calculates expected values
+
+    Here multiple datasets are used. To save time, the first
+    dataset is re-used, excluding the third point.
+    """
+
+    x, y = setup_single(usestat, usesys)
+
+    data1 = x.datasets[0]
+    model1 = y.parts[0]
+
+    x, y = setup_single(usestat, usesys)
+
+    data2 = x.datasets[0]
+    data2.ignore(1, 3.5)
+
+    # not an essential part of the stats code; more a check that
+    # things are working correctly
+    assert_equal(data2.mask, np.asarray([True, True, False, True]))
+
+    mdata = DataSimulFit('simul', (data1, data2))
+    mmodel = SimulFitModel('simul', (model1, model1))
+
+    statobj = stat()
+    answer = statobj.calc_chisqr(mdata, mmodel)
+
+    expected = np.concatenate((expected1,
+                               expected1[data2.mask]))
+    assert_almost_equal(answer, expected)
+
+
+@pytest.mark.parametrize("usestat,usesys,expected", [
+    (False, True, np.concatenate((exp_cvar_ft,
+                                  np.asarray([0.001141, 0.07887213,
+                                              0.04401839])))),
+    (False, False, np.concatenate((exp_cvar_ff,
+                                   np.asarray([0.00123457, 0.07901235,
+                                               0.04444444])))),
+])
+def test_stats_calc_chisqr_multi_cvar(usestat, usesys, expected):
+    """chi-quare statistics calculates expected values: constvar
+
+    Here multiple datasets are used. To save time, the first
+    dataset is re-used, excluding the third point. This means that
+    the constvar results are a little-bit different to the other
+    statistics.
+    """
+
+    x, y = setup_single(usestat, usesys)
+
+    data1 = x.datasets[0]
+    model1 = y.parts[0]
+
+    x, y = setup_single(usestat, usesys)
+
+    data2 = x.datasets[0]
+    data2.ignore(1, 3.5)
+
+    # not an essential part of the stats code; more a check that
+    # things are working correctly
+    assert_equal(data2.mask, np.asarray([True, True, False, True]))
+
+    mdata = DataSimulFit('simul', (data1, data2))
+    mmodel = SimulFitModel('simul', (model1, model1))
+
+    statobj = Chi2ConstVar()
+    answer = statobj.calc_chisqr(mdata, mmodel)
+
+    assert_almost_equal(answer, expected)

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -17,17 +17,31 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-# Unit tests for changes to the stats module
+# Unit tests for changes to the stats module. Since this provides
+# the primary interface to the stats C++ code, checks are made here
+# of the results of that code (in part to make sure the data is being
+# sent to these routines correctly).
 #
-# The chi-square tests are similar to those in
-# sherpa/tests/test_fit_unit.py
+# The calc_info/chisqr tests are similar to those in
+# sherpa/tests/test_fit_unit.py; once there are enough here it may
+# be possible to reduce the number of tests in test_fit_unit.py.
+#
+# TODO:
+#   add calc_stat_from_data tests for wstat
+#
+#   add some tests with Data2D and/or DataIMG (to check nD where n > 1)
+#
+#   add some error checks for mixed data types - e.g. Data1D and Data1DInt
+#   as well as those with and without errors (e.g. to check that they are
+#   caught and raise an error if necessary)
+#
 
 import pytest
 import numpy as np
 
 from numpy.testing import assert_almost_equal, assert_equal
 
-from sherpa.data import Data1D, DataSimulFit
+from sherpa.data import Data1D, Data1DInt, DataSimulFit
 from sherpa.models.model import SimulFitModel
 from sherpa.models.basic import Polynom1D
 from sherpa.utils.err import StatErr
@@ -48,7 +62,8 @@ def setup_single(stat, sys):
     Returns
     -------
     data, model
-        DataSimulFit and SimulFitModel objects.
+        DataSimulFit and SimulFitModel objects. The data is a Data1D
+        object.
 
     """
 
@@ -74,6 +89,130 @@ def setup_single(stat, sys):
     return DataSimulFit('tst', (data,)), SimulFitModel('mdl', (mdl,))
 
 
+def setup_single_1dint(stat, sys):
+    """Return a single data set and model (as SimulFit objects).
+
+    Parameters
+    ----------
+    stat, sys : bool
+        Should statistical and systematic errors be explicitly set
+        (True) or taken from the statistic (False)?
+
+    Returns
+    -------
+    data, model
+        DataSimulFit and SimulFitModel objects. The data is a
+        Data1DInt object.
+
+    """
+
+    xlo = np.asarray([-10, -5, 3, 4])
+    xhi = np.asarray([-5, 2, 4, 7])
+
+    y = np.asarray([16.3, 2.4, 4.3, 5.6])
+    if stat:
+        # pick values close to sqrt(y)
+        staterr = np.asarray([4.0, 1.6, 2.1, 2.4])
+    else:
+        staterr = None
+    if sys:
+        syserr = 0.05 * y
+    else:
+        syserr = None
+
+    data = Data1DInt('tst1', xlo, xhi, y, staterror=staterr, syserror=syserr)
+
+    # As the model is integrated, the normalization values need to
+    # be divided by the bin width, but the bins are not constant
+    # width, so pick a value which gives reasonable values.
+    #
+    mdl = Polynom1D('mdl1')
+    mdl.c0 = 0
+    mdl.c2 = 0.08
+    mdl.offset = -1
+
+    return DataSimulFit('tst', (data,)), SimulFitModel('mdl', (mdl,))
+
+
+def setup_multiple(usestat, usesys):
+    """Return multiple data sets and model (as SimulFit objects).
+
+    To save time, the first dataset is re-used, excluding the third point.
+
+    Parameters
+    ----------
+    stat, sys : bool
+        Should statistical and systematic errors be explicitly set
+        (True) or taken from the statistic (False)?
+
+    Returns
+    -------
+    data, model
+        DataSimulFit and SimulFitModel objects. The data sets
+        are Data1D objects.
+    """
+
+    x, y = setup_single(usestat, usesys)
+
+    data1 = x.datasets[0]
+    model1 = y.parts[0]
+
+    x, y = setup_single(usestat, usesys)
+
+    data2 = x.datasets[0]
+    data2.ignore(1, 3.5)
+
+    # not an essential part of the stats code; more a check that
+    # things are working correctly (i.e. that this invariant hasn't
+    # been broken by some change to the test).
+    assert_equal(data2.mask, np.asarray([True, True, False, True]))
+
+    mdata = DataSimulFit('simul', (data1, data2))
+    mmodel = SimulFitModel('simul', (model1, model1))
+
+    return mdata, mmodel
+
+
+def setup_multiple_1dint(stat, sys):
+    """Return multiple data sets and models (as SimulFit objects).
+
+    To save time, the first dataset is re-used, excluding the third point.
+
+    Parameters
+    ----------
+    stat, sys : bool
+        Should statistical and systematic errors be explicitly set
+        (True) or taken from the statistic (False)?
+
+    Returns
+    -------
+    data, model
+        DataSimulFit and SimulFitModel objects. The data sets are
+        Data1DInt objects.
+
+    """
+
+    x, y = setup_single_1dint(stat, sys)
+
+    data1 = x.datasets[0]
+    model1 = y.parts[0]
+
+    x, y = setup_single_1dint(stat, sys)
+
+    # The bins cover (-10,-5), (-5,2), (3,4), (4,7)
+    data2 = x.datasets[0]
+    data2.ignore(2.5, 3.5)
+
+    # not an essential part of the stats code; more a check that
+    # things are working correctly
+    assert_equal(data2.mask, np.asarray([True, True, False, True]))
+
+    mdata = DataSimulFit('simul', (data1, data2))
+    mmodel = SimulFitModel('simul', (model1, model1))
+
+    return mdata, mmodel
+
+
 @pytest.mark.parametrize("stat", [Cash, CStat, WStat, UserStat])
 def test_stats_calc_chisqr_missing(stat):
     """non chi-quare statistics do not have a calc_chisqr."""
@@ -86,10 +225,35 @@ def test_stats_calc_chisqr_missing(stat):
 def test_stats_calc_chisqr_chi2_nostat(usesys):
     """chi-quare statistic with no staterror fails"""
 
-    data, models = setup_single(False, usesys)
+    data, model = setup_single(False, usesys)
     statobj = Chi2()
     with pytest.raises(StatErr):
-        statobj.calc_chisqr(data, models)
+        statobj.calc_chisqr(data, model)
+
+
+@pytest.mark.parametrize("usesys", [True, False])
+def test_stats_calc_stat_chi2_nostat(usesys):
+    """chi-quare statistic with no staterror fails"""
+
+    data, model = setup_single(False, usesys)
+    statobj = Chi2()
+    with pytest.raises(StatErr):
+        statobj.calc_stat_from_data(data, model)
+
+
+@pytest.mark.parametrize("usestat,usesys", [
+    (True, True),
+    (True, False),
+    (False, True),
+    (False, False),
+])
+def test_stats_calc_stat_wstat(usestat, usesys):
+    """wstat statistic fails with no background"""
+
+    data, model = setup_single(usestat, usesys)
+    statobj = WStat()
+    with pytest.raises(StatErr):
+        statobj.calc_stat_from_data(data, model)
 
 
 # Numeric answers calculated using CIAO 4.8 (sherpa 4.8.0)
@@ -100,6 +264,9 @@ exp_lsq = exp_delta * exp_delta
 
 exp_chi2_tt = np.asarray([0.00060009, 0.24860162, 0.27153028, 0.06166073])
 exp_chi2_tf = np.asarray([0.000625, 0.25, 0.27437642, 0.0625])
+
+exp_gehrels_ft = np.asarray([0.00037075, 0.08296552, 0.11425155, 0.02887336])
+exp_gehrels_ff = np.asarray([0.00038011, 0.08312068, 0.11475241, 0.02905606])
 
 exp_dvar_ft = np.asarray([0.00058948, 0.26507621, 0.27840252, 0.06339814])
 exp_dvar_ff = np.asarray([0.0006135, 0.26666667, 0.28139535, 0.06428571])
@@ -119,6 +286,9 @@ exp_mvar_xf = np.asarray([0.00061728, 0.2, 0.378125, 0.072])
     (LeastSq, False, True, exp_lsq),
     (LeastSq, False, False, exp_lsq),
     (Chi2Gehrels, True, True, exp_chi2_tt),
+    (Chi2Gehrels, True, False, exp_chi2_tf),
+    (Chi2Gehrels, False, True, exp_gehrels_ft),
+    (Chi2Gehrels, False, False, exp_gehrels_ff),
     (Chi2DataVar, True, True, exp_chi2_tt),
     (Chi2DataVar, True, False, exp_chi2_tf),
     (Chi2DataVar, False, True, exp_dvar_ft),
@@ -139,9 +309,75 @@ exp_mvar_xf = np.asarray([0.00061728, 0.2, 0.378125, 0.072])
 def test_stats_calc_chisqr(stat, usestat, usesys, expected):
     """chi-quare statistics calculates expected values"""
 
-    data, models = setup_single(usestat, usesys)
+    data, model = setup_single(usestat, usesys)
     statobj = stat()
-    answer = statobj.calc_chisqr(data, models)
+    answer = statobj.calc_chisqr(data, model)
+    assert_almost_equal(answer, expected)
+
+
+exp1dint_delta = np.asarray([1.43333333, 0.02666667, 2.67333333, 4.72])
+exp1dint_lsq = exp1dint_delta * exp1dint_delta
+
+exp1dint_chi2_tt = np.asarray([0.123284728, 0.000276224018,
+                               1.60375904, 3.81583996])
+exp1dint_chi2_tf = np.asarray([0.128402778, 0.000277777778,
+                               1.62056941, 3.86777778])
+
+exp1dint_gehrels_ft = np.asarray([0.0761679608, 0.0000921839121,
+                                  0.674812245, 1.78681175])
+exp1dint_gehrels_ff = np.asarray([0.0780910272, 0.0000923563159,
+                                  0.677770505, 1.79811827])
+
+exp1dint_dvar_ft = np.asarray([0.121104527, 0.000294529122,
+                               1.64434909, 3.92335869])
+exp1dint_dvar_ff = np.asarray([0.126039536, 0.000296296296,
+                               1.66202584, 3.97828571])
+
+exp1dint_cvar_ft = np.asarray([0.262910838, 0.0000992561989,
+                               0.993119463, 3.08206519])
+exp1dint_cvar_ff = np.asarray([0.287334887, 0.0000994560995,
+                               0.999540016, 3.11586014])
+
+exp1dint_mvar_xt = np.asarray([0.111669408, 0.000291311631,
+                               4.27207048, 2.14248346])
+exp1dint_mvar_xf = np.asarray([0.115852130, 0.000293040293,
+                               4.39346995, 2.15875969])
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (Chi2, True, True, exp1dint_chi2_tt),
+    (Chi2, True, False, exp1dint_chi2_tf),
+    (LeastSq, True, True, exp1dint_lsq),
+    (LeastSq, True, False, exp1dint_lsq),
+    (LeastSq, False, True, exp1dint_lsq),
+    (LeastSq, False, False, exp1dint_lsq),
+    (Chi2Gehrels, True, True, exp1dint_chi2_tt),
+    (Chi2Gehrels, True, False, exp1dint_chi2_tf),
+    (Chi2Gehrels, False, True, exp1dint_gehrels_ft),
+    (Chi2Gehrels, False, False, exp1dint_gehrels_ff),
+    (Chi2DataVar, True, True, exp1dint_chi2_tt),
+    (Chi2DataVar, True, False, exp1dint_chi2_tf),
+    (Chi2DataVar, False, True, exp1dint_dvar_ft),
+    (Chi2DataVar, False, False, exp1dint_dvar_ff),
+    (Chi2XspecVar, True, True, exp1dint_chi2_tt),
+    (Chi2XspecVar, True, False, exp1dint_chi2_tf),
+    (Chi2XspecVar, False, True, exp1dint_dvar_ft),
+    (Chi2XspecVar, False, False, exp1dint_dvar_ff),
+    (Chi2ConstVar, True, True, exp1dint_chi2_tt),
+    (Chi2ConstVar, True, False, exp1dint_chi2_tf),
+    (Chi2ConstVar, False, True, exp1dint_cvar_ft),
+    (Chi2ConstVar, False, False, exp1dint_cvar_ff),
+    (Chi2ModVar, True, True, exp1dint_mvar_xt),
+    (Chi2ModVar, True, False, exp1dint_mvar_xf),
+    (Chi2ModVar, False, True, exp1dint_mvar_xt),
+    (Chi2ModVar, False, False, exp1dint_mvar_xf)
+])
+def test_stats_calc_chisqr_1dint(stat, usestat, usesys, expected):
+    """chi-quare statistics calculates expected values"""
+
+    data, model = setup_single_1dint(usestat, usesys)
+    statobj = stat()
+    answer = statobj.calc_chisqr(data, model)
     assert_almost_equal(answer, expected)
 
 
@@ -153,6 +389,9 @@ def test_stats_calc_chisqr(stat, usestat, usesys, expected):
     (LeastSq, False, True, exp_lsq),
     (LeastSq, False, False, exp_lsq),
     (Chi2Gehrels, True, True, exp_chi2_tt),
+    (Chi2Gehrels, True, False, exp_chi2_tf),
+    (Chi2Gehrels, False, True, exp_gehrels_ft),
+    (Chi2Gehrels, False, False, exp_gehrels_ff),
     (Chi2DataVar, True, True, exp_chi2_tt),
     (Chi2DataVar, True, False, exp_chi2_tf),
     (Chi2DataVar, False, True, exp_dvar_ft),
@@ -174,42 +413,72 @@ def test_stats_calc_chisqr(stat, usestat, usesys, expected):
 def test_stats_calc_chisqr_multi(stat, usestat, usesys, expected1):
     """chi-quare statistics calculates expected values
 
-    Here multiple datasets are used. To save time, the first
-    dataset is re-used, excluding the third point.
+    Here multiple datasets are used.
     """
 
-    x, y = setup_single(usestat, usesys)
-
-    data1 = x.datasets[0]
-    model1 = y.parts[0]
-
-    x, y = setup_single(usestat, usesys)
-
-    data2 = x.datasets[0]
-    data2.ignore(1, 3.5)
-
-    # not an essential part of the stats code; more a check that
-    # things are working correctly
-    assert_equal(data2.mask, np.asarray([True, True, False, True]))
-
-    mdata = DataSimulFit('simul', (data1, data2))
-    mmodel = SimulFitModel('simul', (model1, model1))
-
+    data, model = setup_multiple(usestat, usesys)
     statobj = stat()
-    answer = statobj.calc_chisqr(mdata, mmodel)
+    answer = statobj.calc_chisqr(data, model)
 
+    data2 = data.datasets[1]
     expected = np.concatenate((expected1,
                                expected1[data2.mask]))
     assert_almost_equal(answer, expected)
 
 
+@pytest.mark.parametrize("stat,usestat,usesys,expected1", [
+    (Chi2, True, True, exp1dint_chi2_tt),
+    (Chi2, True, False, exp1dint_chi2_tf),
+    (LeastSq, True, True, exp1dint_lsq),
+    (LeastSq, True, False, exp1dint_lsq),
+    (LeastSq, False, True, exp1dint_lsq),
+    (LeastSq, False, False, exp1dint_lsq),
+    (Chi2Gehrels, True, True, exp1dint_chi2_tt),
+    (Chi2Gehrels, True, False, exp1dint_chi2_tf),
+    (Chi2Gehrels, False, True, exp1dint_gehrels_ft),
+    (Chi2Gehrels, False, False, exp1dint_gehrels_ff),
+    (Chi2DataVar, True, True, exp1dint_chi2_tt),
+    (Chi2DataVar, True, False, exp1dint_chi2_tf),
+    (Chi2DataVar, False, True, exp1dint_dvar_ft),
+    (Chi2DataVar, False, False, exp1dint_dvar_ff),
+    (Chi2XspecVar, True, True, exp1dint_chi2_tt),
+    (Chi2XspecVar, True, False, exp1dint_chi2_tf),
+    (Chi2XspecVar, False, True, exp1dint_dvar_ft),
+    (Chi2XspecVar, False, False, exp1dint_dvar_ff),
+    (Chi2ConstVar, True, True, exp1dint_chi2_tt),
+    (Chi2ConstVar, True, False, exp1dint_chi2_tf),
+    # See test_stats_calc_chisqr_1dint_multi_cvar for the next two
+    # (Chi2ConstVar, False, True, exp1dint_cvar_ft),
+    # (Chi2ConstVar, False, False, exp1dint_cvar_ff),
+    (Chi2ModVar, True, True, exp1dint_mvar_xt),
+    (Chi2ModVar, True, False, exp1dint_mvar_xf),
+    (Chi2ModVar, False, True, exp1dint_mvar_xt),
+    (Chi2ModVar, False, False, exp1dint_mvar_xf)
+])
+def test_stats_calc_chisqr_1dint_multi(stat, usestat, usesys, expected1):
+    """chi-quare statistics calculates expected values
+
+    Here multiple datasets are used. To save time, the first
+    dataset is re-used, excluding the third point.
+    """
+
+    data, model = setup_multiple_1dint(usestat, usesys)
+    statobj = stat()
+    answer = statobj.calc_chisqr(data, model)
+
+    data2 = data.datasets[1]
+    expected = np.concatenate((expected1,
+                               expected1[data2.mask]))
+    assert_almost_equal(answer, expected)
+
+
+exp_cvar_2_ft = np.asarray([0.001141, 0.07887213, 0.04401839])
+exp_cvar_2_ff = np.asarray([0.00123457, 0.07901235, 0.04444444])
+
+
 @pytest.mark.parametrize("usestat,usesys,expected", [
-    (False, True, np.concatenate((exp_cvar_ft,
-                                  np.asarray([0.001141, 0.07887213,
-                                              0.04401839])))),
-    (False, False, np.concatenate((exp_cvar_ff,
-                                   np.asarray([0.00123457, 0.07901235,
-                                               0.04444444])))),
+    (False, True, np.concatenate((exp_cvar_ft, exp_cvar_2_ft))),
+    (False, False, np.concatenate((exp_cvar_ff, exp_cvar_2_ff))),
 ])
 def test_stats_calc_chisqr_multi_cvar(usestat, usesys, expected):
     """chi-quare statistics calculates expected values: constvar
@@ -220,24 +489,177 @@ def test_stats_calc_chisqr_multi_cvar(usestat, usesys, expected):
     statistics.
     """
 
-    x, y = setup_single(usestat, usesys)
-
-    data1 = x.datasets[0]
-    model1 = y.parts[0]
-
-    x, y = setup_single(usestat, usesys)
-
-    data2 = x.datasets[0]
-    data2.ignore(1, 3.5)
-
-    # not an essential part of the stats code; more a check that
-    # things are working correctly
-    assert_equal(data2.mask, np.asarray([True, True, False, True]))
-
-    mdata = DataSimulFit('simul', (data1, data2))
-    mmodel = SimulFitModel('simul', (model1, model1))
-
+    data, model = setup_multiple(usestat, usesys)
     statobj = Chi2ConstVar()
-    answer = statobj.calc_chisqr(mdata, mmodel)
+    answer = statobj.calc_chisqr(data, model)
+    assert_almost_equal(answer, expected)
 
+
+@pytest.mark.parametrize("usestat,usesys,expected", [
+    (False, True, np.concatenate((exp1dint_cvar_ft,
+                                  np.asarray([0.234412563, 0.0000876356984,
+                                              2.72405360])))),
+    (False, False, np.concatenate((exp1dint_cvar_ff,
+                                   np.asarray([0.253635117, 0.0000877914952,
+                                               2.75041975])))),
+])
+def test_stats_calc_chisqr_1dint_multi_cvar(usestat, usesys, expected):
+    """chi-quare statistics calculates expected values: constvar
+
+    Here multiple datasets are used. To save time, the first
+    dataset is re-used, excluding the third point. This means that
+    the constvar results are a little-bit different to the other
+    statistics.
+    """
+
+    data, model = setup_multiple_1dint(usestat, usesys)
+    statobj = Chi2ConstVar()
+    answer = statobj.calc_chisqr(data, model)
+    assert_almost_equal(answer, expected)
+
+
+# Numeric answers calculated using CIAO 4.8 (sherpa 4.8.0)
+# on a 64-bit Linux machine.
+#
+stat_lsq = exp_lsq.sum()
+
+stat_chi2_tt = exp_chi2_tt.sum()
+stat_chi2_tf = exp_chi2_tf.sum()
+
+stat_gehrels_ft = exp_gehrels_ft.sum()
+stat_gehrels_ff = exp_gehrels_ff.sum()
+
+stat_dvar_ft = exp_dvar_ft.sum()
+stat_dvar_ff = exp_dvar_ff.sum()
+
+stat_cvar_ft = exp_cvar_ft.sum()
+stat_cvar_ff = exp_cvar_ff.sum()
+
+stat_mvar_xt = exp_mvar_xt.sum()
+stat_mvar_xf = exp_mvar_xf.sum()
+
+stat_cash = -69.2032919676
+stat_cstat = 0.630015576282
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (Chi2, True, True, stat_chi2_tt),
+    (Chi2, True, False, stat_chi2_tf),
+    (LeastSq, True, True, stat_lsq),
+    (LeastSq, True, False, stat_lsq),
+    (LeastSq, False, True, stat_lsq),
+    (LeastSq, False, False, stat_lsq),
+    (Chi2Gehrels, True, True, stat_chi2_tt),
+    (Chi2Gehrels, True, False, stat_chi2_tf),
+    (Chi2Gehrels, False, True, stat_gehrels_ft),
+    (Chi2Gehrels, False, False, stat_gehrels_ff),
+    (Chi2DataVar, True, True, stat_chi2_tt),
+    (Chi2DataVar, True, False, stat_chi2_tf),
+    (Chi2DataVar, False, True, stat_dvar_ft),
+    (Chi2DataVar, False, False, stat_dvar_ff),
+    (Chi2XspecVar, True, True, stat_chi2_tt),
+    (Chi2XspecVar, True, False, stat_chi2_tf),
+    (Chi2XspecVar, False, True, stat_dvar_ft),
+    (Chi2XspecVar, False, False, stat_dvar_ff),
+    (Chi2ConstVar, True, True, stat_chi2_tt),
+    (Chi2ConstVar, True, False, stat_chi2_tf),
+    (Chi2ConstVar, False, True, stat_cvar_ft),
+    (Chi2ConstVar, False, False, stat_cvar_ff),
+    (Chi2ModVar, True, True, stat_mvar_xt),
+    (Chi2ModVar, True, False, stat_mvar_xf),
+    (Chi2ModVar, False, True, stat_mvar_xt),
+    (Chi2ModVar, False, False, stat_mvar_xf),
+
+    (Cash, True, True, stat_cash),
+    (Cash, True, False, stat_cash),
+    (Cash, False, True, stat_cash),
+    (Cash, False, False, stat_cash),
+    (CStat, True, True, stat_cstat),
+    (CStat, True, False, stat_cstat),
+    (CStat, False, True, stat_cstat),
+    (CStat, False, False, stat_cstat),
+
+])
+def test_stats_calc_stat(stat, usestat, usesys, expected):
+    """statistic calculates expected values: single dataset"""
+
+    data, model = setup_single(usestat, usesys)
+    statobj = stat()
+    # do not check fvec
+    answer, _ = statobj.calc_stat_from_data(data, model)
+    assert_almost_equal(answer, expected)
+
+
+delta_lsq = exp_lsq[2]
+
+delta_chi2_tt = exp_chi2_tt[2]
+delta_chi2_tf = exp_chi2_tf[2]
+
+delta_gehrels_ft = exp_gehrels_ft[2]
+delta_gehrels_ff = exp_gehrels_ff[2]
+
+delta_dvar_ft = exp_dvar_ft[2]
+delta_dvar_ff = exp_dvar_ff[2]
+
+# These do not follow the "expected" rule
+delta_cvar_ft = exp_cvar_ft.sum() - exp_cvar_2_ft.sum()
+delta_cvar_ff = exp_cvar_ff.sum() - exp_cvar_2_ff.sum()
+
+delta_mvar_xt = exp_mvar_xt[2]
+delta_mvar_xf = exp_mvar_xf[2]
+
+delta_cash = -3.60309696433
+delta_cstat = 0.340992230887
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected1,delta", [
+    (Chi2, True, True, stat_chi2_tt, delta_chi2_tt),
+    (Chi2, True, False, stat_chi2_tf, delta_chi2_tf),
+    (LeastSq, True, True, stat_lsq, delta_lsq),
+    (LeastSq, True, False, stat_lsq, delta_lsq),
+    (LeastSq, False, True, stat_lsq, delta_lsq),
+    (LeastSq, False, False, stat_lsq, delta_lsq),
+    (Chi2Gehrels, True, True, stat_chi2_tt, delta_chi2_tt),
+    (Chi2Gehrels, True, False, stat_chi2_tf, delta_chi2_tf),
+    (Chi2Gehrels, False, True, stat_gehrels_ft, delta_gehrels_ft),
+    (Chi2Gehrels, False, False, stat_gehrels_ff, delta_gehrels_ff),
+    (Chi2DataVar, True, True, stat_chi2_tt, delta_chi2_tt),
+    (Chi2DataVar, True, False, stat_chi2_tf, delta_chi2_tf),
+    (Chi2DataVar, False, True, stat_dvar_ft, delta_dvar_ft),
+    (Chi2DataVar, False, False, stat_dvar_ff, delta_dvar_ff),
+    (Chi2XspecVar, True, True, stat_chi2_tt, delta_chi2_tt),
+    (Chi2XspecVar, True, False, stat_chi2_tf, delta_chi2_tf),
+    (Chi2XspecVar, False, True, stat_dvar_ft, delta_dvar_ft),
+    (Chi2XspecVar, False, False, stat_dvar_ff, delta_dvar_ff),
+    (Chi2ConstVar, True, True, stat_chi2_tt, delta_chi2_tt),
+    (Chi2ConstVar, True, False, stat_chi2_tf, delta_chi2_tf),
+    # Unlike test_stats_calcchisqr_multi, the following two
+    # can be included in this test
+    (Chi2ConstVar, False, True, stat_cvar_ft, delta_cvar_ft),
+    (Chi2ConstVar, False, False, stat_cvar_ff, delta_cvar_ff),
+    (Chi2ModVar, True, True, stat_mvar_xt, delta_mvar_xt),
+    (Chi2ModVar, True, False, stat_mvar_xf, delta_mvar_xf),
+    (Chi2ModVar, False, True, stat_mvar_xt, delta_mvar_xt),
+    (Chi2ModVar, False, False, stat_mvar_xf, delta_mvar_xf),
+
+    (Cash, True, True, stat_cash, delta_cash),
+    (Cash, True, False, stat_cash, delta_cash),
+    (Cash, False, True, stat_cash, delta_cash),
+    (Cash, False, False, stat_cash, delta_cash),
+    (CStat, True, True, stat_cstat, delta_cstat),
+    (CStat, True, False, stat_cstat, delta_cstat),
+    (CStat, False, True, stat_cstat, delta_cstat),
+    (CStat, False, False, stat_cstat, delta_cstat),
+
+])
+def test_stats_calc_stat_multi(stat, usestat, usesys, expected1, delta):
+    """statistic calculates expected values: multiple dataset"""
+
+    data, model = setup_multiple(usestat, usesys)
+    statobj = stat()
+    # do not check fvec
+    answer, _ = statobj.calc_stat_from_data(data, model)
+
+    # correct for the one missing bin in the second dataset
+    expected = 2 * expected1 - delta
     assert_almost_equal(answer, expected)

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1059,8 +1059,9 @@ stat_pha_gehrels_ft = 0.989239848562
 stat_pha_gehrels_bg_ff = 1.43234664248
 stat_pha_gehrels_bg_ft = 1.03105762001
 
-# TODO: should the background subtraction actually raise an errror
-#       for the likelihood statistics?
+# NOTE: The code should error out rather than calculate a
+#       statistic for background subtracted data for the
+#       likelihood stats (wstat may behave differently)
 #
 stat_pha_cash = -299.771783393
 stat_pha_cash_bg = -297.366618448
@@ -1072,8 +1073,10 @@ stat_pha_cstat_bg = 1.8269289994
 # is different to the CIAO 4.8 value
 #    CIAO 4.8  stat_pha_wstat_bg = 1.89508667251
 #          PR                    = 1.8959639988070474
-# but as this should be an error I am not investigating it
-# further.
+# because of the way the 4.8 code has to be run to calculate
+# this (to avoid the bugs in the 4.8 code with handling filtered
+# backscal arrays). As this code should not be running I am not
+# going to try and work out a regression value using 4.8.
 #
 stat_pha_wstat = 1.81735155799
 stat_pha_wstat_bg = 1.8959639988070474

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -409,7 +409,7 @@ def test_stats_calc_stat_chi2_nostat(usesys):
     data, model = setup_single(False, usesys)
     statobj = Chi2()
     with pytest.raises(StatErr) as excinfo:
-        statobj.calc_stat_from_data(data, model)
+        statobj.calc_stat(data, model)
 
     emsg = 'If you select chi2 as the statistic, all datasets ' + \
            'must provide a staterror column'
@@ -426,7 +426,7 @@ def test_stats_calc_stat_likelihood_bgnd(stat):
     data.datasets[1].subtract()
     statobj = stat()
     with pytest.raises(FitErr) as excinfo:
-        statobj.calc_stat_from_data(data, model)
+        statobj.calc_stat(data, model)
 
     emsg = '{} statistics cannot be used with '.format(statobj.name) + \
            'background subtracted data'
@@ -445,7 +445,7 @@ def test_stats_calc_stat_wstat_nobg(usestat, usesys):
     statobj = WStat()
     data, model = setup_single(usestat, usesys)
     with pytest.raises(StatErr):
-        statobj.calc_stat_from_data(data, model)
+        statobj.calc_stat(data, model)
 
 
 def test_stats_calc_stat_wstat_pha_nobg():
@@ -454,7 +454,7 @@ def test_stats_calc_stat_wstat_pha_nobg():
     statobj = WStat()
     data, model = setup_single_pha(False, False, background=False)
     with pytest.raises(StatErr):
-        statobj.calc_stat_from_data(data, model)
+        statobj.calc_stat(data, model)
 
 
 def test_stats_calc_stat_wstat_diffbins():
@@ -479,7 +479,7 @@ def test_stats_calc_stat_wstat_diffbins():
 
     # There is no Sherpa error for this, which seems surprising
     with pytest.raises(TypeError):
-        statobj.calc_stat_from_data(data, model)
+        statobj.calc_stat(data, model)
 
 
 # Numeric answers calculated using CIAO 4.8 (sherpa 4.8.0)
@@ -852,7 +852,7 @@ def test_stats_calc_stat(stat, usestat, usesys, expected):
     data, model = setup_single(usestat, usesys)
     statobj = stat()
     # do not check fvec
-    answer, _ = statobj.calc_stat_from_data(data, model)
+    answer, _ = statobj.calc_stat(data, model)
     assert_almost_equal(answer, expected)
 
 
@@ -921,7 +921,7 @@ def test_stats_calc_stat_1dint(stat, usestat, usesys, expected):
     data, model = setup_single_1dint(usestat, usesys)
     statobj = stat()
     # do not check fvec
-    answer, _ = statobj.calc_stat_from_data(data, model)
+    answer, _ = statobj.calc_stat(data, model)
     assert_almost_equal(answer, expected)
 
 
@@ -969,7 +969,7 @@ def test_stats_calc_stat_2d(stat, usestat, usesys, expected):
     data, model = setup_single_2d(usestat, usesys)
     statobj = stat()
     # do not check fvec
-    answer, _ = statobj.calc_stat_from_data(data, model)
+    answer, _ = statobj.calc_stat(data, model)
     assert_almost_equal(answer, expected)
 
 
@@ -1041,7 +1041,7 @@ def test_stats_calc_stat_multi(stat, usestat, usesys, expected1, delta):
     data, model = setup_multiple(usestat, usesys)
     statobj = stat()
     # do not check fvec
-    answer, _ = statobj.calc_stat_from_data(data, model)
+    answer, _ = statobj.calc_stat(data, model)
 
     # correct for the one missing bin in the second dataset
     expected = 2 * expected1 - delta
@@ -1130,7 +1130,7 @@ def test_stats_calc_stat_pha(stat, usestat, usesys,
 
     statobj = stat()
     # do not check fvec
-    answer, _ = statobj.calc_stat_from_data(data, model)
+    answer, _ = statobj.calc_stat(data, model)
     assert_almost_equal(answer, expected)
 
 
@@ -1221,7 +1221,7 @@ def test_stats_calc_stat_pha_multi(stat, usestat, usesys,
 
     statobj = stat()
     # do not check fvec
-    answer, _ = statobj.calc_stat_from_data(data, model)
+    answer, _ = statobj.calc_stat(data, model)
 
     # correct for the one missing bin in the second dataset
     expected = 2 * expected1 - delta

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -799,10 +799,14 @@ def test_stats_calc_stat_multi(stat, usestat, usesys, expected1, delta):
 # These values were created on a 64-bit Linux machine using
 # CIAO 4.8
 #
+stat_pha_lsq = 51.82
+
 stat_pha_chi2_tt = 1.30511684776
 stat_pha_chi2_tf = 2.0728
 
 # with background subtraction
+stat_pha_lsq_bg = 53.9958239163
+
 stat_pha_chi2_bg_tt = 1.36147410407
 stat_pha_chi2_bg_tf = 2.15970543269
 
@@ -818,6 +822,14 @@ stat_pha_gehrels_bg_ft = 1.03105762001
 # okay with the others.
 #
 @pytest.mark.parametrize("stat,usestat,usesys,havebg,usebg,expected", [
+    (LeastSq, True, True, False, False, stat_pha_lsq),
+    (LeastSq, True, True, True, False, stat_pha_lsq),
+    (LeastSq, True, True, True, True, stat_pha_lsq_bg),
+
+    (LeastSq, False, False, False, False, stat_pha_lsq),
+    (LeastSq, False, False, True, False, stat_pha_lsq),
+    (LeastSq, False, False, True, True, stat_pha_lsq_bg),
+
     (Chi2, True, True, False, False, stat_pha_chi2_tt),
     (Chi2, True, True, True, False, stat_pha_chi2_tt),
     (Chi2, True, True, True, True, stat_pha_chi2_bg_tt),

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -860,6 +860,8 @@ stat_pha_cash_bg = -297.366618448
 stat_pha_cstat = 1.75191290087
 stat_pha_cstat_bg = 1.8269289994
 
+stat_pha_wstat = 1.81735155799
+
 
 # This is not as extensive as some of the earlier checks as the
 # assumption is that if it works for these variants it should be
@@ -906,6 +908,10 @@ stat_pha_cstat_bg = 1.8269289994
     (CStat, False, False, False, False, stat_pha_cstat),
     (CStat, False, False, True, True, stat_pha_cstat_bg),
 
+    # Using havebg=False for wstat will raise an error
+    (WStat, False, False, True, False, stat_pha_wstat),
+    (WStat, True, True, True, False, stat_pha_wstat),
+
 ])
 def test_stats_calc_stat_pha(stat, usestat, usesys,
                              havebg, usebg, expected):
@@ -941,6 +947,8 @@ delta_pha_cash_bg = -114.907812934
 
 delta_pha_cstat = 1.56044177301
 delta_pha_cstat_bg = 1.62535170774
+
+delta_pha_wstat = 1.61766768199
 
 
 @pytest.mark.parametrize("stat,usestat,usesys,havebg,usebg,expected1,delta", [
@@ -996,6 +1004,8 @@ delta_pha_cstat_bg = 1.62535170774
     (CStat, False, False, False, False, stat_pha_cstat, delta_pha_cstat),
     (CStat, False, False, True, True, stat_pha_cstat_bg, delta_pha_cstat_bg),
 
+    # Using havebg=False for wstat will raise an error
+    (WStat, False, False, True, False, stat_pha_wstat, delta_pha_wstat),
 ])
 def test_stats_calc_stat_pha_multi(stat, usestat, usesys,
                                    havebg, usebg,

--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -23,6 +23,10 @@
 # elsewhere, but for now it is useful to have some testing of
 # the various options.
 #
+# Note: sherpa/tests/test_fit_unit.py has been added which replicates
+#       some of these tests. A review has not been done to see if
+#       these tests can be removed.
+#
 # At present the statistic tests are not broken up into unit and
 # integration tests, as most of the functionality is tested either
 # in integration tests (directly or implicitly).
@@ -320,7 +324,7 @@ class test_wstat_group_counts(SherpaTestCase):
     into test_wstat_two_scalar (since it avoids having multiple
     copies of the settings, and lets the wstat be tested on
     > 2 data sets), but for now keep as a separate set of tests
-    to make sure it is obvioud what is and isn't failing.
+    to make sure it is obvious what is and isn't failing.
     """
 
     def setUp(self):
@@ -377,7 +381,6 @@ class test_wstat_group_counts(SherpaTestCase):
         stat = ui.calc_stat(idval)
         self.assertAlmostEqual(expected, stat, places=7)
 
-    @expectedFailure
     def test_wstat_grouped_all(self):
 
         # Used git commit 770359b5004374b969ebb63c173f293419397b4c
@@ -385,7 +388,6 @@ class test_wstat_group_counts(SherpaTestCase):
         expval = 401.75572944361613
         self._check_stat(1, 148, expval)
 
-    @expectedFailure
     def test_wstat_grouped_filtered(self):
         self._filter_data()
 
@@ -482,14 +484,12 @@ class test_wstat_single_array(SherpaTestCase):
         stat = ui.calc_stat()
         self.assertAlmostEqual(expected, stat, places=7)
 
-    @expectedFailure
     def test_wstat_grouped_all(self):
 
         # Used git commit 770359b5004374b969ebb63c173f293419397b4c
         # to create the oracle value, on a linux 64-bit machine.
         self._check_stat(46, 71.21845954979574)
 
-    @expectedFailure
     def test_wstat_grouped_filtered(self):
         self._filter_data()
 
@@ -504,7 +504,6 @@ class test_wstat_single_array(SherpaTestCase):
         # to create the oracle value, on a linux 64-bit machine.
         self._check_stat(1024, 663.0160968458746)
 
-    @expectedFailure
     def test_wstat_ungrouped_filtered(self):
         ui.ungroup()
         self._filter_data()

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -84,12 +84,6 @@
 # Note that the stats test should be probing those cases, as here they
 # are just representative tests.
 #
-# *) remove wstat _response_ids workaround
-#
-# For Sherpa 4.8.2 and earlier, the wstat tests need to fake a response,
-# by setting the _response_ids field of the source dataset. This should
-# be removed as soon as possible.
-#
 
 import pytest
 import numpy as np
@@ -942,18 +936,7 @@ def setup_pha_single(scalar, usestat, usesys, flo, fhi, stat=None):
     else:
         statobj = stat
 
-    fit = Fit(src, mdl, stat=statobj)
-
-    # Due to the way wstat is handled in Sherpa 4.8.0, need the
-    # following work around, otherwise the code thinks there's
-    # no background. All that is needed is for the response_ids
-    # attribute to be the non-empty list - i.e. it does not even
-    # have to have a response - but you can not change response_ids
-    # directly, so I work around this.
-    #
-    src._response_ids = [1]
-
-    return fit
+    return Fit(src, mdl, stat=statobj)
 
 
 def setup_pha_multiple(flo, fhi):
@@ -1031,13 +1014,6 @@ def setup_pha_multiple(flo, fhi):
     src2.notice(lo=flo, hi=fhi)
     bg2.notice(lo=flo, hi=fhi)
     bg3.notice(lo=flo, hi=fhi)
-
-    # work around issue with wstat in Sherpa 4.8.0 (in that it
-    # requires both background_ids and response_ids arrays to
-    # not be empty)
-    src1._response_ids = [1]
-    src2._response_ids = [1]
-    src3._response_ids = [1]
 
     # Model components
     m1 = Gauss1D('m1')
@@ -1331,16 +1307,6 @@ def test_fit_calc_stat_wstat_grouped_single(flo, fhi, expected):
 
     # For now restrict to the default statistic values
     fit = Fit(src, mdl, stat=WStat())
-
-    # Due to the way wstat is handled in Sherpa 4.8.0, need the
-    # following work around, otherwise the code thinks there's
-    # no background. All that is needed is for the response_ids
-    # attribute to be the non-empty list - i.e. it does not even
-    # have to have a response - but you can not change response_ids
-    # directly, so I work around this.
-    #
-    src._response_ids = [1]
-
     assert_almost_equal(fit.calc_stat(), expected)
 
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2209,7 +2209,7 @@ def test_est_errors_single_pha(stat, scalar, usestat, usesys, filtflag):
 # Due to the way the errors are set in setup_pha_multiple(), can not
 # use Chi2 here.
 #
-@pytest.mark.parametrize("stat,flo,fhi",[
+@pytest.mark.parametrize("stat,flo,fhi", [
     (Chi2Gehrels, None, None),
     (Chi2Gehrels, 2, None),
     (Chi2Gehrels, None, 8),

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1148,42 +1148,72 @@ def test_fit_calc_stat_wstat_single(scalar, usestat, usesys,
     assert_almost_equal(fit.calc_stat(), expected)
 
 
-@pytest.mark.parametrize("scalar,usestat,usesys,flo,fhi,nbin,expected", [
-    (True, False, False, None, None, 5, wstat_single_scalar_stat),
-    (True, True, False, None, None, 5, wstat_single_scalar_stat),
-    (True, False, True, None, None, 5, wstat_single_scalar_stat),
-    (True, True, True, None, None, 5, wstat_single_scalar_stat),
+# The qval values were calculated using changeset
+# b47c94ec7a28b7572b0665ac735db404d0dad13b
+qval_scalar = 0.000819438167689
+qval_scalar_lo = 0.000675824858126
+qval_scalar_hi = 0.00158163032114
+qval_scalar_mid = 0.00118201779597
 
-    (True, False, False, -10, 10, 5, wstat_single_scalar_stat),
-    (True, False, False, 1, 5, 5, wstat_single_scalar_stat),
+qval_array = 0.000824015790193
+qval_array_lo = 0.000679780437499
+qval_array_hi = 0.00159083325587
+qval_array_mid = 0.00118932173205
 
-    (True, False, False, 2, None, 4, wstat_single_scalar_lo_stat),
-    (True, False, False, 1.2, None, 4, wstat_single_scalar_lo_stat),
-    (True, True, True, 2, None, 4, wstat_single_scalar_lo_stat),
-    (True, False, False, None, 4.1, 4, wstat_single_scalar_hi_stat),
-    (True, True, True, None, 4.1, 4, wstat_single_scalar_hi_stat),
-    (True, False, False, 1.2, 4.1, 3, wstat_single_scalar_mid_stat),
-    (True, False, False, 2, 4.1, 3, wstat_single_scalar_mid_stat),
-    (True, True, True, 1.2, 4.1, 3, wstat_single_scalar_mid_stat),
 
-    (False, False, False, None, None, 5, wstat_single_array_stat),
-    (False, True, False, None, None, 5, wstat_single_array_stat),
-    (False, False, True, None, None, 5, wstat_single_array_stat),
-    (False, True, True, None, None, 5, wstat_single_array_stat),
+@pytest.mark.parametrize("scalar,usestat,usesys,flo,fhi,nbin,expected,qval", [
+    (True, False, False, None, None, 5, wstat_single_scalar_stat, qval_scalar),
+    (True, True, False, None, None, 5, wstat_single_scalar_stat, qval_scalar),
+    (True, False, True, None, None, 5, wstat_single_scalar_stat, qval_scalar),
+    (True, True, True, None, None, 5, wstat_single_scalar_stat, qval_scalar),
 
-    (False, False, False, -1, 6, 5, wstat_single_array_stat),
-    (False, False, False, 1, 5, 5, wstat_single_array_stat),
+    (True, False, False, -10, 10, 5, wstat_single_scalar_stat, qval_scalar),
+    (True, False, False, 1, 5, 5, wstat_single_scalar_stat, qval_scalar),
 
-    (False, True, False, 1.2, None, 4, wstat_single_array_lo_stat),
-    (False, False, True, 2, None, 4, wstat_single_array_lo_stat),
+    (True, False, False, 2, None, 4, wstat_single_scalar_lo_stat,
+     qval_scalar_lo),
+    (True, False, False, 1.2, None, 4, wstat_single_scalar_lo_stat,
+     qval_scalar_lo),
+    (True, True, True, 2, None, 4, wstat_single_scalar_lo_stat,
+     qval_scalar_lo),
 
-    (False, False, False, None, 4.1, 4, wstat_single_array_hi_stat),
-    (False, False, False, 1.2, 4.1, 3, wstat_single_array_mid_stat),
-    (False, False, False, 2, 4.1, 3, wstat_single_array_mid_stat),
-    (False, False, False, 2, 4, 3, wstat_single_array_mid_stat)
+    (True, False, False, None, 4.1, 4, wstat_single_scalar_hi_stat,
+     qval_scalar_hi),
+    (True, True, True, None, 4.1, 4, wstat_single_scalar_hi_stat,
+     qval_scalar_hi),
+
+    (True, False, False, 1.2, 4.1, 3, wstat_single_scalar_mid_stat,
+     qval_scalar_mid),
+    (True, False, False, 2, 4.1, 3, wstat_single_scalar_mid_stat,
+     qval_scalar_mid),
+    (True, True, True, 1.2, 4.1, 3, wstat_single_scalar_mid_stat,
+     qval_scalar_mid),
+
+    (False, False, False, None, None, 5, wstat_single_array_stat, qval_array),
+    (False, True, False, None, None, 5, wstat_single_array_stat, qval_array),
+    (False, False, True, None, None, 5, wstat_single_array_stat, qval_array),
+    (False, True, True, None, None, 5, wstat_single_array_stat, qval_array),
+
+    (False, False, False, -1, 6, 5, wstat_single_array_stat, qval_array),
+    (False, False, False, 1, 5, 5, wstat_single_array_stat, qval_array),
+
+    (False, True, False, 1.2, None, 4, wstat_single_array_lo_stat,
+     qval_array_lo),
+    (False, False, True, 2, None, 4, wstat_single_array_lo_stat,
+     qval_array_lo),
+
+    (False, False, False, None, 4.1, 4, wstat_single_array_hi_stat,
+     qval_array_hi),
+
+    (False, False, False, 1.2, 4.1, 3, wstat_single_array_mid_stat,
+     qval_array_mid),
+    (False, False, False, 2, 4.1, 3, wstat_single_array_mid_stat,
+     qval_array_mid),
+    (False, False, False, 2, 4, 3, wstat_single_array_mid_stat,
+     qval_array_mid),
 ])
 def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
-                                         flo, fhi, nbin, expected):
+                                         flo, fhi, nbin, expected, qval):
     """Test the results from the calc_stat_info method of Fit for 1 data set: wstat
 
     This was created using the CIAO 4.8 version of Sherpa
@@ -1208,13 +1238,8 @@ def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
     assert ans.dof == dof
     assert_almost_equal(ans.statval, expected)
 
-    # TODO: as this is derived from cstat, shouldn't it calculate
-    #       a q value and reduced stat?
-    assert ans.qval is None
-    assert ans.rstat is None
-
-    # assert_almost_equal(ans.qval, qval)
-    # assert_almost_equal(ans.rstat, ans.statval / dof)
+    assert_almost_equal(ans.qval, qval)
+    assert_almost_equal(ans.rstat, expected / dof)
 
 
 # Do not really need to go through all these options, but it's easy
@@ -1384,20 +1409,27 @@ wstat_multi_lo_nbins = wstat_multi_nbins - 2
 wstat_multi_hi_nbins = wstat_multi_nbins - 1
 wstat_multi_mid_nbins = wstat_multi_nbins - 3
 
+# The qval values were calculated using changeset
+# b47c94ec7a28b7572b0665ac735db404d0dad13b
+qval_multi = 0.106711635305
+qval_multi_lo = 0.0731604652765
+qval_multi_hi = 0.0839948772314
+qval_multi_mid = 0.0555167652247
 
-@pytest.mark.parametrize("flo,fhi,nbin,expected", [
-    (None, None, wstat_multi_nbins, wstat_multi_all),
-    (None, 1000, wstat_multi_nbins, wstat_multi_all),
-    (0, None, wstat_multi_nbins, wstat_multi_all),
-    (0, 1000, wstat_multi_nbins, wstat_multi_all),
-    (1, None, wstat_multi_nbins, wstat_multi_all),
-    (1, 1000, wstat_multi_nbins, wstat_multi_all),
 
-    (2, None, wstat_multi_lo_nbins, wstat_multi_lo),
-    (None, 8, wstat_multi_hi_nbins, wstat_multi_hi),
-    (2, 8, wstat_multi_mid_nbins, wstat_multi_mid),
+@pytest.mark.parametrize("flo,fhi,nbin,expected, qval", [
+    (None, None, wstat_multi_nbins, wstat_multi_all, qval_multi),
+    (None, 1000, wstat_multi_nbins, wstat_multi_all, qval_multi),
+    (0, None, wstat_multi_nbins, wstat_multi_all, qval_multi),
+    (0, 1000, wstat_multi_nbins, wstat_multi_all, qval_multi),
+    (1, None, wstat_multi_nbins, wstat_multi_all, qval_multi),
+    (1, 1000, wstat_multi_nbins, wstat_multi_all, qval_multi),
+
+    (2, None, wstat_multi_lo_nbins, wstat_multi_lo, qval_multi_lo),
+    (None, 8, wstat_multi_hi_nbins, wstat_multi_hi, qval_multi_hi),
+    (2, 8, wstat_multi_mid_nbins, wstat_multi_mid, qval_multi_mid),
 ])
-def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected):
+def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected, qval):
     """Test the results from the calc_stat_info method of Fit for 3 data sets: wstat
 
     This was created using the CIAO 4.8 version of Sherpa
@@ -1421,13 +1453,8 @@ def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected):
     assert ans.dof == dof
     assert_almost_equal(ans.statval, expected)
 
-    # TODO: as this is derived from cstat, shouldn't it calculate
-    #       a q value and reduced stat?
-    assert ans.qval is None
-    assert ans.rstat is None
-
-    # assert_almost_equal(ans.qval, qval)
-    # assert_almost_equal(ans.rstat, ans.statval / dof)
+    assert_almost_equal(ans.qval, qval)
+    assert_almost_equal(ans.rstat, expected / dof)
 
 
 @pytest.mark.parametrize("flo,fhi,expected", [
@@ -2382,9 +2409,14 @@ def test_fit_iterfit_single_sigmarej_chi2gehrels():
     assert fr.dof == 4
 
 
-# Check that rstat and qval are displayed for WSTAT
-@pytest.mark.xfail()
-def test_wstat_rstat_qval():
+def test_wstat_rstat_qval_fields_not_none():
+    """It turns out there are other tests that check if rstat/qval
+    are populated, but leave these in.
+
+    Note the tests do not check the numerical values (these are
+    handled elsewhere), just that the qval and rstat fields are
+    not None.
+    """
 
     fit = setup_pha_single(True, False, False, None, None)
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -300,15 +300,6 @@ def setup_pha_single(scalar, usestat, usesys, flo, fhi, stat=None):
     else:
         statobj = stat
 
-    # HACK
-    #
-    # This is needed for Sherpa 4.8.2 code; I had thought I could remove
-    # this, but it is still needed to get the fit object to work when using
-    # the WStat statistic (when calc_stat_from_data is moved to calc_stat
-    # in the stat object then this should be able to be removed).
-    #
-    src._response_ids = [1]
-
     return Fit(src, mdl, stat=statobj)
 
 
@@ -377,16 +368,6 @@ def setup_pha_multiple(flo, fhi, stat=None):
     src1.set_background(bg1)
     src2.set_background(bg2)
     src3.set_background(bg3)
-
-    # HACK
-    #
-    # This is needed for Sherpa 4.8.2 code; I had thought I could remove
-    # this, but it is still needed to get the fit object to work when using
-    # the WStat statistic (when calc_stat_from_data is moved to calc_stat
-    # in the stat object then this should be able to be removed).
-    #
-    for src in [src1, src2, src3]:
-        src._response_ids = [1]
 
     # Apply filtering to
     #  1: source only
@@ -1839,9 +1820,9 @@ fit_pha_wstat_t = 18.5533195269
 fit_pha_filt_wstat_t = 6.91786326729
 fit_pha_wstat_f = 18.552838794
 
-# The expected value was calculated in CIAO 4.8 and so may not
-# be correct (due to known issues there).
-fit_pha_filt_wstat_f = fit_pha_filt_wstat_t
+# This value is not from CIAO 4.8 since the code there does not
+# calculate the correct value.
+fit_pha_filt_wstat_f = 6.89372285597
 
 
 @pytest.mark.parametrize("stat,scalar,usestat,usesys,filtflag,finalstat", [
@@ -1872,10 +1853,7 @@ fit_pha_filt_wstat_f = fit_pha_filt_wstat_t
     (WStat, True, True, False, False, fit_pha_wstat_t),
     (WStat, True, True, False, True, fit_pha_filt_wstat_t),
     (WStat, False, True, False, False, fit_pha_wstat_f),
-
-    # This errors out due to a mis-match in the number of bins.
-    pytest.mark.xfail((WStat, False, True, False, True,
-                       fit_pha_filt_wstat_f)),
+    (WStat, False, True, False, True, fit_pha_filt_wstat_f),
 ])
 def test_fit_single_pha(stat, scalar, usestat, usesys, filtflag, finalstat):
     """Check that the fit method works: single dataset, PHA, successful fit
@@ -2174,10 +2152,7 @@ def test_est_errors_multiple(stat):
     (CStat, True, False, False, False),
     (CStat, True, False, False, True),
     (WStat, False, False, False, False),
-
-    # This errors out due to a mis-match in the number of bins.
-    pytest.mark.xfail((WStat, False, False, False, True)),
-
+    (WStat, False, False, False, True),
     (WStat, True, False, False, False),
     (WStat, True, False, False, True),
 ])
@@ -2225,11 +2200,9 @@ def test_est_errors_single_pha(stat, scalar, usestat, usesys, filtflag):
     (CStat, None, 8),
     (CStat, 2, 8),
     (WStat, None, None),
-
-    # filtering/grouping issues
-    pytest.mark.xfail((WStat, 2, None)),
-    pytest.mark.xfail((WStat, None, 8)),
-    pytest.mark.xfail((WStat, 2, 8)),
+    (WStat, 2, None),
+    (WStat, None, 8),
+    (WStat, 2, 8)
 ])
 def test_est_errors_multiple_pha(stat, flo, fhi):
     """Check that the est_errors method works: multiple datasets, PHA, successful fit

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1101,19 +1101,13 @@ wstat_single_array_mid_stat = 13.468744214842486
     (False, False, False, -1, 6, wstat_single_array_stat),
     (False, False, False, 1, 5, wstat_single_array_stat),
 
-    pytest.mark.xfail((False, True, False, 1.2, None,
-                       wstat_single_array_lo_stat)),
-    pytest.mark.xfail((False, False, True, 2, None,
-                       wstat_single_array_lo_stat)),
+    (False, True, False, 1.2, None, wstat_single_array_lo_stat),
+    (False, False, True, 2, None, wstat_single_array_lo_stat),
 
-    pytest.mark.xfail((False, False, False, None, 4.1,
-                       wstat_single_array_hi_stat)),
-    pytest.mark.xfail((False, False, False, 1.2, 4.1,
-                       wstat_single_array_mid_stat)),
-    pytest.mark.xfail((False, False, False, 2, 4.1,
-                       wstat_single_array_mid_stat)),
-    pytest.mark.xfail((False, False, False, 2, 4,
-                       wstat_single_array_mid_stat))
+    (False, False, False, None, 4.1, wstat_single_array_hi_stat),
+    (False, False, False, 1.2, 4.1, wstat_single_array_mid_stat),
+    (False, False, False, 2, 4.1, wstat_single_array_mid_stat),
+    (False, False, False, 2, 4, wstat_single_array_mid_stat)
 ])
 def test_fit_calc_stat_wstat_single(scalar, usestat, usesys,
                                     flo, fhi, expected):
@@ -1155,19 +1149,13 @@ def test_fit_calc_stat_wstat_single(scalar, usestat, usesys,
     (False, False, False, -1, 6, 5, wstat_single_array_stat),
     (False, False, False, 1, 5, 5, wstat_single_array_stat),
 
-    pytest.mark.xfail((False, True, False, 1.2, None, 4,
-                       wstat_single_array_lo_stat)),
-    pytest.mark.xfail((False, False, True, 2, None, 4,
-                       wstat_single_array_lo_stat)),
+    (False, True, False, 1.2, None, 4, wstat_single_array_lo_stat),
+    (False, False, True, 2, None, 4, wstat_single_array_lo_stat),
 
-    pytest.mark.xfail((False, False, False, None, 4.1, 4,
-                       wstat_single_array_hi_stat)),
-    pytest.mark.xfail((False, False, False, 1.2, 4.1, 3,
-                       wstat_single_array_mid_stat)),
-    pytest.mark.xfail((False, False, False, 2, 4.1, 3,
-                       wstat_single_array_mid_stat)),
-    pytest.mark.xfail((False, False, False, 2, 4, 3,
-                       wstat_single_array_mid_stat))
+    (False, False, False, None, 4.1, 4, wstat_single_array_hi_stat),
+    (False, False, False, 1.2, 4.1, 3, wstat_single_array_mid_stat),
+    (False, False, False, 2, 4.1, 3, wstat_single_array_mid_stat),
+    (False, False, False, 2, 4, 3, wstat_single_array_mid_stat)
 ])
 def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
                                          flo, fhi, nbin, expected):
@@ -1263,10 +1251,10 @@ def test_fit_calc_chisqr_wstat_single(scalar, usestat, usesys,
     # (using a slightly different approach to the final fix,
     # see #269, commit 332feb2ff70595d28fc4d6cd9e2f158a95ee46d9)
     #
-    pytest.mark.xfail((None, None, 179.593636089)),
-    pytest.mark.xfail((3, None, 177.863206820)),
-    pytest.mark.xfail((None, 12, 77.7333219274)),
-    pytest.mark.xfail((5, 15, 97.7590037051)),
+    (None, None, 179.593636089),
+    (3, None, 177.863206820),
+    (None, 12, 77.7333219274),
+    (5, 15, 97.7590037051),
 
 ])
 def test_fit_calc_stat_wstat_grouped_single(flo, fhi, expected):
@@ -1350,9 +1338,9 @@ wstat_multi_mid = 27.177406768
     (1, None, wstat_multi_all),
     (1, 1000, wstat_multi_all),
 
-    pytest.mark.xfail((2, None, wstat_multi_lo)),
-    pytest.mark.xfail((None, 8, wstat_multi_hi)),
-    pytest.mark.xfail((2, 8, wstat_multi_mid)),
+    (2, None, wstat_multi_lo),
+    (None, 8, wstat_multi_hi),
+    (2, 8, wstat_multi_mid),
 ])
 def test_fit_calc_stat_wstat_multiple(flo, fhi, expected):
     """Test the results from the calc_stat method of Fit for 3 data sets: wstat
@@ -1390,9 +1378,9 @@ wstat_multi_mid_nbins = wstat_multi_nbins - 3
     (1, None, wstat_multi_nbins, wstat_multi_all),
     (1, 1000, wstat_multi_nbins, wstat_multi_all),
 
-    pytest.mark.xfail((2, None, wstat_multi_lo_nbins, wstat_multi_lo)),
-    pytest.mark.xfail((None, 8, wstat_multi_hi_nbins, wstat_multi_hi)),
-    pytest.mark.xfail((2, 8, wstat_multi_mid_nbins, wstat_multi_mid)),
+    (2, None, wstat_multi_lo_nbins, wstat_multi_lo),
+    (None, 8, wstat_multi_hi_nbins, wstat_multi_hi),
+    (2, 8, wstat_multi_mid_nbins, wstat_multi_mid),
 ])
 def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected):
     """Test the results from the calc_stat_info method of Fit for 3 data sets: wstat
@@ -1486,6 +1474,61 @@ def test_fit_calc_stat_error_on_wstat():
         f = Fit(d, m, stat=Chi2())
         with pytest.raises(StatErr):
             f.calc_stat()
+
+
+# The Fit constructor should probably check, and error out if there
+# is a size mis-match. These should really be a unit test of the
+# stat class.
+#
+@pytest.mark.parametrize("stat", [
+    LeastSq, Chi2, Chi2DataVar, Cash, CStat
+])
+def test_fit_calc_stat_error_on_mismatch(stat):
+    """Check that an error message is raised when ndata != nmodel"""
+
+    # Do not need the fit objects returned by setup_stat_multiple,
+    # but easier to extract the information (data and models) from
+    # them.
+    #
+    statobj = stat()
+    _, fits = setup_stat_multiple(statobj, False, False)
+
+    data = [f.data for f in fits]
+    models = [f.model for f in fits]
+
+    dobj = DataSimulFit('too-many-data', data)
+    mobj = SimulFitModel('not-enough-models', models[0:2])
+    f = Fit(dobj, mobj, stat=statobj)
+    with pytest.raises(StatErr):
+        f.calc_stat()
+
+    dobj = DataSimulFit('not-enough-data', data[0:2])
+    mobj = SimulFitModel('too-many-models', models)
+    f = Fit(dobj, mobj, stat=statobj)
+    with pytest.raises(StatErr):
+        f.calc_stat()
+
+
+def test_fit_calc_stat_error_on_mismatch_wstat():
+    """Check that an error message is raised when ndata != nmodel + wstat"""
+
+    statobj = WStat()
+    _, fits = setup_wstat_multiple(None, None)
+
+    data = [f.data for f in fits]
+    models = [f.model for f in fits]
+
+    dobj = DataSimulFit('too-many-data', data)
+    mobj = SimulFitModel('not-enough-models', models[0:2])
+    f = Fit(dobj, mobj, stat=statobj)
+    with pytest.raises(StatErr):
+        f.calc_stat()
+
+    dobj = DataSimulFit('not-enough-data', data[0:2])
+    mobj = SimulFitModel('too-many-models', models)
+    f = Fit(dobj, mobj, stat=statobj)
+    with pytest.raises(StatErr):
+        f.calc_stat()
 
 
 def test_fit_calc_stat_error_no_cache():

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -20,7 +20,8 @@
 # Unit tests for fit to support the statistic redesign (part of
 # investigating #248 and #227).
 #
-# It does *not* include tests of the fit/error calculations.
+# It includes very-basic tests of the fit/error calculations
+# (at present fit only).
 #
 # Notes
 #
@@ -1604,3 +1605,160 @@ def test_fit_str_multiple(stat):
     expected = "\n".join(["{:9s} = {}".format(*e) for e in expected])
 
     assert out == expected
+
+
+# Calculated using LevMar
+#
+fit_lsq = 26.1355932203
+
+fit_chi2_tt = 3.76425157747
+fit_chi2_tf = 8.32136015756
+
+fit_gehrels_ff = 1.22882590966
+fit_gehrels_ft = 1.04190448781
+
+# Chi2DataVar fails as can not calculate the errors. There was
+# a change in Sherpa 4.8.2 - PR #? - but maybe this didn't make it to
+# the fit code (calculating errors)
+#
+# fit_dvar_ff = np.nan
+# fit_dvar_ft = np.nan
+
+fit_xvar_ff = 2.1192140563
+fit_xvar_ft = 1.61852598
+
+fit_cvar_ff = 2.41996233522
+fit_cvar_ft = 1.78836616916
+
+fit_mvar_xt = 1.42493962338
+fit_mvar_xf = 1.84372887153
+
+fit_cash = -173.299239257
+fit_cstat = 1.96098192899
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,finalstat", [
+    (LeastSq, False, False, fit_lsq),
+    (LeastSq, True, True, fit_lsq),
+    (Chi2, True, True, fit_chi2_tt),
+    (Chi2, True, False, fit_chi2_tf),
+    (Chi2Gehrels, True, True, fit_chi2_tt),
+    (Chi2Gehrels, True, False, fit_chi2_tf),
+    (Chi2Gehrels, False, False, fit_gehrels_ff),
+    (Chi2Gehrels, False, True, fit_gehrels_ft),
+    (Chi2DataVar, True, True, fit_chi2_tt),
+    (Chi2DataVar, True, False, fit_chi2_tf),
+    # (Chi2DataVar, False, False, fit_dvar_ff),
+    # (Chi2DataVar, False, True, fit_dvar_ft),
+    (Chi2XspecVar, True, True, fit_chi2_tt),
+    (Chi2XspecVar, True, False, fit_chi2_tf),
+    (Chi2XspecVar, False, False, fit_xvar_ff),
+    (Chi2XspecVar, False, True, fit_xvar_ft),
+    (Chi2ConstVar, True, True, fit_chi2_tt),
+    (Chi2ConstVar, True, False, fit_chi2_tf),
+    (Chi2ConstVar, False, False, fit_cvar_ff),
+    (Chi2ConstVar, False, True, fit_cvar_ft),
+    (Chi2ModVar, True, True, fit_mvar_xt),
+    (Chi2ModVar, True, False, fit_mvar_xf),
+    (Chi2ModVar, False, False, fit_mvar_xf),
+    (Chi2ModVar, False, True, fit_mvar_xt),
+
+    (Cash, True, True, fit_cash),
+    (Cash, True, False, fit_cash),
+    (Cash, False, False, fit_cash),
+    (Cash, False, True, fit_cash),
+
+    (CStat, True, True, fit_cstat),
+    (CStat, True, False, fit_cstat),
+    (CStat, False, False, fit_cstat),
+    (CStat, False, True, fit_cstat),
+])
+def test_fit_single(stat, usestat, usesys, finalstat):
+    """Check that the fit method works: single dataset, successful fit
+
+    This is a minimal test, in that it just checks the
+    final statistic of the fit (not the model parameters).
+    The data and models are not designed to give good fit
+    results.
+    """
+
+    statobj = stat()
+    fit = setup_stat_single(statobj, usestat, usesys)
+    fr = fit.fit()
+    assert fr.succeeded is True
+    assert_almost_equal(fr.statval, finalstat)
+
+
+# Calculated using LevMar
+#
+fit_multi_lsq = 12992.8666667
+
+fit_multi_chi2_tt = 27.6895333147
+fit_multi_chi2_tf = 156.932316029
+
+fit_multi_gehrels_ff = 136.866794565
+fit_multi_gehrels_ft = 100.624578034
+
+fit_multi_xvar_ff = 171.96397815
+fit_multi_xvar_ft = 117.858874425
+
+fit_multi_cvar_ff = 114.086122486
+fit_multi_cvar_ft = 92.2492728722
+
+fit_multi_mvar_xt = 87.8410045128
+fit_multi_mvar_xf = 107.836151226
+
+fit_multi_cash = -137160.045124
+fit_multi_cstat = 133.900187108
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,finalstat", [
+    (LeastSq, False, False, fit_multi_lsq),
+    (LeastSq, True, True, fit_multi_lsq),
+    (Chi2, True, True, fit_multi_chi2_tt),
+    (Chi2, True, False, fit_multi_chi2_tf),
+    (Chi2Gehrels, True, True, fit_multi_chi2_tt),
+    (Chi2Gehrels, True, False, fit_multi_chi2_tf),
+    (Chi2Gehrels, False, False, fit_multi_gehrels_ff),
+    (Chi2Gehrels, False, True, fit_multi_gehrels_ft),
+    (Chi2DataVar, True, True, fit_multi_chi2_tt),
+    (Chi2DataVar, True, False, fit_multi_chi2_tf),
+    # (Chi2DataVar, False, False, fit_multi_dvar_ff),
+    # (Chi2DataVar, False, True, fit_multi_dvar_ft),
+    (Chi2XspecVar, True, True, fit_multi_chi2_tt),
+    (Chi2XspecVar, True, False, fit_multi_chi2_tf),
+    (Chi2XspecVar, False, False, fit_multi_xvar_ff),
+    (Chi2XspecVar, False, True, fit_multi_xvar_ft),
+    (Chi2ConstVar, True, True, fit_multi_chi2_tt),
+    (Chi2ConstVar, True, False, fit_multi_chi2_tf),
+    (Chi2ConstVar, False, False, fit_multi_cvar_ff),
+    (Chi2ConstVar, False, True, fit_multi_cvar_ft),
+    (Chi2ModVar, True, True, fit_multi_mvar_xt),
+    (Chi2ModVar, True, False, fit_multi_mvar_xf),
+    (Chi2ModVar, False, False, fit_multi_mvar_xf),
+    (Chi2ModVar, False, True, fit_multi_mvar_xt),
+
+    (Cash, True, True, fit_multi_cash),
+    (Cash, True, False, fit_multi_cash),
+    (Cash, False, False, fit_multi_cash),
+    (Cash, False, True, fit_multi_cash),
+
+    (CStat, True, True, fit_multi_cstat),
+    (CStat, True, False, fit_multi_cstat),
+    (CStat, False, False, fit_multi_cstat),
+    (CStat, False, True, fit_multi_cstat),
+])
+def test_fit_multiple(stat, usestat, usesys, finalstat):
+    """Check that the fit method works: multiple datasets, successful fit
+
+    This is a minimal test, in that it just checks the
+    final statistic of the fit (not the model parameters).
+    The data and models are not designed to give good fit
+    results.
+    """
+
+    statobj = stat()
+    fit, _ = setup_stat_multiple(statobj, usestat, usesys)
+    fr = fit.fit()
+    assert fr.succeeded is True
+    assert_almost_equal(fr.statval, finalstat)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2380,3 +2380,24 @@ def test_fit_iterfit_single_sigmarej_chi2gehrels():
 
     assert fr.numpoints == 6
     assert fr.dof == 4
+
+
+# Check that rstat and qval are displayed for WSTAT
+@pytest.mark.xfail()
+def test_wstat_rstat_qval():
+
+    fit = setup_pha_single(True, False, False, None, None)
+
+    s1 = fit.calc_stat_info()
+    assert s1.rstat is not None
+    assert s1.qval is not None
+
+    fr = fit.fit()
+    assert fr.rstat is not None
+    assert fr.qval is not None
+
+    s2 = fit.calc_stat_info()
+    assert s2.rstat is not None
+    assert s2.qval is not None
+    assert s2.rstat < s1.rstat
+    assert s2.qval > s1.qval

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2095,3 +2095,52 @@ def test_est_errors_single(stat, usestat, usesys):
     # check that a new best-fit location was not found during error
     # analysis
     assert result.nfits == 0
+
+
+@pytest.mark.parametrize("stat,scalar,usestat,usesys,filtflag", [
+    (Chi2, False, True, True, False),
+    (Chi2, False, True, True, True),
+    (Chi2, True, True, True, True),
+    (Chi2Gehrels, False, False, False, False),
+    (Chi2Gehrels, False, False, False, True),
+    (Chi2ModVar, True, True, True, True),
+    (Chi2ModVar, True, True, True, False),
+    (Cash, False, False, False, False),
+    (Cash, False, False, False, True),
+    (Cash, True, False, False, False),
+    (Cash, True, False, False, True),
+    (CStat, False, False, False, False),
+    (CStat, False, False, False, True),
+    (CStat, True, False, False, False),
+    (CStat, True, False, False, True),
+    (WStat, False, False, False, False),
+
+    # This errors out due to a mis-match in the number of bins.
+    pytest.mark.xfail((WStat, False, False, False, True)),
+
+    (WStat, True, False, False, False),
+    (WStat, True, False, False, True),
+])
+def test_est_errors_single_pha(stat, scalar, usestat, usesys, filtflag):
+    """Check that the est_errors method works: single dataset, PHA, successful fit
+
+    This is a minimal test, in that it just checks that the
+    error routine runs without raising an error.
+    """
+
+    statobj = stat()
+    fit = setup_pha_single(scalar, usestat, usesys, None, None,
+                           stat=statobj)
+    assert fit.method.name == 'levmar'
+    assert fit.data.subtracted is False
+
+    if filtflag:
+        fit.data.ignore(3.8, 4.5)
+
+    fit.estmethod = Covariance()
+    fit.fit()
+    result = fit.est_errors()
+
+    # check that a new best-fit location was not found during error
+    # analysis
+    assert result.nfits == 0

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1,0 +1,1571 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Unit tests for fit to support the statistic redesign (part of
+# investigating #248 and #227).
+#
+# It does *not* include tests of the fit/error calculations.
+#
+# Notes
+#
+# Since the multiple-dataset setup code returns Fit objects for the
+# individual data as well as the combined set, they could be used
+# for the "single dataset" test. This might clean up the test code
+# a bit. However, for now leave as is. The data values and model
+# parameter values should also be adjusted to provide a better test of
+# the "q value" calculated for chi-square like statistics (at present
+# the value is often << 1e-7, which is the limit for
+# assert_almost_equal).
+#
+# Some of these tests may be superfluous (e.g. testing both the single
+# and multiple dataset handling for calc_chisqr with wstat), but given
+# the current design, where the functionality is embedded within several
+# different classes, it is not clear how much we can rely on testing
+# separate behavior and then assuming they work together well. This is
+# the reason for some of the suggestions in the possible improvements
+# section below: really we should be able to rely on the filter/group
+# behavior of the data objects, so that we don't need to check as
+# many combinations as we do), but the current logic (and API of
+# some of the classes) means that they need to be tested here.
+#
+# As these tests are really a combination of the behavior of the
+# Fit, Data, Model, and Stats classes, perhaps the file name shoule be
+# changed.
+#
+# Possible improvements:
+#
+# Ideally would test grouping/filtering for non-wstat statistics, to check
+# that, when passing through fit, the mapping gets handled correctly.
+#
+# Similarly, add tests of DataPHA objects (with and without background
+# subtraction) for non-wstat statistics.
+#
+# The existing filter tests are very simple, in that the filtered data is
+# a single, contiguous chunk. A test like:
+#     notice(None, None)
+#     ignore(a, b)
+# could be used, where a >> xlo and b << xhi (i.e. a-b is a range
+# of one-or-more bins within the dataset that does not extend to
+# the edges).
+#
+# To dos:
+#
+# *) wstat and rstat/qval
+#
+# Shouldn't WStat report both a rstat and qval?
+#
+# *) weights (and chi-square stistices)
+#
+# The tests do not include any ability to change the weights (e.g. for
+# the chi-square statistic). I (DougBurke) may have missed it, but it's
+# not clear how the Data class handles weights, so is this functionality
+# that the stats class has but isn't available to the Fit class?
+#
+# *) chi2datavar and chi2xspecvar
+#
+# There are several places where it is not clear to me (DougBurke) why
+# the Chi2XspecVar result agrees or disagrees with the Chi2DataVar result.
+# Note that the stats test should be probing those cases, as here they
+# are just representative tests.
+#
+# *) remove wstat _response_ids workaround
+#
+# For Sherpa 4.8.2 and earlier, the wstat tests need to fake a response,
+# by setting the _response_ids field of the source dataset. This should
+# be removed as soon as possible.
+#
+
+import pytest
+import numpy as np
+
+from numpy.testing import assert_almost_equal
+
+from sherpa.fit import Fit, StatInfoResults
+from sherpa.data import Data1D, DataSimulFit
+from sherpa.astro.data import DataPHA
+from sherpa.models.model import SimulFitModel
+from sherpa.models.basic import Const1D, Gauss1D, Polynom1D, StepLo1D
+from sherpa.utils.err import StatErr
+
+from sherpa.stats import LeastSq, Chi2, Chi2Gehrels, Chi2DataVar, \
+    Chi2ConstVar, Chi2ModVar, Chi2XspecVar, Cash, CStat, WStat, UserStat
+
+
+def setup_stat_single(stat, usestat, usesys):
+    """Set up a single dataset with the given statistic.
+
+    A sherpa.data.Data1D instance is used.
+
+    Parameters
+    ----------
+    stat : sherpa.stats.Stat instance
+        The statistic object to use
+    usestat, usesys : bool
+        Should statistical or systematic errors be used?
+
+    Returns
+    -------
+    fit : sherpa.fit.Fit instance
+    """
+
+    # Ensure there's a bin with a dependent-axis value of 0
+    x = np.asarray([10, 20, 30, 35, 42])
+    y = np.asarray([12, 15, 10, 17, 0])
+    if usestat:
+        ystat = np.asarray([1.2, 1.3, 2.1, 0.8, 0.4])
+    else:
+        ystat = None
+    if usesys:
+        ysys = np.asarray([1.3, 1.2, 2.4, 0.2, 1.4])
+    else:
+        ysys = None
+
+    data = Data1D("test", x, y, staterror=ystat, syserror=ysys)
+
+    # Use a model which varies with position, to check that
+    # the independent axis is being passed through correctly.
+    # A simple model (single component) is sufficient, but
+    # this is done to better-handle the last y value (of 0),
+    # to make sure the data and model values are not too far
+    # apart.
+    #
+    mdl = (Polynom1D("poly") * StepLo1D("step")) + Const1D("bg")
+    pars = {p.fullname: p for p in mdl.pars}
+    pars['poly.c0'].val = 8
+    pars['poly.c1'].val = 0.15
+    pars['step.xcut'].val = 40
+    pars['bg.c0'].val = 2
+
+    return Fit(data, mdl, stat=stat)
+
+
+def setup_stat_multiple(stat, usestat, usesys):
+    """Set up multiple datasets with the given statistic.
+
+    The data is stored in sherpa.data.Data1D instances.
+
+    Parameters
+    ----------
+    stat : sherpa.stats.Stat instance
+        The statistic object to use
+    usestat, usesys : bool
+        Should statistical or systematic errors be used?
+
+    Returns
+    -------
+    fit, fits : sherpa.fit.Fit instance, list of sherpa.fit.Fit instances
+        The first fit is for the combined dataset, and then fit objects
+        for the individual data sets are returned in a list.
+
+    """
+
+    x1 = np.asarray([10, 20, 35])
+    y1 = np.asarray([12, 15, 17])
+    x2 = np.asarray([-400, -350, -325, -300])
+    y2 = np.asarray([150, 30, 180, 98])
+    x3 = np.asarray([100, 200, 300, 400, 500])
+    y3 = np.asarray([2002, 2009, 2021, 2033, 2038])
+    if usestat:
+        ystat1 = np.asarray([1.2, 1.3, 0.8])
+        ystat2 = np.asarray([30, 40, 25, 12])
+        ystat3 = np.asarray([0.2, 0.3, 0.35, 0.4, 0.5])
+    else:
+        ystat1 = None
+        ystat2 = None
+        ystat3 = None
+    if usesys:
+        ysys1 = np.asarray([1.3, 1.2, 0.2])
+        ysys2 = np.asarray([5, 6, 4, 3])
+        ysys3 = np.asarray([1, 2, 2, 1, 2])
+    else:
+        ysys1 = None
+        ysys2 = None
+        ysys3 = None
+
+    data1 = Data1D("test1", x1, y1, staterror=ystat1, syserror=ysys1)
+    data2 = Data1D("test2", x2, y2, staterror=ystat2, syserror=ysys2)
+    data3 = Data1D("test3", x3, y3, staterror=ystat3, syserror=ysys3)
+
+    data = DataSimulFit("multidata", (data1, data2, data3))
+
+    mdl1 = Const1D("mdl1")
+    mdl1.c0 = 14
+    mdl2 = Const1D("mdl2")
+    mdl2.c0 = 100
+    mdl3 = Polynom1D("mdl3")
+    mdl3.c0 = 1990
+    mdl3.c1 = 0.1
+
+    mdl = SimulFitModel("multimodel", (mdl1, mdl2, mdl3))
+
+    fit = Fit(data, mdl, stat=stat)
+    fit1 = Fit(data1, mdl1, stat=stat)
+    fit2 = Fit(data2, mdl2, stat=stat)
+    fit3 = Fit(data3, mdl3, stat=stat)
+
+    return fit, [fit1, fit2, fit3]
+
+expected_leastsq = 31.5625
+
+expected_chi2_tf = 36.9174680011
+expected_chi2_tt = 9.73944684193
+
+expected_gehrels_ff = 2.5415403715
+expected_gehrels_ft = 1.85309576866
+
+# The datavar_ft result was calculated using Sherpa 4.8.2 since this
+# combination raised an error in earlier releases (see PR #153)
+#
+expected_chi2_datavar_ff = 6.49264705882
+expected_chi2_datavar_ft = 3.76700948927
+
+expected_chi2_constvar_ff = 2.9224537037
+expected_chi2_constvar_ft = 2.1656375594
+
+expected_chi2_xspecvar_ff = expected_chi2_datavar_ff
+expected_chi2_xspecvar_ft = 3.07754451409
+
+expected_mod_statonly = 3.9268028344
+expected_mod_stat_sys = 2.50586379978
+
+expected_cash = -169.183485665
+expected_cstat = 6.07673552072
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (LeastSq, False, False, expected_leastsq),
+    (LeastSq, True, False, expected_leastsq),
+    (LeastSq, False, True, expected_leastsq),
+    (LeastSq, True, True, expected_leastsq),
+
+    # Note that Chi2 needs a staterror column but the other Chi2xxx don't
+    (Chi2, True, False, expected_chi2_tf),
+    (Chi2, True, True, expected_chi2_tt),
+
+    (Chi2Gehrels, False, False, expected_gehrels_ff),
+    (Chi2Gehrels, True, False, expected_chi2_tf),
+    (Chi2Gehrels, False, True, expected_gehrels_ft),
+    (Chi2Gehrels, True, True, expected_chi2_tt),
+
+    (Chi2DataVar, False, False, expected_chi2_datavar_ff),
+    (Chi2DataVar, True, False, expected_chi2_tf),
+    (Chi2DataVar, False, True, expected_chi2_datavar_ft),
+    (Chi2DataVar, True, True, expected_chi2_tt),
+
+    (Chi2ConstVar, False, False, expected_chi2_constvar_ff),
+    (Chi2ConstVar, True, False, expected_chi2_tf),
+    (Chi2ConstVar, False, True, expected_chi2_constvar_ft),
+    (Chi2ConstVar, True, True, expected_chi2_tt),
+
+    # Chi2ModVar does not behave similarly to the other
+    # Chi2 statistics; it is assumed that the following
+    # is correct.
+    (Chi2ModVar, False, False, expected_mod_statonly),
+    (Chi2ModVar, True, False, expected_mod_statonly),
+    (Chi2ModVar, False, True, expected_mod_stat_sys),
+    (Chi2ModVar, True, True, expected_mod_stat_sys),
+
+    (Chi2XspecVar, False, False, expected_chi2_xspecvar_ff),
+    (Chi2XspecVar, True, False, expected_chi2_tf),
+    (Chi2XspecVar, False, True, expected_chi2_xspecvar_ft),
+    (Chi2XspecVar, True, True, expected_chi2_tt),
+
+    (Cash, False, False, expected_cash),
+    (Cash, True, False, expected_cash),
+    (Cash, False, True, expected_cash),
+    (Cash, True, True, expected_cash),
+
+    (CStat, False, False, expected_cstat),
+    (CStat, True, False, expected_cstat),
+    (CStat, False, True, expected_cstat),
+    (CStat, True, True, expected_cstat)
+])
+def test_fit_calc_stat_single(stat, usestat, usesys, expected):
+    """Test the results from the calc_stat method of Fit for 1 data set.
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    # For now restrict the tests to using the default statistic values
+    #
+    fit = setup_stat_single(stat(), usestat, usesys)
+    assert_almost_equal(fit.calc_stat(), expected)
+
+
+# Unfortunately the parameter choces mean that the qval values,
+# when calculated, are often very small.
+#
+q_chi2_tf = 0.0  # actually ~ 1e-9 but check os to 7 dp
+q_chi2_tt = 0.0018035516
+
+q_mod_statonly = 0.0475222107
+q_mod_sysonly = 0.1134232786
+
+q_chi2_datavar_ff = 0.0108321566
+q_chi2_datavar_ft = 0.0522730121
+
+q_chi2_xspecvar_ff = q_chi2_datavar_ff
+q_chi2_xspecvar_ft = 0.07938028609
+
+q_cstat = 0.0136973660
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected,qval", [
+    (LeastSq, False, False, expected_leastsq, None),
+    (LeastSq, True, False, expected_leastsq, None),
+    (LeastSq, False, True, expected_leastsq, None),
+    (LeastSq, True, True, expected_leastsq, None),
+
+    (Chi2, True, False, expected_chi2_tf, q_chi2_tf),
+    (Chi2, True, True, expected_chi2_tt, q_chi2_tt),
+
+    (Chi2Gehrels, False, False, expected_gehrels_ff, 0.1108865604),
+    (Chi2Gehrels, True, False, expected_chi2_tf, q_chi2_tf),
+    (Chi2Gehrels, False, True, expected_gehrels_ft, 0.1734237670),
+    (Chi2Gehrels, True, True, expected_chi2_tt, q_chi2_tt),
+
+    (Chi2DataVar, False, False, expected_chi2_datavar_ff, q_chi2_datavar_ff),
+    (Chi2DataVar, True, False, expected_chi2_tf, q_chi2_tf),
+    (Chi2DataVar, False, True, expected_chi2_datavar_ft, q_chi2_datavar_ft),
+    (Chi2DataVar, True, True, expected_chi2_tt, q_chi2_tt),
+
+    (Chi2ConstVar, False, False, expected_chi2_constvar_ff, 0.0873549369),
+    (Chi2ConstVar, True, False, expected_chi2_tf, q_chi2_tf),
+    (Chi2ConstVar, False, True, expected_chi2_constvar_ft, 0.1411260797),
+    (Chi2ConstVar, True, True, expected_chi2_tt, q_chi2_tt),
+
+    (Chi2ModVar, False, False, expected_mod_statonly, q_mod_statonly),
+    (Chi2ModVar, True, False, expected_mod_statonly, q_mod_statonly),
+    (Chi2ModVar, False, True, expected_mod_stat_sys, q_mod_sysonly),
+    (Chi2ModVar, True, True, expected_mod_stat_sys, q_mod_sysonly),
+
+    (Chi2XspecVar, False, False, expected_chi2_xspecvar_ff,
+     q_chi2_xspecvar_ff),
+    (Chi2XspecVar, True, False, expected_chi2_tf, q_chi2_tf),
+    (Chi2XspecVar, False, True, expected_chi2_xspecvar_ft,
+     q_chi2_xspecvar_ft),
+    (Chi2XspecVar, True, True, expected_chi2_tt, q_chi2_tt),
+
+    (Cash, False, False, expected_cash, None),
+    (Cash, True, False, expected_cash, None),
+    (Cash, False, True, expected_cash, None),
+    (Cash, True, True, expected_cash, None),
+
+    (CStat, False, False, expected_cstat, q_cstat),
+    (CStat, True, False, expected_cstat, q_cstat),
+    (CStat, False, True, expected_cstat, q_cstat),
+    (CStat, True, True, expected_cstat, q_cstat)
+
+])
+def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
+    """See test_fit_calc_stat_single for the origin of the
+    expected values.
+    """
+
+    statobj = stat()
+    fit = setup_stat_single(statobj, usestat, usesys)
+    ans = fit.calc_stat_info()
+
+    assert isinstance(ans, StatInfoResults)
+    assert ans.name == ""
+    assert ans.ids is None
+    assert ans.bkg_ids is None
+    assert ans.numpoints == 5
+    assert ans.dof == 1
+    assert_almost_equal(ans.statval, expected)
+
+    # The choice of ans.statname is interesting for chi-squared
+    # cases, since it depends on whether usestat is True.
+    #
+    if statobj.name.startswith('chi2') and usestat:
+        assert ans.statname == 'chi2'
+    else:
+        assert ans.statname == statobj.name
+
+    if qval is None:
+        assert ans.qval is None
+        assert ans.rstat is None
+
+    else:
+        assert_almost_equal(ans.qval, qval)
+        # as there's only 1 dof, statval == rstat
+        assert_almost_equal(ans.rstat, ans.statval)
+
+
+chisqr_leastsq = [0.25, 4.0, 20.25, 3.0625, 4.0]
+chisqr_chi2_tf = [0.173611111, 2.366863905, 4.591836735,
+                  4.785156250, 25.0]
+chisqr_chi2_tt = [0.079872204, 1.277955272, 1.991150442,
+                  4.503676471, 1.886792453]
+
+chisqr_gehrels_ff = [0.011966630, 0.162026931, 1.106107770,
+                     0.112690724, 1.148748316]
+chisqr_gehrels_ft = [0.011071045, 0.153096839, 0.841385758,
+                     0.112525101, 0.735017026]
+
+chisqr_datavar_ff = [0.020833333, 0.266666667, 2.025000000,
+                     0.180147059, 4.0]
+chisqr_datavar_ft = [0.018261505, 0.243309002, 1.284898477,
+                     0.179724178, 2.040816327]
+
+chisqr_const_ff = [0.023148148, 0.370370370, 1.875,
+                   0.283564815, 0.370370370]
+chisqr_const_ft = [0.020016013, 0.326797386, 1.222826087,
+                   0.282518450, 0.313479624]
+
+chisqr_mod_xf = [0.021739130, 0.307692308, 1.396551724,
+                 0.200819672, 2.0]
+chisqr_mod_xt = [0.018953753, 0.277008310, 0.999506417,
+                 0.200294310, 1.010101010]
+
+chisqr_xspecvar_ff = chisqr_datavar_ff
+chisqr_xspecvar_ft = [0.018261505, 0.243309002, 1.284898477,
+                      0.179724178, 1.351351351]
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (LeastSq, False, False, chisqr_leastsq),
+    (LeastSq, True, False, chisqr_leastsq),
+    (LeastSq, False, True, chisqr_leastsq),
+    (LeastSq, True, True, chisqr_leastsq),
+
+    (Chi2, True, False, chisqr_chi2_tf),
+    (Chi2, True, True, chisqr_chi2_tt),
+
+    (Chi2Gehrels, False, False, chisqr_gehrels_ff),
+    (Chi2Gehrels, True, False, chisqr_chi2_tf),
+    (Chi2Gehrels, False, True, chisqr_gehrels_ft),
+    (Chi2Gehrels, True, True, chisqr_chi2_tt),
+
+    (Chi2DataVar, False, False, chisqr_datavar_ff),
+    (Chi2DataVar, True, False, chisqr_chi2_tf),
+    (Chi2DataVar, False, True, chisqr_datavar_ft),
+    (Chi2DataVar, True, True, chisqr_chi2_tt),
+
+    (Chi2ConstVar, False, False, chisqr_const_ff),
+    (Chi2ConstVar, True, False, chisqr_chi2_tf),
+    (Chi2ConstVar, False, True, chisqr_const_ft),
+    (Chi2ConstVar, True, True, chisqr_chi2_tt),
+
+    (Chi2ModVar, False, False, chisqr_mod_xf),
+    (Chi2ModVar, True, False, chisqr_mod_xf),
+    (Chi2ModVar, False, True, chisqr_mod_xt),
+    (Chi2ModVar, True, True, chisqr_mod_xt),
+
+    (Chi2XspecVar, False, False, chisqr_xspecvar_ff),
+    (Chi2XspecVar, True, False, chisqr_chi2_tf),
+    (Chi2XspecVar, False, True, chisqr_xspecvar_ft),
+    (Chi2XspecVar, True, True, chisqr_chi2_tt),
+
+    (Cash, False, False, None),
+    (Cash, True, False, None),
+    (Cash, False, True, None),
+    (Cash, True, True, None),
+
+    (CStat, False, False, None),
+    (CStat, True, False, None),
+    (CStat, False, True, None),
+    (CStat, True, True, None)
+])
+def test_fit_calc_chisqr_single(stat, usestat, usesys, expected):
+    """Test the results from the calc_chisqr method of Fit for 1 data set.
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    # For now restrict the tests to using the default statistic values
+    #
+    fit = setup_stat_single(stat(), usestat, usesys)
+    ans = fit.calc_chisqr()
+    if expected is None:
+        assert ans is None
+    else:
+        assert_almost_equal(ans, expected)
+
+
+expected_multi_leastsq = 13837.0
+expected_multi_chi2 = 225.06442572689826
+expected_multi_chi2_tt = 43.574115140290814
+
+expected_multi_chi2_gehrels_ff = 159.83814050225632
+expected_multi_chi2_gehrels_ft = 103.64602941062347
+
+expected_multi_chi2_datavar_ff = 216.53516387719822
+expected_multi_chi2_datavar_ft = 122.10913451612139
+
+expected_multi_chi2_constvar_ff = 121.5229005671909
+expected_multi_chi2_constvar_ft = 100.48181690303166
+
+expected_multi_chi2_xspecvar_ff = expected_multi_chi2_datavar_ff
+expected_multi_chi2_xspecvar_ft = expected_multi_chi2_datavar_ft
+
+expected_multi_chi2_mod_stat = 139.04938684379346
+expected_multi_chi2_mod_sys = 112.20863259556128
+
+expected_multi_cash = -137151.91981923723
+expected_multi_cstat = 142.0254918602011
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (LeastSq, False, False, expected_multi_leastsq),
+    (LeastSq, True, False, expected_multi_leastsq),
+    (LeastSq, False, True, expected_multi_leastsq),
+    (LeastSq, True, True, expected_multi_leastsq),
+
+    (Chi2, True, False, expected_multi_chi2),
+    (Chi2, True, True, expected_multi_chi2_tt),
+
+    (Chi2Gehrels, False, False, expected_multi_chi2_gehrels_ff),
+    (Chi2Gehrels, True, False, expected_multi_chi2),
+    (Chi2Gehrels, False, True, expected_multi_chi2_gehrels_ft),
+    (Chi2Gehrels, True, True, expected_multi_chi2_tt),
+
+    (Chi2DataVar, False, False, expected_multi_chi2_datavar_ff),
+    (Chi2DataVar, True, False, expected_multi_chi2),
+    (Chi2DataVar, False, True, expected_multi_chi2_datavar_ft),
+    (Chi2DataVar, True, True, expected_multi_chi2_tt),
+
+    (Chi2ConstVar, False, False, expected_multi_chi2_constvar_ff),
+    (Chi2ConstVar, True, False, expected_multi_chi2),
+    (Chi2ConstVar, False, True, expected_multi_chi2_constvar_ft),
+    (Chi2ConstVar, True, True, expected_multi_chi2_tt),
+
+    (Chi2ModVar, False, False, expected_multi_chi2_mod_stat),
+    (Chi2ModVar, True, False, expected_multi_chi2_mod_stat),
+    (Chi2ModVar, False, True, expected_multi_chi2_mod_sys),
+    (Chi2ModVar, True, True, expected_multi_chi2_mod_sys),
+
+    (Chi2XspecVar, False, False, expected_multi_chi2_xspecvar_ff),
+    (Chi2XspecVar, True, False, expected_multi_chi2),
+    (Chi2XspecVar, False, True, expected_multi_chi2_xspecvar_ft),
+    (Chi2XspecVar, True, True, expected_multi_chi2_tt),
+
+    (Cash, False, False, expected_multi_cash),
+    (Cash, True, False, expected_multi_cash),
+    (Cash, False, True, expected_multi_cash),
+    (Cash, True, True, expected_multi_cash),
+
+    (CStat, False, False, expected_multi_cstat),
+    (CStat, True, False, expected_multi_cstat),
+    (CStat, False, True, expected_multi_cstat),
+    (CStat, True, True, expected_multi_cstat)
+])
+def test_fit_calc_stat_multiple(stat, usestat, usesys, expected):
+    """Test the results from the calc_stat method of Fit for 3 data sets.
+
+    The idea is to check that the data sets are being sent around
+    correctly, particularly when they have different sizes.
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    # For now restrict to the default statistic values
+    #
+    statobj = stat()
+    fit, fits = setup_stat_multiple(statobj, usestat, usesys)
+
+    assert_almost_equal(fit.calc_stat(), expected)
+
+    # Test that the sum of the individual cases matches the expected
+    # value.
+    stats = [f.calc_stat() for f in fits]
+    assert_almost_equal(sum(stats), expected)
+
+
+# The choice of model parameter values does not create "good" fits,
+# hence the q values are all << 1e-7, which means that the current
+# checks can't distinguish them from zero.
+#
+q_multi_chi2_tf = 0.0  # ~ 1.8e-43
+q_multi_chi2_tt = 1.69072e-06
+
+q_multi_mod_statonly = 0.0
+q_multi_mod_sysonly = 0.0
+
+q_multi_xspecvar_ff = 0.0  # ~ 5e-22
+q_multi_xspecvar_ft = 0.0
+
+q_multi_cstat = 0.0  # ~ 4e-26
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected,qval", [
+    (LeastSq, False, False, expected_multi_leastsq, None),
+    (LeastSq, True, False, expected_multi_leastsq, None),
+    (LeastSq, False, True, expected_multi_leastsq, None),
+    (LeastSq, True, True, expected_multi_leastsq, None),
+
+    (Chi2, True, False, expected_multi_chi2, q_multi_chi2_tf),
+    (Chi2, True, True, expected_multi_chi2_tt, q_multi_chi2_tt),
+
+    (Chi2Gehrels, False, False, expected_multi_chi2_gehrels_ff, 0.0),
+    (Chi2Gehrels, True, False, expected_multi_chi2, q_multi_chi2_tf),
+    (Chi2Gehrels, False, True, expected_multi_chi2_gehrels_ft, 0.0),
+    (Chi2Gehrels, True, True, expected_multi_chi2_tt, q_multi_chi2_tt),
+
+    (Chi2DataVar, False, False, expected_multi_chi2_datavar_ff, 0.0),
+    (Chi2DataVar, True, False, expected_multi_chi2, q_multi_chi2_tf),
+    (Chi2DataVar, False, True, expected_multi_chi2_datavar_ft, 0.0),
+    (Chi2DataVar, True, True, expected_multi_chi2_tt, q_multi_chi2_tt),
+
+    (Chi2ConstVar, False, False, expected_multi_chi2_constvar_ff, 0.0),
+    (Chi2ConstVar, True, False, expected_multi_chi2, q_multi_chi2_tf),
+    (Chi2ConstVar, False, True, expected_multi_chi2_constvar_ft, 0.0),
+    (Chi2ConstVar, True, True, expected_multi_chi2_tt,
+     q_multi_chi2_tt),
+
+    (Chi2ModVar, False, False, expected_multi_chi2_mod_stat, 0.0),
+    (Chi2ModVar, True, False, expected_multi_chi2_mod_stat, 0.0),
+    (Chi2ModVar, False, True, expected_multi_chi2_mod_sys, 0.0),
+    (Chi2ModVar, True, True, expected_multi_chi2_mod_sys, 0.0),
+
+    (Chi2XspecVar, False, False, expected_multi_chi2_xspecvar_ff,
+     q_multi_xspecvar_ff),
+    (Chi2XspecVar, True, False, expected_multi_chi2, q_multi_chi2_tf),
+    (Chi2XspecVar, False, True, expected_multi_chi2_xspecvar_ft,
+     q_multi_xspecvar_ft),
+    (Chi2XspecVar, True, True, expected_multi_chi2_tt,
+     q_multi_chi2_tt),
+
+    (Cash, False, False, expected_multi_cash, None),
+    (Cash, True, False, expected_multi_cash, None),
+    (Cash, False, True, expected_multi_cash, None),
+    (Cash, True, True, expected_multi_cash, None),
+
+    (CStat, False, False, expected_multi_cstat, q_multi_cstat),
+    (CStat, True, False, expected_multi_cstat, q_multi_cstat),
+    (CStat, False, True, expected_multi_cstat, q_multi_cstat),
+    (CStat, True, True, expected_multi_cstat, q_multi_cstat)
+])
+def test_fit_calc_stat_info_multiple(stat, usestat, usesys, expected, qval):
+    """Test the results from the calc_stat_info method of Fit for 3 data sets.
+
+    The idea is to check that the data sets are being sent around
+    correctly, particularly when they have different sizes.
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    # channels, per dataset
+    nbins = [3, 4, 5]
+    nchannels = sum(nbins)
+
+    # number of free parameters, per model
+    nfree = [1, 1, 1]
+
+    ndof = nchannels - sum(nfree)
+
+    # This test does not use the individual data set results
+    statobj = stat()
+    fit, _ = setup_stat_multiple(statobj, usestat, usesys)
+
+    ans = fit.calc_stat_info()
+
+    assert isinstance(ans, StatInfoResults)
+    assert ans.name == ""
+    assert ans.ids is None
+    assert ans.bkg_ids is None
+    assert ans.numpoints == nchannels
+    assert ans.dof == ndof
+    assert_almost_equal(ans.statval, expected)
+
+    # The choice of ans.statname is interesting for chi-squared
+    # cases, since it depends on whether usestat is True.
+    #
+    if statobj.name.startswith('chi2') and usestat:
+        assert ans.statname == 'chi2'
+    else:
+        assert ans.statname == statobj.name
+
+    if qval is None:
+        assert ans.qval is None
+        assert ans.rstat is None
+
+    else:
+        assert_almost_equal(ans.qval, qval)
+        assert_almost_equal(ans.rstat, ans.statval / ndof)
+
+
+chisqr_multi_leastsq = [4.0, 1.0, 9.0, 2500.0, 4900.0, 6400.0,
+                        4.0, 4.0, 1.0, 1.0, 9.0, 4.0]
+
+chisqr_multi_chi2 = [2.777777778, 0.591715976, 14.062500000,
+                     2.777777778, 3.062500000, 10.240000000,
+                     0.027777778, 100.000000000, 11.111111111,
+                     8.163265306, 56.250000000, 16.000000000]
+chisqr_multi_chi2_tt = [1.277955272, 0.319488818, 13.235294118,
+                        2.702702703, 2.995110024, 9.984399376,
+                        0.026143791, 3.846153846, 0.244498778,
+                        0.242571255, 7.758620690, 0.941176471]
+
+chisqr_multi_gehrels_ff = [0.191466084, 0.040506733, 0.331172741,
+                           14.179887089, 114.377652560, 30.675043738,
+                           0.033437936, 0.001910900, 0.000476097,
+                           0.000473333, 0.004235405, 0.001877886]
+chisqr_multi_gehrels_ft = [0.177136713, 0.038274210, 0.330686011,
+                           12.418900956, 62.150769352, 28.490198523,
+                           0.031098249, 0.001909988, 0.000475192,
+                           0.000472438, 0.004233413, 0.001874366]
+
+chisqr_multi_datavar_ff = [0.333333333, 0.066666667, 0.529411765,
+                           16.666666667, 163.333333333, 35.555555556,
+                           0.040816327, 0.001998002, 0.000497760,
+                           0.000494805, 0.004426955, 0.001962709]
+chisqr_multi_datavar_ft = [0.292184076, 0.060827251, 0.528169014,
+                           14.285714286, 74.242424242, 32.653061224,
+                           0.037383178, 0.001997004, 0.000496771,
+                           0.000493827, 0.004424779, 0.001958864]
+
+chisqr_multi_constvar_ff = [0.272727273, 0.068181818, 0.613636364,
+                            21.834061135, 42.794759825, 55.895196507,
+                            0.034934498, 0.001979610, 0.000494903,
+                            0.000494903, 0.004454123, 0.001979610]
+chisqr_multi_constvar_ft = [0.244548604, 0.062086093, 0.611967362,
+                            17.921146953, 32.558139535, 49.042145594,
+                            0.032388664, 0.001978631, 0.000493925,
+                            0.000493925, 0.004451919, 0.001975699]
+
+chisqr_multi_mod_stat = [0.285714286, 0.071428571, 0.642857143,
+                         25.000000000, 49.000000000, 64.000000000,
+                         0.040000000, 0.002000000, 0.000497512,
+                         0.000495050, 0.004433498, 0.001960784]
+chisqr_multi_mod_sys = [0.254939452, 0.064766839, 0.641025641,
+                        20.000000000, 36.029411765, 55.172413793,
+                        0.036697248, 0.001999000, 0.000496524,
+                        0.000494071, 0.004431315, 0.001956947]
+
+chisqr_multi_xspecvar_ff = [0.333333333, 0.066666667, 0.529411765,
+                            16.666666667, 163.333333333, 35.555555556,
+                            0.040816327, 0.001998002, 0.000497760,
+                            0.000494805, 0.004426955, 0.001962709]
+chisqr_multi_xspecvar_ft = [0.292184076, 0.060827251, 0.528169014,
+                            14.285714286, 74.242424242, 32.653061224,
+                            0.037383178, 0.001997004, 0.000496771,
+                            0.000493827, 0.004424779, 0.001958864]
+
+chisqr_multi_cash = None
+chisqr_multi_cstat = None
+
+
+@pytest.mark.parametrize("stat,usestat,usesys,expected", [
+    (LeastSq, False, False, chisqr_multi_leastsq),
+    (LeastSq, True, False, chisqr_multi_leastsq),
+    (LeastSq, False, True, chisqr_multi_leastsq),
+    (LeastSq, True, True, chisqr_multi_leastsq),
+
+    (Chi2, True, False, chisqr_multi_chi2),
+    (Chi2, True, True, chisqr_multi_chi2_tt),
+
+    (Chi2Gehrels, False, False, chisqr_multi_gehrels_ff),
+    (Chi2Gehrels, True, False, chisqr_multi_chi2),
+    (Chi2Gehrels, False, True, chisqr_multi_gehrels_ft),
+    (Chi2Gehrels, True, True, chisqr_multi_chi2_tt),
+
+    (Chi2DataVar, False, False, chisqr_multi_datavar_ff),
+    (Chi2DataVar, True, False, chisqr_multi_chi2),
+    (Chi2DataVar, False, True, chisqr_multi_datavar_ft),
+    (Chi2DataVar, True, True, chisqr_multi_chi2_tt),
+
+    (Chi2ConstVar, False, False, chisqr_multi_constvar_ff),
+    (Chi2ConstVar, True, False, chisqr_multi_chi2),
+    (Chi2ConstVar, False, True, chisqr_multi_constvar_ft),
+    (Chi2ConstVar, True, True, chisqr_multi_chi2_tt),
+
+    (Chi2ModVar, False, False, chisqr_multi_mod_stat),
+    (Chi2ModVar, True, False, chisqr_multi_mod_stat),
+    (Chi2ModVar, False, True, chisqr_multi_mod_sys),
+    (Chi2ModVar, True, True, chisqr_multi_mod_sys),
+
+    (Chi2XspecVar, False, False, chisqr_multi_xspecvar_ff),
+    (Chi2XspecVar, True, False, chisqr_multi_chi2),
+    (Chi2XspecVar, False, True, chisqr_multi_xspecvar_ft),
+    (Chi2XspecVar, True, True, chisqr_multi_chi2_tt),
+
+    (Cash, False, False, chisqr_multi_cash),
+    (Cash, True, False, chisqr_multi_cash),
+    (Cash, False, True, chisqr_multi_cash),
+    (Cash, True, True, chisqr_multi_cash),
+
+    (CStat, False, False, chisqr_multi_cstat),
+    (CStat, True, False, chisqr_multi_cstat),
+    (CStat, False, True, chisqr_multi_cstat),
+    (CStat, True, True, chisqr_multi_cstat)
+])
+def test_fit_calc_chisqr_multiple(stat, usestat, usesys, expected):
+    """Test the results from the calc_chisqr method of Fit for 3 data sets.
+
+    The idea is to check that the data sets are being sent around
+    correctly, particularly when they have different sizes.
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    # For now restrict the tests to using the default statistic values
+    #
+    fit, fits = setup_stat_multiple(stat(), usestat, usesys)
+    ans = fit.calc_chisqr()
+
+    allans = [f.calc_chisqr() for f in fits]
+
+    if expected is None:
+        assert ans is None
+        assert all([a is None for a in allans])
+    else:
+        assert_almost_equal(ans, expected)
+        combined = np.concatenate(allans)
+        assert_almost_equal(combined, expected)
+
+
+def setup_wstat_single(scalar, usestat, usesys, flo, fhi):
+    """Set up a single dataset for the WSTAT tests.
+
+    A sherpa.data.DataPHA instance is used, with an associated
+    background data set.
+
+    Parameters
+    ----------
+    scalar : bool
+        Should a scalar BACKSCAL value be used for the background
+        region (True) or an array (False)? The source always uses
+        a scalar BACKSCAL.
+    usestat, usesys : bool
+        Should statistical or systematic errors be used?
+    flo, fhi : None or number
+        The channel filters (used in a notice call) that is applied
+        to the source only.
+
+    Returns
+    -------
+    fit : sherpa.fit.Fit instance
+    """
+
+    # ran numpy.random.poisson([10, 10, 10, 10, 10]) to get
+    # the src_counts values below, and with values of 2 for
+    # the background counts (just to get poisson-distributed
+    # data; it doesn't actually matter how it is distributed
+    # here as just evaluating at these values and not fitting).
+    #
+    # The channel starts at 1 just to follow the expected PHA
+    # behavior, but it should not matter here.
+    #
+    channels = np.arange(1, 6, dtype=np.int)
+    src_counts = np.asarray([14, 15, 11, 3, 8], dtype=np.int)
+    bg_counts = np.asarray([2, 0, 2, 3, 4], dtype=np.int)
+
+    # TODO: can add a grouping flag; if given use a larger set of bins and set
+    # up grouping
+
+    src = DataPHA('tst', channels, src_counts,
+                  exposure=100.0, backscal=0.01)
+
+    if scalar:
+        backscal = 0.03
+    else:
+        backscal = np.asarray([0.03, 0.02, 0.04, 0.03, 0.03])
+
+    bg = DataPHA('tstbg', channels, bg_counts,
+                 exposure=200.0, backscal=backscal)
+
+    if usestat:
+        src.staterror = np.sqrt(src.counts)
+        bg.staterror = np.sqrt(bg.counts)
+
+    if usesys:
+        src.syserror = 0.1 * src.counts
+        bg.syserror = 0.1 * bg.counts
+
+    src.set_background(bg)
+
+    # Filtering is *only* applied to the source
+    src.notice(lo=flo, hi=fhi)
+
+    # Pick something that varies with the channel number, to
+    # make sure that filtering is handled correctly.
+    mdl = Polynom1D('mdl')
+    mdl.c0 = 8
+    mdl.c1 = 1.2
+
+    # For now restrict to the default statistic values
+    fit = Fit(src, mdl, stat=WStat())
+
+    # Due to the way wstat is handled in Sherpa 4.8.0, need the
+    # following work around, otherwise the code thinks there's
+    # no background. All that is needed is for the response_ids
+    # attribute to be the non-empty list - i.e. it does not even
+    # have to have a response - but you can not change response_ids
+    # directly, so I work around this.
+    #
+    src._response_ids = [1]
+
+    return fit
+
+
+def setup_wstat_multiple(flo, fhi):
+    """Set up multiple datasets for the WSTAT tests.
+
+    A sherpa.data.DataPHA instance is used, with an associated
+    background data set.
+
+    Parameters
+    ----------
+    flo, fhi : None or number
+        The channel filters (used in a notice call). These filters are
+        applied to source only, both, and background only.
+
+    Returns
+    -------
+    fit, fits : sherpa.fit.Fit instance, list of sherpa.fit.Fit instances
+        The fit object for the combined data set and a list of those
+        for the individual data sets.
+    """
+
+    # Using three data sets means that can have scalar and array
+    # backscale values.
+    #
+    x1 = np.arange(1, 10)
+    y1 = np.asarray([2, 3, 2, 5, 3, 0, 0, 2, 1])
+    b1 = np.asarray([4, 2, 1, 2, 1, 0, 1, 3, 2])
+
+    x2 = np.arange(1, 6)
+    y2 = np.asarray([10, 12, 14, 12, 14])
+    b2 = np.asarray([2, 4, 3, 2, 1])
+
+    x3 = np.arange(1, 12)
+    y3 = np.asarray([0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
+    b3 = np.asarray([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+
+    e1 = 100.0
+    be1 = 125.0
+    bscal1 = 0.012
+    bbscal1 = np.asarray([0.024, 0.024, 0.023, 0.025, 0.03, 0.025,
+                          0.04, 0.035, 0.031])
+
+    e2 = 1000.0
+    be2 = 1000.0
+    bscal2 = np.asarray([0.12, 0.13, 0.12, 0.09, 0.08])
+    bbscal2 = 0.24
+
+    e3 = 800.0
+    be3 = 700.0
+    bscal3 = 0.0145 * np.ones(y3.size)
+    bbscal3 = 0.0232 * np.ones(y3.size)
+    bscal3[0] = 0.008
+    bbscal3[-1] = 0.012
+
+    src1 = DataPHA('p1', x1, y1, exposure=e1, backscal=bscal1)
+    src2 = DataPHA('p2', x2, y2, exposure=e2, backscal=bscal2)
+    src3 = DataPHA('p3', x3, y3, exposure=e3, backscal=bscal3)
+
+    bg1 = DataPHA('b1', x1, b1, exposure=be1, backscal=bbscal1)
+    bg2 = DataPHA('b2', x2, b2, exposure=be2, backscal=bbscal2)
+    bg3 = DataPHA('b3', x3, b3, exposure=be3, backscal=bbscal3)
+
+    src1.set_background(bg1)
+    src2.set_background(bg2)
+    src3.set_background(bg3)
+
+    # Apply filtering to
+    #  1: source only
+    #  2: source and background (same filter)
+    #  3: background only
+    #
+    # The background filters should be ignored
+    #
+    src1.notice(lo=flo, hi=fhi)
+    src2.notice(lo=flo, hi=fhi)
+    bg2.notice(lo=flo, hi=fhi)
+    bg3.notice(lo=flo, hi=fhi)
+
+    # work around issue with wstat in Sherpa 4.8.0 (in that it
+    # requires both background_ids and response_ids arrays to
+    # not be empty)
+    src1._response_ids = [1]
+    src2._response_ids = [1]
+    src3._response_ids = [1]
+
+    # Model components
+    m1 = Gauss1D('m1')
+    m1.fwhm = 0.8
+    m1.pos = 4.05
+    m1.ampl = 4.5
+
+    m2 = Const1D('m2')
+    m2.c0 = 12
+
+    m3 = Polynom1D('m3')
+    m3.c0 = 1.1
+    m3.c1 = -0.05
+
+    # Models for the datasets; at present no component is re-used,
+    # since support for that functionality should be tested elsewhere,
+    # and it should not be directly relevant to the statistics code
+    # being tested.
+    mexpr1 = m1
+    mexpr2 = m2
+    mexpr3 = m3
+
+    data = DataSimulFit("multi", (src1, src2, src3))
+    model = SimulFitModel("multi", (mexpr1, mexpr2, mexpr3))
+
+    statobj = WStat()
+
+    fit = Fit(data, model, stat=statobj)
+
+    fit1 = Fit(src1, mexpr1, stat=statobj)
+    fit2 = Fit(src2, mexpr2, stat=statobj)
+    fit3 = Fit(src3, mexpr3, stat=statobj)
+
+    return fit, [fit1, fit2, fit3]
+
+
+wstat_single_scalar_stat = 18.907726418126835
+wstat_single_scalar_lo_stat = 17.094447413086726
+wstat_single_scalar_hi_stat = 15.29434361363597
+wstat_single_scalar_mid_stat = 13.481064608595863
+
+wstat_single_array_stat = 18.895406024373457
+
+# The expected values have been calculated by
+# manually filtering the backscal array, and so should be
+# correct (i.e. the tests should fail once #248 is fixed).
+#
+wstat_single_array_lo_stat = 17.08212701933335
+wstat_single_array_hi_stat = 15.282023219882593
+wstat_single_array_mid_stat = 13.468744214842486
+
+
+# There are some other combinations that we currently do not
+# exercise for wstat:
+#   - grouped vs ungrouped (WSTAT is primarily for ungrouped data,
+#     but it is possible to use with grouped data)
+#   - multiple backgrounds
+#
+@pytest.mark.parametrize("scalar,usestat,usesys,flo,fhi,expected", [
+    (True, False, False, None, None, wstat_single_scalar_stat),
+    (True, True, False, None, None, wstat_single_scalar_stat),
+    (True, False, True, None, None, wstat_single_scalar_stat),
+    (True, True, True, None, None, wstat_single_scalar_stat),
+    # I am not going to iterate through every usestat/sys combination
+    # with flo/fhi options
+    #
+    # Start with some edge cases
+    (True, False, False, -10, 10, wstat_single_scalar_stat),
+    (True, False, False, 1, 5, wstat_single_scalar_stat),
+    #
+    # Now some more-general choices
+    (True, False, False, 2, None, wstat_single_scalar_lo_stat),
+    (True, False, False, 1.2, None, wstat_single_scalar_lo_stat),
+    (True, True, True, 2, None, wstat_single_scalar_lo_stat),
+    (True, False, False, None, 4.1, wstat_single_scalar_hi_stat),
+    (True, True, True, None, 4.1, wstat_single_scalar_hi_stat),
+    (True, False, False, 1.2, 4.1, wstat_single_scalar_mid_stat),
+    (True, False, False, 2, 4.1, wstat_single_scalar_mid_stat),
+    (True, True, True, 1.2, 4.1, wstat_single_scalar_mid_stat),
+
+    # switch to an array for the background backscal
+    (False, False, False, None, None, wstat_single_array_stat),
+    (False, True, False, None, None, wstat_single_array_stat),
+    (False, False, True, None, None, wstat_single_array_stat),
+    (False, True, True, None, None, wstat_single_array_stat),
+
+    (False, False, False, -1, 6, wstat_single_array_stat),
+    (False, False, False, 1, 5, wstat_single_array_stat),
+
+    pytest.mark.xfail((False, True, False, 1.2, None,
+                       wstat_single_array_lo_stat)),
+    pytest.mark.xfail((False, False, True, 2, None,
+                       wstat_single_array_lo_stat)),
+
+    pytest.mark.xfail((False, False, False, None, 4.1,
+                       wstat_single_array_hi_stat)),
+    pytest.mark.xfail((False, False, False, 1.2, 4.1,
+                       wstat_single_array_mid_stat)),
+    pytest.mark.xfail((False, False, False, 2, 4.1,
+                       wstat_single_array_mid_stat)),
+    pytest.mark.xfail((False, False, False, 2, 4,
+                       wstat_single_array_mid_stat))
+])
+def test_fit_calc_stat_wstat_single(scalar, usestat, usesys,
+                                    flo, fhi, expected):
+    """Test the results from the calc_stat method of Fit for 1 data set: wstat
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    fit = setup_wstat_single(scalar, usestat, usesys, flo, fhi)
+    assert_almost_equal(fit.calc_stat(), expected)
+
+
+@pytest.mark.parametrize("scalar,usestat,usesys,flo,fhi,nbin,expected", [
+    (True, False, False, None, None, 5, wstat_single_scalar_stat),
+    (True, True, False, None, None, 5, wstat_single_scalar_stat),
+    (True, False, True, None, None, 5, wstat_single_scalar_stat),
+    (True, True, True, None, None, 5, wstat_single_scalar_stat),
+
+    (True, False, False, -10, 10, 5, wstat_single_scalar_stat),
+    (True, False, False, 1, 5, 5, wstat_single_scalar_stat),
+
+    (True, False, False, 2, None, 4, wstat_single_scalar_lo_stat),
+    (True, False, False, 1.2, None, 4, wstat_single_scalar_lo_stat),
+    (True, True, True, 2, None, 4, wstat_single_scalar_lo_stat),
+    (True, False, False, None, 4.1, 4, wstat_single_scalar_hi_stat),
+    (True, True, True, None, 4.1, 4, wstat_single_scalar_hi_stat),
+    (True, False, False, 1.2, 4.1, 3, wstat_single_scalar_mid_stat),
+    (True, False, False, 2, 4.1, 3, wstat_single_scalar_mid_stat),
+    (True, True, True, 1.2, 4.1, 3, wstat_single_scalar_mid_stat),
+
+    (False, False, False, None, None, 5, wstat_single_array_stat),
+    (False, True, False, None, None, 5, wstat_single_array_stat),
+    (False, False, True, None, None, 5, wstat_single_array_stat),
+    (False, True, True, None, None, 5, wstat_single_array_stat),
+
+    (False, False, False, -1, 6, 5, wstat_single_array_stat),
+    (False, False, False, 1, 5, 5, wstat_single_array_stat),
+
+    pytest.mark.xfail((False, True, False, 1.2, None, 4,
+                       wstat_single_array_lo_stat)),
+    pytest.mark.xfail((False, False, True, 2, None, 4,
+                       wstat_single_array_lo_stat)),
+
+    pytest.mark.xfail((False, False, False, None, 4.1, 4,
+                       wstat_single_array_hi_stat)),
+    pytest.mark.xfail((False, False, False, 1.2, 4.1, 3,
+                       wstat_single_array_mid_stat)),
+    pytest.mark.xfail((False, False, False, 2, 4.1, 3,
+                       wstat_single_array_mid_stat)),
+    pytest.mark.xfail((False, False, False, 2, 4, 3,
+                       wstat_single_array_mid_stat))
+])
+def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
+                                         flo, fhi, nbin, expected):
+    """Test the results from the calc_stat_info method of Fit for 1 data set: wstat
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    fit = setup_wstat_single(scalar, usestat, usesys, flo, fhi)
+    ans = fit.calc_stat_info()
+
+    # mdl.c0 is the only thawed parameter
+    dof = nbin - 1
+
+    assert_almost_equal(fit.calc_stat(), expected)
+    assert isinstance(ans, StatInfoResults)
+    assert ans.name == ""
+    assert ans.statname == "wstat"
+    assert ans.ids is None
+    assert ans.bkg_ids is None
+    assert ans.numpoints == nbin
+    assert ans.dof == dof
+    assert_almost_equal(ans.statval, expected)
+
+    # TODO: as this is derived from cstat, shouldn't it calculate
+    #       a q value and reduced stat?
+    assert ans.qval is None
+    assert ans.rstat is None
+
+    # assert_almost_equal(ans.qval, qval)
+    # assert_almost_equal(ans.rstat, ans.statval / dof)
+
+
+# Do not really need to go through all these options, but it's easy
+# to keep them.
+@pytest.mark.parametrize("scalar,usestat,usesys,flo,fhi", [
+    (True, False, False, None, None),
+    (True, True, False, None, None),
+    (True, False, True, None, None),
+    (True, True, True, None, None),
+    (True, False, False, -10, 10),
+    (True, False, False, 1, 5),
+    (True, False, False, 2, None),
+    (True, False, False, 1.2, None),
+    (True, True, True, 2, None),
+    (True, False, False, None, 4.1),
+    (True, True, True, None, 4.1),
+    (True, False, False, 1.2, 4.1),
+    (True, False, False, 2, 4.1),
+    (True, True, True, 1.2, 4.1),
+    (False, False, False, None, None),
+    (False, True, False, None, None),
+    (False, False, True, None, None),
+    (False, True, True, None, None),
+    (False, False, False, -1, 6),
+    (False, False, False, 1, 5),
+    (False, True, False, 1.2, None),
+    (False, False, True, 2, None),
+    (False, False, False, None, 4.1),
+    (False, False, False, 1.2, 4.1),
+    (False, False, False, 2, 4.1),
+    (False, False, False, 2, 4)
+])
+def test_fit_calc_chisqr_wstat_single(scalar, usestat, usesys,
+                                      flo, fhi):
+    """Test the results from the calc_chisqr method of Fit for 1 data set: wstat
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    fit = setup_wstat_single(scalar, usestat, usesys, flo, fhi)
+    ans = fit.calc_chisqr()
+    assert ans is None
+
+
+# TODO: is the filtering applied to both src and background or are
+#       they different?
+#       ditto grouping and quality
+#
+# QUS: how is background subtraction handled, as that is essentially the same
+# as wstat calculation in terms of source + bgnd handling for those
+# settings which can be different.
+
+@pytest.mark.parametrize("flo,fhi,expected", [
+    # The following four fail in CIAO 4.8 so the expected values
+    # were created with an early version of a fix for #248
+    # (using a slightly different approach to the final fix,
+    # see #269, commit 332feb2ff70595d28fc4d6cd9e2f158a95ee46d9)
+    #
+    pytest.mark.xfail((None, None, 179.593636089)),
+    pytest.mark.xfail((3, None, 177.863206820)),
+    pytest.mark.xfail((None, 12, 77.7333219274)),
+    pytest.mark.xfail((5, 15, 97.7590037051)),
+
+])
+def test_fit_calc_stat_wstat_grouped_single(flo, fhi, expected):
+    """Test the results from the calc_stat method of Fit for 1 data set: wstat
+
+    This uses grouped data; it could be included in
+    test_fit_calc_stat_wstat_single but it's getting a bit messy
+    so pull out into a separate test.
+
+    """
+
+    nbins = 20
+    channels = np.arange(1, nbins + 1, dtype=np.int)
+    src_counts = (10 + 5 * np.sin(channels / 2.0)).astype(np.int8)
+    bg_counts = np.ones(nbins, dtype=np.int8)
+
+    # grouping: 1 to start a bin, -1 to continue a bin
+    # quality: 0 for good, 1 or more for bad
+    #
+    # The code behaves differently if a NumPy array or Python
+    # list is used for the grouping column, so force a numpy
+    # array for now.
+    #
+    grouping = np.asarray([1, -1, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1,
+                           1, 1, 1, 1, 1, -1, -1, -1])
+    assert len(grouping) == nbins, 'internal error; can not count'
+
+    src = DataPHA('tst', channels, src_counts, grouping=grouping,
+                  exposure=100.0, backscal=0.01)
+
+    # The backscal array should be variable so that it has to be
+    # "averaged" in some way by the grouping.
+    #
+    backscal = 0.04 - 0.00015 * channels
+    bg = DataPHA('tstbg', channels, bg_counts,
+                 exposure=200.0, backscal=backscal)
+
+    src.set_background(bg)
+
+    # Filtering is *only* applied to the source
+    src.notice(lo=flo, hi=fhi)
+
+    # Pick something that varies with the channel number, to
+    # make sure that filtering is handled correctly.
+    mdl = Polynom1D('mdl')
+    mdl.c0 = 8
+    mdl.c1 = 1.2
+
+    # For now restrict to the default statistic values
+    fit = Fit(src, mdl, stat=WStat())
+
+    # Due to the way wstat is handled in Sherpa 4.8.0, need the
+    # following work around, otherwise the code thinks there's
+    # no background. All that is needed is for the response_ids
+    # attribute to be the non-empty list - i.e. it does not even
+    # have to have a response - but you can not change response_ids
+    # directly, so I work around this.
+    #
+    src._response_ids = [1]
+
+    assert_almost_equal(fit.calc_stat(), expected)
+
+
+wstat_multi_all = 28.114709948
+
+# The following three fail in CIAO 4.8 so the expected values
+# were created with an early version of a fix for #248
+# (using a slightly different approach to the final fix,
+# see #269, commit 332feb2ff70595d28fc4d6cd9e2f158a95ee46d9)
+#
+wstat_multi_lo = 27.321455143
+wstat_multi_hi = 27.970661573
+wstat_multi_mid = 27.177406768
+
+
+@pytest.mark.parametrize("flo,fhi,expected", [
+    (None, None, wstat_multi_all),
+    (None, 1000, wstat_multi_all),
+    (0, None, wstat_multi_all),
+    (0, 1000, wstat_multi_all),
+    (1, None, wstat_multi_all),
+    (1, 1000, wstat_multi_all),
+
+    pytest.mark.xfail((2, None, wstat_multi_lo)),
+    pytest.mark.xfail((None, 8, wstat_multi_hi)),
+    pytest.mark.xfail((2, 8, wstat_multi_mid)),
+])
+def test_fit_calc_stat_wstat_multiple(flo, fhi, expected):
+    """Test the results from the calc_stat method of Fit for 3 data sets: wstat
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    fit, fits = setup_wstat_multiple(flo, fhi)
+    assert_almost_equal(fit.calc_stat(), expected)
+
+    # Test that the sum of the individual cases matches the expected
+    # value.
+    stats = [f.calc_stat() for f in fits]
+    assert_almost_equal(sum(stats), expected)
+
+
+# Remember, the filter is only applied to the background for the third
+# dataset, so it is ignored (as only fitler/grouping applied to the
+# source is important for WStat).
+#
+wstat_multi_nbins = 9 + 5 + 11
+wstat_multi_lo_nbins = wstat_multi_nbins - 2
+wstat_multi_hi_nbins = wstat_multi_nbins - 1
+wstat_multi_mid_nbins = wstat_multi_nbins - 3
+
+
+@pytest.mark.parametrize("flo,fhi,nbin,expected", [
+    (None, None, wstat_multi_nbins, wstat_multi_all),
+    (None, 1000, wstat_multi_nbins, wstat_multi_all),
+    (0, None, wstat_multi_nbins, wstat_multi_all),
+    (0, 1000, wstat_multi_nbins, wstat_multi_all),
+    (1, None, wstat_multi_nbins, wstat_multi_all),
+    (1, 1000, wstat_multi_nbins, wstat_multi_all),
+
+    pytest.mark.xfail((2, None, wstat_multi_lo_nbins, wstat_multi_lo)),
+    pytest.mark.xfail((None, 8, wstat_multi_hi_nbins, wstat_multi_hi)),
+    pytest.mark.xfail((2, 8, wstat_multi_mid_nbins, wstat_multi_mid)),
+])
+def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected):
+    """Test the results from the calc_stat_info method of Fit for 3 data sets: wstat
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    fit, _ = setup_wstat_multiple(flo, fhi)
+    ans = fit.calc_stat_info()
+
+    dof = nbin - 5
+
+    assert_almost_equal(fit.calc_stat(), expected)
+    assert isinstance(ans, StatInfoResults)
+    assert ans.name == ""
+    assert ans.statname == "wstat"
+    assert ans.ids is None
+    assert ans.bkg_ids is None
+    assert ans.numpoints == nbin
+    assert ans.dof == dof
+    assert_almost_equal(ans.statval, expected)
+
+    # TODO: as this is derived from cstat, shouldn't it calculate
+    #       a q value and reduced stat?
+    assert ans.qval is None
+    assert ans.rstat is None
+
+    # assert_almost_equal(ans.qval, qval)
+    # assert_almost_equal(ans.rstat, ans.statval / dof)
+
+
+@pytest.mark.parametrize("flo,fhi,expected", [
+    (None, None, wstat_multi_all),
+    (None, 1000, wstat_multi_all),
+    (0, None, wstat_multi_all),
+    (0, 1000, wstat_multi_all),
+    (1, None, wstat_multi_all),
+    (1, 1000, wstat_multi_all),
+    (2, None, wstat_multi_lo),
+    (None, 8, wstat_multi_hi),
+    (2, 8, wstat_multi_mid),
+])
+def test_fit_calc_chisqr_wstat_multiple(flo, fhi, expected):
+    """Test the results from the calc_chisqr method of Fit for 3 data sets: wstat
+
+    This was created using the CIAO 4.8 version of Sherpa
+    5ba2a7acdba6ae23bdb9462a7a57f6a60cbed685 on Linux 64 to
+    calculate the expected values.
+
+    """
+
+    fit, fits = setup_wstat_multiple(flo, fhi)
+
+    assert fit.calc_chisqr() is None
+    assert all([f.calc_chisqr() is None for f in fits])
+
+
+def test_fit_calc_stat_error_on_chi2():
+    """Check that an error message is raised when staterror is None."""
+
+    d = Data1D("x", np.asarray([1, 2]), np.asarray([3, 4]),
+               staterror=None, syserror=None)
+    m = Const1D()
+    f = Fit(d, m, stat=Chi2())
+    with pytest.raises(StatErr):
+        f.calc_stat()
+
+    d.syserror = [2, 3]
+    with pytest.raises(StatErr):
+        f.calc_stat()
+
+
+def test_fit_calc_stat_error_on_wstat():
+    """Check that raise errors when using wstat incorrectly"""
+
+    # wstat will error out if there is no background; that is,
+    # at present it only works with DataPHA data sets with an
+    # associated background.
+    #
+    dbasic = Data1D("x", np.asarray([1, 2]), np.asarray([3, 4]),
+                    staterror=None, syserror=None)
+    dpha = DataPHA("x", np.asarray([1, 2]), np.asarray([3, 4]),
+                   exposure=1.0, backscal=1.0)
+
+    m = Const1D()
+
+    for d in [dbasic, dpha]:
+        f = Fit(d, m, stat=Chi2())
+        with pytest.raises(StatErr):
+            f.calc_stat()
+
+
+def test_fit_calc_stat_error_no_cache():
+    """Check that data/errors/models are not cached.
+
+    At present the fit does not cache the results, which
+    lets things be changed and the statistic re-evaluated.
+    Add a check to ensure there's no cache-ing of
+    some relevant values.
+    """
+
+    d = Data1D("x", np.asarray([1, 2]), np.asarray([3, 4]),
+               staterror=[1.2, 1.3], syserror=None)
+    m = Const1D()
+    m.c0 = 3
+    f = Fit(d, m, stat=Chi2())
+
+    def ans(delta, dy):
+        return (delta / dy) ** 2
+
+    assert_almost_equal(f.calc_stat(), ans(1.0, 1.3))
+
+    d.y = np.asarray([3.1, 4.1])
+    d.staterror = np.asarray([1.1, 1.5])
+    m.c0 = 4.1
+
+    assert_almost_equal(f.calc_stat(), ans(1.0, 1.1))
+
+
+@pytest.mark.parametrize("stat", [
+    LeastSq, Chi2, Chi2DataVar, Cash, CStat, WStat, UserStat
+])
+def test_fit_str_single(stat):
+    """Test the str method of the fit object: single dataset.
+
+    Not an ideal test, since it essentially just repeats the code from
+    the __str__ method. Note that the test also doesn't check that
+    the data is "valid" (e.g. the wstat statistic can not be
+    evaluated for this fit object since there's no background
+    component).
+
+    """
+
+    statobj = stat()
+    fit = setup_stat_single(statobj, False, False)
+    out = str(fit)
+
+    expected = [("data", "test"),
+                ("model", "((poly * step) + bg)"),
+                ("stat", stat.__name__),
+                ("method", "LevMar"),
+                ("estmethod", "Covariance")]
+    expected = "\n".join(["{:9s} = {}".format(*e) for e in expected])
+
+    assert out == expected
+
+
+@pytest.mark.parametrize("stat", [
+    LeastSq, Chi2, Chi2DataVar, Cash, CStat, WStat, UserStat
+])
+def test_fit_str_multiple(stat):
+    """Test the str method of the fit object: multiple datasets.
+
+    Not an ideal test, since it essentially just repeats the code from
+    the __str__ method. Note that the test also doesn't check that
+    the data is "valid" (e.g. the wstat statistic can not be
+    evaluated for this fit object since there's no background
+    component).
+
+    """
+
+    statobj = stat()
+    fit, _ = setup_stat_multiple(statobj, True, True)
+    out = str(fit)
+
+    expected = [("data", "multidata"),
+                ("model", "multimodel"),
+                ("stat", stat.__name__),
+                ("method", "LevMar"),
+                ("estmethod", "Covariance")]
+    expected = "\n".join(["{:9s} = {}".format(*e) for e in expected])
+
+    assert out == expected

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -344,6 +344,7 @@ class StatErr(SherpaErr):
             'badstat': '%s not applicable using current statistic: %s',
             'chi2noerr': 'If you select chi2 as the statistic, all datasets must provide a staterror column',
             'usecstat': 'No background data has been supplied. Use cstat',
+            'mismatch': 'size mismatch between %s (%d) and %s (%d)',
             }
 
     def __init__(self, key, *args):


### PR DESCRIPTION
# Status

Finished (there is a question about the support for weighted columns).

# Summary

The aim is to move logic from the `sherpa.fit.Fit` class into the `sherpa.stats.Stat` class, namely the choice of what data is actually needed to calculate the given statistic. It is the approach discussed in https://github.com/sherpa/sherpa/issues/248#issuecomment-251795903

As well as (hopefully) cleaning up the API, it addresses the following issues: #227, #248, #289, #292.

Although it does not directly address #238 - in that it does not substantially change `sherpa/stats/tests/test_stat.py` (the changes made to this file are related to the code changes, and do not address the fact that many tests should ideally be run without the need for I/O), there are a number of tests added to `sherpa/stats/tests/test_stat_unit.py` and `sherpa/tests/test_fit_unit.py` that test the low-level statistic code without the need for an I/O library.

It does not address #293.

# To do

- [X] change `calc_stat_from_data` so that it accepts a single dataset/model (at present the inputs must be `*SimulFit*` objects)
- [X] review remaining `sherpa.fit.Fit` methods to see which need to use `calc_stat_from_data` rather than `calc_stat`: have used this approach to convert `calc_chisqr`
- [ ] review the remaining 'to do' notes and questions, including:
  - [X] tests of background-subtracted data
  - [ ] how is the weight column passed to the statistics object
  - [X] is the current wstat implementation really restricted to the first background component (e.g. if there are multiple ones in grating data). I believe it is (see #293)
- [X] delete the old `calc_stat` routine and rename `calc_stat_from_data`
- [X] the calculation of qval and reduced statistic should also be moved from the `sherpa.fit.Fit` class to the `sherpa.stats.Stat` class (this could be done in a separate PR). Note that the conversion of `calc_chisqr` has already moved extra logic into the `Stat` class, but that qval/rstat is also used by the `esterrors` method, which looks complicated. **MOVED** into the "Follow up changes" section below
- [X] should there be improvements to the docstrings to explain what is going on (e.g. stats) **MOVED** into the "Follow up changes" section below.
- [X] should there be any discussion about the data API - e.g. there doesn't seem to be a nice way to extract the data for a background component to match the source dataset, or for getting at some of the `DataPHA` extras, such as the BACKSCAL values grouped to match the data (it may be that the current API is okay and that the extra complexity needed here is okay). **MOVED** into the "Follow up changes" section below.

# Design notes

The `sherpa.fit.Fit` object needs to calculate the statistic value for a given set of data (including any filtering, grouping) and models. It does this by deconstructing the data objects (i.e. the subclasses of `sherpa.data.Data`) to get the "raw" data - e.g. count per bin, model value per bin - and then sending this to the `sherpa.stats.Stat.calc_stat` method to calculate the statistic.

There are several issues with this approach: 
- The code does not use the `sherpa.data.Data` API to get at the data, instead doing things manually - e.g. the backscal values. This is the cause of the original wstat error #248 (and problems with the original fix in #249) , because the grouping/filtering isn't being applied correctly as there really isn't a simple API to get at these values. The PR #269 addresses this issue (i.e. fixes up the code), but that doesn't address the following points
- The decision about what items a given stats class needs is being made by the fit object, not the stats object itself. This leads to an API that is brittle and not easily extensible. For example, to calcuate the wstat statistic we need to send in items such as the backscal ratio and exposure times, which meant that the fit object had to be changed. Other statistics may need different elements, but there's no way of supporting this without also changing the fit object.
- There are other places in the fit object where knowledge about how the stats object behaves is required. For example, the decision of whether this is a "chi-square" or "chi-square-like" statistic in `calc_chisqr` and `calc_stat_info`.

The proposed solution is to change the interface so that the fit object sends the stat object the data _object(s)_, rather than raw arrays, and then the stat object can pull out the data it needs. This should be more extensible (e.g. easier to add in new statistics); in particular I plan to improve on the "multi statistic example" using this new interface. 

I do not claim that this is the final solution, since I think that there are design issues for the interplay between the statistic and data objects: as mentioned above, there is no nice API to get at all the information needed by wstat, which means that the sherpa.stats.WStat class probably has too much knowledge of the `sherpa.data.Data` class in it, but
1. this is actually true of the existing code, where the logic is embedded within the fit class
2. addressing this particular issue is a much larger change than this work

# Outstanding issues

The only regression that I am aware of in this PR is that the old code path supported a weights column for chi-square based statistics. This functionality has currently been removed. Note that no tests fail because of it, so it appears to have been untested. I'm also not sure how users of the `sherpa.astro.ui` API would have access to this (i.e. if I have called `load_data("somefilename")` then how do I set/change the weights? I do not think it would be hard to add back in support for the weights keyword (I think it's mainly a case of supporting `**kwargs` in the `sherpa.stats.Stat.calc_stat[chisqr]` routine), but have not investigated this.

In both the `master` branch and this PR, the WSTAT calculation only uses the first background component if multiple components (e.g. Chandra HETG datasets with `BACKGROUND_UP` and `BACKGROUND_DOWN` columns) are present. The PR adds a warning message to tell the user, but this code path has not been tested. So this PR does not address #293.

I added explicit tests of the sigma-rejection iterated-fit routine in this PR (to check that the changes did not change its behavior) but there are no tests of the primini iterated-fit routine.
# Follow up changes

These are changes that could be made in new PRs if this one is accepted.

As mentioned above, there is some code in the `Fit` class - e.g. calculation of the "q" value - that should probably be in the relevant `Stat` class.

There are a number of cases where explicit checks for a `Chi2` instance is made (excluding `LeastSq`) which really should just be a check that they have the concept of `staterror` (i.e. that `calc_staterror` does not return `None`). An example of this is the "sigmarej" iterated-fit method. This is potentially an invasive change since there are some cases where `calc_staterror` returns something (e.g. `LeastSq`) and it probably should be changed to return `None`. An associated change would be to to remove the statistical and systematic error values returned by the `sherpa.data.Data.to_fit` method, requiring code that needs them to ask for them explicitly (in other words, remove the assumption that the data has these error values which means you need to special case likelihood statistics where this is not relevant).

This PR is not the place to make the data docstring changes discussed above - e.g. how to access various components, such as raw data, data to be fit, models evaluated on the data grid. Also, how t special case things like background data sets or the BACKSCAL scalar/array which are only supported by one or more sub classes (in this case `sherpa.astro.data.DataPHA`)? I have added method-level docstrings to at least explain what the statistic routines are doing, but we don't have any overview-level documentation where the overall information flow and procedures should be documented.
