### PR TITLE
Add docs directory to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,6 +37,9 @@ include sherpa/optmethods/tests/tstopt.hh
 include sherpa/sherpa.rc
 include sherpa/sherpa-standalone.rc
 
+# Sphinx documentation
+recursive-include docs *
+
 # Quick Start Tutorial
 include notebooks/SherpaQuickStart.ipynb
 


### PR DESCRIPTION
# Summary

Ensure the Sphinx documentation directory is included in the Python distribution.

# Details

This addresses #511 

With this fix I can take the tar file created by `python setup.py sdist` and, after unpacking/cd-ing into it, run `python setup.py build_sphinx` and get the HTML built [1]. Without this change the attempt fails with 

```
% python setup.py build_sphinx
running build_sphinx
error: error in 'source_dir' option: 'docs' does not exist or is not a directory
```

[1] the Sphinx build requires that the `numpy`, `sphinx`, and `sphinx_rtd_theme` packages are installed and that python 3.5 or later is used (limited checking on Python versions other than 3.5).