### PR TITLE
remove requires_data decorator from make_data_path fixture

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -21,7 +21,7 @@ import pytest
 import os
 import sys
 import re
-from sherpa.utils import SherpaTestCase, requires_data
+from sherpa.utils import SherpaTestCase
 
 from six.moves import reload_module
 
@@ -148,7 +148,6 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="session")
-@requires_data
 def make_data_path():
     """
     Fixture for tests requiring the test data dir. It returns a function that can be used to make paths by using

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -25,8 +25,10 @@ import pytest
 import six
 
 from sherpa.ui.utils import Session
+from sherpa.utils import requires_data
 
 
+@requires_data
 def test_309(make_data_path):
 
     idval = 'bug309'


### PR DESCRIPTION
This fixes the CIAO issue SH-3.

The `make_data_path` fixture was decorated with `requires_data` so to simplify the creation of tests that use the fixture, which are assumed to require external data. By decorating the fixture, tests were skipped without requiring the tests themselves to be decorated.

However, this does not seem to work in CIAO, were the tests are always skipped.