### PR TITLE
put back `verbosity.level` option in sherpa.rc

### DIFF
--- a/sherpa/sherpa-standalone.rc
+++ b/sherpa/sherpa-standalone.rc
@@ -22,6 +22,11 @@ trunc_value: 1.0e-25
 minimum_energy: 1.0e-10
 
 [verbosity]
+# Sherpa Chatter level
+# a non-zero value will
+# display full error traceback
+# This option is only used by Sherpa up to version 4.10.1
+level      : 10000
 # NumPy arrays have a threshold size print option, such that when an
 # array greater than that size is converted to a string, for printing,
 # only the first few and last few elements are shown.  If the array is

--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -22,6 +22,11 @@ trunc_value: 1.0e-25
 minimum_energy: 1.0e-10
 
 [verbosity]
+# Sherpa Chatter level
+# a non-zero value will
+# display full error traceback
+# This option is only used by Sherpa up to version 4.10.1
+level      : 0
 # NumPy arrays have a threshold size print option, such that when an
 # array greater than that size is converted to a string, for printing,
 # only the first few and last few elements are shown.  If the array is


### PR DESCRIPTION
This PR reverts back some of the change in #537. In particular it introduces the `verbosity.level` option back in the `.rc` files for both CIAO and Standalone, with an additional comment that the option is ignored by Sherpa > v.4.10.1.

This way the configuration files can work with both old and new versions of Sherpa.

A much better approach would be #490, but we can't do that now.