### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Release History
 
 4.8.2: 23 September 2016 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.154744.svg)](https://doi.org/10.5281/zenodo.154744)
 
-4.8.1: 15 April 2016 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.49832.svg)](http://dx.doi.org/10.5281/zenodo.49832)
+4.8.1: 15 April 2016 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.49832.svg)](https://doi.org/10.5281/zenodo.49832)
 
-4.8.0: 27 January 2016 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.45243.svg)](http://dx.doi.org/10.5281/zenodo.45243)
+4.8.0: 27 January 2016 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.45243.svg)](https://doi.org/10.5281/zenodo.45243)
 

--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -644,7 +644,7 @@ class NelderMead(OptMethod):
 
     .. [1] "A simplex method for function minimization", J.A. Nelder
            and R. Mead (Computer Journal, 1965, vol 7, pp 308-313)
-           http://dx.doi.org/10.1093%2Fcomjnl%2F7.4.308
+           https://doi.org/10.1093%2Fcomjnl%2F7.4.308
 
     .. [2] "Convergence Properties of the Nelder-Mead Simplex
            Algorithm in Low Dimensions", Jeffrey C. Lagarias, James


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links.

Cheers!