### PR TITLE
Add a simple DataPlot test with PHA data

### DIFF
--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -17,11 +17,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import numpy
-from sherpa.utils.testing import SherpaTestCase
+from sherpa.utils.testing import SherpaTestCase, requires_data, requires_fits
 from sherpa.astro.data import DataPHA
-from sherpa.astro.plot import SourcePlot
+from sherpa.astro.plot import DataPlot, SourcePlot
 from sherpa.models.basic import PowLaw1D
 from sherpa.astro.optical import AbsorptionGaussian
+from sherpa import stats
+
+import pytest
+
 
 import logging
 logger = logging.getLogger('sherpa')
@@ -46,3 +50,59 @@ class test_plot(SherpaTestCase):
         sp = SourcePlot()
         sp.prepare(self.data, self.src)
         #sp.plot()
+
+
+# Low-level test of the DataPlot prepare method for PHA style analysis
+# with a range of statistics. Note that the results are not checked,
+# just that the call to the prepare method can be called without
+# error. This test can also be run when there is no plotting backend.
+#
+# Extra tests could be added to check the __str__ method of DataPlot(),
+# since this does query the state of the data (e.g. filtering,
+# background subtraction) when creating the arrays.
+#
+# The pytest.param calls seem to get recorded as 2 xfails; I think
+# this is for the error and because of warning messages, but it is not
+# clear.
+#
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("stat",
+                         [None,
+                          stats.Chi2(),
+                          stats.Chi2ConstVar(),
+                          stats.Chi2DataVar(),
+                          stats.Chi2Gehrels(),
+                          stats.Chi2ModVar(),
+                          stats.Chi2XspecVar(),
+                          pytest.param(stats.LeastSq(),
+                                       marks=pytest.mark.xfail),
+                          pytest.param(stats.Cash(),
+                                       marks=pytest.mark.xfail),
+                          pytest.param(stats.CStat(),
+                                       marks=pytest.mark.xfail),
+                          pytest.param(stats.WStat(),
+                                       marks=pytest.mark.xfail),
+                         ])
+def test_astro_data_plot_with_stat_simple(make_data_path, stat):
+
+    from sherpa.astro import io
+
+    infile = make_data_path('3c273.pi')
+    pha = io.read_pha(infile)
+
+    # tweak the data set so that we aren't using the default
+    # options (it shouldn't matter for this test but just
+    # in case).
+    #
+    # Note that background subtraction would normally be an issue
+    # for some of the stats (e.g. WStat), but this shouldn't
+    # trigger a problem here.
+    #
+    pha.set_analysis('energy')
+    pha.subtract()
+    pha.ignore(None, 0.5)
+    pha.ignore(7.0, None)
+
+    dplot = DataPlot()
+    dplot.prepare(pha, stat=stat)


### PR DESCRIPTION
This tests out the handling of the error calculation for data
objects. At present the only test is that the plot can be
prepared for each statistic value. The primary motivation for
this test is because the error calculation is known to be
wrong for non-Chi2XXX statistic classes due to a recent
change from the Sphinx documentation. This commit adds a simple
test which can validate any change.