### PR TITLE
Minor additions to Sphinx build

### DIFF
--- a/docs/_static/copybutton.js
+++ b/docs/_static/copybutton.js
@@ -1,0 +1,66 @@
+// Copyright 2014 PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+// File originates from the cpython source found in Doc/tools/sphinxext/static/copybutton.js
+
+$(document).ready(function() {
+    /* Add a [>>>] button on the top-right corner of code samples to hide
+     * the >>> and ... prompts and the output and thus make the code
+     * copyable. */
+    var div = $('.highlight-python .highlight,' +
+                '.highlight-default .highlight,' +
+                '.highlight-python3 .highlight')
+    var pre = div.find('pre');
+
+    // get the styles from the current theme
+    pre.parent().parent().css('position', 'relative');
+    var hide_text = 'Hide the prompts and output';
+    var show_text = 'Show the prompts and output';
+    var border_width = pre.css('border-top-width');
+    var border_style = pre.css('border-top-style');
+    var border_color = pre.css('border-top-color');
+    var button_styles = {
+        'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
+        'border-color': border_color, 'border-style': border_style,
+        'border-width': border_width, 'color': border_color, 'text-size': '75%',
+        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
+        'border-radius': '0 3px 0 0'
+    }
+
+    // create and add the button to all the code blocks that contain >>>
+    div.each(function(index) {
+        var jthis = $(this);
+        if (jthis.find('.gp').length > 0) {
+            var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
+            button.css(button_styles)
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+            jthis.prepend(button);
+        }
+        // tracebacks (.gt) contain bare text elements that need to be
+        // wrapped in a span to work with .nextUntil() (see later)
+        jthis.find('pre:has(.gt)').contents().filter(function() {
+            return ((this.nodeType == 3) && (this.data.trim().length > 0));
+        }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('title', show_text);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+        }
+    });
+});
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Sherpa'
-copyright = '2018, Chandra X-ray Center, Smithsonian Astrophysical Observatory'
+copyright = '2018, Chandra X-ray Center, Smithsonian Astrophysical Observatory.'
 author = 'Chandra X-ray Center, Smithsonian Astrophysical Observatory'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -286,6 +286,10 @@ html_static_path = ['_static']
 # The empty string is equivalent to '%b %d, %Y'.
 #
 # html_last_updated_fmt = None
+
+# Follow AstroPy's convention for the date format.
+#
+html_last_updated_fmt = '%d %b %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -238,6 +238,19 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Graphviz based on values from AstroPy - see
+# https://github.com/astropy/sphinx-astropy/blob/master/sphinx_astropy/conf/v1.py
+#
+graphviz_output_format = "svg"
+
+graphviz_dot_args = [
+    '-Nfontsize=10',
+    '-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif',
+    '-Efontsize=10',
+    '-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif',
+    '-Gfontsize=10',
+    '-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif'
+]
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -474,3 +474,14 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
+
+# -- try and get copybuttons to work --
+#
+# docs/_static/copybutton.js is copied from
+# https://raw.githubusercontent.com/scipy/scipy-sphinx-theme/master/_theme/scipy/static/js/copybutton.js
+# version is from
+# https://github.com/scipy/scipy-sphinx-theme/commit/a8aa8a6aad1524c9577a861fc4faa82d6c167138
+#
+
+def setup(app):
+    app.add_javascript('copybutton.js')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,8 +149,9 @@ extensions = [
     # Use napoleon over numpydoc for now since it stops a large number
     # of warning messages (about missing links) that I don't have time
     # to investigate.
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
     # 'numpydoc.numpydoc'
+    'sphinx_astropy.ext.edit_on_github'
 ]
 
 napoleon_google_docstring = False
@@ -251,6 +252,14 @@ graphviz_dot_args = [
     '-Gfontsize=10',
     '-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif'
 ]
+
+# Ensure sphinx_astropy.ext.edit_on_github knows where to send
+# the edit links.
+#
+edit_on_github_project = 'sherpa/sherpa'
+# edit_on_github_branch = '4.10.1'
+edit_on_github_source_root = ''
+edit_on_github_doc_root = 'docs'
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,9 @@ except ImportError:
     from mock import MagicMock as BaseMock
 
 
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+
 # I found this somewhere (probably the rtd link given above). I was
 # hoping it would support building with Python 2.7 but it doesn't seem
 # to.
@@ -116,17 +119,18 @@ if os.path.split(os.getcwd())[1] == 'docs':
 import sherpa
 
 # For now include the '+...' part of the version string
-# and that I can drop the '+...' part.
+# in the full version, but drop the ".dirty" suffix.
 #
 sherpa_release = sherpa._version.get_versions()['version']
+if on_rtd and sherpa_release.endswith('.dirty'):
+    sherpa_release = sherpa_release[:-6]
+
 sherpa_version = sherpa_release[:sherpa_release.find('+')]
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
-
 # If use napoleon, force 1.3 rather than try and support the external
 # napoleon code.
 #

--- a/docs/examples/simple_user_model.rst
+++ b/docs/examples/simple_user_model.rst
@@ -265,7 +265,9 @@ nowhere near the expected values.
    Reduced chi square = 14.48
 
 Visually comparing the model and data values highlights how poor
-this fit is (the data plot needs re-generating because ::
+this fit is (the data plot does not need regenerating in this
+case, but :py:meth:`~sherpa.plot.DataPlot.prepare` is called
+just to make sure that the correct data is being displayed)::
 
   >>> dplot.prepare(d)
   >>> mplot.prepare(d, mdl)

--- a/docs/examples/simple_user_model.rst
+++ b/docs/examples/simple_user_model.rst
@@ -252,9 +252,19 @@ based on the statistic and number of degrees of freedom).
    Probability [Q-value] = 5.64518e-19
    Reduced statistic     = 14.4802
    Change in statistic   = 531.862
-      plateau.c0     10.8792     
-      rise.offset    457.221     
-      rise.coeff     24.3662     
+      plateau.c0     10.8792      +/- 0.428815    
+      rise.offset    457.221      +/- 0           
+      rise.coeff     24.3662      +/- 0           
+
+.. versionchanged:: 4.10.1
+          
+   The implementation of the :py:class:`~sherpa.optmethods.LevMar`
+   class has been changed from Fortran to C++ in the 4.10.1 release.
+   The results of the optimiser are expected not to change
+   significantly, but one of the more-noticeable changes is that
+   the covariance matrix is now returned directly from a fit,
+   which results in an error estimate provided as part of the
+   fit output (the values after the +/- terms above).
 
 The reduced chi-square value is large, as shown in the screen
 output above and the explicit access below, the probability
@@ -360,6 +370,8 @@ represent the asymptote of the curve.
 
 .. image:: ../_static/examples/user_model/model_data_reset.png
 
+.. _simple_user_model_refit:
+
 A new fit object could be created, but it is also possible
 to re-use the existing object. This leaves the optimiser set to
 :py:class:`~sherpa.optmethods.NelderMead`, although in this
@@ -378,10 +390,10 @@ attribute had been changed back to
    Probability [Q-value] = 0.9999
    Reduced statistic     = 0.0428198
    Change in statistic   = 168.12
-      plateau.c0     14.9694     
-      rise.offset    4.17729     
-      rise.coeff     -0.420696   
-
+      plateau.c0     14.9694      +/- 0.859633    
+      rise.offset    4.17729      +/- 0.630148    
+      rise.coeff     -0.420696    +/- 0.118487
+   
 These results already look a lot better than the previous attempt;
 the reduced statistic is much smaller, and the values are similar
 to the reported values. As shown in the plot below, the model
@@ -520,6 +532,9 @@ as other techniques.
       plateau.c0        14.9694    -0.880442     0.880442
       rise.offset       4.17729    -0.646012     0.646012
       rise.coeff      -0.420696     -0.12247      0.12247
+
+These errors are similar to those reported
+:ref:`during the fit <simple_user_model_refit>`.
 
 As :ref:`shown below <simple_user_model_compare_errors>`,
 the error values can be extracted from the output of
@@ -780,9 +795,9 @@ This can be used as any other Sherpa model::
    Probability [Q-value] = 0.9999
    Reduced statistic     = 0.0428198
    Change in statistic   = 632.924
-      plateau2.c0    14.9694     
-      rise2.a        1.75734     
-      rise2.b        -0.420685   
+      plateau2.c0    14.9694      +/- 0.859768    
+      rise2.a        1.75734      +/- 0.419169    
+      rise2.b        -0.420685    +/- 0.118473    
 
    >>> dplot.prepare(d)
    >>> mplot2 = ModelPlot()

--- a/docs/examples/simple_user_model.rst
+++ b/docs/examples/simple_user_model.rst
@@ -432,7 +432,7 @@ For this plot, the :py:class:`~sherpa.plot.FitPlot` class is going
 to be used to show both the data and model rather than doing it
 manually as above:
 
-   >>> from sherp.plot import FitPlot
+   >>> from sherpa.plot import FitPlot
    >>> fitplot = FitPlot()
    >>> dplot.prepare(d)
    >>> mplot.prepare(d, mdl)

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -19,9 +19,9 @@ Glossary
        the :term:`OGIP` Calibration Memo
        `CAL/GEN/02-002 <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
 
-   astropy
+   Astropy
        A community Python library for Astronomy:
-       <http://www.astropy.org/>_.
+       http://www.astropy.org/.
        
    ChIPS
        The Chandra Imaging and Plotting System, ChIPS, is one of
@@ -117,7 +117,11 @@ Glossary
        The phrase World Coordinate System for an Astronomical data set
        represents the mapping between the measured position on the detector
        and a "celestial" coordinate. The most common case is in providing
-       a location on the sky (e.g. in Equatorial or Galactic coordinates)
+       a location on the sky (e.g. in
+       `Equatorial
+       <https://en.wikipedia.org/wiki/Equatorial_coordinate_system>`_
+       or `Galactic <https://en.wikipedia.org/wiki/Galactic_coordinate_system>`_
+       coordinates)
        for a given image pixel, but it can also be used to map between
        row on a spectrograph and the corresponding wavelength of light.
        

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -315,7 +315,7 @@ additional packages:
 * Python 3.5 or greater
 * `Sphinx <http://sphinx.pocoo.org/>`_, version 1.3 or later
 * The ``sphinx_rtd_theme``
-* NumPy and six
+* NumPy, six, and `sphinx_astropy <https://github.com/astropy/sphinx-astropy/>`_
 
 With these installed, the documentation can be built with the
 ``build_sphinx`` target::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -316,6 +316,7 @@ additional packages:
 * `Sphinx <http://sphinx.pocoo.org/>`_, version 1.3 or later
 * The ``sphinx_rtd_theme``
 * NumPy, six, and `sphinx_astropy <https://github.com/astropy/sphinx-astropy/>`_
+* `Graphviz <https://www.graphviz.org/>`_ (for the inheritance diagrams)
 
 With these installed, the documentation can be built with the
 ``build_sphinx`` target::

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,2 +1,3 @@
 numpy
 six
+sphinx_astropy

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -46,7 +46,7 @@ if [ -n "${XSPECVER}" ];
  then export XSPEC="xspec-modelsonly=${XSPECVER} ${xorg}";
 fi
 if [ "${DOCS}" == true ];
- then export DOCSBUILD="sphinx sphinx_rtd_theme";
+ then export DOCSBUILD="sphinx sphinx_rtd_theme graphviz";
 fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC} ${DOCSBUILD}"
 


### PR DESCRIPTION
# Summary

Several tweaks to the Sphinx setup and build to improve the user experience on Read The Docs, inspired by the AstroPy documentation:

  - addition of an "edit on github" link for symbols (classes, methods, functions) which take the
    reader to the docstring on the Sherpa GitHub page, ready for editing
  - for Python code examples, a ">>>" now appears at the top-right of the code area: clicking on this
    will hide the prompt and output (making it easier for the user to copy-and-paste the code), and
    clicking on the icon (which now has a strike-through symbol added to it) will restore the prompt
    and output
  - tweaks to the GraphViz settings which will hopefully make the Class Inheritance diagrams
    more readable
  - remove the ".dirty" suffix on the revision value (seen in the page title)
  - minor tweaks to the footer of the page

The commit adds javascript code taken from https://github.com/scipy/scipy-sphinx-theme/blob/master/_theme/scipy/static/js/copybutton.js at version https://github.com/scipy/scipy-sphinx-theme/commit/a8aa8a6aad1524c9577a861fc4faa82d6c167138 - the header of this file says

// Copyright 2014 PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
// File originates from the cpython source found in Doc/tools/sphinxext/static/copybutton.js

It also makes the `sphinx_astropy` a requirement for building the documentation.

# Details

I have built this PR on ReadTheDocs to check the changes work.

There are several issues with these changes, but I don't think the user-experience is any worse for it.

1. The footer change was meant to get the page to display the date the page was last created, rather
    than the revision, but it appears that RTD has its own footer so more work would be needed to
    address this.
2. The links in the class-inheritance diagrams do not work (i.e. they 404); in the previous version the
    links didn't always appear (so this just changes one broken thing for another)
3. The edit-on-github links don't always take you to the place you'd want. This seems to happen for
    overloaded methods in sub-classes which don't have any documentation. The link takes you to
    the overloaded version rather than the superclass version with the docstring

I have only added a note about the new requirement of `sphinx_astropy` when building the documentation to the Sphinx documentation, not to the README, since we plan to simplify the README file soon.

I have also made several small documentation fixes/additions as part of this PR to address issues reported in #501.