### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,25 +36,35 @@ matrix:
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
 
 before_install:
+  # General configurations
   - export LIBGFORTRANVER="3.0"
   - export SHERPA_CHANNEL=sherpa
   - export XSPEC_CHANNEL=cxc/channel/dev
   - export MINICONDA=/home/travis/miniconda
+
+  # Install, update, and configure conda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p $MINICONDA
   - export PATH=$MINICONDA/bin:$PATH
   - conda update --yes conda
+  - conda config --add channels ${SHERPA_CHANNEL}
+  - conda config --add channels ${XSPEC_CHANNEL}
+
+  # Figure out requested dependencies
   - if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
   - if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
   - if [ -n "${XSPECVER}" ];
      then export XSPEC="xspec-modelsonly=${XSPECVER}";
     fi
   - echo ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}
-  - conda config --add channels ${SHERPA_CHANNEL}
-  - conda config --add channels ${XSPEC_CHANNEL}
+
+  # Create and activate conda build environment
+  # We create a new environment so we don't care about the python version in the root environment.
   - conda create --yes -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC $FITS
   - source activate build
+
+  # XSPEC and DS9
   - if [ -n "${XSPECVER}" ];
      then DS9_SITE=http://ds9.si.edu/download/centos6/;
      XPA_SITE=http://ds9.si.edu/download/centos6/;
@@ -72,9 +82,13 @@ before_install:
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
      sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
     fi
+
+  # No test data, then remove submodule (git automatically clones recursively)
   - if [ ${TEST} == none ];
      then git submodule deinit -f .;
     fi
+
+  # Install test data as a package, then remove the submodule
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;
      git submodule deinit -f .;
@@ -84,12 +98,19 @@ install:
     - python setup.py $INSTALL_TYPE &> install.log
 
 script:
+  # Build smoke test switches, to ensure requested dependencies are reachable
   - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x"; fi
   - if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
   - SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
+
+  # Install coverage tooling and run tests using setuptools
   - if [ ${TEST} == submodule ]; then pip install pytest-cov; python setup.py test -a "--cov sherpa --cov-report term"; fi
+
+  # Run smoke test
   - cd /home;
   - sherpa_smoke ${SMOKEVARS};
+
+  # Run regression tests using sherpa_test
   - if [ ${TEST} == package ] || [ ${TEST} == none ];
         then cd $HOME;
         sherpa_test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
 
   # Create and activate conda build environment
   # We create a new environment so we don't care about the python version in the root environment.
-  - conda create --yes -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC $FITS
+  - conda create --yes --quiet -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC $FITS
   - source activate build
 
   # XSPEC and DS9
@@ -70,8 +70,8 @@ before_install:
      XPA_SITE=http://ds9.si.edu/download/centos6/;
      DS9_TAR=ds9.centos6.7.5.tar.gz;
      XPA_TAR=xpa.centos6.2.1.17.tar.gz;
-     wget $DS9_SITE$DS9_TAR;
-     wget $XPA_SITE$XPA_TAR;
+     wget --quiet $DS9_SITE$DS9_TAR;
+     wget --quiet $XPA_SITE$XPA_TAR;
      THIS_DIR=`pwd`;
      cd $MINICONDA/bin; tar xf $THIS_DIR/$DS9_TAR; tar xf $THIS_DIR/$XPA_TAR; cd -;
      export DISPLAY=:99;
@@ -104,7 +104,7 @@ script:
   - SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
 
   # Install coverage tooling and run tests using setuptools
-  - if [ ${TEST} == submodule ]; then pip install pytest-cov; python setup.py test -a "--cov sherpa --cov-report term"; fi
+  - if [ ${TEST} == submodule ]; then pip install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term"; fi
 
   # Run smoke test
   - cd /home;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
 before_install:
   - export LIBGFORTRANVER="3.0"
   - export SHERPA_CHANNEL=sherpa
+  - export XSPEC_CHANNEL=cxc/channel/dev
   - export MINICONDA=/home/travis/miniconda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -46,16 +47,14 @@ before_install:
   - conda update --yes conda
   - if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
   - if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
-  - echo ${MATPLOTLIB} ${NUMPY} ${FITS}
-  - conda create --yes -n build python=$TRAVIS_PYTHON_VERSION
-  - source activate build
-  - if [ -n "${FITS}" ]; then conda install --yes -c ${SHERPA_CHANNEL} ${FITS} ${MKL}; fi
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER
-  - conda config --add channels ${SHERPA_CHANNEL}
-  - if [ ${TEST} == package ];
-     then pip install ./sherpa-test-data;
-     git submodule deinit -f .;
+  - if [ -n "${XSPECVER}" ];
+     then export XSPEC="xspec-modelsonly=${XSPECVER}";
     fi
+  - echo ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}
+  - conda config --add channels ${SHERPA_CHANNEL}
+  - conda config --add channels ${XSPEC_CHANNEL}
+  - conda create --yes -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC
+  - source activate build
   - if [ -n "${XSPECVER}" ];
      then DS9_SITE=http://ds9.si.edu/download/centos6/;
      XPA_SITE=http://ds9.si.edu/download/centos6/;
@@ -67,10 +66,7 @@ before_install:
      cd $MINICONDA/bin; tar xf $THIS_DIR/$DS9_TAR; tar xf $THIS_DIR/$XPA_TAR; cd -;
      export DISPLAY=:99;
      /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16;
-    fi
-  - if [ -n "${XSPECVER}" ];
-     then sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
-     conda install --quiet --yes -c cxc/channel/dev xspec-modelsonly=${XSPECVER};
+     sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
      export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
      export LD_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
@@ -78,6 +74,10 @@ before_install:
     fi
   - if [ ${TEST} == smoke ] || [ ${TEST} == none ];
      then git submodule deinit -f .;
+    fi
+  - if [ ${TEST} == package ];
+     then pip install ./sherpa-test-data;
+     git submodule deinit -f .;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
       - gfortran
 
 # Barebone build to check tests pass when most of the tests must be skipped.
-# We need to use TEST=package to avoid dependencies from being installed by pytest
-env: INSTALL_TYPE=install TEST=package NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
+# We need to use TEST=none to remove the test-data submodule.
+env: INSTALL_TYPE=install TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
 
 matrix:
   fast_finish: true
@@ -77,7 +77,7 @@ before_install:
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
      sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
     fi
-  - if [ ${TEST} == smoke ];
+  - if [ ${TEST} == smoke || ${TEST} == none ];
      then git submodule deinit -f .;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
   - echo ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}
   - conda config --add channels ${SHERPA_CHANNEL}
   - conda config --add channels ${XSPEC_CHANNEL}
-  - conda create --yes -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC
+  - conda create --yes -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC $FITS
   - source activate build
   - if [ -n "${XSPECVER}" ];
      then DS9_SITE=http://ds9.si.edu/download/centos6/;
@@ -72,7 +72,7 @@ before_install:
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
      sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
     fi
-  - if [ ${TEST} == smoke ] || [ ${TEST} == none ];
+  - if [ ${TEST} == none ];
      then git submodule deinit -f .;
     fi
   - if [ ${TEST} == package ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     # Install astropy without matplotlib (checks tests are properly skipped)
     - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
   allow_failures:
+    # Python 3.6 build fails because of unhandled warnings coming (mostly?) from the ds9 integration.
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,66 +1,44 @@
-language: python
-
-python:
-  - "2.7"
+language: c
 
 sudo: false
-
-cache:
-  directories:
-    - $HOME/xspec
 
 addons:
   apt:
     packages: &default_apt
-      - build-essential
       - gfortran
-      - flex
-      - bison
 
-# We use matrix include so that xspec builds (which are more complicated and long) are started first
+# Barebone build to check tests pass when most of the tests must be skipped.
+# We need to use TEST=package to avoid dependencies from being installed by pytest
+env: INSTALL_TYPE=install TEST=package NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
+
 matrix:
-  allow_failures:
-      - python: "3.5"
   fast_finish: true
   include:
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=smoke MATPLOTLIBVER=1.5
-      python: "2.7"
+    # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
       sudo: required
       dist: trusty
-    - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "2.7"
+    # As above, Python 3.5
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
       sudo: required
       dist: trusty
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 MKL=nomkl
-      python: "2.7"
+    # As above, Python 3.6, setup.py install
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "3.5"
-      sudo: required
-      dist: trusty
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "2.7"
-      sudo: required
-      dist: trusty
-    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5
-      python: "2.7"
-    - env: FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-      python: "2.7"
-    - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.4 NUMPYVER=1.9
-      python: "2.7"
-    - env: FITS="astropy" INSTALL_TYPE=install TEST=package MATPLOTLIBVER=1.5 NUMPYVER=1.10
-      python: "2.7"
-    - env: INSTALL_TYPE=install TEST=package NUMPYVER=1.11
-      python: "2.7"
+    # Install sherpatest package rather than relying on relative location of the submodule
+    # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
+    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="2.7"
+    # Install astropy without matplotlib (checks tests are properly skipped)
+    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
+    # Barebone build with no test data
+    - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
   allow_failures:
-    - env: XSPECVER="12.8.2q" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5
-
-env: FITS="pyfits" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.4 # 1.5 does not support numpy 1.8, required by pyfits
+    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
 
 before_install:
-  - export LIBGFORTRANVER="1.0"
-  - export SHERPA_CHANNEL=https://conda.anaconda.org/sherpa
+  - export LIBGFORTRANVER="3.0"
+  - export SHERPA_CHANNEL=sherpa
   - export MINICONDA=/home/travis/miniconda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -75,16 +53,15 @@ before_install:
   - if [ -n "${FITS}" ]; then conda install --yes -c ${SHERPA_CHANNEL} ${FITS} ${MKL}; fi
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER
   - conda config --add channels ${SHERPA_CHANNEL}
-  - pip install -r test_requirements.txt
   - if [ ${TEST} == package ];
      then pip install ./sherpa-test-data;
      git submodule deinit -f .;
     fi
   - if [ -n "${XSPECVER}" ];
-     then DS9_SITE=http://ds9.si.edu/download/linux64/;
-     XPA_SITE=http://ds9.si.edu/download/linux64_5/;
-     DS9_TAR=ds9.linux64.7.3.2.tar.gz;
-     XPA_TAR=xpa.linux64_5.2.1.14.tar.gz;
+     then DS9_SITE=http://ds9.si.edu/download/centos6/;
+     XPA_SITE=http://ds9.si.edu/download/centos6/;
+     DS9_TAR=ds9.centos6.7.5.tar.gz;
+     XPA_TAR=xpa.centos6.2.1.17.tar.gz;
      wget $DS9_SITE$DS9_TAR;
      wget $XPA_SITE$XPA_TAR;
      THIS_DIR=`pwd`;
@@ -94,7 +71,7 @@ before_install:
     fi
   - if [ -n "${XSPECVER}" ];
      then sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
-     conda install --yes -c https://conda.anaconda.org/cxc/channel/dev xspec-modelsonly=${XSPECVER};
+     conda install --quiet --yes -c cxc/channel/dev xspec-modelsonly=${XSPECVER};
      export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
      export LD_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
@@ -112,11 +89,9 @@ script:
   - if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
   - SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
   - if [ ${TEST} == submodule ]; then pip install pytest-cov; python setup.py test -a "--cov sherpa --cov-report term"; fi
-  - if [ ${TEST} == smoke ];
-        then cd /home;
-        sherpa_smoke ${SMOKEVARS};
-    fi
-  - if [ ${TEST} == package ];
+  - cd /home;
+  - sherpa_smoke ${SMOKEVARS};
+  - if [ ${TEST} == package ] || [ ${TEST} == none ];
         then cd $HOME;
         sherpa_test;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
      sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
     fi
-  - if [ ${TEST} == smoke || ${TEST} == none ];
+  - if [ ${TEST} == smoke ] || [ ${TEST} == none ];
      then git submodule deinit -f .;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ addons:
 
 # Barebone build to check tests pass when most of the tests must be skipped.
 # We need to use TEST=none to remove the test-data submodule.
-env: INSTALL_TYPE=install TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
+# Barebone build with no test data
+env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
 
 matrix:
   fast_finish: true
@@ -31,8 +32,6 @@ matrix:
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="2.7"
     # Install astropy without matplotlib (checks tests are properly skipped)
     - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
-    # Barebone build with no test data
-    - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
   allow_failures:
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
 

--- a/helpers/test.py
+++ b/helpers/test.py
@@ -50,7 +50,7 @@ try:
             # import here, cause outside the eggs aren't loaded
             import pytest
             if not self.pytest_args:
-                self.pytest_args = 'sherpa'
+                self.pytest_args = ['sherpa',]
             errno = pytest.main(self.pytest_args)
             sys.exit(errno)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = -rs --verbose --ignore=setup.py --ignore=test_requirements.txt
+addopts = -rs --ignore=setup.py --ignore=test_requirements.txt
 norecursedirs = .git build dist tmp* .eggs

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -58,7 +58,7 @@ def run(verbosity=0, require_failure=False, fits=None, xspec=False):
     The function will exit with a non-zero exit status if any errors are detected.
     """
     test_suite = SmokeTestSuite(require_failure=require_failure)
-    runner = unittest.TextTestRunner(verbosity=verbosity)
+    runner = unittest.TextTestRunner(verbosity=int(verbosity))
     result = runner.run(test_suite)
 
     missing_requirements = []


### PR DESCRIPTION
This PR consolidates Travis builds and updates most dependencies, in particular:
  * language is now C, which is more appropriate for a project that uses conda to get Python. Also, the C environment reduces the number of required build dependencies, in fact:
  * apt dependencies (used for all non-xspec builds) have been reduced.
  * smoke test is now run at the end of all builds, in addition to the other tests. The test probes for the dependencies that are known to be installed in each build, so e.g. if astropy is installed the smoke test checks the module can be imported so the proper tests are run... if it can't, it will fail.
  * we now test for python 2.7, 3.5, and 3.6, although the 3.6 build is still allowed to fail (and it does fail because of some unhandled warnings).
  * numpy v1.11 and up are being tested (i.e. 1.9 and 1.10 are not tested anymore)
  * pyfits build has been removed
  * there is now a bare bone 2.7 build with no optional dependencies and no test data, to make sure most tests are properly skipped and dependencies properly installed in this particular case (see #326 and #335)
  * libgfortran dependency has been updated to 3.0 (1.0 was needed by the pyfits package and its obsolete dependencies)
  * ds9 was updated to version 7.5, and xpa to version 2.1.17
  * conda now installs quietly, hoping this reduces the size of the logs on Travis
  * `pip install -r test_requirements.txt` is not run explicitly anymore. We now have machinery that should always install dependencies.
  * builds are less verbose
  * there are fewer builds. Hopefully they still probe all useful cases (although the matrix does not cover all the possible combinations), in particular:
     * full builds (including xspec, ds9, and all of the optional dependencies) are tested with python 2.7, 3.5, and 3.6
     * a bare bone build checks tests are properly skipped when no optional dependencies and no test data are installed
     * both `develop` and `install` commands are used
     * test data is not installed, it is installed as a package, or it is available as a submodule
     * there is a build with only matplotlib installed (no xspec, no astropy)
     * there is a build with only astropy installed (no xspec, no matplotlib)
     * numpy is installed as both v 1.11 and at its latest version available in conda
     * matplotlib is installed as 1.5 and 2.0

Two more changes are piggybacking in this PR:
  * a fix to #240.
  * a fix to the smoke test, which did not work on Python3 if the verbosity argument was passed to it.

Note: xspec has not been updated to 12.9.1 because the package is too big, and it easily takes more than 10 minutes to download, which results in the build failing.