### PR TITLE
fix image_getregion in Python 3 (#319)

### DIFF
--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -655,11 +655,15 @@ class DS9Win:
 
         Raises RuntimeError if anything is written to stderr.
         """
-        return xpaget(
+        return_value = xpaget(
             cmd=cmd,
             template=self.template,
             doRaise=self.doRaise,
         )
+        if six.PY2:
+            return return_value
+        else:
+            return return_value.decode()
 
     def xpaset(self, cmd, data=None, dataFunc=None):
         """Executes a simple xpaset command:

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -308,7 +308,11 @@ def xpaget(cmd, template=_DefTemplate, doRaise=True):
                     raise RuntimeErr('cmdfail', fullCmd, errMsg)
                 else:
                     warnings.warn(fullErrMsg)
-            return p.stdout.read()
+            return_value = p.stdout.read()
+            if six.PY2:
+                return return_value
+            else:
+                return return_value.decode()
         finally:
             p.stdout.close()
             p.stderr.close()
@@ -655,15 +659,11 @@ class DS9Win:
 
         Raises RuntimeError if anything is written to stderr.
         """
-        return_value = xpaget(
+        return xpaget(
             cmd=cmd,
             template=self.template,
             doRaise=self.doRaise,
         )
-        if six.PY2:
-            return return_value
-        else:
-            return return_value.decode()
 
     def xpaset(self, cmd, data=None, dataFunc=None):
         """Executes a simple xpaset command:

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -25,6 +25,11 @@ from sherpa.utils.err import DS9Err
 
 imager = DS9.DS9Win(DS9._DefTemplate, False)
 
+
+# TODO: the except blocks would ideally catch explicit errors; the present
+#       catch-anything approach means that we lose potentially-useful
+#       information on the type of error.
+#
 
 def close():
     if imager.isOpen():
@@ -57,6 +62,7 @@ def get_region(coord):
 
         regionstr = imager.xpaget(regionstr)
         return regionstr
+
     except:
         raise DS9Err('retreg')
 


### PR DESCRIPTION
This is a proof-of-concept. It has shown that we need to decide at what "level" of the API do we want to convert from byte string to string: is it just `sherpa.ui.utils.image_getregion` (and `image_xpaget`), or the `sherpa.image.ds9_backend` module, or `sherpa.image.DS9`?