### PR TITLE
Refactor testing utilities to work with pytest

### DIFF
--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -59,52 +59,6 @@ from sherpa.utils import requires_data, requires_fits
 from sherpa.astro import ui
 
 
-# pytest.mark.parametrize and requires_data do not seem to be playing
-# well together, in that when requires_data should lead to the test
-# being skipped it ends up causing parametrize to error out claiming
-# that a function argument is not being used. Switching to
-# pytest.mark.skipif rather than unittest.skipIf (as used by
-# requires_xxx) in the hope that this fixes things.
-#
-# The sherpa.utils module doesn't provide simple access to the
-# logic used by the decorators, so - rather than copy the
-# implementation which could lead to version skew - use the
-# following scheme.
-#
-@requires_data
-def _datadir_not_set():
-    return False
-
-
-@requires_fits
-def _fits_not_available():
-    return False
-
-try:
-    no_datadir = _datadir_not_set()
-except:
-    no_datadir = True
-
-try:
-    no_fits = _fits_not_available()
-except:
-    no_fits = True
-
-
-def has_data(fn):
-    """A pytest-compatible version of requires_data."""
-
-    return pytest.mark.skipif(no_datadir,
-                              reason='required test data missing')(fn)
-
-
-def has_fits(fn):
-    """A pytest-compatible version of requires_fits."""
-
-    return pytest.mark.skipif(no_fits,
-                              reason='FITS backend required')(fn)
-
-
 def expected_basic_areascal():
     """Return the expected areascal values."""
 
@@ -1044,8 +998,8 @@ def validate_xspec_result(l, h, npts, ndof, statval):
 #   ignore **-209,291-**
 #   ignore **-7,768-**
 #
-@has_data
-@has_fits
+@requires_data
+@requires_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(99, 153, 51, 49, 62.31),
                           (211, 296, 81, 79, 244.80),
@@ -1077,8 +1031,8 @@ def test_cstat_comparison_xspec(make_data_path, l, h, ndp, ndof, statval):
     ui.clean()
 
 
-@has_data
-@has_fits
+@requires_data
+@requires_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(99, 153, 51, 49, 61.82),
                           (211, 296, 81, 79, 242.89),
@@ -1113,8 +1067,8 @@ def test_wstat_comparison_xspec(make_data_path, l, h, ndp, ndof, statval):
 # for range comparisons [inclusive or exclusive], or if there's
 # some numerical differences in play at times).
 #
-@has_data
-@has_fits
+@requires_data
+@requires_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(0.5, 2.0, 101, 99, 201.21),
                           (3.2, 4.1, 57, 55, 255.23),
@@ -1154,8 +1108,8 @@ def test_xspecvar_no_grouping_no_bg_comparison_xspec(make_data_path,
     ui.clean()
 
 
-@has_data
-@has_fits
+@requires_data
+@requires_fits
 @pytest.mark.parametrize("l,h,ndp,ndof,statval",
                          [(0.5, 2.0, 101, 99, 228.21),
                           (3.2, 4.1, 57, 55, 251.95),

--- a/sherpa/astro/ui/tests/test_chips_unit.py
+++ b/sherpa/astro/ui/tests/test_chips_unit.py
@@ -57,8 +57,6 @@ def clean_up(request, ui):
     request.addfinalizer(fin)
 
 
-@requires_data
-@requires_fits
 @pytest.fixture(autouse=True)
 def load_data(ui, make_data_path):
     """
@@ -70,6 +68,8 @@ def load_data(ui, make_data_path):
     ui.fit()
 
 
+@requires_data
+@requires_fits
 @pytest.mark.parametrize("call, args", [
     ("model", ()),
     ("arf", ()),

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -46,14 +46,14 @@ from numpy.testing import assert_array_equal
 
 from sherpa.utils import SherpaTestCase
 from sherpa.utils import requires_data, requires_xspec, \
-    _has_package_from_list, requires_fits, requires_group
+    has_package_from_list, requires_fits, requires_group
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
 
 import logging
 logger = logging.getLogger('sherpa')
 
-has_xspec = _has_package_from_list("sherpa.astro.xspec")
+has_xspec = has_package_from_list("sherpa.astro.xspec")
 
 # The tests can either check that the output ASCII is identical
 # to a canonical form, or try to execute the saved file and

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -20,8 +20,8 @@
 import unittest
 from tempfile import NamedTemporaryFile
 
-from sherpa.utils import requires_fits, requires_xspec
 from sherpa.astro import ui
+from sherpa.utils import has_package_from_list
 from numpy.testing import assert_almost_equal
 import logging
 import sys
@@ -132,7 +132,7 @@ class SmokeTest(unittest.TestCase):
         observed = [model.c0.val, model.c1.val]
         assert_almost_equal(observed, expected)
 
-    @requires_fits
+    @unittest.skipIf(not has_package_from_list('pyfits', 'astropy.io.fits', 'pycrates'), reason="Requires fits backend")
     def test_fits_io(self):
         """
         Test that basic FITS I/O functions work.
@@ -144,7 +144,7 @@ class SmokeTest(unittest.TestCase):
         with NamedTemporaryFile() as f:
             ui.save_pha(f.name, ascii=False, clobber=True)
 
-    @requires_xspec
+    @unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'), reason="Requires xspec")
     def test_xspec(self):
         """
         Perform a very simple fit with an xspec model.

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -132,6 +132,8 @@ class SmokeTest(unittest.TestCase):
         observed = [model.c0.val, model.c1.val]
         assert_almost_equal(observed, expected)
 
+    # Using skipIf directly as we need these tests to run when there is no pytest installed, so we can't use
+    # the decorators in sherpa.utils.testing
     @unittest.skipIf(not has_package_from_list('pyfits', 'astropy.io.fits', 'pycrates'), reason="Requires fits backend")
     def test_fits_io(self):
         """

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -21,14 +21,13 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import tempfile
-
+import unittest
 import os
 import sherpa
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
 from sherpa.utils import requires_ds9
-
 
 # Create a rectangular array for the tests just to ensure that
 # there are no issues with Fortran/C order.

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -21,7 +21,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import tempfile
-import unittest
 import os
 import sherpa
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -180,6 +180,8 @@ requires_ds9 = testing.requires_ds9
 
 requires_xspec = testing.requires_xspec
 
+requires_package = testing.requires_package
+
 has_package_from_list = testing.has_package_from_list
 
 ###############################################################################

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -1,0 +1,279 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import numpy
+import unittest
+import os
+import importlib
+
+from sherpa.utils._utils import sao_fcmp
+
+try:
+    import pytest
+    HAS_PYTEST = True
+except ImportError:
+    HAS_PYTEST = False
+
+
+def _get_datadir():
+    import os
+    try:
+        import sherpatest
+        datadir = os.path.dirname(sherpatest.__file__)
+    except ImportError:
+        try:
+            import sherpa
+            datadir = os.path.join(os.path.dirname(sherpa.__file__), os.pardir,
+                                   'sherpa-test-data', 'sherpatest')
+            if not os.path.exists(datadir) or not os.listdir(datadir):
+                # The dir is empty, maybe the submodule was not initialized
+                datadir = None
+        except ImportError:
+            # neither sherpatest nor sherpa can be found, falling back to None
+            datadir = None
+    return datadir
+
+
+class SherpaTestCase(unittest.TestCase):
+    """
+    Base class for Sherpa unit tests. The use of this class is deprecated in favor of pytest functions.
+    """
+
+    # The location of the Sherpa test data (it is optional)
+    datadir = _get_datadir()
+
+    def make_path(self, *segments):
+        """Add the segments onto the test data location.
+
+        Parameters
+        ----------
+        *segments
+           Path segments to combine together with the location of the
+           test data.
+
+        Returns
+        -------
+        fullpath : None or string
+           The full path to the repository, or None if the
+           data directory is not set.
+
+        """
+        if self.datadir is None:
+            return None
+        return os.path.join(self.datadir, *segments)
+
+    # What is the benefit of this over numpy.testing.assert_allclose(),
+    # which was added in version 1.5 of NumPy?
+    def assertEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
+        """
+
+        self.assertFalse(numpy.any(sao_fcmp(first, second, tol)), msg)
+
+    def assertNotEqualWithinTol(self, first, second, tol=1e-7, msg=None):
+        """Check that the values are not equal within an absolute tolerance.
+
+        Parameters
+        ----------
+        first : number or array_like
+           The expected value, or values.
+        second : number or array_like
+           The value, or values, to check. If first is an array, then
+           second must be an array of the same size. If first is
+           a scalar then second can be a scalar or an array.
+        tol : number
+           The absolute tolerance used for comparison.
+        msg : string
+           The message to display if the check fails.
+
+        """
+
+        self.assertTrue(numpy.all(sao_fcmp(first, second, tol)), msg)
+
+    # for running regression tests from sherpa-test-data
+    def run_thread(self, name, scriptname='fit.py'):
+        """Run a regression test from the sherpa-test-data submodule.
+
+        Parameters
+        ----------
+        name : string
+           The name of the science thread to run (e.g., pha_read,
+           radpro). The name should match the corresponding thread
+           name in the sherpa-test-data submodule. See examples below.
+        scriptname : string
+           The suffix of the test script file name, usually "fit.py."
+
+        Examples
+        --------
+        Regression test script file names have the structure
+        "name-scriptname.py." By default, scriptname is set to "fit.py."
+        For example, if one wants to run the regression test
+        "pha_read-fit.py," they would write
+
+        >>> run_thread("pha_read")
+
+        If the regression test name is "lev3fft-bar.py," they would do
+
+        >>> run_thread("lev3fft", scriptname="bar.py")
+
+        """
+
+        scriptname = name + "-" + scriptname
+        self.locals = {}
+        cwd = os.getcwd()
+        os.chdir(self.datadir)
+        try:
+            with open(scriptname, "rb") as fh:
+                cts = fh.read()
+            exec(compile(cts, scriptname, 'exec'), {}, self.locals)
+        finally:
+            os.chdir(cwd)
+
+
+def has_package_from_list(*packages):
+    """
+    Returns True if at least one of the ``packages`` args is importable.
+    """
+    for package in packages:
+        try:
+            importlib.import_module(package)
+            return True
+        except:
+            pass
+    return False
+
+
+def requires_package(msg=None, *packages):
+    """
+    Decorator for test functions requiring specific packages.
+    """
+    condition = has_package_from_list(*packages)
+    msg = msg or "required module missing among {}.".format(
+        ", ".join(packages))
+
+    def decorator(test_function):
+        return pytest.mark.skipif(not condition, reason=msg)(test_function)
+
+    return decorator
+
+
+if HAS_PYTEST:
+    #  Pytest cannot be assumed to be installed by the regular user, unlike unittest, which is part of Python's
+    #  standard library. The decorator will be defined if pytest is missing, but if the tests are run they throw
+    #  and exception prompting users to install pytest, in those cases where pytest is not installed automatically.
+
+    requires_data = pytest.mark.skipif(SherpaTestCase.datadir is None,
+                                       reason="required test data missing")
+
+
+    def requires_plotting(test_function):
+        """
+        Decorator for test functions requiring a plotting library.
+        """
+        packages = ('pylab', 'pychips')
+        msg = "plotting backend required"
+        return requires_package(msg, *packages)(test_function)
+
+
+    def requires_pylab(test_function):
+        """
+        Returns True if the pylab module is available (pylab).
+        Used to skip tests requiring matplotlib
+        """
+        packages = ('pylab',
+                    )
+        msg = "matplotlib backend required"
+        return requires_package(msg, *packages)(test_function)
+
+
+    def requires_fits(test_function):
+        """
+        Returns True if there is an importable backend for FITS I/O.
+        Used to skip tests requiring fits_io
+        """
+        packages = ('pyfits',
+                    'astropy.io.fits',
+                    'pycrates',
+                    )
+        msg = "FITS backend required"
+        return requires_package(msg, *packages)(test_function)
+
+
+    def requires_group(test_function):
+        """Decorator for test functions requiring group library"""
+        return requires_package("group library required", 'group')(test_function)
+
+
+    def requires_stk(test_function):
+        """Decorator for test functions requiring stk library"""
+        return requires_package("stk library required", 'stk')(test_function)
+
+
+    def requires_ds9(test_function):
+        """Decorator for test functions requiring ds9"""
+        return requires_package('ds9 required', 'sherpa.image.ds9_backend')(test_function)
+
+
+    def requires_xspec(test_function):
+        return requires_package("xspec required", "sherpa.astro.xspec")(test_function)
+
+else:
+
+    def wrapped():
+        raise ImportError(PYTEST_MISSING_MESSAGE)
+
+
+    def make_fake():
+        def wrapper(*arg, **kwargs):
+            return wrapped
+        return wrapper
+
+    requires_data = make_fake()
+
+    requires_plotting = make_fake()
+
+    requires_pylab = make_fake()
+
+    requires_fits = make_fake()
+
+    requires_group = make_fake()
+
+    requires_stk = make_fake()
+
+    requires_ds9 = make_fake()
+
+    requires_xspec = make_fake()
+
+
+PYTEST_MISSING_MESSAGE = "Package `pytest` is missing. Please install `pytest` before running tests or using the test" \
+                         "decorators"

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -173,20 +173,6 @@ def has_package_from_list(*packages):
     return False
 
 
-def requires_package(msg=None, *packages):
-    """
-    Decorator for test functions requiring specific packages.
-    """
-    condition = has_package_from_list(*packages)
-    msg = msg or "required module missing among {}.".format(
-        ", ".join(packages))
-
-    def decorator(test_function):
-        return pytest.mark.skipif(not condition, reason=msg)(test_function)
-
-    return decorator
-
-
 if HAS_PYTEST:
     #  Pytest cannot be assumed to be installed by the regular user, unlike unittest, which is part of Python's
     #  standard library. The decorator will be defined if pytest is missing, but if the tests are run they throw
@@ -194,6 +180,20 @@ if HAS_PYTEST:
 
     requires_data = pytest.mark.skipif(SherpaTestCase.datadir is None,
                                        reason="required test data missing")
+
+
+    def requires_package(msg=None, *packages):
+        """
+        Decorator for test functions requiring specific packages.
+        """
+        condition = has_package_from_list(*packages)
+        msg = msg or "required module missing among {}.".format(
+            ", ".join(packages))
+
+        def decorator(test_function):
+            return pytest.mark.skipif(not condition, reason=msg)(test_function)
+
+        return decorator
 
 
     def requires_plotting(test_function):
@@ -254,7 +254,7 @@ else:
 
 
     def make_fake():
-        def wrapper(*arg, **kwargs):
+        def wrapper(*args, **kwargs):
             return wrapped
         return wrapper
 
@@ -273,6 +273,9 @@ else:
     requires_ds9 = make_fake()
 
     requires_xspec = make_fake()
+
+    def requires_package(*args):
+        return make_fake()
 
 
 PYTEST_MISSING_MESSAGE = "Package `pytest` is missing. Please install `pytest` before running tests or using the test" \

--- a/sherpa/utils/tests/test_utils_error_unit.py
+++ b/sherpa/utils/tests/test_utils_error_unit.py
@@ -1,0 +1,91 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import sherpa
+import pytest
+
+from six.moves import reload_module
+
+SKIP_MESSAGE = "This test should have been skipped"
+
+
+def test_decorator_exception_when_pytest_is_absent(monkeypatch):
+    """
+    Test that when pytest is not installed (simulated with monkeypatch) the decorators raise an exception whe
+    a test is run.
+    """
+    import sys
+    monkeypatch.setitem(sys.modules, 'pytest', None)
+    reload_module(sherpa.utils.testing)
+    reload_module(sherpa.utils)
+
+    from sherpa import utils
+
+    @utils.requires_data
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_plotting
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_pylab
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_fits
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_group
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_stk
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_ds9
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+    @utils.requires_xspec
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
+
+
+def assert_decorated_function(function):
+    """
+    Pytest cannot be assumed to be installed by the regular user, unlike unittest, which is part of Python's
+    standard library. The tests ensures that the decorators can still be used but if the tests are run they throw
+    and exception prompting users to install pytest, in those cases where pytest is not installed automatically.
+    """
+
+    with pytest.raises(ImportError) as excinfo:
+        function()
+
+    assert sherpa.utils.testing.PYTEST_MISSING_MESSAGE == str(excinfo.value)

--- a/sherpa/utils/tests/test_utils_error_unit.py
+++ b/sherpa/utils/tests/test_utils_error_unit.py
@@ -27,7 +27,7 @@ SKIP_MESSAGE = "This test should have been skipped"
 
 def test_decorator_exception_when_pytest_is_absent(monkeypatch):
     """
-    Test that when pytest is not installed (simulated with monkeypatch) the decorators raise an exception whe
+    Test that when pytest is not installed (simulated with monkeypatch) the decorators raise an exception when
     a test is run.
     """
     import sys
@@ -77,6 +77,10 @@ def test_decorator_exception_when_pytest_is_absent(monkeypatch):
         raise RuntimeError(SKIP_MESSAGE)
     assert_decorated_function(foo)
 
+    @utils.requires_package("non.existent.package")
+    def foo():
+        raise RuntimeError(SKIP_MESSAGE)
+    assert_decorated_function(foo)
 
 def assert_decorated_function(function):
     """


### PR DESCRIPTION
This was discussed in the context of #351 but we decided to issue a new PR.
This PR makes the `requires_*` decorators work with pytest, in order to achieve a better integration with other pytest markers, which required an ugly workaround in #351 itself.

I took the opportunity to split `sherpa.astro.utils`, as requested several times by @DougBurke, but the module still defines the utilities in its own namespace, for backward compatibility.