### PR TITLE
Fix travis jobs by pinning numpy to an old version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ matrix:
     # We need to use TEST=none to remove the test-data submodule.
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
     # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
+    - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py27_0" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
       sudo: required
       dist: trusty
     # As above, Python 3.5
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py35_0" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
       sudo: required
       dist: trusty
     # As above, Python 3.6, setup.py install
-    - env: XSPECVER="12.9.0i" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
+    - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py36_0" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
     # As above, xspec 12.9.1n

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,17 @@ matrix:
     # We need to use TEST=none to remove the test-data submodule.
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
     # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
+    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
     - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py27_0" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
       sudo: required
       dist: trusty
     # As above, Python 3.5
+    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
     - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py35_0" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
       sudo: required
       dist: trusty
     # As above, Python 3.6, setup.py install
+    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
     - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py36_0" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty


### PR DESCRIPTION
Latest versions of the numpy conda package include a dependency on libgfortran-ng, which seems incompatible with our conda packages for xspec. This PR makes sure an older version of the numpy package is installed, thus fixing the failing jobs.

We'll need to discuss the way forward (which is basically #426, except that now several older numpy conda packages have been rebuilt with libgfortran-ng as a dependency).