### PR TITLE
add release notes that were dropped

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,11 @@ macos-python3.6-conda-build:
   variables:
       SHERPA_PYTHON_VERSION: "3.6.*"
 
+macos-python3.7-conda-build:
+  <<: *template_macos_conda_build
+  variables:
+      SHERPA_PYTHON_VERSION: "3.7.*"
+
 linux-python2.7-conda-build:
   <<: *template_conda_build
   variables:
@@ -89,6 +94,11 @@ linux-python3.6-conda-build:
   variables:
     SHERPA_PYTHON_VERSION: '3.6.*'
 
+linux-python3.7-conda-build:
+  <<: *template_conda_build
+  variables:
+    SHERPA_PYTHON_VERSION: '3.7.*'
+
 conda:
   stage: deploy
   tags:
@@ -98,9 +108,11 @@ conda:
       - linux-python2.7-conda-build
       - linux-python3.5-conda-build
       - linux-python3.6-conda-build
+      - linux-python3.7-conda-build
       - macos-python2.7-conda-build
       - macos-python3.5-conda-build
       - macos-python3.6-conda-build
+      - macos-python3.7-conda-build
   script:
       - echo $CONDA_UPLOAD_TOKEN
       - anaconda -t $CONDA_UPLOAD_TOKEN upload -u sherpa -c dev packages/linux-64/sherpa* --force
@@ -134,6 +146,11 @@ conda:
       - pip install /master.zip
       - sherpa_smoke -f astropy
       - sherpa_test
+      - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - source activate test37
+      - pip install /master.zip
+      - sherpa_smoke -f astropy
+      - sherpa_test
 
 centos6-test:
   <<: *template-linux-test
@@ -154,26 +171,16 @@ ubuntu16-test:
   before_script:
       - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
 
-#ubuntu17-test:
-#  <<: *template-linux-test
-#  image: ubuntu:17.10
-#  before_script:
-#      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
-#
-#ubuntu18-test:
-#  <<: *template-linux-test
-#  image: ubuntu:18.04
-#  before_script:
-#      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
-
-fedora26-test:
+ubuntu18-test:
   <<: *template-linux-test
-  image: fedora:26
+  image: ubuntu:18.04
+  before_script:
+      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
 
 fedora27-test:
   <<: *template-linux-test
   image: fedora:27
 
-#fedora28-test:
-#  <<: *template-linux-test
-#  image: fedora:28
+fedora28-test:
+  <<: *template-linux-test
+  image: fedora:28

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,105 @@
 Release Notes
 
+Sherpa 4.10.2
+==========
+
+This release fixes a regression introduced in Sherpa 4.10.1 related to PSF convolution. As part of the long term PSF rebinning improvements,
+Sherpa 4.10.1 introduced a check to validate that the data pixel size and the PSF pixel size match. If they don't match, then a warning is issued.
+The change did not account for an edge error case. Sherpa 4.10.2 solves this problem.
+The regression introduced a downstream regression in the gammapy project.
+
+Details
+---------
+
+#551 Fix gammapy/gammapy#1905, catch errors with psf pixel size.
+Sherpa did not properly catch errors when checking the PSF pixel size matches the image pixel size. This has now been fixed.
+
+Caveats
+-----------
+There is a potential issue for macOS conda users with python > 3.6 and matplotlib v3.0.1, when pyqt5 is not installed and selected as a matplotlib
+backend. With this specific combination of platform and dependencies matplotlib can fail to work properly. The issue can be replicated without
+importing Sherpa, so this is not a Sherpa bug.
+
+Several workarounds exist, the simplest of which are:
+    * install pyqt5 (`conda install pyqt`).
+    * downgrade matplotlib to v2 or v3.0.0 (`conda install matplotlib=3.0.0`)
+
+Sherpa 4.10.1
+=============
+
+This release fixes several bugs and introduces a few new features, notably the ability to evaluate model components on
+arbitrary grids and generate user-defined ARFs and RMFs. Also, as of this release Sherpa will no longer rely on any
+Fortran code. See the following section for details.
+
+It is now possible to build the Sherpa documentation using Sphinx. Additionally, the Sphinx documentation is
+automatically built and hosted on ReadTheDocs: https://sherpa.readthedocs.io/
+
+Details
+-------
+
+#407 Ensure 0-length array is an error in filter_resp (fix #405)
+    Add an explicit check in the C++ filter_resp code to error out if the noticed channels array
+    is empty.
+
+#422 Improve error message with wrong xspec version
+    Improve the handling of XSPEC versions mismatch.
+
+#466 Fix bounding box out-of-bounds memory read
+    Avoid an out-of-bounds memory read when calling pad_bounding_box (when the data is not
+    matching the expected conditions for this call).
+
+#469 Evaluate model on finer grid
+    Sherpa users can now define arbitrary grids, called evaluation spaces, on which to
+    evaluate individual model components, both in 1D and 2D. This can be useful in a number
+    of cases, for instance when it is desirable to evaluate models on a finer grid than the one
+    defined by the data, or in convolution models where information outside of the data range
+    can be used to reduce boundary effects or to inform the evaluation inside the data space.
+    Also, when plotting individual 1D model components (plot_source_component), if a specific
+    evaluation space was attached to the model then the plot will be of the model evaluated
+    over that evaluation space, not the data space. Other plotting commands should be
+    unaffected by this change.
+
+#470 Order for np.ones() should be a one length string not a bool
+    Fixed a `DeprecationWarning` in the optimization module.
+
+#471 Using overwrite rather than clobber of astropy.io.fits
+    `clobber` in astropy has been deprecated for a while now in favour of overwrite and thus
+    issues a `DeprecationWarning`. Sherpa now uses `overwrite` instead.
+
+#475 Fix unecessary runtime warning (fix #402)
+    A condition check in the optimization code was modified so as not to produce a warning
+    when the value is a NaN.
+
+#481 Remove Fortran code
+    Sherpa does not rely on any Fortran routines anymore, except those compiled in XSPEC.
+    The existing Fortran code, which was used mainly in some of the optimization routines, has
+    been replaced by equivalent C++ code. This means that gfortran is no longer required for
+    building Sherpa, although a version of libgfortran compatible with the one used to link the
+    XSPEC libraries would still be needed at runtime if the XSPEC extension is
+    built.
+
+#482 ARF/RMF creation functions
+    The `create_rmf` and `create_arf` functions now allow users to easily generate user
+    defined response objects.
+
+#486 `ZeroDivisionError` in `calc_stat_info` (fix #476)
+    Sherpa did not catch divisions by zero in the calc_stat_info command. That has been fixed.
+
+#484 Equivalent Width errors
+    Several optional arguments `(params=None, error=False, otherids=(), niter=1000)`, were
+    added to `eqwidth`. If `error = True`, then get_draws shall be run if the fit stat is one of the
+    following: (Cash,  CStat, WStat) otherwise a multivariate normal distribution shall be run to
+    generate the samples. The optional niter parameter is used to generate the number of
+    samples. The optional parameter otherids is only used if get_draws is used internally when
+    multiple data sets were used to fit. Alternatively, the user can enter the samples via the
+    `params` option where the samples must be a `numpy.ndarray` of dimension `(num, npar)`.
+
+#487 PSF bin size warning
+    Sherpa assumes that the PSF image and the data have the same pixel size. When this is
+    not true Sherpa ignores the difference, which results in a larger PSF being applied. From
+    now on Sherpa will issue a warning when the PSF image
+    pixel size and the data image pixel size are different.
+
 Sherpa 4.10.0
 =============
 This release of Standalone Sherpa corresponds to the Sherpa code released as part of CIAO 4.10.


### PR DESCRIPTION
It looks like I made a mistake when I merged the 4.10.1 release into master, so I lost some changes to the release notes, which this PR puts back, along with the 4.10.2 release notes.

The reason I lost the commits is that I used the wrong switch on the `git` command line when merging the 4.10.1 release branch and fixing the conflicts.

For future reference here is a detailed description of the issue:
  * A while back we started cherry-picking merge commits from master into the release branches. Earlier we used to issue PRs against the release branch, which was inconvenient for several reasons.
  * However bumping the version number should not make it into the master branch until after the release is merged.
  * So I pushed a couple of commits to the release branch, including the release note changes (the other change was to the README, but that was superseded by later changes into master).
  * When I tried to merge the release branch into master I had some conflicts, and I believe I mistakenly used the `ours` merge strategy rather than the `ours` option in the `recursive` strategy, i.e. I did `git merge -s ours 4.10.1` instead of `git merge -X ours 4.10.1`.

The `ours` option in `recursive` makes sense because if you exclude the version bumping happening in `RELEASE_NOTES` and `README.md` all the changes in the release branch have already been merged into master, and any conflicts are just PRs in master that superseded the ones in the release branch. So the `ours` version should always win.

I guess this incident will make sure I never forget the warning in the git documentation:

> This should not be confused with the 'ours' merge strategy, which does not even look at what the other tree contains at all. It discards everything the other tree did, declaring 'our' history contains all that happened in it.