### PR TITLE
XSPEC build and functionality improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,10 @@ before_install:
      sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
      export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
      export LD_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
+     export XSPEC_INCLUDE_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/include/;
      sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
      sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
+     sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=$XSPEC_INCLUDE_PATH|g" setup.cfg;
     fi
 
   # No test data, then remove submodule (git automatically clones recursively)

--- a/README.md
+++ b/README.md
@@ -451,13 +451,17 @@ used, but the full path should be in your own copy of the file):
 
  1. If the full XSPEC system has been built, then use
 
-        xspec_lib_dirs=$HEADAS/lib
-        ccfits_libraries=CCfits_2.5
-        wcs_libraries=wcs-5.16
+        xspec_include_dirs = $HEADAS/include
+        xspec_lib_dirs = $HEADAS/lib
+        xspec_libraries = XSFunctions XSModel XSUtil XS
+        cfitsio_libraries = cfitsio
+        ccfits_libraries = CCfits_2.5
+        wcs_libraries = wcs-5.16
 
     The environment variable `$HEADAS` should be expanded out, and the
     version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
-    may need to be changed, depending on the version of XSPEC.
+    may need to be changed, depending on the version of XSPEC (the
+    values given above are valid for XSPEC 12.9.1).
 
  2. Use the model-only build of XSPEC, which will also require
     building the
@@ -465,15 +469,22 @@ used, but the full path should be in your own copy of the file):
     [CCfits](http://heasarc.gsfc.nasa.gov/docs/software/fitsio/ccfits/),
     and
     [WCSLIB](http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/)
-    libraries. If all the libraries are installed into the same location
-    ($HEADAS/lib), then a similar set up to the full XSPEC build is used
+    libraries. If all the libraries are installed
+    into the same location ($HEADAS), then a similar set up to the
+    full XSPEC build is used
 
-        xspec_lib_dirs=$HEADAS/lib
+        xspec_include_dirs = $HEADAS/include
+        xspec_lib_dirs = $HEADAS/lib
+        xspec_libraries = XSFunctions XSModel XSUtil XS
+        cfitsio_libraries = cfitsio
+        ccfits_libraries = CCfits
+        wcs_libraries = wcs
 
-    and the appropriate `*_libraries` may need to be set. If the libraries
-    are placed in different directories then the `cfitsio_lib_dirs`,
-    `ccfits_lib_dirs`, and (possibly) `gfortran_lib_dirs` values should be
-    set appropriately.
+    although check on whether version numbers are required for the
+    `cfitiso`, `CCfits`, and `wcs` libraries. If placed in different
+    directories then the `cfitsio_lib_dirs`, `ccfits_lib_dirs`,
+    and (possibly) `gfortran_lib_dirs` values should be set
+    appropriately.
 
  3. or point to the XSPEC libraries provided by
     [CIAO](http://cxc.harvard.edu/ciao/). In this case the

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,26 +71,24 @@ bdist_wheel = sherpa_config bdist_wheel
 # If with-xspec is True, make sure to point Sherpa to right
 # XSPEC-related libraries.
 #
-# If you are using a full XSPEC build, then set xspec_lib_dirs
-# to $HEADAS/lib and add the correct version numbers to
-# the cfitsio, CCfits, and wcs libraries used in the build
-# (an example is cfitsio_3.37, CCfits_2.4, and wcs-4.20).
+# The xspec_include_dirs and xspec_lib_dirs items should be set
+# to $HEADAS/include and $HEADAS/lib respectively (expand out the
+# environment variable).
 #
-# If you are using the models-only XSPEC build, then set
-# xspec_lib_dirs to $HEADAS/lib (that is, the prefix setting
-# used to configure the build, with <os name>/lib appended to
-# it, where <os name> looks something like
-# 'x86_64-unknown-linux-gnu-libc2.21-0'). The cfitsio_lib_dirs,
+# If you are using a full XSPEC build, then add the correct version
+# numbers to the cfitsio, CCfits, and wcs libraries used in the build,
+# if necessary. For XSPEC 12.9.1 this means using CCfits_2.5 and
+# wcs-5.16.
+#
+# If you are using the models-only XSPEC build, then the cfitsio_lib_dirs,
 # ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if
-# these libraries are installed in a different location.
-#
-# If you are building against the XSPEC libraries provided as
-# part of CIAO then set xspec_lib_dirs to $ASCDS_INSTALL_LIB/ots
-# and set wcslib_libraries to None.
+# these libraries are installed in a different location to the XSPEC
+# libraries.
 #
 # The gfortran_lib_dirs should be set if needed.
 #
 #xspec_lib_dirs = None
+#xspec_include_dirs = None
 #xspec_libraries = XSFunctions XSModel XSUtil XS
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -185,11 +185,12 @@ def get_xsstate():
     set_xsstate
     """
 
+    # Do not return the internal dictionary but a copy of it.
     return {"abund": get_xsabund(),
             "chatter": get_xschatter(),
             "cosmo": get_xscosmo(),
             "xsect": get_xsxsect(),
-            "modelstrings": modelstrings}
+            "modelstrings": modelstrings.copy()}
 
 
 def set_xsstate(state):

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -68,6 +68,9 @@ except AttributeError:
 # http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSxset.html
 modelstrings = {}
 
+# Store any path changes
+xspecpaths = {}
+
 
 def get_xsxset(name):
     """Return the X-Spec model setting.
@@ -160,6 +163,40 @@ def set_xsxset(name, value):
         modelstrings[name] = get_xsxset(name)
 
 
+# Since these are not included in __all__, create a symbol in this
+# module to avoid "unused symbol" if they were to be imported
+# directly from _xspec.
+#
+get_xspath_manager = _xspec.get_xspath_manager
+get_xspath_model = _xspec.get_xspath_model
+
+
+def set_xspath_manager(path):
+    """Set the path to the files describing the XSPEC models.
+
+    Parameters
+    ----------
+    path : str
+        The new path.
+
+    See Also
+    --------
+    get_xspath_manager : Return the path to the files describing the XSPEC models.
+
+    Examples
+    --------
+    >>> set_xspath_manager('/data/xspec/spectral/manager')
+    """
+
+    _xspec.set_xspath_manager(path)
+    spath = get_xspath_manager()
+    if spath != path:
+        raise IOError("Unable to set the XSPEC manager path " +
+                      "to '{}'".format(path))
+
+    xspecpaths['manager'] = path
+
+
 # Provide XSPEC module state as a dictionary.  The "cosmo" state is
 # a 3-tuple, and "modelstrings" is a dictionary of model strings
 # applicable to certain models.  The abund and xsect settings are
@@ -168,6 +205,13 @@ def set_xsxset(name, value):
 # cosmo, xsect, and xset.
 # http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Control.html
 # http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Setting.html
+#
+# The path dictionary contains the manager path, which can be
+# explicitly set. It could also contain the model path, but there
+# is no XSPEC routine to change that; instead a user would set the
+# XSPEC_MDATA_DIR environment variable before starting XSPEC.
+# Should this path be included?
+#
 def get_xsstate():
     """Return the state of the XSPEC module.
 
@@ -176,8 +220,8 @@ def get_xsstate():
     state : dict
         The current settings for the XSPEC module, including but not
         limited to: the abundance and cross-section settings, parameters
-        for the cosmological model, and any XSET parameters that have
-        been set.
+        for the cosmological model, any XSET parameters that have been
+        set, and changes to the paths used by the model library.
 
     See Also
     --------
@@ -190,7 +234,8 @@ def get_xsstate():
             "chatter": get_xschatter(),
             "cosmo": get_xscosmo(),
             "xsect": get_xsxsect(),
-            "modelstrings": modelstrings.copy()}
+            "modelstrings": modelstrings.copy(),
+            "paths": xspecpaths.copy()}
 
 
 def set_xsstate(state):
@@ -200,8 +245,9 @@ def set_xsstate(state):
     ----------
     state : dict
         The current settings for the XSPEC module. This is expected to
-        match the return value of ``get_xsstate``, and so requires the
-        keys: 'abund', 'chatter', 'cosmo', 'xsect', and 'modelstrings'.
+        match the return value of ``get_xsstate``, and so uses the
+        keys: 'abund', 'chatter', 'cosmo', 'xsect', 'modelstrings',
+        and 'paths'.
 
     See Also
     --------
@@ -211,21 +257,37 @@ def set_xsstate(state):
     Notes
     -----
     The state of the XSPEC module will only be changed if all
-    the required keys in the dictionary are present.
+    the required keys in the dictionary are present. All keys apart
+    from 'paths' are required.
     """
 
-    if (type(state) == dict and
-        'abund' in state and
-        'chatter' in state and
-        'cosmo' in state and
-        'xsect' in state and
-        'modelstrings' in state):
+    if type(state) == dict and \
+       'abund' in state and \
+       'chatter' in state and \
+       'cosmo' in state and \
+       'xsect' in state and \
+       'modelstrings' in state:
+
+        h0, q0, l0 = state["cosmo"]
+
         set_xsabund(state["abund"])
         set_xschatter(state["chatter"])
-        set_xscosmo(state["cosmo"][0], state["cosmo"][1], state["cosmo"][2])
+        set_xscosmo(h0, q0, l0)
         set_xsxsect(state["xsect"])
         for name in state["modelstrings"].keys():
             set_xsxset(name, state["modelstrings"][name])
+
+        # This is optional to support re-loading state information
+        # from a version of XSPEC which did not provide the path
+        # information.
+        #
+        try:
+            managerpath = state['paths']['manager']
+        except KeyError:
+            managerpath = None
+
+        if managerpath is not None:
+            set_xspath_manager(managerpath)
 
 
 def read_xstable_model(modelname, filename):
@@ -297,6 +359,9 @@ def read_xstable_model(modelname, filename):
 
 
 # The model classes are added to __all__ at the end of the file
+#
+# Note that not all routines from _xspec are re-exported here.
+#
 __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'set_xschatter', 'set_xsabund', 'set_xscosmo', 'set_xsxsect',
            'get_xsversion', 'set_xsxset', 'get_xsxset', 'set_xsstate',

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -55,9 +55,14 @@ int _sherpa_init_xspec_library();
 // csmpq0	Put q$_0$.
 // xs_getVersion (or xgvers)	Retrieve XSPEC's version string.
 //
-// Functions which are currently not wrapped:
+// Functions which are not wrapped as their functionality is available:
 // RFLABD	Read abundance data from a file, then load and set this to be the current abundance table. (Essentially this combines a file read with the FPSLFL and FPSOLR functions.)
+//
+// Functions not wrapped as not felt to be that useful:
 // fzsq	Computes the luminosity distance, (c/H$_0$)*fzsq. The function is valid for small values of q$_0$*z for the case of no cosmological constant and uses the approximation of Pen (1999 ApJS 120, 49) for the case of a cosmological constant and a flat Universe. The function is not valid for non-zero cosmological constant if the Universe is not flat.
+//
+// Functions not wrapped since they are not useful as is (they need
+// functionality from 12.9.1 to set the XFLT keywords):
 // DGFILT	Get a particular XFLT keyword value from a data file.
 // DGNFLT	Get the number of XFLT keywords in a data file.
 //
@@ -266,6 +271,12 @@ void C_btapec(const double* energy, int nFlux, const double* params, int spectru
 
 }
 
+// This routine could be called when the module is being initialized,
+// but this would cause XSPEC module initialization even if XSPEC
+// functionality is not used. So each function/model has to ensure
+// that they call _sherpa_init_xspec_library before calling any
+// XSPEC routine.
+//
 // Sun's C++ compiler complains if this is declared static
 int _sherpa_init_xspec_library()
 {

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1045,7 +1045,7 @@ static PyMethodDef XSpecMethods[] = {
     (char*) "get_xscosmo()\n\n"
             "Return the X-Spec cosmology settings.\n"
             RETURNSDOC
-            "(h0,q0,l0)\n"
+            "(h0, q0, l0)\n"
             "   The Hubble constant, in km/s/Mpc, the deceleration\n"
             "   parameter, and the cosmological constant.\n"
             SEEALSODOC

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -29,32 +29,46 @@ int _sherpa_init_xspec_library();
 #include <iostream>
 #include <fstream>
 
+// The symbols listed in XSPEC version 12.9.1
+// at https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html
+// are given below. Note that this is the C/FORTRAN interface, not the
+// more-featureful FunctionUtility module.
+//
+// Functions which are used below:
+// FNINIT	Initializes data directory locations needed by the models. See below for a fuller description.
+// FGABND	Get an element abundance.
+// FGCHAT	Get current chatter level setting for model functions' output verbosity.
+// FPCHAT	Set the chatter level. Default is 10, higher chatter levels produce more output.
+// FGMSTR	Get a model string value (see XSPEC xset command).
+// FPMSTR	Set a model string value.
+// FPSLFL	Load values of a file solar abundance table (see abund command).
+// FGSOLR	Get the solar abundance table setting.
+// FPSOLR	Set the solar abundance table.
+// FGXSCT	Get the cross section table setting.
+// FPXSCT	Set the cross section table.
+// csmgh0	Get the cosmology H$_0$ setting (see the cosmo command).
+// csmph0	Set H$_0$.
+// csmgl0	Get $\Lambda_0$.
+// csmpl0	Set $\Lambda_0$.
+// csmgq0	Get q$_0$.
+// csmpq0	Put q$_0$.
+// xs_getVersion (or xgvers)	Retrieve XSPEC's version string.
+//
+// Functions which are currently not wrapped:
+// FGDATD	Get the model .dat files path.
+// FPDATD	Set the model .dat files path.
+// FGMODF	Get the model ion data path.
+// RFLABD	Read abundance data from a file, then load and set this to be the current abundance table. (Essentially this combines a file read with the FPSLFL and FPSOLR functions.)
+// fzsq	Computes the luminosity distance, (c/H$_0$)*fzsq. The function is valid for small values of q$_0$*z for the case of no cosmological constant and uses the approximation of Pen (1999 ApJS 120, 49) for the case of a cosmological constant and a flat Universe. The function is not valid for non-zero cosmological constant if the Universe is not flat.
+// DGFILT	Get a particular XFLT keyword value from a data file.
+// DGNFLT	Get the number of XFLT keywords in a data file.
+//
+#include "xsFortran.h"
+
+// TODO: is this defined in an XSPEC header file?
 #define ABUND_SIZE (30) // number of elements in Solar Abundance table
 
 extern "C" {
-
-// Lifted from XSPEC 12 include directory
-char* FGXSCT(void); 
-char* FGSOLR(void);
-
-char* FGMSTR(char* dname);
-float FGABND(char* element);
-
-void FPSOLR(const char* table, int* ierr);
-void FPXSCT(const char* csection, int* ierr);
-void FPMSTR(const char* value1, const char* value2);
-void FPSLFL(float rvalue[], int nvalue, int *ierr);
-
-void FNINIT(void);
-float csmgq0(void);
-float csmgh0(void);
-float csmgl0(void);
-void csmpq0(float q0);
-void csmph0(float H0);
-void csmpl0(float lambda0);
-int FGCHAT();
-void FPCHAT(int chat);
-int xs_getVersion(char* buffer, int buffSize);
 
 void xsaped_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -39,6 +39,9 @@ int _sherpa_init_xspec_library();
 // FPCHAT	Set the chatter level. Default is 10, higher chatter levels produce more output.
 // FGMSTR	Get a model string value (see XSPEC xset command).
 // FPMSTR	Set a model string value.
+// FGDATD	Get the model .dat files path.
+// FPDATD	Set the model .dat files path.
+// FGMODF	Get the model ion data path.
 // FPSLFL	Load values of a file solar abundance table (see abund command).
 // FGSOLR	Get the solar abundance table setting.
 // FPSOLR	Set the solar abundance table.
@@ -53,9 +56,6 @@ int _sherpa_init_xspec_library();
 // xs_getVersion (or xgvers)	Retrieve XSPEC's version string.
 //
 // Functions which are currently not wrapped:
-// FGDATD	Get the model .dat files path.
-// FPDATD	Set the model .dat files path.
-// FGMODF	Get the model ion data path.
 // RFLABD	Read abundance data from a file, then load and set this to be the current abundance table. (Essentially this combines a file read with the FPSLFL and FPSOLR functions.)
 // fzsq	Computes the luminosity distance, (c/H$_0$)*fzsq. The function is valid for small values of q$_0$*z for the case of no cosmological constant and uses the approximation of Pen (1999 ApJS 120, 49) for the case of a cosmological constant and a flat Universe. The function is not valid for non-zero cosmological constant if the Universe is not flat.
 // DGFILT	Get a particular XFLT keyword value from a data file.
@@ -721,7 +721,7 @@ static PyObject* set_cross( PyObject *self, PyObject *args )
     return NULL;
   }
 
-  Py_RETURN_NONE;  
+  Py_RETURN_NONE;
 
 }
 
@@ -756,7 +756,7 @@ static PyObject* set_xset( PyObject *self, PyObject *args )
     return NULL;
   }
 
-  Py_RETURN_NONE;  
+  Py_RETURN_NONE;
 
 }
 
@@ -823,6 +823,34 @@ static PyObject* get_manager_data_path( PyObject *self )
 static PyObject* get_model_data_path( PyObject *self )
 {
   return get_xspec_path("model", FGMODF);
+}
+
+static PyObject* set_manager_data_path( PyObject *self, PyObject *args )
+{
+
+  if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
+    return NULL;
+
+  char* path = NULL;
+
+  if ( !PyArg_ParseTuple( args, (char*)"s", &path ) )
+    return NULL;
+
+  try {
+
+    FPDATD( path );
+
+  } catch(...) {
+
+    std::ostringstream emsg;
+    emsg << "could not set XSPEC manager path to '" << path << "'";
+    PyErr_SetString( PyExc_ValueError,
+                     emsg.str().c_str() );
+    return NULL;
+  }
+
+  Py_RETURN_NONE;
+
 }
 
 // for documentation
@@ -1130,7 +1158,8 @@ static PyMethodDef XSpecMethods[] = {
             "   The path to the manager directory containing the various\n"
             "   *.dat files used by XSPEC.\n"
             SEEALSODOC
-            "set_xspath_model : Return the path to the model data files.\n"
+            "get_xspath_model : Return the path to the model data files.\n"
+            "set_xspath_manager : Set the path to the files describing the XSPEC models.\n"
             EXAMPLESDOC "\n"
             ">>> get_xspath_manager()\n"
             "'/usr/local/heasoft-6.22/x86_64-unknown-linux-gnu-libc2.24/../spectral/manager'\n\n"},
@@ -1144,10 +1173,22 @@ static PyMethodDef XSpecMethods[] = {
             "   The path to the directory containing the files used by\n"
             "   the XSPEC models.\n"
             SEEALSODOC
-            "set_xspath_manager : Return the path to the files describing the XSPEC models.\n"
+            "get_xspath_manager : Return the path to the files describing the XSPEC models.\n"
             EXAMPLESDOC "\n"
             ">>> get_xspath_model()\n"
             "'/usr/local/heasoft-6.22/x86_64-unknown-linux-gnu-libc2.24/../spectral/modelData'\n\n"},
+
+  { (char*)"set_xspath_manager",
+    (PyCFunction)set_manager_data_path, METH_VARARGS,
+    (char*) "set_xspath_manager(path)\n\n"
+            "Set the path to the files describing the XSPEC models.\n"
+            PARAMETERSDOC
+            "path : str\n"
+            "   The new path.\n"
+            SEEALSODOC
+            "get_xspath_manager : Return the path to the files describing the XSPEC models.\n"
+            EXAMPLESDOC "\n"
+            ">>> set_xspath_manager('/data/xspec/spectral/manager')\n\n"},
 
   XSPECMODELFCT_NORM( xsaped, 4 ),
   XSPECMODELFCT_NORM( xsbape, 5 ),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -61,6 +61,39 @@ int _sherpa_init_xspec_library();
 // DGFILT	Get a particular XFLT keyword value from a data file.
 // DGNFLT	Get the number of XFLT keywords in a data file.
 //
+// Other symbols in xsFortran.h are:
+// DGQFLT       Does a XFLT keyword exist?
+// PDBVAL       Set a database value
+//
+// Symbols in 12.9.1/HEASOFT 6.22 but not in 12.9.0/HEASOFT 6.19
+// FGABNZ
+// FGTABN
+// FGTABZ
+// FGELTI
+// FGNELT
+// FGABFL
+// FPABFL
+// FGAPTH
+// FPAPTH
+// csmpall
+// DPFILT
+// DCLFLT
+// GDBVAL
+// CDBASE
+// FGATDV
+// FPATDV
+//
+// These seem unlikely to be useful for Sherpa
+// xs_getChat
+// xs_write
+// xs_read
+//
+// These are numeric functions which we should have available elsewhere
+// xs_erf
+// xs_erfc
+// gammap
+// gammq
+//
 #include "xsFortran.h"
 
 // TODO: is this defined in an XSPEC header file?

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,6 +1,4 @@
-// 
-//  Copyright (C) 2007, 2015, 2016, 2017
-//     Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -68,18 +66,15 @@ int _sherpa_init_xspec_library();
 // TODO: is this defined in an XSPEC header file?
 #define ABUND_SIZE (30) // number of elements in Solar Abundance table
 
+// C_<model> are declared here
+#include "funcWrappers.h"
+
 extern "C" {
 
 void xsaped_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsblbd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbbrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-//void xsbexrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xsbexrav(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_xsbexriv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_brokenPowerLaw(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_broken2PowerLaw(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_sirf(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsbmc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbrms_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbvpe_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -88,16 +83,10 @@ void c6pmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float*
 void c6pvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void c6vmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void cemekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_cemVMekal(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xscflw_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xscflw(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void compbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void compls_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xscompps_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xscompps(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void compst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xstitg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_cutoffPowerLaw(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void disk_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void diskir_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsdskb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -106,81 +95,35 @@ void diskm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* p
 void disko_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void diskpbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsdiskpn_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// was  void xeq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_equil(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsxpdec_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void ezdiskbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsgaul_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xnneq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_gnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void grad_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsgrbm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_kerrbb(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_kerrdisk(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void spin_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xslaor(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void laor2_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_laor2(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xslorz_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsmeka_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xsmkcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xsmkcf(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void C_xneq(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_nei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_nlapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xshock_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_npshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void nsa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsagrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsatmos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsmax_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xsnteea_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xsnteea(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void nthcomp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_nthcomp(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xspegp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xspexrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xspexrav(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_xspexriv(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsp1tr_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_powerLaw(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsposm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xneqs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_pshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsrays_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xredge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsrefsch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xsedov_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_sedov(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void srcut_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void sresc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsstep_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbrmv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xseq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_vequil(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xsnneq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_vgnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsvmek_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xsvmcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xsvmcf(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void C_xsneq(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xsshock_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_vnpshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xsneqs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_vpshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsvrys_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xssedov_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_vsedov(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xszbod_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszbrm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xszgau_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xszgau(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_zpowerLaw(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_xsabsori(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void acisabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xscnst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xscabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -189,28 +132,17 @@ void xsdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void xsedge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsabsc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsexp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xsgabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_gaussianAbsorptionLine(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xshecu_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xshrfl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsntch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsabsp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsphab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsplab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void xspwab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xspwab(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xscred_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xssmdg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_superExpCutoff(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsspln_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xssssi_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void swind1_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void tbabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_tbabs(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void tbgrain_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_tbgrain(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void tbvabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_tbvabs(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsred_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsabsv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvphb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -225,8 +157,6 @@ void xszphb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void zxipcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszcrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void msldst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// void ztbabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_ztbabs(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xszvab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszvfe_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszvph_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -235,21 +165,12 @@ void xszwnb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 
 // New XSPEC 12.7 models
 
-void C_cplinear(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xseqpair_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xseqpair(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xseqth_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xseqth(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-// void xscompth_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_xscompth(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xsbvvp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvvap_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void zigm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
 // New XSPEC 12.7.1 models
 
-void C_gaussDem(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vgaussDem(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void logpar_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void eplogpar_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void optxagn_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -259,20 +180,10 @@ void pexmon_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 // Models from 12.8.0, 12.8.1, and 12.8.2
 
 // additive
-void C_agauss(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_zagauss(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xscompmag(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xscomptb(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void nsmaxg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsx_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void C_rnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vrnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vvrnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vvgnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vvnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vvnpshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vvpshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void C_vvsedov(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 
 //multiplicative
 void xsphei_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -789,6 +789,42 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 
 }
 
+// Perhaps this should be expanded to some of the other routines
+// that return a string, rather than just the paths?
+//
+static PyObject* get_xspec_path( const char *label, char *getfunc() )
+{
+
+  if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
+    return NULL;
+
+  char* str_value = NULL;
+  try {
+    str_value = getfunc();
+  } catch(...) {
+
+    std::ostringstream emsg;
+    emsg << "could not get XSPEC " << label << " path";
+    PyErr_SetString( PyExc_LookupError,
+                     emsg.str().c_str() );
+    return NULL;
+
+  }
+
+  return Py_BuildValue( (char*)"s", str_value );
+
+}
+
+static PyObject* get_manager_data_path( PyObject *self )
+{
+  return get_xspec_path("manager", FGDATD);
+}
+
+static PyObject* get_model_data_path( PyObject *self )
+{
+  return get_xspec_path("model", FGMODF);
+}
+
 // for documentation
 #define SEEALSODOC "\nSee also\n--------\n"
 #define NOTESDOC "\nNotes\n-----\n"
@@ -1084,6 +1120,34 @@ static PyMethodDef XSpecMethods[] = {
             "will only return a value if it has previously been set\n"
             "with a call to `set_xsxset`. There is no way to retrive\n"
             "the default value of a setting.\n\n"},
+
+  { (char*)"get_xspath_manager",
+    (PyCFunction)get_manager_data_path, METH_NOARGS,
+    (char*) "get_xspath_manager()\n\n"
+            "Return the path to the files describing the XSPEC models.\n"
+            RETURNSDOC
+            "path : str\n"
+            "   The path to the manager directory containing the various\n"
+            "   *.dat files used by XSPEC.\n"
+            SEEALSODOC
+            "set_xspath_model : Return the path to the model data files.\n"
+            EXAMPLESDOC "\n"
+            ">>> get_xspath_manager()\n"
+            "'/usr/local/heasoft-6.22/x86_64-unknown-linux-gnu-libc2.24/../spectral/manager'\n\n"},
+
+  { (char*)"get_xspath_model",
+    (PyCFunction)get_model_data_path, METH_NOARGS,
+    (char*) "get_xspath_model()\n\n"
+            "Return the path to the model data files.\n"
+            RETURNSDOC
+            "path : str\n"
+            "   The path to the directory containing the files used by\n"
+            "   the XSPEC models.\n"
+            SEEALSODOC
+            "set_xspath_manager : Return the path to the files describing the XSPEC models.\n"
+            EXAMPLESDOC "\n"
+            ">>> get_xspath_model()\n"
+            "'/usr/local/heasoft-6.22/x86_64-unknown-linux-gnu-libc2.24/../spectral/modelData'\n\n"},
 
   XSPECMODELFCT_NORM( xsaped, 4 ),
   XSPECMODELFCT_NORM( xsbape, 5 ),

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,11 +20,360 @@
 # Supplement test_xspec.py with py.test tests
 #
 
+from tempfile import NamedTemporaryFile
+
 import pytest
+import six
 
 from numpy.testing import assert_almost_equal
 
 from sherpa.utils import requires_data, requires_fits, requires_xspec
+
+
+# It is hard to test many of the state routines, since it requires
+# a full understanding of how they are implemented; the simplest
+# way is to check those that change the state and ensure values
+# pass through a round trip - i.e. that if you set it to a given
+# value then request it, you get back the value you set.
+#
+# There is currently no (or limited) checks for invalid inputs.
+#
+
+# The following can depend on the XSPEC version; how much of a
+# contract do we want to make with the initialization code to set
+# to our values versus the default XSPEC settings?
+#
+DEFAULT_ABUND = 'angr'
+DEFAULT_XSECT = 'bcmc'
+
+# XSPEC presmably has its own default for these, but Sherpa explicitly
+# sets values for these parameters.
+#
+DEFAULT_CHATTER = 0
+DEFAULT_COSMO = (70.0, 0.0, 0.73)
+
+# The XSET names are (currently) not validated, so pick a name that
+# will not be used by an actual model so we can set it.
+#
+DEFAULT_XSET_NAME = 'SHERPA-TEST-DUMMY-NAME'
+DEFAULT_XSET_VALUE = ''
+
+# The number of elements in the abundance table
+ELEMENT_NAMES = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
+                 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K',
+                 'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni',
+                 'Cu', 'Zn']
+NELEM = len(ELEMENT_NAMES)
+
+
+@pytest.mark.xfail
+@requires_xspec
+def test_chatter_default():
+    """Check the expected default setting for chatter.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+
+    For some reason the chatter setting appears to default to 50,
+    rather than 0. It is not at all clear why, so has been marked
+    as xfail.
+
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xschatter()
+    assert oval == DEFAULT_CHATTER
+
+
+@requires_xspec
+def test_version():
+    """Can we get at the XSPEC version?
+
+    There is limited testing of the return value.
+    """
+
+    from sherpa.astro import xspec
+
+    v = xspec.get_xsversion()
+    assert isinstance(v, six.string_types)
+    assert len(v) > 0
+
+    # Could check it's of the form a.b.c[optional] but leave that for
+    # now.
+
+
+@requires_xspec
+def test_abund_default():
+    """Check the expected default setting for the abundance.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xsabund()
+    assert oval == DEFAULT_ABUND
+
+
+@requires_xspec
+def test_xset_default():
+    """Check the expected default setting for the xset setting.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+
+    This is tricky since XSPEC does not return a value until
+    one has been set (that is, if it returns '' then the
+    setting is presumably taken to be "use the default value"
+    by the model code).
+    """
+
+    from sherpa.astro import xspec
+
+    # The test is case insensitive, but this test doesn't really
+    # test this out (since it is expected to return '' whatever
+    # the input name is).
+    #
+    name = DEFAULT_XSET_NAME.lower()
+    oval = xspec.get_xsxset(name)
+    assert oval == DEFAULT_XSET_VALUE
+
+
+@requires_xspec
+def test_xsect_default():
+    """Check the expected default setting for the xsect setting.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xsxsect()
+    assert oval == DEFAULT_XSECT
+
+
+@requires_xspec
+def test_cosmo_default():
+    """Check the expected default setting for the cosmology settings.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xscosmo()
+
+    # Since this is a tuple of numbers, check individually
+    assert len(oval) == 3
+    assert oval[0] == pytest.approx(DEFAULT_COSMO[0])
+    assert oval[1] == pytest.approx(DEFAULT_COSMO[1])
+    assert oval[2] == pytest.approx(DEFAULT_COSMO[2])
+
+
+@requires_xspec
+def test_abund_element():
+    """Can we access the elemental settings?
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xsabund()
+    try:
+        xspec.set_xsabund('wilm')
+        h = xspec.get_xsabund('H')
+        he = xspec.get_xsabund('He')
+        si = xspec.get_xsabund('Si')
+        ar = xspec.get_xsabund('Ar')
+        k = xspec.get_xsabund('K')
+        fe = xspec.get_xsabund('Fe')
+
+    finally:
+        xspec.set_xsabund(oval)
+
+    # These values were found from HEASOFT version 6.19
+    # spectral/manager/abundances.dat
+    # The values are given to two decimal places in this file.
+    # It is not worth testing all settings, since we are not
+    # testing the XSPEC implementation itself, just our use of it.
+    #
+    assert h == pytest.approx(1.0)
+    assert he == pytest.approx(9.77e-2)
+    assert si == pytest.approx(1.86e-05)
+    assert ar == pytest.approx(2.57e-06)
+    assert k == pytest.approx(0.0)
+    assert fe == pytest.approx(2.69e-05)
+
+
+def validate_xspec_setting(getfunc, setfunc, newval, altval):
+    """Check we can change an XSPEC setting.
+
+    Parameters
+    ----------
+    getfunc : function
+        The XSPEC function to query the setting: it returns a
+        value and has no arguments.
+    setfunc : function
+        The XSPEC function to change the setting: it takes a
+        single argument and returns nothing.
+    newval, altval
+        The value to use (newval) and an alternative (altval) if
+        the current setting is already at newval (this is perhaps
+        a bit excessive but it avoids issues if other tests have
+        changed things).
+    """
+
+    oval = getfunc()
+    if oval == newval:
+        nval = altval
+    else:
+        nval = newval
+
+    try:
+        setfunc(nval)
+        xval = getfunc()
+    finally:
+        setfunc(oval)
+
+    assert xval == nval
+    assert getfunc() == oval
+
+
+@requires_xspec
+def test_chatter_change():
+    """Can we change the chatter setting."""
+
+    from sherpa.astro import xspec
+
+    validate_xspec_setting(xspec.get_xschatter,
+                           xspec.set_xschatter,
+                           25, 35)
+
+
+@requires_xspec
+def test_abund_change_string():
+    """Can we change the abundance setting: string
+
+    This only checks that we can use one of the hard-coded
+    abundance names. It does not check the file I/O.
+    """
+
+    from sherpa.astro import xspec
+
+    validate_xspec_setting(xspec.get_xsabund,
+                           xspec.set_xsabund,
+                           'grsa', 'wilm')
+
+
+@requires_xspec
+def test_abund_change_file():
+    """Can we change the abundance setting: file
+
+    This test hard-codes the number of elements expected in the
+    file.
+    """
+
+    from sherpa.astro import xspec
+
+    elems = {n: i * 0.1 for i, n in enumerate(ELEMENT_NAMES)}
+
+    tfh = NamedTemporaryFile(mode='w', suffix='.xspec')
+    for n in ELEMENT_NAMES:
+        tfh.write("{}\n".format(elems[n]))
+
+    tfh.flush()
+
+    oval = xspec.get_xsabund()
+    try:
+        xspec.set_xsabund(tfh.name)
+
+        abund = xspec.get_xsabund()
+        out = {n: xspec.get_xsabund(n)
+               for n in ELEMENT_NAMES}
+
+    finally:
+        xspec.set_xsabund(oval)
+
+    assert abund == 'file'
+    for n in ELEMENT_NAMES:
+        assert out[n] == pytest.approx(elems[n])
+
+
+@requires_xspec
+def test_xset_change():
+    """Can we change the xset setting.
+    """
+
+    from sherpa.astro import xspec
+
+    def getfunc():
+        return xspec.get_xsxset(DEFAULT_XSET_NAME)
+
+    def setfunc(val):
+        xspec.set_xsxset(DEFAULT_XSET_NAME.lower(), val)
+
+    val1 = 'dummy value'
+    val2 = 'a different setting'
+    validate_xspec_setting(getfunc, setfunc, val1, val2)
+
+    # A separate part of the XSET interface is that the settings
+    # are recorded in the XSPEC state maintained by the xspec
+    # module, so check that the stored value is included in this.
+    #
+    modelvals = xspec.get_xsstate()['modelstrings']
+    assert DEFAULT_XSET_NAME in modelvals
+
+    # Is it worth changing the code so we know which to check for?
+    assert modelvals[DEFAULT_XSET_NAME] in [val1, val2]
+
+
+@requires_xspec
+def test_xsect_change():
+    """Can we change the xsect setting: string
+
+    This only checks that we can use one of the hard-coded
+    abundance names. It does not check the file I/O.
+    """
+
+    from sherpa.astro import xspec
+
+    validate_xspec_setting(xspec.get_xsxsect,
+                           xspec.set_xsxsect,
+                           'obcm', 'vern')
+
+
+@requires_xspec
+def test_cosmo_change():
+    """Can we change the cosmology settings.
+    """
+
+    from sherpa.astro import xspec
+
+    old_h0, old_q0, old_l0 = xspec.get_xscosmo()
+
+    new_h0 = 51.0
+    new_q0 = 0.2
+    new_l0 = 0.48
+
+    if old_h0 == pytest.approx(new_h0):
+        new_h0 -= 10.0
+    if old_q0 == pytest.approx(new_q0):
+        new_q0 -= 0.05
+    if old_l0 == pytest.approx(new_l0):
+        new_l0 += 0.01
+
+    try:
+        xspec.set_xscosmo(new_h0, new_q0, new_l0)
+        nval_h0, nval_q0, nval_l0 = xspec.get_xscosmo()
+    finally:
+        xspec.set_xscosmo(old_h0, old_q0, old_l0)
+
+    assert nval_h0 == pytest.approx(new_h0)
+    assert nval_q0 == pytest.approx(new_q0)
+    assert nval_l0 == pytest.approx(new_l0)
 
 
 @requires_data

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -20,6 +20,7 @@
 # Supplement test_xspec.py with py.test tests
 #
 
+import os
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -153,6 +154,44 @@ def test_xsect_default():
 
     oval = xspec.get_xsxsect()
     assert oval == DEFAULT_XSECT
+
+
+@requires_xspec
+def test_manager_path_default():
+    """Check the expected default setting for the manager path.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+    """
+
+    # Is this always going to be correct?
+    default_path = os.path.join(os.environ['HEADAS'],
+                                '../spectral/manager')
+
+    # At present this is not exposed in the xspec module
+    from sherpa.astro.xspec import _xspec
+
+    oval = _xspec.get_xspath_manager()
+    assert oval == default_path
+
+
+@requires_xspec
+def test_model_path_default():
+    """Check the expected default setting for the model data path.
+
+    Ideally this test would be run before any other
+    tests of XSPEC are made (i.e. any XSPEC code is called).
+    """
+
+    # Is this always going to be correct?
+    default_path = os.path.join(os.environ['HEADAS'],
+                                '../spectral/modelData/')
+
+    # At present this is not exposed in the xspec module
+    from sherpa.astro.xspec import _xspec
+
+    oval = _xspec.get_xspath_model()
+    assert oval == default_path
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -183,12 +183,16 @@ def test_model_path_default():
     tests of XSPEC are made (i.e. any XSPEC code is called).
     """
 
-    # Is this always going to be correct?
-    default_path = os.path.join(os.environ['HEADAS'],
-                                '../spectral/modelData/')
-
     # At present this is not exposed in the xspec module
     from sherpa.astro.xspec import _xspec
+
+    # Is this always going to be correct?
+    #
+    try:
+        default_path = os.environ['XSPEC_MDATA_DIR']
+    except KeyError:
+        default_path = os.path.join(os.environ['HEADAS'],
+                                    '../spectral/modelData/')
 
     oval = _xspec.get_xspath_model()
     assert oval == default_path

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -21,7 +21,7 @@
 #
 
 import os
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, gettempdir
 
 import pytest
 import six
@@ -282,6 +282,8 @@ def validate_xspec_setting(getfunc, setfunc, newval, altval):
         setfunc(oval)
 
     assert xval == nval
+
+    # As a sanity check ensure we are back at the starting point
     assert getfunc() == oval
 
 
@@ -417,6 +419,19 @@ def test_cosmo_change():
     assert nval_h0 == pytest.approx(new_h0)
     assert nval_q0 == pytest.approx(new_q0)
     assert nval_l0 == pytest.approx(new_l0)
+
+
+@requires_xspec
+def test_path_manager_change():
+    """Can we change the manager-path setting?
+    """
+
+    from sherpa.astro.xspec import _xspec
+
+    validate_xspec_setting(_xspec.get_xspath_manager,
+                           _xspec.set_xspath_manager,
+                           '/dev/null',
+                           gettempdir())
 
 
 @requires_data

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -297,13 +297,6 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
           XSpecFunc( &fear[0], &npts, &pars[0], &ifl,
                      &result[0], &error[0] );
 
-	} catch(std::exception& exc) {
-
-          std::ostringstream err;
-          err << "XSPEC model evaluation failed: " << exc.what();
-          PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-          return NULL;
-
 	} catch(...) {
 
           PyErr_SetString( PyExc_ValueError,
@@ -535,13 +528,6 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
           int npts = ngrid - 1;
           XSpecFunc( &ear[0], npts, &pars[0], ifl,
                      &result[0], &error[0], NULL );
-
-	} catch(std::exception& exc) {
-
-          std::ostringstream err;
-          err << "XSPEC model evaluation failed: " << exc.what();
-          PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-          return NULL;
 
 	} catch(...) {
 
@@ -1251,13 +1237,6 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
           int npts = ngrid - 1;
           XSpecFunc( &fear[0], npts, &pars[0], filename, ifl,
                      &result[0], &error[0] );
-
-	} catch(std::exception& exc) {
-
-          std::ostringstream err;
-          err << "XSPEC model evaluation failed: " << exc.what();
-          PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-          return NULL;
 
 	} catch(...) {
 

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -297,6 +297,13 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
           XSpecFunc( &fear[0], &npts, &pars[0], &ifl,
                      &result[0], &error[0] );
 
+	} catch(std::exception& exc) {
+
+          std::ostringstream err;
+          err << "XSPEC model evaluation failed: " << exc.what();
+          PyErr_SetString( PyExc_ValueError, err.str().c_str() );
+          return NULL;
+
 	} catch(...) {
 
           PyErr_SetString( PyExc_ValueError,
@@ -528,6 +535,13 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
           int npts = ngrid - 1;
           XSpecFunc( &ear[0], npts, &pars[0], ifl,
                      &result[0], &error[0], NULL );
+
+	} catch(std::exception& exc) {
+
+          std::ostringstream err;
+          err << "XSPEC model evaluation failed: " << exc.what();
+          PyErr_SetString( PyExc_ValueError, err.str().c_str() );
+          return NULL;
 
 	} catch(...) {
 
@@ -1237,6 +1251,13 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
           int npts = ngrid - 1;
           XSpecFunc( &fear[0], npts, &pars[0], filename, ifl,
                      &result[0], &error[0] );
+
+	} catch(std::exception& exc) {
+
+          std::ostringstream err;
+          err << "XSPEC model evaluation failed: " << exc.what();
+          PyErr_SetString( PyExc_ValueError, err.str().c_str() );
+          return NULL;
 
 	} catch(...) {
 


### PR DESCRIPTION
# Release notes

Add support for reading and changing the path to the XSPEC "manager" directory, and reading the current XSPEC "model" directory (`get_xspath_manager`, `set_xspath_manager`, and `get_xspath_model`). These are intended for the power user and so require an explicit import from `sherpa.astro.xspec`.

There are several improvements to the build and interface to the XSPEC model library: these have no user-visible changes.

# Details

At present this code is intended to build with XSPEC 12.9.0. There are additional routines which could be implemented if we 

- bumped out minimum version to XSPEC 12.9.1
- started using the C++ `FunctionUtility` code rather than `xsFortran`, but there are implications on the build (see the Issues section below)
- take advantage of the "optional" machinery introduced in #395

# Status

Ready for review. I've left it as pr:hold since I expect it to clash with other XSPEC-related PRs we have going.

This adds basic tests for existing XSPEC functionality, namely reading
and writing values such as the abundance and cross section tables,
as well as the chatter settings.

One test is marked as "expected fail" as it is not clear why it returns
a chatter setting of 50 rather than 0. Actually, this is down to Sherpa test suite changing the chatter level for the tests. Options are to stop this or change the expected value in the test; I prefer the former but not strongly.

The code has been changed to use XSPEC's own include file for declaring functions, rather than using our own internal copy of this file.

Interfaces to three functions have been added (read and write of the manager path, read the model path) . The "state" mechanism we use for the XSPEC module has been updated to support this (only the manager path), and tests added for the state handling (there were none).

# Issues

The state-handling tests have shown up an issue that could be addressed, but it needs thinking about and may best be done outside the PR: the problem is that if a user has used `set_xsxset` or `set_xspath_manager` and then used `load_xsstate` to load in a new XSPEC state, there is no guarantee that the changes made will be reverted. There is a relatively-clear way to do this for the xset case (explicitly set the currently-set variables to `""` before loading in a new state), but not so obvious for the path (since there's no "default" value like `""` here).

I would have liked to use the C++ `FunctionUtility` interface rather than the `xsFortran` wrapper around it which we currently use, since it has more features, and the XSPEC team suggest it's the better choice for C++ code. However, there are include issues with this - the include files in an XSPEC installation don't have the same directory structure as the build environment, which causes include problems - which makes it only really feasible to go with this approach if we use the XSPEC build location rather than the install location. This is not unprecedented - it is the only way to build user models when using the XSPEC executable - but isn't really what we want for Sherpa.