### PR TITLE
Use relative imports for XSPEC module

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -17,16 +17,19 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import absolute_import
+
 from six.moves import xrange
 
 import string
 from sherpa.models import Parameter, ArithmeticModel, modelCacher1d
 from sherpa.models.parameter import hugeval
-import sherpa.astro.xspec._xspec
 from sherpa.utils import bool_cast, guess_amplitude, param_apply_limits
 from sherpa.astro.utils import get_xspec_position
-from sherpa.astro.xspec._xspec import get_xschatter, get_xsabund, \
-    get_xscosmo, get_xsxsect, set_xschatter, set_xsabund, set_xscosmo, \
+
+from . import _xspec
+from ._xspec import get_xschatter, get_xsabund, get_xscosmo, \
+    get_xsxsect, set_xschatter, set_xsabund, set_xscosmo, \
     set_xsxsect, get_xsversion
 
 try:
@@ -69,7 +72,7 @@ def get_xsxset(name):
     setting.
     """
     name = name.upper()
-    return sherpa.astro.xspec._xspec.get_xsxset(name)
+    return _xspec.get_xsxset(name)
 
 
 def set_xsxset(name, value):
@@ -128,7 +131,7 @@ def set_xsxset(name, value):
 
     """
     name = name.upper()
-    sherpa.astro.xspec._xspec.set_xsxset(name, value)
+    _xspec.set_xsxset(name, value)
     if get_xsxset(name) != "":
         modelstrings[name] = get_xsxset(name)
 


### PR DESCRIPTION
This is needed for Sphinx to be able to import the XSPEC module,
and is probably a "good thing" to do. There are no functional changes
in this commit.