### PR TITLE
Release/4.10.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,179 @@
+stages:
+  - extract
+  - build and package
+  - deploy
+  - test deploy
+
+extract:
+  stage: extract
+  image: registry.gitlab.com/olaurino/sherpa-docker-build:master
+  variables:
+     GIT_SUBMODULE_STRATEGY: 'none'
+  script:
+     - conda install numpy
+     - python setup.py sdist
+     - python -c "import sherpa; print(sherpa._version.get_versions()['version'])" > dist/version
+     - python -c "import sherpa; print(sherpa._version.get_versions()['full'])" > dist/full
+     - cat dist/version dist/full
+  artifacts:
+     expire_in: "2 weeks"
+     paths:
+         - dist
+
+.template-conda-build: &template_conda_build
+  image: registry.gitlab.com/olaurino/sherpa-docker-build:master
+  stage: build and package
+  tags:
+      - sherpa
+  script:
+      - export SHERPA_FULL_VERSION=$(git describe --tags --always)
+      - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
+      - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
+      - export SHERPA_TARBALL=$(pwd)/$(ls dist/*.tar.gz)
+      - conda build --output-folder /opt/project/packages /opt/project/recipes/sherpa.conda
+      - cp -R /opt/project/packages .
+  dependencies:
+      - extract
+  artifacts:
+    expire_in: "2 weeks"
+    paths:
+        - packages/
+
+.template-macos-conda-build: &template_macos_conda_build
+  tags:
+      - sherpa-macos-build
+  stage: build and package
+  script:
+      - export SHERPA_FULL_VERSION=$(git describe --tags --always)
+      - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
+      - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
+      - export SHERPA_TARBALL=$(pwd)/$(ls dist/*.tar.gz)
+      - mkdir ~/packages
+      - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/olaurino/sherpa-docker-build ~/sherpa-docker-build
+      - conda build --output-folder ~/packages ~/sherpa-docker-build/recipes/sherpa.conda
+      - cp -R ~/packages .
+  dependencies:
+      - extract
+  artifacts:
+      expire_in: "2 weeks"
+      paths:
+          - packages/
+
+macos-python2.7-conda-build:
+  <<: *template_macos_conda_build
+  variables:
+      SHERPA_PYTHON_VERSION: "2.7.*"
+
+macos-python3.5-conda-build:
+  <<: *template_macos_conda_build
+  variables:
+      SHERPA_PYTHON_VERSION: "3.5.*"
+
+macos-python3.6-conda-build:
+  <<: *template_macos_conda_build
+  variables:
+      SHERPA_PYTHON_VERSION: "3.6.*"
+
+linux-python2.7-conda-build:
+  <<: *template_conda_build
+  variables:
+    SHERPA_PYTHON_VERSION: '2.7.*'
+
+linux-python3.5-conda-build:
+  <<: *template_conda_build
+  variables:
+    SHERPA_PYTHON_VERSION: '3.5.*'
+
+linux-python3.6-conda-build:
+  <<: *template_conda_build
+  variables:
+    SHERPA_PYTHON_VERSION: '3.6.*'
+
+conda:
+  stage: deploy
+  tags:
+      - sherpa
+  image: registry.gitlab.com/olaurino/sherpa-docker-build:master
+  dependencies:
+      - linux-python2.7-conda-build
+      - linux-python3.5-conda-build
+      - linux-python3.6-conda-build
+      - macos-python2.7-conda-build
+      - macos-python3.5-conda-build
+      - macos-python3.6-conda-build
+  script:
+      - echo $CONDA_UPLOAD_TOKEN
+      - anaconda -t $CONDA_UPLOAD_TOKEN upload -u sherpa -c dev packages/linux-64/sherpa* --force
+      - anaconda -t $CONDA_UPLOAD_TOKEN upload -u sherpa -c dev packages/osx-64/sherpa* --force
+
+.template-linux-test: &template-linux-test
+  stage: test deploy
+  image: centos:6
+  variables:
+      PAGER: 'less'
+  before_script:
+      - yum install -y -q bzip2 libXext libSM libXrender curl less
+  script:
+      - cd /
+      - curl -LO -k http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip # Hack, gitlab can't checkout the submodule from github
+      - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
+      - export PATH=~/miniconda/bin:$PATH
+      - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - source activate test
+      - pip install /master.zip
+      - sherpa_smoke -f astropy
+      - sherpa_test
+      - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - source activate test35
+      - pip install /master.zip
+      - sherpa_smoke -f astropy
+      - sherpa_test
+      - conda create -n test36 --yes -q -c sherpa/label/dev python=3.6 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - source activate test36
+      - pip install /master.zip
+      - sherpa_smoke -f astropy
+      - sherpa_test
+
+centos6-test:
+  <<: *template-linux-test
+
+centos7-test:
+  <<: *template-linux-test
+  image: centos:7
+
+ubuntu14-test:
+  <<: *template-linux-test
+  image: ubuntu:14.04
+  before_script:
+      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
+
+ubuntu16-test:
+  <<: *template-linux-test
+  image: ubuntu:16.04
+  before_script:
+      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
+
+#ubuntu17-test:
+#  <<: *template-linux-test
+#  image: ubuntu:17.10
+#  before_script:
+#      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
+#
+#ubuntu18-test:
+#  <<: *template-linux-test
+#  image: ubuntu:18.04
+#  before_script:
+#      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
+
+fedora26-test:
+  <<: *template-linux-test
+  image: fedora:26
+
+fedora27-test:
+  <<: *template-linux-test
+  image: fedora:27
+
+#fedora28-test:
+#  <<: *template-linux-test
+#  image: fedora:28

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ How To Install Sherpa
 =====================
 
 Sherpa can be installed from a binary distribution or built from
-sources. The 4.9.1 release is available for Python 2.7, 3.5, and 3.6.
+sources. The 4.10.0 release is available for Python 2.7, 3.5, and 3.6.
 
 The binary distribution is available for Linux and Mac OS X via conda installation 
 described in sections [1a](#1a-anaconda) and [1b](#1b-starting-from-scratch). This is the fastest
@@ -111,7 +111,7 @@ and then refer to section [1a](#1a-anaconda).
 Notice that section [1b](#1b-starting-from-scratch). only provides instructions on how to install a minimal
 Anaconda-powered environment, not the full Anaconda distribution.
 
-The Sherpa 4.9.1  release - which is the latest binary release - is
+The Sherpa 4.10.0 release - which is the latest binary release - is
 compatible with Python 2.7 and with Python 3.5.
 
 
@@ -175,7 +175,7 @@ Add the Sherpa conda repositories to your configuration:
 
 Create a new environment and install Sherpa:
 
-    $ conda create -n sherpa sherpa=4.9
+    $ conda create -n sherpa sherpa=4.10
 
 The above command will download and install Sherpa and its dependencies in an
 isolated environment, so that Sherpa will not interfere with your System's
@@ -265,12 +265,12 @@ You can clone the Sherpa repository with:
     $ git clone https://github.com/sherpa/sherpa
     $ cd sherpa
 
-The most stable code is available through the 4.9.1 tag. The main
+The most stable code is available through the 4.10.0 tag. The main
 development code, which is unstable, is available in the `master`
 branch. New features and bug fixes or other, even less stable versions
 of the code may be available in other branches.
 
-The master branch supports Python 2.7, 3.5, and 3.6 (4.9.1 tag). Note the
+The master branch supports Python 2.7, 3.5, and 3.6. Note the
 4.8.1 tag and earlier are only compatible with Python 2.7.
 
 ### 2c. Build Sherpa
@@ -358,7 +358,7 @@ was installed.
 The external test data files can be
 installed from GitHub channel by saying:
 
-    $ pip install https://github.com/sherpa/sherpa-test-data/archive/4.9.1.tar.gz
+    $ pip install https://github.com/sherpa/sherpa-test-data/archive/4.10.0.tar.gz
 
 At this point, `sherpa_test` will pick up the data and so run more
 tests.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ to seamlessly install Sherpa.
 First you need to add the Sherpa channel to your configuration,
 and then install Sherpa:
 
-    $ conda config --add channels https://conda.anaconda.org/sherpa
+    $ conda config --add channels sherpa
     $ conda install sherpa
 
 To update Sherpa:
@@ -171,7 +171,7 @@ for BASH or `$HOME/.cshrc` for TCSH.
 
 Add the Sherpa conda repositories to your configuration:
 
-    $ conda config --add channels https://conda.anaconda.org/sherpa
+    $ conda config --add channels sherpa
 
 Create a new environment and install Sherpa:
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,122 @@
 Release Notes
 
+Sherpa 4.10.0
+=============
+This release of Standalone Sherpa corresponds to the Sherpa code released as part of CIAO 4.10.
+
+Sherpa 4.10.0 fixes several bugs related to the support of instrumental responses, including improved support of XMM and
+Swift responses.
+
+Also, this release fixes a significant bug in the support of user statistics, improvements to the Python 3 compatibility,
+more robust usage of the numpy API, as well as several other minor bug fixes and new tests.
+
+Additionally, this release introduces support for XSPEC 12.9.1n models, as well as the ability to use aliases for
+parameter names. Some parameter names have been deprecated and may be removed in a future release. We reviewed the
+parameter limits for many models and updated them to reflect the latest XSPEC specification. Also, multiple versions of
+XSPEC are now supported, through optional models and version-dependent low-level function calls. This feature is for
+advanced users building Sherpa from source. Note that Sherpa has been tested against XSPEC 12.9.0i, 12.9.0o, and
+12.9.1n. Note that XSPEC is not directly supported by the standalone binary builds, and users are expected to build
+Sherpa from sources if they want to link it against their version of XSPEC. These changes make it easier for user to
+link different versions of XSPEC with the same Sherpa code base. Also note, however, that XSPEC 12.10 is not currently
+supported.
+
+Sherpa now requires pytest-3.3 or later for running the tests.
+
+Details
+---------
+
+#438 Change from error to warning for OGIP violations
+  Given that users can not easily change a response file, and previous versions of Sherpa would allow the responses to
+  be used, this commit changes some of the errors recently introduced (in PR #383) into warnings. The errors for the
+  first bin edge being <= 0 are still left in because users of the sherpa.astro.ui module will find that these files are
+  auto-corrected for them (by PR #383).
+
+#430 Update XSPEC parameters
+  XSPEC model parameter default values, limits, and properties were reviewed and updated to reflect changes in or
+  mismatches with the model.dat file shipped with XSPEC 12.9.1n.
+
+#428 handle function name changes in XSPEC 12.9.1
+  Sherpa now supports multiple versions of the XSPEC models from the 12.9.0 and 12.9.1 series. Some models recommend
+  using the C-style interface over the older FORTRAN one, which may also resolve some memory access issues. For CIAO
+  4.10 users this means the interfaces to XSPEC models have been updated to the 12.9.1n versions. For Standalone Sherpa
+  users this means they can build and run Sherpa against a larger range of XSPEC versions, and Sherpa will pick the
+  XSPEC low level model function accordingly. Note that Sherpa has been tested against XSPEC 12.9.0i, 12.9.0o, and
+  12.9.1n. The 14 models that have been changed are: apec, bapec, bvapec, bvvapec, gaussian, lorentz, meka, mekal,
+  raymond, vapec, vmeka, vmekal, vraymond, and vvapec.
+
+#427 Add support for XSPEC models added in 12.9.1 (fix #331)
+  Add support for models added in XSPEC 12.9.1: bvtapec, bvvtapec, tapec, vtapec, vvtapec, carbatm, hatm, ismabs,
+  slimbh, snapec, TBfeo, TBgas, TBpcf, TBrel, voigt, xscat.
+  Version 12.9.0 of XSPEC can still be used, in which case the models can be generated - e.g. a user can say xstapec.mdl
+  to create a Python object - but it will error out when evaluated.
+  The Si and S elemental parameters for the ismabs model have been renamed from the XSPEC versions since they are not
+  unique using the caseinsensitive matching used by Sherpa: so SI, SII, SIII and SiI, SiII, SiIII have been renamed S_I,
+  S_II, S_III and Si_I, Si_II, and Si_III respectively.
+  Low level support for the following convolution models from XSPEC 12.9.1 has also been added, but there is no Python
+  model support for these: clumin, rfxconv, vashift, vmshift, xilconv.
+
+#412 support ROSAT PSPC (and similar) RMF files with AstroPy
+  Add explicit tests for reading in, and using, ROSAT PSPC PHA and RMF files. Fix a bug in the AstroPy back-end handling
+  of the ROSAT RMF file.
+
+#409 EmissionGaussian model when skew parameter is not unity (fix #403)
+  The `sherpa.astro.optical.EmissionGaussian` code has been fixed for the case when the skew parameter is not unity. The
+  documentation has also been updated.
+
+#399 Python 3 fixes and new tests for pha2 datasets
+  Fixed several problems when using Sherpa with Python 3: failures when calling `list_bkg_ids` and `list_response_ids`
+  and the parameter querying after `paramprompt(True)` has been called.
+  There is also a change to avoid a `FutureWarning` being raised in the astropy backend when reading in PHA2 data files.
+  Tests have been added to test the reading of a PHA2 format dataset, and new files added to the `sherpa-test-data`
+  repository for this purpose.
+
+#398 Check that list_samplers returns a list (fix #397)
+  The `list_samplers` function now returns a list in Python 3 as well.
+
+#396 Fix `set_xlog` and related commands using Python 3 (fix #393)
+  Fix use of commands that set the plot state using the `sherpa.astro.ui` module, such as `set_xlog` and `set_xlinear`,
+  when using Python 3.
+
+#395 Add xspec optional models
+  Sherpa has new infrastructure for supporting multiple versions of XSPEC at the same time, with models that are built
+  and enabled conditionally depending on the version of XSPEC being linked. Models are assumed to have the same
+  parameters and low level functions across supported versions.
+
+#394 XSPEC build and functionality improvements
+  Add support for reading and changing the path to the XSPEC "manager" directory, and reading the current XSPEC "model"
+  directory (`get_xspath_manager`, `set_xspath_manager`, and `get_xspath_model`). These are intended for the power user
+  and so require an explicit import from `sherpa.astro.xspec`.
+  There are several improvements to the build and interface to the XSPEC model library: these have no user-visible
+  changes.
+
+#390 Add nlapec model
+  The `nlapec` XSpec model has been added. Note that XSPEC 12.9.0 is now required.
+
+#385 DS9 calls return string in Python 2 and 3 (fix #319)
+  Some low lever `xpa` calls were returning byte strings rather than strings in Python 3. This had particular impact on
+  the `image_getregion` function. This has now been fixed.
+
+#383 Replace 0-energy bins in ARF and RMFs (fix #332)
+  Sherpa now performs some validation of the energy ranges of ARF and RMF files against the OGIP standard. If the ranges
+  are inconsistent then the code will return with an error. If one energy bound is 0 the bound is replaced with a small
+  number to avoid numerical issues like division by zero. A new configuration option `minimum_energy`, if present,
+  allows users to override Sherpa's default behavior.
+
+#379 Use a line not span to draw horizontal line (fix #378)
+  Ensure that the line at y=0 (residual) or y=1 (ratio) is drawn for residual or ratio plots when using matplotlib 2.0.
+
+#373 Make sure ds9 properly works with Python 2.7 (fix #368)
+ For Python versions prior to 3.2 add in explicit code to make _Popen work as a context manager.
+
+#352 Add low-level support for the XSPEC rgsxsrc convolution model
+  Add low-level support for the rgsxsrc convolution model in XSPEC. This is intended for R&D into fully supporting XSPEC
+  convolution models in Sherpa.
+
+#255 Add aliases for parameter names so to support new xspec names (fix #74)
+  The XSPEC models have been updated to use parameter names that match the new XSPEC naming scheme introduced in XSPEC
+  12.9.0. The old parameter names can still be used as aliases for the new name, but are deprecated and may be removed
+  in a next major release. Note this allows any models to define aliases for their parameters.
+
 Sherpa 4.9.1
 ============
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-# Copyright (C) 2014, 2017  Smithsonian Astrophysical Observatory
+# Copyright (C) 2014, 2017, 2018 Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -66,6 +66,7 @@ meta = dict(name='sherpa',
             description='Modeling and fitting package for scientific data analysis',
             license='GNU GPL v3',
             long_description=open('README.md', 'rt').read(),
+            long_description_content_type='text/markdown',
             platforms='Linux, Mac OS X',
             install_requires=['numpy', 'six'],
             tests_require=['mock', 'pytest-xvfb', 'pytest>=3.3'],

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -38,6 +38,7 @@ the standard subpackages, use ``import sherpa.all`` or
 import logging
 import os
 import os.path
+import subprocess
 import sys
 
 
@@ -159,8 +160,8 @@ def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=F
 def _install_test_deps():
     def install(package_name):
         try:
-            import pip
-            pip.main(['install', package_name])
+            subprocess.call([sys.executable, '-m', 'pip', 'install', package_name],
+                               stdout=sys.stdout, stderr=sys.stderr)
         except:
             print("""Cannot import pip or install packages with it.
             You need pytest, and possibly pytest-cov, in order to run the tests.


### PR DESCRIPTION
In addition to the code from master, minor changes to the text files were made, and a gitlab-ci configuration file was added for creating and testing the conda binaries. Additionally, code was added to `setup.py` for compatibility with the new `PyPI` web application, as the README is now correctly rendered as markdown. Changes were also made to make sure the testing code would install dependencies with pip 10.