### PR TITLE
Improve caching

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -403,6 +403,9 @@ class DataRMF(DataOgipResponse):
         self._rsp = matrix
         self._lo = energ_lo
         self._hi = energ_hi
+        self._lo_unfiltered = self._lo[:]
+        self._hi_unfiltered = self._hi[:]
+        self.bin_mask = None
         BaseData.__init__(self)
 
     def __str__(self):
@@ -475,7 +478,8 @@ class DataRMF(DataOgipResponse):
                                      self.n_chan, self.matrix, self.offset)
             self._lo = self.energ_lo[bin_mask]
             self._hi = self.energ_hi[bin_mask]
-
+        if bin_mask is not None:
+            self.bin_mask = bin_mask[:]
         return bin_mask
 
     def get_indep(self, filter=False):

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018
+#            Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -556,7 +556,13 @@ class RSPModelPHA(RSPModel):
     def calc(self, p, x, xhi=None, *args, **kwargs):
         # x could be channels or x, xhi could be energy|wave
 
-        src = self.model.calc(p, self.xlo, self.xhi)
+        bin_mask = self.rmf.bin_mask
+        if bin_mask is None:
+            src = self.model.calc(p, self.xlo, self.xhi)
+        else:
+            xlo = self.rmf._lo_unfiltered
+            xhi = self.rmf._hi_unfiltered
+            src = self.model.calc(p, xlo, xhi)[bin_mask]
         src = self.arf.apply_arf(src, *self.arfargs)
         src = self.rmf.apply_rmf(src, *self.rmfargs)
 

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -25,10 +25,10 @@ from sherpa.utils import requires_data, requires_xspec, requires_fits
 from sherpa.utils import SherpaTestCase
 
 from sherpa.models import Polynom1D, SimulFitModel
-from sherpa.astro.models import Lorentz1D
+from sherpa.models.basic import Gauss1D
 from sherpa.data import Data1D, DataSimulFit
-from sherpa.optmethods import NelderMead
-from sherpa.stats import Cash
+from sherpa.optmethods import NelderMead, LevMar
+from sherpa.stats import Cash, LeastSq
 from sherpa.fit import Fit
 
 import logging
@@ -56,49 +56,57 @@ class test_cache(SherpaTestCase):
                                 1.9361738167035432, 0.4791446119040638,
                                 1.342017385707699, 0.49194814027685246])
         }
+
+    _fit_g2g2_bench = {
+        'numpoints': 200,
+        'dof': 194,
+        'istatval': 4.274899468449953,
+        'statval': 0.504555457862299,
+        'parnames': ('gauss1d.fwhm', 'gauss1d.pos', 'gauss1d.ampl',
+                     'gauss1d.fwhm', 'gauss1d.pos', 'gauss1d.ampl'),
+        'parvals': numpy.array([1.1421173550314392, 1.1963309074397634,
+                                0.9677194890720789, 4.1688184531922765,
+                                -1.3386595864803255, 1.0047067939881642])
+        }
+
     def setUp(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
 
-        x1 = [  1.,  3.,  5.,  7.,  9., 11., 13., 15., 17., 19., 21., 23.,
-                25., 27., 29., 31., 33., 35., 37., 39., 41., 43., 45.,
-                47., 49., 51., 53., 55., 57., 59., 61., 63., 65., 67.,
-                69., 71., 73., 75., 77., 79., 81., 83., 85., 87., 89.,
-                91., 93., 95., 97., 99.,101.]
+        x = numpy.linspace(1.0, 101., num=101)[0::2]
         y1 = [ 1., 5., 2., 4., 7.,11., 9., 8.,12.,18.,12.,11.,13.,12.,13.,
                13.,20.,23.,16.,20.,24.,17.,21.,26.,22.,24.,24.,21.,28.,
                28.,26.,25.,34.,26.,34.,33.,25.,38.,31.,43.,35.,42.,50.,
                41.,43.,47.,57.,53.,60.,46.,54.]
-
-        x2 = [ 1.,  3.,  5.,  7.,  9., 11., 13., 15., 17., 19., 21., 23.,
-               25., 27., 29., 31., 33., 35., 37., 39., 41., 43., 45., 47.,
-               49., 51., 53., 55., 57., 59., 61., 63., 65., 67., 69., 71.,
-               73., 75., 77., 79., 81., 83., 85., 87., 89., 91., 93., 95.,
-               97., 99.,101.]
         y2 = [ 0., 7., 6., 3., 5., 5., 9.,11.,13., 8.,14.,13.,14.,18.,11.,
                15.,17.,26., 15.,19.,25.,30.,15.,29.,16.,25.,27.,29.,36.,
                41.,22.,27.,33.,32.,45.,37.,38.,38.,34.,52.,40.,41.,31.,
                47.,38.,52.,57.,33.,48.,53.,45.]
-
-        x3 = [ 1.,  3.,  5.,  7.,  9., 11., 13., 15., 17., 19., 21., 23.,
-               25., 27., 29., 31., 33., 35., 37., 39., 41., 43., 45., 47.,
-               49., 51., 53., 55., 57., 59., 61., 63., 65., 67., 69., 71.,
-               73., 75., 77., 79., 81., 83., 85., 87., 89., 91., 93., 95.,
-               97., 99.,101.]
         y3 = [ 1., 2., 4., 2., 5., 8.,15.,10.,13.,10.,16.,10.,13.,12.,16.,
                17.,17.,20., 23.,16.,25.,22.,19.,31.,26.,24.,21.,29.,36.,
                30.,33.,30.,37.,27.,36.,32., 42.,44.,39.,30.,40.,33.,39.,
                49.,56.,47.,46.,35.,63.,40.,57.]
+        self.d1 = Data1D('1', x, y1)
+        self.d2 = Data1D('2', x, y2)
+        self.d3 = Data1D('3', x, y3)
 
-        self.d1 = Data1D('1', x1, y1)
-        self.d2 = Data1D('2', x2, y2)
-        self.d3 = Data1D('3', x3, y3)
+        x = numpy.linspace(-5., 5., 100)
+        g1, g2 = Gauss1D(), Gauss1D()
+        g1.fwhm = 1.14
+        g1.pos = 1.2
+        g2.fwhm = 4.13
+        g2.pos = -1.3
+        numpy.random.seed(0)
+        y1 = g1(x) + numpy.random.normal(0.0, 0.05, x.shape)
+        y2 = g2(x) + numpy.random.normal(0.0, 0.05, x.shape)
+        self.d4 = Data1D('4', x, y1)
+        self.d5 = Data1D('5', x, y2)
 
     def tearDown(self):
         if hasattr(self, "_old_logger_level"):
             logger.setLevel(self._old_logger_level)
 
-    def compare_results(self, arg1, arg2, tol=1e-6):
+    def compare_results(self, arg1, arg2, tol=1e-4):
 
         for key in ["numpoints", "dof"]:
             assert arg1[key] == int(getattr(arg2, key))
@@ -124,7 +132,7 @@ class test_cache(SherpaTestCase):
         poly1.pars[1].thaw()
         poly2.pars[1].thaw()
         poly3.pars[1].thaw()
-        sdata = DataSimulFit('all', (self.d1, self.d2, self.d3))
+        sdata = DataSimulFit('d123', (self.d1, self.d2, self.d3))
         smodel = SimulFitModel('diff', (poly1, poly2, poly3))
         sfit = Fit(sdata, smodel, method=NelderMead(), stat=Cash())
         result = sfit.fit()
@@ -133,8 +141,20 @@ class test_cache(SherpaTestCase):
     def test_same_cache(self):
         poly = Polynom1D()
         poly.pars[1].thaw()
-        sdata = DataSimulFit('all', (self.d1, self.d2, self.d3))
+        sdata = DataSimulFit('d1d2d3', (self.d1, self.d2, self.d3))
         smodel = SimulFitModel('same', (poly, poly, poly))
         sfit = Fit(sdata, smodel, method=NelderMead(), stat=Cash())
         result = sfit.fit()
         self.compare_results(self._fit_same_poly_bench, result)
+
+    def test_gauss_gauss(self):
+        g1, g2 = Gauss1D(), Gauss1D()
+        g1.fwhm = 1.3
+        g1.pos = 1.5
+        g2.fwhm = 4.
+        g2.pos = -2.0
+        sdata = DataSimulFit('d4d5', (self.d4, self.d5))
+        smodel = SimulFitModel('g1g2', (g1, g2))
+        sfit = Fit(sdata, smodel, method=LevMar(), stat=LeastSq())
+        result = sfit.fit()
+        self.compare_results(self._fit_g2g2_bench, result)

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -21,8 +21,7 @@ from __future__ import print_function
 
 import numpy
 
-from sherpa.utils import requires_data, requires_xspec, requires_fits
-from sherpa.utils import SherpaTestCase
+from sherpa.utils.testing import SherpaTestCase
 
 from sherpa.models import Polynom1D, SimulFitModel
 from sherpa.models.basic import Gauss1D

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -1,0 +1,140 @@
+from __future__ import print_function
+
+#
+#  Copyright (C) 2018  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import numpy
+
+from sherpa.utils import requires_data, requires_xspec, requires_fits
+from sherpa.utils import SherpaTestCase
+
+from sherpa.models import Polynom1D, SimulFitModel
+from sherpa.astro.models import Lorentz1D
+from sherpa.data import Data1D, DataSimulFit
+from sherpa.optmethods import NelderMead
+from sherpa.stats import Cash
+from sherpa.fit import Fit
+
+import logging
+logger = logging.getLogger("sherpa")
+
+class test_cache(SherpaTestCase):
+
+    _fit_same_poly_bench = {
+        'numpoints': 153,
+        'dof': 151,
+        'istatval': 306.0,
+        'statval': -19417.55547762454,
+        'parnames': ('polynom1d.c0', 'polynom1d.c1'),
+        'parvals': numpy.array([1.6874869548492573, 0.4796635263358297])
+        }
+
+    _fit_diff_poly_bench = {
+        'numpoints': 153,
+        'dof': 147,
+        'istatval': 306.0,
+        'statval': -19418.614329430166,
+        'parnames': ('polynom1d.c0', 'polynom1d.c1', 'polynom1d.c0',
+                     'polynom1d.c1', 'polynom1d.c0', 'polynom1d.c1'),
+        'parvals': numpy.array([1.755035876061136, 0.46847103779088173,
+                                1.9361738167035432, 0.4791446119040638,
+                                1.342017385707699, 0.49194814027685246])
+        }
+    def setUp(self):
+        self._old_logger_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
+
+        x1 = [  1.,  3.,  5.,  7.,  9., 11., 13., 15., 17., 19., 21., 23.,
+                25., 27., 29., 31., 33., 35., 37., 39., 41., 43., 45.,
+                47., 49., 51., 53., 55., 57., 59., 61., 63., 65., 67.,
+                69., 71., 73., 75., 77., 79., 81., 83., 85., 87., 89.,
+                91., 93., 95., 97., 99.,101.]
+        y1 = [ 1., 5., 2., 4., 7.,11., 9., 8.,12.,18.,12.,11.,13.,12.,13.,
+               13.,20.,23.,16.,20.,24.,17.,21.,26.,22.,24.,24.,21.,28.,
+               28.,26.,25.,34.,26.,34.,33.,25.,38.,31.,43.,35.,42.,50.,
+               41.,43.,47.,57.,53.,60.,46.,54.]
+
+        x2 = [ 1.,  3.,  5.,  7.,  9., 11., 13., 15., 17., 19., 21., 23.,
+               25., 27., 29., 31., 33., 35., 37., 39., 41., 43., 45., 47.,
+               49., 51., 53., 55., 57., 59., 61., 63., 65., 67., 69., 71.,
+               73., 75., 77., 79., 81., 83., 85., 87., 89., 91., 93., 95.,
+               97., 99.,101.]
+        y2 = [ 0., 7., 6., 3., 5., 5., 9.,11.,13., 8.,14.,13.,14.,18.,11.,
+               15.,17.,26., 15.,19.,25.,30.,15.,29.,16.,25.,27.,29.,36.,
+               41.,22.,27.,33.,32.,45.,37.,38.,38.,34.,52.,40.,41.,31.,
+               47.,38.,52.,57.,33.,48.,53.,45.]
+
+        x3 = [ 1.,  3.,  5.,  7.,  9., 11., 13., 15., 17., 19., 21., 23.,
+               25., 27., 29., 31., 33., 35., 37., 39., 41., 43., 45., 47.,
+               49., 51., 53., 55., 57., 59., 61., 63., 65., 67., 69., 71.,
+               73., 75., 77., 79., 81., 83., 85., 87., 89., 91., 93., 95.,
+               97., 99.,101.]
+        y3 = [ 1., 2., 4., 2., 5., 8.,15.,10.,13.,10.,16.,10.,13.,12.,16.,
+               17.,17.,20., 23.,16.,25.,22.,19.,31.,26.,24.,21.,29.,36.,
+               30.,33.,30.,37.,27.,36.,32., 42.,44.,39.,30.,40.,33.,39.,
+               49.,56.,47.,46.,35.,63.,40.,57.]
+
+        self.d1 = Data1D('1', x1, y1)
+        self.d2 = Data1D('2', x2, y2)
+        self.d3 = Data1D('3', x3, y3)
+
+    def tearDown(self):
+        if hasattr(self, "_old_logger_level"):
+            logger.setLevel(self._old_logger_level)
+
+    def compare_results(self, arg1, arg2, tol=1e-6):
+
+        for key in ["numpoints", "dof"]:
+            assert arg1[key] == int(getattr(arg2, key))
+
+        for key in ["istatval", "statval"]:
+            numpy.testing.assert_allclose(float(arg1[key]),
+                                          float(getattr(arg2, key)), tol)
+
+        for key in ["parvals"]:
+            try:
+                numpy.testing.assert_allclose(arg1[key],
+                                              getattr(arg2, key), tol)
+            except AssertionError:
+                print('parvals bench: ', arg1[key])
+                print('parvals fit:   ', getattr(arg2, key))
+                print('results', arg2)
+                raise
+
+    def test_diff_cache(self):
+        poly1 = Polynom1D()
+        poly2 = Polynom1D()
+        poly3 = Polynom1D()
+        poly1.pars[1].thaw()
+        poly2.pars[1].thaw()
+        poly3.pars[1].thaw()
+        sdata = DataSimulFit('all', (self.d1, self.d2, self.d3))
+        smodel = SimulFitModel('diff', (poly1, poly2, poly3))
+        sfit = Fit(sdata, smodel, method=NelderMead(), stat=Cash())
+        result = sfit.fit()
+        self.compare_results(self._fit_diff_poly_bench, result)
+
+    def test_same_cache(self):
+        poly = Polynom1D()
+        poly.pars[1].thaw()
+        sdata = DataSimulFit('all', (self.d1, self.d2, self.d3))
+        smodel = SimulFitModel('same', (poly, poly, poly))
+        sfit = Fit(sdata, smodel, method=NelderMead(), stat=Cash())
+        result = sfit.fit()
+        self.compare_results(self._fit_same_poly_bench, result)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -189,6 +189,9 @@ class Data(BaseData):
     def eval_model_to_fit(self, modelfunc):
         return modelfunc(*self.get_indep(filter=True, model=modelfunc))
 
+    def _get_indep(self, filter=False):
+        return self.get_indep(filter=filter)
+
     #
     # Primary properties.  These can depend only on normal attributes (and not
     # other properties).

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -503,7 +503,7 @@ class ArithmeticModel(Model):
         # Model caching ability
         # queue memory of maximum size
         self.cache = 5
-        self._use_caching = False  # FIXME: reduce number of variables?
+        self._use_caching = True  # FIXME: reduce number of variables?
         self._queue = ['']
         self._cache = {}
         Model.__init__(self, name, pars)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2010, 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016, 2017, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2017, 2018 Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -863,7 +863,7 @@ class WStat(Likelihood):
         # original code used this approach.
         #
         data_src = []
-        data_model = []
+        data_model = data.eval_model_to_fit(model)
         data_bkg = []
         nelems = []
         exp_src = []
@@ -874,7 +874,6 @@ class WStat(Likelihood):
 
             y = dset.to_fit(staterrfunc=None)[0]
             data_src.append(y)
-            data_model.append(dset.eval_model_to_fit(mexpr))
             nelems.append(y.size)
 
             try:
@@ -952,7 +951,6 @@ class WStat(Likelihood):
             exp_bkg.append(bset.exposure * ascal)
 
         data_src = numpy.concatenate(data_src)
-        data_model = numpy.concatenate(data_model)
         exp_src = numpy.concatenate(exp_src)
         exp_bkg = numpy.concatenate(exp_bkg)
         data_bkg = numpy.concatenate(data_bkg)

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2017, 2018 Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2017, 2018
+#             Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
# Release Note
When fitting multiple datasets simultaneously Sherpa now tries to cache model evaluations to improve performance.

# Notes

This PR addresses one element of #442, in particular:

    2b/ Slowness in fitting X-ray spectra:
          - issues in simultaneous fitting of multiple data (more general) - do not reevaluate the models with
            the same parameters multiple times 