### PR TITLE
Remove unused typedef (avoid NPY_CHAR is deprecated warning)

### DIFF
--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -29,7 +29,7 @@ typedef double SherpaFloat;
 typedef sherpa::Array< double, NPY_DOUBLE > DoubleArray;
 typedef DoubleArray SherpaFloatArray;
 
-typedef sherpa::Array< char, NPY_CHAR > CharArray;
+typedef sherpa::Array< char, NPY_STRING > CharArray;
 typedef sherpa::Array< int, NPY_INT > IntArray;
 
 typedef int (*converter)( PyObject*, void* );

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -29,7 +29,6 @@ typedef double SherpaFloat;
 typedef sherpa::Array< double, NPY_DOUBLE > DoubleArray;
 typedef DoubleArray SherpaFloatArray;
 
-typedef sherpa::Array< char, NPY_STRING > CharArray;
 typedef sherpa::Array< int, NPY_INT > IntArray;
 
 typedef int (*converter)( PyObject*, void* );


### PR DESCRIPTION
# Summary

Remove the CharArray typedef as it was not used and causing warning messages during compilation.

# Original note (now out of date)

This avoids the following compilation message

sherpa/include/sherpa/extension.hh:32:30: warning: ‘NPY_CHAR’ is deprecated:
Use NPY_STRING [-Wdeprecated-declarations]

and avoids a deprecation warning when running code in NumPy 1.13 and
higher (see https://github.com/numpy/numpy/pull/8948).

The NPY_STRING symbol was added in NumPy 1.7, which I think is early enough
that we don't need to try and support both the old and new versions (i.e.
we do not guarantee support for Sherpa using versions as old as NumPy 1.7).