### PR TITLE
Move XSPEC table support to load_xstable_model and deprecate its support in load_table_model (Fix #270)

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -24,7 +24,6 @@
 #
 
 import os
-import tempfile
 
 import pytest
 
@@ -32,8 +31,6 @@ import pytest
 
 from sherpa.astro import ui
 from sherpa.utils import requires_data, requires_fits, requires_xspec
-
-tmpdir = tempfile.gettempdir()
 
 
 # Note that the logic in load_table_model is quite convoluted,
@@ -48,38 +45,32 @@ tmpdir = tempfile.gettempdir()
 #
 
 @requires_fits
-@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
-                    reason='temp directory does not exist')
-def test_load_table_model_fails_with_dir():
+def test_load_table_model_fails_with_dir(tmpdir):
     """Check that the function fails with invalid input: directory
 
-    The temporary directory is used for this (the test is skipped if
-    it does not exist).
+    The temporary directory is used for this.
     """
 
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
-        ui.load_table_model('tmpdir', tmpdir)
+        ui.load_table_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 
 
 @requires_fits
 @requires_xspec
-@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
-                    reason='temp directory does not exist')
-def test_load_xstable_model_fails_with_dir():
+def test_load_xstable_model_fails_with_dir(tmpdir):
     """Check that the function fails with invalid input: directory
 
-    The temporary directory is used for this (the test is skipped if
-    it does not exist).
+    The temporary directory is used for this.
     """
 
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
-        ui.load_xstable_model('tmpdir', tmpdir)
+        ui.load_xstable_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -31,21 +31,27 @@ import pytest
 # from numpy.testing import assert_almost_equal
 
 from sherpa.astro import ui
-from sherpa.utils import requires_data, requires_fits
+from sherpa.utils import requires_data, requires_fits, requires_xspec
 
 tmpdir = tempfile.gettempdir()
 
 
 # Note that the logic in load_table_model is quite convoluted,
 # since it has a lot of fall-through cases, so these checks are
-# used in case of any refactoring.
+# used in case of any refactoring. Since load_table_model and
+# load_xstable_model are similar in these regards the tests are
+# used for both.
+#
+# The tests are manually repeated, rather than sending in the
+# load function as a parameter, as I was unable to get the latter
+# to work well.
 #
 
 @requires_fits
 @pytest.mark.skipif(not(os.path.isdir(tmpdir)),
                     reason='temp directory does not exist')
 def test_load_table_model_fails_with_dir():
-    """Check that load_table_model fails with invalid input: directory
+    """Check that the function fails with invalid input: directory
 
     The temporary directory is used for this (the test is skipped if
     it does not exist).
@@ -55,6 +61,25 @@ def test_load_table_model_fails_with_dir():
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
         ui.load_table_model('tmpdir', tmpdir)
+
+    assert ui.list_model_components() == []
+
+
+@requires_fits
+@requires_xspec
+@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
+                    reason='temp directory does not exist')
+def test_load_xstable_model_fails_with_dir():
+    """Check that the function fails with invalid input: directory
+
+    The temporary directory is used for this (the test is skipped if
+    it does not exist).
+    """
+
+    ui.clean()
+    assert ui.list_model_components() == []
+    with pytest.raises(IOError):
+        ui.load_xstable_model('tmpdir', tmpdir)
 
     assert ui.list_model_components() == []
 
@@ -71,14 +96,36 @@ def test_load_table_model_fails_with_dev_null():
 
     ui.clean()
     assert ui.list_model_components() == []
-    # There is currently no explicit test for no data, so an
-    # internal error is raised.
+
+    # The error depends on the load function
     with pytest.raises(ValueError):
         ui.load_table_model('devnull', '/dev/null')
 
     assert ui.list_model_components() == []
 
 
+@requires_fits
+@requires_xspec
+@pytest.mark.skipif(not(os.path.exists('/dev/null')),
+                    reason='/dev/null does not exist')
+def test_load_xstable_model_fails_with_dev_null():
+    """Check that load_table_model fails with invalid input: /dev/null
+
+    This simulates an empty file (and relies on the system
+    containing a /dev/null file that reads in 0 bytes).
+    """
+
+    ui.clean()
+    assert ui.list_model_components() == []
+
+    # The error depends on the load function
+    with pytest.raises(IOError):
+        ui.load_xstable_model('devnull', '/dev/null')
+
+    assert ui.list_model_components() == []
+
+
+@requires_fits
 @requires_data
 def test_load_table_model_fails_with_text_column(make_data_path):
     """Check that load_table_model fails with invalid input: text column
@@ -94,11 +141,34 @@ def test_load_table_model_fails_with_text_column(make_data_path):
 
     ui.clean()
     assert ui.list_model_components() == []
-    with pytest.raises(ValueError) as exc:
+
+    # The error depends on the load function.
+    with pytest.raises(Exception):
         ui.load_table_model('stringcol', infile)
 
-    emsg = 'The file {} could not be loaded, probably '.format(infile) + \
-           'because it contained spurious data and/or strings'
-    assert str(exc.value) == emsg
+    assert ui.list_model_components() == []
+
+
+@requires_fits
+@requires_xspec
+@requires_data
+def test_load_xstable_model_fails_with_text_column(make_data_path):
+    """Check that load_table_model fails with invalid input: text column
+
+    The first column is text (and an ASCII file) so it is
+    expected to fail.
+    """
+
+    # Check that this file hasn't been changed (as I am re-using it for
+    # this test)
+    infile = make_data_path('table.txt')
+    assert os.path.isfile(infile)
+
+    ui.clean()
+    assert ui.list_model_components() == []
+
+    # The error depends on the load function.
+    with pytest.raises(Exception):
+        ui.load_xstable_model('stringcol', infile)
 
     assert ui.list_model_components() == []

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -1,0 +1,104 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Basic tests of sherpa.astro.ui.utils routines.
+#
+# This supplements test_astro_ui_ui.py (in that tests are being moved
+# out of a single file) but uses pytest instead of unittest.
+#
+
+import os
+import tempfile
+
+import pytest
+
+# from numpy.testing import assert_almost_equal
+
+from sherpa.astro import ui
+from sherpa.utils import requires_data, requires_fits
+
+tmpdir = tempfile.gettempdir()
+
+
+# Note that the logic in load_table_model is quite convoluted,
+# since it has a lot of fall-through cases, so these checks are
+# used in case of any refactoring.
+#
+
+@requires_fits
+@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
+                    reason='temp directory does not exist')
+def test_load_table_model_fails_with_dir():
+    """Check that load_table_model fails with invalid input: directory
+
+    The temporary directory is used for this (the test is skipped if
+    it does not exist).
+    """
+
+    ui.clean()
+    assert ui.list_model_components() == []
+    with pytest.raises(IOError):
+        ui.load_table_model('tmpdir', tmpdir)
+
+    assert ui.list_model_components() == []
+
+
+@requires_fits
+@pytest.mark.skipif(not(os.path.exists('/dev/null')),
+                    reason='/dev/null does not exist')
+def test_load_table_model_fails_with_dev_null():
+    """Check that load_table_model fails with invalid input: /dev/null
+
+    This simulates an empty file (and relies on the system
+    containing a /dev/null file that reads in 0 bytes).
+    """
+
+    ui.clean()
+    assert ui.list_model_components() == []
+    # There is currently no explicit test for no data, so an
+    # internal error is raised.
+    with pytest.raises(ValueError):
+        ui.load_table_model('devnull', '/dev/null')
+
+    assert ui.list_model_components() == []
+
+
+@requires_data
+def test_load_table_model_fails_with_text_column(make_data_path):
+    """Check that load_table_model fails with invalid input: text column
+
+    The first column is text (and an ASCII file) so it is
+    expected to fail.
+    """
+
+    # Check that this file hasn't been changed (as I am re-using it for
+    # this test)
+    infile = make_data_path('table.txt')
+    assert os.path.isfile(infile)
+
+    ui.clean()
+    assert ui.list_model_components() == []
+    with pytest.raises(ValueError) as exc:
+        ui.load_table_model('stringcol', infile)
+
+    emsg = 'The file {} could not be loaded, probably '.format(infile) + \
+           'because it contained spurious data and/or strings'
+    assert str(exc.value) == emsg
+
+    assert ui.list_model_components() == []

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8946,33 +8946,9 @@ class Session(sherpa.ui.utils.Session):
             if not sherpa.utils.is_binary_file(filename):
                 raise Exception("Not a FITS file")
 
-            read_tbl = sherpa.astro.io.backend.get_table_data
-            read_hdr = sherpa.astro.io.backend.get_header_data
-
-            blkname = 'PRIMARY'
-            hdrkeys = ['HDUCLAS1', 'REDSHIFT', 'ADDMODEL']
-            hdr = read_hdr(filename, blockname=blkname, hdrkeys=hdrkeys)
-
-            addmodel = sherpa.utils.bool_cast(hdr[hdrkeys[2]])
-            addredshift = sherpa.utils.bool_cast(hdr[hdrkeys[1]])
-
-            if str(hdr[hdrkeys[0]]).upper() != 'XSPEC TABLE MODEL':
-                raise Exception("Not an XSPEC table model")
-
-            XSTableModel = sherpa.astro.xspec.XSTableModel
-
-            blkname = 'PARAMETERS'
-            colkeys = ['NAME', 'INITIAL', 'DELTA', 'BOTTOM', 'TOP',
-                       'MINIMUM', 'MAXIMUM']
-            hdrkeys = ['NINTPARM', 'NADDPARM']
-
-            (colnames, cols,
-             name, hdr) = read_tbl(filename, colkeys=colkeys, hdrkeys=hdrkeys,
-                                   blockname=blkname, fix_type=False)
-            nint = int(hdr[hdrkeys[0]])
-            tablemodel = XSTableModel(filename, modelname, *cols,
-                                      nint=nint, addmodel=addmodel,
-                                      addredshift=addredshift)
+            # If the import fails the exception handler will catch it
+            from sherpa.astro import xspec
+            tablemodel = xspec.read_xstable_model(modelname, filename)
 
         except Exception:
             x = None

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -26,7 +26,7 @@ import sherpa.ui.utils
 from sherpa.ui.utils import _argument_type_error, _check_type, _send_to_pager
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
-    IdentifierErr, IOErr, ModelErr
+    IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.data import Data1D
 import sherpa.astro.all
 import sherpa.astro.plot
@@ -8865,11 +8865,85 @@ class Session(sherpa.ui.utils.Session):
                     raise
         return (x, y)
 
+    def load_xstable_model(self, modelname, filename):
+        """Load a XSPEC table model.
+
+        Create an additive (``atable``, [1]_) or multiplicative
+        (``mtable``, [2]_) XSPEC table model component. These models
+        may have multiple model parameters.
+
+        Parameters
+        ----------
+        modelname : str
+           The identifier for this model component.
+        filename : str
+           The name of the FITS file containing the data, which should
+           match the XSPEC table model definition [3]_.
+
+        Raises
+        ------
+        sherpa.utils.err.ImportErr
+           If XSPEC support is not enabled.
+
+        See Also
+        --------
+        load_conv : Load a 1D convolution model.
+        load_psf : Create a PSF model
+        load_template_model : Load a set of templates and use it as a model component.
+        load_table_model : Load tabular or image data and use it as a model component.
+        set_model : Set the source model expression for a data set.
+        set_full_model : Define the convolved model expression for a data set.
+
+        Notes
+        -----
+        NASA's HEASARC site contains a link to community-provided
+        XSPEC table models [4]_.
+
+        References
+        ----------
+
+        .. [1] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
+
+        .. [2] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
+
+        .. [3] http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
+
+        .. [4] https://heasarc.gsfc.nasa.gov/xanadu/xspec/newmodels.html
+
+        Examples
+        --------
+
+        Load in the XSPEC table model from the file 'bbrefl_1xsolar.fits'
+        and create a model component labelled 'xtbl', which is then
+        used in a source expression:
+
+        >>> load_xstable_model('xtbl', 'bbrefl_1xsolar.fits')
+        >>> set_source(xsphabs.gal * xtbl)
+        >>> print(xtbl)
+
+        """
+
+        try:
+            from sherpa.astro import xspec
+        except ImportError:
+            # TODO: what is the best error to raise here?
+            raise ImportErr('notsupported', 'XSPEC')
+
+        tablemodel = xspec.read_xstable_model(modelname, filename)
+        self._tbl_models.append(tablemodel)
+        self._add_model_component(tablemodel)
+
     # also in sherpa.utils
     # DOC-NOTE: can filename be a crate/hdulist?
     # DOC-TODO: how to describe the supported args/kwargs (not just for this function)?
     def load_table_model(self, modelname, filename, method=sherpa.utils.linear_interp, *args, **kwargs):
         """Load tabular or image data and use it as a model component.
+
+        .. note:: Deprecated in Sherpa 4.9
+                  The new `load_xstable_model` routine should be used for
+                  loading XSPEC table model files. Support for these files
+                  will be removed from ``load_table_model` in the next
+                  release.
 
         A table model is defined on a grid of points which is
         interpolated onto the independent axis of the data set.  The
@@ -8898,6 +8972,7 @@ class Session(sherpa.ui.utils.Session):
         load_conv : Load a 1D convolution model.
         load_psf : Create a PSF model
         load_template_model : Load a set of templates and use it as a model component.
+        load_xstable_model : Load a XSPEC table model.
         set_model : Set the source model expression for a data set.
         set_full_model : Define the convolved model expression for a data set.
 
@@ -8946,9 +9021,8 @@ class Session(sherpa.ui.utils.Session):
             if not sherpa.utils.is_binary_file(filename):
                 raise Exception("Not a FITS file")
 
-            # If the import fails the exception handler will catch it
-            from sherpa.astro import xspec
-            tablemodel = xspec.read_xstable_model(modelname, filename)
+            self.load_xstable_model(modelname, filename)
+            return
 
         except Exception:
             x = None
@@ -8967,7 +9041,7 @@ class Session(sherpa.ui.utils.Session):
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
 
-    ### also in sherpa.utils
+    # ## also in sherpa.utils
     # DOC-TODO: how to describe *args/**kwargs
     # DOC-TODO: how is the _y value used if set
     def load_user_model(self, func, modelname, filename=None, *args, **kwargs):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -18,10 +18,13 @@
 #
 from six.moves import zip as izip
 from six import string_types
+import logging
 import os
 import sys
-import logging
+import warnings
+
 import numpy
+
 import sherpa.ui.utils
 from sherpa.ui.utils import _argument_type_error, _check_type, _send_to_pager
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange
@@ -8978,20 +8981,9 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        X-Spec style additive (atable, [1]_) and multiplicative
-        (mtable, [2]_) table models are supported. These models may
-        have multiple model parameters.
-
         Examples of interpolation schemes provided by `sherpa.utils`
         are: `linear_interp`, `nearest_interp`, `neville`, and
         `neville2d`.
-
-        References
-        ----------
-
-        .. [1] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
-
-        .. [2] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
 
         Examples
         --------
@@ -9022,6 +9014,8 @@ class Session(sherpa.ui.utils.Session):
                 raise Exception("Not a FITS file")
 
             self.load_xstable_model(modelname, filename)
+            warnings.warn('Use load_xstable_model to load XSPEC table models',
+                          DeprecationWarning)
             return
 
         except Exception:

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -209,9 +209,10 @@ def read_xstable_model(modelname, filename):
     Parameters
     ----------
     modelname : str
-       The identifier for this table model.
+       The identifier for this model component.
     filename : str
-       The name of the file containing the XSPEC table model.
+       The name of the FITS file containing the data, which should
+       match the XSPEC table model definition [3]_.
 
     Returns
     -------
@@ -223,6 +224,8 @@ def read_xstable_model(modelname, filename):
     .. [1] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
 
     .. [2] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
+
+    .. [3] http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
 
     Examples
     --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -23,11 +23,11 @@ import string
 from sherpa.models import Parameter, ArithmeticModel, modelCacher1d
 from sherpa.models.parameter import hugeval
 import sherpa.astro.xspec._xspec
-from sherpa.utils import guess_amplitude, param_apply_limits
+from sherpa.utils import bool_cast, guess_amplitude, param_apply_limits
 from sherpa.astro.utils import get_xspec_position
-from sherpa.astro.xspec._xspec import get_xschatter, get_xsabund, get_xscosmo, \
-     get_xsxsect, set_xschatter, set_xsabund, set_xscosmo, set_xsxsect, \
-     get_xsversion
+from sherpa.astro.xspec._xspec import get_xschatter, get_xsabund, \
+    get_xscosmo, get_xsxsect, set_xschatter, set_xsabund, set_xscosmo, \
+    set_xsxsect, get_xsversion
 
 try:
     maketrans = string.maketrans  # Python 2
@@ -40,6 +40,7 @@ except AttributeError:
 # See:
 # http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSxset.html
 modelstrings = {}
+
 
 def get_xsxset(name):
     """Return the X-Spec model setting.
@@ -69,6 +70,7 @@ def get_xsxset(name):
     """
     name = name.upper()
     return sherpa.astro.xspec._xspec.get_xsxset(name)
+
 
 def set_xsxset(name, value):
     """Set a X-Spec model setting.
@@ -127,8 +129,9 @@ def set_xsxset(name, value):
     """
     name = name.upper()
     sherpa.astro.xspec._xspec.set_xsxset(name, value)
-    if (get_xsxset(name) != ""):
+    if get_xsxset(name) != "":
         modelstrings[name] = get_xsxset(name)
+
 
 # Provide XSPEC module state as a dictionary.  The "cosmo" state is
 # a 3-tuple, and "modelstrings" is a dictionary of model strings
@@ -160,6 +163,7 @@ def get_xsstate():
             "cosmo": get_xscosmo(),
             "xsect": get_xsxsect(),
             "modelstrings": modelstrings}
+
 
 def set_xsstate(state):
     """Restore the state of the XSPEC module.

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -16,7 +16,7 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+import pytest
 import numpy
 from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
@@ -398,7 +398,8 @@ class test_xspec(SherpaTestCase):
     @requires_data
     @requires_fits
     def test_xspec_tablemodel(self):
-        self._test_xspec_tablemodel(ui.load_table_model)
+        with pytest.warns(DeprecationWarning):
+            self._test_xspec_tablemodel(ui.load_table_model)
 
     @requires_data
     @requires_fits

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1,0 +1,72 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Supplement test_xspec.py with py.test tests
+#
+
+import pytest
+
+from numpy.testing import assert_almost_equal
+
+from sherpa.utils import requires_data, requires_fits, requires_xspec
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+def test_read_xstable_model(make_data_path):
+    """Limited test (only one file).
+
+    Evaluation tests using this model are in
+    sherpa.astro.xspec.tests.test_xspec.
+    """
+
+    from sherpa.astro import xspec
+
+    path = make_data_path('xspec-tablemodel-RCS.mod')
+    tbl = xspec.read_xstable_model('bar', path)
+
+    assert tbl.name == 'bar'
+    assert isinstance(tbl, xspec.XSTableModel)
+    assert tbl.addmodel
+
+    assert len(tbl.pars) == 4
+    assert tbl.pars[0].name == 'tau'
+    assert tbl.pars[1].name == 'beta'
+    assert tbl.pars[2].name == 't'
+    assert tbl.pars[3].name == 'norm'
+
+    assert_almost_equal(tbl.tau.val, 1)
+    assert_almost_equal(tbl.tau.min, 1)
+    assert_almost_equal(tbl.tau.max, 10)
+
+    assert_almost_equal(tbl.beta.val, 0.1)
+    assert_almost_equal(tbl.beta.min, 0.1)
+    assert_almost_equal(tbl.beta.max, 0.5)
+
+    assert_almost_equal(tbl.t.val, 0.1)
+    assert_almost_equal(tbl.t.min, 0.1)
+    assert_almost_equal(tbl.t.max, 1.3)
+
+    assert_almost_equal(tbl.norm.val, 1)
+    assert_almost_equal(tbl.norm.min, 0)
+    assert_almost_equal(tbl.norm.max, 1e24)
+
+    for p in tbl.pars:
+        assert not(p.frozen)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -45,7 +45,8 @@ known_warnings = {
         [
             r"unorderable dtypes.*",
             r"Non-string object detected for the array ordering.*",
-            r"using a non-integer number instead of an integer will result in an error in the future"
+            r"using a non-integer number instead of an integer will result in an error in the future",
+            r"Use load_xstable_model to load XSPEC table models"
         ],
     UserWarning:
         [

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -17,7 +17,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import six
 import pytest
 import os
 import sys
@@ -69,6 +68,9 @@ if sys.version_info >= (3, 2):
                 r"unclosed file .*aref_Cedge.fits.* closefd=True>",
                 r"unclosed file .*aref_sample.fits.* closefd=True>",
                 r"unclosed file .*/tmp.* closefd=True>",
+                # added for sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+                r"unclosed file .*/dev/null.* closefd=True>",
+                r"unclosed file .*table.txt.* closefd=True>",
             ]
     }
     known_warnings.update(python3_warnings)

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -131,6 +131,7 @@ class NotImplementedErr(SherpaErr):
 class ImportErr(SherpaErr):
 
     dict = {'importfailed': "failed to import %s module; %s routines are not available",
+            'notsupported': '%s support is not enabled in this build of Sherpa'
             }
 
     def __init__(self, key, *args):


### PR DESCRIPTION
# Status

Finished. [argh - somehow firefox managed to overwrite my original summary, so re-creating it]

# Summary

Add the `load_xstable_model` routine to the `sherpa.astro.ui` module, which supports loading XSPEC additive or multiplicative (atable and mtable) models. The support for these models is still available via `load_table_model` in this release, but it is deprecated. The `read_xstable_model` routine has been added to the `sherpa.astro.xspec` module.

This addresses #270.

# Details

The read logic has been moved to `sherpa.astro.xspec.read_xstable_model`, which returns a model instance. This is then used by the `sherpa.astro.ui.utils.load_xstable_model` routine to create the model and add it to the session. The `load_table_model` routine calls `load_xstable_model` and creates a `DeprecationWarning` warning if the call succeeds.

There is a slight difference in `load_table_model` and `load_xstable_model`, in that the former calls `sherpa.utils.is_binary_file` before calling `read_xstable_model` whereas there is no equivalent check in `load_xstable_model`. This is intentional as it matches the old behavior of `load_table_model`, but I believe that we should move away from using `is_binary_file`, since it is based on a *very* simple heuristic, and instead rely on the IO library to raise a sensible exception.

# Example

The two routines - `load_table_model` and `load_xstable_model` - behave the same:

```
>>> from sherpa.astro import ui
>>> ui.load_table_model('m1', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
>>> ui.load_xstable_model('m2', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
>>> print(m1)
xstablemodel.m1
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   m1.tau       thawed            1            1           10           
   m1.beta      thawed          0.1          0.1          0.5           
   m1.t         thawed          0.1          0.1          1.3           
   m1.norm      thawed            1            0        1e+24           
>>> print(m2)
xstablemodel.m2
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   m2.tau       thawed            1            1           10           
   m2.beta      thawed          0.1          0.1          0.5           
   m2.t         thawed          0.1          0.1          1.3           
   m2.norm      thawed            1            0        1e+24           
```

If we turn on warnings, we see a warning from `load_table_model` (not shown, but `load_xstable_model` does not raise this warning):

```
>>> import warnings
>>> warnings.filterwarnings('always')
>>> ui.load_table_model('m1', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
/home/djburke/sherpa/sherpa-fix-270/sherpa/astro/ui/utils.py:9018: DeprecationWarning: Use load_xstable_model to load XSPEC table models
  DeprecationWarning)
>>> ui.load_xstable_model('m2', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
>>> ui.load_table_model('m1', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
/home/djburke/sherpa/sherpa-fix-270/sherpa/astro/ui/utils.py:9018: DeprecationWarning: Use load_xstable_model to load XSPEC table models
  DeprecationWarning)
```

If you change the warning to "once" then the warning is only displayed the first time it is used:

```
>>> warnings.filterwarnings('once')
>>> ui.load_table_model('m1', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
/home/djburke/sherpa/sherpa-fix-270/sherpa/astro/ui/utils.py:9018: DeprecationWarning: Use load_xstable_model to load XSPEC table models
  DeprecationWarning)
>>> ui.load_table_model('m1', 'sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod')
>>> 
```