### PR TITLE
Fix regression with responses `get_x` method

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -29,6 +29,7 @@ import numpy
 import hashlib
 
 from sherpa.data import BaseData, Data1DInt, Data2D, DataND, Data
+from sherpa.models.regrid import EvaluationSpace1D
 from sherpa.utils.err import DataErr, ImportErr
 from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
     create_expr, parse_expr, bool_cast, rebin, filter_bins
@@ -250,6 +251,9 @@ class DataOgipResponse(Data1DInt):
 
         return elo, ehi
 
+    def _get_data_space(self, filter=False):
+        return EvaluationSpace1D(self._lo, self._hi)
+
 
 class DataARF(DataOgipResponse):
     """ARF data set.
@@ -363,11 +367,9 @@ class DataARF(DataOgipResponse):
             self._hi = self.energ_hi[bin_mask]
 
     def get_indep(self, filter=False):
-        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return (self._lo, self._hi)
 
     def get_dep(self, filter=False):
-        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return self._rsp
 
     def get_xlabel(self):
@@ -517,11 +519,9 @@ class DataRMF(DataOgipResponse):
         return bin_mask
 
     def get_indep(self, filter=False):
-        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return (self._lo, self._hi)
 
     def get_dep(self, filter=False):
-        filter = bool_cast(filter)  # QUS: is this to validate filter?
         return self.apply_rmf(numpy.ones(self.energ_lo.shape, SherpaFloat))
 
     def get_xlabel(self):

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -859,3 +859,23 @@ def test_arf_rmf_get_x(make_data_path):
 
     np.testing.assert_array_almost_equal(expected_array_10, actual_arf_10)
     np.testing.assert_array_almost_equal(expected_array_10, actual_rmf_10)
+
+
+def test_arf_rmf_get_x_unit():
+
+    session = Session()
+
+    arf_x_lo, arf_x_hi = np.array([12.0, 12.1, 12.2]), np.array([12.1, 12.2, 12.3])
+    rmf_x_lo, rmf_x_hi = np.array([21.0, 21.1, 21.2]), np.array([21.1, 21.2, 21.3])
+
+    arf = session.create_arf(arf_x_lo, arf_x_hi)
+    rmf = session.create_rmf(rmf_x_lo, rmf_x_hi)
+
+    expected_arf_x = (arf_x_hi + arf_x_lo)/2
+    expected_rmf_x = (rmf_x_hi + rmf_x_lo)/2
+
+    actual_arf_x = arf.get_x()
+    actual_rmf_x = rmf.get_x()
+
+    np.testing.assert_array_almost_equal(expected_arf_x, actual_arf_x)
+    np.testing.assert_array_almost_equal(expected_rmf_x, actual_rmf_x)

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -839,3 +839,23 @@ def test_rmf_with_grid_below_thresh_zero():
     emsg = "The RMF 'delta-rmf' has an ENERG_HI value <= " + \
            "the replacement value of 1e-05"
     assert str(exc.value) == emsg
+
+
+# Bug https://github.com/sherpa/sherpa/issues/572
+@requires_data
+@requires_fits
+def test_arf_rmf_get_x(make_data_path):
+    arf_name = make_data_path('3c120_heg_-1.arf')
+    rmf_name = make_data_path('3c120_heg_-1.rmf')
+
+    session = Session()
+    arf = session.unpack_arf(arf_name)
+    rmf = session.unpack_rmf(rmf_name)
+
+    expected_array_10 = [0.57724115, 0.57730836, 0.57737556, 0.5774428, 0.57751006,
+                         0.57757729, 0.57764456, 0.57771185, 0.57777914, 0.57784647]
+    actual_arf_10 = arf.get_x()[0:10]
+    actual_rmf_10 = rmf.get_x()[0:10]
+
+    np.testing.assert_array_almost_equal(expected_array_10, actual_arf_10)
+    np.testing.assert_array_almost_equal(expected_array_10, actual_rmf_10)

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -861,21 +861,19 @@ def test_arf_rmf_get_x(make_data_path):
     np.testing.assert_array_almost_equal(expected_array_10, actual_rmf_10)
 
 
-def test_arf_rmf_get_x_unit():
-
+def test_arf_get_x_unit():
     session = Session()
-
     arf_x_lo, arf_x_hi = np.array([12.0, 12.1, 12.2]), np.array([12.1, 12.2, 12.3])
-    rmf_x_lo, rmf_x_hi = np.array([21.0, 21.1, 21.2]), np.array([21.1, 21.2, 21.3])
-
     arf = session.create_arf(arf_x_lo, arf_x_hi)
-    rmf = session.create_rmf(rmf_x_lo, rmf_x_hi)
-
     expected_arf_x = (arf_x_hi + arf_x_lo)/2
-    expected_rmf_x = (rmf_x_hi + rmf_x_lo)/2
-
     actual_arf_x = arf.get_x()
-    actual_rmf_x = rmf.get_x()
-
     np.testing.assert_array_almost_equal(expected_arf_x, actual_arf_x)
+
+
+def test_rmf_get_x_unit():
+    session = Session()
+    rmf_x_lo, rmf_x_hi = np.array([21.0, 21.1, 21.2]), np.array([21.1, 21.2, 21.3])
+    rmf = session.create_rmf(rmf_x_lo, rmf_x_hi)
+    expected_rmf_x = (rmf_x_hi + rmf_x_lo)/2
+    actual_rmf_x = rmf.get_x()
     np.testing.assert_array_almost_equal(expected_rmf_x, actual_rmf_x)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -635,6 +635,26 @@ class Data1D(DataND):
             return evaluation_space.grid,
 
     def _get_data_space(self, filter):
+        """
+        Return the data space for this object. The method is called by the get_x and get_indep methods, which need
+        an EvaluationSpace1D representation of the data space to return the appropriate data to the client.
+
+        This is a hook method providing the default implementation for subclasses. Subclasses should override this
+        method to provide alternative callback when the default implementation does not apply to the new class.
+        At this point, this means that if you develop a subclass you should be aware of the default implementation and
+        override it if it does not apply to your subclass. Future versions of Sherpa may implement a cleaner and more
+        extensible API.
+
+        Parameters
+        ----------
+        filter : bool or string to be parsed as bool
+            Whether the data returned should be filtered or not.
+
+        Returns
+        -------
+        data_space : EvaluationSpace1D
+            An instance of the EvaluationSpace1D representing the data space for this object.
+        """
         filter = bool_cast(filter)
         if filter:
             data_x = self._x


### PR DESCRIPTION
# Release Note
Version 4.10.1 introduced a regression which made the `get_x()` method fail when called on RMF and ARF objects. This has been resolved.

# Details
This PR fixes #572. I scanned the code for more classes that needed the `_get_data_space` method overridden, and I don't think there are any more.

I checked if plotting was at all affected by this issue, and it does not look like it is, as I could happily `plot_arf()` with CIAO 4.10.

I took the opportunity to remove two calls that did not have any effect. While they might have caught issues with the `filter` argument, since the argument is ignored in the first place it didn't seem to make sense to keep them.