### PR TITLE
WIP  'analytic' derivs sometimes give better results then numerical derivs

### DIFF
--- a/sherpa/optmethods/src/minpack/LevMar.cc
+++ b/sherpa/optmethods/src/minpack/LevMar.cc
@@ -19,12 +19,24 @@
 //  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 //
 
-
 #include "LevMar.hh"
 
 #include "tests/tstopt.hh"
 
-void tstlm( Init init, FctVec fct, int npar, std::vector<double>& par,
+#ifdef USE_ADEPT
+typedef void (*FctVecAdept)(int m, int n, adept::adouble *x, adept::adouble *fvec, int& ierr, mybounds);
+typedef void (*tstLMder)( Init init, FctVecAdept fct, int npar, std::vector<double>& par, std::vector<double>& lo, std::vector<double>& hi, double tol, const char* fct_name, int npop, int maxfev, double xprob, double sfactor );
+#define ARG1 tstLMder
+#define ARG2 adept::adouble
+#define ARG3 FctVecAdept
+#else
+#define ARG1 tstFctVec
+#define ARG2 double
+#define ARG3 FctVec
+#endif
+
+template<typename aFunc>
+void tstlm( Init init, aFunc fct, int npar, std::vector<double>& par,
 	    std::vector<double>& lo, std::vector<double>& hi,
 	    double tol, const char* fct_name, int npop, int maxfev,
 	    double xprob, double sfactor ) {
@@ -33,27 +45,34 @@ void tstlm( Init init, FctVec fct, int npar, std::vector<double>& par,
 
     int mfcts;
     double answer;
-
-    init( npar, mfcts, answer, &par[0], &lo[0], &hi[0] );
-    sherpa::Bounds<double> bounds(lo, hi);
-    minpack::LevMarDif< FctVec, mybounds, double > lm( fct, bounds, mfcts );
-
-    int maxnfev=128*npar, nfev;
+    int maxnfev=128*npar, nfev=0;
     double fmin=0.0;
 
+    init( npar, mfcts, answer, &par[0], &lo[0], &hi[0] );
     int nprint = 0;
-    double epsfcn = std::sqrt( std::numeric_limits< double >::epsilon( ) );
     double factor=100.0;
-    std::vector<double> covarerr( 8 * npar );
+    std::vector<double> covarerr( 8 * npar, 0.0 );
     std::vector<double> fjac( mfcts * npar );
+    sherpa::Bounds<double> bounds(lo, hi);
 
+#ifdef USE_ADEPT
+    minpack::LevMarDerAdept< aFunc, mybounds, double > lm( fct, bounds, mfcts, npar );
+    int njev = 0;
+    lm( npar, tol, tol, tol, maxnfev, factor, nprint, par, nfev, njev,
+        fmin, bounds, fjac, covarerr );
+    double mytol = 1.0e4*sqrt( std::numeric_limits<double>::epsilon());
+    print_pars( "lmder_", fct_name, nfev, fmin, answer, npar, par,
+         	&covarerr[0], mytol, njev );
+#else
+    minpack::LevMarDif< aFunc, mybounds, double > lm( fct, bounds, mfcts );
+    double epsfcn = std::sqrt( std::numeric_limits< double >::epsilon( ) );
     lm( npar, tol, tol, tol, maxnfev, epsfcn, factor, nprint, par, nfev, fmin,
         bounds, fjac, covarerr );
-
-    // lm.minimize( &par[0], tol, maxnfev, nfev, fmin );
-
     print_pars( "lmdif_", fct_name, nfev, fmin, answer, npar, par,
 		&covarerr[0] );
+
+#endif
+
 
   } catch( const sherpa::OptErr& oe ) {
 
@@ -62,209 +81,6 @@ void tstlm( Init init, FctVec fct, int npar, std::vector<double>& par,
   }
 
 }
-
-typedef struct  {
-    int m;
-    double *y;
-    double *xmin;
-    double *xmax;
-} fcndata_t;
-
-typedef int (*fcnLMDER)(int m, int n, const double *x, double *fvec, double *fjac, int ldfjac, int iflag, fcndata_t*);
-
-
-int fcn(int m, int n, const double *x, double *fvec, double *fjac,
-        int ldfjac, int iflag, fcndata_t* p) {
-
-  /*      subroutine fcn for lmder example. */
-
-  int i;
-  double tmp1, tmp2, tmp3, tmp4;
-  const double *y = ((fcndata_t*)p)->y;
-#ifdef BOX_CONSTRAINTS
-  const double *xmin = ((fcndata_t*)p)->xmin;
-  const double *xmax = ((fcndata_t*)p)->xmax;
-  int j;
-  double xb[3];
-  double jacfac[3];
-  double xmiddle, xwidth, th;
-
-  for (j = 0; j < 3; ++j) {
-    xmiddle = (xmin[j]+xmax[j])/2.;
-    xwidth = (xmax[j]-xmin[j])/2.;
-    th =  tanh((x[j]-xmiddle)/xwidth);
-    xb[j] = (xmin[j]+xmax[j])/2. + th * xwidth;
-    jacfac[j] = 1. - th * th;
-  }
-  x = xb;
-#endif
-
-  // assert(m == 15 && n == 3);
-
-  if (iflag == 0) {
-    /*      insert print statements here when nprint is positive. */
-    /* if the nprint parameter to lmder is positive, the function is
-       called every nprint iterations with iflag=0, so that the
-       function may perform special operations, such as printing
-       residuals. */
-    return 0;
-  }
-
-  if (iflag != 2) {
-    /* compute residuals */
-    for (i=0; i < 15; ++i) {
-      tmp1 = i + 1;
-      tmp2 = 15 - i;
-      tmp3 = (i > 7) ? tmp2 : tmp1;
-      fvec[i] = y[i] - (x[0] + tmp1/(x[1]*tmp2 + x[2]*tmp3));
-    }
-  } else {
-    /* compute Jacobian */
-    for (i=0; i<15; ++i) {
-      tmp1 = i + 1;
-      tmp2 = 15 - i;
-      tmp3 = (i > 7) ? tmp2 : tmp1;
-      tmp4 = (x[1]*tmp2 + x[2]*tmp3); tmp4 = tmp4*tmp4;
-      fjac[i + ldfjac*0] = -1.;
-      fjac[i + ldfjac*1] = tmp1*tmp2/tmp4;
-      fjac[i + ldfjac*2] = tmp1*tmp3/tmp4;
-    }
-#    ifdef BOX_CONSTRAINTS
-    for (j = 0; j < 3; ++j) {
-      for (i=0; i < 15; ++i) {
-        fjac[i + ldfjac*j] *= jacfac[j];
-      }
-    }
-#    endif
-  }
-  return 0;
-}
-
-
-void tstlmder( ) {
-  const int m = 15;
-  const int n = 3;
-
-  double xx[n] = {1.0, 1.0, 1.0};
-  double y[m] = {1.4e-1, 1.8e-1, 2.2e-1, 2.5e-1, 2.9e-1, 3.2e-1, 3.5e-1,
-                  3.9e-1, 3.7e-1, 5.8e-1, 7.3e-1, 9.6e-1, 1.34, 2.1, 4.39};
-
-  double xmin[n] = {0., 0.1, 0.5};
-  double xmax[n] = {2., 1.5, 2.3};
-  std::vector<double> low(n);
-  std::vector<double> high(n);
-  std::vector<double> x(n);
-  std::vector<double> fjac(m*n);
-  for ( int ii = 0; ii < n; ++ii ) {
-    low[ii] = xmin[ii];
-    high[ii] = xmax[ii];
-    x[ii] = xx[ii];
-  }
-
-  fcndata_t data;
-  data.m = m;
-  data.y = y;
-
-  data.xmin = xmin;
-  data.xmax = xmax;
-
-  double ftol = std::sqrt( std::numeric_limits<double>::epsilon( ) );
-  double xtol = std::sqrt( std::numeric_limits<double>::epsilon( ) );
-  double epsfcn = ftol;
-  double factor = 100.0;
-  double gtol = 0.;
-  double fmin;
-  int nprint = 0;
-  int nfev=0, njev=0, maxfev=400, rank;
-
-  const sherpa::Bounds<double> bounds( low, high );
-
-  minpack::LevMarDer< fcnLMDER, fcndata_t*, double > lm( fcn, &data, m );
-  lm.fitme( n, ftol, xtol, gtol, maxfev, epsfcn, factor, nprint, x, nfev, njev,
-            fmin, fjac, bounds, rank );
-
-  double answer[n] = {0.0836609, 1.17808, 2.3 };
-
-  for ( int ii = 0; ii < n; ++ii )
-    if ( 0 != sao_fcmp( x[ii], answer[ii], 1.0e-5 ) )
-      std::cerr << "answer (" << answer[ii ] << ") != x (" << x[ii] << ")\n";
-
-  double myfjac[n][n] =
-    {
-      { 0.000153669, 0.00299417, -0.00278012 },
-      { 0.00299417, 0.102588, -0.0986002 },
-      { -0.00278012, -0.0986002, 0.0952316 }
-    };
-
-  for (int i=0; i<n; ++i)
-    for (int j=0; j<n; ++j)
-      if ( 0 != sao_fcmp( fjac[ i  * m + j ], myfjac[i][j], 1.0e-5 ) )
-        std::cerr << "fjac " << fjac[ i  * m + j ] << " !=  myfjac " << myfjac[i][j] << '\n';
-
-}
-
-// void tstlmder_bounds( ) {
-//   const int m = 15;
-//   const int n = 3;
-
-//   std::vector<double> fjac( m * n );
-//   double xx[n] = {1.0, 1.0, 1.0};
-//   double y[m] = {1.4e-1, 1.8e-1, 2.2e-1, 2.5e-1, 2.9e-1, 3.2e-1, 3.5e-1,
-//                   3.9e-1, 3.7e-1, 5.8e-1, 7.3e-1, 9.6e-1, 1.34, 2.1, 4.39};
-
-//   double xmin[n] = {0., 0.1, 0.5};
-//   double xmax[n] = {2., 1.5, 2.3};
-//   std::vector<double> low(n);
-//   std::vector<double> high(n);
-//   std::vector<double> x(n);
-//   for ( int ii = 0; ii < n; ++ii ) {
-//     low[ii] = xmin[ii];
-//     high[ii] = xmax[ii];
-//     x[ii] = xx[ii];
-//   }
-
-//   fcndata_t data;
-//   data.m = m;
-//   data.y = y;
-
-//   data.xmin = xmin;
-//   data.xmax = xmax;
-
-//   double ftol = std::sqrt( std::numeric_limits<double>::epsilon( ) );
-//   double xtol = std::sqrt( std::numeric_limits<double>::epsilon( ) );
-//   double epsfcn = ftol;
-//   double factor = 100.0;
-//   double gtol = 0.;
-//   double fmin;
-//   int nprint = 0;
-//   int nfev=0, njev=0, maxfev=400, rank;
-
-//   const sherpa::Bounds<double> bounds( low, high );
-
-//   minpack::LevMarDer< fcnLMDER, fcndata_t*, double > lm( fcn, &data, m, n );
-//   lm.fitme( n, ftol, xtol, gtol, maxfev, epsfcn, factor, nprint, x, nfev, njev,
-//             fmin, bounds, rank );
-
-//   double answer[n] = {0.08241058, 1.133037, 2.343695};
-//   for ( int ii = 0; ii < n; ++ii )
-//     if ( 0 != sao_fcmp( x[ii], answer[ii], 1.0e-6 ) )
-//       std::cerr << "answer (" << answer[ii ] << ") != x (" << x[ii] << ")\n";
-
-//   double myfjac[n][n] =
-//     {
-//       { 0.0001531202, 0.002869941, -0.002656662 },
-//       {0.002869941, 0.09480935, -0.09098995},
-//       {-0.002656662, -0.09098995, 0.08778727}
-//     };
-
-//   for (int i=0; i<n; ++i)
-//     for (int j=0; j<n; ++j)
-//       if ( 0 != sao_fcmp( fjac[ i  * m + j ], myfjac[i][j], 1.0e-6 ) )
-//         std::cerr << "fjac " << fjac[ i  * m + j ] << " !=  myfjac " << myfjac[i][j] << '\n';
-
-// }
-
-
 
 int main( int argc, char* argv[] ) {
 
@@ -279,79 +95,27 @@ int main( int argc, char* argv[] ) {
   }
 
   double tol = std::sqrt( std::numeric_limits< double >::epsilon() );
-
   int maxfev=128, npop=0;
   double xprob=0.0, sfactor=0.0;
-
   std::cout << "#\n#:npar = " << npar << "\n";
   std::cout << "#:tol=" << tol << '\n';
   std::cout << "# A negative value for the nfev signifies that the "
     "optimization method did not converge\n#\n";
-  std::cout << "name\tnfev\tanswer\tfval\tpar\terr\nS\tN\tN\tN\tN\tN\n";
-  tst_unc_opt( npar, tol, tstlm, npop, maxfev, xprob, sfactor );
-
-  tstlmder();
+  std::cout << "name\tnfev\tnjev\tanswer\tfval\tpar\terr\nS\tN\tN\tN\tN\tN\n";
+  tst_unc_opt<ARG1, ARG2>( npar, tol, tstlm<ARG3>, npop, maxfev, xprob,
+                           sfactor);
 
   return 0;
 
 }
 #endif
-
 /*
-g++ -ansi -pedantic -Wall -O3 -I. -I../../../include -I../.. -DtestLevMar.cc LevMar.cc -o levmar
 
-==23858== Memcheck, a memory error detector
-==23858== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
-==23858== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
-==23858== Command: a.out
-==23858==
-#
-#:npar = 16
-#:tol=1.49012e-08
-# A negative value for the nfev signifies that the optimization method did not converge
-#
-name	nfev	answer	fval	par	err
-S	N	N	N	N	N
-lmdif_Rosenbrock	278	0	0	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1	1,2.00262,1,2.00262,1,2.00262,1,2.00262,1,2.00262,1,2.00262,1,2.00262,1,2.00262
-lmdif_FreudensteinRoth	-142	0	391.874	11.4122,-0.896849,11.4122,-0.896849,11.4122,-0.896849,11.4122,-0.896849,11.4122,-0.896849,11.4122,-0.896849,11.4122,-0.896849,11.4122,-0.896849	22488.5,1680.69,22488.5,1680.68,22488.5,1680.68,22488.5,1680.69,22488.5,1680.69,22488.5,1680.69,22488.5,1680.69,22488.5,1680.69
-lmdif_PowellBadlyScaled	291	0	6.16298e-32	1.09816e-05,9.10615,1.09816e-05,9.10615,1.09816e-05,9.10615,1.09816e-05,9.10615,1.09816e-05,9.10615,1.09816e-05,9.10615,1.09816e-05,9.10615,1.09816e-05,9.10615	1.09816e-05,0,1.09816e-05,0,1.09816e-05,0,1.09816e-05,0,1.09816e-05,0,1.09816e-05,0,1.09816e-05,0,1.09816e-05,0
-lmdif_BrownBadlyScaled	256	0	0	1e+06,2e-06,1e+06,2e-06,1e+06,2e-06,1e+06,2e-06,1e+06,2e-06,1e+06,2e-06,1e+06,2e-06,1e+06,2e-06	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1e-06
-lmdif_Beale	121	0	1.46521e-25	3,0.5,3,0.5,3,0.5,3,0.5,3,0.5,3,0.5,3,0.5,3,0.5	2.49987,0.653901,2.49987,0.653901,2.49987,0.653901,2.49987,0.653901,2.49987,0.653901,2.49987,0.653901,2.49987,0.653901,2.49987,0.653901
-lmdif_JennrichSampson	213	994.896	994.897	0.25782,0.257829,0.25782,0.257829,0.25782,0.257829,0.25782,0.257829,0.25782,0.257829,0.25782,0.257829,0.25782,0.257829,0.25782,0.257829	475.937,475.894,475.937,475.894,475.937,475.894,475.937,475.894,475.937,475.894,475.937,475.894,475.937,475.894,475.937,475.894
-lmdif_HelicalValley	35	0	9.69231e-33	1,-6.18577e-18,0	0.1,0.631452,1
-lmdif_Bard	21	0.00821487	0.00821488	0.0824106,1.13304,2.34369	0.472941,11.7696,11.3259
-lmdif_Gaussian	13	1.12793e-08	1.12793e-08	0.398956,1.00002,-3.34829e-13	0.65051,3.76595,0
-lmdif_Meyer	-387	87.9458	868.804	0.00742627,5949.59,337.349	1.91166e-06,0,0.00676072
-lmdif_GulfResearchDevelopment	384	0	3.50541e-08	5.37938,36.6053,0.984953	39819,41145.7,1837.58
-lmdif_Box3d	29	0	2.27799e-30	1,10,1	2.16805,37.3451,1.82013
-lmdif_PowellSingular	287	0	4.83914e-58	3.98842e-15,-3.98842e-16,1.78612e-15,1.78612e-15	0,0.1,0.447214,0
-lmdif_Wood	326	0	6.01112e-28	1,1,1,1	0.534245,1.06654,0.534359,1.06654
-lmdif_KowalikOsborne	82	0.000307505	0.000307506	0.192806,0.191308,0.123062,0.136074	1.72542,29.6232,12.1971,13.5846
-lmdif_BrownDennis	-516	85822.2	107689	-7.17716,11.686,-0.975378,-0.29509	0.0903093,0.0237209,0.339559,0.569962
-lmdif_Osborne1	93	5.46489e-05	5.46489e-05	0.37541,1.93582,-1.46466,0.0128675,0.0221228	1.48308,157.674,158.705,0.321153,0.64027
-lmdif_Biggs	7	0	0	1,10,1,5,4,3	0,204.524,64.0215,274.359,302.262,211.652
-lmdif_Osborne2	148	0.0401377	0.0401683	1.30997,0.431458,0.633631,0.599303,0.753912,0.905584,1.36503,4.8248,2.39882,4.56887,5.67537	0.675508,0.859748,0.481427,1.30486,1.88631,5.0202,6.71742,17.2964,1.14824,1.05994,0.599554
-lmdif_Watson	-36	0.00228767	0.00260576	1.88024e-22,1.01364,-0.244321,1.37383,-1.68571,1.09812	1,0.759043,5.37417,14.8652,16.8648,6.7074
-lmdif_PenaltyI	-126	9.37629e-06	2.24998e-05	0.250021,0.250012,0.249996,0.250002	273.871,273.843,273.868,273.864
-lmdif_PenaltyII	514	9.37629e-06	9.37903e-06	0.199999,0.215019,0.467088,0.514755	1,1757.2,1771.19,2236.35
-lmdif_VariablyDimensioned	154	0	1.21393e-24	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1	0.999665,0.99866,0.996984,0.994633,0.991605,0.987892,0.983487,0.978381,0.972563,0.966018,0.958733,0.950688,0.941863,0.932236,0.921779,0.910462
-lmdif_Trigonometric	527	0	0	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0	1.00006,0.999085,0.998112,0.99714,0.99617,0.995201,0.994235,0.993271,0.992308,0.991348,0.990389,0.989432,0.988477,0.987523,0.986572,0.985622
-lmdif_BrownAlmostLinear	54	1	1	-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,-0.0556601,17.8906	0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0.966227,0
-lmdif_DiscreteBoundary	69	0	3.73713e-34	-0.0462988,-0.0908017,-0.0889284,-0.086703,-0.0840814,-0.0810162,-0.0774561,-0.0733461,-0.0686267,-0.0632337,-0.0570977,-0.0501438,-0.0422906,-0.0334499,-0.0235258,-0.0124139	1.86639,3.60664,3.48577,3.36158,3.2335,3.10082,2.96264,2.81783,2.66494,2.50202,2.3264,2.13427,1.9198,1.67333,1.3762,0.981057
-lmdif_DiscreteIntegral	69	0	1.59314e-32	-0.0284861,-0.0550797,-0.0795978,-0.101833,-0.121548,-0.138475,-0.152302,-0.162673,-0.169172,-0.171318,-0.168542,-0.160174,-0.145417,-0.123314,-0.0927079,-0.0521848	0.995075,0.990626,0.9866,0.982949,0.979634,0.976625,0.973909,0.971491,0.969403,0.967718,0.966569,0.966179,0.966917,0.969379,0.974523,0.983895
-lmdif_BroydenTridiagonal	86	0	7.34587e-26	-0.580265,-0.707105,-0.707103,-0.707097,-0.707083,-0.70705,-0.70697,-0.706777,-0.70631,-0.705184,-0.702468,-0.69593,-0.680249,-0.642988,-0.556421,-0.366025	0.206486,0.227555,0.227556,0.227558,0.227562,0.227573,0.227599,0.227661,0.227813,0.228181,0.22908,0.23129,0.236692,0.249269,0.273268,0.288683
-lmdif_BroydenBanded	103	0	9.97564e-24	-0.428303,-0.476596,-0.519652,-0.558099,-0.592506,-0.624504,-0.623239,-0.62142,-0.619616,-0.618226,-0.617518,-0.617732,-0.617901,-0.617982,-0.618896,-0.586311	0.210531,0.185079,0.165401,0.150094,0.137961,0.127799,0.128205,0.128803,0.1294,0.129858,0.130092,0.130023,0.129968,0.129943,0.129615,0.140127
-lmdif_LinearFullRank	35	0	7.88861e-31	-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
-lmdif_LinearFullRank1	34	3.63636	3.63636	-176.185,-87.5926,-161.918,-43.2963,-320.277,-80.4592,210.955,-21.1481,-58.5169,-159.638,86.4791,-39.7296,125.641,105.978,52.753,-29.5472	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0016159
-lmdif_LinearFullRank0cols0rows	34	5.13793	5.13793	1,102.112,305.423,51.5561,-65.5527,153.211,-281.776,26.2781,110.795,-32.2763,-45.1477,77.1057,0.221514,-140.388,46.907,1	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.00209255,0
-lmdif_Chebyquad	84	0	3.50827e-25	0.0442053,0.199491,0.235619,0.416047,0.5,0.583953,0.764381,0.800509,0.955795	0.370106,2.06127,1.55376,2.76913,2.92582,2.76943,1.55377,2.06202,0.369586
-==23858==
-==23858== HEAP SUMMARY:
-==23858==     in use at exit: 0 bytes in 0 blocks
-==23858==   total heap usage: 345 allocs, 345 frees, 115,024 bytes allocated
-==23858==
-==23858== All heap blocks were freed -- no leaks are possible
-==23858==
-==23858== For counts of detected and suppressed errors, rerun with: -v
-==23858== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 6 from 6)
-*/
+setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib
+
+g++ -I. -I../../../include -I../.. -I/data/scialg/staff/dtn/soft/autodiff/adept-1.1/include -Wall -ansi -pedantic -O3 -g -fopenmp -DtestLevMar -DUSE_ADEPT LevMar.cc -L/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib -lm -ladept -o tst_lmder
+
+g++ -I. -I../../../include -I../.. -Wall -ansi -pedantic -O3 -g -DtestLevMar LevMar.cc -o tst_lmdif
+
+
+ */

--- a/sherpa/optmethods/src/minpack/LevMar.cc
+++ b/sherpa/optmethods/src/minpack/LevMar.cc
@@ -21,22 +21,20 @@
 
 #include "LevMar.hh"
 
+#include "sherpa/fcmp.hh"
 #include "tests/tstopt.hh"
 
+
 #ifdef USE_ADEPT
+
 typedef void (*FctVecAdept)(int m, int n, adept::adouble *x, adept::adouble *fvec, int& ierr, mybounds);
-typedef void (*tstLMder)( Init init, FctVecAdept fct, int npar, std::vector<double>& par, std::vector<double>& lo, std::vector<double>& hi, double tol, const char* fct_name, int npop, int maxfev, double xprob, double sfactor );
+typedef void (*tstLMder)( Init init, FctVec fcn, FctVecAdept fctadept, int npar, std::vector<double>& par, std::vector<double>& lo, std::vector<double>& hi, double tol, const char* fct_name, int npop, int maxfev, double xprob, double sfactor );
 #define ARG1 tstLMder
 #define ARG2 adept::adouble
 #define ARG3 FctVecAdept
-#else
-#define ARG1 tstFctVec
-#define ARG2 double
-#define ARG3 FctVec
-#endif
 
-template<typename aFunc>
-void tstlm( Init init, aFunc fct, int npar, std::vector<double>& par,
+template<typename Fcn, typename Func>
+void tstlm_adept( Init init, Fcn fcn, Func func, int npar, std::vector<double>& par,
 	    std::vector<double>& lo, std::vector<double>& hi,
 	    double tol, const char* fct_name, int npop, int maxfev,
 	    double xprob, double sfactor ) {
@@ -55,24 +53,14 @@ void tstlm( Init init, aFunc fct, int npar, std::vector<double>& par,
     std::vector<double> fjac( mfcts * npar );
     sherpa::Bounds<double> bounds(lo, hi);
 
-#ifdef USE_ADEPT
-    minpack::LevMarDerAdept< aFunc, mybounds, double > lm( fct, bounds, mfcts, npar );
+    minpack::LevMarDerAdept< Fcn, Func, mybounds, double >
+      lm( fcn, func, bounds, mfcts, npar );
     int njev = 0;
     lm( npar, tol, tol, tol, maxnfev, factor, nprint, par, nfev, njev,
         fmin, bounds, fjac, covarerr );
     double mytol = 1.0e4*sqrt( std::numeric_limits<double>::epsilon());
     print_pars( "lmder_", fct_name, nfev, fmin, answer, npar, par,
          	&covarerr[0], mytol, njev );
-#else
-    minpack::LevMarDif< aFunc, mybounds, double > lm( fct, bounds, mfcts );
-    double epsfcn = std::sqrt( std::numeric_limits< double >::epsilon( ) );
-    lm( npar, tol, tol, tol, maxnfev, epsfcn, factor, nprint, par, nfev, fmin,
-        bounds, fjac, covarerr );
-    print_pars( "lmdif_", fct_name, nfev, fmin, answer, npar, par,
-		&covarerr[0] );
-
-#endif
-
 
   } catch( const sherpa::OptErr& oe ) {
 
@@ -81,6 +69,48 @@ void tstlm( Init init, aFunc fct, int npar, std::vector<double>& par,
   }
 
 }
+#else
+
+#define ARG1 tstFctVec
+#define ARG2 double
+#define ARG3 FctVec
+
+template<typename Func>
+void tstlm( Init init, Func func, int npar, std::vector<double>& par,
+	    std::vector<double>& lo, std::vector<double>& hi,
+	    double tol, const char* fct_name, int npop, int maxfev,
+	    double xprob, double sfactor ) {
+
+  try {
+
+    int mfcts;
+    double answer;
+    int maxnfev=128*npar, nfev=0;
+    double fmin=0.0;
+
+    init( npar, mfcts, answer, &par[0], &lo[0], &hi[0] );
+    int nprint = 0;
+    double factor=100.0;
+    std::vector<double> covarerr( 8 * npar, 0.0 );
+    std::vector<double> fjac( mfcts * npar );
+    sherpa::Bounds<double> bounds(lo, hi);
+
+    minpack::LevMarDif< Func, mybounds, double > lm( func, bounds, mfcts );
+    double epsfcn = std::sqrt( std::numeric_limits< double >::epsilon( ) );
+    lm( npar, tol, tol, tol, maxnfev, epsfcn, factor, nprint, par, nfev, fmin,
+        bounds, fjac, covarerr );
+    print_pars( "lmdif_", fct_name, nfev, fmin, answer, npar, par,
+		&covarerr[0] );
+
+  } catch( const sherpa::OptErr& oe ) {
+
+    std::cerr << oe << '\n';
+
+  }
+
+}
+
+#endif
 
 int main( int argc, char* argv[] ) {
 
@@ -102,8 +132,14 @@ int main( int argc, char* argv[] ) {
   std::cout << "# A negative value for the nfev signifies that the "
     "optimization method did not converge\n#\n";
   std::cout << "name\tnfev\tnjev\tanswer\tfval\tpar\terr\nS\tN\tN\tN\tN\tN\n";
+
+#ifdef USE_ADEPT
+  tst_unc_opt<ARG1, ARG2>( npar, tol, tstlm_adept<FctVec, ARG3>, npop, maxfev,
+                           xprob, sfactor);
+ #else
   tst_unc_opt<ARG1, ARG2>( npar, tol, tstlm<ARG3>, npop, maxfev, xprob,
                            sfactor);
+#endif
 
   return 0;
 
@@ -113,7 +149,7 @@ int main( int argc, char* argv[] ) {
 
 setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib
 
-g++ -I. -I../../../include -I../.. -I/data/scialg/staff/dtn/soft/autodiff/adept-1.1/include -Wall -ansi -pedantic -O3 -g -fopenmp -DtestLevMar -DUSE_ADEPT LevMar.cc -L/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib -lm -ladept -o tst_lmder
+g++ -I. -I../../../include -I../.. -I/data/scialg/staff/dtn/soft/autodiff/adept-1.1/include -Wall -ansi -pedantic -O3 -g -DtestLevMar -DUSE_ADEPT LevMar.cc -L/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib -lm -ladept -o tst_lmder
 
 g++ -I. -I../../../include -I../.. -Wall -ansi -pedantic -O3 -g -DtestLevMar LevMar.cc -o tst_lmdif
 

--- a/sherpa/optmethods/tests/tstopt.hh
+++ b/sherpa/optmethods/tests/tstopt.hh
@@ -206,175 +206,275 @@ void tst_global( int npar, double tol, Opt opt, int npop, int maxfev,
 
 template <typename Opt, typename Real>
 void tst_unc_opt( int npar, double tol, Opt opt, int npop, int maxfev,
-		  double c1, double c2 ) {
+                  double c1, double c2 ) {
 
   const int dim=npar*32;
   std::vector< double > par( dim, 0 ), lo( dim, -1.0e2 ), hi( dim, 1.0e2 );
 
   {
     opt( tstoptfct::RosenbrockInit<double>,
+#ifdef USE_ADEPT
+         tstoptfct::Rosenbrock<double, mybounds>,
+#endif
 	 tstoptfct::Rosenbrock<Real, mybounds>, npar, par, lo, hi, tol,
 	 "Rosenbrock", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::FreudensteinRothInit<double>,
+#ifdef USE_ADEPT
+         tstoptfct::FreudensteinRoth<double, mybounds>,
+#endif
 	 tstoptfct::FreudensteinRoth<Real, mybounds>, npar, par, lo, hi, tol,
 	 "FreudensteinRoth", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PowellBadlyScaledInit<double>,
+#ifdef USE_ADEPT
+         tstoptfct::PowellBadlyScaled<double, mybounds>,
+#endif
 	 tstoptfct::PowellBadlyScaled<Real, mybounds>, npar, par, lo, hi, tol,
 	 "PowellBadlyScaled", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BrownBadlyScaledInit<double>,
+#ifdef USE_ADEPT
+         tstoptfct::BrownBadlyScaled<double, mybounds>,
+#endif
 	 tstoptfct::BrownBadlyScaled<Real, mybounds>, npar, par, lo, hi, tol,
 	 "BrownBadlyScaled", npop, maxfev, c1, c2 );
   }
   {
-    opt( tstoptfct::BealeInit<double>, tstoptfct::Beale<Real, mybounds>,
+    opt( tstoptfct::BealeInit<double>,
+#ifdef USE_ADEPT
+         tstoptfct::Beale<double, mybounds>,
+#endif
+         tstoptfct::Beale<Real, mybounds>,
 	 npar, par, lo, hi, tol, "Beale", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::JennrichSampsonInit<double>,
-	 tstoptfct::JennrichSampson<Real, mybounds>, npar, par, lo, hi, tol,
-	 "JennrichSampson", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::JennrichSampson<double, mybounds>,
+#endif
+         tstoptfct::JennrichSampson<Real, mybounds>, npar, par, lo, hi, tol,
+         "JennrichSampson", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::HelicalValleyInit<double>,
-	 tstoptfct::HelicalValley<Real, mybounds>, 3, par, lo, hi, tol,
-	 "HelicalValley", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::HelicalValley<double, mybounds>,
+#endif
+         tstoptfct::HelicalValley<Real, mybounds>, 3, par, lo, hi, tol,
+         "HelicalValley", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BardInit<double>,
-	 tstoptfct::Bard<Real, mybounds>, 3, par, lo, hi, tol,
-	 "Bard", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Bard<double, mybounds>,
+#endif
+         tstoptfct::Bard<Real, mybounds>, 3, par, lo, hi, tol,
+         "Bard", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::GaussianInit<double>,
-	 tstoptfct::Gaussian<Real, mybounds>, 3, par, lo, hi, tol,
-	 "Gaussian", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Gaussian<double, mybounds>,
+#endif
+         tstoptfct::Gaussian<Real, mybounds>, 3, par, lo, hi, tol,
+         "Gaussian", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::MeyerInit<double>,
-	 tstoptfct::Meyer<Real, mybounds>, 3, par, lo, hi, tol,
-	 "Meyer", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Meyer<double, mybounds>,
+#endif
+         tstoptfct::Meyer<Real, mybounds>, 3, par, lo, hi, tol,
+         "Meyer", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::GulfResearchDevelopmentInit<double>,
-	 tstoptfct::GulfResearchDevelopment<Real, mybounds>, 3, par, lo, hi,
+#ifdef USE_ADEPT
+         tstoptfct::GulfResearchDevelopment<double, mybounds>,
+#endif
+         tstoptfct::GulfResearchDevelopment<Real, mybounds>, 3, par, lo, hi,
          tol, "GulfResearchDevelopment", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Box3dInit<double>,
-	 tstoptfct::Box3d<Real, mybounds>, 3, par, lo, hi, tol,
-	 "Box3d", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Box3d<double, mybounds>,
+#endif
+         tstoptfct::Box3d<Real, mybounds>, 3, par, lo, hi, tol,
+         "Box3d", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PowellSingularInit<double>,
-	 tstoptfct::PowellSingular<Real, mybounds>, 4, par, lo, hi, tol,
-	 "PowellSingular", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::PowellSingular<double, mybounds>,
+#endif
+         tstoptfct::PowellSingular<Real, mybounds>, 4, par, lo, hi, tol,
+         "PowellSingular", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::WoodInit<double>,
-	 tstoptfct::Wood<Real, mybounds>, 4, par, lo, hi, tol,
-	 "Wood", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Wood<double, mybounds>,
+#endif
+         tstoptfct::Wood<Real, mybounds>, 4, par, lo, hi, tol,
+         "Wood", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::KowalikOsborneInit<double>,
-	 tstoptfct::KowalikOsborne<Real, mybounds>, 4, par, lo, hi, tol,
-	 "KowalikOsborne", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::KowalikOsborne<double, mybounds>,
+#endif
+         tstoptfct::KowalikOsborne<Real, mybounds>, 4, par, lo, hi, tol,
+         "KowalikOsborne", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BrownDennisInit<double>,
-	 tstoptfct::BrownDennis<Real, mybounds>, 4, par, lo, hi, tol,
-	 "BrownDennis", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::BrownDennis<double, mybounds>,
+#endif
+         tstoptfct::BrownDennis<Real, mybounds>, 4, par, lo, hi, tol,
+         "BrownDennis", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Osborne1Init<double>,
-	 tstoptfct::Osborne1<Real, mybounds>, 5, par, lo, hi, tol,
-	 "Osborne1", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Osborne1<double, mybounds>,
+#endif
+         tstoptfct::Osborne1<Real, mybounds>, 5, par, lo, hi, tol,
+         "Osborne1", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BiggsInit<double>,
-	 tstoptfct::Biggs<Real, mybounds>, 6, par, lo, hi, tol,
-	 "Biggs", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Biggs<double, mybounds>,
+#endif
+         tstoptfct::Biggs<Real, mybounds>, 6, par, lo, hi, tol,
+         "Biggs", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Osborne2Init<double>,
-	 tstoptfct::Osborne2<Real, mybounds>, 11, par, lo, hi, tol,
-	 "Osborne2", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Osborne2<double, mybounds>,
+#endif
+         tstoptfct::Osborne2<Real, mybounds>, 11, par, lo, hi, tol,
+         "Osborne2", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::WatsonInit<double>,
-	 tstoptfct::Watson<Real, mybounds>, 6, par, lo, hi, tol,
-	 "Watson", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Watson<double, mybounds>,
+#endif
+         tstoptfct::Watson<Real, mybounds>, 6, par, lo, hi, tol,
+         "Watson", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PenaltyIInit<double>,
-	 tstoptfct::PenaltyI<Real, mybounds>, 4, par, lo, hi, tol,
-	 "PenaltyI", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::PenaltyI<double, mybounds>,
+#endif
+         tstoptfct::PenaltyI<Real, mybounds>, 4, par, lo, hi, tol,
+         "PenaltyI", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PenaltyIIInit<double>,
-	 tstoptfct::PenaltyII<Real, mybounds>, 4, par, lo, hi, tol,
-	 "PenaltyII", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::PenaltyII<double, mybounds>,
+#endif
+         tstoptfct::PenaltyII<Real, mybounds>, 4, par, lo, hi, tol,
+         "PenaltyII", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::VariablyDimensionedInit<double>,
-	 tstoptfct::VariablyDimensioned<Real, mybounds>, npar, par, lo, hi,
+#ifdef USE_ADEPT
+         tstoptfct::VariablyDimensioned<double, mybounds>,
+#endif
+         tstoptfct::VariablyDimensioned<Real, mybounds>, npar, par, lo, hi,
          tol, "VariablyDimensioned", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::TrigonometricInit<double>,
-	 tstoptfct::Trigonometric<Real, mybounds>, npar, par, lo, hi, tol,
-	 "Trigonometric", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Trigonometric<double, mybounds>,
+#endif
+         tstoptfct::Trigonometric<Real, mybounds>, npar, par, lo, hi, tol,
+         "Trigonometric", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BrownAlmostLinearInit<double>,
-	 tstoptfct::BrownAlmostLinear<Real, mybounds>, npar, par, lo, hi, tol,
-	 "BrownAlmostLinear", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::BrownAlmostLinear<double, mybounds>,
+#endif
+         tstoptfct::BrownAlmostLinear<Real, mybounds>, npar, par, lo, hi, tol,
+         "BrownAlmostLinear", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::DiscreteBoundaryInit<double>,
-	 tstoptfct::DiscreteBoundary<Real, mybounds>, npar, par, lo, hi, tol,
-	 "DiscreteBoundary", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::DiscreteBoundary<double, mybounds>,
+#endif
+         tstoptfct::DiscreteBoundary<Real, mybounds>, npar, par, lo, hi, tol,
+         "DiscreteBoundary", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::DiscreteIntegralInit<double>,
-	 tstoptfct::DiscreteIntegral<Real, mybounds>, npar, par, lo, hi, tol,
-	 "DiscreteIntegral", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::DiscreteIntegral<double, mybounds>,
+#endif
+         tstoptfct::DiscreteIntegral<Real, mybounds>, npar, par, lo, hi, tol,
+         "DiscreteIntegral", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BroydenTridiagonalInit<double>,
-	 tstoptfct::BroydenTridiagonal<Real, mybounds>, npar, par, lo, hi, tol,
-	 "BroydenTridiagonal", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::BroydenTridiagonal<double, mybounds>,
+#endif
+         tstoptfct::BroydenTridiagonal<Real, mybounds>, npar, par, lo, hi, tol,
+         "BroydenTridiagonal", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BroydenBandedInit<double>,
-	 tstoptfct::BroydenBanded<Real, mybounds>, npar, par, lo, hi, tol,
-	 "BroydenBanded", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::BroydenBanded<double, mybounds>,
+#endif
+         tstoptfct::BroydenBanded<Real, mybounds>, npar, par, lo, hi, tol,
+         "BroydenBanded", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LinearFullRankInit<double>,
-	 tstoptfct::LinearFullRank<Real, mybounds>, npar, par, lo, hi, tol,
-	 "LinearFullRank", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::LinearFullRank<double, mybounds>,
+#endif
+         tstoptfct::LinearFullRank<Real, mybounds>, npar, par, lo, hi, tol,
+         "LinearFullRank", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LinearFullRank1Init<double>,
-	 tstoptfct::LinearFullRank1<Real, mybounds>, npar, par, lo, hi, tol,
-	 "LinearFullRank1", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::LinearFullRank1<double, mybounds>,
+#endif
+         tstoptfct::LinearFullRank1<Real, mybounds>, npar, par, lo, hi, tol,
+         "LinearFullRank1", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LinearFullRank0cols0rowsInit<double>,
-	 tstoptfct::LinearFullRank0cols0rows<Real, mybounds>, npar, par, lo,
+#ifdef USE_ADEPT
+         tstoptfct::LinearFullRank0cols0rows<double, mybounds>,
+#endif
+         tstoptfct::LinearFullRank0cols0rows<Real, mybounds>, npar, par, lo,
          hi, tol, "LinearFullRank0cols0rows", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::ChebyquadInit<double>,
-	 tstoptfct::Chebyquad<Real, mybounds>, 9, par, lo, hi, tol,
-	 "Chebyquad", npop, maxfev, c1, c2 );
+#ifdef USE_ADEPT
+         tstoptfct::Chebyquad<double, mybounds>,
+#endif
+         tstoptfct::Chebyquad<Real, mybounds>, 9, par, lo, hi, tol,
+         "Chebyquad", npop, maxfev, c1, c2 );
   }
-
 } // tst_unc_opt
+
 #endif

--- a/sherpa/optmethods/tests/tstopt.hh
+++ b/sherpa/optmethods/tests/tstopt.hh
@@ -1,4 +1,4 @@
-// 
+//
 //  Copyright (C) 2011  Smithsonian Astrophysical Observatory
 //
 //
@@ -24,21 +24,27 @@
 #include "sherpa/fcmp.hh"
 #include "tests/tstoptfct.hh"
 
+typedef const sherpa::Bounds<double>& mybounds;
 typedef void (*Init)( int, int&, double&, double*, double*, double* );
-typedef void (*Fct)( int, double*, double&, int&, void* );
-typedef void (*FctVec)( int, int, double*, double*, int&, void* );
+typedef void (*Fct)( int, double*, double&, int&, mybounds );
+typedef void (*FctVec)( int, int, double*, double*, int&, mybounds );
+typedef void (*tstFct)( Init init, Fct fct, int npar, std::vector<double>& par, std::vector<double>& lo, std::vector<double>& hi, double tol, const char* fct_name, int npop, int maxfev, double xprob, double sfactor );
+typedef void (*tstFctVec)( Init init, FctVec fct, int npar, std::vector<double>& par, std::vector<double>& lo, std::vector<double>& hi, double tol, const char* fct_name, int npop, int maxfev, double xprob, double sfactor );
 
 template <typename Real>
 void print_pars( const char* prefix, const char* name, int nfev, Real stat,
 		 Real answer, int n, const std::vector< Real >& x,
 		 Real* covarerr=NULL,
-		 Real tol=1.0e4*sqrt( std::numeric_limits<Real>::epsilon())) {
+		 Real tol=1.0e4*sqrt( std::numeric_limits<Real>::epsilon()),
+                 int njev=-1) {
 
   std::cout << prefix << name << '\t';
   if ( 0 == sao_fcmp( stat, answer, std::sqrt(tol) ) )
     std::cout << nfev << '\t';
   else
     std::cout << -nfev << '\t';
+  if ( njev > 0)
+    std::cout << njev << '\t';
   std::cout << answer << '\t';
   std::cout << stat << '\t';
   std::cout << x[0];
@@ -62,143 +68,143 @@ void tst_global( int npar, double tol, Opt opt, int npop, int maxfev,
 
   {
     opt( tstoptfct::McCormickInit<double>,
-	 tstoptfct::McCormick<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::McCormick<double,mybounds>, 2, par, lo, hi, tol,
 	 "McCormick", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BoxBettsInit<double>,
-	 tstoptfct::BoxBetts<double,void*>, 3, par, lo, hi, tol,
+	 tstoptfct::BoxBetts<double,mybounds>, 3, par, lo, hi, tol,
 	 "BoxBetts", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PavianiInit<double>,
-	 tstoptfct::Paviani<double,void*>, 10, par, lo, hi, tol,
+	 tstoptfct::Paviani<double,mybounds>, 10, par, lo, hi, tol,
 	 "Paviani", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::GoldsteinPriceInit<double>,
-	 tstoptfct::GoldsteinPrice<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::GoldsteinPrice<double,mybounds>, 2, par, lo, hi, tol,
 	 "GoldsteinPrice", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Shekel5Init<double>,
-	 tstoptfct::Shekel5<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::Shekel5<double,mybounds>, 4, par, lo, hi, tol,
 	 "Shekel5", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Shekel7Init<double>,
-	 tstoptfct::Shekel7<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::Shekel7<double,mybounds>, 4, par, lo, hi, tol,
 	 "Shekel7", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Shekel10Init<double>,
-	 tstoptfct::Shekel10<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::Shekel10<double,mybounds>, 4, par, lo, hi, tol,
 	 "Shekel10", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LevyInit<double>,
-	 tstoptfct::Levy<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::Levy<double,mybounds>, 4, par, lo, hi, tol,
 	 "Levy4", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LevyInit<double>,
-	 tstoptfct::Levy<double,void*>, 5, par, lo, hi, tol,
+	 tstoptfct::Levy<double,mybounds>, 5, par, lo, hi, tol,
 	 "Levy5", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LevyInit<double>,
-	 tstoptfct::Levy<double,void*>, 6, par, lo, hi, tol,
+	 tstoptfct::Levy<double,mybounds>, 6, par, lo, hi, tol,
 	 "Levy6", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LevyInit<double>,
-	 tstoptfct::Levy<double,void*>, 7, par, lo, hi, tol,
+	 tstoptfct::Levy<double,mybounds>, 7, par, lo, hi, tol,
 	 "Levy7", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::GriewankInit<double>,
-	 tstoptfct::Griewank<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Griewank<double,mybounds>, 2, par, lo, hi, tol,
 	 "Griewank", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::SixHumpCamelInit<double>,
-	 tstoptfct::SixHumpCamel<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::SixHumpCamel<double,mybounds>, 2, par, lo, hi, tol,
 	 "SixHumpCamel", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BraninInit<double>,
-	 tstoptfct::Branin<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Branin<double,mybounds>, 2, par, lo, hi, tol,
 	 "Branin", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::ShubertInit<double>,
-	 tstoptfct::Shubert<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Shubert<double,mybounds>, 2, par, lo, hi, tol,
 	 "Shubert", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::HansenInit<double>,
-	 tstoptfct::Hansen<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Hansen<double,mybounds>, 2, par, lo, hi, tol,
 	 "Hansen", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::ColaInit<double>,
-	 tstoptfct::Cola<double,void*>, 17, par, lo, hi, tol,
+	 tstoptfct::Cola<double,mybounds>, 17, par, lo, hi, tol,
 	 "Cola", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::AckleyInit<double>,
-	 tstoptfct::Ackley<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Ackley<double,mybounds>, 2, par, lo, hi, tol,
 	 "Ackley", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Bohachevsky1Init<double>,
-	 tstoptfct::Bohachevsky1<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Bohachevsky1<double,mybounds>, 2, par, lo, hi, tol,
 	 "Bohachevsky1", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Bohachevsky2Init<double>,
-	 tstoptfct::Bohachevsky2<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Bohachevsky2<double,mybounds>, 2, par, lo, hi, tol,
 	 "Bohachevsky2", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Bohachevsky3Init<double>,
-	 tstoptfct::Bohachevsky3<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Bohachevsky3<double,mybounds>, 2, par, lo, hi, tol,
 	 "Bohachevsky3", npop, maxfev, c1, c2 );
   }
 //   {
 //     opt( tstoptfct::DixonPriceInit<double>,
-// 	 tstoptfct::DixonPrice<double,void*>, 25, par, lo, hi, tol,
+// 	 tstoptfct::DixonPrice<double,mybounds>, 25, par, lo, hi, tol,
 // 	 "DixonPrice", npop, maxfev, c1, c2 );
 //   }
   {
     opt( tstoptfct::EasomInit<double>,
-	 tstoptfct::Easom<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Easom<double,mybounds>, 2, par, lo, hi, tol,
 	 "Easom", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::RastriginInit<double>,
-	 tstoptfct::Rastrigin<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Rastrigin<double,mybounds>, 2, par, lo, hi, tol,
 	 "Rastrigin", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::MichalewiczInit<double>,
-	 tstoptfct::Michalewicz<double,void*>, 2, par, lo, hi, tol,
+	 tstoptfct::Michalewicz<double,mybounds>, 2, par, lo, hi, tol,
 	 "Michalewicz2", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::MichalewiczInit<double>,
-	 tstoptfct::Michalewicz<double,void*>, 5, par, lo, hi, tol,
+	 tstoptfct::Michalewicz<double,mybounds>, 5, par, lo, hi, tol,
 	 "Michalewicz5", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::MichalewiczInit<double>,
-	 tstoptfct::Michalewicz<double,void*>, 10, par, lo, hi, tol,
+	 tstoptfct::Michalewicz<double,mybounds>, 10, par, lo, hi, tol,
 	 "Michalewicz10", npop, maxfev, c1, c2 );
   }
 
 }
 
-template < typename Opt >
+template <typename Opt, typename Real>
 void tst_unc_opt( int npar, double tol, Opt opt, int npop, int maxfev,
 		  double c1, double c2 ) {
 
@@ -207,169 +213,168 @@ void tst_unc_opt( int npar, double tol, Opt opt, int npop, int maxfev,
 
   {
     opt( tstoptfct::RosenbrockInit<double>,
-	 tstoptfct::Rosenbrock<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::Rosenbrock<Real, mybounds>, npar, par, lo, hi, tol,
 	 "Rosenbrock", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::FreudensteinRothInit<double>,
-	 tstoptfct::FreudensteinRoth<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::FreudensteinRoth<Real, mybounds>, npar, par, lo, hi, tol,
 	 "FreudensteinRoth", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PowellBadlyScaledInit<double>,
-	 tstoptfct::PowellBadlyScaled<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::PowellBadlyScaled<Real, mybounds>, npar, par, lo, hi, tol,
 	 "PowellBadlyScaled", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BrownBadlyScaledInit<double>,
-	 tstoptfct::BrownBadlyScaled<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::BrownBadlyScaled<Real, mybounds>, npar, par, lo, hi, tol,
 	 "BrownBadlyScaled", npop, maxfev, c1, c2 );
   }
   {
-    opt( tstoptfct::BealeInit<double>, tstoptfct::Beale<double,void*>,
+    opt( tstoptfct::BealeInit<double>, tstoptfct::Beale<Real, mybounds>,
 	 npar, par, lo, hi, tol, "Beale", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::JennrichSampsonInit<double>,
-	 tstoptfct::JennrichSampson<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::JennrichSampson<Real, mybounds>, npar, par, lo, hi, tol,
 	 "JennrichSampson", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::HelicalValleyInit<double>,
-	 tstoptfct::HelicalValley<double,void*>, 3, par, lo, hi, tol,
+	 tstoptfct::HelicalValley<Real, mybounds>, 3, par, lo, hi, tol,
 	 "HelicalValley", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BardInit<double>,
-	 tstoptfct::Bard<double,void*>, 3, par, lo, hi, tol,
+	 tstoptfct::Bard<Real, mybounds>, 3, par, lo, hi, tol,
 	 "Bard", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::GaussianInit<double>,
-	 tstoptfct::Gaussian<double,void*>, 3, par, lo, hi, tol,
+	 tstoptfct::Gaussian<Real, mybounds>, 3, par, lo, hi, tol,
 	 "Gaussian", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::MeyerInit<double>,
-	 tstoptfct::Meyer<double,void*>, 3, par, lo, hi, tol,
+	 tstoptfct::Meyer<Real, mybounds>, 3, par, lo, hi, tol,
 	 "Meyer", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::GulfResearchDevelopmentInit<double>,
-	 tstoptfct::GulfResearchDevelopment<double,void*>, 3, par, lo, hi, tol,
-	 "GulfResearchDevelopment", npop, maxfev, c1, c2 );
+	 tstoptfct::GulfResearchDevelopment<Real, mybounds>, 3, par, lo, hi,
+         tol, "GulfResearchDevelopment", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Box3dInit<double>,
-	 tstoptfct::Box3d<double,void*>, 3, par, lo, hi, tol,
+	 tstoptfct::Box3d<Real, mybounds>, 3, par, lo, hi, tol,
 	 "Box3d", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PowellSingularInit<double>,
-	 tstoptfct::PowellSingular<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::PowellSingular<Real, mybounds>, 4, par, lo, hi, tol,
 	 "PowellSingular", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::WoodInit<double>,
-	 tstoptfct::Wood<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::Wood<Real, mybounds>, 4, par, lo, hi, tol,
 	 "Wood", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::KowalikOsborneInit<double>,
-	 tstoptfct::KowalikOsborne<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::KowalikOsborne<Real, mybounds>, 4, par, lo, hi, tol,
 	 "KowalikOsborne", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BrownDennisInit<double>,
-	 tstoptfct::BrownDennis<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::BrownDennis<Real, mybounds>, 4, par, lo, hi, tol,
 	 "BrownDennis", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Osborne1Init<double>,
-	 tstoptfct::Osborne1<double,void*>, 5, par, lo, hi, tol,
+	 tstoptfct::Osborne1<Real, mybounds>, 5, par, lo, hi, tol,
 	 "Osborne1", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BiggsInit<double>,
-	 tstoptfct::Biggs<double,void*>, 6, par, lo, hi, tol,
+	 tstoptfct::Biggs<Real, mybounds>, 6, par, lo, hi, tol,
 	 "Biggs", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::Osborne2Init<double>,
-	 tstoptfct::Osborne2<double,void*>, 11, par, lo, hi, tol,
+	 tstoptfct::Osborne2<Real, mybounds>, 11, par, lo, hi, tol,
 	 "Osborne2", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::WatsonInit<double>,
-	 tstoptfct::Watson<double,void*>, 6, par, lo, hi, tol,
+	 tstoptfct::Watson<Real, mybounds>, 6, par, lo, hi, tol,
 	 "Watson", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PenaltyIInit<double>,
-	 tstoptfct::PenaltyI<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::PenaltyI<Real, mybounds>, 4, par, lo, hi, tol,
 	 "PenaltyI", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::PenaltyIIInit<double>,
-	 tstoptfct::PenaltyII<double,void*>, 4, par, lo, hi, tol,
+	 tstoptfct::PenaltyII<Real, mybounds>, 4, par, lo, hi, tol,
 	 "PenaltyII", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::VariablyDimensionedInit<double>,
-	 tstoptfct::VariablyDimensioned<double,void*>, npar, par, lo, hi, tol,
-	 "VariablyDimensioned", npop, maxfev, c1, c2 );
+	 tstoptfct::VariablyDimensioned<Real, mybounds>, npar, par, lo, hi,
+         tol, "VariablyDimensioned", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::TrigonometricInit<double>,
-	 tstoptfct::Trigonometric<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::Trigonometric<Real, mybounds>, npar, par, lo, hi, tol,
 	 "Trigonometric", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BrownAlmostLinearInit<double>,
-	 tstoptfct::BrownAlmostLinear<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::BrownAlmostLinear<Real, mybounds>, npar, par, lo, hi, tol,
 	 "BrownAlmostLinear", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::DiscreteBoundaryInit<double>,
-	 tstoptfct::DiscreteBoundary<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::DiscreteBoundary<Real, mybounds>, npar, par, lo, hi, tol,
 	 "DiscreteBoundary", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::DiscreteIntegralInit<double>,
-	 tstoptfct::DiscreteIntegral<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::DiscreteIntegral<Real, mybounds>, npar, par, lo, hi, tol,
 	 "DiscreteIntegral", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BroydenTridiagonalInit<double>,
-	 tstoptfct::BroydenTridiagonal<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::BroydenTridiagonal<Real, mybounds>, npar, par, lo, hi, tol,
 	 "BroydenTridiagonal", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::BroydenBandedInit<double>,
-	 tstoptfct::BroydenBanded<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::BroydenBanded<Real, mybounds>, npar, par, lo, hi, tol,
 	 "BroydenBanded", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LinearFullRankInit<double>,
-	 tstoptfct::LinearFullRank<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::LinearFullRank<Real, mybounds>, npar, par, lo, hi, tol,
 	 "LinearFullRank", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LinearFullRank1Init<double>,
-	 tstoptfct::LinearFullRank1<double,void*>, npar, par, lo, hi, tol,
+	 tstoptfct::LinearFullRank1<Real, mybounds>, npar, par, lo, hi, tol,
 	 "LinearFullRank1", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::LinearFullRank0cols0rowsInit<double>,
-	 tstoptfct::LinearFullRank0cols0rows<double,void*>, npar, par, lo, hi, tol,
-	 "LinearFullRank0cols0rows", npop, maxfev, c1, c2 );
+	 tstoptfct::LinearFullRank0cols0rows<Real, mybounds>, npar, par, lo,
+         hi, tol, "LinearFullRank0cols0rows", npop, maxfev, c1, c2 );
   }
   {
     opt( tstoptfct::ChebyquadInit<double>,
-	 tstoptfct::Chebyquad<double,void*>, 9, par, lo, hi, tol,
+	 tstoptfct::Chebyquad<Real, mybounds>, 9, par, lo, hi, tol,
 	 "Chebyquad", npop, maxfev, c1, c2 );
   }
 
-}
-
+} // tst_unc_opt
 #endif


### PR DESCRIPTION
caveat: This is not a PR in a classic sense, the code is made available so anyone
can check out my claim about using 'analytic' derivatives sometimes give better
results then numerical derivatives using minpack's implementation of the
Levenberg-Marquardt algorithm.


The performance improvements in sherpa as requested by SDS, as described in the doc:

https://docs.google.com/document/d/1wQmHUEviv2K4U5rSK3EH1hYO0ByAVY3SpbgkHG7T7RU/edit#heading=h.nnxa3ik6wnm8

have mostly been implemented with limited success.  While working on this project,
I realized that to get signifcant performance gain (when using Xspec-models to fit
using the LevMar) then the following options should be considered:

  1) The default convergence criteria for xpec are more tolerant then sherpa
  2) Xspec uses analytic derivatives

Changing the convergence tolerances for LevMar routine is rather trivial and can
be done by the user at run time, alternatively the default values can be changed
by SDS. Modifying sherpa to handle analytical derivatives is a little more work.
However, there is an additional benefit to using analytic derivatives (vs numerical
derivatives), sometimes it could lead to more accurate results.

The unconstrained test functions (which are shipped with sherpa) are described in the
following article:

http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.641.3566&rep=rep1&type=pdf

will be used to test sherpa's Levenberg-Marquardt algorithm using numerical and
'analytic' derivatives.  The analytic derivatives for the said test functions can
be found at the following url:

http://netlib.org/minpack/ex/file17

but it would take too much time/effort to convert the Fortran code to C/C++ so I
decided to take a short cut by using a C++ autodiff library to evaluate the
analytic Jacobians.

To compile the test programs, tst_lmdif and tst_mder go to the following dir:

(sherpa3) [dtn@devel12 minpack]$ pwd
?????/sherpa/sherpa/optmethods/src/minpack

To compile  tst_lmdif, type:

(sherpa3) [dtn@devel12 minpack]$ g++ -I. -I../../../include -I../.. -Wall -ansi -pedantic -O3 -g -DtestLevMar LevMar.cc -o tst_lmdif

(sherpa3) [dtn@devel12 minpack]$ time tst_lmdif > tst_lmdif.out
0.017u 0.002s 0:00.02 50.0%	0+0k 0+16io 0pf+0w


To compile tst_lmder, type:

One can download the adept autodiff lib at the following url:

http://www.met.reading.ac.uk/clouds/adept/

Adept version 1.1 is good enough, no need to get version 2.0, or one could use my
compiled version as seen below:

(sherpa3) [dtn@devel12 minpack]$ g++ -I. -I../../../include -I../.. -I/data/scialg/staff/dtn/soft/autodiff/adept-1.1/include -Wall -ansi -pedantic -O3 -g -fopenmp -DtestLevMar -DUSE_ADEPT LevMar.cc -L/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib  -lm -ladept -o tst_lmder

before running tst_lmder, one must set the LD_LIBRARY_PATH

setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/data/scialg/staff/dtn/soft/autodiff/adept-1.1/lib

(sherpa3) [dtn@devel12 minpack]$ time tst_lmder > tst_lmder.out
0.403u 0.005s 0:00.04 1000.0%	0+0k 160+16io 0pf+0w

The output of the tst_lmder.out files are:
1) the name of fit routine used and name of the model function
2) the number of function evaluations, if nfev < 0 then the expected min was not found
3) the number of jacobian evalutations
4) expected value at minimum
5) the value of the function at minimum (to be compared with col 4)
6) parameters at minimum
7) err on the pars at minimum

name	nfev	njev	answer	fval	par	err
S	N	N	N	N	N
..
lmder_Meyer	126	116	87.9458	87.9459	0.00560964,6181.35,345.224	1.45186e-06,0,0.00688985
..
lmder_BrownDennis	254	236	85822.2	85822.2	-11.5913,13.2025,-0.403574,0.236736	0.0548502,0.0168074,0.383514,0.543374
..
lmder_Watson	8	7	0.00228767	0.00228767	-0.015725,1.01243,-0.232992,1.26043,-1.51373,0.992997	0.944386,0.760504,5.40955,16.2023,19.4854,8.98356
..

The output of the tst_lmdif.out files are:
1) the name of fit routine used and name of the model function
2) the number of function evaluations, if nfev < 0 then the expected min was not found
3) expected value at minimum
4) the value of the function at minimum (to be compared with col 4)
5) parameters at minimum
6) err on the pars at minimum

name	nfev	answer	fval	par	err
S	N	N	N	N	N
..
lmdif_Meyer	-387	87.9458	868.804	0.00742627,5949.59,337.349	1.91166e-06,0,0.00676072
..
lmdif_BrownDennis	-516	85822.2	107689	-7.17716,11.686,-0.975378,-0.29509	0.0903093,0.0237209,0.339559,0.569962
..
lmdif_Watson	-36	0.00228767	0.00260576	1.88024e-22,1.01364,-0.244321,1.37383,-1.68571,1.09812	1,0.759043,5.37417,14.8652,16.8648,6.7074
..

Using the 'analytic' instead of numerical derivs: one can get the known minimum values in
three more cases, out of thirty five test cases.

Note that tst_lmdif runs much faster then tst_lmder but I expect an optimized version of
the analitic derivatives should be faster then the numerical derivatives. See for example:

http://ceres-solver.org/analytical_derivatives.html#chapter-analytical-derivatives

A comparison of the time it takes to compute the various type (analytic, numerical,
autodiff, eetc... ) of derivatives can be seen at the following url:

http://ceres-solver.org/automatic_derivatives.html

Note:  Looking through sherpa code, it is hard to see how one can modify it without
loosing effeciency when the NelderMead or MonCar opt algorithm is used.

Xspec's main optimization routine is the Levenberg Marquardt.  Minuit is also shipped
with Xspec, but the most useful algorithm in Minuit does need a first deriv.

sherpa's conf can be improved if the analytic derivatives for the Xspec functions are used.
The computational complexity of conf can be improved from 1.84 to quadratic
convergence by switching the root finding algorithm from the Mueller's to Newton's
method (convergence rate is  quadratic).  Better yet, one could in theory use Halley's root
finding algorithm to get a cubic convergence rate.

valgrind the tst_lmder program will show some memory leaks but the memory leak is
due to the '-fopenmp' flag.

devel12-291: cat memleak.cc
int main(int argc, char* argv[] ) {
  return 0;
}
devel12-292: g++ memleak.cc -o memleak
devel12-293: valgrind memleak
==20823== Memcheck, a memory error detector
==20823== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==20823== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==20823== Command: memleak
==20823==
==20823==
==20823== HEAP SUMMARY:
==20823==     in use at exit: 0 bytes in 0 blocks
==20823==   total heap usage: 0 allocs, 0 frees, 0 bytes allocated
==20823==
==20823== All heap blocks were freed -- no leaks are possible
==20823==
==20823== For counts of detected and suppressed errors, rerun with: -v
==20823== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


devel12-295: g++ -c mem_leak.cc -o memleak.o
devel12-296: g++ -fopenmp memleak.o -o memleak
devel12-297: valgrind memleak
==20955== Memcheck, a memory error detector
==20955== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==20955== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==20955== Command: memleak
==20955==
==20955==
==20955== HEAP SUMMARY:
==20955==     in use at exit: 8 bytes in 1 blocks
==20955==   total heap usage: 2 allocs, 1 frees, 32,824 bytes allocated
==20955==
==20955== LEAK SUMMARY:
==20955==    definitely lost: 0 bytes in 0 blocks
==20955==    indirectly lost: 0 bytes in 0 blocks
==20955==      possibly lost: 0 bytes in 0 blocks
==20955==    still reachable: 8 bytes in 1 blocks
==20955==         suppressed: 0 bytes in 0 blocks
==20955== Rerun with --leak-check=full to see details of leaked memory
==20955==
==20955== For counts of detected and suppressed errors, rerun with: -v
==20955== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


caveat emptor:
1) I did not do a comprehensive study which C++ autodiff package to use, chose adept
'cause it seems like the easiest one to incorporate into sherpa besides it has a very liberal
copyright license.
2) Note: the memory leak is due to the (required) linking with the openmp library.

