### PR TITLE
Fix #476 - `ZeroDivisionError` in `calc_stat_info`

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1199,7 +1199,10 @@ class Fit(NoNewAttributesAfterInit):
         if _can_calculate_rstat(self.stat):
             if stat >= 0.0:
                 qval = igamc(dof / 2., stat / 2.)
-            rstat = stat / dof
+            try:
+                rstat = stat / dof
+            except ZeroDivisionError:
+                rstat = nan
 
         name = _cleanup_chi2_name(self.stat, self.data)
 


### PR DESCRIPTION
# Release Note
Sherpa did not catch divisions by zero in the `calc_stat_info` command. That has been fixed.

# Notes
This PR fixes #476.

I am no comfortable with the way the UI function is implemented, as it should be using the internal machinery rather than performing the calculation. The whole reason why the bug was there is that changes to the way the statistic is calculated are not reflected in the UI function `calc_stat_info`. However, this is a big change and it might not be worthwhile to do it now, unless @kglotfelty feels strongly we should.