### PR TITLE
PSF bin size warning

### DIFF
--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -16,6 +16,7 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+import warnings
 
 from six import string_types
 
@@ -550,6 +551,8 @@ class PSFModel(Model):
     def fold(self, data):
         # FIXME how will we know the native dimensionality of the
         # raveled model without the values?
+        self._check_pixel_size(data)
+
         kargs = {}
 
         kshape = None
@@ -697,7 +700,6 @@ class PSFModel(Model):
 
         indep, dep, kshape, lo, hi = self._get_kernel_data(data, subkernel)
 
-        dataset = None
         ndim = len(kshape)
         if ndim == 1:
             dataset = Data1D('kernel', indep[0], dep)
@@ -708,3 +710,14 @@ class PSFModel(Model):
             raise PSFErr('ndim')
 
         return dataset
+
+    def _check_pixel_size(self, data):
+        if hasattr(self.kernel, "sky"):
+            # This corresponds to the case when the kernel is actually a psf image, not just a model.
+            psf_pixel_size = self.kernel.sky.cdelt
+            data_pixel_size = data.sky.cdelt
+
+            if not numpy.allclose(psf_pixel_size, data_pixel_size):
+                warnings.warn("NOTE: The PSF pixel size ({}) does not correspond to the Image Pixel Size ({})".format(
+                    psf_pixel_size, data_pixel_size
+                ))

--- a/sherpa/models/tests/test_psf_rebin.py
+++ b/sherpa/models/tests/test_psf_rebin.py
@@ -22,6 +22,7 @@
 import pytest
 
 from sherpa.astro.ui.utils import Session
+from sherpa.utils import requires_data
 
 
 @pytest.fixture
@@ -33,6 +34,7 @@ def setup(make_data_path):
     return Session(), image, psf_bin05, psf_bin1
 
 
+@requires_data
 def test_psf_rebin_warning(setup):
     ui, image, _, psf_bin1 = setup
 
@@ -43,6 +45,7 @@ def test_psf_rebin_warning(setup):
         ui.set_psf('psf')
 
 
+@requires_data
 def test_psf_rebin_no_warning(setup):
     ui, image, psf_bin05, _ = setup
 

--- a/sherpa/models/tests/test_psf_rebin.py
+++ b/sherpa/models/tests/test_psf_rebin.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Smithsonian Astrophysical Observatory
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+# disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pytest
+
+from sherpa.astro.ui.utils import Session
+
+
+@pytest.fixture
+def setup(make_data_path):
+    image = make_data_path('sim_0.5bin_2g+c.fits')
+    psf_bin1 = make_data_path('psf_0.0_00_bin1.img')
+    psf_bin05 = make_data_path('psf_0.0_00_bin0.5.img')
+
+    return Session(), image, psf_bin05, psf_bin1
+
+
+def test_psf_rebin_warning(setup):
+    ui, image, _, psf_bin1 = setup
+
+    ui.load_image(image)
+    ui.load_psf('psf', psf_bin1)
+
+    with pytest.warns(UserWarning):
+        ui.set_psf('psf')
+
+
+def test_psf_rebin_no_warning(setup):
+    ui, image, psf_bin05, _ = setup
+
+    ui.load_image(image)
+    ui.load_psf('psf', psf_bin05)
+    ui.set_psf('psf')

--- a/sherpa/models/tests/test_psf_rebin.py
+++ b/sherpa/models/tests/test_psf_rebin.py
@@ -22,7 +22,7 @@
 import pytest
 
 from sherpa.astro.ui.utils import Session
-from sherpa.utils import requires_data
+from sherpa.utils import requires_data, requires_fits
 
 
 @pytest.fixture
@@ -34,6 +34,7 @@ def setup(make_data_path):
     return Session(), image, psf_bin05, psf_bin1
 
 
+@requires_fits
 @requires_data
 def test_psf_rebin_warning(setup):
     ui, image, _, psf_bin1 = setup
@@ -45,6 +46,7 @@ def test_psf_rebin_warning(setup):
         ui.set_psf('psf')
 
 
+@requires_fits
 @requires_data
 def test_psf_rebin_no_warning(setup):
     ui, image, psf_bin05, _ = setup

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -11,7 +11,7 @@ then
     sudo apt-get install -qq libwcs4 wcslib-dev libx11-dev libsm-dev libxrender-dev
 
     # set os-specific variables
-    ds9_os=centos6
+    ds9_os=ubuntu14
     xspec_root=$miniconda/envs/build/Xspec/x86_64-unknown-linux-gnu-libc2.15-0
 
     # Newer versions (or conda builds) of numpy bring in a libgfortran-ng dependency, which our

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -36,7 +36,7 @@ fi
 
 ### DS9 and XPA
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.7.5.tar.gz
+ds9_tar=ds9.${ds9_os}.7.6.tar.gz
 xpa_tar=xpa.${ds9_os}.2.1.17.tar.gz
 
 # Fetch them


### PR DESCRIPTION
# Release Note
Sherpa assumes that the PSF image and the data have the same pixel size. When this is not true Sherpa ignores the difference, which results in a larger PSF being applied. From now on Sherpa will issue a warning when the PSF image pixel size and the data image pixel size are different.

# Note
It looks like we are not going to be able to implement the whole PSF rebinning logic into 4.10.1. This PR at least makes sure that a warning is issued when the PSF image and the data image do not have the same binning size.