### PR TITLE
Remove several warnings from the build

### DIFF
--- a/sherpa/estmethods/src/estutils.hh
+++ b/sherpa/estmethods/src/estutils.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2017  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -45,10 +45,6 @@ struct est_return_code {
 };
 
 
-static double get_stat(double* new_min_stat, double* new_min_parval,
-               const int parnum, const double* pars,
-               const double* pars_mins, const double* pars_maxs,
-               const int numpars, double (*fcn)(double*, int));
 int neville( int n, const double *x, const double *y, double xinterp,
 	     double& answer ) throw();
 int at_param_space_bound(const double par, 

--- a/sherpa/optmethods/tests/tstoptfct.hh
+++ b/sherpa/optmethods/tests/tstoptfct.hh
@@ -2,7 +2,7 @@
 #define tstoptfct_hh
 
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2017  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -205,8 +205,9 @@ namespace tstoptfct {
   void Booth( int npar, Real* x, Real& fval, int& ierr, Type xptr ) {
 
     if ( 2 != npar ) {
-    if ( npar % 2 )
-      throw std::runtime_error( "npar for the Booth func must be 2\n" );
+      if ( npar % 2 ) {
+        throw std::runtime_error( "npar for the Booth func must be 2\n" );
+      }
       return;
     }
 


### PR DESCRIPTION
Remove two build warnings (there are no functional changes to the code or output because of these changes):

 - a warning about an unused function definition
 - a warning about possibly-confusing indentation in an if statement
