### PR TITLE
Fix `setup.py` install command

### DIFF
--- a/helpers/install.py
+++ b/helpers/install.py
@@ -27,4 +27,4 @@ class install(_install):
     def run(self):
         self.get_finalized_command('xspec_config', True).run()
         self.get_finalized_command('sherpa_config', True).run()
-        _install.run(self)
+        _install.do_egg_install(self)


### PR DESCRIPTION
# Release Note
The `setup.py install` command was not enforcing the installation of the dependencies listed in `setup.py`. This has been fixed.

# Description
It was reported that `six` would not be installed with Sherpa when doing a simple `python setup.py install`. It turns out one needs to call a special method from an extension of the `install` command for this to work.