### PR TITLE
update zenodo doi with the one listed in zenodo itself [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ extend (whether to other areas of Astronomy or in other domains).
 Release History
 ---------------
 
-4.9.1: 01 August 2017 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.825839.svg)](https://doi.org/10.5281/zenodo.825839)
+4.9.1: 01 August 2017 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.838686.svg)](https://doi.org/10.5281/zenodo.838686)
 
 4.9.0: 27 January 2017 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.260416.svg)](https://doi.org/10.5281/zenodo.260416)
 


### PR DESCRIPTION
Long overdue but trivial update to Zenodo's DOI. We included a DOI that I had "reserved" before the release on GitHub, but that DOI wasn't used to automatically create the new release on Zenodo, and it can't be changed now. So we change the README instead.