### PR TITLE
Using overwrite rather than deprecated cobber of astropy.io.fits

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ Sherpa. We also recommend that you install `astropy` for enabling FITS I/O.
 
     $ conda install ipython-notebook matplotlib astropy
 
+The minimum required version of `astropy` is version 1.3, although only 
+versions 2 and higher are used in testing. There are no known
+incompatabilities with `matplotlib`, but there has only been limited
+testing. Please [report any problems](https://github.com/sherpa/sherpa/issues/)
+you find.
 
 Source Build
 ------------

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1010,7 +1010,7 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
     tbl.name = 'HISTOGRAM'
     if packup:
         return tbl
-    tbl.writeto(filename, clobber=True)
+    tbl.writeto(filename, overwrite=True)
 
 
 def _create_header(header):
@@ -1048,7 +1048,7 @@ def set_pha_data(filename, data, col_names, header=None,
     pha.name = 'SPECTRUM'
     if packup:
         return pha
-    pha.writeto(filename, clobber=True)
+    pha.writeto(filename, overwrite=True)
 
 
 def set_image_data(filename, data, header, ascii=False, clobber=False,
@@ -1112,7 +1112,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     img = fits.PrimaryHDU(data['pixels'], header=fits.Header(hdrlist))
     if packup:
         return img
-    img.writeto(filename, clobber=True)
+    img.writeto(filename, overwrite=True)
 
 
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
@@ -1152,4 +1152,4 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
     tbl = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
     tbl.name = 'TABLE'
-    tbl.writeto(filename, clobber=True)
+    tbl.writeto(filename, overwrite=True)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -31,7 +31,6 @@ except ImportError:  # Python 2
     import mock
 
 try:
-    from astropy.utils.exceptions import AstropyDeprecationWarning
     from astropy.io.fits.verify import VerifyWarning
     have_astropy = True
 except ImportError:
@@ -100,13 +99,6 @@ if sys.version_info >= (3, 2):
 
 if have_astropy:
     astropy_warnings = {
-        AstropyDeprecationWarning:
-        [
-            # leave in the 1.3 warning since there was a release version
-            # with this message in
-            r".*clobber.*deprecated.*1.3",
-            r".*clobber.*deprecated.*2.0",
-        ],
         # See bug #372 on GitHub
         ImportWarning:
         [


### PR DESCRIPTION
`clobber` in astropy has been deprecated for a while now in favour of `overwrite` and thus issues a DeprecationWarnings that makes the CI fail for downstream packages.