### PR TITLE
Be explicit about "invalid escape characters" in strings

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -646,7 +646,7 @@ class IterFit(NoNewAttributesAfterInit):
 
     def primini(self, statfunc, pars, parmins, parmaxes, statargs=(),
                 statkwargs=None):
-        """An iterative scheme, where the variance is computed from
+        r"""An iterative scheme, where the variance is computed from
         the model amplitudes.
 
         This is a chi-square statistic where the variance is computed

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2006-2010, 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2006-2010, 2016, 2017, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,7 +18,7 @@
 #
 
 
-"""
+r"""
 Interface for viewing images with the ds9 image viewer.
 Loosely based on XPA, by Andrew Williams.
 

--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -510,7 +510,7 @@ class MonCar(OptMethod):
 # ## DOC-TODO: finalximplex=4 and 5 list the same conditions, it is likely
 # ##           a cut-n-paste error, so what is the correct description?
 class NelderMead(OptMethod):
-    """Nelder-Mead Simplex optimization method.
+    r"""Nelder-Mead Simplex optimization method.
 
     The Nelder-Mead Simplex algorithm, devised by J.A. Nelder and
     R. Mead [1]_, is a direct search method of optimization for

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1185,8 +1185,8 @@ class ChisqrPlot(ModelPlot):
         staterr = data.get_yerr(True, stat.calc_staterror)
 
         self.y = self._calc_chisqr(y, staterr)
-        self.ylabel = get_latex_for_string('\chi^2')
-        self.title = _make_title(get_latex_for_string('\chi^2'), data.name)
+        self.ylabel = get_latex_for_string(r'\chi^2')
+        self.title = _make_title(get_latex_for_string(r'\chi^2'), data.name)
 
     def plot(self, overplot=False, clearwindow=True):
         Plot.plot(self, self.x, self.y, title=self.title,


### PR DESCRIPTION
# Summary

Convert strings that contain "invalid" escape characters, which newer versions of Python complain about, to raw strings by preceding them with a 'r' character.

This avoids the test suite from reporting DeprecationWarnings.

# Details

I was surprised the tests didn't fail because of the DeprecationWarnings, but I know there have been changes to how warnings are handled by pytest. I decided not to add any tests to show the original problem as it didn't seem worth it. I manually ran Sphinx on this PR and things looked good.