### PR TITLE
Fix #368 so that ds9 works with Python 2.7

### DIFF
--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -237,8 +237,30 @@ def setup(doRaise=True, debug=False):
 
         if doRaise:
             raise RuntimeErr('badwin', _ex)
+
+    elif sys.version_info < (3, 2):
+        class _Popen(subprocess.Popen):
+            # Add in the necessary methods so it can be used as a
+            # context manager (for Python 3.1 and earlier).
+            #
+            # See https://stackoverflow.com/a/30421047
+            #
+            def __enter__(self):
+                return self
+
+            def __exit__(self, type, value, traceback):
+                if self.stdout:
+                    self.stdout.close()
+                if self.stderr:
+                    self.stderr.close()
+                if self.stdin:
+                    self.stdin.close()
+                # Wait for the process to terminate, to avoid zombies.
+                self.wait()
+
     else:
         _Popen = subprocess.Popen
+
     return _SetupError
 
 


### PR DESCRIPTION
For Python versions prior to 3.2 add in explicit code to make _Popen work as a context manager.

# Testing

I ran `python setup.py test -a sherpa/image/tests/test_image.py ` with Python 2.7 before and after this fix and verified that the tests are now run (with no errors) rather than being skipped. I also tried

```
% python -V
Python 2.7.13 :: Continuum Analytics, Inc.
% python -c 'import sherpa.astro.ui'
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
```

and there is also no-longer any message about DS9 failing to load because of an `__exit__` attribute error.

I have not made any changes to the test suite as it looks like @olaurino is working on that.