### PR TITLE
Hide AstroPy deprecation warnings for clobber - Fix #327

### DIFF
--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,12 +17,47 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, requires_data, requires_fits, requires_xspec
+from sherpa.utils import SherpaTestCase, requires_data, requires_fits, \
+    requires_xspec
 from sherpa.astro import ui
 
-from unittest import skipIf
 from tempfile import NamedTemporaryFile
 import warnings
+
+try:
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+    have_astropy = True
+except ImportError:
+    have_astropy = False
+
+
+def strip_astropy_clobber_deprecation(ws):
+    """Remove the AstroPy deprecation warning from the warning list.
+
+    Parameters
+    ----------
+    ws : seq of warnings
+        The warnings thrown by the code
+
+    Returns
+    -------
+    ws : list of warnings
+        A copy of the input sequence, excluding any that are
+        an Astropy Deprecation warning for the clobber parameter
+        introduced in AstroPy 1.3.0.
+    """
+
+    wmsg = '"clobber" was deprecated in version 1.3 and will be ' + \
+           'removed in a future version. Use argument "overwrite" instead.'
+
+    def keep(w):
+        # it is not clear how stable _category_name is, but it is
+        # simpler than checking against w.category
+        if w._category_name != 'AstropyDeprecationWarning':
+            return True
+        return str(w.message) != wmsg
+
+    return [w for w in ws if keep(w)]
 
 
 class test_89_issues(SherpaTestCase):
@@ -40,22 +75,24 @@ class test_89_issues(SherpaTestCase):
 
     @requires_fits
     def test_warnings_are_gone_arrays(self):
+        ui.load_arrays(1, [1, 2, 3], [4, 5, 6])
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             with NamedTemporaryFile() as f:
-                ui.load_arrays(1, [1,2,3], [4,5,6])
                 ui.save_data(1, f.name, ascii=True, clobber=True)
             with NamedTemporaryFile() as f:
                 ui.save_data(1, f.name, ascii=False, clobber=True)
+            w = strip_astropy_clobber_deprecation(w)
             assert len(w) == 0
 
     @requires_fits
     @requires_data
     def test_warnings_are_gone_pha(self):
         pha = self.make_path("3c273.pi")
+        ui.load_pha(pha)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             with NamedTemporaryFile() as f:
-                ui.load_pha(pha)
                 ui.save_data(1, f.name, ascii=False, clobber=True)
+            w = strip_astropy_clobber_deprecation(w)
             assert len(w) == 0

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -30,6 +30,12 @@ try:  # Python 3
 except ImportError:  # Python 2
     import mock
 
+try:
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+    have_astropy = True
+except ImportError:
+    have_astropy = False
+
 
 TEST_DATA_OPTION = "--test-data"
 
@@ -39,7 +45,8 @@ def pytest_addoption(parser):
                      help="Alternative location of test data files")
 
 
-# Whilelist of known warnings. One can associate different warning messages to the same warning class
+# Whilelist of known warnings. One can associate different warning messages
+# to the same warning class
 known_warnings = {
     DeprecationWarning:
         [
@@ -75,6 +82,17 @@ if sys.version_info >= (3, 2):
             ]
     }
     known_warnings.update(python3_warnings)
+
+
+if have_astropy:
+    astropy_warnings = {
+        AstropyDeprecationWarning:
+        [
+            r'"clobber" was deprecated in version 1.3 and will be ' +
+            'removed in a future version.*'
+        ]
+    }
+    known_warnings.update(astropy_warnings)
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
This is not a long-term solution, since that will involve code changes,
but for now just hide these deprecation warnings.

These warnings could have been made to only be checked for with
AstroPy >= 1.3, but I did not feel it was worthwhile adding this
level of complication.