### PR TITLE
Add requires_group decorator to wstat tests

### DIFF
--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -80,7 +80,8 @@
 
 import numpy as np
 
-from sherpa.utils import SherpaTestCase, requires_data, requires_fits
+from sherpa.utils import SherpaTestCase, requires_data, requires_fits, \
+    requires_group
 from sherpa.astro import ui
 
 from unittest import expectedFailure
@@ -178,6 +179,7 @@ class test_wstat_single_scalar(SherpaTestCase):
         self._check_stat(375, 416.0601496345599)
 
 
+@requires_group
 @requires_data
 @requires_fits
 class test_wstat_two_scalar(SherpaTestCase):
@@ -308,6 +310,7 @@ class test_wstat_two_scalar(SherpaTestCase):
         self._check_stat2(exp1 + exp2)
 
 
+@requires_group
 @requires_data
 @requires_fits
 class test_wstat_group_counts(SherpaTestCase):


### PR DESCRIPTION
Summary
=======

Several of the wstat tests require that the optional grouping module is
present but do not test for it. This commit adds the requisite
decorator.

Details
=======

I found this when trying to build Sherpa as discussed in #260 - namely

    python setup.py build_ext -i
    py.test -v

In this case, the optional modules do not seem to be build (e.g. `stk`, `group`, and there are issues with `wcs` as discussed in #260), which showed up as test failures for the recently-added wstat tests. The fix is simple, and I have verified it on my local build, but there's no way to test this fix with the current Travis setup. I do not propose adding such tests to Travis at this time, as I don't think we have decided how much support we want to give to people building Sherpa this way. My suggestion is to accept this PR as is, and leave the decision of how to test the optional modules to #260 and the current rewrite of the Travis build setup by @olaurino 