### PR TITLE
Add simple MacOS Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,19 @@ matrix:
     # We need to use TEST=none to remove the test-data submodule.
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
     # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
-    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
-    - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py27_0" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
+    - env: XSPECVER="12.9.0i" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
       sudo: required
       dist: trusty
     # As above, Python 3.5
-    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
-    - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py35_0" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.9.0i" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
       sudo: required
       dist: trusty
     # As above, Python 3.6, setup.py install
-    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
-    - env: XSPECVER="12.9.0i" NUMPYVER="1.11.3=py36_0" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
+    - env: XSPECVER="12.9.0i" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
     # As above, xspec 12.9.1n
-    # Note we are pinning down the numpy version to the latest that worked with our xspec conda package
-    - env: XSPECVER="12.9.1" NUMPYVER="1.13.3=py36ha12f23b_0" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="3.6"
+    - env: XSPECVER="12.9.1" NUMPYVER="1.14" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
     # Install sherpatest package rather than relying on relative location of the submodule

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,18 +37,18 @@ matrix:
     - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
 
 before_install:
-  - . travis/setup_conda.sh
+  - source travis/setup_conda.sh
 
   # XSPEC and DS9
   - if [ -n "${XSPECVER}" ];
-      then . travis/setup_xspec_ds9.sh;
+      then source travis/setup_xspec_ds9.sh;
     fi
 
 install:
     - python setup.py $INSTALL_TYPE &> install.log
 
 script:
-  - . travis/test.sh
+  - source travis/test.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ language: c
 
 sudo: false
 
-addons:
-  apt:
-    packages: &default_apt
-      - gfortran
-
 matrix:
   fast_finish: true
   include:
+    # macOS build
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="3.6"
+      os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
@@ -43,85 +41,18 @@ matrix:
     - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
 
 before_install:
-  # General configurations
-  - export LIBGFORTRANVER="3.0"
-  - export SHERPA_CHANNEL=sherpa
-  - export XSPEC_CHANNEL=cxc/channel/dev
-  - export MINICONDA=/home/travis/miniconda
-
-  # Install, update, and configure conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $MINICONDA
-  - export PATH=$MINICONDA/bin:$PATH
-  - conda update --yes conda
-  - conda config --add channels ${SHERPA_CHANNEL}
-  - conda config --add channels ${XSPEC_CHANNEL}
-
-  # Figure out requested dependencies
-  - if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
-  - if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
-  - if [ -n "${XSPECVER}" ];
-     then export XSPEC="xspec-modelsonly=${XSPECVER}";
-    fi
-  - echo ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}
-
-  # Create and activate conda build environment
-  # We create a new environment so we don't care about the python version in the root environment.
-  - conda create --yes --quiet -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} ${MKL} libgfortran=$LIBGFORTRANVER $XSPEC $FITS
-  - source activate build
+  - . travis/setup_conda.sh
 
   # XSPEC and DS9
   - if [ -n "${XSPECVER}" ];
-     then DS9_SITE=http://ds9.si.edu/download/centos6/;
-     XPA_SITE=http://ds9.si.edu/download/centos6/;
-     DS9_TAR=ds9.centos6.7.5.tar.gz;
-     XPA_TAR=xpa.centos6.2.1.17.tar.gz;
-     wget --quiet $DS9_SITE$DS9_TAR;
-     wget --quiet $XPA_SITE$XPA_TAR;
-     THIS_DIR=`pwd`;
-     cd $MINICONDA/bin; tar xf $THIS_DIR/$DS9_TAR; tar xf $THIS_DIR/$XPA_TAR; cd -;
-     sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
-     export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
-     export LD_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
-     export XSPEC_INCLUDE_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/include/;
-     sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
-     sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=$LD_LIBRARY_PATH|g" setup.cfg;
-     sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=$XSPEC_INCLUDE_PATH|g" setup.cfg;
-    fi
-
-  # No test data, then remove submodule (git automatically clones recursively)
-  - if [ ${TEST} == none ];
-     then git submodule deinit -f .;
-    fi
-
-  # Install test data as a package, then remove the submodule
-  - if [ ${TEST} == package ];
-     then pip install ./sherpa-test-data;
-     git submodule deinit -f .;
+      then . travis/setup_xspec_ds9.sh;
     fi
 
 install:
-    - python setup.py $INSTALL_TYPE &> install.log
+    - python setup.py $INSTALL_TYPE
 
 script:
-  # Build smoke test switches, to ensure requested dependencies are reachable
-  - if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
-  - if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
-  - SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
-
-  # Install coverage tooling and run tests using setuptools
-  - if [ ${TEST} == submodule ]; then pip install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term"; fi
-
-  # Run smoke test
-  - cd /home;
-  - sherpa_smoke ${SMOKEVARS};
-
-  # Run regression tests using sherpa_test
-  - if [ ${TEST} == package ] || [ ${TEST} == none ];
-        then cd $HOME;
-        sherpa_test;
-    fi
+  - . travis/test.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
     fi
 
 install:
-    - python setup.py $INSTALL_TYPE
+    - python setup.py $INSTALL_TYPE &> install.log
 
 script:
   - . travis/test.sh

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Environment
+LIBGFORTRANVER="3.0"
+SHERPA_CHANNEL=sherpa
+XSPEC_CHANNEL=cxc/channel/dev
+MINICONDA=$HOME/miniconda
+
+if [[ ${TRAVIS_OS_NAME} == linux ]];
+then
+    MINICONDA_OS=Linux
+    export COMPILERS="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
+    sed -i.orig "s|#extra-fortran-link-flags=|extra-fortran-link-flags=-shared|" setup.cfg
+else  # osx
+    MINICONDA_OS=MacOSX
+    export COMPILERS="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
+
+    # This is required on macOS when building with conda
+    sed -i.orig "s|#extra-fortran-link-flags=|extra-fortran-link-flags=-undefined dynamic_lookup -bundle|" setup.cfg
+
+    # It looks like xvfb doesn't "just work" on osx travis, so...
+    sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+fi
+
+# Download and install conda
+wget http://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p $MINICONDA
+export PATH=$MINICONDA/bin:$PATH
+
+# update and add channels
+conda update --yes conda
+conda config --add channels ${SHERPA_CHANNEL}
+conda config --add channels ${XSPEC_CHANNEL}
+
+# Figure out requested dependencies
+if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
+if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
+if [ -n "${XSPECVER}" ];
+ then export XSPEC="xspec-modelsonly=${XSPECVER}";
+fi
+echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}"
+
+# Create and activate conda build environment
+# We create a new environment so we don't care about the python version in the root environment.
+conda create --yes --quiet -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} $XSPEC $FITS ${COMPILERS}\
+  libgfortran=${LIBGFORTRANVER}
+
+source activate build
+
+# It looks like on some systems (well, linux) the F90 variable needs to be set. Not sure why
+export F90=${F77}
+
+# This is required to make sure that the CIAO python extensions being build pick the correct flags
+export PYTHON_LDFLAGS=" "

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -51,5 +51,5 @@ source activate build
 # It looks like on some systems (well, linux) the F90 variable needs to be set. Not sure why
 export F90=${F77}
 
-# This is required to make sure that the CIAO python extensions being build pick the correct flags
+# This is required to make sure that the CIAO python extensions being built pick the correct flags
 export PYTHON_LDFLAGS=" "

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
 # Environment
-LIBGFORTRANVER="3.0"
-SHERPA_CHANNEL=sherpa
-XSPEC_CHANNEL=cxc/channel/dev
-MINICONDA=$HOME/miniconda
+libgfortranver="3.0"
+sherpa_channel=sherpa
+xspec_channel=cxc/channel/dev
+miniconda=$HOME/miniconda
 
 if [[ ${TRAVIS_OS_NAME} == linux ]];
 then
-    MINICONDA_OS=Linux
-    export COMPILERS="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
+    miniconda_os=Linux
+    compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
     sed -i.orig "s|#extra-fortran-link-flags=|extra-fortran-link-flags=-shared|" setup.cfg
 else  # osx
-    MINICONDA_OS=MacOSX
-    export COMPILERS="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
+    miniconda_os=MacOSX
+    compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
 
     # This is required on macOS when building with conda
     sed -i.orig "s|#extra-fortran-link-flags=|extra-fortran-link-flags=-undefined dynamic_lookup -bundle|" setup.cfg
@@ -23,15 +23,15 @@ else  # osx
 fi
 
 # Download and install conda
-wget http://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh -O miniconda.sh
+wget http://repo.continuum.io/miniconda/Miniconda3-latest-${miniconda_os}-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
-./miniconda.sh -b -p $MINICONDA
-export PATH=$MINICONDA/bin:$PATH
+./miniconda.sh -b -p $miniconda
+export PATH=$miniconda/bin:$PATH
 
 # update and add channels
 conda update --yes conda
-conda config --add channels ${SHERPA_CHANNEL}
-conda config --add channels ${XSPEC_CHANNEL}
+conda config --add channels ${sherpa_channel}
+conda config --add channels ${xspec_channel}
 
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
@@ -43,8 +43,8 @@ echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}"
 
 # Create and activate conda build environment
 # We create a new environment so we don't care about the python version in the root environment.
-conda create --yes --quiet -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} $XSPEC $FITS ${COMPILERS}\
-  libgfortran=${LIBGFORTRANVER}
+conda create --yes --quiet -n build python=$TRAVIS_PYTHON_VERSION pip ${MATPLOTLIB} ${NUMPY} $XSPEC $FITS ${compilers}\
+  libgfortran=${libgfortranver}
 
 source activate build
 

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Tarballs to fetch
+DS9_SITE=http://ds9.si.edu/download/centos6/;
+XPA_SITE=http://ds9.si.edu/download/centos6/;
+DS9_TAR=ds9.centos6.7.5.tar.gz;
+XPA_TAR=xpa.centos6.2.1.17.tar.gz;
+
+# Fetch them
+wget --quiet $DS9_SITE$DS9_TAR;
+wget --quiet $XPA_SITE$XPA_TAR;
+
+# untar them
+THIS_DIR=$(pwd);
+cd $MINICONDA/bin; tar xf $THIS_DIR/$DS9_TAR; tar xf $THIS_DIR/$XPA_TAR; cd -;
+
+# install build dependencies
+sudo apt-get update
+sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
+
+# Some relevant environment variables
+export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
+export LD_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
+export XSPEC_INCLUDE_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/include/;
+export WCS_DIR_PATH=/usr/lib/x86_64-linux-gnu/
+
+# Change build configuration
+sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
+sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${LD_LIBRARY_PATH}|g" setup.cfg;
+sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${XSPEC_INCLUDE_PATH}|g" setup.cfg;
+sed -i.orig "s|#wcslib_lib_dirs = None|wcslib_lib_dirs=${WCS_DIR_PATH}|g" setup.cfg;
+sed -i.orig "s|#gfortran_libraries = gfortran|gfortran_libraries= :libgfortran.so.3|g" setup.cfg;

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -1,32 +1,36 @@
 #!/usr/bin/env bash
 
 # Tarballs to fetch
-DS9_SITE=http://ds9.si.edu/download/centos6/;
-XPA_SITE=http://ds9.si.edu/download/centos6/;
-DS9_TAR=ds9.centos6.7.5.tar.gz;
-XPA_TAR=xpa.centos6.2.1.17.tar.gz;
+ds9_site=http://ds9.si.edu/download/centos6/
+xpa_site=http://ds9.si.edu/download/centos6/
+ds9_tar=ds9.centos6.7.5.tar.gz
+xpa_tar=xpa.centos6.2.1.17.tar.gz
 
 # Fetch them
-wget --quiet $DS9_SITE$DS9_TAR;
-wget --quiet $XPA_SITE$XPA_TAR;
+wget --quiet $ds9_site$ds9_tar
+wget --quiet $xpa_site$xpa_tar
 
 # untar them
-THIS_DIR=$(pwd);
-cd $MINICONDA/bin; tar xf $THIS_DIR/$DS9_TAR; tar xf $THIS_DIR/$XPA_TAR; cd -;
+THIS_DIR=$(pwd)
+cd $miniconda/bin
+tar xf $THIS_DIR/$ds9_tar
+tar xf $THIS_DIR/$xpa_tar
+cd -
 
 # install build dependencies
 sudo apt-get update
-sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
+sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev
 
-# Some relevant environment variables
-export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
-export XSPEC_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
-export XSPEC_INCLUDE_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/include/;
-export WCS_DIR_PATH=/usr/lib/x86_64-linux-gnu/
+# Set HEADAS environment variables
+export HEADAS=$miniconda/envs/build/Xspec/spectral
+
+xspec_library_path=$miniconda/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/
+xpec_include_path=$miniconda/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/include/
+wcs_library_path=/usr/lib/x86_64-linux-gnu/
 
 # Change build configuration
-sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
-sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${XSPEC_LIBRARY_PATH}|g" setup.cfg;
-sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${XSPEC_INCLUDE_PATH}|g" setup.cfg;
-sed -i.orig "s|#wcslib_lib_dirs = None|wcslib_lib_dirs=${WCS_DIR_PATH}|g" setup.cfg;
-sed -i.orig "s|#gfortran_libraries = gfortran|gfortran_libraries= :libgfortran.so.3|g" setup.cfg;
+sed -i.orig "s/#with-xspec=True/with-xspec=True/g" setup.cfg
+sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${xspec_library_path}|g" setup.cfg
+sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xpec_include_path}|g" setup.cfg
+sed -i.orig "s|#wcslib_lib_dirs = None|wcslib_lib_dirs=${wcs_library_path}|g" setup.cfg
+sed -i.orig "s|#gfortran_libraries = gfortran|gfortran_libraries= :libgfortran.so.3|g" setup.cfg

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -20,13 +20,13 @@ sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev;
 
 # Some relevant environment variables
 export HEADAS=$MINICONDA/envs/build/Xspec/spectral;
-export LD_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
+export XSPEC_LIBRARY_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/lib/;
 export XSPEC_INCLUDE_PATH=$MINICONDA/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0/include/;
 export WCS_DIR_PATH=/usr/lib/x86_64-linux-gnu/
 
 # Change build configuration
 sed -i.orig s/#with-xspec=True/with-xspec=True/g setup.cfg;
-sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${LD_LIBRARY_PATH}|g" setup.cfg;
+sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${XSPEC_LIBRARY_PATH}|g" setup.cfg;
 sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${XSPEC_INCLUDE_PATH}|g" setup.cfg;
 sed -i.orig "s|#wcslib_lib_dirs = None|wcslib_lib_dirs=${WCS_DIR_PATH}|g" setup.cfg;
 sed -i.orig "s|#gfortran_libraries = gfortran|gfortran_libraries= :libgfortran.so.3|g" setup.cfg;

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -14,7 +14,7 @@ fi
 # Build smoke test switches, to ensure requested dependencies are reachable
 if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
 if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
-SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
+smokevars="${XSPECTEST} ${FITSTEST} -v 3"
 
 # Install coverage tooling and run tests using setuptools
 if [ ${TEST} == submodule ]; then
@@ -23,7 +23,7 @@ fi
 
 # Run smoke test
 cd /home;
-sherpa_smoke ${SMOKEVARS};
+sherpa_smoke ${smokevars};
 
 # Run regression tests using sherpa_test
 if [ ${TEST} == package ] || [ ${TEST} == none ];

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# No test data, then remove submodule (git automatically clones recursively)
+if [ ${TEST} == none ];
+ then git submodule deinit -f .;
+fi
+
+# Install test data as a package, then remove the submodule
+if [ ${TEST} == package ];
+ then pip install ./sherpa-test-data;
+ git submodule deinit -f .;
+fi
+
+# Build smoke test switches, to ensure requested dependencies are reachable
+if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
+if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
+SMOKEVARS="${XSPECTEST} ${FITSTEST} -v 3"
+
+# Install coverage tooling and run tests using setuptools
+if [ ${TEST} == submodule ]; then
+    pip install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term";
+fi
+
+# Run smoke test
+cd /home;
+sherpa_smoke ${SMOKEVARS};
+
+# Run regression tests using sherpa_test
+if [ ${TEST} == package ] || [ ${TEST} == none ];
+    then cd $HOME;
+    sherpa_test;
+fi


### PR DESCRIPTION
This PR introduces a Travis job for macOS. The job does not include the xspec and ds9 tests, which will be included in a different PR when the xspec conda package for macOS will be available.

Note that in order to make the builds possible on Travis both for macOS and Linux, and in order to make them both simple and not too different from each other, the travis configuration is a complete overhaul of the previous one. As a result, this will fix #199 (@DougBurke please confirm) and it will also fix #426, as there is now special configuration for making sure that the xspec extension links against libgfortran-3 and not the newer versions brought in by numpy. The new builds now use the conda built-in compilers.

I can't reproduce #425 with the new jobs, so probably that should be closed too. I don't have time to investigate, I'd rather close the issue and open it again if it comes back (@DougBurke again please confirm).