### PR TITLE
Ensure the ui modules have a unique list of exported symbols (fix #502)

### DIFF
--- a/sherpa/astro/ui/__init__.py
+++ b/sherpa/astro/ui/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@ import sherpa.all
 import sherpa.astro.all
 import sherpa.astro.ui.utils
 from sherpa.utils import calc_mlr, calc_ftest, rebin, histogram1d, \
-    histogram2d, gamma, lgam, erf, igamc, igam, incbet, multinormal_pdf, \
+    histogram2d, gamma, lgam, igamc, igam, incbet, multinormal_pdf, \
     multit_pdf
 from sherpa.data import Data1D, Data1DInt, Data2D, Data2DInt
 from sherpa.astro.data import DataARF, DataRMF, DataPHA, DataIMG, DataIMGInt
@@ -29,9 +29,9 @@ from sherpa.logposterior import Prior
 
 
 # We build up __all__ as we go along
-__all__ = ['DataARF', 'DataRMF','DataPHA', 'DataIMG', 'DataIMGInt', 'Data1D',
-           'Data1DInt','Data2D', 'Data2DInt', 'calc_mlr', 'calc_ftest', 'rebin',
-           'histogram1d', 'histogram2d', 'gamma', 'lgam', 'erf', 'igamc',
+__all__ = ['DataARF', 'DataRMF', 'DataPHA', 'DataIMG', 'DataIMGInt', 'Data1D',
+           'Data1DInt', 'Data2D', 'Data2DInt', 'calc_mlr', 'calc_ftest', 'rebin',
+           'histogram1d', 'histogram2d', 'gamma', 'lgam', 'igamc',
            'igam', 'incbet', 'Prior', 'multinormal_pdf', 'multit_pdf']
 
 _session = utils.Session()

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -27,8 +27,6 @@ this duplication?
 
 from sherpa.astro import ui
 
-import pytest
-
 
 # This is part of #397
 #
@@ -53,7 +51,6 @@ def test_list_samplers_contents():
         assert expected in samplers
 
 
-@pytest.mark.xfail
 def test_all_has_no_repeated_elements():
     """Ensure __all__ does not contain repeated elements.
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,9 +19,15 @@
 
 """
 Should these tests be moved to test_astro_session.py?
+
+This is almost a copy of sherpa/ui/tests/test_ui_unit.py, but
+some of the answers are different. Is there a better way than
+this duplication?
 """
 
 from sherpa.astro import ui
+
+import pytest
 
 
 # This is part of #397
@@ -45,3 +51,20 @@ def test_list_samplers_contents():
     samplers = ui.list_samplers()
     for expected in ['mh', 'metropolismh', 'pragbayes', 'fullbayes']:
         assert expected in samplers
+
+
+@pytest.mark.xfail
+def test_all_has_no_repeated_elements():
+    """Ensure __all__ does not contain repeated elements.
+
+    It is not actually a problem if this happens, but it does
+    indicate the possibility of confusion over what functionality
+    the repeated symbol has (originally noticed with erf, which
+    could be either sherpa.utils.erf or the ModelWrapper version
+    of sherpa.models.basic.Erf). See
+    https://github.com/sherpa/sherpa/issues/502
+    """
+
+    n1 = len(ui.__all__)
+    n2 = len(set(ui.__all__))
+    assert n1 == n2

--- a/sherpa/ui/__init__.py
+++ b/sherpa/ui/__init__.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,15 +20,15 @@
 import sherpa.all
 import sherpa.ui.utils
 from sherpa.utils import calc_mlr, calc_ftest, rebin, histogram1d, \
-    histogram2d, gamma, lgam, erf, igamc, igam, incbet, multinormal_pdf, \
+    histogram2d, gamma, lgam, igamc, igam, incbet, multinormal_pdf, \
     multit_pdf
 from sherpa.data import Data1D, Data1DInt, Data2D, Data2DInt
 from sherpa.logposterior import Prior
 
 # We build up __all__ as we go along
-__all__ = ['calc_mlr', 'calc_ftest','Data1D', 'Data1DInt',
+__all__ = ['calc_mlr', 'calc_ftest', 'Data1D', 'Data1DInt',
            'Data2D', 'Data2DInt', 'rebin', 'histogram1d',
-           'histogram2d','gamma', 'lgam', 'erf', 'igamc',
+           'histogram2d', 'gamma', 'lgam', 'igamc',
            'igam', 'incbet', 'Prior', 'multinormal_pdf', 'multit_pdf']
 
 _session = utils.Session()

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -26,8 +26,6 @@ sherpa/astro/ui/tests/test_astro_ui_unit.py
 
 from sherpa import ui
 
-import pytest
-
 
 # This is part of #397
 #
@@ -51,7 +49,6 @@ def test_list_samplers_contents():
         assert expected in samplers
 
 
-@pytest.mark.xfail
 def test_all_has_no_repeated_elements():
     """Ensure __all__ does not contain repeated elements.
 

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,9 +19,14 @@
 
 """
 Should these tests be moved to test_session.py?
+
+Note that this test is almost duplicated in
+sherpa/astro/ui/tests/test_astro_ui_unit.py
 """
 
 from sherpa import ui
+
+import pytest
 
 
 # This is part of #397
@@ -44,3 +49,20 @@ def test_list_samplers_contents():
     samplers = ui.list_samplers()
     for expected in ['mh', 'metropolismh']:
         assert expected in samplers
+
+
+@pytest.mark.xfail
+def test_all_has_no_repeated_elements():
+    """Ensure __all__ does not contain repeated elements.
+
+    It is not actually a problem if this happens, but it does
+    indicate the possibility of confusion over what functionality
+    the repeated symbol has (originally noticed with erf, which
+    could be either sherpa.utils.erf or the ModelWrapper version
+    of sherpa.models.basic.Erf). See
+    https://github.com/sherpa/sherpa/issues/502
+    """
+
+    n1 = len(ui.__all__)
+    n2 = len(set(ui.__all__))
+    assert n1 == n2


### PR DESCRIPTION
# Summary

Remove the `sherpa.utils.erf` symbol from the two `ui` modules as it is "over-written" by the ModelWrapper-created symbol when applied to `sherpa.models.basic.Erf`.

Tests have been added to point out if this ever happens again: for example, if any new models are added to Sherpa, they could conflict with an existing symbol, and these tests will pick that up.

# Details

I originally thought this was a minor issue, but it strikes me that it is possible to add a Sherpa model and accidentally shadow an existing symbol that a user could be relying on. Of course, we are exporting too many symbols in the `sherpa.ui` and `sherpa.astro.ui` modules, but that's a discussion for another day. 

#502 only mentions `sherpa.astro.ui` but when fixing it I noticed it also happens for `sherpa.ui` too (which is not too surprising given their ancestry/relationship).