### PR TITLE
handle function name changes in XSPEC 12.9.1

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,6 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018
-#         Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015-2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -595,7 +594,8 @@ class XSapec(XSAdditiveModel):
 
     """
 
-    __function__ = "xsaped"
+    # __function__ = "xsaped"
+    __function__ = "C_apec"
 
     def __init__(self, name='apec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -686,7 +686,8 @@ class XSbapec(XSAdditiveModel):
 
     """
 
-    __function__ = "xsbape"
+    # __function__ = "xsbape"
+    __function__ = "C_bapec"
 
     def __init__(self, name='bapec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -1110,7 +1111,8 @@ class XSbvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "xsbvpe"
+    # __function__ = "xsbvpe"
+    __function__ = "C_bvapec"
 
     def __init__(self, name='bvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -2286,7 +2288,8 @@ class XSgaussian(XSAdditiveModel):
 
     """
 
-    __function__ = "xsgaul"
+    # __function__ = "xsgaul"
+    __function__ = "C_gaussianLine"
 
     def __init__(self, name='gaussian'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -2796,7 +2799,8 @@ class XSlorentz(XSAdditiveModel):
 
     """
 
-    __function__ = "xslorz"
+    # __function__ = "xslorz"
+    __function__ = "C_lorentzianLine"
 
     def __init__(self, name='lorentz'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -2841,7 +2845,8 @@ class XSmeka(XSAdditiveModel):
 
     """
 
-    __function__ = "xsmeka"
+    # __function__ = "xsmeka"
+    __function__ = "C_meka"
 
     def __init__(self, name='meka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -2888,7 +2893,8 @@ class XSmekal(XSAdditiveModel):
 
     """
 
-    __function__ = "xsmekl"
+    # __function__ = "xsmekl"
+    __function__ = "C_mekal"
 
     def __init__(self, name='mekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -3955,7 +3961,8 @@ class XSraymond(XSAdditiveModel):
 
     """
 
-    __function__ = "xsrays"
+    # __function__ = "xsrays"
+    __function__ = "C_raysmith"
 
     def __init__(self, name='raymond'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -4322,7 +4329,8 @@ class XSvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "xsvape"
+    # __function__ = "xsvape"
+    __function__ = "C_vapec"
 
     def __init__(self, name='vapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -4620,7 +4628,8 @@ class XSvmeka(XSAdditiveModel):
 
     """
 
-    __function__ = "xsvmek"
+    # __function__ = "xsvmek"
+    __function__ = "C_vmeka"
 
     def __init__(self, name='vmeka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -4679,7 +4688,8 @@ class XSvmekal(XSAdditiveModel):
 
     """
 
-    __function__ = "xsvmkl"
+    # __function__ = "xsvmkl"
+    __function__ = "C_vmekal"
 
     def __init__(self, name='vmekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -5222,7 +5232,8 @@ class XSvraymond(XSAdditiveModel):
 
     """
 
-    __function__ = "xsvrys"
+    # __function__ = "xsvrys"
+    __function__ = "C_vraysmith"
 
     def __init__(self, name='vraymond'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -7729,7 +7740,8 @@ class XSbvvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "xsbvvp"
+    # __function__ = "xsbvvp"
+    __function__ = "C_bvvapec"
 
     def __init__(self, name='bvvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -7799,7 +7811,8 @@ class XSvvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "xsvvap"
+    # __function__ = "xsvvap"
+    __function__ = "C_vvapec"
 
     def __init__(self, name='vvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -50,7 +50,7 @@ from sherpa.models.parameter import hugeval
 from sherpa.utils import guess_amplitude, param_apply_limits, bool_cast
 from sherpa.astro.utils import get_xspec_position
 
-from .utils import ModelMeta, version_at_least
+from .utils import ModelMeta, version_at_least, equal_or_greater_than
 from . import _xspec
 from ._xspec import get_xschatter, get_xsabund, get_xscosmo, \
     get_xsxsect, set_xschatter, set_xsabund, set_xscosmo, \
@@ -593,9 +593,7 @@ class XSapec(XSAdditiveModel):
     .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelApec.html
 
     """
-
-    # __function__ = "xsaped"
-    __function__ = "C_apec"
+    __function__ = "C_apec" if equal_or_greater_than("12.9.1") else "xsaped"
 
     def __init__(self, name='apec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -686,8 +684,7 @@ class XSbapec(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsbape"
-    __function__ = "C_bapec"
+    __function__ = "C_bapec" if equal_or_greater_than("12.9.1") else "xsbape"
 
     def __init__(self, name='bapec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -1111,8 +1108,7 @@ class XSbvapec(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsbvpe"
-    __function__ = "C_bvapec"
+    __function__ = "C_bvapec" if equal_or_greater_than("12.9.1") else "xsbvpe"
 
     def __init__(self, name='bvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -2288,8 +2284,7 @@ class XSgaussian(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsgaul"
-    __function__ = "C_gaussianLine"
+    __function__ = "C_gaussianLine" if equal_or_greater_than("12.9.1") else "xsgaul"
 
     def __init__(self, name='gaussian'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -2799,8 +2794,7 @@ class XSlorentz(XSAdditiveModel):
 
     """
 
-    # __function__ = "xslorz"
-    __function__ = "C_lorentzianLine"
+    __function__ = "C_lorentzianLine" if equal_or_greater_than("12.9.1") else "xslorz"
 
     def __init__(self, name='lorentz'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -2845,8 +2839,7 @@ class XSmeka(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsmeka"
-    __function__ = "C_meka"
+    __function__ = "C_meka" if equal_or_greater_than("12.9.1") else "xsmeka"
 
     def __init__(self, name='meka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -2893,8 +2886,7 @@ class XSmekal(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsmekl"
-    __function__ = "C_mekal"
+    __function__ = "C_mekal" if equal_or_greater_than("12.9.1") else "xsmekl"
 
     def __init__(self, name='mekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -3961,8 +3953,7 @@ class XSraymond(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsrays"
-    __function__ = "C_raysmith"
+    __function__ = "C_raysmith" if equal_or_greater_than("12.9.1") else "xsrays"
 
     def __init__(self, name='raymond'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -4329,8 +4320,7 @@ class XSvapec(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsvape"
-    __function__ = "C_vapec"
+    __function__ = "C_vapec" if equal_or_greater_than("12.9.1") else "xsvape"
 
     def __init__(self, name='vapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -4628,8 +4618,7 @@ class XSvmeka(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsvmek"
-    __function__ = "C_vmeka"
+    __function__ = "C_vmeka" if equal_or_greater_than("12.9.1") else "xsvmek"
 
     def __init__(self, name='vmeka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -4688,8 +4677,7 @@ class XSvmekal(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsvmkl"
-    __function__ = "C_vmekal"
+    __function__ = "C_vmekal" if equal_or_greater_than("12.9.1") else "xsvmkl"
 
     def __init__(self, name='vmekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -5232,8 +5220,7 @@ class XSvraymond(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsvrys"
-    __function__ = "C_vraysmith"
+    __function__ = "C_vraysmith" if equal_or_greater_than("12.9.1") else "xsvrys"
 
     def __init__(self, name='vraymond'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -7740,8 +7727,7 @@ class XSbvvapec(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsbvvp"
-    __function__ = "C_bvvapec"
+    __function__ = "C_bvvapec" if equal_or_greater_than("12.9.1") else "xsbvvp"
 
     def __init__(self, name='bvvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -7811,8 +7797,7 @@ class XSvvapec(XSAdditiveModel):
 
     """
 
-    # __function__ = "xsvvap"
-    __function__ = "C_vvapec"
+    __function__ = "C_vvapec" if equal_or_greater_than("12.9.1") else "xsvvap"
 
     def __init__(self, name='vvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -109,13 +109,25 @@ int _sherpa_init_xspec_library();
 
 extern "C" {
 
+#ifdef XSPEC_12_9_1
+void C_apec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_bapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsaped_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+
 void xsblbd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbbrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbmc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbrms_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+
+#ifdef XSPEC_12_9_1
+void C_bvapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsbvpe_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+
 void c6mekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void c6pmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void c6pvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -135,13 +147,39 @@ void diskpbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float*
 void xsdiskpn_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsxpdec_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void ezdiskbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+
+#ifdef XSPEC_12_9_1
+void C_gaussianLine(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsgaul_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif  
+
+// void xnneq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_gnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void grad_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsgrbm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void spin_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_xslaor(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void laor2_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_laor2(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+#ifdef XSPEC_12_9_1
+void C_lorentzianLine(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_meka(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_mekal(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xslorz_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsmeka_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+  
+// void xsmkcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_xsmkcf(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void C_xneq(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_nei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_nlapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xshock_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_npshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void nsa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsagrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsatmos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -149,17 +187,58 @@ void nsmax_(float* ear, int* ne, float* param, int* ifl, float* photar, float* p
 void xspegp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsp1tr_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsposm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+// void xneqs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_pshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+#ifdef XSPEC_12_9_1
+void C_raysmith(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsrays_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+  
 void xredge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsrefsch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void srcut_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void sresc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsstep_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+
+#ifdef XSPEC_12_9_1
+void C_vapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsvape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsbrmv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+  
+  void xsbrmv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+// void xseq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_vequil(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xsnneq_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_vgnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+#ifdef XSPEC_12_9_1
+void C_vmeka(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_vmekal(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsvmek_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+  
+// void xsvmcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_xsvmcf(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void C_xsneq(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_vnei(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xsshock_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_vnpshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xsneqs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_vpshock(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+#ifdef XSPEC_12_9_1
+void C_vraysmith(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsvrys_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+  
+// void xssedov_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_vsedov(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 void xszbod_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszbrm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void acisabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -203,8 +282,22 @@ void xszwnb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 
 // New XSPEC 12.7 models
 
+void C_cplinear(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xseqpair_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_xseqpair(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xseqth_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_xseqth(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+// void xscompth_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void C_xscompth(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+#ifdef XSPEC_12_9_1
+void C_bvvapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+void C_vvapec(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+#else
 void xsbvvp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvvap_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+  
 void zigm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
 // New XSPEC 12.7.1 models
@@ -1219,8 +1312,13 @@ static PyMethodDef XSpecMethods[] = {
             EXAMPLESDOC "\n"
             ">>> set_xspath_manager('/data/xspec/spectral/manager')\n\n"},
 
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_apec, 4 ),
+  XSPECMODELFCT_C_NORM( C_bapec, 5 ),
+#else
   XSPECMODELFCT_NORM( xsaped, 4 ),
   XSPECMODELFCT_NORM( xsbape, 5 ),
+#endif
   XSPECMODELFCT_NORM( xsblbd, 2 ),
   XSPECMODELFCT_NORM( xsbbrd, 2 ),
   XSPECMODELFCT_C_NORM( C_xsbexrav, 10 ),
@@ -1230,7 +1328,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_sirf, 10 ),
   XSPECMODELFCT_NORM( xsbmc, 4 ),
   XSPECMODELFCT_NORM( xsbrms, 2 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_bvapec, 17 ),
+#else  
   XSPECMODELFCT_NORM( xsbvpe, 17 ),
+#endif
   XSPECMODELFCT_NORM( c6mekl, 11 ),
   XSPECMODELFCT_NORM( c6pmekl, 11 ),
   XSPECMODELFCT_NORM( c6pvmkl, 24 ),
@@ -1255,7 +1357,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_equil, 4 ),
   XSPECMODELFCT_NORM( xsxpdec, 2 ),
   XSPECMODELFCT_NORM( ezdiskbb, 2 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_gaussianLine, 3 ),
+#else
   XSPECMODELFCT_NORM( xsgaul, 3 ),
+#endif
   XSPECMODELFCT_C_NORM( C_gnei, 6 ),
   XSPECMODELFCT_NORM( grad, 7 ),
   XSPECMODELFCT_NORM( xsgrbm, 4 ),
@@ -1264,9 +1370,15 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( spin, 10 ),
   XSPECMODELFCT_C_NORM( C_xslaor, 6 ),
   XSPECMODELFCT_C_NORM( C_laor2, 8 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_lorentzianLine, 3 ),
+  XSPECMODELFCT_C_NORM( C_meka, 5 ),
+  XSPECMODELFCT_C_NORM( C_mekal, 6 ),
+#else
   XSPECMODELFCT_NORM( xslorz, 3 ),
   XSPECMODELFCT_NORM( xsmeka, 5 ),
   XSPECMODELFCT_NORM( xsmekl, 6 ),
+#endif  
   XSPECMODELFCT_C_NORM( C_xsmkcf, 6 ),
   XSPECMODELFCT_C_NORM( C_nei, 5 ),
   XSPECMODELFCT_C_NORM( C_nlapec, 4 ),
@@ -1284,24 +1396,41 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_powerLaw, 2 ),
   XSPECMODELFCT_NORM( xsposm, 1 ),
   XSPECMODELFCT_C_NORM( C_pshock, 6 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM(C_raysmith, 4 ),
+#else
   XSPECMODELFCT_NORM( xsrays, 4 ),
+#endif  
   XSPECMODELFCT_NORM( xredge, 3 ),
   XSPECMODELFCT_NORM( xsrefsch, 14 ),
   XSPECMODELFCT_C_NORM( C_sedov, 6 ),
   XSPECMODELFCT_NORM( srcut, 3 ),
   XSPECMODELFCT_NORM( sresc, 3 ),
   XSPECMODELFCT_NORM( xsstep, 3 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_vapec, 16 ),
+#else  
   XSPECMODELFCT_NORM( xsvape, 16 ),
+#endif  
   XSPECMODELFCT_NORM( xsbrmv, 3 ),
   XSPECMODELFCT_C_NORM( C_vequil, 15 ),
   XSPECMODELFCT_C_NORM( C_vgnei, 18 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_vmeka, 18 ),
+  XSPECMODELFCT_C_NORM( C_vmekal, 19 ),
+#else
   XSPECMODELFCT_NORM( xsvmek, 18 ),
   XSPECMODELFCT_NORM( xsvmkl, 19 ),
+#endif  
   XSPECMODELFCT_C_NORM( C_xsvmcf, 19 ),
   XSPECMODELFCT_C_NORM( C_vnei, 17 ),
   XSPECMODELFCT_C_NORM( C_vnpshock, 19 ),
   XSPECMODELFCT_C_NORM( C_vpshock, 18 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_vraysmith, 15 ),
+#else
   XSPECMODELFCT_NORM( xsvrys, 15 ),
+#endif  
   XSPECMODELFCT_C_NORM( C_vsedov, 18 ),
   XSPECMODELFCT_NORM( xszbod, 3 ),
   XSPECMODELFCT_NORM( xszbrm, 3 ),
@@ -1358,8 +1487,13 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_xseqpair, 21 ),
   XSPECMODELFCT_C_NORM( C_xseqth, 21 ),
   XSPECMODELFCT_C_NORM( C_xscompth, 21 ),
+#ifdef XSPEC_12_9_1
+  XSPECMODELFCT_C_NORM( C_bvvapec, 34 ),
+  XSPECMODELFCT_C_NORM( C_vvapec, 33 ),
+#else  
   XSPECMODELFCT_NORM( xsbvvp, 34 ),
   XSPECMODELFCT_NORM( xsvvap, 33 ),
+#endif
   XSPECMODELFCT( zigm, 3 ),
   // New XSPEC 12.7.1 models
   XSPECMODELFCT_C_NORM( C_gaussDem, 7 ),

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -567,7 +567,7 @@ def test_not_compiled_model():
     """
     from sherpa.models import Parameter
     from sherpa.astro.xspec.utils import include_if, ModelMeta
-    from sherpa.astro.xspec import get_xsversion, XSAdditiveModel
+    from sherpa.astro.xspec import XSAdditiveModel
 
     @include_if(True)
     class XSfoo(XSAdditiveModel):

--- a/sherpa/astro/xspec/utils.py
+++ b/sherpa/astro/xspec/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -61,6 +61,22 @@ class ModelMeta(type):
         raise AttributeError(ModelMeta.NOT_COMPILED_FUNCTION_MESSAGE)
 
 
+def equal_or_greater_than(version_string):
+    """
+    Utility function that compares a version string with the version of the current xspec instance.
+
+    For better or worse the xspec current instance is not cached across calls. It probably could be but
+    it just seems safer not to, and any overhead insists on models initialization only.
+
+    The comparison is made in terms of the `distutils.version.LooseVersion` class.
+
+    :param version_string: the version against which to compare the current xspec version
+    :return: `True` if the version of xspec is equal or greater than the argument, `False` otherwise
+    """
+    xspec_version = LooseVersion(_xspec.get_xsversion())
+    return xspec_version >= LooseVersion(version_string)
+
+
 class include_if(object):
     """
     Generic decorator for including xspec models conditionally. It takes a boolean condition as an argument.
@@ -95,5 +111,4 @@ class version_at_least(include_if):
     the xspec version detected at runtime is equal or greater than the one provided to the decorator.
     """
     def __init__(self, version_string):
-        xspec_version = LooseVersion(_xspec.get_xsversion())
-        include_if.__init__(self, xspec_version >= LooseVersion(version_string))
+        include_if.__init__(self, equal_or_greater_than(version_string))


### PR DESCRIPTION
# Release Note
Sherpa now supports multiple versions of the XSPEC models from the 12.9.0 and 12.9.1 series. Some models recommend using the C-style interface over the older FORTRAN one, which may also resolve some memory access issues. For CIAO 4.10 users this means the interfaces to XSPEC models have been updated to the 12.9.1n versions. For Standalone Sherpa users this means they can build and run Sherpa against a larger range of XSPEC versions, and Sherpa will pick the XSPEC low level model function accordingly. Note that Sherpa has been tested against XSPEC 12.9.0i, 12.9.0o, and 12.9.1n.

# Notes

Several models in XSPEC 12.9.1 have changed from a FORTRAN to C style interface. Can we support them?

The first commit is actually just to see how working around the numpy version failure works and doesn't address the subject line. The second line supports conditional compilation for the compiled code - that is, it should build against XSPEC 12.9.0 and 12.9.1. However, the Python module code only supports a single version, which I have chosen to be 12.9.1.

Is there a way to make the function name depend on the XSPEC version? That is, for https://github.com/DougBurke/sherpa/blob/69fb779d8d09723ba235df0289047dd762472608/sherpa/astro/xspec/__init__.py#L531 make `__function__` depend on the XSPEC version? Something like

    __function__ = if_at_least((12,9,1), "C_apec", "xsaped")

I wasn't sure how this would interact with the new support for conditional compilation, which turned the value of the data stored `__function__` into a string rather than a symbol.