### PR TITLE
Docs: python 3.7 support and update XSPEC installation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 2.7, 3.5, and 3.6. 
+and is compatible with Python versions 2.7, 3.5, 3.6, and 3.7.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI) 
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 2.7, 3.5, or 3.6
+* Python 2.7, 3.5, 3.6, or 3.7
 * NumPy (the exact lower limit has not been determined,
   but it is likely to be 1.7.0 or later)
 * Linux or OS-X (patches to add Windows support are welcome)
@@ -56,8 +56,8 @@ What version of Sherpa is installed?
 The version number and git commit id of Sherpa can be retrieved from
 the ``sherpa._version`` module using the following command::
 
-    python -c 'import sherpa._version; print(sherpa._version.get_versions())'
-    {'full': '8638ca0fe411693ea3b1eebe0df47512ec5bd542', 'version': '4.9.0'}
+    % python -c 'import sherpa._version; print(sherpa._version.get_versions())'
+    {'version': '4.10.0', 'full': 'c7732043124b08d5e949b9a95c2eb6833e009421'}
 
 Citing Sherpa
 -------------
@@ -113,7 +113,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 2.7, 3.5, 3.6
+* Python versions: 2.7, 3.5, 3.6, 3.7
 * Python packages: ``setuptools``, ``numpy``
 * System: ``gcc``, ``g++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these
@@ -130,7 +130,7 @@ automatically for you by the test suite if they do not already exist.
 
 .. note::
 
-   As of the Sherpa 4.10.1 release, a Fortran compiled is no-longer
+   As of the Sherpa 4.10.1 release, a Fortran compiler is no-longer
    required to build Sherpa.
 
 Obtaining the source package
@@ -180,11 +180,14 @@ options changed to match the location of the local installation.
 XSPEC
 ^^^^^
 
-Sherpa does not build support for
-`XSPEC models <https://heasarc.gsfc.nasa.gov/xanadu/xspec/>`_
-by default. This can be changed by options in the ``xspec_config``
-section of the ``setup.cfg`` file::
-  
+Sherpa can be built to use the Astronomy models provided by
+:term:`XSPEC` versions 12.9.0 and 12.9.1 (progress on
+XSPEC 12.10.0 support is tracked at
+`issue 436 <https://github.com/sherpa/sherpa/issues/436>`_).
+To enable this, several changes must be made to the
+``xspec_config`` section of the ``setup.cfg`` file. The
+available options are::
+
     with-xspec=True
     xspec_lib_dirs=None
     xspec_include_dirs=None
@@ -198,7 +201,8 @@ section of the ``setup.cfg`` file::
     gfortran_lib_dirs=None
     gfortran_libraries=gfortran
 
-The ``with-xspec`` option must be set to ``True`` and then the
+To build the :py:mod:`sherpa.astro.xspec` module, the
+``with-xspec`` option must be set to ``True`` and then the
 remaining options set based on whether just the
 XSPEC model library or the full XSPEC system has been installed.
 
@@ -221,17 +225,14 @@ XSPEC model library or the full XSPEC system has been installed.
    not need version numbers and locations, depending on how the
    ``cfistio``, ``CCfits``, and ``wcs`` libraries were installed
 
-A common problem is to set the `xspec_lib_dirs` option to the value
-of `$HEADAS` instead of `$HEADAS/lib`. This will cause the build to
-fail with errors about being unable to find the various XSPEC libraries,
-such as ``XSFunctions`` and ``XSModel``.
+A common problem is to set the `xspec_lib_dirs` and `xspec_lib_include`
+options to the value of `$HEADAS` instead of
+`$HEADAS/lib` and `$HEADAS/include` respectively. Doing so will cause the
+build to fail with errors about being unable to find various XSPEC
+libraries such as ``XSFunctions`` and ``XSModel``.
 
 The ``gfortran`` options should be adjusted if there are problems
 using the XSPEC module.
-
-The current supported versions of XSPEC are 12.9.0 and
-12.9.1 (although not all models in the later versions are currently
-available).
 
 In order for the XSPEC module to be used from Python, the
 ``HEADAS`` environment variable **must** be set before the
@@ -241,9 +242,8 @@ The Sherpa test suite includes an extensive set of tests of this
 module, but a quick check of an installed version can be done with
 the following::
 
-    >>> from sherpa.astro import xspec
-    >>> xspec.get_xsversion()
-    '12.9.1n'
+    % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
+    12.9.1n
 
 Other options
 ^^^^^^^^^^^^^


### PR DESCRIPTION
# Summary

Two minor changes to the Sphinx documentation:

  - point out support for Python 3.7
  - tweak the "build with XSPEC" section to better point out what XSPEC versions are currently supported and removed some outdated notes.

# Details

I do not believe either change is important enough to be included in the 4.10.1 release, but would like this to be added to `master` sooner rather than later to avoid version skew.
