### PR TITLE
Feature/support deprecated parameter names

### DIFF
--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -37,11 +37,8 @@ class test_sim(SherpaTestCase):
     @requires_fits
     @requires_xspec
     def setUp(self):
-        try:
-            from sherpa.astro.io import read_pha
-            from sherpa.astro.xspec import XSwabs, XSpowerlaw
-        except:
-            return
+        from sherpa.astro.io import read_pha
+        from sherpa.astro.xspec import XSwabs, XSpowerlaw
         # self.startdir = os.getcwd()
         self.old_level = logger.getEffectiveLevel()
         logger.setLevel(logging.CRITICAL)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1005,8 +1005,8 @@ class XSc6mekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
-              ``switch`` will be removed in the next release as it has been
+    .. note:: Deprecated in Sherpa 4.10.0
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1033,7 +1033,7 @@ class XSc6mekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1070,8 +1070,8 @@ class XSc6pmekl(XSAdditiveModel):
     The model is described at [1]_. It differs from ``XSc6mekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
 
-    .. note:: Deprecated in Sherpa 4.9.0
-              ``switch`` will be removed in the next release as it has been
+    .. note:: Deprecated in Sherpa 4.10.0
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1098,7 +1098,7 @@ class XSc6pmekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1135,7 +1135,7 @@ class XSc6pvmkl(XSAdditiveModel):
     The model is described at [1]_. It differs from ``XSc6vmekl`` by
     by using the exponential of the 6th order Chebyshev polynomial.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1163,7 +1163,7 @@ class XSc6pvmkl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1212,7 +1212,7 @@ class XSc6vmekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1240,7 +1240,7 @@ class XSc6vmekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1289,7 +1289,7 @@ class XScemekl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1319,7 +1319,7 @@ class XScemekl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1351,7 +1351,7 @@ class XScevmkl(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -1381,7 +1381,7 @@ class XScevmkl(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -1542,7 +1542,7 @@ class XScompPS(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``tauy`` and ``HRcyl`` will be removed in the next release as
               they have been replaced by ``tau_y`` and ``HovR_cyl``
               respectively, to match the XSPEC naming convention.
@@ -1600,7 +1600,7 @@ class XScompPS(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 ``tauy`` has been renamed to ``tau_y`` and
+    In Sherpa 4.10.0 ``tauy`` has been renamed to ``tau_y`` and
     ``HRcyl`` to ``HovR_cyl``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -1755,7 +1755,7 @@ class XSdisk(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``NSmass`` will be removed in the next release as it has been
               replaced by ``CenMass``, to match the XSPEC naming convention.
 
@@ -1777,7 +1777,7 @@ class XSdisk(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``NSmass`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``NSmass`` parameter has been renamed to
     ``CenMass``. It can still be accessed using ``NSMass`` for the time
     being, but this attribute has been deprecated.
 
@@ -1806,7 +1806,7 @@ class XSdiskir(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``LcLd`` will be removed in the next release as it has been
               replaced by ``LcovrLd``, to match the XSPEC naming convention.
 
@@ -1845,7 +1845,7 @@ class XSdiskir(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``LcLd`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``LcLd`` parameter has been renamed to
     ``LcovrLd``. It can still be accessed using ``LcLd`` for the time
     being, but this attribute has been deprecated.
 
@@ -1910,7 +1910,7 @@ class XSdiskline(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``RinM`` and ``RoutM`` will be removed in the next release as
               they have been replaced by ``Rin_M`` and ``Rout_M``
               respectively, to match the XSPEC naming convention.
@@ -1932,7 +1932,7 @@ class XSdiskline(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``RinM`` has been renamed to ``Rin_M`` and
+    In Sherpa 4.10.0 ``RinM`` has been renamed to ``Rin_M`` and
     ``RoutM`` to ``Rout_M``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -2120,7 +2120,7 @@ class XSequil(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``kT_ave`` will be removed in the next release as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
@@ -2281,7 +2281,7 @@ class XSgnei(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
     ``meankT``. It can still be accessed using ``kT_ave`` for the time
     being, but this attribute has been deprecated.
 
@@ -2312,7 +2312,7 @@ class XSgrad(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``TclTef`` will be removed in the next release as it has been
               replaced by ``TclovTef``, to match the XSPEC naming convention.
 
@@ -2344,7 +2344,7 @@ class XSgrad(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``TclTef`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``TclTef`` parameter has been renamed to
     ``TclovTef``. It can still be accessed using ``TclTef`` for the time
     being, but this attribute has been deprecated.
 
@@ -2376,7 +2376,7 @@ class XSgrbm(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``temp`` will be removed in the next release as it has been
               replaced by ``tem``, to match the XSPEC naming convention.
 
@@ -2393,7 +2393,7 @@ class XSgrbm(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``temp`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``temp`` parameter has been renamed to
     ``tem``. It can still be accessed using ``temp`` for the time
     being, but this attribute has been deprecated.
 
@@ -2489,7 +2489,7 @@ class XSkerrd(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``TcolTeff`` will be removed in the next release as it has been
               replaced by ``TcoloTeff``, to match the XSPEC naming convention.
 
@@ -2521,7 +2521,7 @@ class XSkerrd(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``TcolTeff`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``TcolTeff`` parameter has been renamed to
     ``TcoloTeff``. It can still be accessed using ``TcolTeff`` for the time
     being, but this attribute has been deprecated.
 
@@ -2554,7 +2554,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``r_brg``, ``Rinms``, and ``Routms`` will be removed in the
               next release as they have been replaced by ``r_br_g``,
               ``Rin_ms``, and ``Rout_ms`` respectively, to match the XSPEC
@@ -2593,7 +2593,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``r_brg`` has been renamed to ``r_br_g``, ``Rinms``
+    In Sherpa 4.10.0 ``r_brg`` has been renamed to ``r_br_g``, ``Rinms``
     to ``Rin_ms``, and ``Routms`` to ``Rout_ms``. They can still be
     accessed using the old names for the time being, but these attributes
     have been deprecated.
@@ -2636,7 +2636,7 @@ class XSlaor(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``RinG`` and ``RoutG`` will be removed in the next release as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
@@ -2663,7 +2663,7 @@ class XSlaor(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``RinG`` has been renamed to ``Rin_G`` and
+    In Sherpa 4.10.0 ``RinG`` has been renamed to ``Rin_G`` and
     ``RoutG`` to ``Rout_G``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -2699,7 +2699,7 @@ class XSlaor2(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``RinG`` and ``RoutG`` will be removed in the next release as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
@@ -2730,7 +2730,7 @@ class XSlaor2(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``RinG`` has been renamed to ``Rin_G`` and
+    In Sherpa 4.10.0 ``RinG`` has been renamed to ``Rin_G`` and
     ``RoutG`` to ``Rout_G``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -2807,7 +2807,7 @@ class XSmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -2879,7 +2879,7 @@ class XSmekal(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -2911,7 +2911,7 @@ class XSmkcflow(XSAdditiveModel):
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -2939,7 +2939,7 @@ class XSmkcflow(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -3370,7 +3370,7 @@ class XSnsmax(XSAdditiveModel):
     The model is described at [1]_. It has been superceeded by
     ``XSnsmaxg``.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``specfile`` will be removed in the next release as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
@@ -3391,7 +3391,7 @@ class XSnsmax(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
     ``_specfile``. It can still be accessed using ``specfile`` for the
     time being, but this attribute has been deprecated.
 
@@ -3420,7 +3420,7 @@ class XSnsmaxg(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``specfile`` will be removed in the next release as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
@@ -3445,7 +3445,7 @@ class XSnsmaxg(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
     ``_specfile``. It can still be accessed using ``specfile`` for the
     time being, but this attribute has been deprecated.
 
@@ -3476,7 +3476,7 @@ class XSnsx(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``specfile`` will be removed in the next release as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
@@ -3501,7 +3501,7 @@ class XSnsx(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``specfile`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``specfile`` parameter has been renamed to
     ``_specfile``. It can still be accessed using ``specfile`` for the
     time being, but this attribute has been deprecated.
 
@@ -3818,7 +3818,7 @@ class XSplcabs(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``nmax`` and ``FAST`` will be removed in the next release as
               they have been replaced by ``_nmax`` and ``_FAST``
               respectively, to match the XSPEC naming convention.
@@ -3853,7 +3853,7 @@ class XSplcabs(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``nmax`` has been renamed to ``_nmax`` and
+    In Sherpa 4.10.0 ``nmax`` has been renamed to ``_nmax`` and
     ``FAST`` to ``_FAST``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -4243,7 +4243,7 @@ class XSsrcut(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``breakfreq`` will be removed in the next release as it has
               been replaced by ``break_``, to match the XSPEC naming
               convention.
@@ -4264,7 +4264,7 @@ class XSsrcut(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``breakfreq`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``breakfreq`` parameter has been renamed to
     ``break_``. It can still be accessed using ``breakfreq`` for the time
     being, but this attribute has been deprecated.
 
@@ -4418,7 +4418,7 @@ class XSvbremss(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``HeH`` will be removed in the next release as it has been
               replaced by ``HeovrH``, to match the XSPEC naming convention.
 
@@ -4438,7 +4438,7 @@ class XSvbremss(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``HeH`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``HeH`` parameter has been renamed to
     ``HeovrH``. It can still be accessed using ``HeH`` for the time
     being, but this attribute has been deprecated.
 
@@ -4468,7 +4468,7 @@ class XSvequil(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``kT_ave`` will be removed in the next release as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
@@ -4523,7 +4523,7 @@ class XSvgnei(XSAdditiveModel):
     functions are used to set and query the XSPEC XSET parameters, in
     particular the keyword "NEIVERS".
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``kT_ave`` will be removed in the next release as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
@@ -4552,7 +4552,7 @@ class XSvgnei(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
     ``meankT``. It can still be accessed using ``kT_ave`` for the time
     being, but this attribute has been deprecated.
 
@@ -4623,7 +4623,7 @@ class XSvvgnei(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``kT_ave`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``kT_ave`` parameter has been renamed to
     ``meankT``. It can still be accessed using ``kT_ave`` for the time
     being, but this attribute has been deprecated.
 
@@ -4682,7 +4682,7 @@ class XSvmeka(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -4765,7 +4765,7 @@ class XSvmekal(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -4810,7 +4810,7 @@ class XSvmcflow(XSAdditiveModel):
     The model is described at [1]_. The results of this model depend
     on the cosmology settings set with ``set_xscosmo``.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``switch`` will be removed in the next release as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
@@ -4838,7 +4838,7 @@ class XSvmcflow(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``switch`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``switch`` parameter has been renamed to
     ``_switch``. It can still be accessed using ``switch`` for the time
     being, but this attribute has been deprecated.
 
@@ -5927,7 +5927,7 @@ class XSgabs(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``Tau`` will be removed in the next release as it has been
               replaced by ``Strength``, to match the XSPEC namin
               convention.
@@ -5944,7 +5944,7 @@ class XSgabs(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``Tau`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``Tau`` parameter has been renamed to
     ``Strength``. It can still be accessed using ``Tau`` for the time
     being, but this attribute has been deprecated.
 
@@ -6223,7 +6223,7 @@ class XSredden(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -6238,7 +6238,7 @@ class XSredden(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -6391,7 +6391,7 @@ class XSswind1(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logxi`` will be removed in the next release as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
@@ -6408,7 +6408,7 @@ class XSswind1(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logxi`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logxi`` parameter has been renamed to
     ``log_xi``. It can still be accessed using ``logxi`` for the time
     being, but this attribute has been deprecated.
 
@@ -6611,7 +6611,7 @@ class XSuvred(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -6622,7 +6622,7 @@ class XSuvred(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -6811,7 +6811,7 @@ class XSxion(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``lxld`` will be removed in the next release as it has been
               replaced by ``lxovrld``, to match the XSPEC naming convention.
 
@@ -6846,7 +6846,7 @@ class XSxion(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``lxld`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``lxld`` parameter has been renamed to
     ``lxovrld``. It can still be accessed using ``lxld`` for the time
     being, but this attribute has been deprecated.
 
@@ -6884,7 +6884,7 @@ class XSzdust(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``method`` and ``EBV`` will be removed in the next release as
               they have been replaced by ``_method`` and ``E_BmV``
               respectively, to match the XSPEC naming convention.
@@ -6903,7 +6903,7 @@ class XSzdust(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``method`` has been renamed to ``_method`` and
+    In Sherpa 4.10.0 ``method`` has been renamed to ``_method`` and
     ``EBV`` to ``E_BmV``. They can still be accessed using the old
     names for the time being, but these attributes have been deprecated.
 
@@ -7076,7 +7076,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logxi`` will be removed in the next release as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
@@ -7093,7 +7093,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logxi`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logxi`` parameter has been renamed to
     ``log_xi``. It can still be accessed using ``logxi`` for the time
     being, but this attribute has been deprecated.
 
@@ -7122,7 +7122,7 @@ class XSzredden(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -7139,7 +7139,7 @@ class XSzredden(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -7166,7 +7166,7 @@ class XSzsmdust(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``EBV`` will be removed in the next release as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
@@ -7183,7 +7183,7 @@ class XSzsmdust(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``EBV`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``EBV`` parameter has been renamed to
     ``E_Bmv``. It can still be accessed using ``EBV`` for the time
     being, but this attribute has been deprecated.
 
@@ -7462,7 +7462,7 @@ class XScplinear(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               The ``energy01`` to ``energy09`` attributes will be removed in
               the next release as they has been replaced by ``_energy01``
               to ``_energy09``, to match the XSPEC naming convention.
@@ -7480,7 +7480,7 @@ class XScplinear(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``energy01`` to ``energy09`` attributes have been
+    In Sherpa 4.10.0 the ``energy01`` to ``energy09`` attributes have been
     renamed to ``_energy01`` to ``_energy09``. They can still be
     accessed using the old names, but they have been deprecated.
 
@@ -7529,7 +7529,7 @@ class XSeqpair(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
               next release as they have been replaced by ``l_hovl_s``,
               ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
@@ -7604,7 +7604,7 @@ class XSeqpair(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
+    In Sherpa 4.10.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
     ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
     be accessed using the old names for the time being, but these attributes
     have been deprecated.
@@ -7653,7 +7653,7 @@ class XSeqtherm(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``l_hl_s``, ``l_ntl_h``, and ``AbHe`` will be removed in the
               next release as they have been replaced by ``l_hovl_s``,
               ``l_ntol_h``, and ``Ab_met`` respectively, to match the XSPEC
@@ -7728,7 +7728,7 @@ class XSeqtherm(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
+    In Sherpa 4.10.0 ``l_hl_s`` has been renamed to ``l_hovl_s``,
     ``l_ntl_h`` to ``l_ntol_h``, and ``AbHe`` to ``Ab_met``. They can still
     be accessed using the old names for the time being, but these attributes
     have been deprecated.
@@ -7780,7 +7780,7 @@ class XScompth(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``AbHe`` will be removed in the next release as it has been
               replaced by ``Ab_met``, to match the XSPEC naming convention.
 
@@ -7849,7 +7849,7 @@ class XScompth(XSAdditiveModel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
-    In Sherpa 4.9.0 the ``AbHe`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``AbHe`` parameter has been renamed to
     ``Ab_met``. It can still be accessed using ``AbHe`` for the time
     being, but this attribute has been deprecated.
 
@@ -8036,7 +8036,7 @@ class XSzigm(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``redshift``, ``model``, and ``lyman_limit`` will be removed
                in the next release as they have been replaced by
                ``_redshift``, ``_model``, and ``_lyman_limit``
@@ -8056,7 +8056,7 @@ class XSzigm(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 all the parameters have been renamed so that they
+    In Sherpa 4.10.0 all the parameters have been renamed so that they
     start with an underscore character. They can still be accessed using
     the old names for the time being, but these attributes have been
     deprecated.
@@ -8252,7 +8252,7 @@ class XSlogpar(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``pivotE`` will be removed in the next release as it has been
               replaced by ``_pivotE``, to match the XSPEC naming convention.
 
@@ -8273,7 +8273,7 @@ class XSlogpar(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``pivotE`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``pivotE`` parameter has been renamed to
     ``_pivotE``. It can still be accessed using ``pivotE`` for the time
     being, but this attribute has been deprecated.
 
@@ -8302,7 +8302,7 @@ class XSoptxagn(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logLLEdd`` will be removed in the next release as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
@@ -8352,7 +8352,7 @@ class XSoptxagn(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logLLEdd`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logLLEdd`` parameter has been renamed to
     ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
     time being, but this attribute has been deprecated.
 
@@ -8391,7 +8391,7 @@ class XSoptxagnf(XSAdditiveModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``logLLEdd`` will be removed in the next release as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
@@ -8435,7 +8435,7 @@ class XSoptxagnf(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logLLEdd`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``logLLEdd`` parameter has been renamed to
     ``logLoLedd``. It can still be accessed using ``logLLEdd`` for the
     time being, but this attribute has been deprecated.
 
@@ -8700,7 +8700,7 @@ class XSheilin(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``redshift`` will be removed in the next release as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
@@ -8720,7 +8720,7 @@ class XSheilin(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``redshift`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``redshift`` parameter has been renamed to
     ``z``. It can still be accessed using ``redshift`` for the time
     being, but this attribute has been deprecated.
 
@@ -8748,7 +8748,7 @@ class XSlyman(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``nHeI`` and ``redshift`` will be removed in the next
               release as they have been replaced by ``n`` and ``z``
               respectively, to match the XSPEC naming convention.
@@ -8770,7 +8770,7 @@ class XSlyman(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 ``nHeI`` has been renamed to ``n`` and ``redshift``
+    In Sherpa 4.10.0 ``nHeI`` has been renamed to ``n`` and ``redshift``
     to ``z``. They can still be accessed using the old names for the
     time being, but these attributes have been deprecated.
 
@@ -8799,7 +8799,7 @@ class XSzbabs(XSMultiplicativeModel):
 
     The model is described at [1]_.
 
-    .. note:: Deprecated in Sherpa 4.9.0
+    .. note:: Deprecated in Sherpa 4.10.0
               ``redshift`` will be removed in the next release as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
@@ -8817,7 +8817,7 @@ class XSzbabs(XSMultiplicativeModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``redshift`` parameter has been renamed to
+    In Sherpa 4.10.0 the ``redshift`` parameter has been renamed to
     ``z``. It can still be accessed using ``redshift`` for the time
     being, but this attribute has been deprecated.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -908,9 +908,8 @@ class XSbmc(XSAdditiveModel):
     def __init__(self, name='bmc'):
         self.kT = Parameter(name, 'kT', 1., 1.e-2, 100., 0.0, hugeval, 'keV')
         self.alpha = Parameter(name, 'alpha', 1., 1.e-2, 4.0, 0.0, hugeval)
-        self.log_A = Parameter(name, 'log_A', 0.0, -6.0, 6.0, -hugeval, hugeval)
+        self.log_A = Parameter(name, 'log_A', 0.0, -6.0, 6.0, -hugeval, hugeval, aliases=["logA"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-        self._renamedpars = [('logA', 'log_A')]
         XSAdditiveModel.__init__(self, name, (self.kT, self.alpha, self.log_A, self.norm))
 
 
@@ -1056,10 +1055,8 @@ class XSc6mekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
@@ -1121,10 +1118,8 @@ class XSc6pmekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
@@ -1199,10 +1194,8 @@ class XSc6pvmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -1276,10 +1269,8 @@ class XSc6vmekl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -1338,10 +1329,8 @@ class XScemekl(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift, self._switch, self.norm))
 
@@ -1413,10 +1402,8 @@ class XScevmkl(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -1619,9 +1606,9 @@ class XScompPS(XSAdditiveModel):
         self.Gmin = Parameter(name, 'Gmin', -1., -1., 10., -hugeval, hugeval, frozen=True)
         self.Gmax = Parameter(name, 'Gmax', 1.e3, 10., 1.e4, 0.0, hugeval, frozen=True)
         self.kTbb = Parameter(name, 'kTbb', 0.1, 0.001, 10., 0.0, hugeval, 'keV', True)
-        self.tau_y = Parameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.0, hugeval)
+        self.tau_y = Parameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.0, hugeval, aliases=["tauy"])
         self.geom = Parameter(name, 'geom', 0.0, -5.0, 4.0, -hugeval, hugeval, frozen=True)
-        self.HovR_cyl = Parameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.0, hugeval, frozen=True)
+        self.HovR_cyl = Parameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.0, hugeval, frozen=True, aliases=["HRcyl"])
         self.cosIncl = Parameter(name, 'cosIncl', 0.5, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.cov_frac = Parameter(name, 'cov_frac', 1.0, 0.0, 1.0, 0.0, hugeval, frozen=True)
         self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e4, 0.0, hugeval, frozen=True)
@@ -1634,8 +1621,6 @@ class XScompPS(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'Rs', True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('tauy', 'tau_y'), ('HRcyl', 'HovR_cyl')]
 
         XSAdditiveModel.__init__(self, name, (self.kTe, self.EleIndex, self.Gmin, self.Gmax, self.kTbb, self.tau_y, self.geom, self.HovR_cyl, self.cosIncl, self.cov_frac, self.rel_refl, self.Fe_ab_re, self.Me_ab, self.xi, self.Tdisk, self.Betor10, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -1792,11 +1777,9 @@ class XSdisk(XSAdditiveModel):
 
     def __init__(self, name='disk'):
         self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 0.0, hugeval)
-        self.CenMass = Parameter(name, 'CenMass', 1.4, .4, 10., 0.0, hugeval, units='Msun', frozen=True)
+        self.CenMass = Parameter(name, 'CenMass', 1.4, .4, 10., 0.0, hugeval, units='Msun', frozen=True, aliases=["NSmass"])
         self.Rinn = Parameter(name, 'Rinn', 1.03, 1.01, 1.03, 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('NSmass', 'CenMass')]
 
         XSAdditiveModel.__init__(self, name, (self.accrate, self.CenMass, self.Rinn, self.norm))
 
@@ -1862,14 +1845,12 @@ class XSdiskir(XSAdditiveModel):
         self.kT_disk = Parameter(name, 'kT_disk', 1.0, 0.01, 5., 0.0, hugeval, 'keV')
         self.Gamma = Parameter(name, 'Gamma', 1.7, 1.001, 5., 0.0, hugeval)
         self.kT_e = Parameter(name, 'kT_e', 100., 5., 1.e3, 0.0, hugeval, 'keV')
-        self.LcovrLd = Parameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, hugeval)
+        self.LcovrLd = Parameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, hugeval, aliases=["LcLd"])
         self.fin = Parameter(name, 'fin', 1.e-1, 0.0, 1., 0.0, hugeval, frozen=True)
         self.rirr = Parameter(name, 'rirr', 1.2, 1.0001, 10., 1.0001, hugeval)
         self.fout = Parameter(name, 'fout', 1.e-4, 0.0, 1.e-1, 0.0, hugeval)
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('LcLd', 'LcovrLd')]
 
         XSAdditiveModel.__init__(self, name, (self.kT_disk, self.Gamma, self.kT_e, self.LcovrLd, self.fin, self.rirr, self.fout, self.logrout, self.norm))
 
@@ -1948,12 +1929,10 @@ class XSdiskline(XSAdditiveModel):
     def __init__(self, name='diskline'):
         self.LineE = Parameter(name, 'LineE', 6.7, 0., 100., 0.0, hugeval, 'keV')
         self.Betor10 = Parameter(name, 'Betor10', -2., -10., 20., -hugeval, hugeval, frozen=True)
-        self.Rin_M = Parameter(name, 'Rin_M', 10., 6., 1000., 0.0, hugeval, frozen=True)
-        self.Rout_M = Parameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, hugeval, frozen=True)
+        self.Rin_M = Parameter(name, 'Rin_M', 10., 6., 1000., 0.0, hugeval, frozen=True, aliases=["RinM"])
+        self.Rout_M = Parameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, hugeval, frozen=True, aliases=["RoutM"])
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('RinM', 'Rin_M'), ('RoutM', 'Rout_M')]
 
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Betor10, self.Rin_M, self.Rout_M, self.Incl, self.norm))
 
@@ -2298,11 +2277,9 @@ class XSgnei(XSAdditiveModel):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 0.0, hugeval, 's/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV', aliases=["kT_ave"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('kT_ave', 'meankT')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau, self.meankT, self.redshift, self.norm))
 
@@ -2362,11 +2339,9 @@ class XSgrad(XSAdditiveModel):
         self.i = Parameter(name, 'i', 0.0, 0.0, 90.0, 0.0, hugeval, 'deg', True)
         self.Mass = Parameter(name, 'Mass', 1.0, 0.0, 100.0, 0.0, hugeval, 'solar')
         self.Mdot = Parameter(name, 'Mdot', 1.0, 0.0, 100.0, 0.0, hugeval, '1e18')
-        self.TclovTef = Parameter(name, 'TclovTef', 1.7, 1.0, 10.0, 0.0, hugeval, frozen=True)
+        self.TclovTef = Parameter(name, 'TclovTef', 1.7, 1.0, 10.0, 0.0, hugeval, frozen=True, aliases=["TclTef"])
         self.refflag = Parameter(name, 'refflag', 1.0, -1.0, 1.0, -hugeval, hugeval, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('TclTef', 'TclovTef')]
 
         XSAdditiveModel.__init__(self, name, (self.D, self.i, self.Mass, self.Mdot, self.TclovTef, self.refflag, self.norm))
 
@@ -2409,10 +2384,8 @@ class XSgrbm(XSAdditiveModel):
     def __init__(self, name='grbm'):
         self.alpha = Parameter(name, 'alpha', -1., -3., +2., -hugeval, hugeval)
         self.beta = Parameter(name, 'beta', -2., -5., +2., -hugeval, hugeval)
-        self.tem = Parameter(name, 'tem', +300., +50., +1000., 0.0, hugeval, 'keV')
+        self.tem = Parameter(name, 'tem', +300., +50., +1000., 0.0, hugeval, 'keV', aliases=["temp"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('temp', 'tem')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.tem, self.norm))
 
@@ -2536,15 +2509,13 @@ class XSkerrd(XSAdditiveModel):
 
     def __init__(self, name='kerrd'):
         self.distance = Parameter(name, 'distance', 1., 0.01, 1000., 0.0, hugeval, 'kpc', True)
-        self.TcoloTeff = Parameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 0.0, hugeval, frozen=True)
+        self.TcoloTeff = Parameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 0.0, hugeval, frozen=True, aliases=["TcolTeff"])
         self.M = Parameter(name, 'M', 1.0, 0.1, 100., 0.0, hugeval, 'solar')
         self.Mdot = Parameter(name, 'Mdot', 1.0, 0.01, 100., 0.0, hugeval, '1e18')
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.Rin = Parameter(name, 'Rin', 1.235, 1.235, 100., 0.0, hugeval, 'Rg', True)
         self.Rout = Parameter(name, 'Rout', 1e5, 1e4, 1e8, 0.0, hugeval, 'Rg', True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('TcolTeff', 'TcoloTeff')]
 
         XSAdditiveModel.__init__(self, name, (self.distance, self.TcoloTeff, self.M, self.Mdot, self.Incl, self.Rin, self.Rout, self.norm))
 
@@ -2611,17 +2582,13 @@ class XSkerrdisk(XSAdditiveModel):
         self.lineE = Parameter(name, 'lineE', 6.4, 0.1, 100., 0.0, hugeval, 'keV')
         self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -hugeval, hugeval, frozen=True)
         self.Index2 = Parameter(name, 'Index2', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.r_br_g = Parameter(name, 'r_br_g', 6.0, 1.0, 400., 0.0, hugeval, frozen=True)
+        self.r_br_g = Parameter(name, 'r_br_g', 6.0, 1.0, 400., 0.0, hugeval, frozen=True, aliases=["r_brg"])
         self.a = Parameter(name, 'a', 0.998, 0.0, 0.998, 0.0, hugeval)
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
-        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, 1.0, 400., 0.0, hugeval, frozen=True)
-        self.Rout_ms = Parameter(name, 'Rout_ms', 400., 1.0, 400., 0.0, hugeval, frozen=True)
+        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, 1.0, 400., 0.0, hugeval, frozen=True, aliases=["Rinms"])
+        self.Rout_ms = Parameter(name, 'Rout_ms', 400., 1.0, 400., 0.0, hugeval, frozen=True, aliases=["Routms"])
         self.z = Parameter(name, 'z', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('r_brg', 'r_br_g'),
-                             ('Rinms', 'Rin_ms'),
-                             ('Routms', 'Rout_ms')]
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index1, self.Index2, self.r_br_g, self.a, self.Incl, self.Rin_ms, self.Rout_ms, self.z, self.norm))
 
@@ -2679,12 +2646,10 @@ class XSlaor(XSAdditiveModel):
     def __init__(self, name='laor'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
         self.Index = Parameter(name, 'Index', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
-        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True, aliases=["RinG"])
+        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True, aliases=[""])
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('RinG', 'Rin_G'), ('RoutG', 'Rout_G')]
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.norm))
 
@@ -2746,14 +2711,12 @@ class XSlaor2(XSAdditiveModel):
     def __init__(self, name='laor2'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
         self.Index = Parameter(name, 'Index', 3., -10., 10., -hugeval, hugeval, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True)
-        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 0.0, hugeval, frozen=True, aliases=["RinG"])
+        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 0.0, hugeval, frozen=True, aliases=["RoutG"])
         self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, hugeval, 'deg', True)
         self.Rbreak = Parameter(name, 'Rbreak', 20., 1.235, 400., 0.0, hugeval, frozen=True)
         self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('RinG', 'Rin_G'), ('RoutG', 'Rout_G')]
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.Rbreak, self.Index1, self.norm))
 
@@ -2897,10 +2860,8 @@ class XSmekal(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 0.0, hugeval, 'cm-3', True)
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self._switch, self.norm))
 
@@ -2957,10 +2918,8 @@ class XSmkcflow(XSAdditiveModel):
         self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self._switch, self.norm))
 
@@ -3407,10 +3366,8 @@ class XSnsmax(XSAdditiveModel):
     def __init__(self, name='nsmax'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.8, 0.0, hugeval, 'K')
         self.redshift = Parameter(name, 'redshift', 0.1, 0.0, 1.5, 0.0, 2.0)
-        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('specfile', '_specfile')]
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self._specfile, self.norm))
 
@@ -3463,10 +3420,8 @@ class XSnsmaxg(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 1200, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('specfile', '_specfile')]
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
 
@@ -3519,10 +3474,8 @@ class XSnsx(XSAdditiveModel):
         self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
         self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
         self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self._specfile = Parameter(name, '_specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True)
+        self._specfile = Parameter(name, '_specfile', 6, 0, 1.0e6, 0, 1.0e6, alwaysfrozen=True, aliases=["specfile"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('specfile', '_specfile')]
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self._specfile, self.norm))
 
@@ -3868,18 +3821,16 @@ class XSplcabs(XSAdditiveModel):
 
     def __init__(self, name='plcabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
-        self._nmax = Parameter(name, '_nmax', 1, alwaysfrozen=True)
+        self._nmax = Parameter(name, '_nmax', 1, alwaysfrozen=True, aliases=["nmax"])
         self.FeAbun = Parameter(name, 'FeAbun', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.FeKedge = Parameter(name, 'FeKedge', 7.11, 7., 10., 0.0, hugeval, 'KeV', True)
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -2., 9., -hugeval, hugeval)
         self.HighECut = Parameter(name, 'HighECut', 25., 1., 50., 0.0, 90., 'keV', True)
         self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 0.0, hugeval, frozen=True)
         self.acrit = Parameter(name, 'acrit', 1., 0.0, 1.0, 0.0, hugeval, frozen=True)
-        self._FAST = Parameter(name, '_FAST', 0, alwaysfrozen=True)
+        self._FAST = Parameter(name, '_FAST', 0, alwaysfrozen=True, aliases=["FAST"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('nmax', '_nmax'), ('FAST', '_FAST')]
 
         XSAdditiveModel.__init__(self, name, (self.nH, self._nmax, self.FeAbun, self.FeKedge, self.PhoIndex, self.HighECut, self.foldE, self.acrit, self._FAST, self.redshift, self.norm))
 
@@ -4279,10 +4230,8 @@ class XSsrcut(XSAdditiveModel):
 
     def __init__(self, name='srcut'):
         self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 0.0, hugeval)
-        self.break_ = Parameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 0.0, hugeval, 'Hz')
+        self.break_ = Parameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 0.0, hugeval, 'Hz', aliases=["breakfreq"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('breakfreq', 'break_')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.break_, self.norm))
 
@@ -4453,10 +4402,8 @@ class XSvbremss(XSAdditiveModel):
 
     def __init__(self, name='vbremss'):
         self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 0.0, hugeval, 'keV')
-        self.HeovrH = Parameter(name, 'HeovrH', 1.0, 0., 100., 0.0, hugeval)
+        self.HeovrH = Parameter(name, 'HeovrH', 1.0, 0., 100., 0.0, hugeval, aliases=["HeH"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('HeH', 'HeovrH')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.HeovrH, self.norm))
 
@@ -4581,11 +4528,9 @@ class XSvgnei(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, hugeval, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 0.0, hugeval, 's/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV', aliases=["kT_ave"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('kT_ave', 'meankT')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.meankT, self.redshift, self.norm))
 
@@ -4669,12 +4614,10 @@ class XSvvgnei(XSAdditiveModel):
         self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 10000.0, frozen=True)
         self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 10000.0, frozen=True)
         self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, 'keV')
+        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, 'keV', aliases=["kT_ave"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('kT_ave', 'meankT')]
-
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
+
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.meankT, self.redshift, self.norm))
 
 class XSvmeka(XSAdditiveModel):
@@ -4796,10 +4739,8 @@ class XSvmekal(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -4869,10 +4810,8 @@ class XSvmcflow(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 1, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self._switch, self.norm))
 
@@ -5960,9 +5899,7 @@ class XSgabs(XSMultiplicativeModel):
     def __init__(self, name='gabs'):
         self.LineE = Parameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, hugeval, 'keV')
         self.Sigma = Parameter(name, 'Sigma', 0.01, 0., 10., 0.0, hugeval, 'keV')
-        self.Strength = Parameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, hugeval)
-
-        self._renamedpars = [('Tau', 'Strength')]
+        self.Strength = Parameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, hugeval, aliases=["Tau"])
 
         XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Sigma, self.Strength))
 
@@ -6252,9 +6189,7 @@ class XSredden(XSMultiplicativeModel):
     _calc =  _xspec.xscred
 
     def __init__(self, name='redden'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval, aliases=["EBV"])
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
@@ -6423,11 +6358,9 @@ class XSswind1(XSMultiplicativeModel):
 
     def __init__(self, name='swind1'):
         self.column = Parameter(name, 'column', 6., 3., 50., 0.0, hugeval)
-        self.log_xi = Parameter(name, 'log_xi', 2.5, 2.1, 4.1, 0.0, hugeval)
+        self.log_xi = Parameter(name, 'log_xi', 2.5, 2.1, 4.1, 0.0, hugeval, aliases=["logxi"])
         self.sigma = Parameter(name, 'sigma', 0.1, 0., .5, 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('logxi', 'log_xi')]
 
         XSMultiplicativeModel.__init__(self, name, (self.column, self.log_xi, self.sigma, self.redshift))
 
@@ -6636,9 +6569,7 @@ class XSuvred(XSMultiplicativeModel):
     _calc =  _xspec.xsred
 
     def __init__(self, name='uvred'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval, aliases=["EBV"])
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
@@ -6861,7 +6792,7 @@ class XSxion(XSMultiplicativeModel):
 
     def __init__(self, name='xion'):
         self.height = Parameter(name, 'height', 5., 0.0, 1.e2, 0.0, hugeval, 'r_s')
-        self.lxovrld = Parameter(name, 'lxovrld', 0.3, 0.02, 100, 0.0, hugeval)
+        self.lxovrld = Parameter(name, 'lxovrld', 0.3, 0.02, 100, 0.0, hugeval, aliases=["lxld"])
         self.rate = Parameter(name, 'rate', 0.05, 1.e-3, 1., 0.0, hugeval)
         self.cosAng = Parameter(name, 'cosAng', 0.9, 0., 1., 0.0, hugeval)
         self.inner = Parameter(name, 'inner', 3., 2., 1.e3, 0.0, hugeval, 'r_s')
@@ -6873,8 +6804,6 @@ class XSxion(XSMultiplicativeModel):
         self.Ref_type = Parameter(name, 'Ref_type', 1., 1., 3., 0.0, hugeval, frozen=True)
         self.Rel_smear = Parameter(name, 'Rel_smear', 4., 1., 4., 0.0, hugeval, frozen=True)
         self.Geometry = Parameter(name, 'Geometry', 1., 1., 4., 0.0, hugeval, frozen=True)
-
-        self._renamedpars = [('lxld', 'lxovrld')]
 
         XSMultiplicativeModel.__init__(self, name, (self.height, self.lxovrld, self.rate, self.cosAng, self.inner, self.outer, self.index, self.redshift, self.Feabun, self.E_cut, self.Ref_type, self.Rel_smear, self.Geometry))
 
@@ -6918,12 +6847,10 @@ class XSzdust(XSMultiplicativeModel):
     _calc =  _xspec.mszdst
 
     def __init__(self, name='zdust'):
-        self._method = Parameter(name, '_method', 1, 1, 3, 1, 3, alwaysfrozen=True)
-        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval)
+        self._method = Parameter(name, '_method', 1, 1, 3, 1, 3, alwaysfrozen=True, aliases=["method"])
+        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval, aliases=["EBV"])
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
-
-        self._renamedpars = [('method', '_method'), ('EBV', 'E_BmV')]
 
         XSMultiplicativeModel.__init__(self, name, (self._method, self.E_BmV, self.Rv, self.redshift))
 
@@ -7108,11 +7035,9 @@ class XSzxipcf(XSMultiplicativeModel):
 
     def __init__(self, name='zxipcf'):
         self.Nh = Parameter(name, 'Nh', 10, 0.05, 500, 0.0, hugeval, '10^22 atoms / cm^2')
-        self.log_xi = Parameter(name, 'log_xi', 3, -3, 6, -hugeval, hugeval)
+        self.log_xi = Parameter(name, 'log_xi', 3, -3, 6, -hugeval, hugeval, aliases=["logxi"])
         self.CvrFract = Parameter(name, 'CvrFract', 0.5, 0., 1., 0.0, hugeval)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('logxi', 'log_xi')]
 
         XSMultiplicativeModel.__init__(self, name, (self.Nh, self.log_xi, self.CvrFract, self.redshift))
 
@@ -7153,10 +7078,8 @@ class XSzredden(XSMultiplicativeModel):
     _calc =  _xspec.xszcrd
 
     def __init__(self, name='zredden'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, hugeval, aliases=["EBV"])
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.redshift))
 
@@ -7197,12 +7120,10 @@ class XSzsmdust(XSMultiplicativeModel):
     _calc =  _xspec.msldst
 
     def __init__(self, name='zsmdust'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval)
+        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, hugeval, aliases=["EBV"])
         self.ExtIndex = Parameter(name, 'ExtIndex', 1.0, -10.0, 10., -hugeval, hugeval)
         self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, hugeval, 'z', True)
-
-        self._renamedpars = [('EBV', 'E_BmV')]
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.ExtIndex, self.Rv, self.redshift))
 
@@ -7494,16 +7415,16 @@ class XScplinear(XSAdditiveModel):
     _calc = _xspec.C_cplinear
 
     def __init__(self, name='cplinear'):
-        self._energy00 = Parameter(name, '_energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy01 = Parameter(name, '_energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy02 = Parameter(name, '_energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy03 = Parameter(name, '_energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy04 = Parameter(name, '_energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy05 = Parameter(name, '_energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy06 = Parameter(name, '_energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy07 = Parameter(name, '_energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy08 = Parameter(name, '_energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
-        self._energy09 = Parameter(name, '_energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True)
+        self._energy00 = Parameter(name, '_energy00', 0.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy00"])
+        self._energy01 = Parameter(name, '_energy01', 1., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy01"])
+        self._energy02 = Parameter(name, '_energy02', 1.5, min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy02"])
+        self._energy03 = Parameter(name, '_energy03', 2., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy03"])
+        self._energy04 = Parameter(name, '_energy04', 3., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy04"])
+        self._energy05 = Parameter(name, '_energy05', 4., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy05"])
+        self._energy06 = Parameter(name, '_energy06', 5., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy06"])
+        self._energy07 = Parameter(name, '_energy07', 6., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy07"])
+        self._energy08 = Parameter(name, '_energy08', 7., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy08"])
+        self._energy09 = Parameter(name, '_energy09', 8., min=0.0, max=10.0, units='keV', alwaysfrozen=True, aliases=["energy09"])
         self.log_rate00 = Parameter(name, 'log_rate00', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate01 = Parameter(name, 'log_rate01', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate02 = Parameter(name, 'log_rate02', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
@@ -7515,11 +7436,6 @@ class XScplinear(XSAdditiveModel):
         self.log_rate08 = Parameter(name, 'log_rate08', 0., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.log_rate09 = Parameter(name, 'log_rate09', 1., -19.0, 19.0, -hugeval, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [(n, '_' + n) for n in
-                             ['energy{:02d}'.format(i)
-                              for i in range(10)]
-                             ]
 
         XSAdditiveModel.__init__(self, name, (self._energy00, self._energy01, self._energy02, self._energy03, self._energy04, self._energy05, self._energy06, self._energy07, self._energy08, self._energy09, self.log_rate00, self.log_rate01, self.log_rate02, self.log_rate03, self.log_rate04, self.log_rate05, self.log_rate06, self.log_rate07, self.log_rate08, self.log_rate09, self.norm))
 
@@ -7619,10 +7535,10 @@ class XSeqpair(XSAdditiveModel):
     _calc = _xspec.C_xseqpair
 
     def __init__(self, name='eqpair'):
-        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
+        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval, aliases=["l_hl_s"])
         self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, hugeval)
         self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 0.0, hugeval, 'eV', True)
-        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval)
+        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval, aliases=["l_ntl_h"])
         self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 0.0, hugeval, frozen=True)
         self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 0.0, hugeval, 'cm', True)
         self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 0.0, hugeval, frozen=True)
@@ -7632,7 +7548,7 @@ class XSeqpair(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True, aliases=["AbHe"])
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7640,10 +7556,6 @@ class XSeqpair(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('l_hl_s', 'l_hovl_s'),
-                             ('l_ntl_h', 'l_ntol_h'),
-                             ('AbHe', 'Ab_met')]
 
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -7743,10 +7655,10 @@ class XSeqtherm(XSAdditiveModel):
     _calc = _xspec.C_xseqth
 
     def __init__(self, name='eqtherm'):
-        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval)
+        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 0.0, hugeval, aliases=["l_hl_s"])
         self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, hugeval)
         self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 0.0, hugeval, 'eV', True)
-        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval)
+        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, hugeval, aliases=["l_ntl_h"])
         self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 0.0, hugeval, frozen=True)
         self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 0.0, hugeval, 'cm', True)
         self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 0.0, hugeval, frozen=True)
@@ -7756,7 +7668,7 @@ class XSeqtherm(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True, aliases=["AbHe"])
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7764,10 +7676,6 @@ class XSeqtherm(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('l_hl_s', 'l_hovl_s'),
-                             ('l_ntl_h', 'l_ntol_h'),
-                             ('AbHe', 'Ab_met')]
 
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -7876,7 +7784,7 @@ class XScompth(XSAdditiveModel):
         self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.0, hugeval, frozen=True)
         self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, hugeval, frozen=True)
         self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.0, hugeval, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True)
+        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.0, hugeval, frozen=True, aliases=["AbHe"])
         self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 0.0, hugeval, 'K', True)
         self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, hugeval)
         self.Beta = Parameter(name, 'Beta', -10., -10., 10., -hugeval, hugeval, frozen=True)
@@ -7884,8 +7792,6 @@ class XScompth(XSAdditiveModel):
         self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, hugeval, 'M', True)
         self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('AbHe', 'Ab_met')]
 
         XSAdditiveModel.__init__(self, name, (self.theta, self.showbb, self.kT_bb, self.RefOn, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
 
@@ -8071,13 +7977,9 @@ class XSzigm(XSMultiplicativeModel):
     _calc = _xspec.zigm
 
     def __init__(self, name='zigm'):
-        self._redshift = Parameter(name, '_redshift', 0.0, alwaysfrozen=True)
-        self._model = Parameter(name, '_model', 0, 0, 1, 0, 1, alwaysfrozen=True)
-        self._lyman_limit = Parameter(name, '_lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True)
-
-        self._renamedpars = [('redshift', '_redshift'),
-                             ('model', '_model'),
-                             ('lyman_limit', '_lyman_limit')]
+        self._redshift = Parameter(name, '_redshift', 0.0, alwaysfrozen=True, aliases=["redshift"])
+        self._model = Parameter(name, '_model', 0, 0, 1, 0, 1, alwaysfrozen=True, aliases=["model"])
+        self._lyman_limit = Parameter(name, '_lyman_limit', 1, 0, 1, 0, 1, alwaysfrozen=True, aliases=["lyman_limit"])
 
         XSMultiplicativeModel.__init__(self, name, (self._redshift, self._model, self._lyman_limit))
 
@@ -8135,10 +8037,8 @@ class XSgadem(XSAdditiveModel):
         self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 0.0, hugeval, 'cm^-3', True)
         self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift, self._switch, self.norm))
 
@@ -8205,10 +8105,8 @@ class XSvgadem(XSAdditiveModel):
         self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -hugeval, hugeval, frozen=True)
-        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True)
+        self._switch = Parameter(name, '_switch', 2, 0, 2, 0, 2, alwaysfrozen=True, aliases=["switch"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('switch', '_switch')]
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self._switch, self.norm))
 
@@ -8289,10 +8187,8 @@ class XSlogpar(XSAdditiveModel):
     def __init__(self, name='logpar'):
         self.alpha = Parameter(name, 'alpha', 1.5, 0., 4., 0.0, hugeval)
         self.beta = Parameter(name, 'beta', 0.2, -4., 4., -hugeval, hugeval)
-        self._pivotE = Parameter(name, '_pivotE', 1.0, units='keV', alwaysfrozen=True)
+        self._pivotE = Parameter(name, '_pivotE', 1.0, units='keV', alwaysfrozen=True, aliases=["pivotE"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
-
-        self._renamedpars = [('pivotE', '_pivotE')]
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self._pivotE, self.norm))
 
@@ -8368,7 +8264,7 @@ class XSoptxagn(XSAdditiveModel):
     def __init__(self, name='optxagn'):
         self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 0.0, hugeval, 'solar', True)
         self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.0, hugeval, 'Mpc', True)
-        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval)
+        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval, aliases=["logLLEdd"])
         self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, hugeval, frozen=True)
         self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 0.0, hugeval, 'rg')
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval, frozen=True)
@@ -8380,8 +8276,6 @@ class XSoptxagn(XSAdditiveModel):
         self.tscat = Parameter(name, 'tscat', 1.e5, 1e4, 1e5, 0.0, hugeval, frozen=True)
         self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
-
-        self._renamedpars = [('logLLEdd', 'logLoLedd')]
 
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.fcol, self.tscat, self.Redshift, self.norm))
 
@@ -8451,7 +8345,7 @@ class XSoptxagnf(XSAdditiveModel):
     def __init__(self, name='optxagnf'):
         self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 0.0, hugeval, 'solar', True)
         self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.0, hugeval, 'Mpc', True)
-        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval)
+        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -hugeval, hugeval, aliases=["logLLEdd"])
         self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, hugeval, frozen=True)
         self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 0.0, hugeval, 'rg')
         self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 0.0, hugeval, frozen=True)
@@ -8461,8 +8355,6 @@ class XSoptxagnf(XSAdditiveModel):
         self.fpl = Parameter(name, 'fpl', 1.e-4, 0.0, 1., 0.0, hugeval)
         self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, hugeval, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
-
-        self._renamedpars = [('logLLEdd', 'logLoLedd')]
 
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.Redshift, self.norm))
 
@@ -8736,9 +8628,7 @@ class XSheilin(XSMultiplicativeModel):
     def __init__(self, name='heilin'):
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
-
-        self._renamedpars = [('redshift', 'z')]
+        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
 
         # TODO: correct self.nHei to self.nHeI
         XSMultiplicativeModel.__init__(self, name, (self.nHei, self.b, self.z))
@@ -8784,13 +8674,10 @@ class XSlyman(XSMultiplicativeModel):
     _calc =  _xspec.xslyman
 
     def __init__(self, name='lyman'):
-        self.n = Parameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
+        self.n = Parameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2', aliases=["nHeI"])
         self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5)
+        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
         self.ZA = Parameter(name, 'ZA', 1.0, 1.0, 2.0, 1.0, 2.0)
-
-        self._renamedpars = [('nHeI', 'n'),
-                             ('redshift', 'z')]
 
         XSMultiplicativeModel.__init__(self, name, (self.n, self.b, self.z, self.ZA))
 
@@ -8834,9 +8721,7 @@ class XSzbabs(XSMultiplicativeModel):
         self.nH = Parameter(name, 'nH', 1.e-4, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
         self.nHeII = Parameter(name, 'nHeII', 1.e-6, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')
-        self.z = Parameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6)
-
-        self._renamedpars = [('redshift', 'z')]
+        self.z = Parameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6, aliases=["redshift"])
 
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.nHeI, self.nHeII, self.z))
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -875,7 +875,7 @@ class XSbmc(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.9.0
-              ``logA`` will be removed in the next release as it has been
+              ``logA`` may be removed in future releases as it has been
               replaced by ``log_A``, to match the XSPEC naming convention.
 
     Attributes
@@ -892,9 +892,9 @@ class XSbmc(XSAdditiveModel):
 
     Notes
     -----
-    In Sherpa 4.9.0 the ``logA`` parameter has been renamed to ``log_A``.
-    It can still be accessed using ``log_A`` for the time being, but this
-    attribute has been deprecated.
+    In Sherpa 4.10.0 the ``logA`` parameter has been renamed to ``log_A``.
+    It can still be accessed using ``logA`` for the time being, but this
+    attribute name has been deprecated.
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1136,7 +1136,7 @@ class XSc6pvmkl(XSAdditiveModel):
     by using the exponential of the 6th order Chebyshev polynomial.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1213,7 +1213,7 @@ class XSc6vmekl(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1290,7 +1290,7 @@ class XScemekl(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1352,7 +1352,7 @@ class XScevmkl(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -1543,7 +1543,7 @@ class XScompPS(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``tauy`` and ``HRcyl`` will be removed in the next release as
+              ``tauy`` and ``HRcyl`` might be removed in future releases as
               they have been replaced by ``tau_y`` and ``HovR_cyl``
               respectively, to match the XSPEC naming convention.
 
@@ -1756,7 +1756,7 @@ class XSdisk(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``NSmass`` will be removed in the next release as it has been
+              ``NSmass`` might be removed in future releases as it has been
               replaced by ``CenMass``, to match the XSPEC naming convention.
 
     Attributes
@@ -1807,7 +1807,7 @@ class XSdiskir(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``LcLd`` will be removed in the next release as it has been
+              ``LcLd`` might be removed in future releases as it has been
               replaced by ``LcovrLd``, to match the XSPEC naming convention.
 
     Attributes
@@ -1911,7 +1911,7 @@ class XSdiskline(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinM`` and ``RoutM`` will be removed in the next release as
+              ``RinM`` and ``RoutM`` might be removed in future releases as
               they have been replaced by ``Rin_M`` and ``Rout_M``
               respectively, to match the XSPEC naming convention.
 
@@ -2121,7 +2121,7 @@ class XSequil(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` will be removed in the next release as it has been
+              ``kT_ave`` might be removed in future releases as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
@@ -2313,7 +2313,7 @@ class XSgrad(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``TclTef`` will be removed in the next release as it has been
+              ``TclTef`` might be removed in future releases as it has been
               replaced by ``TclovTef``, to match the XSPEC naming convention.
 
     Attributes
@@ -2377,7 +2377,7 @@ class XSgrbm(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``temp`` will be removed in the next release as it has been
+              ``temp`` might be removed in future releases as it has been
               replaced by ``tem``, to match the XSPEC naming convention.
 
     Attributes
@@ -2490,7 +2490,7 @@ class XSkerrd(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``TcolTeff`` will be removed in the next release as it has been
+              ``TcolTeff`` might be removed in future releases as it has been
               replaced by ``TcoloTeff``, to match the XSPEC naming convention.
 
     Attributes
@@ -2637,7 +2637,7 @@ class XSlaor(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinG`` and ``RoutG`` will be removed in the next release as
+              ``RinG`` and ``RoutG`` might be removed in future releases as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
 
@@ -2700,7 +2700,7 @@ class XSlaor2(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``RinG`` and ``RoutG`` will be removed in the next release as
+              ``RinG`` and ``RoutG`` might be removed in future releases as
               they have been replaced by ``Rin_G`` and ``Rout_G``
               respectively, to match the XSPEC naming convention.
 
@@ -2808,7 +2808,7 @@ class XSmeka(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -2912,7 +2912,7 @@ class XSmkcflow(XSAdditiveModel):
     on the cosmology settings set with ``set_xscosmo``.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -3371,7 +3371,7 @@ class XSnsmax(XSAdditiveModel):
     ``XSnsmaxg``.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` will be removed in the next release as it has been
+              ``specfile`` might be removed in future releases as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
@@ -3421,7 +3421,7 @@ class XSnsmaxg(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` will be removed in the next release as it has been
+              ``specfile`` might be removed in future releases as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
@@ -3477,7 +3477,7 @@ class XSnsx(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``specfile`` will be removed in the next release as it has been
+              ``specfile`` might be removed in future releases as it has been
               replaced by ``_specfile``, to match the XSPEC naming convention.
 
     Attributes
@@ -3819,7 +3819,7 @@ class XSplcabs(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``nmax`` and ``FAST`` will be removed in the next release as
+              ``nmax`` and ``FAST`` might be removed in future releases as
               they have been replaced by ``_nmax`` and ``_FAST``
               respectively, to match the XSPEC naming convention.
 
@@ -4244,7 +4244,7 @@ class XSsrcut(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``breakfreq`` will be removed in the next release as it has
+              ``breakfreq`` might be removed in future releases as it has
               been replaced by ``break_``, to match the XSPEC naming
               convention.
 
@@ -4419,7 +4419,7 @@ class XSvbremss(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``HeH`` will be removed in the next release as it has been
+              ``HeH`` might be removed in future releases as it has been
               replaced by ``HeovrH``, to match the XSPEC naming convention.
 
     Attributes
@@ -4469,7 +4469,7 @@ class XSvequil(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` will be removed in the next release as it has been
+              ``kT_ave`` might be removed in future releases as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
@@ -4524,7 +4524,7 @@ class XSvgnei(XSAdditiveModel):
     particular the keyword "NEIVERS".
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``kT_ave`` will be removed in the next release as it has been
+              ``kT_ave`` might be removed in future releases as it has been
               replaced by ``meankT``, to match the XSPEC naming convention.
 
     Attributes
@@ -4683,7 +4683,7 @@ class XSvmeka(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -4811,7 +4811,7 @@ class XSvmcflow(XSAdditiveModel):
     on the cosmology settings set with ``set_xscosmo``.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``switch`` will be removed in the next release as it has been
+              ``switch`` might be removed in future releases as it has been
               replaced by ``_switch``, to match the XSPEC naming convention.
 
     Attributes
@@ -5928,7 +5928,7 @@ class XSgabs(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``Tau`` will be removed in the next release as it has been
+              ``Tau`` might be removed in future releases as it has been
               replaced by ``Strength``, to match the XSPEC namin
               convention.
 
@@ -6224,7 +6224,7 @@ class XSredden(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -6392,7 +6392,7 @@ class XSswind1(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logxi`` will be removed in the next release as it has been
+              ``logxi`` might be removed in future releases as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
     Attributes
@@ -6612,7 +6612,7 @@ class XSuvred(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -6812,7 +6812,7 @@ class XSxion(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``lxld`` will be removed in the next release as it has been
+              ``lxld`` might be removed in future releases as it has been
               replaced by ``lxovrld``, to match the XSPEC naming convention.
 
     Attributes
@@ -6885,7 +6885,7 @@ class XSzdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``method`` and ``EBV`` will be removed in the next release as
+              ``method`` and ``EBV`` might be removed in future releases as
               they have been replaced by ``_method`` and ``E_BmV``
               respectively, to match the XSPEC naming convention.
 
@@ -7077,7 +7077,7 @@ class XSzxipcf(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logxi`` will be removed in the next release as it has been
+              ``logxi`` might be removed in future releases as it has been
               replaced by ``log_xi``, to match the XSPEC naming convention.
 
     Attributes
@@ -7123,7 +7123,7 @@ class XSzredden(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -7167,7 +7167,7 @@ class XSzsmdust(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``EBV`` will be removed in the next release as it has been
+              ``EBV`` might be removed in future releases as it has been
               replaced by ``E_BmV``, to match the XSPEC naming convention.
 
     Attributes
@@ -7781,7 +7781,7 @@ class XScompth(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``AbHe`` will be removed in the next release as it has been
+              ``AbHe`` might be removed in future releases as it has been
               replaced by ``Ab_met``, to match the XSPEC naming convention.
 
     Attributes
@@ -8253,7 +8253,7 @@ class XSlogpar(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``pivotE`` will be removed in the next release as it has been
+              ``pivotE`` might be removed in future releases as it has been
               replaced by ``_pivotE``, to match the XSPEC naming convention.
 
     Attributes
@@ -8303,7 +8303,7 @@ class XSoptxagn(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logLLEdd`` will be removed in the next release as it has
+              ``logLLEdd`` might be removed in future releases as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
 
@@ -8392,7 +8392,7 @@ class XSoptxagnf(XSAdditiveModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``logLLEdd`` will be removed in the next release as it has
+              ``logLLEdd`` might be removed in future releases as it has
               been replaced by ``logLoLedd``, to match the XSPEC naming
               convention.
 
@@ -8701,7 +8701,7 @@ class XSheilin(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift`` will be removed in the next release as it has
+              ``redshift`` might be removed in future releases as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
 
@@ -8800,7 +8800,7 @@ class XSzbabs(XSMultiplicativeModel):
     The model is described at [1]_.
 
     .. note:: Deprecated in Sherpa 4.10.0
-              ``redshift`` will be removed in the next release as it has
+              ``redshift`` might be removed in future releases as it has
               been replaced by ``z``, to match the XSPEC naming
               convention.
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -59,8 +59,6 @@ known_warnings = {
             #  This does not have to do with Sherpa and is coming from some versions of
             #  jupyter_client
             r"metadata .* was set from the constructor.*",
-            r"Parameter name norm is deprecated for model RenamedPars, use ampl instead",
-            r"Parameter name NORM is deprecated for model ParameterCase, use ampl instead"
         ],
     UserWarning:
         [

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -206,12 +206,8 @@ class Model(NoNewAttributesAfterInit):
 
         else:
             for key in self.__dict__:
-                try:
-                    kname = key.lower()
-                except AttributeError:
-                    continue
 
-                if lname == kname:
+                if lname == key.lower():
                     val = self.__dict__.get(key)
                     if isinstance(val, Parameter):
                         return val

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -242,7 +242,7 @@ class Parameter(NoNewAttributesAfterInit):
 
     def __init__(self, modelname, name, val, min=-hugeval, max=hugeval,
                  hard_min=-hugeval, hard_max=hugeval, units='',
-                 frozen=False, alwaysfrozen=False, hidden=False):
+                 frozen=False, alwaysfrozen=False, hidden=False, aliases=None):
         self.modelname = modelname
         self.name = name
         self.fullname = '%s.%s' % (modelname, name)
@@ -269,6 +269,8 @@ class Parameter(NoNewAttributesAfterInit):
         self.default_val = val
         self.link = None
         self._guessed = False
+
+        self.aliases = [a.lower() for a in aliases] if aliases is not None else []
 
         NoNewAttributesAfterInit.__init__(self)
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -173,10 +173,14 @@ class test_composite_model(SherpaTestCase):
 # the Sin model (which lets the tests be re-used).
 #
 class RenamedPars(Sin):
+    # The only reason I am extending Sin is to inherit the method implementations
 
     def __init__(self, name='renamedpars'):
-        self._renamedpars = [('norm', 'ampl')]
-        Sin.__init__(self, name)
+        self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
+        self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
+        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=['norm'])
+        ArithmeticModel.__init__(self, name,
+                                 (self.period, self.offset, self.ampl))
 
 
 class test_model_renamed(test_model):
@@ -227,8 +231,7 @@ class ParameterCase(ArithmeticModel):
     def __init__(self, name='parametercase'):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
         self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
-        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0)
-        self._renamedpars = [('NORM', 'ampl')]
+        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
 
         with warnings.catch_warnings(record=True) as warn:
             pars = (self.perioD, self.oFFSEt, self.NORM)
@@ -245,7 +248,7 @@ class ParameterCase(ArithmeticModel):
         return self._basemodel.calc(*args, **kwargs)
 
 
-def validate_warning(warning_capturer, parameter_name="NORM", model_name="ParameterCase"):
+def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase"):
     assert 1 == len(warning_capturer)
     warning = warning_capturer[-1]
     assert issubclass(warning.category, DeprecationWarning)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -190,17 +190,19 @@ class test_model_renamed(test_model):
 
     def test_getpar_rename(self):
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             for par in (self.m.norm, self.m.NorM, self.m.NOrm):
                 self.assertIs(par, self.m.pars[2])
             if self.__class__ == test_model_renamed:
-                validate_warning(warn, "norm", "RenamedPars")
+                validate_warning(warn, "norm", "RenamedPars", num=3)
             else:
-                validate_warning(warn)
+                validate_warning(warn, num=3)
 
     def test_setpar_rename(self):
         self.m.ampl = 1
         self.assertNotEqual(self.m.ampl.val, 12.0)
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             self.m.norm = 12
             if (self.__class__ == test_model_renamed):
                 validate_warning(warn, "norm", "RenamedPars")
@@ -210,6 +212,7 @@ class test_model_renamed(test_model):
         self.assertEqual(self.m.ampl.val, 12.0)
 
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             self.m.NoRM = 18
             if self.__class__ == test_model_renamed:
                 validate_warning(warn, "norm", "RenamedPars")
@@ -234,6 +237,7 @@ class ParameterCase(ArithmeticModel):
         self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
 
         with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always", DeprecationWarning)
             pars = (self.perioD, self.oFFSEt, self.NORM)
             validate_warning(warn)
 
@@ -248,14 +252,14 @@ class ParameterCase(ArithmeticModel):
         return self._basemodel.calc(*args, **kwargs)
 
 
-def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase"):
-    assert 1 == len(warning_capturer)
-    warning = warning_capturer[-1]
-    assert issubclass(warning.category, DeprecationWarning)
-    expected_warning_message = 'Parameter name {} is deprecated for model {}, use ampl instead'.format(
-        parameter_name, model_name
-    )
-    assert expected_warning_message == str(warning.message)
+def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase", num=1):
+    assert num == len(warning_capturer)
+    for warning in warning_capturer:
+        assert issubclass(warning.category, DeprecationWarning)
+        expected_warning_message = 'Parameter name {} is deprecated for model {}, use ampl instead'.format(
+            parameter_name, model_name
+        )
+        assert expected_warning_message == str(warning.message)
 
 
 class test_model_parametercase_instance(test_model_renamed):

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -210,8 +210,8 @@ class ParameterCase(ArithmeticModel):
         self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
         self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
         self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0)
-        pars = (self.perioD, self.oFFSEt, self.AMPL)
         self._renamedpars = [('NORM', 'ampl')]
+        pars = (self.perioD, self.oFFSEt, self.NORM)
 
         self._basemodel = Sin()
 
@@ -232,3 +232,4 @@ class test_model_parametercase_instance(test_model_renamed):
 
     def test_name(self):
         self.assertEqual(self.m.name, 'parametercase')
+        self.assertEqual(self.m.NORM.name, 'ampl')

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -38,6 +38,7 @@ class test_model(SherpaTestCase):
 
     def setUp(self):
         self.m = Sin('m')
+        self.expected_names = ['period', 'offset', 'ampl']
 
     def test_name(self):
         self.assertEqual(self.m.name, 'm')
@@ -51,7 +52,7 @@ class test_model(SherpaTestCase):
 
     def test_par_names(self):
         self.assertEqual([p.name for p in self.m.pars],
-                         ['period', 'offset', 'ampl'])
+                         self.expected_names)
 
     def test_getpar(self):
         for par in (self.m.period, self.m.PerioD, self.m.PERIod):
@@ -186,6 +187,7 @@ class RenamedPars(Sin):
 class test_model_renamed(test_model):
 
     def setUp(self):
+        test_model.setUp(self)
         self.m = RenamedPars('m')
 
     def test_getpar_rename(self):
@@ -194,7 +196,7 @@ class test_model_renamed(test_model):
             for par in (self.m.norm, self.m.NorM, self.m.NOrm):
                 self.assertIs(par, self.m.pars[2])
             if self.__class__ == test_model_renamed:
-                validate_warning(warn, "norm", "RenamedPars", num=3)
+                validate_warning(warn, "norm", "RenamedPars", "ampl", num=3)
             else:
                 validate_warning(warn, num=3)
 
@@ -205,7 +207,7 @@ class test_model_renamed(test_model):
             warnings.simplefilter("always", DeprecationWarning)
             self.m.norm = 12
             if (self.__class__ == test_model_renamed):
-                validate_warning(warn, "norm", "RenamedPars")
+                validate_warning(warn, "norm", "RenamedPars", "ampl")
             else:
                 validate_warning(warn)
 
@@ -215,7 +217,7 @@ class test_model_renamed(test_model):
             warnings.simplefilter("always", DeprecationWarning)
             self.m.NoRM = 18
             if self.__class__ == test_model_renamed:
-                validate_warning(warn, "norm", "RenamedPars")
+                validate_warning(warn, "norm", "RenamedPars", "ampl")
             else:
                 validate_warning(warn)
 
@@ -232,9 +234,9 @@ class ParameterCase(ArithmeticModel):
     """Re-implemenent Sin model so can copy tests"""
 
     def __init__(self, name='parametercase'):
-        self.period = Parameter(name, 'period', 1, 1e-10, 10, tinyval)
-        self.offset = Parameter(name, 'offset', 0, 0, hard_min=0)
-        self.ampl = Parameter(name, 'ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
+        self.period = Parameter(name, 'Period', 1, 1e-10, 10, tinyval)
+        self.offset = Parameter(name, 'Offset', 0, 0, hard_min=0)
+        self.ampl = Parameter(name, 'Ampl', 1, 1e-05, hard_min=0, aliases=["NORM"])
 
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always", DeprecationWarning)
@@ -252,12 +254,12 @@ class ParameterCase(ArithmeticModel):
         return self._basemodel.calc(*args, **kwargs)
 
 
-def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase", num=1):
+def validate_warning(warning_capturer, parameter_name="norm", model_name="ParameterCase", actual_name="Ampl", num=1):
     assert num == len(warning_capturer)
     for warning in warning_capturer:
         assert issubclass(warning.category, DeprecationWarning)
-        expected_warning_message = 'Parameter name {} is deprecated for model {}, use ampl instead'.format(
-            parameter_name, model_name
+        expected_warning_message = 'Parameter name {} is deprecated for model {}, use {} instead'.format(
+            parameter_name, model_name, actual_name
         )
         assert expected_warning_message == str(warning.message)
 
@@ -266,6 +268,7 @@ class test_model_parametercase_instance(test_model_renamed):
 
     def setUp(self):
         self.m = ParameterCase()
+        self.expected_names = ['Period', 'Offset', 'Ampl']
 
     def test_name(self):
         self.assertEqual(self.m.name, 'parametercase')


### PR DESCRIPTION
I still need to fix the xspec models aliases (but tests are passing so we probably need to add some tests for the xspec models). Before I do that I would like to make sure @DougBurke agrees on the new design. (Plus, I have to figure out why some Travis jobs are failing, ugh.)

One change might be to make it the model class's responsibility to define the aliases. On one hand, it's the model that has to provide clients with the parameters through its attributes. On the other hand, since the `Parameter` already knows about its name, it seems to make sense it also knows about its aliases. Also, if in the future we decide to clean up the design and make parameters class level instances, e.g. through the [descriptor](https://www.smallsurething.com/python-descriptors-made-simple/) protocol, that's easier to do if the renaming is done at the parameter level, as you would still need a model initializer to setup the aliases otherwise, or some special class level descriptors just for that.