### PR TITLE
Improve testing of non-Chandra OGIP files (fix #357)

### DIFF
--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -226,8 +226,6 @@ def test_read_arf_fails_rmf(make_data_path):
     assert emsg in str(excinfo.value)
 
 
-@pytest.mark.xfail(backend == 'pyfits',
-                   reason='RMF reading is broken using AstroPy backend')
 @requires_data
 @requires_fits
 def test_read_rmf(make_data_path):

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -390,8 +390,8 @@ def test_can_use_swift_data(make_data_path):
     # When using ui.notice(0.3, 8.0); ui.get_indep(filter=True)
     # returns 772 channels, 30 to 801.
     #
-    # Using ui.notice(0.3, 7.995) leaves channels 30 to 800. So
-    # this is used. Alternatively, channel 801 could have been
+    # Using ui.notice(0.3, 7.995) selects channels 30 to 800. So
+    # this range is used. Alternatively, channel 801 could have been
     # excluded explicitly.
     #
     # ui.notice(0.3, 8.0)

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -133,7 +133,9 @@ def test_read_pha_fails_arf(make_data_path):
         etype = IOErr
     elif backend == 'crates':
         emsg = 'File must be a PHA file.'
-        etype == TypeError
+        etype = TypeError
+    else:
+        assert False, "Internal error: unknown backend {}".format(backend)
 
     infile = make_data_path(ARFFILE)
     with pytest.raises(etype) as excinfo:
@@ -153,6 +155,8 @@ def test_read_pha_fails_rmf(make_data_path):
     elif backend == 'crates':
         emsg = 'File must be a PHA file.'
         etype = TypeError
+    else:
+        assert False, "Internal error: unknown backend {}".format(backend)
 
     infile = make_data_path(RMFFILE)
     with pytest.raises(etype) as excinfo:
@@ -203,6 +207,8 @@ def test_read_arf_fails_pha(make_data_path):
         emsg = ' does not appear to be an ARF'
     elif backend == 'crates':
         emsg = "Required column 'ENERG_LO' not found in "
+    else:
+        assert False, "Internal error: unknown backend {}".format(backend)
 
     infile = make_data_path(PHAFILE)
     with pytest.raises(IOErr) as excinfo:
@@ -220,6 +226,8 @@ def test_read_arf_fails_rmf(make_data_path):
         emsg = ' does not appear to be an ARF'
     elif backend == 'crates':
         emsg = "Required column 'SPECRESP' not found in "
+    else:
+        assert False, "Internal error: unknown backend {}".format(backend)
 
     infile = make_data_path(RMFFILE)
     with pytest.raises(IOErr) as excinfo:
@@ -291,6 +299,8 @@ def test_read_rmf_fails_pha(make_data_path):
     elif backend == 'crates':
         emsg = ' does not contain a Response Matrix.'
         etype = TypeError
+    else:
+        assert False, "Internal error: unknown backend {}".format(backend)
 
     infile = make_data_path(PHAFILE)
     with pytest.raises(etype) as excinfo:
@@ -310,6 +320,8 @@ def test_read_rmf_fails_arf(make_data_path):
     elif backend == 'crates':
         emsg = ' does not contain a Response Matrix.'
         etype = TypeError
+    else:
+        assert False, "Internal error: unknown backend {}".format(backend)
 
     infile = make_data_path(ARFFILE)
     with pytest.raises(etype) as excinfo:

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -340,8 +340,8 @@ def test_can_use_swift_data(make_data_path):
 
     assert ui.get_analysis() == 'energy'
 
-    ui.set_source(ui.xspowerlaw.pl)
-    ui.set_par('pl.norm', 0.0003)
+    ui.set_source(ui.powlaw1d.pl)
+    ui.set_par('pl.ampl', 0.0003)
 
     # The responses have the first bin start at an energy of 0,
     # which causes issues for Sherpa. There should be a
@@ -354,7 +354,14 @@ def test_can_use_swift_data(make_data_path):
     assert record[0].message.args[0] == \
         'divide by zero encountered in divide'
 
-    assert np.isnan(stat)
+    # The stat value depends on what power-law model is used. With
+    # xspowerlaw it is NaN, but with powlaw1d it is finite.
+    #
+    # This check is purely a regression test, so the value has
+    # not been externally validated.
+    #
+    # assert np.isnan(stat)
+    assert_allclose(stat, 58.2813692358182)
 
     # Manually adjust the first bin to avoid this problem.
     # Add in asserts just in case this gets "fixed" in the

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -1,0 +1,248 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test handling of Swift [1]_ data.
+
+At the moment the tests are of routines in the sherpa.astro.io module,
+since the high-level routins like sherpa.astro.ui.unpack_pha are a
+very-thin wrapper around the io routines.
+
+References
+----------
+
+.. [1] The Swift Gamma Ray-Burst Mission https://swift.gsfc.nasa.gov/
+
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import pytest
+
+from sherpa.utils import requires_data, requires_fits
+from sherpa.astro.data import DataARF, DataPHA, DataRMF
+
+# Should each test import io instead of this? Also, do we have a
+# better way of determining what the backend is?
+#
+try:
+    from sherpa.astro import io
+    if io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        backend = "pyfits"
+    elif io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        backend = "crates"
+    else:
+        # Should not happen, but do not want to error out here.
+        # Leave io as whatever was loaded, which will likely cause
+        # the tests to fail.
+        backend = None
+
+except ImportError:
+    io = None
+    backend = None
+
+
+# PHA and ARF are stored uncompressed while RMF is gzip-compressed.
+# Use the same name (no .gz suffix) to access all files.
+#
+PHAFILE = 'target_sr.pha'
+ARFFILE = 'target_sr.arf'
+RMFFILE = 'swxpc0to12s6_20130101v014.rmf'
+
+
+@requires_data
+@requires_fits
+def test_read_pha(make_data_path):
+    """Can we read in a Swift PHA file."""
+
+    infile = make_data_path(PHAFILE)
+    pha = io.read_pha(infile)
+    assert isinstance(pha, DataPHA)
+
+    # assert_allclose defaults to a tolerance of 1e-7
+    # which is close to the precision these values are stored
+    # in the file.
+    assert_allclose(pha.exposure, 4812.26699895)
+    assert_allclose(pha.backscal, 1.148e-3)
+    assert_allclose(pha.areascal, 1.0)
+
+    # Although channel is an integer, it's treated as a
+    # float. Note that the channels start at 0 in the file,
+    # but they are promoted to 1 by the crates backend.
+    # XSPEC 12.9.1b, on reading this file, reports channel numbers
+    # between 1 and 1024 inclusive.
+    #
+    nchan = 1024
+    assert_allclose(pha.channel, np.arange(1, nchan + 1))
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    assert len(pha.counts) == nchan
+    assert_allclose(pha.counts.min(), 0.0)
+    assert_allclose(pha.counts.max(), 3.0)
+    assert_allclose(pha.counts.sum(), 58.0)
+    assert np.argmax(pha.counts) == 110
+
+    for field in ['staterror', 'syserror', 'bin_lo', 'bin_hi',
+                  'grouping', 'quality']:
+        assert getattr(pha, field) is None
+
+    assert pha.grouped is False
+    assert pha.subtracted is False
+    assert pha.units == 'channel'
+    assert pha.rate
+    assert pha.plot_fac == 0
+    assert pha.response_ids == []
+    assert pha.background_ids == []
+    assert pha.get_background() is None
+
+
+@requires_data
+@requires_fits
+def test_read_pha_fails_arf(make_data_path):
+    """Just check in we can't read in an ARF as a PHA file."""
+
+    infile = make_data_path(ARFFILE)
+
+    # The error type and message raised depends on the backend:
+    #
+    # Crates:   TypeError: File must be a PHA file.
+    # AstroPy:  IOErr: file '...' does not appear to be a PHA spectrum
+    #
+    # Fortunately both error messages contain PHA so can check for that.
+    #
+    # The Sherpa error hierarchy is based on Exception, so that's the
+    # obvious error to check for. It unfortunately lets through a lot
+    # of errrors.
+    #
+    with pytest.raises(Exception) as excinfo:
+        io.read_pha(infile)
+
+    assert 'PHA' in str(excinfo.value)
+
+
+@requires_data
+@requires_fits
+def test_read_pha_fails_rmf(make_data_path):
+    """Just check in we can't read in a RMF as a PHA file."""
+
+    infile = make_data_path(RMFFILE)
+
+    # The error type and message raised depends on the backend:
+    #
+    # Crates:   TypeError: File must be a PHA file.
+    # AstroPy:  IOErr: file '...' does not appear to be a PHA spectrum
+    #
+    # Fortunately both error messages contain PHA so can check for that.
+    #
+    # The Sherpa error hierarchy is based on Exception, so that's the
+    # obvious error to check for. It unfortunately lets through a lot
+    # of errrors.
+    #
+    with pytest.raises(Exception) as excinfo:
+        io.read_pha(infile)
+
+    assert 'PHA' in str(excinfo.value)
+
+
+@requires_data
+@requires_fits
+def test_read_arf(make_data_path):
+    """Can we read in a Swift ARF."""
+
+    infile = make_data_path(ARFFILE)
+    arf = io.read_arf(infile)
+    assert isinstance(arf, DataARF)
+
+    nbins = 2400
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert len(arf.energ_lo) == nbins
+    assert_allclose(arf.energ_lo[1:], arf.energ_hi[:-1])
+    assert_allclose(arf.energ_lo[0], 0.0)
+    assert_allclose(arf.energ_hi[0], 0.005)
+    assert_allclose(arf.energ_lo[-1], 11.995)
+    assert_allclose(arf.energ_hi[-1], 12.0)
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    assert len(arf.specresp) == nbins
+    assert_allclose(arf.specresp.min(), 0.1506345272064209)
+    assert_allclose(arf.specresp.max(), 145.38259887695312)
+    assert_allclose(arf.specresp.sum(), 178696.1007297188)
+    assert np.argmax(arf.specresp) == 309
+
+    for field in ['bin_lo', 'bin_hi', 'exposure']:
+        assert getattr(arf, field) is None
+
+
+@pytest.mark.xfail(backend == 'pyfits',
+                   reason='RMF reading is broken using AstroPy backend')
+@requires_data
+@requires_fits
+def test_read_rmf(make_data_path):
+    """Can we read in a Swift RMF."""
+
+    infile = make_data_path(RMFFILE)
+    rmf = io.read_rmf(infile)
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 1024
+    nbins = 2400
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 0
+
+    for field in ['energ_lo', 'energ_hi', 'n_grp', 'f_chan',
+                  'n_chan']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.matrix.size == nchans * nbins
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    assert (rmf.n_grp == 1).all()
+    assert (rmf.f_chan == 0).all()
+    assert (rmf.n_chan == nchans).all()
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    assert_allclose(rmf.matrix.min(), 0.0)
+    assert_allclose(rmf.matrix.max(), 0.05834391713142395)
+    assert_allclose(rmf.matrix.sum(), 1133.8128197300257)
+    assert np.argmax(rmf.matrix) == 269443
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert_allclose(rmf.energ_lo[1:], rmf.energ_hi[:-1])
+    assert_allclose(rmf.e_min[1:], rmf.e_max[:-1])
+
+    assert_allclose(rmf.energ_lo[0], 0.0)
+    assert_allclose(rmf.energ_hi[0], 0.005)
+    assert_allclose(rmf.energ_lo[-1], 11.995)
+    assert_allclose(rmf.energ_hi[-1], 12.0)
+
+    assert_allclose(rmf.e_min[0], 0.0)
+    assert_allclose(rmf.e_max[0], 0.01)
+    assert_allclose(rmf.e_min[-1], 10.23)
+    assert_allclose(rmf.e_max[-1], 10.24)

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -350,9 +350,15 @@ def test_can_use_swift_data(make_data_path):
     with pytest.warns(RuntimeWarning) as record:
         stat = ui.calc_stat()
 
+    # The exact form of the message depends on the Python version;
+    # this could be checked, but it feels excessive for this
+    # particular test, which is just a regression check, so use a
+    # more lax approach.
+    #
     assert len(record) == 1
-    assert record[0].message.args[0] == \
-        'divide by zero encountered in divide'
+    assert record[0].message.args[0] in \
+        ['divide by zero encountered in divide',
+         'divide by zero encountered in true_divide']
 
     # The stat value depends on what power-law model is used. With
     # xspowerlaw it is NaN, but with powlaw1d it is finite.

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -91,7 +91,12 @@ if sys.version_info >= (3, 2):
                 # added for sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
                 r"unclosed file .*/dev/null.* closefd=True>",
                 r"unclosed file .*table.txt.* closefd=True>",
-            ]
+            ],
+        RuntimeWarning:
+        [r"invalid value encountered in sqrt",
+         r"divide by zero encountered in true_divide",
+         ],
+
     }
     known_warnings.update(python3_warnings)
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -67,12 +67,6 @@ known_warnings = {
         ],
     RuntimeWarning:
         [r"invalid value encountered in sqrt",
-         # The following is added for the test_can_use_swift_data
-         # test in sherpa/astro/tests/test_astro_data_swift_unit.py;
-         # as the test checks this warning is created it would be useful
-         # if the test could eitehr clear the warnings, or tell this
-         # fixture to ignore it, rather than making it a global flag
-         r"divide by zero encountered in divide",
          ],
 }
 
@@ -94,7 +88,6 @@ if sys.version_info >= (3, 2):
             ],
         RuntimeWarning:
         [r"invalid value encountered in sqrt",
-         r"divide by zero encountered in true_divide",
          ],
 
     }

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -66,7 +66,14 @@ known_warnings = {
             r"File '/data/regression_test/master/in/sherpa/aref_Cedge.fits' does not have write permission.  Changing to read-only mode."
         ],
     RuntimeWarning:
-        [r"invalid value encountered in sqrt", ],
+        [r"invalid value encountered in sqrt",
+         # The following is added for the test_can_use_swift_data
+         # test in sherpa/astro/tests/test_astro_data_swift_unit.py;
+         # as the test checks this warning is created it would be useful
+         # if the test could eitehr clear the warnings, or tell this
+         # fixture to ignore it, rather than making it a global flag
+         r"divide by zero encountered in divide",
+         ],
 }
 
 if sys.version_info >= (3, 2):


### PR DESCRIPTION
# Summary

Fixes issue #357, which meant that a Swift RMF could not be read in when the AstroPy back end was in use. The problem was that the code did not support RMF matrices that were not stored as variable-length arrays. The PR adds tests of reading in Swift PHA, ARF, and RMF files, as well as checks that you can not read in a RMF as a PHA (and various other options), and a simple check that the files work with the `sherpa.astro.ui` API.

# Details

The test that all the files work together calculates the statistic for a model over a fixed energy range, comparing the values to those calculated manually using XSPEC. To do this the code changes the RMF and ARF, to replace the 0-energy lower-edge of the first bin by a small positive value.

I would like to remove pr:hold, but this needs sherpa/sherpa-test-data#11 to be accepted first. I also don't know why the travis tests haven't been run for any of these commits (perhaps because I didn't handle the submodule update correctly?).