### PR TITLE
Add nlapec model

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,14 +433,15 @@ Then, build Sherpa in the standard way:
 XSPEC
 -----
 
-Sherpa does not support
-[`XSPEC`](https://heasarc.gsfc.nasa.gov/xanadu/xspec/) models by
-default. However, it is possible to instruct Sherpa to build its
-`XSPEC` extension module by changing the build configuration options.
+Sherpa can be built with support for
+[`XSPEC`](https://heasarc.gsfc.nasa.gov/xanadu/xspec/), although
+support is not enabled by default. The current supported XSPEC versions
+are 12.9.0 and 12.9.1, and it is expected that it will build against
+newer versions, but without support for new models or features.
 
-The `xspec_config` section of the `setup.cfg` file will need
-changing to point to the libraries, and to turn on the extension.
-In all cases, set
+To build the XSPEC support in Sherpa, the `xspec_config` section of the
+`setup.cfg` file will need changing to point to the libraries, and to
+turn on the extension. In all cases, set
 
     with-xspec=True
 
@@ -499,11 +500,6 @@ Sherpa and XSPEC, in order to avoid possible incompatibilities.
 If there are problems building, or using, the module, then the other
 options may need to be set - in particular the `gfortran_lib_dirs` and
 `gfortran_libraries` settings.
-
-The XSPEC module is designed for use with XSPEC versions 12.9.0 and
-12.8.2, although 12.9.0 is the preferred version. Use with other
-versions may lead to build problems or incomplete support for the
-XSPEC models.
 
 In order for the module to work, the `HEADAS` environment variable has
 to be set in the shell from which the Python session is started.  For

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -540,10 +540,6 @@ class XSnlapec(XSAdditiveModel):
     --------
     XSapec, XSbapec, XSbvapec, XSbvvapec, XSvapec, XSvvapec
 
-    Notes
-    -----
-    This model is only available for XSPEC version 12.9.0 and higher.
-
     References
     ----------
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -24,7 +24,8 @@ from six.moves import xrange
 import string
 from sherpa.models import Parameter, ArithmeticModel, modelCacher1d
 from sherpa.models.parameter import hugeval
-from sherpa.utils import bool_cast, guess_amplitude, param_apply_limits
+
+from sherpa.utils import guess_amplitude, param_apply_limits, bool_cast
 from sherpa.astro.utils import get_xspec_position
 
 from . import _xspec
@@ -385,8 +386,8 @@ class XSTableModel(XSModel):
                  hardmaxes=(), nint=0, addmodel=False, addredshift=False):
 
         # make translation table to turn reserved characters into '_'
-        bad = string.punctuation+string.whitespace
-        tbl = maketrans(bad, '_'*len(bad))
+        bad = string.punctuation + string.whitespace
+        tbl = maketrans(bad, '_' * len(bad))
 
         pars = []
         for ii in xrange(len(parnames)):
@@ -431,7 +432,6 @@ class XSTableModel(XSModel):
             func = _xspec.xsatbl
 
         return func(p, filename=self.filename, *args, **kwargs)
-
 
 
 class XSAdditiveModel(XSModel):
@@ -493,7 +493,7 @@ class XSapec(XSAdditiveModel):
 
     See Also
     --------
-    XSbapec, XSbvapec, XSbvvapec, XSvapec, XSvvapec
+    XSbapec, XSbvapec, XSbvvapec, XSnlapec, XSvapec, XSvvapec
 
     References
     ----------
@@ -502,9 +502,58 @@ class XSapec(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsaped
+    _calc = _xspec.xsaped
 
     def __init__(self, name='apec'):
+        self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
+        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, hugeval, frozen=True)
+        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
+        XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.redshift, self.norm))
+
+
+class XSnlapec(XSAdditiveModel):
+    """The XSPEC nlapec model: continuum-only APEC emission spectrum.
+
+    The model is described at [1]_. The ``set_xsabund`` and ``get_xsabund``
+    functions change and return the current settings for the relative
+    abundances of the metals. The ``set_xsxset`` and ``get_xsxset``
+    functions are used to set and query the XSPEC XSET parameters, in
+    particular the keywords "APECROOT", "APECTHERMAL", "APECVELOCITY",
+    and "APEC_TRACE_ABUND".
+
+    Attributes
+    ----------
+    kT
+        The temperature of the plasma, in keV.
+    Abundanc
+        The metal abundance of the plasma, as defined by the
+        ``set_xsabund`` function and the "APEC_TRACE_ABUND" xset
+        keyword.
+    redshift
+        The redshift of the plasma.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSbapec, XSbvapec, XSbvvapec, XSvapec, XSvvapec
+
+    Notes
+    -----
+    This model is only available for XSPEC version 12.9.0 and higher.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelNlapec.html
+
+    """
+
+    _calc = _xspec.C_nlapec
+
+    def __init__(self, name='nlapec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
         self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, hugeval, frozen=True)
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
@@ -548,7 +597,7 @@ class XSbapec(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsbape
+    _calc = _xspec.xsbape
 
     def __init__(self, name='bapec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -583,7 +632,7 @@ class XSbbody(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsblbd
+    _calc = _xspec.xsblbd
 
     def __init__(self, name='bbody'):
         self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 0.0, hugeval, 'keV')
@@ -615,7 +664,7 @@ class XSbbodyrad(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsbbrd
+    _calc = _xspec.xsbbrd
 
     def __init__(self, name='bbodyrad'):
         self.kT = Parameter(name, 'kT', 3., 1e-3, 100, 0.0, hugeval, 'keV')
@@ -675,7 +724,7 @@ class XSbexrav(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xsbexrav
+    _calc = _xspec.C_xsbexrav
 
     def __init__(self, name='bexrav'):
         self.Gamma1 = Parameter(name, 'Gamma1', 2., -9., 9., -hugeval, hugeval)
@@ -750,7 +799,7 @@ class XSbexriv(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xsbexriv
+    _calc = _xspec.C_xsbexriv
 
     def __init__(self, name='bexriv'):
         self.Gamma1 = Parameter(name, 'Gamma1', 2., -9., 9., -hugeval, hugeval)
@@ -802,7 +851,7 @@ class XSbknpower(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_brokenPowerLaw
+    _calc = _xspec.C_brokenPowerLaw
 
     def __init__(self, name='bknpower'):
         self.PhoIndx1 = Parameter(name, 'PhoIndx1', 1., -2., 9., -hugeval, hugeval)
@@ -851,7 +900,7 @@ class XSbkn2pow(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_broken2PowerLaw
+    _calc = _xspec.C_broken2PowerLaw
 
     def __init__(self, name='bkn2pow'):
         self.PhoIndx1 = Parameter(name, 'PhoIndx1', 1., -2., 9., -hugeval, hugeval)
@@ -893,7 +942,7 @@ class XSbmc(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsbmc
+    _calc = _xspec.xsbmc
 
     def __init__(self, name='bmc'):
         self.kT = Parameter(name, 'kT', 1., 1.e-2, 100., 0.0, hugeval, 'keV')
@@ -927,7 +976,7 @@ class XSbremss(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsbrms
+    _calc = _xspec.xsbrms
 
     def __init__(self, name='bremss'):
         self.kT = Parameter(name, 'kT', 7.0, 1.e-4, 100., 0.0, hugeval, 'keV')
@@ -966,7 +1015,7 @@ class XSbvapec(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsbvpe
+    _calc = _xspec.xsbvpe
 
     def __init__(self, name='bvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -1023,7 +1072,7 @@ class XSc6mekl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.c6mekl
+    _calc = _xspec.c6mekl
 
     def __init__(self, name='c6mekl'):
         self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -hugeval, hugeval)
@@ -1075,7 +1124,7 @@ class XSc6pmekl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.c6pmekl
+    _calc = _xspec.c6pmekl
 
     def __init__(self, name='c6pmekl'):
         self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -hugeval, hugeval)
@@ -1127,7 +1176,7 @@ class XSc6pvmkl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.c6pvmkl
+    _calc = _xspec.c6pvmkl
 
     def __init__(self, name='c6pvmkl'):
         self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -hugeval, hugeval)
@@ -1191,7 +1240,7 @@ class XSc6vmekl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.c6vmekl
+    _calc = _xspec.c6vmekl
 
     def __init__(self, name='c6vmekl'):
         self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -hugeval, hugeval)
@@ -1257,7 +1306,7 @@ class XScemekl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.cemekl
+    _calc = _xspec.cemekl
 
     def __init__(self, name='cemekl'):
         self.alpha = Parameter(name, 'alpha', 1.0, 0.01, 10, 0.0, hugeval, frozen=True)
@@ -1306,7 +1355,7 @@ class XScevmkl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_cemVMekal
+    _calc = _xspec.C_cemVMekal
 
     def __init__(self, name='cevmkl'):
         self.alpha = Parameter(name, 'alpha', 1.0, 0.01, 10, 0.0, hugeval, frozen=True)
@@ -1364,7 +1413,7 @@ class XScflow(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xscflw
+    _calc = _xspec.C_xscflw
 
     def __init__(self, name='cflow'):
         self.slope = Parameter(name, 'slope', 0., -5., 5., -hugeval, hugeval)
@@ -1404,7 +1453,7 @@ class XScompbb(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.compbb
+    _calc = _xspec.compbb
 
     def __init__(self, name='compbb'):
         self.kT = Parameter(name, 'kT', 1.0, 1.e-2, 100., 0.0, hugeval, 'keV')
@@ -1435,7 +1484,7 @@ class XScompLS(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.compls
+    _calc = _xspec.compls
 
     def __init__(self, name='compls'):
         self.kT = Parameter(name, 'kT', 2., .01, 10., 0.0, hugeval, 'keV')
@@ -1513,7 +1562,7 @@ class XScompPS(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xscompps
+    _calc = _xspec.C_xscompps
 
     def __init__(self, name='compps'):
         self.kTe = Parameter(name, 'kTe', 100., 20., 1.e5, 0.0, hugeval, 'keV')
@@ -1560,7 +1609,7 @@ class XScompST(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.compst
+    _calc = _xspec.compst
 
     def __init__(self, name='compst'):
         self.kT = Parameter(name, 'kT', 2., .01, 100., 0.0, hugeval, 'keV')
@@ -1601,7 +1650,7 @@ class XScompTT(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xstitg
+    _calc = _xspec.xstitg
 
     def __init__(self, name='comptt'):
         self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, hugeval, frozen=True)
@@ -1640,7 +1689,7 @@ class XScutoffpl(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_cutoffPowerLaw
+    _calc = _xspec.C_cutoffPowerLaw
 
     def __init__(self, name='cutoffpl'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -hugeval, hugeval)
@@ -1677,7 +1726,7 @@ class XSdisk(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.disk
+    _calc = _xspec.disk
 
     def __init__(self, name='disk'):
         self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 0.0, hugeval)
@@ -1732,7 +1781,7 @@ class XSdiskir(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.diskir
+    _calc = _xspec.diskir
 
     def __init__(self, name='diskir'):
         self.kT_disk = Parameter(name, 'kT_disk', 1.0, 0.01, 5., 0.0, hugeval, 'keV')
@@ -1770,7 +1819,7 @@ class XSdiskbb(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsdskb
+    _calc = _xspec.xsdskb
 
     def __init__(self, name='diskbb'):
         self.Tin = Parameter(name, 'Tin', 1., 0., 1000., 0.0, hugeval, 'keV')
@@ -1805,7 +1854,7 @@ class XSdiskline(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsdili
+    _calc = _xspec.xsdili
 
     def __init__(self, name='diskline'):
         self.LineE = Parameter(name, 'LineE', 6.7, 0., 100., 0.0, hugeval, 'keV')
@@ -1852,7 +1901,7 @@ class XSdiskm(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.diskm
+    _calc = _xspec.diskm
 
     def __init__(self, name='diskm'):
         self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 0.0, hugeval)
@@ -1893,7 +1942,7 @@ class XSdisko(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.disko
+    _calc = _xspec.disko
 
     def __init__(self, name='disko'):
         self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 0.0, hugeval)
@@ -1929,7 +1978,7 @@ class XSdiskpbb(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.diskpbb
+    _calc = _xspec.diskpbb
 
     def __init__(self, name='diskpbb'):
         self.Tin = Parameter(name, 'Tin', 1.0, 0.1, 10.0, 0.0, hugeval, 'keV')
@@ -1963,7 +2012,7 @@ class XSdiskpn(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsdiskpn
+    _calc = _xspec.xsdiskpn
 
     def __init__(self, name='diskpn'):
         self.T_max = Parameter(name, 'T_max', 1., 1e-3, 100, 0.0, hugeval, 'keV')
@@ -2003,7 +2052,7 @@ class XSequil(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_equil
+    _calc = _xspec.C_equil
 
     def __init__(self, name='equil'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -2032,7 +2081,7 @@ class XSexpdec(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsxpdec
+    _calc = _xspec.xsxpdec
 
     def __init__(self, name='expdec'):
         self.factor = Parameter(name, 'factor', 1.0, 0., 100.0, 0.0, hugeval)
@@ -2059,7 +2108,7 @@ class XSezdiskbb(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.ezdiskbb
+    _calc = _xspec.ezdiskbb
 
     def __init__(self, name='ezdiskbb'):
         self.T_max = Parameter(name, 'T_max', 1., 0.01, 100., 0.0, hugeval, 'keV')
@@ -2092,7 +2141,7 @@ class XSgaussian(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsgaul
+    _calc = _xspec.xsgaul
 
     def __init__(self, name='gaussian'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -2141,7 +2190,7 @@ class XSgnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_gnei
+    _calc = _xspec.C_gnei
 
     def __init__(self, name='gnei'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -2191,7 +2240,7 @@ class XSgrad(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.grad
+    _calc = _xspec.grad
 
     def __init__(self, name='grad'):
         self.D = Parameter(name, 'D', 10.0, 0.0, 10000., 0.0, hugeval, 'kpc', True)
@@ -2227,7 +2276,7 @@ class XSgrbm(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsgrbm
+    _calc = _xspec.xsgrbm
 
     def __init__(self, name='grbm'):
         self.alpha = Parameter(name, 'alpha', -1., -3., +2., -hugeval, hugeval)
@@ -2288,7 +2337,7 @@ class XSkerrbb(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_kerrbb
+    _calc = _xspec.C_kerrbb
 
     def __init__(self, name='kerrbb'):
         self.eta = Parameter(name, 'eta', 0., 0., 1.0, 0.0, hugeval, frozen=True)
@@ -2342,7 +2391,7 @@ class XSkerrd(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_kerrdisk
+    _calc = _xspec.C_kerrdisk
 
     def __init__(self, name='kerrd'):
         self.distance = Parameter(name, 'distance', 1., 0.01, 1000., 0.0, hugeval, 'kpc', True)
@@ -2399,7 +2448,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.spin
+    _calc = _xspec.spin
 
     def __init__(self, name='kerrdisk'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0.1, 100., 0.0, hugeval, 'keV')
@@ -2452,7 +2501,7 @@ class XSlaor(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xslaor
+    _calc = _xspec.C_xslaor
 
     def __init__(self, name='laor'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
@@ -2505,7 +2554,7 @@ class XSlaor2(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_laor2
+    _calc = _xspec.C_laor2
 
     def __init__(self, name='laor2'):
         self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, hugeval, 'keV')
@@ -2549,7 +2598,7 @@ class XSlorentz(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xslorz
+    _calc = _xspec.xslorz
 
     def __init__(self, name='lorentz'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -2594,7 +2643,7 @@ class XSmeka(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsmeka
+    _calc = _xspec.xsmeka
 
     def __init__(self, name='meka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -2641,7 +2690,7 @@ class XSmekal(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsmekl
+    _calc = _xspec.xsmekl
 
     def __init__(self, name='mekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -2688,7 +2737,7 @@ class XSmkcflow(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xsmkcf
+    _calc = _xspec.C_xsmkcf
 
     def __init__(self, name='mkcflow'):
         self.lowT = Parameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -2733,7 +2782,7 @@ class XSnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_nei
+    _calc = _xspec.C_nei
 
     def __init__(self, name='nei'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -2779,7 +2828,7 @@ class XSrnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_rnei
+    _calc = _xspec.C_rnei
 
     def __init__(self, name='rnei'):
         self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -2828,7 +2877,7 @@ class XSvrnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vrnei
+    _calc = _xspec.C_vrnei
 
     def __init__(self, name='vrnei'):
         self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -2890,7 +2939,7 @@ class XSvvrnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vvrnei
+    _calc = _xspec.C_vvrnei
 
     def __init__(self, name='vvrnei'):
         self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -2970,7 +3019,7 @@ class XSnpshock(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_npshock
+    _calc = _xspec.C_npshock
 
     def __init__(self, name='npshock'):
         self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -3014,7 +3063,7 @@ class XSnsa(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.nsa
+    _calc = _xspec.nsa
 
     def __init__(self, name='nsa'):
         self.LogT_eff = Parameter(name, 'LogT_eff', 6.0, 5.0, 7.0, 0.0, hugeval, 'K')
@@ -3053,7 +3102,7 @@ class XSnsagrav(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.nsagrav
+    _calc = _xspec.nsagrav
 
     def __init__(self, name='nsagrav'):
         self.LogT_eff = Parameter(name, 'LogT_eff', 6.0, 5.5, 6.5, 0.0, hugeval, 'K')
@@ -3088,7 +3137,7 @@ class XSnsatmos(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.nsatmos
+    _calc = _xspec.nsatmos
 
     def __init__(self, name='nsatmos'):
         self.LogT_eff = Parameter(name, 'LogT_eff', 6.0, 5.0, 6.5, 0.0, hugeval, 'K')
@@ -3127,7 +3176,7 @@ class XSnsmax(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.nsmax
+    _calc = _xspec.nsmax
 
     def __init__(self, name='nsmax'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.8, 0.0, hugeval, 'K')
@@ -3168,7 +3217,7 @@ class XSnsmaxg(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.nsmaxg
+    _calc = _xspec.nsmaxg
 
     def __init__(self, name='nsmaxg'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.9, 5.5, 6.9, units='K')
@@ -3211,7 +3260,7 @@ class XSnsx(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.nsx
+    _calc = _xspec.nsx
 
     def __init__(self, name='nsx'):
         self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.7, 5.5, 6.7, units='K')
@@ -3280,7 +3329,7 @@ class XSnteea(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xsnteea
+    _calc = _xspec.C_xsnteea
 
     def __init__(self, name='nteea'):
         self.l_nth = Parameter(name, 'l_nth', 100., 0., 1.e4, 0.0, hugeval)
@@ -3330,7 +3379,7 @@ class XSnthComp(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_nthcomp
+    _calc = _xspec.C_nthcomp
 
     def __init__(self, name='nthcomp'):
         self.Gamma = Parameter(name, 'Gamma', 1.7, 1.001, 5., 1.001, 10.)
@@ -3371,7 +3420,7 @@ class XSpegpwrlw(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xspegp
+    _calc = _xspec.xspegp
 
     def __init__(self, name='pegpwrlw'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -hugeval, hugeval)
@@ -3428,7 +3477,7 @@ class XSpexrav(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xspexrav
+    _calc = _xspec.C_xspexrav
 
     def __init__(self, name='pexrav'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -9., 9., -hugeval, hugeval)
@@ -3493,7 +3542,7 @@ class XSpexriv(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xspexriv
+    _calc = _xspec.C_xspexriv
 
     def __init__(self, name='pexriv'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -9., 9., -hugeval, hugeval)
@@ -3549,7 +3598,7 @@ class XSplcabs(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsp1tr
+    _calc = _xspec.xsp1tr
 
     def __init__(self, name='plcabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -3591,7 +3640,7 @@ class XSpowerlaw(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_powerLaw
+    _calc = _xspec.C_powerLaw
 
     def __init__(self, name='powerlaw'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -hugeval, hugeval)
@@ -3616,7 +3665,7 @@ class XSposm(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsposm
+    _calc = _xspec.xsposm
 
     def __init__(self, name='posm'):
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
@@ -3658,7 +3707,7 @@ class XSpshock(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_pshock
+    _calc = _xspec.C_pshock
 
     def __init__(self, name='pshock'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -3699,7 +3748,7 @@ class XSraymond(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsrays
+    _calc = _xspec.xsrays
 
     def __init__(self, name='raymond'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -3730,7 +3779,7 @@ class XSredge(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xredge
+    _calc = _xspec.xredge
 
     def __init__(self, name='redge'):
         self.edge = Parameter(name, 'edge', 1.4, 0.001, 100., 0.0, hugeval, 'keV')
@@ -3796,7 +3845,7 @@ class XSrefsch(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsrefsch
+    _calc = _xspec.xsrefsch
 
     def __init__(self, name='refsch'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., -9., 9., -hugeval, hugeval)
@@ -3853,7 +3902,7 @@ class XSsedov(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_sedov
+    _calc = _xspec.C_sedov
 
     def __init__(self, name='sedov'):
         self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -3903,7 +3952,7 @@ class XSsirf(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_sirf
+    _calc = _xspec.C_sirf
 
     def __init__(self, name='sirf'):
         self.tin = Parameter(name,    'tin', 1., 0.01, 100., 0.01, 1000., 'keV')
@@ -3946,7 +3995,7 @@ class XSsrcut(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.srcut
+    _calc = _xspec.srcut
 
     def __init__(self, name='srcut'):
         self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 0.0, hugeval)
@@ -3982,7 +4031,7 @@ class XSsresc(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.sresc
+    _calc = _xspec.sresc
 
     def __init__(self, name='sresc'):
         self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 0.0, hugeval)
@@ -4016,7 +4065,7 @@ class XSstep(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsstep
+    _calc = _xspec.xsstep
 
     def __init__(self, name='step'):
         self.Energy = Parameter(name, 'Energy', 6.5, 0., 100., 0.0, hugeval, 'keV')
@@ -4059,7 +4108,7 @@ class XSvapec(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsvape
+    _calc = _xspec.xsvape
 
     def __init__(self, name='vapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -4107,7 +4156,7 @@ class XSvbremss(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsbrmv
+    _calc = _xspec.xsbrmv
 
     def __init__(self, name='vbremss'):
         self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 0.0, hugeval, 'keV')
@@ -4146,7 +4195,7 @@ class XSvequil(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vequil
+    _calc = _xspec.C_vequil
 
     def __init__(self, name='vequil'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4204,7 +4253,7 @@ class XSvgnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vgnei
+    _calc = _xspec.C_vgnei
 
     def __init__(self, name='vgnei'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4266,7 +4315,7 @@ class XSvvgnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vvgnei
+    _calc = _xspec.C_vvgnei
 
     def __init__(self, name='vvgnei'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4336,7 +4385,7 @@ class XSvmeka(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsvmek
+    _calc = _xspec.xsvmek
 
     def __init__(self, name='vmeka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -4395,7 +4444,7 @@ class XSvmekal(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsvmkl
+    _calc = _xspec.xsvmkl
 
     def __init__(self, name='vmekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4455,7 +4504,7 @@ class XSvmcflow(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xsvmcf
+    _calc = _xspec.C_xsvmcf
 
     def __init__(self, name='vmcflow'):
         self.lowT = Parameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4515,7 +4564,7 @@ class XSvnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vnei
+    _calc = _xspec.C_vnei
 
     def __init__(self, name='vnei'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4574,7 +4623,7 @@ class XSvvnei(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vvnei
+    _calc = _xspec.C_vvnei
 
     def __init__(self, name='vvnei'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -4655,7 +4704,7 @@ class XSvnpshock(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vnpshock
+    _calc = _xspec.C_vnpshock
 
     def __init__(self, name='vnpshock'):
         self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4722,7 +4771,7 @@ class XSvvnpshock(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vvnpshock
+    _calc = _xspec.C_vvnpshock
 
     def __init__(self, name='vvnpshock'):
         self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -4801,7 +4850,7 @@ class XSvpshock(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vpshock
+    _calc = _xspec.C_vpshock
 
     def __init__(self, name='vpshock'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4863,7 +4912,7 @@ class XSvvpshock(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vvpshock
+    _calc = _xspec.C_vvpshock
 
     def __init__(self, name='vvpshock'):
         self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -4932,7 +4981,7 @@ class XSvraymond(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xsvrys
+    _calc = _xspec.xsvrys
 
     def __init__(self, name='vraymond'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -4992,7 +5041,7 @@ class XSvsedov(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vsedov
+    _calc = _xspec.C_vsedov
 
     def __init__(self, name='vsedov'):
         self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -5056,7 +5105,7 @@ class XSvvsedov(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_vvsedov
+    _calc = _xspec.C_vvsedov
 
     def __init__(self, name='vvsedov'):
         self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, hugeval, 'keV')
@@ -5123,7 +5172,7 @@ class XSzbbody(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xszbod
+    _calc = _xspec.xszbod
 
     def __init__(self, name='zbbody'):
         self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 0.0, hugeval, 'keV')
@@ -5158,7 +5207,7 @@ class XSzbremss(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xszbrm
+    _calc = _xspec.xszbrm
 
     def __init__(self, name='zbremss'):
         self.kT = Parameter(name, 'kT', 7.0, 1.e-4, 100., 0.0, hugeval, 'keV')
@@ -5194,7 +5243,7 @@ class XSzgauss(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_xszgau
+    _calc = _xspec.C_xszgau
 
     def __init__(self, name='zgauss'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -5236,7 +5285,7 @@ class XSzpowerlw(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_zpowerLaw
+    _calc = _xspec.C_zpowerLaw
 
     def __init__(self, name='zpowerlw'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -hugeval, hugeval)
@@ -5273,7 +5322,7 @@ class XSabsori(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_xsabsori
+    _calc = _xspec.C_xsabsori
 
     def __init__(self, name='absori'):
         self.PhoIndex = Parameter(name, 'PhoIndex', 2., 0., 4., 0.0, hugeval, frozen=True)
@@ -5315,7 +5364,7 @@ class XSacisabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.acisabs
+    _calc = _xspec.acisabs
 
     def __init__(self, name='acisabs'):
         self.Tdays = Parameter(name, 'Tdays', 850., 0., 10000., 0.0, hugeval, 'days', True)
@@ -5346,7 +5395,7 @@ class XSconstant(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xscnst
+    _calc = _xspec.xscnst
 
     def __init__(self, name='constant'):
         self.factor = Parameter(name, 'factor', 1., 0.0, 1.e10, 0.0, hugeval)
@@ -5370,7 +5419,7 @@ class XScabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xscabs
+    _calc = _xspec.xscabs
 
     def __init__(self, name='cabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -5402,7 +5451,7 @@ class XScyclabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xscycl
+    _calc = _xspec.xscycl
 
     def __init__(self, name='cyclabs'):
         self.Depth0 = Parameter(name, 'Depth0', 2.0, 0., 100., 0.0, hugeval)
@@ -5432,7 +5481,7 @@ class XSdust(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsdust
+    _calc = _xspec.xsdust
 
     def __init__(self, name='dust'):
         self.Frac = Parameter(name, 'Frac', 0.066, 0., 1., 0.0, hugeval, frozen=True)
@@ -5463,7 +5512,7 @@ class XSedge(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsedge
+    _calc = _xspec.xsedge
 
     def __init__(self, name='edge'):
         self.edgeE = Parameter(name, 'edgeE', 7.0, 0., 100., 0.0, hugeval, 'keV')
@@ -5488,7 +5537,7 @@ class XSexpabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsabsc
+    _calc = _xspec.xsabsc
 
     def __init__(self, name='expabs'):
         self.LowECut = Parameter(name, 'LowECut', 2., 0., 100., 0.0, hugeval, 'keV')
@@ -5516,7 +5565,7 @@ class XSexpfac(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsexp
+    _calc = _xspec.xsexp
 
     def __init__(self, name='expfac'):
         self.Ampl = Parameter(name, 'Ampl', 1., 0., 1.e5, 0.0, hugeval)
@@ -5547,7 +5596,7 @@ class XSgabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_gaussianAbsorptionLine
+    _calc = _xspec.C_gaussianAbsorptionLine
 
     def __init__(self, name='gabs'):
         self.LineE = Parameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -5583,7 +5632,7 @@ class XShighecut(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xshecu
+    _calc = _xspec.xshecu
 
     def __init__(self, name='highecut'):
         self.cutoffE = Parameter(name, 'cutoffE', 10., 1.e-2, 1.e6, 0.0, hugeval, 'keV')
@@ -5631,7 +5680,7 @@ class XShrefl(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xshrfl
+    _calc = _xspec.xshrfl
 
     def __init__(self, name='hrefl'):
         self.thetamin = Parameter(name, 'thetamin', 0., 0.0, 90., 0.0, hugeval, frozen=True)
@@ -5666,7 +5715,7 @@ class XSnotch(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsntch
+    _calc = _xspec.xsntch
 
     def __init__(self, name='notch'):
         self.LineE = Parameter(name, 'LineE', 3.5, 0., 20., 0.0, hugeval, 'keV')
@@ -5702,7 +5751,7 @@ class XSpcfabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsabsp
+    _calc = _xspec.xsabsp
 
     def __init__(self, name='pcfabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -5763,7 +5812,7 @@ class XSplabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsplab
+    _calc = _xspec.xsplab
 
     def __init__(self, name='plabs'):
         self.index = Parameter(name, 'index', 2.0, 0.0, 5., 0.0, hugeval)
@@ -5798,7 +5847,7 @@ class XSpwab(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_xspwab
+    _calc = _xspec.C_xspwab
 
     def __init__(self, name='pwab'):
         self.nHmin = Parameter(name, 'nHmin', 1., 1.e-7, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -5828,7 +5877,7 @@ class XSredden(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xscred
+    _calc = _xspec.xscred
 
     def __init__(self, name='redden'):
         self.EBV = Parameter(name, 'EBV', 0.05, 0., 10., 0.0, hugeval)
@@ -5862,7 +5911,7 @@ class XSsmedge(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xssmdg
+    _calc = _xspec.xssmdg
 
     def __init__(self, name='smedge'):
         self.edgeE = Parameter(name, 'edgeE', 7.0, 0.1, 100., 0.0, hugeval, 'keV')
@@ -5891,7 +5940,7 @@ class XSspexpcut(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_superExpCutoff
+    _calc = _xspec.C_superExpCutoff
 
     def __init__(self, name='spexpcut'):
         self.Ecut = Parameter(name, 'Ecut', 10.0, 0.0, 1e6, 0.0, hugeval, 'keV')
@@ -5926,7 +5975,7 @@ class XSspline(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsspln
+    _calc = _xspec.xsspln
 
     def __init__(self, name='spline'):
         self.Estart = Parameter(name, 'Estart', 0.1, 0., 100., 0.0, hugeval, 'keV')
@@ -5955,7 +6004,7 @@ class XSSSS_ice(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xssssi
+    _calc = _xspec.xssssi
 
     def __init__(self, name='sss_ice'):
         self.clumps = Parameter(name, 'clumps', 0.0, 0., 10., 0.0, hugeval)
@@ -5985,7 +6034,7 @@ class XSswind1(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.swind1
+    _calc = _xspec.swind1
 
     def __init__(self, name='swind1'):
         self.column = Parameter(name, 'column', 6., 3., 50., 0.0, hugeval)
@@ -6021,7 +6070,7 @@ class XSTBabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_tbabs
+    _calc = _xspec.C_tbabs
 
     def __init__(self, name='tbabs'):
         self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6065,7 +6114,7 @@ class XSTBgrain(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_tbgrain
+    _calc = _xspec.C_tbgrain
 
     def __init__(self, name='tbgrain'):
         self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6121,7 +6170,7 @@ class XSTBvarabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_tbvabs
+    _calc = _xspec.C_tbvabs
 
     def __init__(self, name='tbvarabs'):
         self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6186,7 +6235,7 @@ class XSuvred(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsred
+    _calc = _xspec.xsred
 
     def __init__(self, name='uvred'):
         self.EBV = Parameter(name, 'EBV', 0.05, 0., 10., 0.0, hugeval)
@@ -6220,7 +6269,7 @@ class XSvarabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsabsv
+    _calc = _xspec.xsabsv
 
     def __init__(self, name='varabs'):
         self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, hugeval, 'sH22', True)
@@ -6273,7 +6322,7 @@ class XSvphabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsvphb
+    _calc = _xspec.xsvphb
 
     def __init__(self, name='vphabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6318,7 +6367,7 @@ class XSwabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsabsw
+    _calc = _xspec.xsabsw
 
     def __init__(self, name='wabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6348,7 +6397,7 @@ class XSwndabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xswnab
+    _calc = _xspec.xswnab
 
     def __init__(self, name='wndabs'):
         self.nH = Parameter(name, 'nH', 1., 0., 10., 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6397,7 +6446,7 @@ class XSxion(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsxirf
+    _calc = _xspec.xsxirf
 
     def __init__(self, name='xion'):
         self.height = Parameter(name, 'height', 5., 0.0, 1.e2, 0.0, hugeval, 'r_s')
@@ -6440,7 +6489,7 @@ class XSzdust(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.mszdst
+    _calc = _xspec.mszdst
 
     def __init__(self, name='zdust'):
         self.method = Parameter(name, 'method', 1, 1, 3, 1, 3, alwaysfrozen=True)
@@ -6475,7 +6524,7 @@ class XSzedge(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszedg
+    _calc = _xspec.xszedg
 
     def __init__(self, name='zedge'):
         self.edgeE = Parameter(name, 'edgeE', 7.0, 0., 100., 0.0, hugeval, 'keV')
@@ -6509,7 +6558,7 @@ class XSzhighect(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszhcu
+    _calc = _xspec.xszhcu
 
     def __init__(self, name='zhighect'):
         self.cutoffE = Parameter(name, 'cutoffE', 10., 1.e-2, 100., 0.0, hugeval, 'keV')
@@ -6547,7 +6596,7 @@ class XSzpcfabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszabp
+    _calc = _xspec.xszabp
 
     def __init__(self, name='zpcfabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6616,7 +6665,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.zxipcf
+    _calc = _xspec.zxipcf
 
     def __init__(self, name='zxipcf'):
         self.Nh = Parameter(name, 'Nh', 10, 0.05, 500, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6649,7 +6698,7 @@ class XSzredden(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszcrd
+    _calc = _xspec.xszcrd
 
     def __init__(self, name='zredden'):
         self.EBV = Parameter(name, 'EBV', 0.05, 0., 10., 0.0, hugeval)
@@ -6680,7 +6729,7 @@ class XSzsmdust(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.msldst
+    _calc = _xspec.msldst
 
     def __init__(self, name='zsmdust'):
         self.EBV = Parameter(name, 'EBV', 0.1, 0.0, 100., 0.0, hugeval)
@@ -6718,7 +6767,7 @@ class XSzTBabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.C_ztbabs
+    _calc = _xspec.C_ztbabs
 
     def __init__(self, name='ztbabs'):
         self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6755,7 +6804,7 @@ class XSzvarabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszvab
+    _calc = _xspec.xszvab
 
     def __init__(self, name='zvarabs'):
         self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, hugeval, 'sH22', True)
@@ -6805,7 +6854,7 @@ class XSzvfeabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszvfe
+    _calc = _xspec.xszvfe
 
     def __init__(self, name='zvfeabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6847,7 +6896,7 @@ class XSzvphabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszvph
+    _calc = _xspec.xszvph
 
     def __init__(self, name='zvphabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6895,7 +6944,7 @@ class XSzwabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszabs
+    _calc = _xspec.xszabs
 
     def __init__(self, name='zwabs'):
         self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, hugeval, '10^22 atoms / cm^2')
@@ -6928,7 +6977,7 @@ class XSzwndabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszwnb
+    _calc = _xspec.xszwnb
 
     def __init__(self, name='zwndabs'):
         self.nH = Parameter(name, 'nH', 1., 0., 10., 0.0, hugeval, '10^22 atoms / cm^2')
@@ -7908,7 +7957,7 @@ class XSagauss(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_agauss
+    _calc = _xspec.C_agauss
 
     def __init__(self, name='agauss'):
         self.LineE = Parameter(name, 'LineE', 10.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
@@ -7943,7 +7992,7 @@ class XSzagauss(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.C_zagauss
+    _calc = _xspec.C_zagauss
 
     def __init__(self, name='zagauss'):
         self.LineE = Parameter(name, 'LineE', 10.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
@@ -7992,7 +8041,7 @@ class XScompmag(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xscompmag
+    _calc = _xspec.xscompmag
 
     def __init__(self, name='compmag'):
         self.kTbb = Parameter(name, 'kTbb', 1.0, 0.2, 10.0, 0.2, 10.0, 'keV')
@@ -8041,7 +8090,7 @@ class XScomptb(XSAdditiveModel):
 
     """
 
-    _calc =  _xspec.xscomptb
+    _calc = _xspec.xscomptb
 
     def __init__(self, name='comptb'):
         self.kTs = Parameter(name, 'kTs', 1.0, 0.1, 10.0, 0.1, 10.0, units='keV')
@@ -8079,7 +8128,7 @@ class XSheilin(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xsphei
+    _calc = _xspec.xsphei
 
     def __init__(self, name='heilin'):
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
@@ -8114,7 +8163,7 @@ class XSlyman(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xslyman
+    _calc = _xspec.xslyman
 
     def __init__(self, name='lyman'):
         self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, '10^22 atoms / cm^2')
@@ -8146,7 +8195,7 @@ class XSzbabs(XSMultiplicativeModel):
 
     """
 
-    _calc =  _xspec.xszbabs
+    _calc = _xspec.xszbabs
 
     def __init__(self, name='zbabs'):
         self.nH = Parameter(name, 'nH', 1.e-4, 0.0, 1.0e5, 0.0, 1.0e6, '10^22 atoms / cm^2')

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -113,6 +113,7 @@ void xsmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void C_xsmkcf(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 // void C_xneq(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void C_nei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_nlapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 // void xshock_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void C_npshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void nsa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -1155,6 +1156,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( xsmekl, 6 ),
   XSPECMODELFCT_C_NORM( C_xsmkcf, 6 ),
   XSPECMODELFCT_C_NORM( C_nei, 5 ),
+  XSPECMODELFCT_C_NORM( C_nlapec, 4 ),
   XSPECMODELFCT_C_NORM( C_npshock, 7 ),
   XSPECMODELFCT_NORM( nsa, 5 ),
   XSPECMODELFCT_NORM( nsagrav, 4 ),

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -24,6 +24,9 @@ from sherpa.utils import SherpaTestCase
 from sherpa.utils import requires_data, requires_fits, requires_xspec
 
 
+# How many models should there be?
+XSPEC_MODELS_COUNT = 165
+
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh
 #
@@ -181,7 +184,7 @@ class test_xspec(SherpaTestCase):
                 cls()
                 count += 1
 
-        self.assertEqual(count, 164)
+        self.assertEqual(count, XSPEC_MODELS_COUNT)
 
     def test_norm_works(self):
         # Check that the norm parameter for additive models


### PR DESCRIPTION
# Release Note
The `nlapec` XSpec model has been added. Note that XSPEC 12.9.0 is now required.

# Notes
This is supposed to replace #299. I edited the commit to have @DougBurke as author as he authored to code I edited.

This PR piggybacks #389 to run the tests with xspec 12.9.1n.