### PR TITLE
fix handling of AREASCAL column in PHA files (fix #350)

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1208,9 +1208,8 @@ class DataPHA(Data1DInt):
                 backscal = self._check_scale(backscal, group=False)
                 bdata = bdata / backscal
 
-            areascal = bkg.areascal
+            areascal = bkg.get_areascal(group=False)
             if areascal is not None:
-                areascal = self._check_scale(areascal, group=False)
                 bdata = bdata / areascal
 
             if bkg.exposure is not None:
@@ -1230,10 +1229,13 @@ class DataPHA(Data1DInt):
             backscal = self._check_scale(backscal, group=False)
             bkgsum = backscal * bkgsum
 
-        areascal = self.areascal
-        if areascal is not None:
-            areascal = self._check_scale(areascal, group=False)
-            bkgsum = areascal * bkgsum
+        # Unlike BACKSCAL, you do not correct the background data by
+        # the AREASCAL values of the data (since it is applied to the
+        # data)
+        # areascal = self.areascal
+        # if areascal is not None:
+        #     areascal = self._check_scale(areascal, group=False)
+        #     bkgsum = areascal * bkgsum
 
         if self.exposure is not None:
             bkgsum = self.exposure * bkgsum

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -22,7 +22,6 @@ Classes for storing, inspecting, and manipulating astronomical data sets
 """
 
 import os.path
-import warnings
 
 import numpy
 from sherpa.data import BaseData, Data1DInt, Data2D, DataND
@@ -1247,22 +1246,16 @@ class DataPHA(Data1DInt):
         # if not self.subtracted:
         #     return self.counts
         # return self.counts - self.sum_background_data()
+
         dep = self.counts
         filter = bool_cast(filter)
 
         # QUS: how to handle area scaling?
         #      could skip if areascal == 1.0
         #
-        areascal = self.areascal
+        areascal = self.get_areascal(group=False)
         if areascal is not None:
-            # Attempt to hide division-by-zero errors from the following
-            # line (e.g. bad-quality points may have a 0 areascal value).
-            # It is unclear whether we should hide such messages from the
-            # user, but they are causing problems with the test suite.
-            #
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
-                dep = dep / areascal
+            dep = dep / areascal
 
         if self.subtracted:
             bkg = self.sum_background_data()

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1301,13 +1301,10 @@ class DataPHA(Data1DInt):
             backscal = self._check_scale(backscal, group=False)
             bkgsum = backscal * bkgsum
 
-        # Unlike BACKSCAL, you do not correct the background data by
-        # the AREASCAL values of the data (since it is applied to the
-        # data)
-        # areascal = self.areascal
-        # if areascal is not None:
-        #     areascal = self._check_scale(areascal, group=False)
-        #     bkgsum = areascal * bkgsum
+        areascal = self.areascal
+        if areascal is not None:
+            areascal = self._check_scale(areascal, group=False)
+            bkgsum = areascal * bkgsum
 
         if self.exposure is not None:
             bkgsum = self.exposure * bkgsum
@@ -1324,12 +1321,12 @@ class DataPHA(Data1DInt):
         dep = self.counts
         filter = bool_cast(filter)
 
-        # The area scaling is not applied to the data since this
-        # is not appropriate for Poisson-based statistics.
-        #
-        # The calculation of the background does include any
-        # background area-scaling terms, but does not scale
-        # by the source area scaling factor.
+        # The area scaling is not applied to the data, since it
+        # should be being applied to the model via the *PHA
+        # instrument model. Note however that the background
+        # contribution does include the source AREASCAL value
+        # (in the same way that the source BACKSCAL value
+        # is used).
         #
         if self.subtracted:
             bkg = self.sum_background_data()

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -244,9 +244,60 @@ class DataRMF(Data1DInt):
 
 
 class DataPHA(Data1DInt):
-    "PHA data set, including any associated instrument and background data"
+    """PHA data set, including any associated instrument and background data.
 
-    mask = property(BaseData._get_mask, BaseData._set_mask)
+    The PHA format is described in an OGIP document [1]_.
+
+    Parameters
+    ----------
+    name : str
+        The name of the data set; often set to the name of the file
+        containing the data.
+    channel, counts : array of int
+        The PHA data.
+    staterror, syserror : scalar or array or None, optional
+        The statistical and systematic errors for the data, if
+        defined.
+    bin_lo, bin_hi : array or None, optional
+    grouping : array of int or None, optional
+    quality : array of int or None, optional
+    exposure : number or None, optional
+    backscal : scalar or array or None, optional
+    areascal : scalar or array or None, optional
+    header : dict or None, optional
+
+    Attributes
+    ----------
+    name : str
+        Used to store the file name, for data read from a file.
+    channel
+    counts
+    staterror
+    syserror
+    bin_lo
+    bin_hi
+    grouping
+    quality
+    exposure
+    backscal
+    areascal
+
+    Notes
+    -----
+    The original data is stored in the attributes - e.g. `counts` - and
+    the data-access methods, such as `get_dep` and `get_staterror`,
+    provide any necessary data manipulation to handle cases such as:
+    background subtraction, filtering, and grouping.
+
+    References
+    ----------
+
+    .. [1] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
+
+    """
+
+    mask = property(BaseData._get_mask, BaseData._set_mask,
+                    doc=BaseData.mask.__doc__)
 
     def _get_grouped(self):
         return self._grouped
@@ -271,7 +322,8 @@ class DataPHA(Data1DInt):
 
         self._grouped = val
 
-    grouped = property(_get_grouped, _set_grouped, doc='Are the data grouped?')
+    grouped = property(_get_grouped, _set_grouped,
+                       doc='Are the data grouped?')
 
     def _get_subtracted(self):
         return self._subtracted
@@ -320,7 +372,8 @@ class DataPHA(Data1DInt):
 
         self._units = units
 
-    units = property(_get_units, _set_units, doc='Units of independent axis')
+    units = property(_get_units, _set_units,
+                     doc='Units of the independent axis')
 
     def _get_rate(self):
         return self._rate

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -86,7 +86,8 @@ def _notice_resp(chans, arf, rmf):
 class DataARF(Data1DInt):
     "ARF data set"
 
-    mask = property(BaseData._get_mask, BaseData._set_mask)
+    mask = property(BaseData._get_mask, BaseData._set_mask,
+                    doc=BaseData.mask.__doc__)
 
     def _get_specresp(self):
         return self._specresp
@@ -164,7 +165,8 @@ class DataARF(Data1DInt):
 class DataRMF(Data1DInt):
     "RMF data set"
 
-    mask = property(BaseData._get_mask, BaseData._set_mask)
+    mask = property(BaseData._get_mask, BaseData._set_mask,
+                    doc=BaseData.mask.__doc__)
 
     def __init__(self, name, detchans, energ_lo, energ_hi, n_grp, f_chan,
                  n_chan, matrix, offset=1, e_min=None, e_max=None,

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -22,6 +22,8 @@ Classes for storing, inspecting, and manipulating astronomical data sets
 """
 
 import os.path
+import warnings
+
 import numpy
 from sherpa.data import BaseData, Data1DInt, Data2D, DataND
 from sherpa.utils.err import DataErr, ImportErr
@@ -1253,7 +1255,14 @@ class DataPHA(Data1DInt):
         #
         areascal = self.areascal
         if areascal is not None:
-            dep = dep / areascal
+            # Attempt to hide division-by-zero errors from the following
+            # line (e.g. bad-quality points may have a 0 areascal value).
+            # It is unclear whether we should hide such messages from the
+            # user, but they are causing problems with the test suite.
+            #
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                dep = dep / areascal
 
         if self.subtracted:
             bkg = self.sum_background_data()

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1374,6 +1374,10 @@ class DataPHA(Data1DInt):
                     bksl = self._check_scale(bksl, filter=filter)
                     berr = berr / bksl
 
+                # Need to apply filter/grouping of the source dataset
+                # to the background areascal, so can not just say
+                #   area = bkg.get_areascal(filter=filter)
+                #
                 area = bkg.areascal
                 if area is not None:
                     area = self._check_scale(area, filter=filter)
@@ -1397,10 +1401,8 @@ class DataPHA(Data1DInt):
                 bscal = self._check_scale(bscal, filter=filter)
                 bkgsum = (bscal * bscal) * bkgsum
 
-            area = self.areascal
-            if area is not None:
-                area = self._check_scale(area, filter=filter)
-                bkgsum = (area * area) * bkgsum
+            # Note that the background counts are not corrected for
+            # the source's AREASCAL setting.
 
             if self.exposure is not None:
                 bkgsum = (self.exposure * self.exposure) * bkgsum

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -16,6 +16,27 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+"""
+Models of common Astronomical models, particularly in X-rays.
+
+The models in this module include support for instrument models that
+describe how X-ray photons are converted to measurable properties,
+such as Pulse-Height Amplitudes (PHA) or Pulse-Invariant channels.
+These 'responses' are assumed to follow OGIP standards, such as
+[1]_.
+
+References
+----------
+
+.. [1] OGIP Calibration Memo CAL/GEN/92-002, "The Calibration Requirements
+       for Spectral Analysis (Definition of RMF and ARF file formats)",
+       Ian M. George1, Keith A. Arnaud, Bill Pence, Laddawan Ruamsuwan and
+       Michael F. Corcoran,
+       https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html
+
+"""
+
 from six.moves import zip as izip
 from six import string_types
 
@@ -49,10 +70,45 @@ __all__ = ('RMFModel', 'ARFModel', 'RSPModel',
            'PSFModel')
 
 
-class RMFModel(CompositeModel, ArithmeticModel):
+def apply_areascal(mdl, pha, instlabel):
+    """Apply the AREASCAL conversion.
 
+    This should be done after applying any RMF or ARF.
+
+    Parameters
+    ----------
+    mdl : array
+        The model values, after being passed through the response.
+        The assumption is that the output is in channel space. No
+        filtering is assumed to have been applied.
+    pha : sherpa.astro.data.DataPHA object
+        The PHA object containing the AREASCAL column, scalar, or
+        None value.
+    instlabel : str
+        The name of the response (expected to be of the form
+        'RMF: filename'). This is only used in case the size of out
+        does not match the AREASCAL vector.
+
+    Returns
+    -------
+    ans : array
+        If AREASCAL is defined then the output is mdl * AREASCAL,
+        otherwise it is just the input array (i.e. mdl).
     """
-    Base class for expressing RMF convolution in model expressions
+
+    ascal = pha.areascal
+    if ascal is None:
+        return mdl
+
+    if numpy.iterable(ascal) and len(ascal) != len(mdl):
+        raise DataErr('mismatch', instlabel,
+                      'AREASCAL: {}'.format(pha.name))
+
+    return mdl * ascal
+
+
+class RMFModel(CompositeModel, ArithmeticModel):
+    """Base class for expressing RMF convolution in model expressions.
     """
 
     def __init__(self, rmf, model):
@@ -103,9 +159,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
 
 
 class ARFModel(CompositeModel, ArithmeticModel):
-
-    """
-    Base class for expressing ARF convolution in model expressions
+    """Base class for expressing ARF convolution in model expressions.
     """
 
     def __init__(self, arf, model):
@@ -154,9 +208,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
 
 
 class RSPModel(CompositeModel, ArithmeticModel):
-
-    """
-    Base class for expressing RMF + ARF convolution in model expressions
+    """Base class for expressing RMF + ARF convolution in model expressions
     """
 
     def __init__(self, arf, rmf, model):
@@ -209,9 +261,12 @@ class RSPModel(CompositeModel, ArithmeticModel):
 
 
 class RMFModelPHA(RMFModel):
+    """RMF convolution model with associated PHA data set.
 
-    """
-    RMF convolution model with associated PHA
+    Notes
+    -----
+    Scaling by the AREASCAL setting (scalar or array) is included in
+    this model.
     """
 
     def __init__(self, rmf, pha, model):
@@ -283,13 +338,19 @@ class RMFModelPHA(RMFModel):
         # x is noticed/full channels here
 
         src = self.model.calc(p, self.xlo, self.xhi)
-        return self.rmf.apply_rmf(src, *self.rmfargs)
+        out = self.rmf.apply_rmf(src, *self.rmfargs)
+
+        return apply_areascal(out, self.pha,
+                              "RMF: {}".format(self.rmf.name))
 
 
 class RMFModelNoPHA(RMFModel):
+    """RMF convolution model without an associated PHA data set.
 
-    """
-    RMF convolution model without associated PHA
+    Notes
+    -----
+    Since there is no PHA data set, there is no correction for any
+    AREASCAL setting associated with the data.
     """
 
     def __init__(self, rmf, model):
@@ -304,9 +365,12 @@ class RMFModelNoPHA(RMFModel):
 
 
 class ARFModelPHA(ARFModel):
+    """ARF convolution model with associated PHA data set.
 
-    """
-    ARF convolution model with associated PHA
+    Notes
+    -----
+    Scaling by the AREASCAL setting (scalar or array) is included in
+    this model. It is not yet clear if this is handled correctly.
     """
 
     def __init__(self, arf, pha, model):
@@ -376,13 +440,19 @@ class ARFModelPHA(ARFModel):
         # x could be channels or x, xhi could be energy|wave
 
         src = self.model.calc(p, self.xlo, self.xhi)
-        return self.arf.apply_arf(src, *self.arfargs)
+        src = self.arf.apply_arf(src, *self.arfargs)
+
+        return apply_areascal(src, self.pha,
+                              "ARF: {}".format(self.arf.name))
 
 
 class ARFModelNoPHA(ARFModel):
+    """ARF convolution model without associated PHA data set.
 
-    """
-    ARF convolution model without associated PHA
+    Notes
+    -----
+    Since there is no PHA data set, there is no correction for any
+    AREASCAL setting associated with the data.
     """
 
     def __init__(self, arf, model):
@@ -402,9 +472,12 @@ class ARFModelNoPHA(ARFModel):
 
 
 class RSPModelPHA(RSPModel):
+    """RMF + ARF convolution model with associated PHA.
 
-    """
-    RMF + ARF convolution model with associated PHA
+    Notes
+    -----
+    Scaling by the AREASCAL setting (scalar or array) is included in
+    this model.
     """
 
     def __init__(self, arf, rmf, pha, model):
@@ -485,13 +558,21 @@ class RSPModelPHA(RSPModel):
 
         src = self.model.calc(p, self.xlo, self.xhi)
         src = self.arf.apply_arf(src, *self.arfargs)
-        return self.rmf.apply_rmf(src, *self.rmfargs)
+        src = self.rmf.apply_rmf(src, *self.rmfargs)
+
+        # Assume any issues with the binning (between AREASCAL
+        # and src) is related to the RMF rather than the ARF.
+        return apply_areascal(src, self.pha,
+                              "RMF: {}".format(self.rmf.name))
 
 
 class RSPModelNoPHA(RSPModel):
+    """RMF + ARF convolution model without associated PHA data set.
 
-    """
-    RMF + ARF convolution model without associated PHA
+    Notes
+    -----
+    Since there is no PHA data set, there is no correction for any
+    AREASCAL setting associated with the data.
     """
 
     def __init__(self, arf, rmf, model):
@@ -815,6 +896,8 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
     def calc(self, p, x, xhi=None, *args, **kwargs):
         pha = self.pha
 
+        # TODO: this should probably include AREASCAL
+
         user_grid = False
         try:
 
@@ -873,6 +956,7 @@ class MultipleResponse1D(Response1D):
 
         model = MultiResponseSumModel(model, pha)
 
+        # TODO: should this include AREASCAL?
         if pha.exposure:
             model = pha.exposure * model
 

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,22 +21,22 @@ from six import string_types
 
 import numpy
 import sherpa
-from sherpa.utils.err import InstrumentErr, DataErr, PSFErr, ArgumentTypeErr
-from sherpa.models.model import ArithmeticFunctionModel, NestedModel, \
-    ArithmeticModel, CompositeModel, Model
+from sherpa.utils.err import InstrumentErr, DataErr, PSFErr
+from sherpa.models.model import ArithmeticModel, CompositeModel, Model
+
+from sherpa.instrument import PSFModel as _PSFModel
+from sherpa.utils import NoNewAttributesAfterInit
+from sherpa.data import Data1D
+from sherpa.astro.data import DataARF, DataRMF, DataPHA, _notice_resp, \
+    DataIMG
+from sherpa.utils import sao_fcmp, sum_intervals, sao_arange
+from sherpa.astro.utils import compile_energy_grid
+
 WCS = None
 try:
     from sherpa.astro.io.wcs import WCS
 except:
     WCS = None
-
-from sherpa.instrument import PSFModel as _PSFModel
-from sherpa.utils import NoNewAttributesAfterInit
-from sherpa.data import BaseData, Data1D
-from sherpa.astro.data import DataARF, DataRMF, DataPHA, _notice_resp, \
-    DataIMG
-from sherpa.utils import sao_fcmp, sum_intervals, sao_arange
-from sherpa.astro.utils import compile_energy_grid
 
 _tol = numpy.finfo(numpy.float32).eps
 
@@ -906,7 +906,16 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         CompositeModel.startup(self)
 
     def teardown(self):
-        pha = self.pha
+
+        # Note:
+        #
+        # The pha variable was declared but not used, so has been commented
+        # out. It has been kept as a comment for future review, since it
+        # is unclear whether anything should be done to the PHA object
+        # during teardown
+        #
+        # pha = self.pha
+
         rmf = self.rmf
         self.channel = sao_arange(1, rmf.detchans)
         self.mask = numpy.ones(rmf.detchans, dtype=bool)

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -1017,8 +1017,9 @@ def test_cstat_comparison_xspec(make_data_path):
 
     ui.clean()
     ui.set_data(dset)
-    ui.set_source(ui.xspowerlaw.pl)
-    ui.set_par('pl.norm', 1e-4)
+    # use powlaw1d rather than xspowerlaw so do not need XSPEC
+    ui.set_source(ui.powlaw1d.pl)
+    ui.set_par('pl.ampl', 1e-4)
 
     ui.set_stat('cstat')
     ui.set_analysis('channel')
@@ -1063,8 +1064,8 @@ def test_wstat_comparison_xspec(make_data_path):
 
     ui.clean()
     ui.set_data(dset)
-    ui.set_source(ui.xspowerlaw.pl)
-    ui.set_par('pl.norm', 1e-4)
+    ui.set_source(ui.powlaw1d.pl)
+    ui.set_par('pl.ampl', 1e-4)
 
     ui.set_stat('wstat')
     ui.set_analysis('channel')

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -1,0 +1,282 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Test handling of area/background scaling in PHA data sets.
+
+A PHA file can have AREASCAL and BACKSCAL values (either a scalar or
+column). The BACKSCAL column has tests in other parts of the system,
+so this file concentrates on the area scaling column.
+
+The area scaling is applied to the counts in that channel, rather than
+being factored into the ARF. This complicates data access.
+
+The tests here focus on the object API, rather than the UI layer
+(which, at present, doesn't do much extra with regard to area
+scaling, so this should catch most problems).
+
+This does *not* test any plots (e.g. to ensure that the correctly-scaled
+data and/or model values are shown).
+
+"""
+
+import pytest
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from sherpa.astro.data import DataPHA
+from sherpa.models.basic import Const1D, StepHi1D
+from sherpa.stats import Chi2DataVar
+
+
+def expected_basic_areascal():
+    """Return the expected areascal values."""
+
+    areascal = np.ones(10)
+    areascal[0] = 0.0
+    areascal[6:] = 0.5
+    return areascal.copy()
+
+
+def expected_basic_counts(scale=False):
+    """Return the expected count values.
+
+    Parameters
+    ----------
+    scale : bool, optional
+        If True then the counts are scaled by areascal, otherwise
+        (when False) it is the value that should be stored in the
+        DataPHA object.
+
+    Notes
+    -----
+    The idea is that there's two constant regions, with values
+    of 20 and 40: i.e.
+
+       Const1D + StepHi1D
+
+    where const1d.c0 = 20, stephi1d.xcut = 5.5,stephi1d.ampl = 20
+
+    However, as areascal is 0.5 for the last 4 bins, the counts
+    are all close to 20 (it is only after applying areascal that
+    the step is obvious).
+    """
+
+    counts = np.asarray([0, 12, 21, 25, 18, 24, 23, 16, 20, 19],
+                        dtype=np.int16)
+    if scale:
+        ascal = expected_basic_areascal()
+
+        # the first channel has areascal=0, so leave (it is 0).
+        counts[1:] = counts[1:] / ascal[1:]
+
+        counts = counts.astype(np.int16)
+
+    return counts.copy()
+
+
+def expected_basic_chisquare_errors():
+    """Return the expected error values (chi square).
+
+    The calculation is sqrt(observed) / areascaling, so should
+    be compared to the Chi2DataVar statistic.
+    """
+
+    # Calculate the errors based on the counts. There are no
+    # counts less than 1, so this is just the square root of
+    # the observed data value, which then has to be scaled by
+    # the area scaling.
+    #
+    # Since ignore_bad has been called we ignore the first bin.
+    counts = expected_basic_counts(scale=False)[1:]
+    ascal = expected_basic_areascal()[1:]
+
+    expected = np.sqrt(counts) / ascal
+    return expected.copy()
+
+
+def setup_basic_dataset():
+    """Create a basic PHA data set with an AREASCAL value.
+
+    Returns
+    -------
+    dataset : sherpa.astro.data.DataPHA instance
+        The first channel has non-zero quality, but is not
+        masked out (so the caller needs to call ignore_bad
+        to ignore it).
+    """
+
+    channels = np.arange(1, 11)
+    counts = expected_basic_counts(scale=False)
+
+    quality = np.zeros(10, dtype=np.int16)
+    quality[0] = 1
+
+    areascal = expected_basic_areascal()
+
+    return DataPHA('test', channel=channels, counts=counts,
+                   quality=quality, areascal=areascal)
+
+
+# The first few tests are really of the DataPHA class, and so
+# should not be necessary here, but they are included just in
+# case.
+#
+def test_analysis_is_channel():
+    """There's no response, so we have to be using channels."""
+
+    dset = setup_basic_dataset()
+    assert dset.get_analysis() == 'channel'
+
+
+def test_counts_is_set():
+    """Is the counts column set correctly?"""
+
+    dset = setup_basic_dataset()
+    expected = expected_basic_counts(scale=False)
+    assert_allclose(dset.counts, expected)
+
+
+def test_areascal_is_set():
+    """Is the areascal column set correctly?"""
+
+    dset = setup_basic_dataset()
+    expected = expected_basic_areascal()
+    assert_allclose(dset.areascal, expected)
+
+
+def test_staterror_is_not_set():
+    """Is the staterror column not set?"""
+
+    dset = setup_basic_dataset()
+    assert dset.staterror is None
+
+
+# The test for the warnings is pulled out into its own case, so that
+# it can be ignored in other testsL recwarn.clear is called as soon
+# as the "problem call" has been made to ensure that the global warning
+# fixture doesn't get triggered; it is not done at the end of the test
+# in case there are other warnings.
+#
+@pytest.mark.xfail
+def test_get_dep_raises_divbyzero(recwarn):
+    """Does the areascal=0 cause problems?"""
+
+    dset = setup_basic_dataset()
+    dset.get_dep()
+
+    assert len(recwarn) == 1
+    w = recwarn.pop(RuntimeWarning)
+    expected = 'invalid value encountered in true_divide'
+    assert w.message.args[0] == expected
+    recwarn.clear()
+
+
+@pytest.mark.xfail
+def test_get_y_raises_divbyzero(recwarn):
+    """Does the areascal=0 cause problems?"""
+
+    dset = setup_basic_dataset()
+    dset.get_y()
+
+    assert len(recwarn) == 1
+    w = recwarn.pop(RuntimeWarning)
+    expected = 'invalid value encountered in true_divide'
+    assert w.message.args[0] == expected
+    recwarn.clear()
+
+
+@pytest.mark.xfail
+def test_get_dep(recwarn):
+    """What does get_dep return"""
+
+    dset = setup_basic_dataset()
+    expected = expected_basic_counts(scale=True)
+    expected = expected.astype(np.float64)
+    expected[0] = np.nan
+
+    assert_allclose(dset.get_dep(), expected,
+                    equal_nan=True)
+    recwarn.clear()
+
+
+@pytest.mark.xfail
+def test_get_y(recwarn):
+    """What does get_y return"""
+
+    dset = setup_basic_dataset()
+    expected = expected_basic_counts(scale=True)
+    expected = expected.astype(np.float64)
+    expected[0] = np.nan
+
+    assert_allclose(dset.get_y(), expected)
+    recwarn.clear()
+
+
+@pytest.mark.xfail
+def test_get_staterror():
+    """What does get_staterror return?
+
+    This uses the data-variance calculation.
+    """
+
+    dset = setup_basic_dataset()
+    dset.ignore_bad()
+
+    stat = Chi2DataVar()
+    errors = dset.get_staterror(filter=True,
+                                staterrfunc=stat.calc_staterror)
+
+    expected = expected_basic_chisquare_errors()
+    assert_allclose(errors, expected)
+
+
+# Ensure that the interfaces used by the statistic object
+# are behaving correctly.
+#
+@pytest.mark.xfail
+def test_chisquare(recwarn):
+    """Is the chi square correct?
+
+    This uses the data-variance calculation.
+    """
+
+    dset = setup_basic_dataset()
+    dset.ignore_bad()
+
+    cpt1 = Const1D()
+    cpt2 = StepHi1D()
+    cpt1.c0 = 20
+    cpt2.ampl = 20
+    cpt2.xcut = 6.5
+    mdl = cpt1 + cpt2
+
+    counts = expected_basic_counts(scale=True)[1:]
+    errors = expected_basic_chisquare_errors()
+    mvals = mdl(dset.channel[1:])
+
+    expected = (counts - mvals)**2 / (errors**2)
+    expected = expected.sum()
+
+    stat = Chi2DataVar()
+    sval = stat.calc_stat(dset, mdl)
+    recwarn.clear()
+
+    assert_allclose(sval[0], expected)

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -53,6 +53,52 @@ from sherpa.utils import requires_data, requires_fits
 from sherpa.astro import ui
 
 
+# pytest.mark.parametrize and requires_data do not seem to be playing
+# well together, in that when requires_data should lead to the test
+# being skipped it ends up causing parametrize to error out claiming
+# that a function argument is not being used. Switching to
+# pytest.mark.skipif rather than unittest.skipIf (as used by
+# requires_xxx) in the hope that this fixes things.
+#
+# The sherpa.utils module doesn't provide simple access to the
+# logic used by the decorators, so - rather than copy the
+# implementation which could lead to version skew - use the
+# following scheme.
+#
+@requires_data
+def _datadir_not_set():
+    return False
+
+
+@requires_fits
+def _fits_not_available():
+    return False
+
+try:
+    no_datadir = _datadir_not_set()
+except:
+    no_datadir = True
+
+try:
+    no_fits = _fits_not_available()
+except:
+    no_fits = True
+
+
+def has_data(fn):
+    """A pytest-compatible version of requires_data."""
+
+    return pytest.mark.skipif(no_datadir,
+                              reason='required test data missing')(fn)
+
+
+def has_fits(fn):
+    """A pytest-compatible version of requires_fits."""
+
+    return pytest.mark.skipif(no_fits,
+                              reason='FITS backend required')(fn)
+
+
 def expected_basic_areascal():
     """Return the expected areascal values."""
 
@@ -1016,8 +1062,8 @@ def validate_xspec_result(l, h, npts, ndof, statval):
 #   ignore **-209,291-**
 #   ignore **-7,768-**
 #
-@requires_data
-@requires_fits
+@has_data
+@has_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(99, 153, 51, 49, 62.31),
                           (211, 296, 81, 79, 244.80),
@@ -1049,8 +1095,8 @@ def test_cstat_comparison_xspec(make_data_path, l, h, ndp, ndof, statval):
     ui.clean()
 
 
-@requires_data
-@requires_fits
+@has_data
+@has_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(99, 153, 51, 49, 61.82),
                           (211, 296, 81, 79, 242.89),
@@ -1083,8 +1129,8 @@ def test_wstat_comparison_xspec(make_data_path, l, h, ndp, ndof, statval):
 #   ignore **-0.5,2.0-**
 #   ignore **-3.2,4.1-**
 #
-@requires_data
-@requires_fits
+@has_data
+@has_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(0.5, 2.0, 101, 99, 201.21),
                           (3.2, 4.1, 57, 55, 255.23),
@@ -1129,8 +1175,8 @@ def test_xspecvar_no_grouping_no_bg_comparison_xspec(make_data_path,
 #   ignore **-0.5,2.0-**
 #   ignore **-3.2,4.1-**
 #
-@requires_data
-@requires_fits
+@has_data
+@has_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(0.5, 2.0, 101, 99, 228.21),
                           pytest.mark.xfail((3.2, 4.1, 57, 55, 251.95)),

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -36,8 +36,6 @@ data and/or model values are shown).
 
 """
 
-import pytest
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -412,7 +410,6 @@ def test_get_staterror_no_bgnd():
     assert_allclose(errors, expected)
 
 
-@pytest.mark.xfail
 def test_get_staterror_bgnd():
     """What does get_staterror return when bgnd is subtracted."""
 

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -36,7 +36,9 @@ data and/or model values are shown).
 
 """
 
-import pytest
+# import pytest
+import six
+import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -179,11 +181,17 @@ def test_get_dep_raises_divbyzero(recwarn):
     """Does the areascal=0 cause problems?"""
 
     dset = setup_basic_dataset()
-    dset.get_dep()
+    with warnings.catch_warnings():
+        warnings.simplefilter('always')
+        dset.get_dep()
 
     assert len(recwarn) == 1
     w = recwarn.pop(RuntimeWarning)
-    expected = 'invalid value encountered in true_divide'
+    if six.PY2:
+        divname = 'divide'
+    else:
+        divname = 'true_divide'
+    expected = 'invalid value encountered in ' + divname
     assert w.message.args[0] == expected
     recwarn.clear()
 
@@ -192,11 +200,17 @@ def test_get_y_raises_divbyzero(recwarn):
     """Does the areascal=0 cause problems?"""
 
     dset = setup_basic_dataset()
-    dset.get_y()
+    with warnings.catch_warnings():
+        warnings.simplefilter('always')
+        dset.get_y()
 
     assert len(recwarn) == 1
     w = recwarn.pop(RuntimeWarning)
-    expected = 'invalid value encountered in true_divide'
+    if six.PY2:
+        divname = 'divide'
+    else:
+        divname = 'true_divide'
+    expected = 'invalid value encountered in ' + divname
     assert w.message.args[0] == expected
     recwarn.clear()
 

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -36,8 +36,6 @@ data and/or model values are shown).
 
 """
 
-import pytest
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -339,7 +337,6 @@ def test_get_y_no_bgnd():
     assert_allclose(dset.get_y(), expected)
 
 
-@pytest.mark.xfail
 def test_get_dep_bgnd():
     """What does get_dep return: background subtracted"""
 
@@ -353,7 +350,6 @@ def test_get_dep_bgnd():
     assert_allclose(dset.get_dep(), expected)
 
 
-@pytest.mark.xfail
 def test_get_y_bgnd():
     """What does get_y return: background but not subtracted"""
 

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -37,8 +37,6 @@ data and/or model values are shown).
 """
 
 import pytest
-import six
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -248,10 +246,8 @@ def test_get_dep():
     dset = setup_basic_dataset()
     expected = expected_basic_counts(scale=True)
     expected = expected.astype(np.float64)
-    expected[0] = np.nan
 
-    assert_allclose(dset.get_dep(), expected,
-                    equal_nan=True)
+    assert_allclose(dset.get_dep(), expected)
 
 
 def test_get_y():
@@ -260,7 +256,6 @@ def test_get_y():
     dset = setup_basic_dataset()
     expected = expected_basic_counts(scale=True)
     expected = expected.astype(np.float64)
-    expected[0] = np.nan
 
     assert_allclose(dset.get_y(), expected)
 
@@ -325,10 +320,8 @@ def test_get_dep_no_bgnd():
 
     expected = expected_basic_counts(scale=True)
     expected = expected.astype(np.float64)
-    expected[0] = np.nan
 
-    assert_allclose(dset.get_dep(), expected,
-                    equal_nan=True)
+    assert_allclose(dset.get_dep(), expected)
 
 
 def test_get_y_no_bgnd():
@@ -342,10 +335,8 @@ def test_get_y_no_bgnd():
 
     expected = expected_basic_counts(scale=True)
     expected = expected.astype(np.float64)
-    expected[0] = np.nan
 
-    assert_allclose(dset.get_y(), expected,
-                    equal_nan=True)
+    assert_allclose(dset.get_y(), expected)
 
 
 @pytest.mark.xfail
@@ -358,10 +349,8 @@ def test_get_dep_bgnd():
     src = expected_basic_counts(scale=True)
     bg = expected_basic_counts_bgnd(scale=True)
     expected = src - bg
-    expected[0] = np.nan
 
-    assert_allclose(dset.get_dep(), expected,
-                    equal_nan=True)
+    assert_allclose(dset.get_dep(), expected)
 
 
 @pytest.mark.xfail
@@ -375,7 +364,5 @@ def test_get_y_bgnd():
     src = expected_basic_counts(scale=True)
     bg = expected_basic_counts_bgnd(scale=True)
     expected = src - bg
-    expected[0] = np.nan
 
-    assert_allclose(dset.get_y(), expected,
-                    equal_nan=True)
+    assert_allclose(dset.get_y(), expected)

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -171,73 +171,7 @@ def test_staterror_is_not_set():
     assert dset.staterror is None
 
 
-# The test for the warnings is pulled out into its own case, so that
-# it can be ignored in other testsL recwarn.clear is called as soon
-# as the "problem call" has been made to ensure that the global warning
-# fixture doesn't get triggered; it is not done at the end of the test
-# in case there are other warnings.
-#
-# Unfortunately, when run as part of the full test suite, the warning
-# has already been created so that there's no warning thrown here (or,
-# at least, that is how the code acts). As the warning message is not a
-# critical part of the interfact the tests have been disabled.
-#
-# Several approaches from
-# http://stackoverflow.com/questions/2390766/how-do-i-disable-and-then-re-enable-a-warning
-# were tried, but they did not fix things.
-#
-# This would fail at the following two tests
-#
-#   python setup.py test  -a 'sherpa/astro/io/tests/test_io.py sherpa/astro/tests/test_astro_pha_scale.py'
-#
-# but this passes
-#
-#   python setup.py test  -a 'sherpa/astro/models/tests/test_models.py sherpa/astro/tests/test_astro_pha_scale.py'
-#
-# I assume it's the import of sherpa.astro.ui that causes the change in
-# behavior.
-#
-
-
-def _test_get_dep_raises_divbyzero(recwarn):
-    """Does the areascal=0 cause problems?"""
-
-    dset = setup_basic_dataset()
-    with warnings.catch_warnings():
-        warnings.simplefilter('always')
-        dset.get_dep()
-
-    assert len(recwarn) == 1
-    w = recwarn.pop(RuntimeWarning)
-    if six.PY2:
-        divname = 'divide'
-    else:
-        divname = 'true_divide'
-    expected = 'invalid value encountered in ' + divname
-    assert w.message.args[0] == expected
-    recwarn.clear()
-
-
-def _test_get_y_raises_divbyzero(recwarn):
-    """Does the areascal=0 cause problems?"""
-
-    dset = setup_basic_dataset()
-    with warnings.catch_warnings():
-        warnings.simplefilter('always')
-        dset.get_y()
-
-    assert len(recwarn) == 1
-    w = recwarn.pop(RuntimeWarning)
-    if six.PY2:
-        divname = 'divide'
-    else:
-        divname = 'true_divide'
-    expected = 'invalid value encountered in ' + divname
-    assert w.message.args[0] == expected
-    recwarn.clear()
-
-
-def test_get_dep(recwarn):
+def test_get_dep():
     """What does get_dep return"""
 
     dset = setup_basic_dataset()
@@ -247,10 +181,9 @@ def test_get_dep(recwarn):
 
     assert_allclose(dset.get_dep(), expected,
                     equal_nan=True)
-    recwarn.clear()
 
 
-def test_get_y(recwarn):
+def test_get_y():
     """What does get_y return"""
 
     dset = setup_basic_dataset()
@@ -259,7 +192,6 @@ def test_get_y(recwarn):
     expected[0] = np.nan
 
     assert_allclose(dset.get_y(), expected)
-    recwarn.clear()
 
 
 def test_get_staterror():
@@ -282,7 +214,7 @@ def test_get_staterror():
 # Ensure that the interfaces used by the statistic object
 # are behaving correctly.
 #
-def test_chisquare(recwarn):
+def test_chisquare():
     """Is the chi square correct?
 
     This uses the data-variance calculation.
@@ -307,6 +239,5 @@ def test_chisquare(recwarn):
 
     stat = Chi2DataVar()
     sval = stat.calc_stat(dset, mdl)
-    recwarn.clear()
 
     assert_allclose(sval[0], expected)

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -177,7 +177,29 @@ def test_staterror_is_not_set():
 # fixture doesn't get triggered; it is not done at the end of the test
 # in case there are other warnings.
 #
-def test_get_dep_raises_divbyzero(recwarn):
+# Unfortunately, when run as part of the full test suite, the warning
+# has already been created so that there's no warning thrown here (or,
+# at least, that is how the code acts). As the warning message is not a
+# critical part of the interfact the tests have been disabled.
+#
+# Several approaches from
+# http://stackoverflow.com/questions/2390766/how-do-i-disable-and-then-re-enable-a-warning
+# were tried, but they did not fix things.
+#
+# This would fail at the following two tests
+#
+#   python setup.py test  -a 'sherpa/astro/io/tests/test_io.py sherpa/astro/tests/test_astro_pha_scale.py'
+#
+# but this passes
+#
+#   python setup.py test  -a 'sherpa/astro/models/tests/test_models.py sherpa/astro/tests/test_astro_pha_scale.py'
+#
+# I assume it's the import of sherpa.astro.ui that causes the change in
+# behavior.
+#
+
+
+def _test_get_dep_raises_divbyzero(recwarn):
     """Does the areascal=0 cause problems?"""
 
     dset = setup_basic_dataset()
@@ -196,7 +218,7 @@ def test_get_dep_raises_divbyzero(recwarn):
     recwarn.clear()
 
 
-def test_get_y_raises_divbyzero(recwarn):
+def _test_get_y_raises_divbyzero(recwarn):
     """Does the areascal=0 cause problems?"""
 
     dset = setup_basic_dataset()

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -175,7 +175,6 @@ def test_staterror_is_not_set():
 # fixture doesn't get triggered; it is not done at the end of the test
 # in case there are other warnings.
 #
-@pytest.mark.xfail
 def test_get_dep_raises_divbyzero(recwarn):
     """Does the areascal=0 cause problems?"""
 
@@ -189,7 +188,6 @@ def test_get_dep_raises_divbyzero(recwarn):
     recwarn.clear()
 
 
-@pytest.mark.xfail
 def test_get_y_raises_divbyzero(recwarn):
     """Does the areascal=0 cause problems?"""
 
@@ -203,7 +201,6 @@ def test_get_y_raises_divbyzero(recwarn):
     recwarn.clear()
 
 
-@pytest.mark.xfail
 def test_get_dep(recwarn):
     """What does get_dep return"""
 
@@ -217,7 +214,6 @@ def test_get_dep(recwarn):
     recwarn.clear()
 
 
-@pytest.mark.xfail
 def test_get_y(recwarn):
     """What does get_y return"""
 
@@ -230,7 +226,6 @@ def test_get_y(recwarn):
     recwarn.clear()
 
 
-@pytest.mark.xfail
 def test_get_staterror():
     """What does get_staterror return?
 
@@ -251,7 +246,6 @@ def test_get_staterror():
 # Ensure that the interfaces used by the statistic object
 # are behaving correctly.
 #
-@pytest.mark.xfail
 def test_chisquare(recwarn):
     """Is the chi square correct?
 

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2008, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -27,11 +27,12 @@ import inspect
 import numpy
 from sherpa.utils.err import DataErr, NotImplementedErr
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
-     print_fields, create_expr, calc_total_error, bool_cast, \
-     filter_bins
+    print_fields, create_expr, calc_total_error, bool_cast, \
+    filter_bins
 
 
-__all__ = ('Data', 'DataSimulFit', 'Data1D', 'Data1DInt', 'Data2D', 'Data2DInt')
+__all__ = ('Data', 'DataSimulFit', 'Data1D', 'Data1DInt', 'Data2D',
+           'Data2DInt')
 
 
 class BaseData(NoNewAttributesAfterInit):
@@ -39,14 +40,17 @@ class BaseData(NoNewAttributesAfterInit):
 
     def _get_filter(self):
         return self._filter
+
     def _set_filter(self, val):
         self._filter = val
         self._mask = True
+
     filter = property(_get_filter, _set_filter,
                       doc='Filter for dependent variable')
 
     def _get_mask(self):
         return self._mask
+
     def _set_mask(self, val):
         if (val is True) or (val is False):
             self._mask = val
@@ -55,13 +59,12 @@ class BaseData(NoNewAttributesAfterInit):
         else:
             self._mask = numpy.asarray(val, numpy.bool_)
         self._filter = None
+
     mask = property(_get_mask, _set_mask,
                     doc='Mask array for dependent variable')
 
     def __init__(self):
-        """
-
-        Initialize a data object.  This method can only be called from
+        """Initialize a data object. This method can only be called from
         a derived class constructor.  Attempts to create a BaseData
         instance will raise NotImplementedErr.
 
@@ -76,7 +79,6 @@ class BaseData(NoNewAttributesAfterInit):
         corresponding attribute name will have an underscore prepended
         (meaning the property will use the value directly instead of
         relying on _get_*/_set_* methods).
-
         """
 
         if type(self) is BaseData:
@@ -102,10 +104,8 @@ class BaseData(NoNewAttributesAfterInit):
 
     def __str__(self):
         """
-
         Return a listing of the attributes listed in self._fields and,
         if present, self._extra_fields.
-
         """
 
         fields = self._fields + getattr(self, '_extra_fields', ())
@@ -135,11 +135,11 @@ class BaseData(NoNewAttributesAfterInit):
     def notice(self, mins, maxes, axislist, ignore=False):
 
         ignore = bool_cast(ignore)
-        if( str in [type(min) for min in mins] ):
+        if str in [type(min) for min in mins]:
             raise DataErr('typecheck', 'lower bound')
-        elif( str in [type(max) for max in maxes] ):
+        elif str in [type(max) for max in maxes]:
             raise DataErr('typecheck', 'upper bound')
-        elif( str in [type(axis) for axis in axislist] ):
+        elif str in [type(axis) for axis in axislist]:
             raise DataErr('typecheck', 'grid')
 
         mask = filter_bins(mins, maxes, axislist)
@@ -164,13 +164,11 @@ class Data(BaseData):
 
     def __init__(self, name, indep, dep, staterror=None, syserror=None):
         """
-
         Initialize a Data instance.  indep should be a tuple of
         independent axis arrays, dep should be an array of dependent
         variable values, and staterror and syserror should be arrays
         of statistical and systematic errors, respectively, in the
         dependent variable (or None).
-
         """
 
         BaseData.__init__(self)
@@ -214,7 +212,7 @@ class Data(BaseData):
 
         """
         indep = getattr(self, 'indep', None)
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             indep = tuple([self.apply_filter(x) for x in indep])
         return indep
@@ -243,7 +241,7 @@ class Data(BaseData):
 
         """
         dep = getattr(self, 'dep', None)
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             dep = self.apply_filter(dep)
         return dep
@@ -276,7 +274,7 @@ class Data(BaseData):
 
         """
         staterror = getattr(self, 'staterror', None)
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             staterror = self.apply_filter(staterror)
 
@@ -311,7 +309,7 @@ class Data(BaseData):
 
         """
         syserr = getattr(self, 'syserror', None)
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             syserr = self.apply_filter(syserr)
         return syserr
@@ -376,7 +374,7 @@ class Data(BaseData):
         return None
 
     def get_xlabel(self):
-        "Return label for linear view ofindependent axis/axes"
+        "Return label for linear view of independent axis/axes"
         return 'x'
 
     def get_y(self, filter=False, yfunc=None):
@@ -414,9 +412,7 @@ class Data(BaseData):
 
     def get_x1label(self):
         """
-
         Return label for second dimension in 2-D view of independent axis/axes
-
         """
         return 'x1'
 
@@ -535,7 +531,8 @@ class DataSimulFit(Data):
 
         if no_staterror:
             total_staterror = None
-        elif numpy.any([numpy.equal(array, None).any() for array in total_staterror]):
+        elif numpy.any([numpy.equal(array, None).any()
+                        for array in total_staterror]):
             raise DataErr('staterrsimulfit')
         else:
             total_staterror = numpy.concatenate(total_staterror)
@@ -556,7 +553,7 @@ class DataND(Data):
 
     def get_dep(self, filter=False):
         y = self.y
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             y = self.apply_filter(y)
         return y
@@ -568,7 +565,7 @@ class DataND(Data):
             dep = numpy.asarray(val, SherpaFloat)
         else:
             val = SherpaFloat(val)
-            dep = numpy.array([val]*len(self.get_indep()[0]))
+            dep = numpy.array([val] * len(self.get_indep()[0]))
         setattr(self, 'y', dep)
 
 
@@ -590,7 +587,7 @@ class Data1D(DataND):
         BaseData.__init__(self)
 
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             return (self._x,)
         return (self.x,)
@@ -631,16 +628,16 @@ class Data1D(DataND):
         "Return 1D dependent variable as a 1 x N image"
         y_img = self.get_y(False, yfunc)
         if yfunc is not None:
-            y_img = (y_img[0].reshape(1,y_img[0].size),
-                     y_img[1].reshape(1,y_img[1].size))
+            y_img = (y_img[0].reshape(1, y_img[0].size),
+                     y_img[1].reshape(1, y_img[1].size))
         else:
-            y_img = y_img.reshape(1,y_img.size)
+            y_img = y_img.reshape(1, y_img.size)
         return y_img
 
     def get_imgerr(self):
         err = self.get_error()
         if err is not None:
-            err = err.reshape(1,err.size)
+            err = err.reshape(1, err.size)
         return err
 
     def notice(self, xlo=None, xhi=None, ignore=False):
@@ -668,7 +665,7 @@ class Data1DInt(Data1D):
         BaseData.__init__(self)
 
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             return (self._lo, self._hi)
         return (self.xlo, self.xhi)
@@ -678,8 +675,8 @@ class Data1DInt(Data1D):
         return (indep[0] + indep[1]) / 2.0
 
     def get_xerr(self, filter=False):
-        xlo,xhi = self.get_indep(filter)
-        return xhi-xlo
+        xlo, xhi = self.get_indep(filter)
+        return xhi - xlo
 
     def notice(self, xlo=None, xhi=None, ignore=False):
         BaseData.notice(self, (None, xlo), (xhi, None), self.get_indep(),
@@ -708,7 +705,7 @@ class Data2D(DataND):
         BaseData.__init__(self)
 
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             return (self._x0, self._x1)
         return (self.x0, self.x1)
@@ -716,17 +713,17 @@ class Data2D(DataND):
     def get_x0(self, filter=False):
         return self.get_indep(filter)[0]
 
-
     def get_x1(self, filter=False):
         return self.get_indep(filter)[1]
 
     def get_axes(self):
         self._check_shape()
         # FIXME: how to filter an axis when self.mask is size of self.y?
-        return (numpy.arange(self.shape[1])+1, numpy.arange(self.shape[0])+1)
+        return (numpy.arange(self.shape[1]) + 1,
+                numpy.arange(self.shape[0]) + 1)
 
     def get_dims(self, filter=False):
-        #self._check_shape()
+        # self._check_shape()
         if self.shape is not None:
             return self.shape[::-1]
         return (len(self.get_x0(filter)), len(self.get_x1(filter)))
@@ -738,7 +735,7 @@ class Data2D(DataND):
 
     def _check_shape(self):
         if self.shape is None:
-            raise DataErr('shape',self.name)
+            raise DataErr('shape', self.name)
 
     def get_max_pos(self, dep=None):
         if dep is None:
@@ -803,7 +800,7 @@ class Data2DInt(Data2D):
         BaseData.__init__(self)
 
     def get_indep(self, filter=False):
-        filter=bool_cast(filter)
+        filter = bool_cast(filter)
         if filter:
             return (self._x0lo, self._x1lo, self._x0hi, self._x1hi)
         return (self.x0lo, self.x1lo, self.x0hi, self.x1hi)

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1163,19 +1163,17 @@ def test_stats_calc_stat_pha(stat, usestat, usesys,
 #
 # At the moment these tests are designed to look for changes in
 # behavior more than to validate that the results are correct.
-# They will be updated to be proper tests (the reason this is not
-# a valid test is that it's currently unclear what the best
-# approach to handling the AREASCAL value is, so things could change)
+# TODO: validate the numbers that are labelled as 'verify' below.
 #
 # TODO: add in more of the tests from tests_stats_calc_stat_pha_ascal
 #       with ascal=scalar/array?
 #
 
 stat_pha_chi2_tttt_ascal_s = 1.3759460338786802  # TODO: verify
-stat_pha_chi2_tttt_ascal_a = 1.356144947892523   # TODO: verify
+stat_pha_chi2_tttt_ascal_a = 1.351664185484744   # TODO: verify
 
 stat_pha_chi2_tftt_ascal_s = 2.181996785102232   # TODO: verify
-stat_pha_chi2_tftt_ascal_a = 2.1517832313119545  # TODO: verify
+stat_pha_chi2_tftt_ascal_a = 2.144959139355457   # TODO: verify
 
 stat_pha_wstat_ascal_s = 1.834065760993965    # TODO: verify
 stat_pha_wstat_ascal_a = 1.8028391355284863   # TODO: verify

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1185,8 +1185,8 @@ stat_pha_cash_ascal_a = -398.59828932753476  # TODO: verify
 
 stat_pha_cstat_ascal_a = 5.023400836432106   # TODO: verify
 
-stat_pha_wstat_ascal_s = 1.8342104940277668  # TODO: verify
-stat_pha_wstat_ascal_a = 4.9750987445200145  # TODO: verify
+stat_pha_wstat_ascal_s = 1.8553805235199778   # TODO: verify, changed
+stat_pha_wstat_ascal_a = 5.001704518726417  # TODO: verify, changed
 
 
 @pytest.mark.parametrize("stat,usestat,usesys,havebg,usebg,ascal,expected", [

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1161,22 +1161,30 @@ def test_stats_calc_stat_pha(stat, usestat, usesys,
 # Do not need to test the areascal="none" setting as that is used
 # in test_stats_calc_stat_pha.
 #
-# At the moment these tests are designed to look for changes in
-# behavior more than to validate that the results are correct.
-# TODO: validate the numbers that are labelled as 'verify' below.
-#
 # TODO: add in more of the tests from tests_stats_calc_stat_pha_ascal
 #       with ascal=scalar/array?
 #
+# These values were calculated with commit
+# ff329492e4e4986cfef5d80dedc7ff1c3dfa8d73
+#
+# The chi-square tests with usebg=False should have the same values
+# as the tests with no areascal values - e.g. test_stats_calc_stat_pha.
+# Similarly the Cash and CStat tests should have the same values.
+# So, the only tests which have different values are
+#  - chi-square with usebg=True (since the background contribution is
+#    now different by the ratio of the area scaling)
+#  - wstat, as the area scaling is now included in the statistic
+#    calculation (as an effective exposure-time term)
+#
 
-stat_pha_chi2_tttt_ascal_s = 1.3759460338786802  # TODO: verify
-stat_pha_chi2_tttt_ascal_a = 1.351664185484744   # TODO: verify
+stat_pha_chi2_tttt_ascal_s = 1.3759460338786802
+stat_pha_chi2_tttt_ascal_a = 1.351664185484744
 
-stat_pha_chi2_tftt_ascal_s = 2.181996785102232   # TODO: verify
-stat_pha_chi2_tftt_ascal_a = 2.144959139355457   # TODO: verify
+stat_pha_chi2_tftt_ascal_s = 2.181996785102232
+stat_pha_chi2_tftt_ascal_a = 2.144959139355457
 
-stat_pha_wstat_ascal_s = 1.834065760993965    # TODO: verify
-stat_pha_wstat_ascal_a = 1.8028391355284863   # TODO: verify
+stat_pha_wstat_ascal_s = 1.834065760993965
+stat_pha_wstat_ascal_a = 1.8028391355284863
 
 
 @pytest.mark.parametrize("stat,usestat,usesys,havebg,usebg,ascal,expected", [

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1171,57 +1171,49 @@ def test_stats_calc_stat_pha(stat, usestat, usesys,
 #       with ascal=scalar/array?
 #
 
-stat_pha_chi2_ascal_a = 2.759294377739783  # TODO: verify
-
-stat_pha_chi2_bg_ascal_s = 1.3759460338786802  # TODO: verify
-stat_pha_chi2_bg_ascal_a = 2.742655351487837   # TODO: verify
-
-stat_pha_chi2_tf_ascal_a = 4.675917692685026   # TODO: verify
+stat_pha_chi2_tttt_ascal_s = 1.3759460338786802  # TODO: verify
+stat_pha_chi2_tttt_ascal_a = 1.356144947892523   # TODO: verify
 
 stat_pha_chi2_tftt_ascal_s = 2.181996785102232   # TODO: verify
-stat_pha_chi2_tftt_ascal_a = 4.647497591569904   # TODO: verify
+stat_pha_chi2_tftt_ascal_a = 2.1517832313119545  # TODO: verify
 
-stat_pha_cash_ascal_a = -398.59828932753476  # TODO: verify
-
-stat_pha_cstat_ascal_a = 5.023400836432106   # TODO: verify
-
-stat_pha_wstat_ascal_s = 1.8553805235199778   # TODO: verify, changed
-stat_pha_wstat_ascal_a = 5.001704518726417  # TODO: verify, changed
+stat_pha_wstat_ascal_s = 1.834065760993965    # TODO: verify
+stat_pha_wstat_ascal_a = 1.8028391355284863   # TODO: verify
 
 
 @pytest.mark.parametrize("stat,usestat,usesys,havebg,usebg,ascal,expected", [
     (Chi2, True, True, False, False, "scalar", stat_pha_chi2_tt),
-    (Chi2, True, True, False, False, "array", stat_pha_chi2_ascal_a),
+    (Chi2, True, True, False, False, "array", stat_pha_chi2_tt),
 
     (Chi2, True, True, False, False, "scalar", stat_pha_chi2_tt),
-    (Chi2, True, True, False, False, "array", stat_pha_chi2_ascal_a),
+    (Chi2, True, True, False, False, "array", stat_pha_chi2_tt),
 
     (Chi2, True, True, True, False, "scalar", stat_pha_chi2_tt),
-    (Chi2, True, True, True, False, "array", stat_pha_chi2_ascal_a),
+    (Chi2, True, True, True, False, "array", stat_pha_chi2_tt),
 
-    (Chi2, True, True, True, True, "scalar", stat_pha_chi2_bg_ascal_s),
-    (Chi2, True, True, True, True, "array", stat_pha_chi2_bg_ascal_a),
+    (Chi2, True, True, True, True, "scalar", stat_pha_chi2_tttt_ascal_s),
+    (Chi2, True, True, True, True, "array", stat_pha_chi2_tttt_ascal_a),
 
     (Chi2, True, False, False, False, "scalar", stat_pha_chi2_tf),
-    (Chi2, True, False, False, False, "array", stat_pha_chi2_tf_ascal_a),
+    (Chi2, True, False, False, False, "array", stat_pha_chi2_tf),
 
     (Chi2, True, False, True, False, "scalar", stat_pha_chi2_tf),
-    (Chi2, True, False, True, False, "array", stat_pha_chi2_tf_ascal_a),
+    (Chi2, True, False, True, False, "array", stat_pha_chi2_tf),
 
     (Chi2, True, False, True, True, "scalar", stat_pha_chi2_tftt_ascal_s),
     (Chi2, True, False, True, True, "array", stat_pha_chi2_tftt_ascal_a),
 
     (Cash, True, True, False, False, "scalar", stat_pha_cash),
-    (Cash, True, True, False, False, "array", stat_pha_cash_ascal_a),
+    (Cash, True, True, False, False, "array", stat_pha_cash),
 
     (Cash, False, False, False, False, "scalar", stat_pha_cash),
-    (Cash, False, False, False, False, "array", stat_pha_cash_ascal_a),
+    (Cash, False, False, False, False, "array", stat_pha_cash),
 
     (CStat, True, True, False, False, "scalar", stat_pha_cstat),
-    (CStat, True, True, False, False, "array", stat_pha_cstat_ascal_a),
+    (CStat, True, True, False, False, "array", stat_pha_cstat),
 
     (CStat, False, False, False, False, "scalar", stat_pha_cstat),
-    (CStat, False, False, False, False, "array", stat_pha_cstat_ascal_a),
+    (CStat, False, False, False, False, "array", stat_pha_cstat),
 
     (WStat, False, False, True, False, "scalar", stat_pha_wstat_ascal_s),
     (WStat, False, False, True, False, "array", stat_pha_wstat_ascal_a),


### PR DESCRIPTION
# Summary

Add support for handling the AREASCAL value (either scalar of vector) for PHA data sets. This array is used in XMM RGS data to handle missing chips.

# Details

The AREASCAL value is provided as part of a PHA data set, either as a keyword (scalar) or column (vector). It can be provided with both source and background data sets. The OGIP PHA standard which describes the value https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node7.html
says

> AreaSc, a 4-byte REAL scalar giving the area scaling for this row (channel). In most cases AREASCAL = 1.0, since the instrumental effective area is provided within the spectral calibration files (specifically by the SPECRESP column of the ARF in the general case - see George et al. 1992a). Internally, XSPEC divides the observed spectrum by AreaSc before comparing it to the model spectrum.

However, this doesn't really make much sense for use with Poisson-based statistics, where you don't want to be changing the data values. Conversations with Keith Arnaud have made it clear that XSPEC does treat it as "part of the exposure time", which makes sense for Poisson-based statistics. This suggests it could be part of the ARF or RMF (as I don't want to change the exposure time from a scalar to a vector), but it is complicated since the data (the AREASCAL values) is associated with a PHA file and not a response file. Fortunately we have the PHA variants of the ARF/RMF/RSP instrument models, which are easy to modify to handle the multiplication by the AREASCAL value.

The DataPHA class needs to be changed:

a) to support handling the AREASCAL when calculating the contribution of the background (when doing background subtraction) and the background error (e.g. `get_dep` and `get_staterror`)

b) to apply the area scaling to the data points when creating plots (e.g. `get_y` and `get_yerr`).

The final change is to pass the AREASCAL values to the WSTAT calculation: this is done by changing the exposure times from scalars to arrays (multiplying the exposure time by the area scaling factor for each channel). This is the only change that requires recompilation.

Tests have been added, including comparison with statistic and data values taken from XSPEC.

There may still be differences to XSPEC when the PHA file contains grouping information (since Sherpa and XSPEC do not handle the grouping of scaling factors the same way), and with the `chi2xspecvar` statistic when 0-count channels are found and background subtraction is turned on (since Sherpa and XSPEC treat these differently; see #356). Neither of these are dircetly related to the code here.