### PR TITLE
Remove pyfits support (address #460)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,7 @@ You can start using Sherpa by starting a Python shell, or you can install
 `ipython` and use it as a more convenient shell. We recommend that you also install
 `ipython-notebook` and `matplotlib` so that you can use the nice `ipython` notebook
 features and the seamless integration with `matplotlib` for plotting from
-Sherpa. We also recommend that you install `astropy` for enabling FITS I/O
-(Sherpa will look for `pyfits` if `astropy` is not present).
+Sherpa. We also recommend that you install `astropy` for enabling FITS I/O.
 
     $ conda install ipython-notebook matplotlib astropy
 
@@ -230,10 +229,9 @@ It is *highly* recommended that [`matplotlib`](http://matplotlib.org/)
 be installed, as this is used to create graphical output (although the
 code can be built and used without this package), and
 [`ipython`](http://ipython.org/), which is for interactive analysis.
-Data I/O requires a `FITS` I/O library. Sherpa looks for
-[`astropy`](http://www.astropy.org) by default,
-and it falls back to [`pyfits`](http://www.stsci.edu/institute/software_hardware/pyfits) 
-if `astropy` is not installed.
+Data I/O requires a `FITS` I/O library; at present the supported
+libraries are [`astropy`](http://www.astropy.org) and
+Crates from CIAO.
 
 The instructions on how to set up the prerequisites vary from system to system,
 and even on the same system there may be multiple ways of setting up the requirements.

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2007, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -94,7 +94,7 @@ try:
 except ImportError:
     raise ImportError("""Cannot import selected FITS I/O backend {}.
     If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
-    If you are using Standalone Sherpa, please install astropy (pyfits should also work, but it's deprecated)."""
+    If you are using Standalone Sherpa, please install astropy."""
                       .format(io_opt))
 
 warning = logging.getLogger(__name__).warning

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -149,7 +149,7 @@ class SmokeTest(unittest.TestCase):
 
     # Using skipIf directly as we need these tests to run when there is no pytest installed, so we can't use
     # the decorators in sherpa.utils.testing
-    @unittest.skipIf(not has_package_from_list('pyfits', 'astropy.io.fits', 'pycrates'), reason="Requires fits backend")
+    @unittest.skipIf(not has_package_from_list('astropy.io.fits', 'pycrates'), reason="Requires fits backend")
     def test_fits_io(self):
         """
         Test that basic FITS I/O functions work.

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -229,8 +229,7 @@ if HAS_PYTEST:
         Returns True if there is an importable backend for FITS I/O.
         Used to skip tests requiring fits_io
         """
-        packages = ('pyfits',
-                    'astropy.io.fits',
+        packages = ('astropy.io.fits',
                     'pycrates',
                     )
         msg = "FITS backend required"


### PR DESCRIPTION
The pyfits support has long been marked as deprecated and we have
not been testing it, so it's not even clear if it worked.

# Notes

One thing I have not done is a systematic check to ensure that all symbols affected by this change have tests. Note that I haven't added any functionality, but it's not clear to me that our test suite really exercises all these code paths, so it might be a good time to expand the test coverage.