### PR TITLE
Ensure 0-length array is an error in filter_resp (fix #405)

### DIFF
--- a/sherpa/astro/utils/src/_utils.cc
+++ b/sherpa/astro/utils/src/_utils.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2017  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -252,6 +252,12 @@ namespace sherpa { namespace astro { namespace utils {
 			    &matrix,
 			    &offset) )
       return NULL;
+
+    if (0 == noticed_chans.get_size()) {
+      PyErr_SetString( PyExc_ValueError,
+		       (char*)"There are no noticed channels" );
+      return NULL;
+    }
 
     if( EXIT_SUCCESS != mask.zeros( 1, n_grp.get_dims() ))
       return NULL;

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -25,7 +25,6 @@ from sherpa.utils import requires_data, requires_fits
 
 
 # See https://github.com/sherpa/sherpa/issues/405
-@pytest.mark.xfail
 def test_filter_resp_nochans():
     """What happens if no channels?
 
@@ -49,7 +48,6 @@ def test_filter_resp_nochans():
 # See https://github.com/sherpa/sherpa/issues/405
 @requires_data
 @requires_fits
-@pytest.mark.xfail
 def test_rmf_filter_no_chans(make_data_path):
     """This is not really a unit test but placed here as it
     is related to test_filter_resp_nochans.

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -1,0 +1,64 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import pytest
+
+from sherpa.astro import ui
+from sherpa.astro.utils import filter_resp
+from sherpa.utils import requires_data, requires_fits
+
+
+# See https://github.com/sherpa/sherpa/issues/405
+@pytest.mark.xfail
+def test_filter_resp_nochans():
+    """What happens if no channels?
+
+    It could be an error, or empty arrays could be returned.
+    """
+
+    # fake up an RMF
+    ngrp = [1, 1]
+    f_chan = [1, 2]
+    n_chan = [1, 1]
+    matrix = [1.0, 1.0]
+    offset = 1
+
+    with pytest.raises(ValueError) as excinfo:
+        filter_resp([], ngrp, f_chan, n_chan, matrix, offset)
+
+    emsg = "There are no noticed channels"
+    assert str(excinfo.value) == emsg
+
+
+# See https://github.com/sherpa/sherpa/issues/405
+@requires_data
+@requires_fits
+@pytest.mark.xfail
+def test_rmf_filter_no_chans(make_data_path):
+    """This is not really a unit test but placed here as it
+    is related to test_filter_resp_nochans.
+    """
+
+    rmffile = make_data_path('3c273.rmf')
+    rmf = ui.unpack_rmf(rmffile)
+    with pytest.raises(ValueError) as excinfo:
+        rmf.notice([])
+
+    emsg = "There are no noticed channels"
+    assert str(excinfo.value) == emsg


### PR DESCRIPTION
# Release Note
Add an explicit check in the C++ filter_resp code to error out if the noticed channels array is empty.

# Notes
This fixes #405.

This is currently the minimal change needed to avoid reading from uninitialized memory with a RMF. I have not audited the other C++ code to see if similar checks should be added. The behavior of the higher-level code (i.e. the Python objects) is up for debate.

# Details

It is not yet clear to me whether we should error out when asking to filter a RMF with an empty channel array, but it seems to fit into other parts of how Sherpa deals with this. Note that it might make sense for the low-level code (such as that changed here) to error out, but the RMF code to explicitly check for the "no channel" case and to handle it separately (e.g. `sherpa.astro.data.DataRMF.ignore`).