### PR TITLE
Remove ResourceWarning warnings from image tests on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,12 @@ addons:
     packages: &default_apt
       - gfortran
 
-# Barebone build to check tests pass when most of the tests must be skipped.
-# We need to use TEST=none to remove the test-data submodule.
-# Barebone build with no test data
-env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
-
 matrix:
   fast_finish: true
   include:
+    # Barebone build to check tests pass when most of the tests must be skipped.
+    # We need to use TEST=none to remove the test-data submodule.
+    - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
     # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="2.7"
     # Install astropy without matplotlib (checks tests are properly skipped)
     - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
+    # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
+    # test, so perhaps could be combined?
+    - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
   allow_failures:
     # Python 3.6 build fails because of unhandled warnings coming (mostly?) from the ds9 integration.
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
     # test, so perhaps could be combined?
     - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
-  allow_failures:
-    # Python 3.6 build fails because of unhandled warnings coming (mostly?) from the ds9 integration.
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
 
 before_install:
   # General configurations

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2015, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 import numpy
 from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import DataPHA
-from sherpa.utils import SherpaTestCase, requires_fits
+from sherpa.utils import SherpaTestCase, requires_data, requires_fits
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -72,7 +72,7 @@ class test_filter_energy_grid(SherpaTestCase):
 
     def test_notice(self):
         #clear mask
-        self.pha.notice()        
+        self.pha.notice()
         self.pha.notice(0.0, 6.0)
         #self.assertEqual(self._notice, self.pha.mask)
         assert (self._notice==numpy.asarray(self.pha.mask)).all()
@@ -245,11 +245,12 @@ class test_filter_wave_grid(SherpaTestCase):
         #clear mask
         self.pha.notice()
         self.pha.ignore(30.01, 225.0)
-        self.pha.ignore(0.1, 6.0)        
+        self.pha.ignore(0.1, 6.0)
         assert (self._ignore==numpy.asarray(self.pha.mask)).all()
 
 
 # It would be nice to add some unit testing here, but it's not trivial and time doesn't allow.
+@requires_data
 @requires_fits
 def test_bug_275(make_data_path):
     session = Session()
@@ -260,4 +261,3 @@ def test_bug_275(make_data_path):
 
     session.load_data(make_data_path('img.fits'))
     str(session.get_data())
-

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2012, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -553,6 +553,7 @@ class test_basic_io(SherpaTestCase):
         self.assertEqualWithinTol(data.y, [4, 5, 6])
 
 
+@requires_data
 @requires_fits
 def test_bug_276(make_data_path):
     ui.load_pha(make_data_path('3c273.pi'))

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -461,19 +461,15 @@ class DS9Win:
             close_fds=True, stdin=None, stdout=None, stderr=None
         )
 
-        # Trick to stop a ResourceWarning warning to be created when
-        # running sherpa/tests/test_image.py
-        #
-        # Adapted from https://hg.python.org/cpython/rev/72946937536e
-        # but I am completely mis-using it, so it is unclear how
-        # sensible a hack this is.
-        #
-        p.returncode = 0
-
         startTime = time.time()
         while True:
             time.sleep(_OpenCheckInterval)
             if self.isOpen():
+                # Trick to stop a ResourceWarning warning to be created when
+                # running sherpa/tests/test_image.py
+                #
+                # Adapted from https://hg.python.org/cpython/rev/72946937536e
+                p.returncode = 0
                 return
             if time.time() - startTime > _MaxOpenTime:
                 raise RuntimeErr('nowin', self.template)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -27,7 +27,7 @@ import sherpa
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
-from sherpa.utils import requires_ds9
+from sherpa.utils import hide_warnings, requires_ds9
 
 
 # Create a rectangular array for the tests just to ensure that
@@ -101,6 +101,16 @@ _atol = 0.0
 _rtol = 1.0e-6
 
 
+# In Python 3.6, a lot of ResourceWarnings are raised with the
+# message "subprocess <n> is stil running". There could be a check
+# to see what version we are running (e.g. if ResourceWarning is
+# defined), but for now do not try to be version specific.
+#
+py36_warnings = hide_warnings([{'message':
+                                "subprocess \d+ is still running"}])
+
+
+@py36_warnings
 @requires_ds9
 def test_ds9():
     ctor = sherpa.image.ds9_backend.DS9.DS9Win
@@ -111,6 +121,8 @@ def test_ds9():
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
+
+@py36_warnings
 @requires_ds9
 def test_image():
     im = Image()
@@ -119,6 +131,8 @@ def test_image():
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
+
+@py36_warnings
 @requires_ds9
 def test_data_image():
     im = DataImage()
@@ -128,6 +142,8 @@ def test_data_image():
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
+
+@py36_warnings
 @requires_ds9
 def test_model_image():
     im = ModelImage()
@@ -137,6 +153,8 @@ def test_model_image():
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
+
+@py36_warnings
 @requires_ds9
 def test_ratio_image():
     im = RatioImage()
@@ -151,6 +169,8 @@ def test_ratio_image():
     expval[0, 0] = 0
     assert_allclose(expval, data_out, atol=_atol, rtol=_rtol)
 
+
+@py36_warnings
 @requires_ds9
 def test_resid_image():
     im = ResidImage()
@@ -161,6 +181,8 @@ def test_resid_image():
     # Return value is all zeros
     assert_allclose(data.y * 0, data_out, atol=_atol, rtol=_rtol)
 
+
+@py36_warnings
 @requires_ds9
 def test_connection_with_x_file():
     """Check that the connection works even if there is a

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -27,7 +27,7 @@ import sherpa
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
-from sherpa.utils import hide_warnings, requires_ds9
+from sherpa.utils import requires_ds9
 
 
 # Create a rectangular array for the tests just to ensure that
@@ -101,16 +101,6 @@ _atol = 0.0
 _rtol = 1.0e-6
 
 
-# In Python 3.6, a lot of ResourceWarnings are raised with the
-# message "subprocess <n> is stil running". There could be a check
-# to see what version we are running (e.g. if ResourceWarning is
-# defined), but for now do not try to be version specific.
-#
-py36_warnings = hide_warnings([{'message':
-                                "subprocess \d+ is still running"}])
-
-
-@py36_warnings
 @requires_ds9
 def test_ds9():
     ctor = sherpa.image.ds9_backend.DS9.DS9Win
@@ -122,7 +112,6 @@ def test_ds9():
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
 
-@py36_warnings
 @requires_ds9
 def test_image():
     im = Image()
@@ -132,7 +121,6 @@ def test_image():
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
 
-@py36_warnings
 @requires_ds9
 def test_data_image():
     im = DataImage()
@@ -143,7 +131,6 @@ def test_data_image():
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
 
-@py36_warnings
 @requires_ds9
 def test_model_image():
     im = ModelImage()
@@ -154,7 +141,6 @@ def test_model_image():
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
 
-@py36_warnings
 @requires_ds9
 def test_ratio_image():
     im = RatioImage()
@@ -170,7 +156,6 @@ def test_ratio_image():
     assert_allclose(expval, data_out, atol=_atol, rtol=_rtol)
 
 
-@py36_warnings
 @requires_ds9
 def test_resid_image():
     im = ResidImage()
@@ -182,7 +167,6 @@ def test_resid_image():
     assert_allclose(data.y * 0, data_out, atol=_atol, rtol=_rtol)
 
 
-@py36_warnings
 @requires_ds9
 def test_connection_with_x_file():
     """Check that the connection works even if there is a


### PR DESCRIPTION
# NOTE

This PR has been superceeded by #368 - which contains the DS9 warning clean up code from this PR but excludes the decorator and `--show-warnings` operator. I've added back pr:hold on this one as there's likely to be conflict, but have left this open for the short term.

--------------------------------------------------------------------------------------------------------------------------------

# Summary

Update the DS9 code so that external processes are cleaned up properly. This removes the `ResourceWarning` warnings raised when running the `sherpa/image/tests/test_image.py` test.

For developers:

- added an explicit decorator to skip certain warnings: this is currently unused
- added a `--show-warnings` option to the test suite to support diagnosing failures due to unexpected warnings being created by a test. This is only needed for developing Sherpa.

# Details

The current test setup supports skipping warnings, but it is a global setting - we ignore all occurrences of a warning. This approach lets us be explicit about which tests are expected to create which warnings. I have found some issues with the current approach to handling warnings - in particular when I wanted to write tests that check that a warning is generated in a piece of code - which is one of the drivers of trying a different (less global) approach.

# Possible updates

Some tests could be converted to use this decorator in this PR. Is it worth it? Should the decorator work be pulled into a separate PR?