### PR TITLE
fix up tests that need the requires_data decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,12 @@ addons:
     packages: &default_apt
       - gfortran
 
-# Barebone build to check tests pass when most of the tests must be skipped.
-# We need to use TEST=none to remove the test-data submodule.
-# Barebone build with no test data
-env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
-
 matrix:
   fast_finish: true
   include:
+    # Barebone build to check tests pass when most of the tests must be skipped.
+    # We need to use TEST=none to remove the test-data submodule.
+    - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
     # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="2.7"
     # Install astropy without matplotlib (checks tests are properly skipped)
     - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
+    # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
+    # test, so perhaps could be combined?
+    - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
   allow_failures:
     # Python 3.6 build fails because of unhandled warnings coming (mostly?) from the ds9 integration.
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 import numpy
 from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import DataPHA
-from sherpa.utils import SherpaTestCase, requires_fits
+from sherpa.utils import SherpaTestCase, requires_data, requires_fits
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -72,7 +72,7 @@ class test_filter_energy_grid(SherpaTestCase):
 
     def test_notice(self):
         #clear mask
-        self.pha.notice()        
+        self.pha.notice()
         self.pha.notice(0.0, 6.0)
         #self.assertEqual(self._notice, self.pha.mask)
         assert (self._notice==numpy.asarray(self.pha.mask)).all()
@@ -245,11 +245,12 @@ class test_filter_wave_grid(SherpaTestCase):
         #clear mask
         self.pha.notice()
         self.pha.ignore(30.01, 225.0)
-        self.pha.ignore(0.1, 6.0)        
+        self.pha.ignore(0.1, 6.0)
         assert (self._ignore==numpy.asarray(self.pha.mask)).all()
 
 
 # It would be nice to add some unit testing here, but it's not trivial and time doesn't allow.
+@requires_data
 @requires_fits
 def test_bug_275(make_data_path):
     session = Session()
@@ -260,4 +261,3 @@ def test_bug_275(make_data_path):
 
     session.load_data(make_data_path('img.fits'))
     str(session.get_data())
-

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2012, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -553,6 +553,7 @@ class test_basic_io(SherpaTestCase):
         self.assertEqualWithinTol(data.y, [4, 5, 6])
 
 
+@requires_data
 @requires_fits
 def test_bug_276(make_data_path):
     ui.load_pha(make_data_path('3c273.pi'))


### PR DESCRIPTION
# Summary

Fix up several tests that were missing the `requires_data` decorator, and adds an AstroPy-with-no-sherpa-test-data build to Travis-CI to check.

# Details

This addresses part of #360 (and maybe a little bit of #260). I think in this case adding an extra build to Travis is okay, but it could be removed.