### PR TITLE
Xspec 12.10 config changes

### DIFF
--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -54,16 +54,16 @@ class xspec_config(Command):
         self.xspec_libraries = 'XSFunctions XSModel XSUtil XS'
         self.cfitsio_include_dirs = ''
         self.cfitsio_lib_dirs = ''
-        self.cfitsio_libraries = 'cfitsio'
+        self.cfitsio_libraries = ''
         self.ccfits_include_dirs = ''
         self.ccfits_lib_dirs = ''
-        self.ccfits_libraries = 'CCfits'
+        self.ccfits_libraries = ''
         self.wcslib_include_dirs = ''
         self.wcslib_lib_dirs = ''
-        self.wcslib_libraries = 'wcs'
+        self.wcslib_libraries = ''
         self.gfortran_include_dirs = ''
         self.gfortran_lib_dirs = ''
-        self.gfortran_libraries = 'gfortran'
+        self.gfortran_libraries = ''
 
     def finalize_options(self):
         pass

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -60,6 +60,9 @@ xpec_include_path=${xspec_root}/include/
 sed -i.orig "s/#with-xspec=True/with-xspec=True/g" setup.cfg
 sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${xspec_library_path}|g" setup.cfg
 sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xpec_include_path}|g" setup.cfg
+sed -i.orig "s/#cfitsio_libraries/cfitsio_libraries/g" setup.cfg
+sed -i.orig "s/#ccfits_libraries/ccfits_libraries/g" setup.cfg
+sed -i.orig "s/#wcslib_libraries/wcslib_libraries/g" setup.cfg
 sed -i.orig "s|#gfortran_libraries = gfortran|gfortran_libraries= ${libgfortran_name}|g" setup.cfg
 
 case "${XSPECVER}" in


### PR DESCRIPTION
This PR changes the default values in the `xspec_config` build helper to support the new XSPEC 12.10 build in CIAO 4.11. The changes to `setup_xspec_ds9.sh` compensate for the "missing" defaults, and reflect what users would need to do when building against an "official", non-CIAO-4.11 build of XSPEC, which requires more information.

I am going to merge this PR as long as Travis is fine (which I know it will, I had tried the changes in a different branch). No review required, but we'll monitor the changes to the user experience for standalone users in #521.