### PR TITLE
fix #297 - replace file -> open

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -120,7 +120,7 @@ def _send_to_pager(all, filename=None, clobber=False):
             _check_type(filename, string_types, 'filename', 'a string')
             if os.path.isfile(filename) and not clobber:
                 raise IOErr('filefound', filename)
-            pager = file(filename, 'w')
+            pager = open(filename, 'w')
         print(all, file=pager)
     except:
         if (pager is not None):
@@ -467,7 +467,7 @@ class Session(NoNewAttributesAfterInit):
         if os.path.isfile(filename) and not clobber:
             raise sherpa.utils.err.IOErr("filefound", filename)
 
-        fout = file(filename, 'wb')
+        fout = open(filename, 'wb')
         try:
             pickle.dump(self, fout, 2)  # Use newer binary protocol
         finally:
@@ -519,7 +519,7 @@ class Session(NoNewAttributesAfterInit):
         """
         _check_type(filename, string_types, 'filename', 'a string')
 
-        fin = file(filename, 'rb')
+        fin = open(filename, 'rb')
         try:
             obj = pickle.load(fin)
         finally:


### PR DESCRIPTION
# Release Note
The `save` and `restore` functions used to use the `file` function which is not compatible with Python 3. This has now been fixed. (Issue #297).

# Notes
The tests are rather simple, as the `save` and `restore` functions were not really tested currently. I don't think proper unit tests for these functions are in the scope of this bug fix, especially given the time constraints.

There was one more usage of `file` that I fixed without adding a test. I have no idea what the offending function does but it looks to require some work to be unit tested, so I simply replaced `file` with `open`.