### PR TITLE
Allow sequence=None when using gridsearch and Python 3.5 (Fix #309) 

### DIFF
--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -25,7 +25,6 @@ from sherpa.utils.err import ModelErr
 from sherpa import ui
 import numpy
 import logging
-import os
 
 logger = logging.getLogger("sherpa")
 

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -27,8 +27,6 @@ import six
 from sherpa.ui.utils import Session
 
 
-@pytest.mark.skipif(not six.PY2,
-                    reason='gridsearch/session=None fails with Python 3')
 def test_309(make_data_path):
 
     idval = 'bug309'

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -1,0 +1,62 @@
+#
+#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# At present this only contains a very basic test for fix 309.
+
+import os
+
+import pytest
+import six
+
+from sherpa.ui.utils import Session
+
+
+@pytest.mark.skipif(not six.PY2,
+                    reason='gridsearch/session=None fails with Python 3')
+def test_309(make_data_path):
+
+    idval = 'bug309'
+
+    # have values near unity for the data
+    ynorm = 1e9
+
+    session = Session()
+
+    dname = make_data_path('load_template_with_interpolation-bb_data.dat')
+
+    session.load_data(idval, dname)
+    session.get_data(idval).y *= ynorm
+
+    indexname = 'bb_index.dat'
+    datadir = make_data_path('')
+
+    # Need to load the data from the same directory as the index
+    basedir = os.getcwd()
+    os.chdir(datadir)
+    try:
+        session.load_template_model('bbtemp', indexname)
+    finally:
+        os.chdir(basedir)
+
+    bbtemp = session.get_model_component('bbtemp')
+    session.set_source(idval, bbtemp * ynorm)
+
+    session.set_method('gridsearch')
+    session.set_method_opt('sequence', None)
+    session.fit(idval)

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -24,7 +24,7 @@ import numpy
 import random
 import sys
 from six.moves import zip as izip
-
+from six.moves import xrange
 
 from . import _minpack
 from . import _minim
@@ -298,7 +298,7 @@ def grid_search( fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
             list_ranges[ ii ] = slice( *list_ranges[ ii ] )
         grid = numpy.mgrid[ list_ranges ]
         mynfev = pow( N, npar )
-        grid = map( numpy.ravel, grid )
+        grid = list(map( numpy.ravel, grid ))
         sequence = []
         for index in xrange( mynfev ):
             tmp = []


### PR DESCRIPTION
# Summary

Allow the `gridsearch` optimiser to be used with the `sequence` option set to `None` for Python 3.5 (fixes issue #309).

# Notes

A very-limited test has been added that essentially repeats the original error report, but using existing Sherpa test data. There is no attempt to check that the fit evaluates to anything sensible, but it appears that the existing tests (which this is based on) do not check the results.

# Test plan

I checked that the test did fail on Python 3.5 before the fix, by manually removing the `skipif` directive and re-running the test.