### PR TITLE
fix #303 - fix python 3 issues with some session commands

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -16,25 +16,11 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
-from sherpa.ui.utils import Session
-from numpy.testing import assert_array_equal
+from sherpa.astro.ui.utils import Session
 
 
 # bug #303
-def test_set_log():
+def test_show_bkg_model():
     session = Session()
-    session.set_xlog()
-    session.set_ylog()
-
-
-# bug #262
-def test_list_ids():
-    session = Session()
-    session.load_arrays(1, [1, 2, 3], [1, 2, 3])
-    session.load_arrays("1", [1, 2, 3], [4, 5, 6])
-
-    # order of 1 and "1" is not determined
-    assert {1, "1"} == set(session.list_data_ids())
-    assert_array_equal([4, 5, 6], session.get_data('1').get_dep())
-    assert_array_equal([1, 2, 3], session.get_data(1).get_dep())
+    session.load_arrays(1, [1, 2], [1, 2])
+    session.show_bkg_model()

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -17,6 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from sherpa.astro.ui.utils import Session
+from sherpa.utils import requires_data, requires_fits
+from sherpa.models import PowLaw1D
 
 
 # bug #303
@@ -24,3 +26,16 @@ def test_show_bkg_model():
     session = Session()
     session.load_arrays(1, [1, 2], [1, 2])
     session.show_bkg_model()
+    session.show_bkg_model('xx')
+    session.show_bkg_source()
+    session.show_bkg_source('xx')
+
+
+# bug #303
+@requires_data
+@requires_fits
+def test_show_bkg_model_with_bkg(make_data_path):
+    session = Session()
+    session.load_data('foo', make_data_path('3c273.pi'))
+    session.show_bkg_model()
+    session.show_bkg_model('foo')

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -360,7 +360,7 @@ class Session(sherpa.ui.utils.Session):
             if bkg_id is not None:
                 bkg_ids = [bkg_id]
             else:
-                bkg_ids = self._background_models.get(id, {}).keys()
+                bkg_ids = list(self._background_models.get(id, {}).keys())
                 bkg_ids.extend(self._background_sources.get(id, {}).keys())
                 bkg_ids = list(set(bkg_ids))
 

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -24,8 +24,16 @@ from numpy.testing import assert_array_equal
 # bug #303
 def test_set_log():
     session = Session()
+    assert not session.get_data_plot_prefs()['xlog']
+    assert not session.get_data_plot_prefs()['ylog']
     session.set_xlog()
+    assert session.get_data_plot_prefs()['xlog']
     session.set_ylog()
+    assert session.get_data_plot_prefs()['ylog']
+    session.set_xlinear()
+    assert not session.get_data_plot_prefs()['xlog']
+    session.set_ylinear()
+    assert not session.get_data_plot_prefs()['ylog']
 
 
 # bug #262

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -11371,7 +11371,7 @@ class Session(NoNewAttributesAfterInit):
             sherpa.plot.end()
 
     def _set_plot_item(self, plottype, item, value):
-        keys = self._plot_types.keys()[:]
+        keys = list(self._plot_types.keys())
 
         if plottype.strip().lower() != "all":
             if plottype not in keys:


### PR DESCRIPTION
# Release Note
The `set_xlog`, `set_ylog`, and `show_bkg_model` functions were not compatible with Python 3. This has now been fixed (Issue #303).

# Notes
Admittedly, the tests are rather simplistic. They just check you don't get an exception, which technically speaking is what the bug report pointed out, but clearly not enough as apparently such functions did not have any unit tests to begin with. I would rather focus on other currently open issues and PRs rather than adding proper unit tests for these function, which I don't expect to be a quick feat.