### PR TITLE
Feature/update fit documentation

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -23,6 +23,9 @@ from six.moves import xrange
 import logging
 import os
 import signal
+
+from functools import wraps
+
 from numpy import arange, array, abs, iterable, sqrt, where, \
     ones_like, isnan, isinf, float, float32, finfo, nan, any, int
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, igamc, \
@@ -42,18 +45,15 @@ __all__ = ('FitResults', 'ErrorEstResults', 'Fit')
 
 
 def evaluates_model(func):
+    """Fit object decorator that runs model startup() and teardown()
     """
-    Fit object decorator that runs model startup() and teardown()
-
-    """
+    @wraps(func)
     def run(fit, *args, **kwargs):
         fit.model.startup()
         result = func(fit, *args, **kwargs)
         fit.model.teardown()
         return result
 
-    run.__name__ = func.__name__
-    run.__doc__ = func.__doc__
     return run
 
 

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -653,13 +653,13 @@ class IterFit(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.FitErr
-            This exception is raised if the statistic is not
-            supported. This method can only be used with
-            Chi-Square statistics with errors.
+            This exception is raised if the statistic is not supported.
+            This method can only be used with Chi-Square statistics
+            with errors.
 
         Notes
         -----
-        The following keys are looked for in the ``itermethod_opts``
+        The following keys are looked for in the `itermethod_opts`
         dictionary:
 
         ========  =========  ===========
@@ -670,19 +670,21 @@ class IterFit(NoNewAttributesAfterInit):
         maxiters  int        The maximum number of iterations.
         ========  =========  ===========
 
-        The variance in bin i is estimated to be:
+        The variance in bin i for iteration j is estimated to be:
 
         .. math::
 
-           \sigma(j)_i^2 = S(i, t_s(j-1)) + (A_s/A_b)^2 B_{off}(i, t_b(j-1))
+           \sigma(j)_i^2 = S(t_s(j-1))_i + (A_s/A_b)^2 B(t_b(j-1))_i
 
-        where j is the number of iterations that have been carried out
-        in the fitting process, B_off is the background model
-        amplitude in bin i of the off-source region, and t_s(j-1) and
-        t_b(j-1) are the set of source and background model parameter
-        values derived during the iteration previous to the current
-        one. The variances are set to an array of ones on the first
-        iteration.
+        where the subscript i indicates the bin number, j is the
+        number of iterations that have been carried out in the
+        fitting process, S is the model-predicted amplitude of
+        the source in the bin, B is the background (off-source)
+        model amplitude, A_s and A_b are the source and background
+        areas (or scaling factors), and t_s and t_b are the set
+        of source and background model parameter values derived in
+        the previous iteration (indicated by the j-1 subscipt).
+        The variances are set to an array of ones on the first iteration.
 
         In addition to reducing parameter estimate bias, this
         statistic can be used even when the number of counts in each
@@ -805,7 +807,7 @@ class IterFit(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The following keys are looked for in the ``itermethod_opts``
+        The following keys are looked for in the `itermethod_opts`
         dictionary:
 
         ========  ==========  ===========

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -683,8 +683,8 @@ class IterFit(NoNewAttributesAfterInit):
         model amplitude, A_s and A_b are the source and background
         areas (or scaling factors), and t_s and t_b are the set
         of source and background model parameter values derived in
-        the previous iteration (indicated by the j-1 subscipt).
-        The variances are set to an array of ones on the first iteration.
+        the previous iteration (indicated by the j-1 term). The
+        variances are set to an array of ones on the first iteration.
 
         In addition to reducing parameter estimate bias, this
         statistic can be used even when the number of counts in each


### PR DESCRIPTION
# Summary

Update the documentation in the `sherpa.fit` module.

# Details

This updates the docstrings (both existing documentation and adding new ones), adds a few comment strings,  and uses the `functools.wraps` function to create a decorator that copies over the function signatures as well as the docstring.