### PR TITLE
EmissionGaussian model when skew parameter is not unity (fix #403)

### DIFF
--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -54,10 +54,16 @@ _tol = numpy.finfo(numpy.float32).eps
 # These models work in wavelength space (Angstroms).
 #
 
-__all__ = ('AbsorptionEdge', 'AccretionDisk', 'AbsorptionGaussian', 'AbsorptionLorentz', 'EmissionLorentz', 'OpticalGaussian', 'EmissionGaussian', 'AbsorptionVoigt', 'BlackBody', 'Bremsstrahlung', 'BrokenPowerlaw', 'CCM', 'LogAbsorption', 'LogEmission', 'Polynomial', 'Powerlaw', 'Recombination', 'EmissionVoigt', 'XGal', 'FM', 'LMC', 'SM', 'SMC', 'Seaton')
+__all__ = ('AbsorptionEdge', 'AccretionDisk', 'AbsorptionGaussian',
+           'AbsorptionLorentz', 'EmissionLorentz', 'OpticalGaussian',
+           'EmissionGaussian', 'AbsorptionVoigt', 'BlackBody',
+           'Bremsstrahlung', 'BrokenPowerlaw', 'CCM', 'LogAbsorption',
+           'LogEmission', 'Polynomial', 'Powerlaw', 'Recombination',
+           'EmissionVoigt', 'XGal', 'FM', 'LMC', 'SM', 'SMC', 'Seaton')
 
 # The speed of light in km/s
 c_km = 2.99792458e+5
+
 
 # Helper function, to do a particular sort of crude interpolation
 # from tables supplied for certain extinction curves.  No general
@@ -76,18 +82,19 @@ def _extinct_interp(xtable, etable, x):
             out[i] = etable[last]
         else:
             index = 0
-            for j in xrange(last+1):
-                if (xval < xtable[j]):
+            for j in xrange(last + 1):
+                if xval < xtable[j]:
                     index = j
                     break
-            x1 = xtable[index-1]
+            x1 = xtable[index - 1]
             x2 = xtable[index]
-            e1 = etable[index-1]
+            e1 = etable[index - 1]
             e2 = etable[index]
 
             out[i] = ((e2 - e1) / (x2 - x1)) * (xval - x1) + e1
 
     return out
+
 
 # This model sets in edge (in Angstroms) beyond which absorption
 # is a significant feature to the spectrum or SED.
@@ -126,7 +133,8 @@ class AbsorptionEdge(ArithmeticModel):
     """
 
     def __init__(self, name='absorptionedge'):
-        self.edgew = Parameter(name, 'edgew', 5000., tinyval, frozen=True, units='angstroms')
+        self.edgew = Parameter(name, 'edgew', 5000., tinyval,
+                               frozen=True, units='angstroms')
         self.tau = Parameter(name, 'tau', 0.5)
         self.index = Parameter(name, 'index', 3.0, alwaysfrozen=True,
                                hidden=True)
@@ -136,7 +144,7 @@ class AbsorptionEdge(ArithmeticModel):
 
     # We can turn on model caching with this commented-out feature,
     # if we find we need it.
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.ones_like(x)
@@ -146,8 +154,9 @@ class AbsorptionEdge(ArithmeticModel):
                              '%s edgew cannot be zero' % self.name)
 
         idx = (x <= p[0])
-        y[idx] = numpy.exp(-(p[1]*numpy.power(x[idx]/p[0], p[2])))
+        y[idx] = numpy.exp(-(p[1] * numpy.power(x[idx] / p[0], p[2])))
         return y
+
 
 # This model is an accretion disk continuum function.
 class AccretionDisk(ArithmeticModel):
@@ -178,16 +187,17 @@ class AccretionDisk(ArithmeticModel):
 
     def __init__(self, name='accretiondisk'):
 
-        self.ref = Parameter(name, 'ref', 5000., frozen=True, units='angstroms')
+        self.ref = Parameter(name, 'ref', 5000., frozen=True,
+                             units='angstroms')
         self.beta = Parameter(name, 'beta', 0.5, -10, 10)
         self.ampl = Parameter(name, 'ampl', 1.)
-        self.norm = Parameter(name, 'norm', 20000.0, tinyval, alwaysfrozen=True,
-                              hidden=True)
+        self.norm = Parameter(name, 'norm', 20000.0, tinyval,
+                              alwaysfrozen=True, hidden=True)
 
         ArithmeticModel.__init__(self, name,
                                  (self.ref, self.beta, self.ampl, self.norm))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -199,7 +209,7 @@ class AccretionDisk(ArithmeticModel):
             raise ValueError('model evaluation failed, ' +
                              'norm cannot be zero')
 
-        return p[2]*numpy.power(x/p[3], -p[1])*numpy.exp(-p[0]/x)
+        return p[2] * numpy.power(x / p[3], -p[1]) * numpy.exp(-p[0] / x)
 
 
 # This model calculates a Gaussian function expressed in
@@ -252,7 +262,8 @@ class AbsorptionGaussian(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.ewidth = Parameter(name, 'ewidth', 1.)
         self.limit = Parameter(name, 'limit', 4., alwaysfrozen=True,
                                hidden=True )
@@ -260,7 +271,7 @@ class AbsorptionGaussian(ArithmeticModel):
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.ewidth, self.limit))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -281,6 +292,7 @@ class AbsorptionGaussian(ArithmeticModel):
         y[idx] = 1.0 - ampl * numpy.exp(- delta[idx] * delta[idx] / 2.0)
 
         return y
+
 
 # This model calculates a Lorentzian function expressed in
 # equivalent width, and models absorption due to this Lorentzian.
@@ -325,12 +337,14 @@ class AbsorptionLorentz(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.ewidth = Parameter(name, 'ewidth', 1.)
 
-        ArithmeticModel.__init__(self, name, (self.fwhm, self.pos, self.ewidth))
+        ArithmeticModel.__init__(self, name,
+                                 (self.fwhm, self.pos, self.ewidth))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -347,6 +361,7 @@ class AbsorptionLorentz(ArithmeticModel):
         y *= 1.571 * p[0] * p[1] / c_km
         y = 1.0 - p[2] / y
         return y
+
 
 # This model computes a Lorentzian profile for emission features.
 class EmissionLorentz(ArithmeticModel):
@@ -391,14 +406,15 @@ class EmissionLorentz(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.flux = Parameter(name, 'flux', 1.)
         self.kurt = Parameter(name, 'kurt', 2., frozen=True)
 
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.flux, self.kurt))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -411,11 +427,13 @@ class EmissionLorentz(ArithmeticModel):
                              '%s pos cannot be zero' % self.name)
 
         sigma = p[0] * p[1] / c_km
-        arg = numpy.power(numpy.abs(x - p[1]), p[3]) + sigma/2.0 * sigma/2.0
+        arg = numpy.power(numpy.abs(x - p[1]), p[3]) + \
+            sigma / 2.0 * sigma / 2.0
 
-        arg[arg<1.0e-15] = 1.0e-15
+        arg[arg < 1.0e-15] = 1.0e-15
 
-        return p[2] * sigma / arg / (numpy.pi*2)
+        return p[2] * sigma / arg / (numpy.pi * 2)
+
 
 # This model computes an absorption Gaussian feature expressed in
 # optical depth.
@@ -467,7 +485,8 @@ class OpticalGaussian(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.tau = Parameter(name, 'tau', 0.5)
         self.limit = Parameter(name, 'limit', 4., alwaysfrozen=True,
                                hidden=True )
@@ -475,7 +494,7 @@ class OpticalGaussian(ArithmeticModel):
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.tau, self.limit))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -495,6 +514,7 @@ class OpticalGaussian(ArithmeticModel):
         y[idx] = numpy.exp(-p[2] * numpy.exp(- delta[idx] * delta[idx] / 2.0))
 
         return y
+
 
 # This model computes a Gaussian profile for emission features.
 class EmissionGaussian(ArithmeticModel):
@@ -555,7 +575,8 @@ class EmissionGaussian(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.flux = Parameter(name, 'flux', 1.)
         self.skew = Parameter(name, 'skew', 1., tinyval, frozen=True)
         self.limit = Parameter(name, 'limit', 4., alwaysfrozen=True,
@@ -565,7 +586,7 @@ class EmissionGaussian(ArithmeticModel):
                                  (self.fwhm, self.pos, self.flux,
                                   self.skew, self.limit))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -598,6 +619,7 @@ class EmissionGaussian(ArithmeticModel):
             y[idx] = 2.0 * p[2] * arg[idx] / sigma / 2.50662828 / (1.0 + p[3])
 
         return y
+
 
 # This model computes absorption as a Voigt function -- i.e., with
 # a Gaussian core and Lorentzian wings.
@@ -650,26 +672,32 @@ class AbsorptionVoigt(ArithmeticModel):
     """
 
     def __init__(self, name='absorptionvoigt'):
-        self.center = Parameter(name, 'center', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
-        self.ew = Parameter(name, 'ew', 1., tinyval, hard_min=tinyval, units="angstroms")
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, units="km/s")
+        self.center = Parameter(name, 'center', 5000., tinyval,
+                                hard_min=tinyval, frozen=True,
+                                units="angstroms")
+        self.ew = Parameter(name, 'ew', 1., tinyval, hard_min=tinyval,
+                            units="angstroms")
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval,
+                              hard_min=tinyval, units="km/s")
         self.lg = Parameter(name, 'lg', 1., tinyval, hard_min=tinyval)
 
         # Create core and wings from Gaussian and Lorentz
         self._core = AbsorptionGaussian()
         self._wings = AbsorptionLorentz()
 
-        ArithmeticModel.__init__(self, name, (self.center, self.ew, self.fwhm, self.lg))
+        ArithmeticModel.__init__(self, name,
+                                 (self.center, self.ew, self.fwhm, self.lg))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         # Combining two absorption components means
         # multiplying them, it appears (at least according
         # to addAbsorption in NarrowBandFunction.java)
 
-        core_pars = numpy.array([ p[2], p[0], p[1] / 2.0, 4.0 ])
-        wing_pars = numpy.array([ p[2] * p[3], p[0], p[1] / 2.0 ])
+        core_pars = numpy.array([p[2], p[0], p[1] / 2.0, 4.0])
+        wing_pars = numpy.array([p[2] * p[3], p[0], p[1] / 2.0])
         return self._core.calc(core_pars, x) * self._wings.calc(wing_pars, x)
+
 
 # This model computes continuum emission as a blackbody function.
 class BlackBody(ArithmeticModel):
@@ -704,25 +732,32 @@ class BlackBody(ArithmeticModel):
     """
 
     def __init__(self, name='blackbody'):
-        self.refer = Parameter(name, 'refer', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
-        self.ampl = Parameter(name, 'ampl', 1., tinyval, hard_min=tinyval, units="angstroms")
-        self.temperature = Parameter(name, 'temperature', 3000., tinyval, hard_min=tinyval, units="Kelvin")
+        self.refer = Parameter(name, 'refer', 5000., tinyval,
+                               hard_min=tinyval, frozen=True,
+                               units="angstroms")
+        self.ampl = Parameter(name, 'ampl', 1., tinyval,
+                              hard_min=tinyval, units="angstroms")
+        self.temperature = Parameter(name, 'temperature', 3000., tinyval,
+                                     hard_min=tinyval, units="Kelvin")
 
         self._argmin = 1.0e-3
         self._argmax = 1000.0
 
-        ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.temperature))
+        ArithmeticModel.__init__(self, name,
+                                 (self.refer, self.ampl, self.temperature))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         c1 = 1.438786e8
         efactor = c1 / p[2]
         if ((efactor / p[0]) > self._argmax):
             # raise error exp too big
-            raise ValueError('model evaluation failed, either temperature or reference wavelength too small')
+            raise ValueError('model evaluation failed, either ' +
+                             'temperature or reference wavelength too small')
 
-        numer = p[1] * numpy.power(p[0], 5.0) * (numpy.exp(efactor / p[0]) - 1.0)
+        numer = p[1] * numpy.power(p[0], 5.0) * \
+            (numpy.exp(efactor / p[0]) - 1.0)
 
         y = numpy.zeros_like(x)
         x0 = numpy.where(x > 0.0)[0]
@@ -733,7 +768,8 @@ class BlackBody(ArithmeticModel):
             denon[x0] = numpy.power(x[x0], 5)
             argmin_slice = numpy.where(arg < self._argmin)[0]
             if (len(argmin_slice) > 0):
-                denon[argmin_slice] *= arg[argmin_slice] * (1.0 + 0.5 * arg[argmin_slice])
+                denon[argmin_slice] *= arg[argmin_slice] * \
+                    (1.0 + 0.5 * arg[argmin_slice])
             arg = numpy.where(arg > self._argmax, self._argmax, arg)
 
             arg_slice = numpy.where(arg >= self._argmin)[0]
@@ -743,6 +779,7 @@ class BlackBody(ArithmeticModel):
             y[x0] = numer / denon[x0]
 
         return y
+
 
 # This model computes continuum emission with the bremsstrahlung function.
 class Bremsstrahlung(ArithmeticModel):
@@ -775,20 +812,27 @@ class Bremsstrahlung(ArithmeticModel):
     """
 
     def __init__(self, name='bremsstrahlung'):
-        self.refer = Parameter(name, 'refer', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
-        self.ampl = Parameter(name, 'ampl', 1., tinyval, hard_min=tinyval, units="angstroms")
-        self.temperature = Parameter(name, 'temperature', 3000., tinyval, hard_min=tinyval, units="Kelvin")
+        self.refer = Parameter(name, 'refer', 5000., tinyval,
+                               hard_min=tinyval, frozen=True,
+                               units="angstroms")
+        self.ampl = Parameter(name, 'ampl', 1., tinyval,
+                              hard_min=tinyval, units="angstroms")
+        self.temperature = Parameter(name, 'temperature', 3000., tinyval,
+                                     hard_min=tinyval, units="Kelvin")
 
-        ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.temperature))
+        ArithmeticModel.__init__(self, name,
+                                 (self.refer, self.ampl, self.temperature))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
                              '%s refer cannot be zero' % self.name)
 
-        return p[1] * numpy.power((p[0] / x), 2) * numpy.exp(-1.438779e8 / x / p[2])
+        return p[1] * numpy.power((p[0] / x), 2) * \
+            numpy.exp(-1.438779e8 / x / p[2])
+
 
 # This model computes continuum emission with a broken power-law;
 # that is, the power-law index changes after a break at a particular
@@ -826,14 +870,19 @@ class BrokenPowerlaw(ArithmeticModel):
     """
 
     def __init__(self, name='brokenpowerlaw'):
-        self.refer = Parameter(name, 'refer', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
-        self.ampl = Parameter(name, 'ampl', 1., tinyval, hard_min=tinyval, units="angstroms")
+        self.refer = Parameter(name, 'refer', 5000., tinyval,
+                               hard_min=tinyval, frozen=True,
+                               units="angstroms")
+        self.ampl = Parameter(name, 'ampl', 1., tinyval, hard_min=tinyval,
+                              units="angstroms")
         self.index1 = Parameter(name, 'index1', 0.1, -10.0, 10.0)
         self.index2 = Parameter(name, 'index2', -0.1, -10.0, 10.0)
 
-        ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.index1, self.index2))
+        ArithmeticModel.__init__(self, name,
+                                 (self.refer, self.ampl, self.index1,
+                                  self.index2))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -841,8 +890,11 @@ class BrokenPowerlaw(ArithmeticModel):
 
         x = numpy.asarray(x, dtype=SherpaFloat)
         arg = x / p[0]
-        arg = p[1] * (numpy.where(arg > 1.0, numpy.power(arg, p[3]), numpy.power(arg, p[2])))
+        arg = p[1] * (numpy.where(arg > 1.0,
+                                  numpy.power(arg, p[3]),
+                                  numpy.power(arg, p[2])))
         return arg
+
 
 # This model computes extinction using the function published by
 # Cardelli, Clayton, and Mathis
@@ -885,7 +937,7 @@ class CCM(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.ebv, self.r))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.zeros_like(x)
@@ -910,9 +962,21 @@ class CCM(ArithmeticModel):
         if (len(opt_slice) > 0):
             y[opt_slice] = x[opt_slice] - 1.82
 
-            a[opt_slice] = 1.0 + 0.17699 * y[opt_slice] - 0.50477 * y[opt_slice] * y[opt_slice] - 0.02427 * numpy.power(y[opt_slice],3) + 0.72085 * numpy.power(y[opt_slice],4) + 0.01979 * numpy.power(y[opt_slice],5) - 0.77530 * numpy.power(y[opt_slice],6) + 0.32999 * numpy.power(y[opt_slice],7)
+            a[opt_slice] = 1.0 + 0.17699 * y[opt_slice] \
+                - 0.50477 * y[opt_slice] * y[opt_slice] \
+                - 0.02427 * numpy.power(y[opt_slice], 3) \
+                + 0.72085 * numpy.power(y[opt_slice], 4) \
+                + 0.01979 * numpy.power(y[opt_slice], 5) \
+                - 0.77530 * numpy.power(y[opt_slice], 6) \
+                + 0.32999 * numpy.power(y[opt_slice], 7)
 
-            b[opt_slice] = 0.0 + 1.41338 * y[opt_slice] + 2.28305 * y[opt_slice] * y[opt_slice] + 1.07233 * numpy.power(y[opt_slice],3) - 5.38434 * numpy.power(y[opt_slice],4) - 0.62551 * numpy.power(y[opt_slice],5) + 5.30260 * numpy.power(y[opt_slice],6) - 2.09002 * numpy.power(y[opt_slice],7)
+            b[opt_slice] = 0.0 + 1.41338 * y[opt_slice] \
+                + 2.28305 * y[opt_slice] * y[opt_slice] \
+                + 1.07233 * numpy.power(y[opt_slice], 3) \
+                - 5.38434 * numpy.power(y[opt_slice], 4) \
+                - 0.62551 * numpy.power(y[opt_slice], 5) \
+                + 5.30260 * numpy.power(y[opt_slice], 6) \
+                - 2.09002 * numpy.power(y[opt_slice], 7)
 
         # Near-UV
         nuv_slice = numpy.where((x > 3.3) & (x <= 8.0))[0]
@@ -926,12 +990,18 @@ class CCM(ArithmeticModel):
                 y2[nuv_slice2] = y[nuv_slice2] * y[nuv_slice2]
                 y3[nuv_slice2] = y2[nuv_slice2] * y[nuv_slice2]
 
-                a[nuv_slice2] = -0.04473 * y2[nuv_slice2] - 0.009779 * y3[nuv_slice2]
-                b[nuv_slice2] = 0.21300 * y2[nuv_slice2] + .120700 * y3[nuv_slice2]
+                a[nuv_slice2] = -0.04473 * y2[nuv_slice2] \
+                    - 0.009779 * y3[nuv_slice2]
+                b[nuv_slice2] = 0.21300 * y2[nuv_slice2] \
+                    + .120700 * y3[nuv_slice2]
 
-            a[nuv_slice] = a[nuv_slice] + 1.752 - 0.316 * x[nuv_slice] - 0.104 / (0.341 + numpy.power((x[nuv_slice]-4.67),2))
+            a[nuv_slice] = a[nuv_slice] + 1.752 \
+                - 0.316 * x[nuv_slice] \
+                - 0.104 / (0.341 + numpy.power((x[nuv_slice] - 4.67), 2))
 
-            b[nuv_slice] = b[nuv_slice] - 3.090 + 1.825 * x[nuv_slice] + 1.206 / (0.263 + numpy.power((x[nuv_slice]-4.62),2))
+            b[nuv_slice] = b[nuv_slice] - 3.090 \
+                + 1.825 * x[nuv_slice] \
+                + 1.206 / (0.263 + numpy.power((x[nuv_slice] - 4.62), 2))
 
         # Far-UV
         fuv_slice = numpy.where((x > 8.0) & (x <= 20.0))[0]
@@ -940,12 +1010,15 @@ class CCM(ArithmeticModel):
             y2[fuv_slice] = y[fuv_slice] * y[fuv_slice]
             y3[fuv_slice] = y2[fuv_slice] * y[fuv_slice]
 
-            a[fuv_slice] = -1.073 - 0.628 * y[fuv_slice] + 0.137 * y2[fuv_slice] - 0.070 * y3[fuv_slice]
-            b[fuv_slice] = 13.670 + 4.257 * y[fuv_slice] - 0.420 * y2[fuv_slice] + 0.374 * y3[fuv_slice]
+            a[fuv_slice] = -1.073 - 0.628 * y[fuv_slice] \
+                + 0.137 * y2[fuv_slice] - 0.070 * y3[fuv_slice]
+            b[fuv_slice] = 13.670 + 4.257 * y[fuv_slice] \
+                - 0.420 * y2[fuv_slice] + 0.374 * y3[fuv_slice]
 
         # Final extinction curve
         aext = p[1] * a + b
-        return numpy.power(10.0,(-0.4 * p[0] * aext))
+        return numpy.power(10.0, (-0.4 * p[0] * aext))
+
 
 # This model computes absorption using a Gaussian function expressed
 # in optical depth, and using the log of the FWHM.
@@ -989,13 +1062,14 @@ class LogAbsorption(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.tau = Parameter(name, 'tau', 0.5)
 
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.tau))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -1013,9 +1087,12 @@ class LogAbsorption(ArithmeticModel):
         if (alpha <= 1.0):
             alpha = 1.0001
 
-        y = numpy.where(x >= p[1], p[2] * numpy.power((x / p[1]), -alpha), p[2] * numpy.power((x / p[1]), alpha))
+        y = numpy.where(x >= p[1],
+                        p[2] * numpy.power((x / p[1]), -alpha),
+                        p[2] * numpy.power((x / p[1]), alpha))
 
         return numpy.exp(-y)
+
 
 # This model computes emission using a Gaussian function expressed
 # in optical depth, and using the log of the FWHM.
@@ -1078,7 +1155,8 @@ class LogEmission(ArithmeticModel):
 
         self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval,
                               units="km/s")
-        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True, units='angstroms')
+        self.pos = Parameter(name, 'pos', 5000., tinyval, frozen=True,
+                             units='angstroms')
         self.flux = Parameter(name, 'flux', 1.)
         self.skew = Parameter(name, 'skew', 1., tinyval, frozen=True)
         self.limit = Parameter(name, 'limit', 4., alwaysfrozen=True,
@@ -1088,7 +1166,7 @@ class LogEmission(ArithmeticModel):
                                  (self.fwhm, self.pos, self.flux,
                                   self.skew, self.limit))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -1104,22 +1182,33 @@ class LogEmission(ArithmeticModel):
             raise ValueError('model evaluation failed, ' +
                              '%s skew cannot be zero' % self.name)
 
-        arg = 0.69314718 / numpy.log (1.0 + p[0] / 2.9979e5 / 2.0);
+        arg = 0.69314718 / numpy.log(1.0 + p[0] / 2.9979e5 / 2.0)
         if (arg <= 1.0):
             arg = 1.0001
 
         fmax = (arg - 1.0) * p[2] / p[1] / 2.0
 
         if (p[3] == 1.0):
-            return numpy.where(x >= p[1], fmax * numpy.power((x / p[1]), -arg), fmax * numpy.power((x / p[1]), arg))
+            return numpy.where(x >= p[1],
+                               fmax * numpy.power((x / p[1]), -arg),
+                               fmax * numpy.power((x / p[1]), arg))
 
-        arg1 = 0.69314718 / numpy.log (1.0 + p[3] * p[0] / 2.9979e5 / 2.0)
+        arg1 = 0.69314718 / numpy.log(1.0 + p[3] * p[0] / 2.9979e5 / 2.0)
         fmax = (arg - 1.0) * p[2] / p[1] / (1.0 + (arg - 1.0) / (arg1 - 1.0))
 
-        return numpy.where(x <= p[1], fmax * numpy.power((x / p[1]), arg), fmax * numpy.power((x / p[1]), -arg1))
+        return numpy.where(x <= p[1],
+                           fmax * numpy.power((x / p[1]), arg),
+                           fmax * numpy.power((x / p[1]), -arg1))
+
 
 # This model computes continuum emission as a polynomial,
-# y = c0 + c1 * (x - offset) + c2 * (x - offset)^2 + c3 * (x - offset)^3 + c4 * (x - offset)^4 + c5 * (x - offset)^5
+# y = c0 +
+#     c1 * (x - offset) +
+#     c2 * (x - offset)^2 +
+#     c3 * (x - offset)^3 +
+#     c4 * (x - offset)^4 +
+#     c5 * (x - offset)^5
+#
 class Polynomial(ArithmeticModel):
     """Polynomial model of order 5.
 
@@ -1171,16 +1260,17 @@ class Polynomial(ArithmeticModel):
         pars.append(self.offset)
         ArithmeticModel.__init__(self, name, pars)
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.zeros_like(x)
         xtemp = x - p[6]
         y += p[5]
-        for i in [4,3,2,1,0]:
-            y = y*xtemp + p[i]
+        for i in [4, 3, 2, 1, 0]:
+            y = y * xtemp + p[i]
 
         return y
+
 
 # This model computes continuum emission using a power-law.
 class Powerlaw(ArithmeticModel):
@@ -1212,13 +1302,17 @@ class Powerlaw(ArithmeticModel):
     """
 
     def __init__(self, name='powerlaw'):
-        self.refer = Parameter(name, 'refer', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
-        self.ampl = Parameter(name, 'ampl', 1., tinyval, hard_min=tinyval, units="angstroms")
+        self.refer = Parameter(name, 'refer', 5000., tinyval,
+                               hard_min=tinyval, frozen=True,
+                               units="angstroms")
+        self.ampl = Parameter(name, 'ampl', 1., tinyval,
+                              hard_min=tinyval, units="angstroms")
         self.index = Parameter(name, 'index', -0.5, -10.0, 10.0)
 
-        ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.index))
+        ArithmeticModel.__init__(self, name,
+                                 (self.refer, self.ampl, self.index))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -1229,6 +1323,7 @@ class Powerlaw(ArithmeticModel):
         arg = p[1] * numpy.power(arg, p[2])
 
         return arg
+
 
 # This model computes the continuum with an optically thin
 # recombination function.
@@ -1270,24 +1365,37 @@ class Recombination(ArithmeticModel):
     """
 
     def __init__(self, name='recombination'):
-        self.refer = Parameter(name, 'refer', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
-        self.ampl = Parameter(name, 'ampl', 1., tinyval, hard_min=tinyval, units="angstroms")
-        self.temperature = Parameter(name, 'temperature', 3000., tinyval, hard_min=tinyval, units="Kelvin")
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, units="km/s")
+        self.refer = Parameter(name, 'refer', 5000., tinyval,
+                               hard_min=tinyval, frozen=True,
+                               units="angstroms")
+        self.ampl = Parameter(name, 'ampl', 1., tinyval,
+                              hard_min=tinyval, units="angstroms")
+        self.temperature = Parameter(name, 'temperature', 3000.,
+                                     tinyval, hard_min=tinyval, units="Kelvin")
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval,
+                              hard_min=tinyval, units="km/s")
 
-        ArithmeticModel.__init__(self, name, (self.refer, self.ampl, self.temperature, self.fwhm))
+        ArithmeticModel.__init__(self, name,
+                                 (self.refer, self.ampl,
+                                  self.temperature, self.fwhm))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
                              '%s refer cannot be zero' % self.name)
 
         x = numpy.asarray(x, dtype=SherpaFloat)
-        sigma = p[0] * p[3] / 705951.5; # = 2.9979e5 / 2.354820044
+        sigma = p[0] * p[3] / 705951.5  # = 2.9979e5 / 2.354820044
         delta = 1.440e8 * (1.0 / x - 1.0 / p[0]) / p[2]
 
-        return numpy.where(delta < 0.0, p[1] * numpy.exp(-numpy.power((x - p[0]), 2.0) / numpy.power(sigma, 2.0) / 2.0), p[1] * numpy.power((p[0] / x), 2.0) * numpy.exp(-delta))
+        return numpy.where(delta < 0.0,
+                           p[1] * numpy.exp(-numpy.power((x - p[0]), 2.0) /
+                                            numpy.power(sigma, 2.0) / 2.0),
+                           p[1] * numpy.power((p[0] / x), 2.0) *
+                           numpy.exp(-delta)
+                           )
+
 
 # This model computes emission as a Voigt function -- i.e., with
 # a Gaussian core and Lorentzian wings.
@@ -1336,26 +1444,32 @@ class EmissionVoigt(ArithmeticModel):
     """
 
     def __init__(self, name='emissionvoigt'):
-        self.center = Parameter(name, 'center', 5000., tinyval, hard_min=tinyval, frozen=True, units="angstroms")
+        self.center = Parameter(name, 'center', 5000., tinyval,
+                                hard_min=tinyval, frozen=True,
+                                units="angstroms")
         self.flux = Parameter(name, 'flux', 1.)
-        self.fwhm = Parameter(name, 'fwhm', 100., tinyval, hard_min=tinyval, units="km/s")
-        self.lg = Parameter(name, 'lg', 1., tinyval, hard_min=tinyval, frozen=True)
+        self.fwhm = Parameter(name, 'fwhm', 100., tinyval,
+                              hard_min=tinyval, units="km/s")
+        self.lg = Parameter(name, 'lg', 1., tinyval,
+                            hard_min=tinyval, frozen=True)
 
         # Create core and wings from Gaussian and Lorentz
         self._core = EmissionGaussian()
         self._wings = EmissionLorentz()
 
-        ArithmeticModel.__init__(self, name, (self.center, self.flux, self.fwhm, self.lg))
+        ArithmeticModel.__init__(self, name,
+                                 (self.center, self.flux, self.fwhm, self.lg))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         # Combining two emission components means
         # adding them, it appears (at least according
         # to addEmission in NarrowBandFunction.java)
 
-        core_pars = numpy.array([ p[2], p[0], p[1], 1.0])
-        wing_pars = numpy.array([ p[3]*p[2], p[0], p[1], 2.0])
+        core_pars = numpy.array([p[2], p[0], p[1], 1.0])
+        wing_pars = numpy.array([p[3] * p[2], p[0], p[1], 2.0])
         return self._core.calc(core_pars, x) + self._wings.calc(wing_pars, x)
+
 
 # This model computes the extragalactic extinction function of
 # Calzetti, Kinney and Storchi-Bergmann, 1994, ApJ, 429, 582
@@ -1394,7 +1508,7 @@ class XGal(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -1410,7 +1524,8 @@ class XGal(ArithmeticModel):
         # Normalize the result according to Kailash Sahu's calculations
         ext *= 2.43
 
-        return numpy.power(10.0,(-0.4 * p[0] * ext))
+        return numpy.power(10.0, (-0.4 * p[0] * ext))
+
 
 # This model computes the extinction curve for wavelengths for UV
 # spectra below 3200 A.  Fitzpatrick and Massa 1988 extinction curve
@@ -1462,7 +1577,7 @@ class FM(ArithmeticModel):
     def __init__(self, name='fm'):
         self.ebv = Parameter(name, 'ebv', 0.5)  # E(B-V)
         self.x0 = Parameter(name, 'x0', 4.6)    # Position of Drude bump
-        self.width = Parameter(name, 'width', 0.06) # Width of Drude bump
+        self.width = Parameter(name, 'width', 0.06)  # Width of Drude bump
         self.c1 = Parameter(name, 'c1', 0.2)
         self.c2 = Parameter(name, 'c2', 0.1)
         self.c3 = Parameter(name, 'c3', 0.02)
@@ -1471,19 +1586,19 @@ class FM(ArithmeticModel):
                                               self.width, self.c1, self.c2,
                                               self.c3, self.c4))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         x = 10000. / x
         av = 3.14
 
-        dru = x * x / ( p[2] * p[2] * x * x + numpy.power(( x - p[1] ),2.0))
+        dru = x * x / (p[2] * p[2] * x * x + numpy.power((x - p[1] ), 2.0))
         dx = x - 5.9
-        fuv = 0.5392 * dx * dx + 0.0564 * numpy.power(dx,3.0)
+        fuv = 0.5392 * dx * dx + 0.0564 * numpy.power(dx, 3.0)
         ext = av + p[3] + p[4] * x + p[5] * dru
         ext = numpy.where(x > 5.9, p[6] * fuv + ext, ext)
 
-        return numpy.power(10.0,( -0.4 * ext * p[0] ))
+        return numpy.power(10.0, (-0.4 * ext * p[0]))
 
 
 # This model computes the extinction curve using the
@@ -1524,7 +1639,7 @@ class LMC(ArithmeticModel):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1539,16 +1654,21 @@ class LMC(ArithmeticModel):
         x = numpy.where(x > 10.96, 10.96, x)
 
         if (len(slice1) > 0):
-            extmag[slice1] = ((1.86 - 0.48 * x[slice1]) * x[slice1] - 0.1) * x[slice1]
+            extmag[slice1] = ((1.86 - 0.48 * x[slice1]) * x[slice1] - 0.1) * \
+                x[slice1]
 
         if (len(slice2) > 0):
-            extmag[slice2] = self._R + 2.04 * (x[slice2] - 1.83) + 0.094 * (x[slice2] - 1.83) * (x[slice2] - 1.83)
+            extmag[slice2] = self._R + 2.04 * (x[slice2] - 1.83) + \
+                0.094 * (x[slice2] - 1.83) * (x[slice2] - 1.83)
 
         # continue out to lambda = 912 A
         if (len(slice3) > 0):
-            extmag[slice3] = self._R - 0.236 + 0.462 * x[slice3] + 0.105 * x[slice3] * x[slice3] + 0.454 / ((x [slice3]- 4.557) * (x[slice3] - 4.557) + 0.293 )
+            extmag[slice3] = self._R - 0.236 + 0.462 * x[slice3] + \
+                0.105 * x[slice3] * x[slice3] + \
+                0.454 / ((x[slice3] - 4.557) * (x[slice3] - 4.557) + 0.293)
 
-        return numpy.power(10.0,( -0.4 * extmag * p[0] ))
+        return numpy.power(10.0, (-0.4 * extmag * p[0]))
+
 
 # This model computes the galactic interstellar extinction function
 # from Savage & Mathis (1979, ARA&A, 17, 73-111)
@@ -1585,20 +1705,20 @@ class SM(ArithmeticModel):
     def __init__(self, name='sm'):
         self.ebv = Parameter(name, 'ebv', 0.5)
 
-        self._xtab = numpy.array([0.00,  0.29,  0.45,  0.80,  1.11,  1.43,
-                                  1.82,  2.27,  2.50,  2.91,  3.65,  4.00,
-                                  4.17,  4.35,  4.57,  4.76,  5.00,  5.26,
-                                  5.56,  5.88,  6.25,  6.71,  7.18,  8.00,
-                                  8.50,  9.00,  9.50,  10.00])
-        self._extab = numpy.array([0.00,  0.16,  0.38,  0.87,  1.50,  2.32,
-                                   3.10,  4.10,  4.40,  4.90,  6.20,  7.29,
-                                   8.00,  8.87,  9.67,  9.33,  8.62,  8.00,
-                                   7.75,  7.87,  8.12,  8.15,  8.49,  9.65,
+        self._xtab = numpy.array([0.00, 0.29, 0.45, 0.80, 1.11, 1.43,
+                                  1.82, 2.27, 2.50, 2.91, 3.65, 4.00,
+                                  4.17, 4.35, 4.57, 4.76, 5.00, 5.26,
+                                  5.56, 5.88, 6.25, 6.71, 7.18, 8.00,
+                                  8.50, 9.00, 9.50, 10.00])
+        self._extab = numpy.array([0.00, 0.16, 0.38, 0.87, 1.50, 2.32,
+                                   3.10, 4.10, 4.40, 4.90, 6.20, 7.29,
+                                   8.00, 8.87, 9.67, 9.33, 8.62, 8.00,
+                                   7.75, 7.87, 8.12, 8.15, 8.49, 9.65,
                                    10.55, 11.55, 12.90, 14.40])
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1606,7 +1726,8 @@ class SM(ArithmeticModel):
 
         extmag = numpy.zeros_like(x)
         extmag = _extinct_interp(self._xtab, self._extab, x)
-        return numpy.power(10.0,( -0.4 * extmag * p[0]))
+        return numpy.power(10.0, (-0.4 * extmag * p[0]))
+
 
 # This model computes the SMC extinction function of
 # Prevot et al. 1984, A&A, 132, 389-392
@@ -1643,22 +1764,22 @@ class SMC(ArithmeticModel):
     def __init__(self, name='smc'):
         self.ebv = Parameter(name, 'ebv', 0.5)
 
-        self._xtab = numpy.array([0.00,  0.29,  0.45,  0.80,  1.11,  1.43,
-                                  1.82,  2.35,  2.70,  3.22,  3.34,  3.46,
-                                  3.60,  3.75,  3.92,  4.09,  4.28,  4.50,
-                                  4.73,  5.00,  5.24,  5.38,  5.52,  5.70,
-                                  5.88,  6.07,  6.27,  6.48,  6.72,  6.98,
-                                  7.23,  7.52,  7.84])
+        self._xtab = numpy.array([0.00, 0.29, 0.45, 0.80, 1.11, 1.43,
+                                  1.82, 2.35, 2.70, 3.22, 3.34, 3.46,
+                                  3.60, 3.75, 3.92, 4.09, 4.28, 4.50,
+                                  4.73, 5.00, 5.24, 5.38, 5.52, 5.70,
+                                  5.88, 6.07, 6.27, 6.48, 6.72, 6.98,
+                                  7.23, 7.52, 7.84])
         self._extab = numpy.array([-3.10, -2.94, -2.72, -2.23, -1.60, -0.78,
-                                   0.00,  1.00,  1.67,  2.29,  2.65,  3.00,
-                                   3.15,  3.49,  3.91,  4.24,  4.53,  5.30,
-                                   5.85,  6.38,  6.76,  6.90,  7.17,  7.71,
-                                   8.01,  8.49,  9.06,  9.28,  9.84, 10.80,
+                                   0.00, 1.00, 1.67, 2.29, 2.65, 3.00,
+                                   3.15, 3.49, 3.91, 4.24, 4.53, 5.30,
+                                   5.85, 6.38, 6.76, 6.90, 7.17, 7.71,
+                                   8.01, 8.49, 9.06, 9.28, 9.84, 10.80,
                                    11.51, 12.52, 13.54])
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1666,7 +1787,8 @@ class SMC(ArithmeticModel):
 
         extmag = numpy.zeros_like(x)
         extmag = _extinct_interp(self._xtab, self._extab, x)
-        return numpy.power(10.0,( -0.4 * extmag * p[0]))
+        return numpy.power(10.0, (-0.4 * extmag * p[0]))
+
 
 # This model computes Seaton's interstellar extinction function.
 # The formulae are based on an adopted value of R = 3.20.
@@ -1749,16 +1871,16 @@ class Seaton(ArithmeticModel):
     def __init__(self, name='seaton'):
         self.ebv = Parameter(name, 'ebv', 0.5)
 
-        self._xtab = numpy.array([0.0,  1.0, 1.1, 1.2, 1.3, 1.4, 1.5,
+        self._xtab = numpy.array([0.0, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5,
                                   1.6, 1.7, 1.8, 1.9, 2.0, 2.1,
                                   2.2, 2.3, 2.4, 2.5, 2.6, 2.7])
-        self._extab = numpy.array([0.0,   1.36, 1.64, 1.84, 2.04, 2.24, 2.44,
+        self._extab = numpy.array([0.0, 1.36, 1.64, 1.84, 2.04, 2.24, 2.44,
                                    2.66, 2.88, 3.14, 3.36, 3.56, 3.77,
                                    3.96, 4.15, 4.26, 4.40, 4.52, 4.64])
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    #@modelCacher1d
+    # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1767,10 +1889,10 @@ class Seaton(ArithmeticModel):
         extmag = numpy.zeros_like(x)
 
         ir_slice = numpy.where(x <= 1.0)[0]
-        opt_slice = numpy.where((x > 1.0) & (x <2.7))[0]
-        uv1_slice = numpy.where((x >= 2.7) &  (x < 3.65))[0]
+        opt_slice = numpy.where((x > 1.0) & (x < 2.7))[0]
+        uv1_slice = numpy.where((x >= 2.7) & (x < 3.65))[0]
         uv2_slice = numpy.where((x >= 3.65) & (x < 7.14))[0]
-        uv3_slice = numpy.where((x >= 7.14) &  (x <= 10.0))[0]
+        uv3_slice = numpy.where((x >= 7.14) & (x <= 10.0))[0]
         uv_extra_slice = numpy.where(x > 10.0)[0]
 
         # Infrared - extend optical results linearly to 0 at 1/lambda = 0
@@ -1779,23 +1901,29 @@ class Seaton(ArithmeticModel):
 
         # Optical - interpolate in Seaton's table 3
         if (len(opt_slice) > 0):
-            extmag[opt_slice] = _extinct_interp(self._xtab, self._extab, x[opt_slice])
+            extmag[opt_slice] = _extinct_interp(self._xtab, self._extab,
+                                                x[opt_slice])
 
         # UV - use analytic formulae from Seaton's table 2
         if (len(uv1_slice) > 0):
-            extmag[uv1_slice] = 1.56 + 1.048 * x[uv1_slice] + 1.01 / (( x[uv1_slice] - 4.6 ) * ( x[uv1_slice] - 4.6 ) + 0.280)
+            extmag[uv1_slice] = 1.56 + 1.048 * x[uv1_slice] + \
+                1.01 / ((x[uv1_slice] - 4.6) * (x[uv1_slice] - 4.6) + 0.280)
 
         # UV again
         if (len(uv2_slice) > 0):
-            extmag[uv2_slice] = 2.29 + 0.848 * x[uv2_slice] + 1.01 / (( x[uv2_slice] - 4.6 ) * ( x[uv2_slice] - 4.6 ) + 0.280)
+            extmag[uv2_slice] = 2.29 + 0.848 * x[uv2_slice] + \
+                1.01 / ((x[uv2_slice] - 4.6) * (x[uv2_slice] - 4.6) + 0.280)
 
         # and more UV still
         if (len(uv3_slice) > 0):
-            extmag[uv3_slice] = 16.17 + x[uv3_slice] * ( -3.20 + 0.2975 * x[uv3_slice] )
+            extmag[uv3_slice] = 16.17 + \
+                x[uv3_slice] * (-3.20 + 0.2975 * x[uv3_slice])
 
         # Extrapolate beyond 1/lambda = 10.0
         if (len(uv_extra_slice) > 0):
-            x[uv_extra_slice] = numpy.where(x[uv_extra_slice] < 50.0, x[uv_extra_slice], 50.0)
-            extmag[uv_extra_slice] = 16.17 + x[uv_extra_slice] * ( -3.20 + 0.2975 * x[uv_extra_slice] )
+            x[uv_extra_slice] = numpy.where(x[uv_extra_slice] < 50.0,
+                                            x[uv_extra_slice], 50.0)
+            extmag[uv_extra_slice] = 16.17 + \
+                x[uv_extra_slice] * (-3.20 + 0.2975 * x[uv_extra_slice])
 
-        return numpy.power(10.0,(-0.4 * extmag * p[0]))
+        return numpy.power(10.0, (-0.4 * extmag * p[0]))

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -250,7 +250,7 @@ class AbsorptionGaussian(ArithmeticModel):
         sigma = pos * fwhm / (2.354820044 * c)
 
     and for integrated data sets the low-edge of the grid is used.
-    The calculation is only done for those points that line in the
+    The calculation is only done for those points that are in the
     range::
 
         |x - pos| < limit * sigma
@@ -473,7 +473,7 @@ class OpticalGaussian(ArithmeticModel):
         sigma = pos * fwhm / (2.9979e5 * 2.354820044)
 
     and for integrated data sets the low-edge of the grid is used.
-    The calculation is only done for those points that line in the
+    The calculation is only done for those points that are in the
     range::
 
         |x - pos| < limit * sigma
@@ -535,7 +535,7 @@ class EmissionGaussian(ArithmeticModel):
     limit
         The model is only evaluated for points that lie within
         limit sigma of pos. It is a hidden parameter, with a
-        value fixed at 4.
+        default value of 4.
 
     See Also
     --------
@@ -555,7 +555,7 @@ class EmissionGaussian(ArithmeticModel):
 
         d2(x) = d(x)                  if x <= pos
 
-              = d(x) / s              otherwise
+              = d(x) / skew           otherwise
 
         s2 = 2.50662828 * s
 
@@ -563,7 +563,7 @@ class EmissionGaussian(ArithmeticModel):
 
     and for integrated data sets the low-edge of the grid is used.
 
-    The calculation is only done for those points that line in the
+    The calculation is only done for those points that are in the
     range::
 
         |x - pos| < limit * sigma

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -590,33 +590,38 @@ class EmissionGaussian(ArithmeticModel):
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
-        if 0.0 == p[0]:
+        fwhm = p[0]
+        pos = p[1]
+        flux = p[2]
+        skew = p[3]
+        if 0.0 == fwhm:
             raise ValueError('model evaluation failed, ' +
                              '%s fwhm cannot be zero' % self.name)
 
-        if 0.0 == p[1]:
+        if 0.0 == pos:
             raise ValueError('model evaluation failed, ' +
                              '%s pos cannot be zero' % self.name)
 
-        if 0.0 == p[3]:
+        if 0.0 == skew:
             raise ValueError('model evaluation failed, ' +
                              '%s skew cannot be zero' % self.name)
 
         y = numpy.zeros_like(x)
-        sigma = p[1] * p[0] / 705951.5     # = 2.9979e5 / 2.354820044
-        delta = numpy.abs((x - p[1]) / sigma)
+        sigma = pos * fwhm / 705951.5     # = 2.9979e5 / 2.354820044
+        delta = numpy.abs((x - pos) / sigma)
         idx = (delta < self.limit.val)
 
         arg = - delta * delta / 2.0
-        if sao_fcmp(p[3], 1.0, _tol) == 0:
-            y[idx] = p[2] * numpy.exp(arg[idx]) / sigma / 2.50662828
+        if sao_fcmp(skew, 1.0, _tol) == 0:
+            y[idx] = flux * numpy.exp(arg[idx]) / sigma / 2.50662828
 
         else:
-            left = (arg <= p[1])
+            left = (arg <= pos)
             arg[left] = numpy.exp(arg[left])
             right = ~left
-            arg[right] = numpy.exp(arg[right] / p[3] / p[3])
-            y[idx] = 2.0 * p[2] * arg[idx] / sigma / 2.50662828 / (1.0 + p[3])
+            arg[right] = numpy.exp(arg[right] / skew / skew)
+            y[idx] = 2.0 * flux * arg[idx] / sigma / 2.50662828 / \
+                (1.0 + skew)
 
         return y
 

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -612,16 +612,16 @@ class EmissionGaussian(ArithmeticModel):
         idx = (delta < self.limit.val)
 
         arg = - delta * delta / 2.0
+        s2 = 2.50662828 * sigma
         if sao_fcmp(skew, 1.0, _tol) == 0:
-            y[idx] = flux * numpy.exp(arg[idx]) / sigma / 2.50662828
+            y[idx] = flux * numpy.exp(arg[idx]) / s2
 
         else:
-            left = (arg <= pos)
+            left = (x <= pos)
             arg[left] = numpy.exp(arg[left])
             right = ~left
             arg[right] = numpy.exp(arg[right] / skew / skew)
-            y[idx] = 2.0 * flux * arg[idx] / sigma / 2.50662828 / \
-                (1.0 + skew)
+            y[idx] = 2.0 * flux * arg[idx] / s2 / (1.0 + skew)
 
         return y
 

--- a/sherpa/astro/optical/tests/test_optical.py
+++ b/sherpa/astro/optical/tests/test_optical.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,7 @@
 #
 
 from numpy import arange, array
+import numpy as np
 import sherpa.astro.optical as models
 from sherpa.utils import SherpaFloat, SherpaTestCase
 from sherpa.models.model import ArithmeticModel
@@ -118,13 +119,13 @@ class test_models(SherpaTestCase):
 
         self.assertEqualWithinTol(standard, models.CCM()(x), 1.0e-4)
 
-
     def test_emissiongaussian(self):
-        standard = array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5632678013191489, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        standard = np.zeros(25)
+        standard[15] = 0.5632678013191489
 
-        x = arange(2000.0,7000.0,200,SherpaFloat)
-
-        self.assertEqualWithinTol(standard, models.EmissionGaussian()(x), 1.0e-4)
+        x = arange(2000.0, 7000.0, 200, SherpaFloat)
+        y = models.EmissionGaussian()(x)
+        self.assertEqualWithinTol(standard, y, 1.0e-4)
 
     def test_emissionlorentz(self):
         standard = array([2.9493539159312757e-08, 3.3857378749894552e-08, 3.9266545212663451e-08, 4.6083652933497467e-08, 5.4843354298635128e-08, 6.6360456699082159e-08, 8.1926486410991892e-08, 1.0368820345249175e-07, 1.3542947896188593e-07, 1.8433454496972647e-07, 2.6544168835398889e-07, 4.1475247581613886e-07, 7.3733711165262667e-07, 1.6590044953853394e-06, 6.6359314568841271e-06, 3.8170761273895537e-01, 6.6359314568841271e-06, 1.6590044953853394e-06, 7.3733711165262667e-07, 4.1475247581613886e-07, 2.6544168835398889e-07, 1.8433454496972647e-07, 1.3542947896188593e-07, 1.0368820345249175e-07, 8.1926486410991892e-08])

--- a/sherpa/astro/optical/tests/test_optical_pytest.py
+++ b/sherpa/astro/optical/tests/test_optical_pytest.py
@@ -1,0 +1,76 @@
+#
+#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+This adds additional tests to test_optical but uses pytest.
+"""
+
+import pytest
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import sherpa.astro.optical as models
+
+
+def test_emissiongaussian_skew1():
+    mdl = models.EmissionGaussian()
+
+    # select an x-axis range which leads to non-zero
+    # values in multiple bins
+    x = np.arange(4995.0, 5006.0, 1.0)
+    y = mdl(x)
+
+    # This is symmetrical since the grid is symmetrical
+    # about the pos parameter (default is 5000).
+    #
+    expected = np.zeros(11)
+    expected[3:8] = [0.01045223, 0.2078923, 0.5632678, 0.2078923,
+                     0.01045223]
+
+    # The same absolute tolerance is used as in test_optical.py;
+    # perhaps a smaller value could be used?
+    assert_allclose(expected, y, atol=1.0e-4, rtol=0)
+
+
+@pytest.mark.xfail
+def test_emissiongaussian_skew3():
+    mdl = models.EmissionGaussian()
+    mdl.skew = 3
+
+    # select an x-axis range which leads to non-zero
+    # values in multiple bins
+    x = np.arange(4995.0, 5006.0, 1.0)
+    y = mdl(x)
+
+    # Check subset is working (i.e. that the outer bins
+    # are zero).
+    #
+    idx0 = np.where((x < 4998) | (x > 5002))
+    assert_allclose(np.zeros(6), y[idx0])
+
+    # This should be asymmetrical about x=5000, with x>5000
+    # being larger than x<5000, and the peak at 5000.
+    #
+    midval = y[5]
+    assert (midval > y[x != 5000]).all()
+
+    lsum = y[x < 5000].sum()
+    hsum = y[x > 5000].sum()
+    assert lsum < hsum

--- a/sherpa/astro/optical/tests/test_optical_pytest.py
+++ b/sherpa/astro/optical/tests/test_optical_pytest.py
@@ -51,6 +51,12 @@ def test_emissiongaussian_skew1():
 
 @pytest.mark.xfail
 def test_emissiongaussian_skew3():
+    # This currently applies several expected properties of the
+    # result (i.e. is it peaked at the right place and skewed)
+    # and does not do an explicit check of the expected values as
+    # it is not clear what they are.
+    #
+
     mdl = models.EmissionGaussian()
     mdl.skew = 3
 
@@ -58,6 +64,9 @@ def test_emissiongaussian_skew3():
     # values in multiple bins
     x = np.arange(4995.0, 5006.0, 1.0)
     y = mdl(x)
+
+    # sanity check
+    assert (y >= 0.0).all()
 
     # Check subset is working (i.e. that the outer bins
     # are zero).
@@ -74,3 +83,37 @@ def test_emissiongaussian_skew3():
     lsum = y[x < 5000].sum()
     hsum = y[x > 5000].sum()
     assert lsum < hsum
+
+
+@pytest.mark.xfail
+def test_emissiongaussian_skew025():
+    # Since the skew is < 1 the lower-x values should now be
+    # higher.
+    #
+
+    mdl = models.EmissionGaussian()
+    mdl.skew = 0.25
+
+    # select an x-axis range which leads to non-zero
+    # values in multiple bins
+    x = np.arange(4995.0, 5006.0, 1.0)
+    y = mdl(x)
+
+    # sanity check
+    assert (y >= 0.0).all()
+
+    # Check subset is working (i.e. that the outer bins
+    # are zero).
+    #
+    idx0 = np.where((x < 4998) | (x > 5002))
+    assert_allclose(np.zeros(6), y[idx0])
+
+    # This should be asymmetrical about x=5000, with x>5000
+    # being smaller than x<5000, and the peak at 5000.
+    #
+    midval = y[5]
+    assert (midval > y[x != 5000]).all()
+
+    lsum = y[x < 5000].sum()
+    hsum = y[x > 5000].sum()
+    assert lsum > hsum

--- a/sherpa/astro/optical/tests/test_optical_pytest.py
+++ b/sherpa/astro/optical/tests/test_optical_pytest.py
@@ -21,8 +21,6 @@
 This adds additional tests to test_optical but uses pytest.
 """
 
-import pytest
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -49,7 +47,6 @@ def test_emissiongaussian_skew1():
     assert_allclose(expected, y, atol=1.0e-4, rtol=0)
 
 
-@pytest.mark.xfail
 def test_emissiongaussian_skew3():
     # This currently applies several expected properties of the
     # result (i.e. is it peaked at the right place and skewed)
@@ -85,7 +82,6 @@ def test_emissiongaussian_skew3():
     assert lsum < hsum
 
 
-@pytest.mark.xfail
 def test_emissiongaussian_skew025():
     # Since the skew is < 1 the lower-x values should now be
     # higher.


### PR DESCRIPTION
# Summary

Fix the `sherpa.astro.optical.EmissionGaussian` code for the case when the `skew` parameter is not unity. The documentation has also been updated.

# Details

The new tests are more "property based" than functional, in that it's not obvious what the correct values should be (I couldn't see any unit tests for specview from a quick look). The new tests check expected behavior - e.g. the peak is at the center of the gaussian, and that skewed values are larger on x>pos (skew>1) or x<pos (skew < 1).

I have cherry-picked my commits from #408 to try and get a clean travis run.
