### PR TITLE
add ds9 to smoke test and refactor dependency smoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 
 script:
   # Build smoke test switches, to ensure requested dependencies are reachable
-  - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x"; fi
+  - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
   - if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
   - SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
 

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -103,7 +103,7 @@ def get_config():
     return os.path.join(os.path.dirname(__file__), filename)
 
 
-def smoke(verbosity=0, require_failure=False, fits=None, xspec=False):
+def smoke(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):
     """
     Run Sherpa's "smoke" test. The smoke test is a simple test that
         ensures the Sherpa installation is functioning. It is not a complete
@@ -128,10 +128,10 @@ def smoke(verbosity=0, require_failure=False, fits=None, xspec=False):
     The method raises the SystemExit if errors are found during the smoke test
     """
     from sherpa.astro.utils import smoke
-    smoke.run(verbosity=verbosity, require_failure=require_failure, fits=fits, xspec=xspec)
+    smoke.run(verbosity=verbosity, require_failure=require_failure, fits=fits, xspec=xspec, ds9=ds9)
 
 
-def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False):
+def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):
     from optparse import OptionParser
     parser = OptionParser()
     parser.add_option("-v", "--verbosity", dest="verbosity",
@@ -142,6 +142,8 @@ def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False):
                       help="require a specific fits module to be present")
     parser.add_option("-x", "--require-xspec", dest="xspec", action="store_true",
                       help="require xspec module")
+    parser.add_option("-d", "--require-ds9", dest="ds9", action="store_true",
+                      help="require DS9")
 
     options, _ = parser.parse_args()
 
@@ -149,8 +151,9 @@ def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False):
     verbosity = options.verbosity or verbosity
     require_failure = options.require_failure or require_failure
     fits = options.fits or fits
+    ds9 = options.ds9 or ds9
 
-    smoke(verbosity=verbosity, require_failure=require_failure, fits=fits, xspec=xspec)
+    smoke(verbosity=verbosity, require_failure=require_failure, fits=fits, xspec=xspec, ds9=ds9)
 
 
 def clitest():

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -27,8 +27,6 @@ import logging
 import sys
 import os
 
-from sherpa.utils.err import RuntimeErr
-
 logger = logging.getLogger("sherpa")
 
 

--- a/sherpa/astro/utils/tests/test_smoke.py
+++ b/sherpa/astro/utils/tests/test_smoke.py
@@ -17,9 +17,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa import smoke
-import pytest
 import mock
+import pytest
+from sherpa import smoke
 
 
 def test_success():
@@ -33,7 +33,7 @@ def test_failure():
     with pytest.raises(SystemExit) as cm:
         smoke(require_failure=True)
 
-    assert "Test failures were detected" == str(cm.value)
+    assert "Test failures were detected" in str(cm.value)
 
 
 @mock.patch.dict('sys.modules', astropy=None)
@@ -41,7 +41,7 @@ def test_fits_failure():
     with pytest.raises(SystemExit) as cm:
         smoke(fits="astropy")
 
-    assert "ERROR: Requested astropy as fits but module not found" == str(cm.value)
+    assert "ERROR: Requested astropy as fits but module not found" in str(cm.value)
 
 
 @mock.patch.dict('sys.modules', values={"sherpa.astro.xspec": None})
@@ -49,4 +49,4 @@ def test_xspec_failure():
     with pytest.raises(SystemExit) as cm:
         smoke(xspec=True)
 
-    assert "ERROR: Requested xspec as xspec but module not found" == str(cm.value)
+    assert "ERROR: Requested xspec as xspec but module not found" in str(cm.value)


### PR DESCRIPTION
This PR adds a `ds9` option to the smoke tests. When DS9 is supposed to be installed (as in some of the Travis jobs and in CIAO installations) one can have the smoke test to fail if DS9 is absent or not useful (see for instance this Travis job: https://travis-ci.org/olaurino/sherpa/jobs/252469728).

I'll rebase this PR when #373 is merged so that this PR can pass the tests.

Note that I also used this change to refactor the smoke test in a saner, more readable way, which also results in a better output.