### PR TITLE
Ensure fields are initialized before use (pileup code)

### DIFF
--- a/sherpa/astro/utils/src/pileup.cc
+++ b/sherpa/astro/utils/src/pileup.cc
@@ -580,6 +580,10 @@ init_kernel(pileup_kernel_t *k, const double* arf_source,
   if ( NULL == (k->results = XMALLOC (NUM_POINTS, double)))
     return NULL;
   k->pileup_fractions = pileup_fractions;
+
+  // Ensure fields have been set in case the first XMALLOC fails.
+  k->arf_s_tmp = NULL;
+  k->arf_s_fft_tmp = NULL;
   
   if ((NULL == (k->arf_s_fft = XMALLOC (4*NUM_POINTS, double)))
       || (NULL == (k->arf_s_tmp = XMALLOC (NUM_POINTS, double)))


### PR DESCRIPTION
# Summary

This avoids a warning message from the compiler, and fixes a potential attempt to free unallocated memory if there was a memory-allocation failure.

# Details

I do not think this is a serious issue, as an attempt to call `free` on an unitialized variable would only happen in an error case (when `XMALLOC` fails), so things are already going wrong in this case. It does just remove one extra warning from the compilation output.

It is also not a 4.10.1 lien.