### PR TITLE
Ignore AstroPy deprecation warnings for clobber - Fix #327

### DIFF
--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,12 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils import SherpaTestCase, requires_data, requires_fits, requires_xspec
+from sherpa.utils import SherpaTestCase, requires_data, requires_fits, \
+    requires_xspec
 from sherpa.astro import ui
 
-from unittest import skipIf
 from tempfile import NamedTemporaryFile
-import warnings
 
 
 class test_89_issues(SherpaTestCase):
@@ -40,22 +39,18 @@ class test_89_issues(SherpaTestCase):
 
     @requires_fits
     def test_warnings_are_gone_arrays(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with NamedTemporaryFile() as f:
-                ui.load_arrays(1, [1,2,3], [4,5,6])
-                ui.save_data(1, f.name, ascii=True, clobber=True)
-            with NamedTemporaryFile() as f:
-                ui.save_data(1, f.name, ascii=False, clobber=True)
-            assert len(w) == 0
+        ui.load_arrays(1, [1, 2, 3], [4, 5, 6])
+        #  We now have logic in conftest.py to catch white-listed warnings and fail on unexpected ones.
+        #  We just need to make any warnings bubble up, here and in the following test.
+        with NamedTemporaryFile() as f:
+            ui.save_data(1, f.name, ascii=True, clobber=True)
+        with NamedTemporaryFile() as f:
+            ui.save_data(1, f.name, ascii=False, clobber=True)
 
     @requires_fits
     @requires_data
     def test_warnings_are_gone_pha(self):
         pha = self.make_path("3c273.pi")
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with NamedTemporaryFile() as f:
-                ui.load_pha(pha)
-                ui.save_data(1, f.name, ascii=False, clobber=True)
-            assert len(w) == 0
+        ui.load_pha(pha)
+        with NamedTemporaryFile() as f:
+            ui.save_data(1, f.name, ascii=False, clobber=True)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -30,6 +30,12 @@ try:  # Python 3
 except ImportError:  # Python 2
     import mock
 
+try:
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+    have_astropy = True
+except ImportError:
+    have_astropy = False
+
 
 TEST_DATA_OPTION = "--test-data"
 
@@ -39,14 +45,18 @@ def pytest_addoption(parser):
                      help="Alternative location of test data files")
 
 
-# Whilelist of known warnings. One can associate different warning messages to the same warning class
+# Whilelist of known warnings. One can associate different warning messages
+# to the same warning class
 known_warnings = {
     DeprecationWarning:
         [
             r"unorderable dtypes.*",
             r"Non-string object detected for the array ordering.*",
             r"using a non-integer number instead of an integer will result in an error in the future",
-            r"Use load_xstable_model to load XSPEC table models"
+            r"Use load_xstable_model to load XSPEC table models",
+            #  This does not have to do with Sherpa and is coming from some versions of
+            #  jupyter_client
+            r"metadata .* was set from the constructor.*",
         ],
     UserWarning:
         [
@@ -75,6 +85,16 @@ if sys.version_info >= (3, 2):
             ]
     }
     known_warnings.update(python3_warnings)
+
+
+if have_astropy:
+    astropy_warnings = {
+        AstropyDeprecationWarning:
+        [
+            r".*clobber.*deprecated.*1.3",
+        ],
+    }
+    known_warnings.update(astropy_warnings)
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
Fix #327.

Replaces #328.

This is not a long-term solution, since that will involve code changes,
but for now just hide these deprecation warnings. However, future changes may depend on what `astropy` developers decide to deal with the deprecation, as there is a chance it will be reverted back.