### PR TITLE
Docs: update build installation instructions for XSPEC 12.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,27 +447,29 @@ newer versions, but without support for new models or features.
 
 To build the XSPEC support in Sherpa, the `xspec_config` section of the
 `setup.cfg` file will need changing to point to the libraries, and to
-turn on the extension. In all cases, set
+turn on the extension, **and** the `xspec_version`` option must be
+set to the XSPEC version. So, in all cases, set
 
-    with-xspec=True
+    with-xspec = True
+    xspec_version = 12.10.0
+
+(changing the XSPEC version to the appropriate value, noting that
+the patch level must not be included).
 
 The remaining settings depend on how the XSPEC libraries have
-been built (in the examples below, environment variables are
-used, but the full path should be in your own copy of the file):
+been built. In the examples below, the `$HEADAS` environment variable 
+**must be replaced** by the actual path to the HEADAS installation,
+and the versions of the libraries - such as `CCfits` - may need to
+be changed:
 
  1. If the full XSPEC 12.10.0 system has been built, then use
 
         xspec_include_dirs = $HEADAS/include
         xspec_lib_dirs = $HEADAS/lib
-        xspec_libraries = XSFunctions XSModel XSUtil XS hdsp_2.9
+        xspec_libraries = XSFunctions XSModel XSUtil XS hdsp_3.0
         cfitsio_libraries = cfitsio
         ccfits_libraries = CCfits_2.5
         wcs_libraries = wcs-5.16
-
-    The environment variable `$HEADAS` should be expanded out, and the
-    version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
-    may need to be changed, depending on the version of XSPEC (the
-    values given above are valid for XSPEC 12.10.0).
 
  2. If the full XSPEC 12.9.x system has been built, then use
 
@@ -477,11 +479,6 @@ used, but the full path should be in your own copy of the file):
         cfitsio_libraries = cfitsio
         ccfits_libraries = CCfits_2.5
         wcs_libraries = wcs-5.16
-
-    The environment variable `$HEADAS` should be expanded out, and the
-    version numbers of the `wcs`, `cfitsio`, and `CCfits` libraries
-    may need to be changed, depending on the version of XSPEC (the
-    values given above are valid for XSPEC 12.9.1).
 
  3. Use the model-only build of XSPEC, which will also require
     building the
@@ -506,18 +503,9 @@ used, but the full path should be in your own copy of the file):
     and (possibly) `gfortran_lib_dirs` values should be set
     appropriately.
 
- 3. or point to the XSPEC libraries provided by
-    [CIAO](http://cxc.harvard.edu/ciao/). In this case the
-    `wcs` library does not need to be specified because of
-    the way the XSPEC models-only version was built with
-    CIAO.
-
-        xspec_lib_dirs=$ASCDS_INSTALL/ots/lib
-
-    **NOTE** Although this is possible, it is strongly recommended
-    that either of the first two approaches is used instead. There
-    have been issues seen using the CIAO binaries on certain OS X
-    systems.
+    Note that XSPEC 12.10.0 has simplified the models-only build process,
+    with the introduction of the `--enable-xs-models-only` flag when
+    building HEASOFT, but it can cause problems for the Sherpa build.
 
 If there are problems building, or using, the module, then the other
 options may need to be set - in particular the `gfortran_lib_dirs` and
@@ -529,17 +517,16 @@ as the one that was used to build XSPEC itself. The `gfortran_libraries`
 option, in particular, can be used on Linux to set the specific name of
 the library, e.g. `:libgfortran.so.3`.
 
-In order for the module to work, the `HEADAS` environment variable has
-to be set in the shell from which the Python session is started.
+In order for the module to work, the `HEADAS` environment variable
+**must** be set in the shell from which the Python session is started.
 
 In order to check that the module is working, importing the
 `sherpa.astro.ui` module will no-longer warn you that the
 `sherpa.astro.xspec` module is not available and you can use routines
 such as:
 
-    >>> from sherpa.astro import xspec
-    >>> xspec.get_xsversion()
-    '12.10.0'
+    % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
+    12.10.0e
 
 Other customization options
 ---------------------------

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,3 +144,6 @@ Glossary
        built with support for the
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
+
+       Sherpa can be built to use XSPEC versions 12.10.0, 12.9.1, or
+       12.9.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,8 +29,7 @@ if installed:
 The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
 functions from the :term:`XSPEC`.
-The supported versions of XSPEC are 12.9.0 and 12.9.1 (unfortunately
-version 12.10.0 is currently incompatible with Sherpa).
+The supported versions of XSPEC are 12.10.0, 12.9.1, and 12.9.0.
 
 Interactive display and manipulation of two-dimensional images
 is available if the :term:`DS9` image viewer and the :term:`XPA`
@@ -180,56 +179,81 @@ options changed to match the location of the local installation.
 XSPEC
 ^^^^^
 
+.. note::
+
+   In order to support XSPEC 12.10.0, the version number of XSPEC
+   **must** be specified using the ``xspec_version`` configuration
+   option, as described below.
+
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC` versions 12.9.0 and 12.9.1 (progress on
-XSPEC 12.10.0 support is tracked at
-`issue 436 <https://github.com/sherpa/sherpa/issues/436>`_).
+:term:`XSPEC` versions 12.10.0, 12.9.1, and 12.9.0.
 To enable this, several changes must be made to the
 ``xspec_config`` section of the ``setup.cfg`` file. The
-available options are::
+available options (with default values) are::
 
-    with-xspec=True
-    xspec_lib_dirs=None
-    xspec_include_dirs=None
-    xspec_libraries=XSFunctions XSModel XSUtil XS
-    cfitsio_lib_dirs=None
-    cfitsio_libraries=cfitsio
-    ccfits_lib_dirs=None
-    ccfits_libraries=CCfits
-    wcslib_lib_dirs=None
-    wcslib_libraries=wcs
-    gfortran_lib_dirs=None
-    gfortran_libraries=gfortran
+    with-xspec = False
+    xspec_version = 12.9.0
+    xspec_lib_dirs = None
+    xspec_include_dirs = None
+    xspec_libraries = XSFunctions XSModel XSUtil XS
+    cfitsio_lib_dirs = None
+    cfitsio_libraries = cfitsio
+    ccfits_lib_dirs = None
+    ccfits_libraries = CCfits
+    wcslib_lib_dirs = None
+    wcslib_libraries = wcs
+    gfortran_lib_dirs = None
+    gfortran_libraries = gfortran
 
 To build the :py:mod:`sherpa.astro.xspec` module, the
-``with-xspec`` option must be set to ``True`` and then the
-remaining options set based on whether just the
-XSPEC model library or the full XSPEC system has been installed.
+``with-xspec`` option must be set to ``True`` **and** the
+``xspec_version`` option set to the correct version string (the XSPEC
+patch level must not be included), and then the
+remaining options depend on the version of XSPEC and whether
+the XSPEC model library or the full XSPEC system has been installed.
 
-1. If the full XSPEC system has been built then use::
+In the examples below, the ``$HEADAS`` value **must be replaced**
+by the actual path to the HEADAS installation, and the versions of
+the libraries - such as ``CCfits_2.5`` - may need to be changed to
+match the contents of the XSPEC installation.
 
-       xspec_lib_dirs=$HEADAS/lib
-       xspec_include_dirs=$HEADAS/include
-       ccfits_libraries=CCfits_2.5
-       wcslib_libraries=wcs-5.16
-     
-   The ``$HEADAS`` environment variable should be replaced by the
-   location of XSPEC.
-   These values are for XSPEC 12.9.1 using a Linux system
-   and may need adjusting for other releases or operating systems
-   (in particular the version numbers of the libraries, such
-   as ``cfitsio``).
+1. If the full XSPEC 12.10.0 system has been built then use::
 
-2. If the model-only build of XSPEC has been installed, then
+       with-xspec = True
+       xspec_version = 12.10.0
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFuynctions XSModel XSUtil XS hdsp_3.0
+       ccfits_libraries = CCfits_2.5
+       wcslib_libraries = wcs-5.16
+
+2. If the full XSPEC 12.9.x system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.9.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFuynctions XSModel XSUtil XS
+       ccfits_libraries = CCfits_2.5
+       wcslib_libraries = wcs-5.16
+
+   changing ``12.9.1`` to ``12.9.0`` as appropriate.
+
+3. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may
    not need version numbers and locations, depending on how the
-   ``cfistio``, ``CCfits``, and ``wcs`` libraries were installed
+   ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
 
-A common problem is to set the `xspec_lib_dirs` and `xspec_lib_include`
-options to the value of `$HEADAS` instead of
-`$HEADAS/lib` and `$HEADAS/include` respectively. Doing so will cause the
-build to fail with errors about being unable to find various XSPEC
-libraries such as ``XSFunctions`` and ``XSModel``.
+   Note that XSPEC 12.10.0 introduces a new ``--enable-xs-models-only``
+   flag when building HEASOFT which simplifies the installation of
+   these extra libraries, but can cause problems for the Sherpa build.
+
+A common problem is to set one or both of the ``xspec_lib_dirs`` 
+and ``xspec_lib_include`` options to the value of ``$HEADAS`` instead of
+``$HEADAS/lib`` and ``$HEADAS/include`` (after expanding out the
+environment variable). Doing so will cause the build to fail with
+errors about being unable to find various XSPEC libraries such as
+``XSFunctions`` and ``XSModel``.
 
 The ``gfortran`` options should be adjusted if there are problems
 using the XSPEC module.
@@ -243,7 +267,7 @@ module, but a quick check of an installed version can be done with
 the following::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.9.1n
+    12.10.0e
 
 Other options
 ^^^^^^^^^^^^^
@@ -374,7 +398,7 @@ Sherpa was configured when built)::
     sherpa_test
 
 The ``sherpa`` Anaconda channel contains the ``sherpatest`` package, which
-provides a number of data files in ASCII and FITS formats. This is
+provides a number of data files in ASCII and :term:`FITS` formats. This is
 only useful when developing Sherpa, since the package is large. It
 will automatically be picked up by the ``sherpa_test`` script
 once it is installed.


### PR DESCRIPTION
# Summary

Update the README and Sphinx documentation to note building against XSPEC 12.10.0.

This doesn't need a release note since it is just part of the newly-added XSPEC 12.10.0 support. It is the only part of the #497 rebase of #465 that hasn't been added.

# Details

Changes include:

 - the addition of the `xspec_version` setting
 - when using XSPEC 12.10.0 some of the settings are different.

I'm not sure what problems there still are when building against the XSPEC 12.10.0 models-only option, so have just left a comment about "there can be problems".