### PR TITLE
ensure XSPEC 12.10.0 uses ATOMDB 3.0.9 by default

### DIFF
--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -393,6 +393,17 @@ int _sherpa_init_xspec_library()
     csmpq0( 0.0 );
     csmpl0( 0.73 );
 
+    // Work around a XSPEC 12.10.0 issue where the atomdb version is
+    // hardcoded to 3.0.7 for the models-only build but it should be
+    // 3.0.9. This is fixed in the yet-to-be-released 12.10.1 (hence
+    // the attempt to only restrict to 12.10.0).
+    //
+#if defined (XSPEC_12_10_0) && !defined (XSPEC_12_10_1)
+    char atomdbVersion1210[6] = "3.0.9";
+    atomdbVersion1210[5] = '\0';
+    FPATDV(atomdbVersion1210);
+#endif
+
   } catch(...) {
 
     

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -71,11 +71,12 @@ def remove_item(xs, x):
 def get_xspec_models():
     """What are the XSpec model names to test.
 
-    This must only be called after making sure that XSPEC support
-    is available.
     """
 
-    import sherpa.astro.xspec as xs
+    try:
+        import sherpa.astro.xspec as xs
+    except ImportError:
+        return []
 
     # The alternate approach is to use that taken by
     # test_create_model_instances

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -598,6 +598,8 @@ def test_old_style_xspec_class():
 def assert_is_finite(vals, modelcls, label):
     """modelcls is the model class (e.g. xspec.XSphabs)"""
 
+    import sherpa.astro.xspec as xs
+
     emsg = "model {} is finite [{}]".format(modelcls, label)
     assert numpy.isfinite(vals).all(), emsg
 
@@ -608,17 +610,17 @@ def assert_is_finite(vals, modelcls, label):
     # mis-match, APEC-style models return all 0 values, so check
     # for this.
     #
-    # Some models (e.g. XSismabs, XSkerrd[isk]?) seem to return
-    # 0's, so skip them for now.
+    # Some models seem to return 0's, so skip them for now.
     #
     # The *cflow models return 0's because:
     #     XSVMCF: Require z > 0 for cooling flow models
     # but the default value is 0 but mkcflox/vmcflow
     # have a default redshift of 0 in XSPEC 12.10.0 model.dat
     #
-    for n in ["ismabs", "kerrd", "mkcflow", "vmcflow"]:
-        if n in modelcls.__name__:
-            return
+    if modelcls in [xs.XSismabs, xs.XSkerrd, xs.XSmkcflow, xs.XSvmcflow]:
+        # perhaps should check that all values == 0 so that
+        # if anything changes the test will start to fail
+        return
 
     emsg = "model {} has a value > 0 [{}]".format(modelcls, label)
     assert (vals > 0.0).any(), emsg


### PR DESCRIPTION
# Summary

Ensure that the default AtomDB version is 3.0.9 when using XSPEC 12.10.0. This is to fix an issue with the models-only XSPEC installation in XSPEC 12.10.0 which uses a default version of 3.0.7 but only provides data files for 3.0.9. Without this change models such as XSapec would return all 0's (unless the AtomDB version was set manually by the user).

# Details

A test is added to ensure that the model evaluation returns at least bin > 0. This means that the default grid had to be increased up to 7 keV for the XSgaussian model. Several models are excluded from this test (XSismabs, XSkerrd*, XSmkcflow, XSvmcflow) since they evaluate to 0. They should be looked at, but it is a different issue (and does not seem to be a regression with XSPEC 12.10.0 support).

I have also updated the XSPEC evaluation tests to change them from unittest to pytest style so that each model is run as an independent test. This improves coverage in the case of a failure (the previous version would stop at the failed model) *and* ensures that the screen output when there is a failure is just related to that model (and not all of them, which was hard to track through on Travis when developing this PR). I have managed to resist converting the whole test to pytest style, which means that there is some repeated logic in the test suite. One immediate advantage of this new test is that I was able to work out why the two `cflow` models return 0 (since I could now see the relevant output from the model evaluation): the default redshift parameter for these two models is set to 0 (I checked that this holds in the XSPEC 12.10.0 model.dat file and it does, so it is not a transcription error on our part) but the model code requires it to be > 0.

You may note that I've forgotten all the rules about string creation in C/C++ code in 1ae44cc so have gone the "lets be overly safe" route to ensure the string is null terminated ;-)