### PR TITLE
remove verbosity.level option and tracebacklimit hack

### DIFF
--- a/sherpa/sherpa-standalone.rc
+++ b/sherpa/sherpa-standalone.rc
@@ -22,10 +22,6 @@ trunc_value: 1.0e-25
 minimum_energy: 1.0e-10
 
 [verbosity]
-# Sherpa Chatter level
-# a non-zero value will
-# display full error traceback
-level      : 10000
 # NumPy arrays have a threshold size print option, such that when an
 # array greater than that size is converted to a string, for printing,
 # only the first few and last few elements are shown.  If the array is

--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -22,10 +22,6 @@ trunc_value: 1.0e-25
 minimum_energy: 1.0e-10
 
 [verbosity]
-# Sherpa Chatter level
-# a non-zero value will
-# display full error traceback
-level      : 0
 # NumPy arrays have a threshold size print option, such that when an
 # array greater than that size is converted to a string, for printing,
 # only the first few and last few elements are shown.  If the array is

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -43,11 +43,7 @@ warning = logging.getLogger(__name__).warning
 
 config = ConfigParser()
 config.read(get_config())
-# Suppress printing of traceback in high-level UI.
-# If needed for debugging, set sys.tracebacklimit to a
-# nonzero value in that session--traceback is for debugging
-# but is irritating to ordinary users.
-sys.tracebacklimit = int(config.get('verbosity', 'level'))
+
 numpy.set_printoptions(threshold=int(config.get('verbosity', 'arraylength')))
 
 __all__ = ('ModelWrapper', 'Session')


### PR DESCRIPTION
# Release Note
The `verbosity.level` option in the `sherpa.rc` and `sherpa-standalone.rc` files has been removed. This option has been causing issues with several versions of IPython including IPython 6.5 and 7. When the option is set to `0` then a chain of exceptions is triggered by any legit exception and in certain case the IPython console crashes. Standalone users should be fine. CIAO users relying on the default `0` in the `sherpa` shell should also be fine. CIAO users setting the option to anything but `0` and the `sherpa` shell would now be required to set `sys.tracebacklimit` manually, as documented for `chips`.

# Notes

See https://github.com/ipython/ipython/issues/9978#issuecomment-433428148 and https://github.com/ipython/ipython/issues/9978#issuecomment-433434648 for a description of the issue, which does not have anything to do with Sherpa.