### PR TITLE
Use a line not span to draw horizontal line (fix #378)

### DIFF
--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -250,11 +250,25 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
         if val is not None:
             getattr(line, 'set_' + var)(val)
 
+    # Should the color for these lines be taken from the current axes?
+    #
+    # Using black (color='k') and the default line width (of 1) in
+    # matplotlib 2.0 produces a slightly-discrepant plot, since the
+    # axis (and tick labels) are drawn with a thickness of 0.8.
+    #
+    #
+    try:
+        lw = axes.spines['left'].get_linewidth()
+    except:
+        # should restrict to a particular error, but I do not know
+        # the axis structure enough to know what can go wrong
+        lw = 1.0
+
     if xaxis:
-        axes.axhspan(ymin=0, ymax=0, xmin=0, xmax=1)
+        axes.axhline(y=0, xmin=0, xmax=1, color='k', linewidth=lw)
 
     if ratioline:
-        axes.axhspan(ymin=1, ymax=1, xmin=0, xmax=1)
+        axes.axhline(y=1, xmin=0, xmax=1, color='k', linewidth=lw)
 
     #pylab.draw()
 


### PR DESCRIPTION
# Summary

Ensure that  the line at y=0 (residual) or y=1 (ratio) is drawn for residual or ratio plots when using matplotlib 2.0.

# Details

This is not needed for the 4.9.1 release.

My guess is that the handling of zero-width spans has changed between
version 1.5 and 2.0 of matplotlib. It is also not clear why axhspan washere
being used in the first place, since axhlie is used in another part of
the module.

There is an attempt to make the line match the axis (by checking what the
linewidth is), since without this change it is visually distracting in
matplotlib 2.0.

As we don't have a systematic check of these plots I have not tried to add any tests of this change. I have manually verified this works with both maplotlib 2.0 and 1.5 using python 3.5 on a linux machine.