### PR TITLE
Fix XSPEC models: mtable table models and ismabs (fix #535 #538)

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3162,7 +3162,7 @@ class XSkerrd(XSAdditiveModel):
 
     """
 
-    __function__ = "C_kerrdisk"
+    __function__ = "C_kerrd" if equal_or_greater_than("12.10.0") else "C_kerrdisk"
 
     def __init__(self, name='kerrd'):
         self.distance = Parameter(name, 'distance', 1., 0.01, 1000., 0.0, hugeval, 'kpc', True)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -44,7 +44,7 @@ import six
 from six.moves import xrange
 
 import string
-from sherpa.models import Parameter, ArithmeticModel, modelCacher1d, RegriddableModel1D
+from sherpa.models import Parameter, modelCacher1d, RegriddableModel1D
 from sherpa.models.parameter import hugeval
 
 from sherpa.utils import guess_amplitude, param_apply_limits, bool_cast

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1250,7 +1250,7 @@ static PyMethodDef XSpecMethods[] = {
 #ifdef XSPEC_12_10_0  
   XSPECMODELFCT_NORM(jet, 16),
 #endif
-  XSPECMODELFCT_NORM(ismabs, 31),
+  XSPECMODELFCT(ismabs, 31),
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),
   XSPECMODELFCT_C_NORM(C_snapec, 7),
   XSPECMODELFCT_C(C_tbfeo, 4),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1002,7 +1002,15 @@ static PyMethodDef XSpecMethods[] = {
 #endif  
   XSPECMODELFCT_NORM( xsgrbm, 4 ),
   XSPECMODELFCT_C_NORM( C_kerrbb, 10 ),
+#ifdef XSPEC_12_10_0
+  /* From an email from Craig Gordon at HEASARC:
+     12.10.0 and later: for kerrd call C_kerrd. For earlier versions kerrd should call C_kerrdisk.
+     (the model.dat file gives C_kerrdisk up to 12.10.1b)
+  */
+  XSPECMODELFCT_C_NORM( C_kerrd, 8 ),
+#else
   XSPECMODELFCT_C_NORM( C_kerrdisk, 8 ),
+#endif
   XSPECMODELFCT_NORM( spin, 10 ),
   XSPECMODELFCT_C_NORM( C_xslaor, 6 ),
   XSPECMODELFCT_C_NORM( C_laor2, 8 ),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1203,7 +1203,7 @@ static PyMethodDef XSpecMethods[] = {
 
   // XSPEC table models
   XSPECTABLEMODEL_NORM( xsatbl ),
-  XSPECTABLEMODEL_NORM( xsmtbl ),
+  XSPECTABLEMODEL( xsmtbl ),
 
   // XSPEC convolution models
   XSPECMODELFCT_CON(C_cflux, 3),

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -197,8 +197,8 @@ class test_xspec(SherpaTestCase):
         # sent in), which makes this more annoying.
         #
         smdl = str(model)
-        for n in ["kerrd", "mkcflow", "vmcflow"]:
-            if n in smdl and "kerrdisk" not in smdl:
+        for n in ["mkcflow", "vmcflow"]:
+            if n in smdl:
                 return
 
         emsg = "model {} has a value > 0 [{}]".format(model, label)
@@ -617,7 +617,7 @@ def assert_is_finite(vals, modelcls, label):
     # but the default value is 0 but mkcflox/vmcflow
     # have a default redshift of 0 in XSPEC 12.10.0 model.dat
     #
-    if modelcls in [xs.XSkerrd, xs.XSmkcflow, xs.XSvmcflow]:
+    if modelcls in [xs.XSmkcflow, xs.XSvmcflow]:
         # Catch the case when this condition is no longer valid
         #
         assert (vals == 0.0).all(), \

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -622,6 +622,7 @@ def assert_is_finite(vals, modelcls, label):
         #
         assert (vals == 0.0).all(), \
             'Expected {} to evaluate to all zeros [{}]'.format(modelcls, label)
+        return
 
     emsg = "model {} has a value > 0 [{}]".format(modelcls, label)
     assert (vals > 0.0).any(), emsg

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -190,14 +190,14 @@ class test_xspec(SherpaTestCase):
         # as it is automatically over-written by the XSPEC init file,
         # but not for the models-only build we use).
         #
-        # Some models (e.g. XSismabs, XSkerrd[isk]?) seem to return
-        # 0's, so skip them for now.
+        # Some models return 0's, so skip them for now.
+        #
         # The logic of what gets sent in for the model
         # argument is unclear (class, object, and strings are
         # sent in), which makes this more annoying.
         #
         smdl = str(model)
-        for n in ["ismabs", "kerrd", "mkcflow", "vmcflow"]:
+        for n in ["kerrd", "mkcflow", "vmcflow"]:
             if n in smdl:
                 return
 
@@ -617,7 +617,7 @@ def assert_is_finite(vals, modelcls, label):
     # but the default value is 0 but mkcflox/vmcflow
     # have a default redshift of 0 in XSPEC 12.10.0 model.dat
     #
-    if modelcls in [xs.XSismabs, xs.XSkerrd, xs.XSmkcflow, xs.XSvmcflow]:
+    if modelcls in [xs.XSkerrd, xs.XSmkcflow, xs.XSvmcflow]:
         # perhaps should check that all values == 0 so that
         # if anything changes the test will start to fail
         return

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -618,9 +618,10 @@ def assert_is_finite(vals, modelcls, label):
     # have a default redshift of 0 in XSPEC 12.10.0 model.dat
     #
     if modelcls in [xs.XSkerrd, xs.XSmkcflow, xs.XSvmcflow]:
-        # perhaps should check that all values == 0 so that
-        # if anything changes the test will start to fail
-        return
+        # Catch the case when this condition is no longer valid
+        #
+        assert (vals == 0.0).all(), \
+            'Expected {} to evaluate to all zeros [{}]'.format(modelcls, label)
 
     emsg = "model {} has a value > 0 [{}]".format(modelcls, label)
     assert (vals > 0.0).any(), emsg

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -198,7 +198,7 @@ class test_xspec(SherpaTestCase):
         #
         smdl = str(model)
         for n in ["kerrd", "mkcflow", "vmcflow"]:
-            if n in smdl:
+            if n in smdl and "kerrdisk" not in smdl:
                 return
 
         emsg = "model {} has a value > 0 [{}]".format(model, label)

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -730,6 +730,41 @@ def test_evaluate_xspec_additive_model_beyond_grid(make_data_path):
     assert (zeros[0] == np.arange(968, 1090)).all()
 
 
+@requires_data
+@requires_fits
+@requires_xspec
+def test_create_xspec_multiplicative_model(make_data_path):
+    """Can we load multiplicative table models?
+    """
+
+    from sherpa.astro import xspec
+
+    path = make_data_path('testpcfabs.mod')
+    tbl = xspec.read_xstable_model('bar', path)
+
+    assert tbl.name == 'bar'
+    assert isinstance(tbl, xspec.XSTableModel)
+    assert not tbl.addmodel
+
+    # Apparently we lose the case of the parameter names;
+    # should investigate
+    #
+    assert len(tbl.pars) == 2
+    assert tbl.pars[0].name == 'nh'
+    assert tbl.pars[1].name == 'fract'
+
+    assert tbl.nh.val == pytest.approx(1)
+    assert tbl.nh.min == pytest.approx(0)
+    assert tbl.nh.max == pytest.approx(1000)
+
+    assert tbl.fract.val == pytest.approx(0.5)
+    assert tbl.fract.min == pytest.approx(0)
+    assert tbl.fract.max == pytest.approx(1)
+
+    for p in tbl.pars:
+        assert not(p.frozen)
+
+
 @requires_xspec
 def test_ismabs_parameter_name_clashes():
     """Check the work around for the ismabs XSPEC 12.9.1 name clashes.


### PR DESCRIPTION
# Summary

This PR fixes:

- #535 XSPEC multiplicative table models (`mtable` models loaded with `load_xstable_model`)
- #538 incorrect evaluation of the `ismabs` model
- #540 the `kerrd` model evaluated to 0 for XSPEC 12.10.0 and later

For the first two, the models were being multiplied by the value of the last parameter of the model. At best this would lead to fits where the overall model amplitude was incorrect but could be corrected. However, it is likely that such fits were not robust (due to the accidental correlation between the overall amplitude and the last parameter of the model), and so it is not guaranteed that the best-fit would be found.

The kerrd model was due to a change in the naming of the XSPEC functions which had not been reflected in the XSPEC `model.dat` file in XSPEC 12.10.0 or 12.10.1b, which meant that the kerrd model in XSPEC 12.10.0 or later was wrong in Sherpa.

# Details

The fix for the first two errors is to switch from the `XXX_NORM` to `XXX` macro when wrapping the XSPEC-supplied functions (`xsmtbl_` and `ismabs_`). Tests were added to catch the errors (for `ismabs` it relies on the redshift parameter being at its default value of 0, which ends up ensuring that the model evaluates to 0 at all bins).

The kerrd fix requires conditional use of the `C_kerrdisk` routine prior to XSPEC 12.10.0 and `C_kerrd` for XSPEC 12.10.0 and later. This was confirmed by Craig Gordon of HEASARC in an email discussion.

There are no checks that the models are calculating the "correct" answers, since this is hard to do for Sherpa. The approach taken instead is to try and validate the answers (e.g. that the models evaluate to at least one bin with a value > 0).

As well as these changes, a test was added to ensure that the table model (whether additive or multiplicative) can be evaluated on energies outside the model-defined range. This is done because this situation caused crashes with XSPEC 12.10.0 (as the XSPEC code was using an uninitialized variable).

The commits are arranged to try and show a failing test and then the next commit fixes it. This breaks down at the end where I made a stupid mistake which required another commit (i.e. 4ebf672 fixes 552aec0), but this fails because of #540 which needed to be fixed in a4bafbb and then tested in eccda95. Note that there is currently no test that this fixes the behavior for XSPEC releases newer than 12.9.1, since the Travis builds do not have a more-recent XSPEC version available for testing.