### PR TITLE
Hide AstroPy 2.0 deprecation warning for use of clobber parameter

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -98,7 +98,10 @@ if have_astropy:
     astropy_warnings = {
         AstropyDeprecationWarning:
         [
+            # leave in the 1.3 warning since there was a release version
+            # with this message in
             r".*clobber.*deprecated.*1.3",
+            r".*clobber.*deprecated.*2.0",
         ],
     }
     known_warnings.update(astropy_warnings)


### PR DESCRIPTION
# Summary

Ensure that the tests can pass with AstroPy 2.0, which has introduced a warning message to note that the `clobber` parameter is deprecated.

# Details

I have left the 1.3 version of the warning suppression in, since it was in a released package (if only briefly).