### PR TITLE
Skip test if no plotting backend is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ matrix:
       python: "2.7"
     - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
       python: "2.7"
+    - env: INSTALL_TYPE=install TEST=package NUMPYVER=1.11
+      python: "2.7"
   allow_failures:
     - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
 

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -17,6 +17,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import sherpa.utils
 from sherpa.ui.utils import Session
 from numpy.testing import assert_array_equal
 
@@ -25,6 +26,7 @@ TEST2 = [4, 5, 6]
 
 
 # bug #303
+@sherpa.utils.requires_plotting
 def test_set_log():
     session = Session()
     assert not session.get_data_plot_prefs()['xlog']

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -95,7 +95,8 @@ __all__ = ('NoNewAttributesAfterInit', 'SherpaTestCase',
            'guess_reference', 'histogram1d', 'histogram2d', 'igam', 'igamc',
            'incbet', 'interpolate', 'is_binary_file', 'Knuth_close',
            'lgam', 'linear_interp', 'nearest_interp',
-           'neville', 'neville2d', 'requires_data', 'requires_fits', 'requires_package',
+           'neville', 'neville2d',
+           'requires_data', 'requires_fits', 'requires_package',
            'new_muller', 'normalize', 'numpy_convolve',
            'pad_bounding_box', 'parallel_map', 'param_apply_limits',
            'parse_expr', 'poisson_noise', 'print_fields', 'rebin',
@@ -367,6 +368,13 @@ def requires_pylab(test_function):
     packages = ('pylab',
                 )
     msg = "matplotlib backend required"
+    return requires_package(msg, *packages)(test_function)
+
+
+def requires_plotting(test_function):
+    """Decorator for test functions requiring a plotting library."""
+    packages = ('pylab', 'pychips')
+    msg = "plotting backend required"
     return requires_package(msg, *packages)(test_function)
 
 


### PR DESCRIPTION
# Summary

Skip the `sherpa.ui.tests.test_session.test_set_log` test when no plotting backend is installed.

# Details

The test added to fix bug #303 fails if there is no plotting backend available, with the following error:

```
=================================== FAILURES ===================================
_________________________________ test_set_log _________________________________

    def test_set_log():
        session = Session()
>       assert not session.get_data_plot_prefs()['xlog']
E       KeyError: 'xlog'

sherpa/ui/tests/test_session.py:32: KeyError
```

The fix is to create a decorator that skips tests if neither chips or matplotlib is installed and apply it to this test. For now I have decided not to export this decorator directly from `sherpa.utils`.