### PR TITLE
An initial release of simultaneous fit on multicores (slower for most…

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,11 +1,6 @@
 #
-<<<<<<< HEAD
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory
-=======
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018
-#             Smithsonian Astrophysical Observatory
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -9998,11 +9993,7 @@ class Session(sherpa.ui.utils.Session):
         # validate the kwds to f.fit() so user typos do not
         # result in regular fit
         # valid_keys = sherpa.utils.get_keyword_names(sherpa.fit.Fit.fit)
-<<<<<<< HEAD
-        valid_keys = ('outfile', 'clobber', 'filter_nan', 'cache')
-=======
         valid_keys = ('outfile', 'clobber', 'filter_nan', 'numcores')
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
         for key in kwargs.keys():
             if key not in valid_keys:
                 raise TypeError("unknown keyword argument: '%s'" % key)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9993,7 +9993,7 @@ class Session(sherpa.ui.utils.Session):
         # validate the kwds to f.fit() so user typos do not
         # result in regular fit
         # valid_keys = sherpa.utils.get_keyword_names(sherpa.fit.Fit.fit)
-        valid_keys = ('outfile', 'clobber', 'filter_nan', 'numcores')
+        valid_keys = ('outfile', 'clobber', 'filter_nan', 'cache', 'numcores')
         for key in kwargs.keys():
             if key not in valid_keys:
                 raise TypeError("unknown keyword argument: '%s'" % key)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,6 +1,11 @@
 #
+<<<<<<< HEAD
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory
+=======
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018
+#             Smithsonian Astrophysical Observatory
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -9803,7 +9808,7 @@ class Session(sherpa.ui.utils.Session):
 
         return fit_to_ids, datasets, models
 
-    def _get_bkg_fit(self, id, otherids=(), estmethod=None):
+    def _get_bkg_fit(self, id, otherids=(), estmethod=None, numcores=1):
 
         fit_to_ids, datasets, models = self._prepare_bkg_fit(id, otherids)
 
@@ -9812,7 +9817,7 @@ class Session(sherpa.ui.utils.Session):
 
         fit_to_ids = tuple(fit_to_ids)
 
-        f = self._get_fit_obj(datasets, models, estmethod)
+        f = self._get_fit_obj(datasets, models, estmethod, numcores)
 
         return fit_to_ids, f
 
@@ -9993,15 +9998,21 @@ class Session(sherpa.ui.utils.Session):
         # validate the kwds to f.fit() so user typos do not
         # result in regular fit
         # valid_keys = sherpa.utils.get_keyword_names(sherpa.fit.Fit.fit)
+<<<<<<< HEAD
         valid_keys = ('outfile', 'clobber', 'filter_nan', 'cache')
+=======
+        valid_keys = ('outfile', 'clobber', 'filter_nan', 'numcores')
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
         for key in kwargs.keys():
             if key not in valid_keys:
                 raise TypeError("unknown keyword argument: '%s'" % key)
 
+        numcores = kwargs.get('numcores', 1)
+
         if fit_bkg:
-            ids, f = self._get_bkg_fit(id, otherids)
+            ids, f = self._get_bkg_fit(id, otherids, numcores=numcores)
         else:
-            ids, f = self._get_fit(id, otherids)
+            ids, f = self._get_fit(id, otherids, numcores=numcores)
 
         if 'filter_nan' in kwargs and kwargs.pop('filter_nan'):
             for i in ids:

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,6 +1,11 @@
 #
+<<<<<<< HEAD
 #  Copyright (C) 2008, 2015, 2016, 2017, 2019, 2020
 #     Smithsonian Astrophysical Observatory
+=======
+#  Copyright (C) 2008, 2015, 2016, 2017, 2018
+#             Smithsonian Astrophysical Observatory
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -30,9 +35,10 @@ from sherpa.models.regrid import EvaluationSpace1D, EvaluationSpace2D
 from sherpa.utils.err import DataErr
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     print_fields, create_expr, calc_total_error, bool_cast, \
-    filter_bins
+    filter_bins, parallel_map_funcs
 
 
+<<<<<<< HEAD
 __all__ = ('Data', 'DataSimulFit', 'Data1D', 'Data1DInt',
            'Data1DAsymmetricErrs', 'Data2D', 'Data2DInt')
 
@@ -89,6 +95,9 @@ class DataSpace1D(EvaluationSpace1D):
             return self
 
         data = self.grid[0]
+=======
+__all__ = ('Data', 'DataSimulFit', 'Data1D', 'Data1DInt', 'Data2D', 'Data2DInt')
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 
         data = self.filter.apply(data)
         return DataSpace1D(self.filter, data)
@@ -866,20 +875,45 @@ class DataSimulFit(NoNewAttributesAfterInit):
 
     """
 
+<<<<<<< HEAD
     def __init__(self, name, datasets):
         self.name = name
+=======
+    def __init__(self, name, datasets, numcores=1):
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
         if len(datasets) == 0:
             raise DataErr('zerodatasimulfit', type(self).__name__)
         self.datasets = tuple(datasets)
         NoNewAttributesAfterInit.__init__(self)
 
     def eval_model_to_fit(self, modelfuncs):
+<<<<<<< HEAD
         total_model = []
 
         for func, data in zip(modelfuncs, self.datasets):
             total_model.append(data.eval_model_to_fit(func))
 
         return numpy.concatenate(total_model)
+=======
+        if self.numcores == 1:
+            total_model = []
+            for func, data in izip(modelfuncs, self.datasets):
+                tmp_model = data.eval_model_to_fit(func)
+                total_model.append(tmp_model)
+            return numpy.concatenate(total_model)
+        else:
+        # best to make this a different derived class
+            funcs = []
+            datasets = []
+            for func, data in izip(modelfuncs, self.datasets):
+                funcs.append(func)
+                datasets.append(data.get_indep(filter=False))
+            total_model = parallel_map_funcs(funcs, datasets)
+            all_model = []
+            for model, data in izip(total_model, self.datasets):
+                all_model.append(data.apply_filter(model))
+            return numpy.concatenate(all_model)
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 
     def to_fit(self, staterrfunc=None):
         total_dep = []

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,11 +1,6 @@
 #
-<<<<<<< HEAD
 #  Copyright (C) 2008, 2015, 2016, 2017, 2019, 2020
 #     Smithsonian Astrophysical Observatory
-=======
-#  Copyright (C) 2008, 2015, 2016, 2017, 2018
-#             Smithsonian Astrophysical Observatory
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -38,7 +33,6 @@ from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     filter_bins, parallel_map_funcs
 
 
-<<<<<<< HEAD
 __all__ = ('Data', 'DataSimulFit', 'Data1D', 'Data1DInt',
            'Data1DAsymmetricErrs', 'Data2D', 'Data2DInt')
 
@@ -95,9 +89,6 @@ class DataSpace1D(EvaluationSpace1D):
             return self
 
         data = self.grid[0]
-=======
-__all__ = ('Data', 'DataSimulFit', 'Data1D', 'Data1DInt', 'Data2D', 'Data2DInt')
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 
         data = self.filter.apply(data)
         return DataSpace1D(self.filter, data)
@@ -875,29 +866,18 @@ class DataSimulFit(NoNewAttributesAfterInit):
 
     """
 
-<<<<<<< HEAD
-    def __init__(self, name, datasets):
-        self.name = name
-=======
     def __init__(self, name, datasets, numcores=1):
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
         if len(datasets) == 0:
             raise DataErr('zerodatasimulfit', type(self).__name__)
+        self.name = name
         self.datasets = tuple(datasets)
+        self.numcores = numcores
         NoNewAttributesAfterInit.__init__(self)
 
     def eval_model_to_fit(self, modelfuncs):
-<<<<<<< HEAD
-        total_model = []
-
-        for func, data in zip(modelfuncs, self.datasets):
-            total_model.append(data.eval_model_to_fit(func))
-
-        return numpy.concatenate(total_model)
-=======
         if self.numcores == 1:
             total_model = []
-            for func, data in izip(modelfuncs, self.datasets):
+            for func, data in zip(modelfuncs, self.datasets):
                 tmp_model = data.eval_model_to_fit(func)
                 total_model.append(tmp_model)
             return numpy.concatenate(total_model)
@@ -905,15 +885,14 @@ class DataSimulFit(NoNewAttributesAfterInit):
         # best to make this a different derived class
             funcs = []
             datasets = []
-            for func, data in izip(modelfuncs, self.datasets):
+            for func, data in zip(modelfuncs, self.datasets):
                 funcs.append(func)
                 datasets.append(data.get_indep(filter=False))
             total_model = parallel_map_funcs(funcs, datasets)
             all_model = []
-            for model, data in izip(total_model, self.datasets):
+            for model, data in zip(total_model, self.datasets):
                 all_model.append(data.apply_filter(model))
             return numpy.concatenate(all_model)
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 
     def to_fit(self, staterrfunc=None):
         total_dep = []

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -888,7 +888,7 @@ class DataSimulFit(NoNewAttributesAfterInit):
             for func, data in zip(modelfuncs, self.datasets):
                 funcs.append(func)
                 datasets.append(data.get_indep(filter=False))
-            total_model = parallel_map_funcs(funcs, datasets)
+            total_model = parallel_map_funcs(funcs, datasets, self.numcores)
             all_model = []
             for model, data in zip(total_model, self.datasets):
                 all_model.append(data.apply_filter(model))

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,11 +1,7 @@
 from __future__ import print_function
 #
-<<<<<<< HEAD
 #  Copyright (C) 2009, 2015, 2016, 2018, 2019
 #     Smithsonian Astrophysical Observatory
-=======
-#  Copyright (C) 2009, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,7 +1,11 @@
 from __future__ import print_function
 #
+<<<<<<< HEAD
 #  Copyright (C) 2009, 2015, 2016, 2018, 2019
 #     Smithsonian Astrophysical Observatory
+=======
+#  Copyright (C) 2009, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1177,7 +1181,7 @@ class Fit(NoNewAttributesAfterInit):
                                dof, qval, rstat)
 
     @evaluates_model
-    def fit(self, outfile=None, clobber=False):
+    def fit(self, outfile=None, clobber=False, numcores=1):
         """Fit the model to the data.
 
         Parameters
@@ -1230,7 +1234,8 @@ class Fit(NoNewAttributesAfterInit):
 
         init_stat = self.calc_stat()
         # output = self.method.fit ...
-        output = self._iterfit.fit(self._iterfit._get_callback(outfile, clobber),
+        tmp = self._iterfit._get_callback(outfile, clobber)
+        output = self._iterfit.fit(tmp,
                                    self.model.thawedpars,
                                    self.model.thawedparmins,
                                    self.model.thawedparmaxes)

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1187,6 +1187,8 @@ class Fit(NoNewAttributesAfterInit):
            this file.
         clobber : bool, optional
            Determines if the output file can be overwritten.
+        numcores : int or None, optional
+           The number of cores to use in fitting simultaneous data.
 
         Returns
         -------

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,5 +1,9 @@
 #
+<<<<<<< HEAD
 #  Copyright (C) 2009, 2015, 2016, 2017, 2018, 2019
+=======
+#  Copyright (C) 2009, 2015, 2016, 2017, 2018
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #             Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,9 +1,5 @@
 #
-<<<<<<< HEAD
 #  Copyright (C) 2009, 2015, 2016, 2017, 2018, 2019
-=======
-#  Copyright (C) 2009, 2015, 2016, 2017, 2018
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #             Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,7 +1,12 @@
 from __future__ import print_function
 #
+<<<<<<< HEAD
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #       Smithsonian Astrophysical Observatory
+=======
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018
+#                Smithsonian Astrophysical Observatory
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -7553,14 +7558,15 @@ class Session(NoNewAttributesAfterInit):
 
         return ids
 
-    def _get_fit_obj(self, datasets, models, estmethod):
+    def _get_fit_obj(self, datasets, models, estmethod, numcores=1):
+
         datasets = tuple(datasets)
         models = tuple(models)
         if len(datasets) == 1:
             d = datasets[0]
             m = models[0]
         else:
-            d = sherpa.data.DataSimulFit('simulfit data', datasets)
+            d = sherpa.data.DataSimulFit('simulfit data', datasets, numcores)
             m = sherpa.models.SimulFitModel('simulfit model', models)
         if not self._current_method.name == 'gridsearch':
             if m.is_discrete:
@@ -7613,13 +7619,13 @@ class Session(NoNewAttributesAfterInit):
 
         return fit_to_ids, datasets, models
 
-    def _get_fit(self, id, otherids=(), estmethod=None):
+    def _get_fit(self, id, otherids=(), estmethod=None, numcores=1):
 
         fit_to_ids, datasets, models = self._prepare_fit(id, otherids)
 
         self._add_extra_data_and_models(fit_to_ids, datasets, models)
 
-        f = self._get_fit_obj(datasets, models, estmethod)
+        f = self._get_fit_obj(datasets, models, estmethod, numcores)
 
         fit_to_ids = tuple(fit_to_ids)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,12 +1,7 @@
 from __future__ import print_function
 #
-<<<<<<< HEAD
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #       Smithsonian Astrophysical Observatory
-=======
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018
-#                Smithsonian Astrophysical Observatory
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2737,6 +2737,7 @@ def parallel_map(function, sequence, numcores=None):
 
     return run_tasks(procs, err_q, out_q, numcores)
 
+
 def parallel_map_funcs(funcs, datasets, numcores=None):
     """Run a sequence of function on a sequence of inputs in parallel.
 
@@ -2754,7 +2755,6 @@ def parallel_map_funcs(funcs, datasets, numcores=None):
     datasets : a list or tuple of array_like
        The data to be passed to ``func``. The number of elements in
        datasets must match the number of elements of funcs.
-
     numcores : int or None, optional
        The number of calls to ``funcs`` to run in parallel. When
        set to ``None``, all the available CPUs on the machine - as
@@ -2770,15 +2770,14 @@ def parallel_map_funcs(funcs, datasets, numcores=None):
 
     Notes
     -----
-    Due to the overhead involve in passing the functions and datasets
+    Due to the overhead involved in passing the functions and datasets
     to the different cores, the functions should be very time consuming
-    to compute.  A similar requirement (the function is expected to be
-    run on computations that take a significant amount of time to run.)
-    to the the parallel_map function
-
-    An ordered iterable (ie tuple or list) should be used to pass multiple
+    to compute (of order 0.1-1s).  This is similar to the ``parallel_map``
+    function.
+    
+    An ordered iterable (i.e. tuple or list) should be used to pass multiple
     values to the multiple functions. The lengths of the iterable funcs and
-    datasets must be equal. The coressponding funcs and datasets are passed
+    datasets must be equal. The corresponding funcs and datasets are passed
     to the different cores to distribute the work in parallel. There is no
     guarantee to the ordering of the tasks.
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,12 +1,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 #
-<<<<<<< HEAD
 #  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
-=======
-#  Copyright (C) 2007, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,9 +1,5 @@
 #
-<<<<<<< HEAD
 #  Copyright (C) 2010, 2016, 2018, 2019, 2020  Smithsonian Astrophysical Observatory
-=======
-#  Copyright (C) 2010, 2016, 2018  Smithsonian Astrophysical Observatory
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -286,7 +282,7 @@ def test_parallel_map(num_tasks, num_segments):
 
         assert_equal(result, numpy.asarray(pararesult))
 
-<<<<<<< HEAD
+
 
 @pytest.mark.parametrize("los, his, axis", [([], [], [0,1,2,3,4]),
                                             ([], [1], [0,1,2,3,4]),
@@ -393,7 +389,7 @@ def test_filter_bins_unordered():
     assert len(flags) == len(expected)
     for got, exp in zip(flags, expected):
         assert got == exp
-=======
+
 def test_paralle_map_funcs():
     for arg in range(1, 5):
         func = [numpy.sum]
@@ -403,4 +399,4 @@ def test_paralle_map_funcs():
         for func, data in zip(funcs, datas):
             result.extend(numpy.asarray(list(map(func, data))))
         assert_equal(result, utils.parallel_map_funcs(funcs, datas, arg))
->>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
+

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -24,6 +24,11 @@ from numpy.testing import assert_allclose, assert_equal
 from sherpa import utils
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit
 from sherpa.utils.testing import SherpaTestCase
+from sherpa.data import Data1D
+from sherpa.models.basic import Gauss1D
+from sherpa.optmethods import LevMar
+from sherpa.stats import LeastSq
+from sherpa.fit import Fit, DataSimulFit, SimulFitModel
 
 
 class test_utils(SherpaTestCase):
@@ -390,7 +395,7 @@ def test_filter_bins_unordered():
     for got, exp in zip(flags, expected):
         assert got == exp
 
-def test_paralle_map_funcs():
+def test_parallel_map_funcs1():
     for arg in range(1, 5):
         func = [numpy.sum]
         funcs = arg * func
@@ -400,3 +405,33 @@ def test_paralle_map_funcs():
             result.extend(numpy.asarray(list(map(func, data))))
         assert_equal(result, utils.parallel_map_funcs(funcs, datas, arg))
 
+def test_parallel_map_funcs2():
+    def tst(ncores, sg, stat, opt):
+        sd = DataSimulFit('sd', [d, d], numcores=2)
+        f = Fit(sd, sg, stat, opt)
+        result = f.fit()
+        return result
+    def cmp_results(result, tol=1.0e-3):
+        assert(result.succeeded == True)
+        parvals = (1.7555670572301785, 1.5092728216164186, 4.893136872267538)
+        assert result.numpoints == 200
+        assert_allclose(result.parvals, parvals, rtol=tol, atol=tol)
+        
+    numpy.random.seed(0)
+    x = numpy.linspace(-5., 5., 100)
+    ampl = 5
+    pos = 1.5
+    sigma = 0.75
+    err = 0.25
+    y = ampl * numpy.exp(-0.5 * (x - pos)**2 / sigma**2)
+    y += numpy.random.normal(0., err, x.shape)
+    d = Data1D('junk', x, y)
+    g = Gauss1D()
+    opt = LevMar()
+    stat = LeastSq()
+    sg = SimulFitModel('sg', [g, g])
+
+    result = tst(1, sg, stat, opt)
+    cmp_results(result)
+    result = tst(2, sg, stat, opt)
+    cmp_results(result)

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,9 @@
 #
+<<<<<<< HEAD
 #  Copyright (C) 2010, 2016, 2018, 2019, 2020  Smithsonian Astrophysical Observatory
+=======
+#  Copyright (C) 2010, 2016, 2018  Smithsonian Astrophysical Observatory
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -282,6 +286,7 @@ def test_parallel_map(num_tasks, num_segments):
 
         assert_equal(result, numpy.asarray(pararesult))
 
+<<<<<<< HEAD
 
 @pytest.mark.parametrize("los, his, axis", [([], [], [0,1,2,3,4]),
                                             ([], [1], [0,1,2,3,4]),
@@ -388,3 +393,14 @@ def test_filter_bins_unordered():
     assert len(flags) == len(expected)
     for got, exp in zip(flags, expected):
         assert got == exp
+=======
+def test_paralle_map_funcs():
+    for arg in range(1, 5):
+        func = [numpy.sum]
+        funcs = arg * func
+        datas = [numpy.arange(1, 2+2*i) for i in range(arg)]
+        result = []
+        for func, data in zip(funcs, datas):
+            result.extend(numpy.asarray(list(map(func, data))))
+        assert_equal(result, utils.parallel_map_funcs(funcs, datas, arg))
+>>>>>>> an initial release of simultaneous fit on multicores (slower for most, ie a lot, of cases :)


### PR DESCRIPTION
# Release Note
Part of the work on sherpa's **Performance Improvements** by performing simultaneous fit on multiple cores.  Note, this is not to be confused with PR #444 and PR #503.

# Description
Sherpa allows the modeling of multiple, independent data sets; However, sherpa evaluates the independent data sets sequentially.  This PR distributes the evaluations of the multiple independent data sets using the multi-cores built-in the user's workstation.  The current default setting for this PR is to evaluate the multiple independent data sets sequentially since the overhead for distributing the workload across multi-cores is high if the evaluation of the data sets is not time consuming.  However, the user/tester can change the default setting at runtime by entering the fit as: ```fit(numcores=N)``` where N is an integer greater then one.

# Notes
The original requirements for this PR can found at #442, although it is hard to say which specific category this PR fits in the initial requirements.