### PR TITLE
add xspec 12.9.1n job to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
     - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
+    # As above, xspec 12.9.1n
+    - env: XSPECVER="12.9.1" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
+      sudo: required
+      dist: trusty
     # Install sherpatest package rather than relying on relative location of the submodule
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       sudo: required
       dist: trusty
     # As above, xspec 12.9.1n
-    - env: XSPECVER="12.9.1" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
+    - env: XSPECVER="12.9.1" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
     # Install sherpatest package rather than relying on relative location of the submodule


### PR DESCRIPTION
This PR introduces a travis job with xspec 12.9.1n.

The conda package name says only 12.9.1, but I don't think that's important, as long as we can confirm the patches are in... how could we do it? I am keeping the VM where I built xspec around, just in case. The patches seem to have been applied correctly, but you never know.