### PR TITLE
Add low-level support for the XSPEC rgsxsrc convolution model

### DIFF
--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -278,7 +278,7 @@ void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 // versions.
 //
 void C_cflux(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-  // void C_lumin(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_clumin(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);  12.9.1
 void C_cpflux(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_xsgsmt(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_ireflct(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
@@ -289,14 +289,13 @@ void C_xslsmt(const double* energy, int nFlux, const double* params, int spectru
 void C_PartialCovering(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_rdblur(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_reflct(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-  // void C_rfxconv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// This appears to be the only convolution-style model that uses the
-// Fortran interface
+  // void C_rfxconv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);   12.9.1
+// rgsxsrc is the only convolution-style model that uses the Fortran interface
 void rgsxsrc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void C_simpl(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-  // void C_vashift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-  // void C_vmshift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-  // void C_xilconv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_vashift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);   12.9.1
+  // void C_vmshift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);   12.9.1
+  // void C_xilconv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);   12.9.1
 void C_zashift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_zmshift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 
@@ -1307,6 +1306,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECTABLEMODEL_NORM( xsmtbl ),
   // XSPEC convolution models
   XSPECMODELFCT_CON(C_cflux, 3),
+  // XSPECMODELFCT_CON(C_clumin, 4),  12.9.1
   XSPECMODELFCT_CON(C_cpflux, 3),
   XSPECMODELFCT_CON(C_xsgsmt, 2),
   XSPECMODELFCT_CON(C_ireflct, 7),
@@ -1317,8 +1317,12 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_PartialCovering, 1),
   XSPECMODELFCT_CON(C_rdblur, 4),
   XSPECMODELFCT_CON(C_reflct, 5),
+  // XSPECMODELFCT_CON(C_rfxconv, 5),  12.9.1
   XSPECMODELFCT_CON_F77(rgsxsrc, 1),
   XSPECMODELFCT_CON(C_simpl, 3),
+  // XSPECMODELFCT_CON(C_vashift, 1),  12.9.1
+  // XSPECMODELFCT_CON(C_vmshift, 1),  12.9.1
+  // XSPECMODELFCT_CON(C_xilconv, 6),  12.9.1
   XSPECMODELFCT_CON(C_zashift, 1),
   XSPECMODELFCT_CON(C_zmshift, 1),
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,5 +1,6 @@
 // 
-//  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2016, 2017
+//     Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -270,8 +271,14 @@ void xsatbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl, 
 	    float* photar, float* photer);
 
-// XSPEC convolution models
+// XSPEC convolution models: ordering below matches that of model.dat
+//
+// Models added in 12.9.1 are commented out as we don't yet have a
+// sensible way to support different sets of functions for different
+// versions.
+//
 void C_cflux(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_lumin(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_cpflux(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_xsgsmt(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_ireflct(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
@@ -282,7 +289,14 @@ void C_xslsmt(const double* energy, int nFlux, const double* params, int spectru
 void C_PartialCovering(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_rdblur(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_reflct(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_rfxconv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// This appears to be the only convolution-style model that uses the
+// Fortran interface
+void rgsxsrc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void C_simpl(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_vashift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_vmshift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  // void C_xilconv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_zashift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_zmshift(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 
@@ -1303,6 +1317,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_PartialCovering, 1),
   XSPECMODELFCT_CON(C_rdblur, 4),
   XSPECMODELFCT_CON(C_reflct, 5),
+  XSPECMODELFCT_CON_F77(rgsxsrc, 1),
   XSPECMODELFCT_CON(C_simpl, 3),
   XSPECMODELFCT_CON(C_zashift, 1),
   XSPECMODELFCT_CON(C_zmshift, 1),
@@ -1313,7 +1328,7 @@ static PyMethodDef XSpecMethods[] = {
   #ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM(C_btapec, 6),
   #endif
-  
+
   { NULL, NULL, 0, NULL }
 
 };


### PR DESCRIPTION
# Summary

Add low-level support for the rgsxsrc convolution model in XSPEC. This is intended for R&D into
fully supporting XSPEC convolution models in Sherpa.

# Details

This model was part of XSPEC version 11 but removed in initial versions
of XSPEC 12, being added back in XSPEC 12.8.1. Somehow I missed this
so there was no support for it in the XSPEC module. I have also
added commented-out support for the convolution models added in XSPEC
12.9.1, since we do not have a way of tailoring the XSPEC module
to the XSPEC version it is being compiled againts.

Adding support for rgsxsrc requires adding new template code, since
it is the only convolution model that uses the F77 XSPEC model
interface (the others use the C interface). I did the minimum job
here (using copy and paste), rather than refactoring the templates
as there is now a lot of repeated logic.

As the convoultion models are only provided at a very-low level, there
are now tests of them, so none is added here for rgsxsrc. Note that
the idea of this interface is to allow us to experiment with what
is needed in Sherpa to properly support XSPEC convolution-style
models.