### PR TITLE
Fix user statistics regression

### DIFF
--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -734,7 +734,10 @@ class UserStat(Stat):
         return self.errfunc(data)
 
     def calc_stat(self, data, model):
-        raise StatErr('nostat', self.name, 'calc_stat()')
+        if not self._statfuncset:
+            raise StatErr('nostat', self.name, 'calc_stat()')
+        else:
+            return self.statfunc(data, model)
 
 
 class WStat(Likelihood):

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -741,7 +741,11 @@ class UserStat(Stat):
         if not self._statfuncset:
             raise StatErr('nostat', self.name, 'calc_stat()')
         else:
-            return self.statfunc(fitdata[0], modeldata)
+            return self.statfunc(fitdata[0],
+                                 modeldata,
+                                 staterror=fitdata[1],
+                                 syserror=fitdata[2],
+                                 weight=None)  # TODO weights
 
 
 class WStat(Likelihood):

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -695,6 +695,7 @@ class UserStat(Stat):
 
         if statfunc is not None:
             self.statfunc = statfunc
+            self._calc = statfunc
             self._statfuncset = True
 
         if errfunc is not None:
@@ -734,10 +735,13 @@ class UserStat(Stat):
         return self.errfunc(data)
 
     def calc_stat(self, data, model):
+        data, model = self._validate_inputs(data, model)
+        fitdata = data.to_fit(staterrfunc=self.calc_staterror)
+        modeldata = data.eval_model_to_fit(model)
         if not self._statfuncset:
             raise StatErr('nostat', self.name, 'calc_stat()')
         else:
-            return self.statfunc(data, model)
+            return self.statfunc(fitdata[0], modeldata)
 
 
 class WStat(Likelihood):

--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -20,6 +20,8 @@
 import numpy as np
 import pytest
 
+from pytest import approx
+
 from sherpa.astro import ui
 from sherpa.data import Data1D
 from sherpa.utils.err import StatErr
@@ -43,12 +45,12 @@ def test_user_stat_unit():
     ui.set_model(1, 'polynom1d.p')
 
     ui.load_user_stat('customstat', calc_stat, lambda x: given_stat_error)
-    ui.set_stat(customstat)
+    ui.set_stat(eval('customstat'))
 
     try:
         ui.fit(1)
     except StatErr:
-        pytest.fail("Call should not be throwing and exception (bug #341)")
+        pytest.fail("Call should not be throwing any exception (bug #341)")
 
     # Test the result is what we made the user stat return
     assert 3.235 == ui.get_fit_results().statval
@@ -91,15 +93,15 @@ def test_user_model_stat_docs():
     ui.clean()
     ui.load_arrays(1, x, y)
     ui.load_user_stat("mystat", my_stat_func, my_staterr_func)
-    ui.set_stat(mystat)
+    ui.set_stat(eval('mystat'))
     ui.load_user_model(myline, "myl")
     ui.add_user_pars("myl", ["m", "b"])
-    ui.set_model(myl)
+    ui.set_model(eval('myl'))
 
     ui.fit()
 
-    assert abs(1 - ui.get_par("myl.m").val) < 0.01
-    assert abs(3 - ui.get_par("myl.b").val) < 0.01
+    assert ui.get_par("myl.m").val == approx(1, abs=0.01)
+    assert ui.get_par("myl.b").val == approx(3, abs=0.01)
 
 
 def test_341():
@@ -163,8 +165,9 @@ def test_341():
 
     calc_stat = CalcStat(newmodel)
     ui.load_user_stat('customstat', calc_stat, lambda x: np.ones_like(x))
-    ui.set_stat(customstat)
+    ui.set_stat(eval('customstat'))
 
     ui.fit(1)
-    assert abs(1 - ui.get_par("simplemodel.m").val) < 0.00001
-    assert abs(3 - ui.get_par("simplemodel.b").val) < 0.00001
+
+    assert ui.get_par("simplemodel.m").val == approx(1, abs=0.00001)
+    assert ui.get_par("simplemodel.b").val == approx(3, abs=0.00001)

--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -1,0 +1,46 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+import numpy as np
+import pytest
+
+from sherpa.astro import ui
+from sherpa.utils.err import StatErr
+
+
+def test_341():
+    def calc_stat(data, _model):
+        return 3.235, np.ones_like(data.get_y())
+
+    xdata = [1, 2, 3]
+    ydata = xdata
+
+    ui.load_arrays(1, xdata, ydata)
+
+    ui.set_model(1, 'polynom1d.p')
+
+    ui.load_user_stat('customstat', calc_stat, lambda x: np.ones_like(x))
+    ui.set_stat(customstat)
+
+    try:
+        ui.fit(1)
+    except StatErr:
+        pytest.fail("Call should not be throwing and exception (bug #341)")
+
+    # Test the result is what we made the user stat return
+    assert 3.235 == ui.get_fit_results().statval

--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 #  Copyright (C) 2017  Smithsonian Astrophysical Observatory
 #


### PR DESCRIPTION
# Release Note
Fix #341. A number of regressions were introduced in version 4.8.1 up to version 4.9.0, so user statistics that were properly working in version 4.7 have not been working any more. This has been fixed, and a number of regression tests have been added.

# TODO:

  * [x] Refactor to avoid repetitions and improve maintainability
  * [ ] Should we improve the error message when the statistic does not return a float?
  * [ ] Should we add a way to get the user statistic from the API without relying on the pollution of the root namespace?
  * [ ] Should we add documentation on how to use classes, rather than functions, as user statistics?
  * [ ] Should we remove any mention of weights? Note that this would change the advertised API for user statistics. Not that I see this as an issue, since the functionality has been broken since v4.8.1 anyway
  * [ ] Should we pass the full data and model objects to the user statistic method? That is a significant change to the API, although a good one. We could make it backward compatible by providing a switch in `load_user_stat` for functions implementing the new API. Maybe out of scope for this PR, though, and not a priority.

# Notes
The tests in this PR make sure the [examples in the documentation](http://cxc.harvard.edu/sherpa4.4/statistics/#userstat) work again. Plus, it also probes for 

In issue #341 the reporter suggests some code that reproduces the issue. However, such code would not work with this PR either, because the user statistic does not return a float, which the underlying C code doesn't like. **Should we make sure that this case provides a more helpful error message? Should we do it in this PR?**

I could not find a way to get the user statistic from the API, which means you have to rely on a variable being present in the root namespace. This is a little more complex to fix, **but there is a question whether this should be possible**.

I think there is a potential confusion as to how the `UserStat` class should be used to create custom statistic *classes*, rather than *functions*, which probably lead to the regression. At first glance, the pattern might seem to be that `UserStat` is a kind of abstract class users can subclass and for which they have to implement the `calc_stat` method. That is not the case though. It looks more like a wrapper class that provides a statistic implementation to wrap callable objects and functions. In this sense the only way users can implement a statistic as a class rather than a function is by creating a callable class, which is what the OP did. Or, they should know how exactly to subclass `UserStat`. So, **I am not sure whether we are OK on the documentation side, or we should address the issue of showing how to create a user statistic class.**

**Do we really need to keep support for the weights?** They are not mentioned anywhere in the documentation, although they are included in the signature (as `None`) for user statistics. We have being punting this, but maybe it's time to remove such keyword? 