### PR TITLE
Add code and tests for "low degree-of-freedom behavior"

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -27,7 +27,7 @@ import signal
 from functools import wraps
 
 from numpy import arange, array, abs, iterable, sqrt, where, \
-    ones_like, isnan, isinf, float, float32, finfo, nan, any, int, sqrt
+    ones_like, isnan, isinf, float, float32, finfo, nan, any, int
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, igamc, \
     bool_cast, is_in, is_iterable, list_to_open_interval, sao_fcmp
 from sherpa.utils.err import FitErr, EstErr, SherpaErr

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2536,6 +2536,38 @@ def test_wstat_rstat_qval_fields_not_none():
     assert s2.qval > s1.qval
 
 
+def validate(expected, val):
+    """Compare numeric values which may also be NaN/None/pytest.approx values
+
+    Try and make it easier for the test writer.
+
+    Parameters
+    ----------
+    expected : float, None, NaN, or pytest.approx instance
+        The expected value. If a float then the standard pytest.approx
+        settings are used, but you can send in an instance with its own
+        values.
+    value : float, None, or NaN
+        The value to test.
+
+    Notes
+    -----
+    The test for whether we have a pytest.approx instance relies on
+    internals of pytest.approx, so could be unreliable long term.
+
+    """
+
+    if expected is None:
+        assert val is None
+    elif hasattr(expected, 'expected'):
+        # Assyme a pytest.approx value
+        assert val == expected
+    elif np.isfinite(expected):
+        assert val == pytest.approx(expected)
+    else:
+        assert np.isnan(val)
+
+
 # Add some basic tests to see how fits where the number of degrees-of-freedom
 # is 0 or negative are handled.
 #
@@ -2554,7 +2586,7 @@ def assert_stat_info(statinfo, npoints, dof, statval, qval, rstat):
         The expected number of degrees of freedom.
     statval : float
         The expected statistic value.
-    qval : float or None
+    qval : float or None or np.nan
         The expected qval value
     rstat : float or None or np.nan
         The expected rstat value.
@@ -2565,17 +2597,8 @@ def assert_stat_info(statinfo, npoints, dof, statval, qval, rstat):
     assert statinfo.dof == dof
     assert statinfo.statval == pytest.approx(statval)
 
-    if qval is None:
-        assert statinfo.qval is None
-    else:
-        assert statinfo.qval == pytest.approx(qval)
-
-    if rstat is None:
-        assert statinfo.rstat is None
-    elif np.isfinite(rstat):
-        assert statinfo.rstat == pytest.approx(rstat)
-    else:
-        assert np.isnan(statinfo.rstat)
+    validate(qval, statinfo.qval)
+    validate(rstat, statinfo.rstat)
 
 
 def assert_fit_results(fitres, rstat):
@@ -2591,16 +2614,7 @@ def assert_fit_results(fitres, rstat):
         The expected rstat value.
     """
 
-    # This is messy but makes the tests a bit easier to write
-    if rstat is None:
-        assert fitres.rstat is None
-    elif hasattr(rstat, 'expected'):
-        assert fitres.rstat == rstat
-    elif np.isfinite(rstat):
-        assert fitres.rstat == pytest.approx(rstat)
-    else:
-        assert np.isnan(fitres.rstat)
-
+    validate(rstat, fitres.rstat)
     assert fitres.succeeded
 
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2578,6 +2578,25 @@ def assert_stat_info(statinfo, npoints, dof, statval, qval, rstat):
         assert np.isnan(statinfo.rstat)
 
 
+# A "canary" to note when issue #563 (WStat assumes arrays are ndarrays
+# but we do not ensure this, so how should this be fixed) is addressed
+#
+# Note that once #563 is fixed the call is expected to raise a
+# sherpa.utils.err.StatErr error with the message
+#   "No background data has been supplied. Use cstat"
+#
+def test_563_still_exists():
+    d = Data1D('test', [1, 2, 3], [4, 5, 6])
+    mdl = Polynom1D()
+    mdl.c0 = 5.1
+
+    fit = Fit(d, mdl, stat=WStat())
+    with pytest.raises(AttributeError) as excinfo:
+        fit.calc_stat_info()
+
+    assert "'list' object has no attribute 'size'" in str(excinfo.value)
+
+
 # These values were found by running the code (so are regression tests)
 # rather than being calculated from first principles.
 #

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2678,8 +2678,8 @@ def test_dof_1(method, stat, statargs):
 
 @pytest.mark.parametrize("method", [LevMar, NelderMead, MonCar])
 @pytest.mark.parametrize("stat,statargs", [(Cash, (dof1_cash, None, None)),
-                                           (CStat, (dof1_cstat, 1.0, np.nan)),
-                                           (Chi2, (dof1_chi2, 1.0, np.nan))])
+                                           (CStat, (dof1_cstat, np.nan, np.nan)),
+                                           (Chi2, (dof1_chi2, np.nan, np.nan))])
 def test_dof_0(method, stat, statargs):
     """DOF is 0"""
 
@@ -2694,19 +2694,11 @@ def test_dof_0(method, stat, statargs):
     assert_stat_info(statinfo, 3, 0, statargs[0], statargs[1], statargs[2])
 
 
-# The CStat and Chi-square runs fail with
-#     TypeError: igamc domain error, a and x must be positive
-# This error should either be caught earlier (in which case we may want
-# to remove these statistics from this test and add a separate
-# regression test for those), or handled in a "better" way.
-#
 @pytest.mark.parametrize("method", [LevMar, NelderMead, MonCar])
 @pytest.mark.parametrize("stat,statargs",
                          [(Cash, (dof1_cash, None, None)),
-                          pytest.param(CStat, (dof1_chi2, 1.0, np.nan),
-                                       marks=pytest.mark.xfail),
-                          pytest.param(Chi2, (dof1_chi2, 1.0, np.nan),
-                                       marks=pytest.mark.xfail)])
+                          (CStat, (dof1_cstat, np.nan, np.nan)),
+                          (Chi2, (dof1_chi2, np.nan, np.nan))])
 def test_dof_neg1(method, stat, statargs):
     """DOF is -1"""
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2598,16 +2598,26 @@ def test_563_still_exists():
 
 
 # These values were found by running the code (so are regression tests)
-# rather than being calculated from first principles.
+# rather than being calculated from first principles. It does not seem
+# worth running all statistics, so I have chosen those with different
+# behaviors:
+#  cash  - likelihood-based, which doesn't have rstat/dof
+#  cstat - likelihood-based but with a measure of goodness of fit
+#  chi2  - our good old friendly chi-square statistic
 #
 dof1_cash = -18.2772161919084
+
+dof1_cstat = 0.40863145212838614
+dof1_cstat_qval = 0.522664944712
+
 dof1_chi2 = 2.03
-dof1_qval = 0.154220607327
+dof1_chi2_qval = 0.154220607327
 
 
 @pytest.mark.parametrize("method", [LevMar, NelderMead, MonCar])
 @pytest.mark.parametrize("stat,statargs", [(Cash, (dof1_cash, None, None)),
-                                           (Chi2, (dof1_chi2, dof1_qval, dof1_chi2))])
+                                           (CStat, (dof1_cstat, dof1_cstat_qval, dof1_cstat)),
+                                           (Chi2, (dof1_chi2, dof1_chi2_qval, dof1_chi2))])
 def test_dof_1(method, stat, statargs):
     """DOF is 1"""
 
@@ -2623,6 +2633,7 @@ def test_dof_1(method, stat, statargs):
 
 @pytest.mark.parametrize("method", [LevMar, NelderMead, MonCar])
 @pytest.mark.parametrize("stat,statargs", [(Cash, (dof1_cash, None, None)),
+                                           (CStat, (dof1_cstat, 1.0, np.nan)),
                                            (Chi2, (dof1_chi2, 1.0, np.nan))])
 def test_dof_0(method, stat, statargs):
     """DOF is 0"""
@@ -2638,15 +2649,17 @@ def test_dof_0(method, stat, statargs):
     assert_stat_info(statinfo, 3, 0, statargs[0], statargs[1], statargs[2])
 
 
-# The Chi-square runs fail with
+# The CStat and Chi-square runs fail with
 #     TypeError: igamc domain error, a and x must be positive
 # This error should either be caught earlier (in which case we may want
-# to remove chi-square values from this test and add a separate
+# to remove these statistics from this test and add a separate
 # regression test for those), or handled in a "better" way.
 #
 @pytest.mark.parametrize("method", [LevMar, NelderMead, MonCar])
 @pytest.mark.parametrize("stat,statargs",
                          [(Cash, (dof1_cash, None, None)),
+                          pytest.param(CStat, (dof1_chi2, 1.0, np.nan),
+                                       marks=pytest.mark.xfail),
                           pytest.param(Chi2, (dof1_chi2, 1.0, np.nan),
                                        marks=pytest.mark.xfail)])
 def test_dof_neg1(method, stat, statargs):


### PR DESCRIPTION
# Note

Closed as some code has been accepted as part of #562 and the remainder was easier to include as a new PR #567

---

The idea is to document the current behavior, so we can work out how any changes we might make change the runtime behavior.

At the moment there is a simple check of Cash and CStat behavior with LevMar, NelderMead, and MonCar optimisers. This calls the `calc_stat_info` method of the `Fit` object, with dof=1, 0, -1. There are later additions to add tests of the `fit` method too.

**EDITED TO ADD**

- There are now tests of both `fit` and `calc_stat_info` methods.
- Some of these commits have been absorbed into #564 
- The PR is no-longer just added tests, since it now also includes code changes to address some of the issues brought up by the test (e.g. see #565)