### PR TITLE
Fix over-zealous code clean up in PR #287 affecting sigmarej

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -806,7 +806,7 @@ class IterFit(NoNewAttributesAfterInit):
                     j = 0
                     kmin = 0
                     for i in xrange(0, ressize):
-                        while newmask[j] is False and j < filsize:
+                        while not(newmask[j]) and j < filsize:
                             j = j + 1
                         if j >= filsize:
                             break
@@ -825,7 +825,7 @@ class IterFit(NoNewAttributesAfterInit):
                         # If we've masked out *all* data,
                         # immediately raise fit error, clean up
                         # on way out.
-                        if any(newmask) is False:
+                        if not(any(newmask)):
                             raise FitErr('nobins')
                         d.mask = newmask
 
@@ -916,7 +916,7 @@ class Fit(NoNewAttributesAfterInit):
         self.thaw_indices = ()
         iter = 0
         for current_par in self.model.pars:
-            if current_par.frozen is True:
+            if current_par.frozen:
                 pass
             else:
                 self.thaw_indices = self.thaw_indices + (iter,)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2415,7 +2415,7 @@ def test_fit_iterfit_fails_nonchi2_wstat(stat, sigmarej):
 
 @pytest.mark.parametrize("stat", [Chi2, Chi2Gehrels])
 def test_fit_iterfit_single_sigmarej_chi2(stat):
-    """Very limited test of iteratet-fit code.
+    """Very limited test of iterated-fit code.
 
     Since setup_single_iter creates a staterror column then
     the Chi2-based statistics (module Chi2ModVar) should all
@@ -2446,7 +2446,7 @@ def test_fit_iterfit_single_sigmarej_chi2(stat):
 
 
 def test_fit_iterfit_single_sigmarej_chi2gehrels():
-    """Very limited test of iterated fit code."""
+    """Very limited test of iterated-fit code."""
 
     # If remove the staterror column and use the data values
     # the fit is "better".
@@ -2474,6 +2474,40 @@ def test_fit_iterfit_single_sigmarej_chi2gehrels():
 
     assert fr.numpoints == 6
     assert fr.dof == 4
+
+
+def test_fit_iterfit_single_sigmarej_ignore_chi2gehrels():
+    """Very limited test of iterated-fit code.
+
+    This ignores some data before the fit since this checks
+    logic that is not tested above.
+    """
+
+    statobj = Chi2Gehrels()
+    fit = setup_single_iter(statobj, sigmarej=True)
+
+    fit.data.ignore(4, 6)
+    fit.data.staterror = None
+
+    # be explicit here since the result is not guaranteed to be a bool
+    start_mask = [True, False, True, True, True, True, True]
+    assert np.all(fit.data.mask == start_mask)
+
+    fr = fit.fit()
+    assert fr.succeeded
+
+    # the discrepant point should be excluded
+    expected_mask = [True, False, True, True, False, True, True]
+    assert np.all(fit.data.mask == expected_mask)
+
+    assert_almost_equal(fr.statval, 0.1245627587)
+
+    mdl = fit.model
+    assert_almost_equal(mdl.c0.val, 9.25537857670)
+    assert_almost_equal(mdl.c1.val, 2.01845980545)
+
+    assert fr.numpoints == 5
+    assert fr.dof == 3
 
 
 def test_wstat_rstat_qval_fields_not_none():


### PR DESCRIPTION
# Summary

Fits using the sigmarej iterated-fit method were broken if a filter
had been applied to the data before the fit and there are any bins
that get ignored at larger bin values than the filtered-out data. This
bug was introduced by PR #287.

# Details

I added a test, checked that it failed before fixing the code and
fixed after the code. This deals with the "while not(newmask...)" line
change.

I manually checked the change for the "if current_par.frozen:" change,
by inserting errors in both branches and checking the test suite errored
out.

The last change - "not(any(newmask))" - does not have any test as it
is for an error condition and it is not obvious how to create a test
that triggers this.