### PR TITLE
Remove ds9 warnings when run under Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
     # test, so perhaps could be combined?
     - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
-  allow_failures:
-    # Python 3.6 build fails because of unhandled warnings coming (mostly?) from the ds9 integration.
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
 
 before_install:
   # General configurations

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/sherpa/sherpa.svg?branch=master)](https://travis-ci.org/sherpa/sherpa)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-2.7,3.5-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-2.7,3.5,3.6-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,8 @@ meta = dict(name='sherpa',
                 'Programming Language :: C',
                 'Programming Language :: Fortran',
                 'Programming Language :: Python :: 2.7',
+                'Programming Language :: Python :: 3.5',
+                'Programming Language :: Python :: 3.6',
                 'Programming Language :: Python :: Implementation :: CPython',
                 'Topic :: Scientific/Engineering :: Astronomy',
                 'Topic :: Scientific/Engineering :: Physics'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-# Copyright (C) 2014  Smithsonian Astrophysical Observatory
+# Copyright (C) 2014, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -461,19 +461,15 @@ class DS9Win:
             close_fds=True, stdin=None, stdout=None, stderr=None
         )
 
-        # Trick to stop a ResourceWarning warning to be created when
-        # running sherpa/tests/test_image.py
-        #
-        # Adapted from https://hg.python.org/cpython/rev/72946937536e
-        # but I am completely mis-using it, so it is unclear how
-        # sensible a hack this is.
-        #
-        p.returncode = 0
-
         startTime = time.time()
         while True:
             time.sleep(_OpenCheckInterval)
             if self.isOpen():
+                # Trick to stop a ResourceWarning warning to be created when
+                # running sherpa/tests/test_image.py
+                #
+                # Adapted from https://hg.python.org/cpython/rev/72946937536e
+                p.returncode = 0
                 return
             if time.time() - startTime > _MaxOpenTime:
                 raise RuntimeErr('nowin', self.template)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -111,6 +111,7 @@ def test_ds9():
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
+
 @requires_ds9
 def test_image():
     im = Image()
@@ -118,6 +119,7 @@ def test_image():
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+
 
 @requires_ds9
 def test_data_image():
@@ -128,6 +130,7 @@ def test_data_image():
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
 
+
 @requires_ds9
 def test_model_image():
     im = ModelImage()
@@ -136,6 +139,7 @@ def test_model_image():
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
     assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+
 
 @requires_ds9
 def test_ratio_image():
@@ -151,6 +155,7 @@ def test_ratio_image():
     expval[0, 0] = 0
     assert_allclose(expval, data_out, atol=_atol, rtol=_rtol)
 
+
 @requires_ds9
 def test_resid_image():
     im = ResidImage()
@@ -160,6 +165,7 @@ def test_resid_image():
     im.xpaset("quit")
     # Return value is all zeros
     assert_allclose(data.y * 0, data_out, atol=_atol, rtol=_rtol)
+
 
 @requires_ds9
 def test_connection_with_x_file():


### PR DESCRIPTION
# Summary

Update the DS9 code so that external processes are cleaned up properly. This removes the `ResourceWarning` warnings raised when running the `sherpa/image/tests/test_image.py` test. The Travis python 3.6 build is no longer allowed to fail.