### PR TITLE
Tweak documentation for Sphinx

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -197,7 +197,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -244,7 +244,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         IOError
-           If ``filename`` does not exist.
+           If `filename` does not exist.
 
         See Also
         --------
@@ -412,7 +412,7 @@ class Session(sherpa.ui.utils.Session):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -420,7 +420,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -430,7 +430,7 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -462,7 +462,7 @@ class Session(sherpa.ui.utils.Session):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -470,7 +470,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -482,7 +482,7 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -515,7 +515,7 @@ class Session(sherpa.ui.utils.Session):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -523,7 +523,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -535,7 +535,7 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -719,19 +719,21 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        a1, .., aN : array_like
+        args : array_like
            Arrays of data. The order, and number, is determined by
-           the ``dstype`` parameter, and listed in the `load_arrays`
+           the `dstype` parameter, and listed in the `load_arrays`
            routine.
         dstype
            The data set type. The default is `Data1D` and values
            include: `Data1D`, `Data1DInt`, `Data2D`, `Data2DInt`,
-           `DataPHA`, and `DataIMG`.
+           `DataPHA`, and `DataIMG`. The class is expected to
+           be derived from `sherpa.data.BaseData`.
 
         Returns
         -------
-        data
-           The data set object matching the requested ``dstype``.
+        instance
+           The data set object matching the requested `dstype`
+           parameter.
 
         See Also
         --------
@@ -884,20 +886,21 @@ class Session(sherpa.ui.utils.Session):
            use by Sherpa: a ``TABLECrate`` for crates, as used by CIAO,
            or a list of AstroPy HDU objects.
         ncols : int, optional
-           The number of columns to read in (the first ``ncols`` columns
+           The number of columns to read in (the first `ncols` columns
            in the file). The meaning of the columns is determined by
-           the ``dstype`` parameter.
+           the `dstype` parameter.
         colkeys : array of str, optional
            An array of the column name to read in. The default is
            ``None``.
         dstype : optional
-           The data class to use. The default is `Data1D`.
+           The data class to use. The default is `Data1D` and it
+           is expected to be derived from `sherpa.data.BaseData`.
 
         Returns
         -------
-        data
+        instance
            The class of the returned object is controlled by the
-           ``dstype`` parameter.
+           `dstype` parameter.
 
         See Also
         --------
@@ -931,7 +934,7 @@ class Session(sherpa.ui.utils.Session):
 
         When using the Crates I/O library, the file name can include
         CIAO Data Model syntax, such as column selection. This can
-        also be done using the ``colkeys`` parameter, as shown above:
+        also be done using the `colkeys` parameter, as shown above:
 
         >>> d = unpack_table('rprof.fits[cols rmid,sur_bri,sur_bri_err]',
                              ncols=3)
@@ -981,8 +984,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -1073,9 +1076,9 @@ class Session(sherpa.ui.utils.Session):
            column depends on the I/O library in use (Crates or
            AstroPy).
         ncols : int, optional
-           The number of columns to read in (the first ``ncols`` columns
+           The number of columns to read in (the first `ncols` columns
            in the file). The meaning of the columns is determined by
-           the ``dstype`` parameter.
+           the `dstype` parameter.
         colkeys : array of str, optional
            An array of the column name to read in. The default is
            ``None``.
@@ -1084,13 +1087,14 @@ class Session(sherpa.ui.utils.Session):
         comment : str, optional
            The comment character. The default is ``'#'``.
         dstype : optional
-           The data class to use. The default is `Data1D`.
+           The data class to use. The default is `Data1D` and it
+           is expected to be derived from `sherpa.data.BaseData`.
 
         Returns
         -------
-        data
-           The class of the returned object is controlled by the
-           ``dstype`` parameter.
+        instance
+           The type of the returned object is controlled by the
+           `dstype` parameter.
 
         See Also
         --------
@@ -1124,7 +1128,7 @@ class Session(sherpa.ui.utils.Session):
 
         When using the Crates I/O library, the file name can include
         CIAO Data Model syntax, such as column selection. This can
-        also be done using the ``colkeys`` parameter, as shown above:
+        also be done using the `colkeys` parameter, as shown above:
 
         >>> d = unpack_ascii('tbl.dat[cols rmid,sur_bri,sur_bri_err]',
                              ncols=3)
@@ -1182,8 +1186,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -1267,14 +1271,16 @@ class Session(sherpa.ui.utils.Session):
            use, as used by the I/O backend in use by Sherpa: e.g.  a
            ``PHACrateDataset``, ``TABLECrate``, or ``IMAGECrate`` for
            crates, as used by CIAO, or a list of AstroPy HDU objects.
-        *args, **kwargs
-           The options supported by
-           `unpack_pha`, `unpack_image`, `unpack_table`, and
-           `unpack_ascii`.
+        args
+           The arguments supported by `unpack_pha`, `unpack_image`,
+           `unpack_table`, and `unpack_ascii`.
+        kwargs
+           The keyword arguments supported by `unpack_pha`, `unpack_image`,
+           `unpack_table`, and `unpack_ascii`.
 
         Returns
         -------
-        data
+        instance
            The data set object.
 
         See Also
@@ -1332,10 +1338,12 @@ class Session(sherpa.ui.utils.Session):
            use, as used by the I/O backend in use by Sherpa: e.g.  a
            ``PHACrateDataset``, ``TABLECrate``, or ``IMAGECrate`` for
            crates, as used by CIAO, or a list of AstroPy HDU objects.
-        *args, **kwargs
-           The options supported by
-           `load_pha`, `load_image`, `load_table`, and
-           `load_ascii`.
+        args
+           The arguments supported by `load_pha`, `load_image`,
+           `load_table`, and `load_ascii`.
+        kwargs
+           The keyword arguments supported by `load_pha`, `load_image`,
+           `load_table`, and `load_ascii`.
 
         See Also
         --------
@@ -1352,8 +1360,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments,
-        then they are interpreted as the ``id`` and ``filename``
+        the `filename` parameter. If given two un-named arguments,
+        then they are interpreted as the `id` and `filename`
         parameters, respectively. The remaining parameters are
         expected to be given as named arguments.
 
@@ -1478,8 +1486,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -1655,8 +1663,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -1804,8 +1812,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -1887,8 +1895,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -1974,8 +1982,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2041,8 +2049,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2126,8 +2134,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2210,8 +2218,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2278,8 +2286,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2338,10 +2346,10 @@ class Session(sherpa.ui.utils.Session):
         val : array or scalar
            The systematic error.
         fractional : bool, optional
-           If ``False`` (the default value), then the ``val`` parameter is
-           the absolute value, otherwise the ``val`` parameter
+           If ``False`` (the default value), then the `val` parameter is
+           the absolute value, otherwise the `val` parameter
            represents the fractional error, so the absolute value is
-           calculated as ``get_dep() * val`` (and ``val`` must be
+           calculated as ``get_dep() * val`` (and `val` must be
            a scalar).
         bkg_id : int or str, optional
            Set to identify which background component to set. The
@@ -2360,8 +2368,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2410,10 +2418,10 @@ class Session(sherpa.ui.utils.Session):
         val : array or scalar
            The systematic error.
         fractional : bool, optional
-           If ``False`` (the default value), then the ``val`` parameter is
-           the absolute value, otherwise the ``val`` parameter
+           If ``False`` (the default value), then the `val` parameter is
+           the absolute value, otherwise the `val` parameter
            represents the fractional error, so the absolute value is
-           calculated as ``get_dep() * val`` (and ``val`` must be
+           calculated as ``get_dep() * val`` (and `val` must be
            a scalar).
         bkg_id : int or str, optional
            Set to identify which background component to set. The
@@ -2432,8 +2440,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2500,8 +2508,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``exptime`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``exptime`` parameters,
+        the `exptime` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `exptime` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2567,8 +2575,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``backscale`` parameter. If given two un-named arguments,
-        then they are interpreted as the ``id`` and ``backscale``
+        the `backscale` parameter. If given two un-named arguments,
+        then they are interpreted as the `id` and `backscale`
         parameters, respectively. The remaining parameters are
         expected to be given as named arguments.
 
@@ -2618,8 +2626,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``area`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``area`` parameters,
+        the `area` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `area` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3447,7 +3455,7 @@ class Session(sherpa.ui.utils.Session):
         args : array of arrays
            The arrays to write out.
         fields : array of str
-           The column names (should match the size of ``args``).
+           The column names (should match the size of `args`).
         ascii : bool, optional
            If ``False`` then the data is written as a FITS format binary
            table. The default is ``True``. The exact format of the
@@ -3461,7 +3469,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3506,7 +3514,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background model should be written out
            rather than the source.
@@ -3516,7 +3524,7 @@ class Session(sherpa.ui.utils.Session):
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3526,7 +3534,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3540,8 +3548,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3589,7 +3597,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background model should be written out
            rather than the source.
@@ -3599,7 +3607,7 @@ class Session(sherpa.ui.utils.Session):
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3609,7 +3617,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3623,8 +3631,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3669,7 +3677,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background residuals should be written out
            rather than the source.
@@ -3679,7 +3687,7 @@ class Session(sherpa.ui.utils.Session):
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3689,7 +3697,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3701,8 +3709,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3741,7 +3749,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background residuals should be written out
            rather than the source.
@@ -3751,7 +3759,7 @@ class Session(sherpa.ui.utils.Session):
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3761,7 +3769,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3773,8 +3781,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3813,7 +3821,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background should be written out rather
            than the source.
@@ -3823,7 +3831,7 @@ class Session(sherpa.ui.utils.Session):
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3833,7 +3841,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.DataErr
            If the data set has not been filtered.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3845,8 +3853,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3903,7 +3911,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background should be written out rather
            than the source.
@@ -3913,7 +3921,7 @@ class Session(sherpa.ui.utils.Session):
            exact format of the output file depends on the
            I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3921,7 +3929,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3934,8 +3942,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3989,7 +3997,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background should be written out rather
            than the source.
@@ -3999,7 +4007,7 @@ class Session(sherpa.ui.utils.Session):
            exact format of the output file depends on the
            I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4009,7 +4017,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.IOErr
            If the data set does not contain any systematic errors.
         sherpa.utils.err.DataErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4022,8 +4030,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4083,7 +4091,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background should be written out rather
            than the source.
@@ -4093,7 +4101,7 @@ class Session(sherpa.ui.utils.Session):
            exact format of the output file depends on the
            I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4101,7 +4109,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4117,8 +4125,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4171,7 +4179,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the background should be written out rather
            than the source.
@@ -4181,7 +4189,7 @@ class Session(sherpa.ui.utils.Session):
            exact format of the output file depends on the
            I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4191,7 +4199,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.ArgumentErr
            If the data set does not contain PHA data.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4202,8 +4210,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4252,7 +4260,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the grouping array should be taken from the
            background associated with the data set.
@@ -4262,7 +4270,7 @@ class Session(sherpa.ui.utils.Session):
            exact format of the output file depends on the
            I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4270,7 +4278,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4283,8 +4291,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4337,7 +4345,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the array to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         bkg_id : int or str, optional
            Set if the quality array should be taken from the
            background associated with the data set.
@@ -4347,7 +4355,7 @@ class Session(sherpa.ui.utils.Session):
            exact format of the output file depends on the
            I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4355,7 +4363,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4368,8 +4376,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4419,14 +4427,14 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the data to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         ascii : bool, optional
            If ``False`` then the data is written as a FITS format binary
            table. The default is ``False``. The exact format of the
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4434,7 +4442,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
            If the data set does not contain 2D data.
 
         See Also
@@ -4449,8 +4457,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4487,14 +4495,14 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         filename : str
            The name of the file to write the data to. The format
-           is determined by the ``ascii`` argument.
+           is determined by the `ascii` argument.
         ascii : bool, optional
            If ``False`` then the data is written as a FITS format binary
            table. The default is ``False``. The exact format of the
            output file depends on the I/O library in use (Crates or
            AstroPy).
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4502,7 +4510,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4517,8 +4525,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4575,7 +4583,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.IdentifierErr
            If there is no matching data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4597,8 +4605,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4825,8 +4833,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arf`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arf`` parameters,
+        the `arf` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arf` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4961,8 +4969,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -5076,8 +5084,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -5132,7 +5140,7 @@ class Session(sherpa.ui.utils.Session):
         parameter use, since it is designed for easy interactive use.
         When called with two arguments, they are assumed to be
         ``filenames`` and ``resp_ids``, and three positional arguments
-        means ``id``, ``filenames``, and ``resp_ids``.
+        means `id`, ``filenames``, and ``resp_ids``.
 
         Examples
         --------
@@ -5264,8 +5272,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``rmf`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``rmf`` parameters,
+        the `rmf` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `rmf` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -5400,8 +5408,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -5510,8 +5518,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -5566,7 +5574,7 @@ class Session(sherpa.ui.utils.Session):
         parameter use, since it is designed for easy interactive use.
         When called with two arguments, they are assumed to be
         ``filenames`` and ``resp_ids``, and three positional arguments
-        means ``id``, ``filenames``, and ``resp_ids``.
+        means `id`, ``filenames``, and ``resp_ids``.
 
         Examples
         --------
@@ -5684,8 +5692,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``bkg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``bkg`` parameters,
+        the `bkg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `bkg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -5819,7 +5827,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IdentifierErr
-           If the ``id`` argument is not recognized.
+           If the `id` argument is not recognized.
 
         See Also
         --------
@@ -5830,8 +5838,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``quantity`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``quantity`` parameters,
+        the `quantity` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `quantity` parameters,
         respectively.
 
         Examples
@@ -5891,7 +5899,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.ArgumentErr
            If the data set does not contain PHA data.
         sherpa.utils.err.IdentifierErr
-           If the ``id`` argument is not recognized.
+           If the `id` argument is not recognized.
 
         See Also
         --------
@@ -5934,8 +5942,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``coord`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``coord`` parameters,
+        the `coord` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `coord` parameters,
         respectively.
 
         Any limits or values already set for model parameters, such as
@@ -5943,8 +5951,8 @@ class Session(sherpa.ui.utils.Session):
         the coordinate system.
 
         The 'logical' system is one in which the center of the
-        lower-left pixel has coordinates ``(1,1)`` and the center of the
-        top-right pixel has coordinates ``(nx,ny)``, for a ``nx``
+        lower-left pixel has coordinates ``(1, 1)`` and the center of the
+        top-right pixel has coordinates ``(nx, ny)``, for a ``nx``
         (columns) by ``ny`` (rows) pixel image. The pixels have a side
         of length 1, so the first pixel covers the range ``x=0.5`` to
         ``x=1.5`` and ``y=0.5`` to ``y=1.5``.
@@ -6008,7 +6016,7 @@ class Session(sherpa.ui.utils.Session):
         sherpa.utils.err.ArgumentErr
            If the data set does not contain image data.
         sherpa.utils.err.IdentifierErr
-           If the ``id`` argument is not recognized.
+           If the `id` argument is not recognized.
 
         See Also
         --------
@@ -6585,8 +6593,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``arg`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``arg`` parameters,
+        the `arg` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -6793,8 +6801,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         References
@@ -6929,8 +6937,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         References
@@ -7143,7 +7151,7 @@ class Session(sherpa.ui.utils.Session):
     def group_bins(self, id, num=None, bkg_id=None, tabStops=None):
         """Group into a fixed number of bins.
 
-        Combine the data so that there ``num`` equal-width bins (or
+        Combine the data so that there `num` equal-width bins (or
         groups). The binning scheme is applied to all the channels,
         but any existing filter - created by the `ignore` or `notice`
         set of functions - is re-applied after the data has been
@@ -7190,8 +7198,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``num`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``num`` parameters,
+        the `num` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `num` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -7256,7 +7264,7 @@ class Session(sherpa.ui.utils.Session):
     def group_width(self, id, num=None, bkg_id=None, tabStops=None):
         """Group into a fixed bin width.
 
-        Combine the data so that each bin contains ``num`` channels.
+        Combine the data so that each bin contains `num` channels.
         The binning scheme is applied to all the channels, but any
         existing filter - created by the `ignore` or `notice` set of
         functions - is re-applied after the data has been grouped.
@@ -7301,8 +7309,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``num`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``num`` parameters,
+        the `num` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `num` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -7364,7 +7372,7 @@ class Session(sherpa.ui.utils.Session):
                      maxLength=None, tabStops=None):
         """Group into a minimum number of counts per bin.
 
-        Combine the data so that each bin contains ``num`` or more
+        Combine the data so that each bin contains `num` or more
         counts. The binning scheme is applied to all the channels, but
         any existing filter - created by the `ignore` or `notice` set
         of functions - is re-applied after the data has been grouped.
@@ -7415,8 +7423,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``num`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``num`` parameters,
+        the `num` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `num` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -7481,7 +7489,7 @@ class Session(sherpa.ui.utils.Session):
         """Group into a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
-        of at least ``snr``. The binning scheme is applied to all the
+        of at least `snr`. The binning scheme is applied to all the
         channels, but any existing filter - created by the `ignore` or
         `notice` set of functions - is re-applied after the data has
         been grouped.  The background is *not* included in this
@@ -7537,8 +7545,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``snr`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``snr`` parameters,
+        the `snr` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `snr` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -7578,7 +7586,7 @@ class Session(sherpa.ui.utils.Session):
                     maxLength=None, tabStops=None):
         """Adaptively group to a minimum number of counts.
 
-        Combine the data so that each bin contains ``min`` or more
+        Combine the data so that each bin contains `min` or more
         counts. The difference to `group_counts` is that this
         algorithm starts with the bins with the largest signal, in
         order to avoid over-grouping bright features, rather than at
@@ -7632,8 +7640,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``min`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``min`` parameters,
+        the `min` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `min` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -7676,7 +7684,7 @@ class Session(sherpa.ui.utils.Session):
         """Adaptively group to a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
-        of at least ``num``. The difference to `group_snr` is that this
+        of at least `num`. The difference to `group_snr` is that this
         algorithm starts with the bins with the largest signal, in
         order to avoid over-grouping bright features, rather than at
         the first channel of the data. The adaptive nature means that
@@ -7735,8 +7743,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``num`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``num`` parameters,
+        the `num` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `num` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -8180,8 +8188,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Some functions - such as `plot_source` and `calc_energy_flux`
@@ -8417,8 +8425,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         This is a generic function, and can be used to model other
@@ -8519,20 +8527,20 @@ class Session(sherpa.ui.utils.Session):
         This returns the model expression for the background of a data
         set, including the instrument response (e.g. ARF and RMF),
         whether created automatically or explicitly, with
-        `set_bkg_full_model`.
+        ``set_bkg_full_model``.
 
         Parameters
         ----------
         id : int or str, optional
            The data set to use. If not given then the default
-           identifier is used, as returned by `get_default_id`.
+           identifier is used, as returned by ``get_default_id``.
         bkg_id : int or str, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
 
         Returns
         -------
-        model
+        instance
            This can contain multiple model components and any
            instrument response. Changing attributes of this model
            changes the model used by the data set.
@@ -8609,8 +8617,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Some functions - such as `plot_bkg_source` - may not work for
@@ -8715,8 +8723,8 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         The emission defined by the background model expression is
@@ -8942,7 +8950,7 @@ class Session(sherpa.ui.utils.Session):
         .. note:: Deprecated in Sherpa 4.9
                   The new `load_xstable_model` routine should be used for
                   loading XSPEC table model files. Support for these files
-                  will be removed from ``load_table_model` in the next
+                  will be removed from `load_table_model` in the next
                   release.
 
         A table model is defined on a grid of points which is
@@ -8964,8 +8972,10 @@ class Session(sherpa.ui.utils.Session):
            the coordinate grid of the data set. Linear,
            nearest-neighbor, and polynomial schemes are provided in
            the sherpa.utils module.
-        *args, **kwargs
+        args
            Arguments for reading in the data.
+        kwargs
+           Keyword arguments for reading in the data.
 
         See Also
         --------
@@ -9055,9 +9065,12 @@ class Session(sherpa.ui.utils.Session):
            Set this to include data from this file in the model. The
            file should contain two columns, and the second column is
            stored in the ``_y`` attribute of the model.
-        *args, **kwargs
-           Options for reading in the data from ``filename``, if set.
+        args
+           Arguments for reading in the data from `filename`, if set.
            See `load_table` and `load_image` for more information.
+        kwargs
+           Keyword arguments for reading in the data from `filename`,
+           if set. See `load_table` and `load_image` for more information.
 
         See Also
         --------
@@ -9106,12 +9119,12 @@ class Session(sherpa.ui.utils.Session):
         use it in a source expression:
 
         >>> def func1d(pars, x, xhi=None):
-                if xhi is not None:
-                    x = (x + xhi)/2
-                return x * pars[1] + pars[0]
-
+        ...     if xhi is not None:
+        ...         x = (x + xhi)/2
+        ...     return x * pars[1] + pars[0]
+        ...
         >>> load_user_model(func1d, "myfunc")
-        >>> add_user_pars(myfunc, ["c","m"], [0,1])
+        >>> add_user_pars(myfunc, ["c", "m"], [0, 1])
         >>> set_source(myfunc + gauss1d.gline)
 
         """
@@ -9247,7 +9260,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.FitErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -9330,7 +9343,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.FitErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -9493,7 +9506,7 @@ class Session(sherpa.ui.utils.Session):
 
         Returns
         -------
-        data
+        instance
            An object representing the data used to create the plot by
            `plot_source`. The return value depends on the data
            set (e.g. PHA, 1D binned, 1D un-binned).
@@ -11267,7 +11280,7 @@ class Session(sherpa.ui.utils.Session):
         -------
         vals
            The return array has the shape ``(num, N+1)``, where ``N`` is the
-           number of free parameters and num is the ``num`` parameter.
+           number of free parameters and num is the `num` parameter.
            The rows of this array contain the flux value, as
            calculated by `calc_photon_flux`, followed by the values of
            the thawed parameters used for that iteration. The order of
@@ -11369,7 +11382,7 @@ class Session(sherpa.ui.utils.Session):
         -------
         vals
            The return array has the shape ``(num, N+1)``, where ``N`` is the
-           number of free parameters and num is the ``num`` parameter.
+           number of free parameters and num is the `num` parameter.
            The rows of this array contain the flux value, as
            calculated by `calc_energy_flux`, followed by the values of
            the thawed parameters used for that iteration. The order of
@@ -11455,12 +11468,12 @@ class Session(sherpa.ui.utils.Session):
            The number of samples to create. The default is 1.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
+           parameters. The form depends on the `correlated`
            parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
+           positive semi-definite (N, N) array, otherwise a 1D array
            of length N, where N is the number of free parameters.
         correlated : bool, optional
-           If ``True`` (the default is ``False``) then ``scales`` is the
+           If ``True`` (the default is ``False``) then `scales` is the
            full covariance matrix, otherwise it is just a 1D array
            containing the variances of the parameters (the diagonal
            elements of the covariance matrix).
@@ -11482,14 +11495,14 @@ class Session(sherpa.ui.utils.Session):
 
         Returns
         -------
-        (fullflux,cptflux,vals)
+        (fullflux, cptflux, vals)
            The fullflux and cptflux arrays contain the results for
-           the full source model and the flux of the ``modelcomponent``
+           the full source model and the flux of the `modelcomponent`
            argument (they can be the same). They have three elements
            and give the median value, upper quartile, and lower
            quartile values of the flux distribution. The vals array
-           has a shape of ``(num+1,N+2)``, where ``N`` is the number of free
-           parameters and num is the ``num`` parameter. The rows of
+           has a shape of ``(num+1, N+2)``, where ``N`` is the number of
+           free parameters and num is the `num` parameter. The rows of
            this array contain the flux value for the iteration (for
            the full source model), the parameter values, and then the
            statistic value for this set of parameters.
@@ -11659,7 +11672,7 @@ class Session(sherpa.ui.utils.Session):
            to use the low value of the data set.
         hi : number, optional
            The maximum limit of the band, which must be larger than
-           ``lo``. Use ``None``, the default, to use the upper value of
+           `lo`. Use ``None``, the default, to use the upper value of
            the data set.
         id : int or str, optional
            Use the source expression associated with this data set. If
@@ -11671,13 +11684,13 @@ class Session(sherpa.ui.utils.Session):
 
         Returns
         -------
-        flux
+        number
            The flux from the source model integrated over the given
            band. This represents the flux from the model without any
            instrument response (i.e. the intrinsic flux of the
            source). For X-Spec style models the units will be
-           photon/cm^2/s. If ``hi`` is ``None`` but ``lo`` is set then the
-           flux density is returned at that point: photon/cm^2/s/keV
+           photon/cm^2/s. If `hi` is ``None`` but `lo` is set the
+           the flux density is returned at that point: photon/cm^2/s/keV
            or photon/cm^2/s/Angstrom depending on the analysis
            setting.
 
@@ -11687,11 +11700,12 @@ class Session(sherpa.ui.utils.Session):
         calc_model_sum : Sum up the fitted model over a pass band.
         calc_energy_flux : Integrate the source model over a pass band.
         calc_source_sum: Sum up the source model over a pass band.
+        set_analysis : Set the units used when fitting and displaying spectral data
         set_model : Set the source model expression for a data set.
 
         Notes
         -----
-        The units of ``lo`` and ``hi`` are determined by the analysis
+        The units of `lo` and `hi` are determined by the analysis
         setting for the data set (e.g. `get_analysis`).
 
         Any existing filter on the data set - e.g. as created by
@@ -11756,25 +11770,25 @@ class Session(sherpa.ui.utils.Session):
            to use the low value of the data set.
         hi : number, optional
            The maximum limit of the band, which must be larger than
-           ``lo``. Use ``None``, the default, to use the upper value of
+           `lo`. Use ``None``, the default, to use the upper value of
            the data set.
         id : int or str, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
-           by `get_default_id`.
+           by ``get_default_id``.
         bkg_id : int or str, optional
            If set, use the model associated with the given background
            component rather than the source model.
 
         Returns
         -------
-        flux
+        number
            The flux from the source model integrated over the given
            band. This represents the flux from the model without any
            instrument response (i.e. the intrinsic flux of the
            source). For X-Spec style models the units will be
-           erg/cm^2/s. If ``hi`` is ``None`` but ``lo`` is set then the flux
-           density is returned at that point: erg/cm^2/s/keV or
+           erg/cm^2/s. If ``hi`` is ``None`` but ``lo`` is set then the
+           flux density is returned at that point: erg/cm^2/s/keV or
            erg/cm^2/s/Angstrom depending on the analysis setting.
 
         See Also
@@ -11783,15 +11797,16 @@ class Session(sherpa.ui.utils.Session):
         calc_model_sum : Sum up the fitted model over a pass band.
         calc_source_sum: Sum up the source model over a pass band.
         calc_photon_flux : Integrate the source model over a pass band.
+        set_analysis : Set the units used when fitting and displaying spectral data
         set_model : Set the source model expression for a data set.
 
         Notes
         -----
         The units of ``lo`` and ``hi`` are determined by the analysis
-        setting for the data set (e.g. `get_analysis`).
+        setting for the data set (e.g. ``get_analysis``).
 
         Any existing filter on the data set - e.g. as created by
-        `ignore` or `notice` - is ignored by this function.
+        ``ignore`` or ``notice`` - is ignored by this function.
 
         The flux is calculated from the given source model, so if it
         includes an absorbing component then the result will represent
@@ -12426,13 +12441,13 @@ class Session(sherpa.ui.utils.Session):
         ----------
         outfile : str or file-like, optional
            If given, the output is written to this file, and the
-           ``clobber`` parameter controls what happens if the
+           `clobber` parameter controls what happens if the
            file already exists.
-           ``outfile`` can be a filename string or a file handle
+           `outfile` can be a filename string or a file handle
            (or file-like object, such as ``StringIO``) to write
            to. If not set then the standard output is used.
         clobber : bool, optional
-           If ``outfile`` is a filename, then this flag controls
+           If `outfile` is a filename, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -12440,7 +12455,7 @@ class Session(sherpa.ui.utils.Session):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -431,7 +431,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -485,7 +485,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         IOError
-           If ``filename`` does not exist.
+           If `filename` does not exist.
 
         See Also
         --------
@@ -665,7 +665,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -673,7 +673,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -684,7 +684,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -712,7 +712,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -720,7 +720,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -730,7 +730,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -770,7 +770,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -778,7 +778,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -790,7 +790,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -817,7 +817,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -825,7 +825,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -834,7 +834,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -860,7 +860,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -868,7 +868,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -881,7 +881,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -911,7 +911,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -919,7 +919,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -930,7 +930,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -961,7 +961,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -969,7 +969,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -980,7 +980,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1009,7 +1009,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1017,7 +1017,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1031,7 +1031,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1070,7 +1070,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1078,7 +1078,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1092,7 +1092,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1127,7 +1127,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1135,7 +1135,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1144,7 +1144,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1168,7 +1168,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1176,7 +1176,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1185,7 +1185,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1209,7 +1209,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1217,7 +1217,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1226,7 +1226,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1254,7 +1254,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1262,7 +1262,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1288,7 +1288,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -1335,7 +1335,7 @@ class Session(NoNewAttributesAfterInit):
            otherwise it is taken to be the name of the file to
            write the results to.
         clobber : bool, optional
-           If ``outfile`` is not ``None``, then this flag controls
+           If `outfile` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -1343,7 +1343,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``outfile`` already exists and ``clobber`` is ``False``.
+           If `outfile` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -1352,7 +1352,7 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        When ``outfile`` is ``None``, the text is displayed via an external
+        When `outfile` is ``None``, the text is displayed via an external
         program to support paging of the information. The program
         used is determined by the ``PAGER`` environment variable. If
         ``PAGER`` is not found then '/usr/bin/more' is used.
@@ -2268,7 +2268,7 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        data
+        instance
            An instance of a sherpa.Data.Data-derived class.
 
         Raises
@@ -2329,8 +2329,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``data`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``data`` parameters,
+        the `data` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `data` parameters,
         respectively.
 
         Examples
@@ -2395,8 +2395,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2464,8 +2464,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2534,8 +2534,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -2592,8 +2592,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2653,8 +2653,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2698,10 +2698,10 @@ class Session(NoNewAttributesAfterInit):
         val : array or scalar
            The systematic error.
         fractional : bool, optional
-           If ``False`` (the default value), then the ``val`` parameter is
-           the absolute value, otherwise the ``val`` parameter
+           If ``False`` (the default value), then the `val` parameter is
+           the absolute value, otherwise the `val` parameter
            represents the fractional error, so the absolute value is
-           calculated as ``get_dep() * val`` (and ``val`` must be
+           calculated as ``get_dep() * val`` (and `val` must be
            a scalar).
 
         See Also
@@ -2716,8 +2716,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -2762,10 +2762,10 @@ class Session(NoNewAttributesAfterInit):
         val : array or scalar
            The systematic error.
         fractional : bool, optional
-           If ``False`` (the default value), then the ``val`` parameter is
-           the absolute value, otherwise the ``val`` parameter
+           If ``False`` (the default value), then the `val` parameter is
+           the absolute value, otherwise the `val` parameter
            represents the fractional error, so the absolute value is
-           calculated as ``get_dep() * val`` (and ``val`` must be
+           calculated as ``get_dep() * val`` (and `val` must be
            a scalar).
 
         See Also
@@ -2780,8 +2780,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``val`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``val`` parameters,
+        the `val` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `val` parameters,
         respectively.
 
         Examples
@@ -3443,17 +3443,18 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        a1, .., aN : array_like
+        args : array_like
            Arrays of data. The order, and number, is determined by
-           the ``dstype`` parameter, and listed in the `load_arrays`
+           the `dstype` parameter, and listed in the `load_arrays`
            routine.
         dstype
            The data set type. The default is `Data1D` and values
            include: `Data1D`, `Data1DInt`, `Data2D`, and `Data2DInt`.
+           It is expected to be derived from `sherpa.data.BaseData`.
 
         Returns
         -------
-        data
+        instance
            The data set object matching the requested ``dstype``.
 
         See Also
@@ -3504,7 +3505,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the ASCII file to read in.
         ncols : int, optional
-           The number of columns to read in (the first ``ncols`` columns
+           The number of columns to read in (the first `ncols` columns
            in the file).
         colkeys : array of str, optional
            An array of the column name to read in. The default is
@@ -3518,19 +3519,19 @@ class Session(NoNewAttributesAfterInit):
         comment : str, optional
            The comment character. The default is ``'#'``.
         require_floats : bool, optional
-           If ``True`` (the default), non-numeric data values will
+           If `True` (the default), non-numeric data values will
            raise a `ValueError`.
 
         Returns
         -------
-        data
+        instance
            The data set object.
 
         Raises
         ------
         ValueError
            If a column value can not be converted into a numeric value
-           and the ``require_floats`` parameter is True.
+           and the `require_floats` parameter is True.
 
         See Also
         --------
@@ -3542,31 +3543,31 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-
         The file reading is performed by `sherpa.io.get_ascii_data`,
         which reads in each line from the file, strips out any unsupported
-        characters (replacing them by the ``sep`` argument), skips
+        characters (replacing them by the `sep` argument), skips
         empty lines, and then identifies whether it is a comment or data
         line.
 
-        The list of unsupported characters are: ``\t``, ``\n``,
-        ``\r``, comma, semi-colon, colon, space, and ``|``.
+        The list of unsupported characters are: tab, new line,
+        carriage return, comma, semi-colon, colon, space, and "|".
 
         The last comment line before the data is used to define the
-        column names, splitting the line by the ``sep`` argument.
+        column names, splitting the line by the `sep` argument.
         If there are no comment lines then the columns are named
-        starting at ``col1``, ``col2``, up to the number of columns.
+        starting at `col1`, `col2`, increasing up to the number of
+        columns.
 
         Data lines are separated into columns - splitting by the
-        ``sep`` comment - and then converted to NumPy arrays.
-        If the ``require_floats`` argument is ``True`` then the
+        `sep` comment - and then converted to NumPy arrays.
+        If the `require_floats` argument is ``True`` then the
         column will be converted to the `sherpa.utils.SherpaFloat`
         type, with an error raised if this fails.
 
         An error is raised if the number of columns per row
         is not constant.
 
-        If the ``colkeys`` argument is used then a case-sensitive
+        If the `colkeys` argument is used then a case-sensitive
         match is used to determine what columns to return.
 
         Examples
@@ -3646,8 +3647,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3801,9 +3802,9 @@ class Session(NoNewAttributesAfterInit):
         args : array of arrays
            The arrays to write out.
         fields : array of str
-           The column names (should match the size of ``args``).
+           The column names (should match the size of `args`).
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3820,7 +3821,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3882,7 +3883,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3896,8 +3897,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -3940,7 +3941,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -3959,7 +3960,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -3973,8 +3974,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4014,7 +4015,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4033,7 +4034,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4045,8 +4046,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4085,7 +4086,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4104,7 +4105,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.IdentifierErr
            If no model has been set for this data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4116,8 +4117,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4164,7 +4165,7 @@ class Session(NoNewAttributesAfterInit):
         comment : str, optional
            The comment character. The default is ``'#'``.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4179,7 +4180,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.IdentifierErr
            If there is no matching data set.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4196,8 +4197,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4237,7 +4238,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4256,7 +4257,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.DataErr
            If the data set has not been filtered.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4268,8 +4269,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4316,7 +4317,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4333,7 +4334,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4346,8 +4347,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4390,7 +4391,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4409,7 +4410,7 @@ class Session(NoNewAttributesAfterInit):
         sherpa.utils.err.IOErr
            If the data set does not contain any systematic errors.
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4422,8 +4423,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4472,7 +4473,7 @@ class Session(NoNewAttributesAfterInit):
         filename : str
            The name of the file to write the array to.
         clobber : bool, optional
-           If ``filename`` is not ``None``, then this flag controls
+           If `filename` is not ``None``, then this flag controls
            whether an existing file can be overwritten (``True``)
            or if it raises an exception (``False``, the default
            setting).
@@ -4489,7 +4490,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.IOErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -4505,8 +4506,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``filename`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``filename`` parameters,
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
@@ -4856,7 +4857,7 @@ class Session(NoNewAttributesAfterInit):
     def paramprompt(self, val=False):
         """Should the user be asked for the parameter values when creating a model?
 
-        When ``val`` is ``True``, calls to `set_model` will cause the user
+        When `val` is ``True``, calls to `set_model` will cause the user
         to be prompted for each parameter in the expression.  The
         prompt includes the parameter name and default value, in ``[]``:
         the valid responses are
@@ -4942,9 +4943,8 @@ class Session(NoNewAttributesAfterInit):
         """Create a user-defined model class.
 
         Create a model from a class. The name of the class can then be
-        used to create model components - e.g.  with
-        `create_model_component` or `set_model` - as with any existing
-        Sherpa model.
+        used to create model components - e.g.  with `set_model` or
+        `create_model_component` - as with any existing Sherpa model.
 
         Parameters
         ----------
@@ -4952,8 +4952,10 @@ class Session(NoNewAttributesAfterInit):
            A class derived from `sherpa.models.model.ArithmeticModel`. This
            class defines the functional form and the parameters of the
            model.
-        args, kwargs : optional
+        args
            Arguments for the class constructor.
+        kwargs
+           Keyword arguments for the class constructor.
 
         See Also
         --------
@@ -4982,7 +4984,9 @@ class Session(NoNewAttributesAfterInit):
         functionality.
 
         >>> from sherpa.models import Gauss1D
-        >>> class MyGauss1D(Gauss1D): pass
+        >>> class MyGauss1D(Gauss1D):
+        ...     pass
+        ...
         >>> add_model(MyGauss1D)
         >>> set_source(mygauss1d.g1 + mygauss1d.g2)
 
@@ -5595,7 +5599,7 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        model
+        instance
            This can contain multiple model components and any
            instrument response. Changing attributes of this model
            changes the model used by the data set.
@@ -5716,8 +5720,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Some functions - such as `plot_source` - may not work for
@@ -5785,8 +5789,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         PHA data sets will automatically apply the instrumental
@@ -6721,9 +6725,11 @@ class Session(NoNewAttributesAfterInit):
            The identifier for this PSF model.
         filename_or_model : str or model instance
            This can be the name of an ASCII file or a Sherpa model component.
-        *args, **kwargs
-           Arguments for `unpack_data` if ``filename_or_model``
-           is a file.
+        args
+           Arguments for `unpack_data` if `filename_or_model` is a file.
+        kwargs
+           Keyword arguments for `unpack_data` if `filename_or_model` is
+           a file.
 
         See Also
         --------
@@ -6794,9 +6800,11 @@ class Session(NoNewAttributesAfterInit):
            The identifier for this PSF model.
         filename_or_model : str or model instance
            This can be the name of an ASCII file or a Sherpa model component.
-        *args, **kwargs
-           Arguments for `unpack_data` if ``filename_or_model``
-           is a file.
+        args
+           Arguments for `unpack_data` if `filename_or_model` is a file.
+        kwargs
+           Keyword arguments for `unpack_data` if `filename_or_model` is
+           a file.
 
         See Also
         --------
@@ -6877,8 +6885,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``psf`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``psf`` parameters,
+        the `psf` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `psf` parameters,
         respectively.
 
         A PSF component should only be applied to a single data set.
@@ -7297,7 +7305,7 @@ class Session(NoNewAttributesAfterInit):
            The parameter to link.
         val
            The value - wihch can be a numeric value or a function
-           of other model parameters, to set ``par`` to.
+           of other model parameters, to set `par` to.
 
         See Also
         --------
@@ -7309,7 +7317,7 @@ class Session(NoNewAttributesAfterInit):
         Notes
         -----
         The ``link`` attribute of the parameter is set to match the
-        mathematical expression used for ``val``.
+        mathematical expression used for `val`.
 
         For a parameter value to be varied during a fit, it must be
         part of one of the source expressions involved in the fit.
@@ -7758,8 +7766,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         The guess function can reduce the time required to fit a
@@ -7934,7 +7942,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.FitErr
-           If ``filename`` already exists and ``clobber`` is ``False``.
+           If `filename` already exists and `clobber` is ``False``.
 
         See Also
         --------
@@ -9249,7 +9257,7 @@ class Session(NoNewAttributesAfterInit):
         ----------
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         parameters : optional
@@ -9376,7 +9384,7 @@ class Session(NoNewAttributesAfterInit):
         ----------
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         parameters : optional
@@ -9570,7 +9578,7 @@ class Session(NoNewAttributesAfterInit):
         ----------
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         parameters : optional
@@ -10267,7 +10275,7 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        data
+        instance
            An object representing the data used to create the plot by
            `plot_model`. The return value depends on the data
            set (e.g. 1D binned or un-binned).
@@ -10298,7 +10306,7 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        data
+        instance
            An object representing the data used to create the plot by
            `plot_source`. The return value depends on the data
            set (e.g. 1D binned or un-binned).
@@ -10335,7 +10343,7 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        data
+        instance
            An object representing the data used to create the plot by
            `plot_model_component`. The return value depends on the
            data set (e.g. 1D binned or un-binned).
@@ -10351,8 +10359,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Examples
@@ -10398,7 +10406,7 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        data
+        instance
            An object representing the data used to create the plot by
            `plot_source_component`. The return value depends on the
            data set (e.g. 1D binned or un-binned).
@@ -10414,8 +10422,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Examples
@@ -11812,8 +11820,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Examples
@@ -11879,8 +11887,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Examples
@@ -13322,7 +13330,7 @@ class Session(NoNewAttributesAfterInit):
            The parameter to plot.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         recalc : bool, optional
@@ -13333,19 +13341,19 @@ class Session(NoNewAttributesAfterInit):
         min : number, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -13416,7 +13424,7 @@ class Session(NoNewAttributesAfterInit):
            The parameter to plot.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         recalc : bool, optional
@@ -13427,19 +13435,19 @@ class Session(NoNewAttributesAfterInit):
         min : number, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -13509,7 +13517,7 @@ class Session(NoNewAttributesAfterInit):
            The parameters to plot on the X and Y axes, respectively.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         recalc : bool, optional
@@ -13524,19 +13532,19 @@ class Session(NoNewAttributesAfterInit):
         min : pair of numbers, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : pair of number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : pair of int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -13549,7 +13557,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the ``sigma`` parameter, if set (the default is
+           over-rides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -13617,7 +13625,7 @@ class Session(NoNewAttributesAfterInit):
            The parameters to plot on the X and Y axes, respectively.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         recalc : bool, optional
@@ -13632,19 +13640,19 @@ class Session(NoNewAttributesAfterInit):
         min : pair of numbers, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : pair of number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : pair of int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -13657,7 +13665,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the ``sigma`` parameter, if set (the default is
+           over-rides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -13755,7 +13763,7 @@ class Session(NoNewAttributesAfterInit):
            The parameter to plot.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         replot : bool, optional
@@ -13768,19 +13776,19 @@ class Session(NoNewAttributesAfterInit):
         min : number, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -13872,7 +13880,7 @@ class Session(NoNewAttributesAfterInit):
            The parameter to plot.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         replot : bool, optional
@@ -13881,19 +13889,19 @@ class Session(NoNewAttributesAfterInit):
         min : number, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -14012,7 +14020,7 @@ class Session(NoNewAttributesAfterInit):
            The parameters to plot on the X and Y axes, respectively.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         replot : bool, optional
@@ -14025,19 +14033,19 @@ class Session(NoNewAttributesAfterInit):
         min : pair of numbers, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : pair of number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : pair of int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -14050,7 +14058,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the ``sigma`` parameter, if set (the default is
+           over-rides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -14140,7 +14148,7 @@ class Session(NoNewAttributesAfterInit):
            The parameters to plot on the X and Y axes, respectively.
         id : str or int, optional
         otherids : list of str or int, optional
-           The ``id`` and ``otherids`` arguments determine which data set
+           The `id` and `otherids` arguments determine which data set
            or data sets are used. If not given, all data sets which
            have a defined source model are used.
         replot : bool, optional
@@ -14149,19 +14157,19 @@ class Session(NoNewAttributesAfterInit):
         min : pair of numbers, optional
            The minimum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         max : pair of number, optional
            The maximum parameter value for the calcutation. The
            default value of ``None`` means that the limit is calculated
-           from the covariance, using the ``fac`` value.
+           from the covariance, using the `fac` value.
         nloop : pair of int, optional
-           The number of steps to use. This is used when ``delv`` is set
+           The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
            The step size for the parameter. Setting this over-rides
-           the ``nloop`` parameter. The default is ``None``.
+           the `nloop` parameter. The default is ``None``.
         fac : number, optional
-           When ``min`` or ``max`` is not given, multiply the covariance
+           When `min` or `max` is not given, multiply the covariance
            of the parameter by this value to calculate the limit
            (which is then added or subtracted to the parameter value,
            as required).
@@ -14174,7 +14182,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the ``sigma`` parameter, if set (the default is
+           over-rides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -14446,8 +14454,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Examples
@@ -14506,8 +14514,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Examples
@@ -14874,8 +14882,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Image visualization is optional, and provided by the
@@ -14956,8 +14964,8 @@ class Session(NoNewAttributesAfterInit):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the ``model`` parameter. If given two un-named arguments, then
-        they are interpreted as the ``id`` and ``model`` parameters,
+        the `model` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `model` parameters,
         respectively.
 
         Image visualization is optional, and provided by the


### PR DESCRIPTION
This is a documentation-only change. There is no meaningful change to the
documentation; the changes are mostly sphinx-related (to avoid problems
generating HTML documentation, often because the suggested standards are
not 100% clear on what is supported), as well as a few minor clean ups
found while reviewing the documentation.