### PR TITLE
make requires_data a function so it works in CIAO too

### DIFF
--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -178,8 +178,14 @@ if HAS_PYTEST:
     #  standard library. The decorator will be defined if pytest is missing, but if the tests are run they throw
     #  and exception prompting users to install pytest, in those cases where pytest is not installed automatically.
 
-    requires_data = pytest.mark.skipif(SherpaTestCase.datadir is None,
-                                       reason="required test data missing")
+    def requires_data(test_function):
+        """
+         Decorator for functions requiring external data (i.e. data not distributed with Sherpa
+         itself) is missing.  This is used to skip tests that require such data.
+         """
+        condition = SherpaTestCase.datadir is None
+        msg = "required test data missing"
+        return pytest.mark.skipif(condition, reason=msg)(test_function)
 
 
     def requires_package(msg=None, *packages):

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -182,6 +182,8 @@ if HAS_PYTEST:
         """
          Decorator for functions requiring external data (i.e. data not distributed with Sherpa
          itself) is missing.  This is used to skip tests that require such data.
+
+         See PR #391 for why this is a function: https://github.com/sherpa/sherpa/pull/391
          """
         condition = SherpaTestCase.datadir is None
         msg = "required test data missing"


### PR DESCRIPTION
I just found out that since #370 those Sherpa tests that require the data folder have always been skipped in CIAO (they are executed or appropriately skipped in the Travis jobs).

This PR most likely ensures that tests are also properly executed in CIAO (we'll see on Tuesday, I just tested manually that the code works, but you never know). Note that there is no reason tests in CIAO should be skipped because of the test data missing.

The deepest reason why this is happening is obscure, but it has to do with the fact that tests are executed in a different way in CIAO, by explicitly calling pytest on the location where Sherpa is installed. This seems to yield to a different order in which `conftest.py` is executed with respect to when the tests are collected. Long story short, the tests are first marked to be skipped and then the data directory is made available to `SherpaTestCase`. There is probably a better implementation that would make this issue go away, but our setup is rather complex, as we have `unittest` and `pytest` style tests mixed together, and we want the data folder to be available in different ways, i.e. through the git submodule, as a package, or through the `--test-data` pytest argument. It doesn't make sense to review this now, but for future reference this could be a good starting point:
https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option 