### PR TITLE
Add XSPEC 12.10.0e to Travis jobs (Linux), Drop Py2.7/XSPEC job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,21 @@ matrix:
   fast_finish: true
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=2.0 XSPECVER="12.9.1" TRAVIS_PYTHON_VERSION="3.6"
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=2 XSPECVER="12.9.1" TRAVIS_PYTHON_VERSION="3.6"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
-    # Full build (including ds9 and xspec), Python 2.7, setup.py develop, astropy, matplotlib 1.5
-    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
+    # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 1.5
+    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1 TRAVIS_PYTHON_VERSION="3.5"
       sudo: required
       dist: trusty
-    # As above, Python 3.5
-    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.5"
+    # As above, Python 3.6, setup.py install, xspec 12.10
+    - env: XSPECVER="12.10.0e" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
-    # As above, Python 3.6, setup.py install
-    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="3.6"
-      sudo: required
-      dist: trusty
-    # As above, xspec 12.9.1n
-    - env: XSPECVER="12.9.1" NUMPYVER="1.14" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="3.6"
+    # As above, python 3.7, numpy 1.14, matplotlib 2.0
+    - env: XSPECVER="12.10.0e" NUMPYVER="1.14" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=3 TRAVIS_PYTHON_VERSION="3.7"
       sudo: required
       dist: trusty
     # Experimental support for using Sphinx to build the documentation
@@ -35,17 +31,12 @@ matrix:
       dist: trusty
     # Install sherpatest package rather than relying on relative location of the submodule
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
-    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2.0 TRAVIS_PYTHON_VERSION="2.7"
+    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="2.7"
     # Install astropy without matplotlib (checks tests are properly skipped)
     - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
     # test, so perhaps could be combined?
     - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
-
-  # This job started failing in December 2018. We'll need to figure out what's wrong, but in the meantime we are just
-  # allowing it to fail. Note it's the only one with python 2.7.
-  allow_failures:
-    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1.5 TRAVIS_PYTHON_VERSION="2.7"
 
 before_install:
   - source travis/setup_conda.sh

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -487,12 +487,14 @@ class test_threads(SherpaTestCase):
     @requires_fits
     @requires_xspec
     def test_proj_bubble(self):
+        xspec.set_xsxsect('bcmc')
+
         self.run_thread('proj_bubble')
 
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         assert covarerr[0] == approx(0, rel=1e-4)
-        assert covarerr[1] == approx(8.74608e-07, rel=1e-3)
+        assert covarerr[1] == approx(8.74608e-07, rel=1e-2)
 
         # Fit -- Results from reminimize
         assert self.locals['mek1'].kt.val == approx(17.8849, rel=1e-2)
@@ -509,9 +511,9 @@ class test_threads(SherpaTestCase):
         #
         # TODO: should this check that parmaxes is -1 * parmins instead?
         covar = ui.get_covar_results()
-        assert covar.parmins[0] == approx(-0.328832, rel=0.01)
+        assert covar.parmins[0] == approx(-0.328832, rel=0.1)
         assert covar.parmins[1] == approx(-8.847916e-7, rel=0.01)
-        assert covar.parmaxes[0] == approx(0.328832, rel=0.01)
+        assert covar.parmaxes[0] == approx(0.328832, rel=0.1)
         assert covar.parmaxes[1] == approx(8.847916e-7, rel=0.01)
 
         # Proj -- Upper bound of kT can't be found

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -52,7 +52,7 @@ echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC} ${DOCSBUILD}"
 
 # Create and activate conda build environment
 # We create a new environment so we don't care about the python version in the root environment.
-conda create --yes --quiet -n build python=${TRAVIS_PYTHON_VERSION} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITS} ${DOCSBUILD} ${compilers}\
+conda create --yes -n build python=${TRAVIS_PYTHON_VERSION} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITS} ${DOCSBUILD} ${compilers}\
   libgfortran=${libgfortranver}
 
 source activate build

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -60,30 +60,27 @@ cd -
 
 ### XSPEC
 xspec_library_path=${xspec_root}/lib/
-xpec_include_path=${xspec_root}/include/
+xspec_include_path=${xspec_root}/include/
 
+case "${XSPECVER}" in
+  12.10.0e)  
+      xspec_version_string="12.10.0"
+      xspec_include_path="$miniconda/envs/build/include"
+      xspec_library_path="$miniconda/envs/build/lib"
+      ;;
+  *)
+      xspec_version_string="12.9.1"
+      sed -i.orig "s/#cfitsio_libraries/cfitsio_libraries/g" setup.cfg
+      sed -i.orig "s/#ccfits_libraries/ccfits_libraries/g" setup.cfg
+      sed -i.orig "s/#wcslib_libraries/wcslib_libraries/g" setup.cfg
+      ;;
+esac
 
 # Change build configuration
 sed -i.orig "s/#with-xspec=True/with-xspec=True/g" setup.cfg
 sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${xspec_library_path}|g" setup.cfg
-sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xpec_include_path}|g" setup.cfg
-sed -i.orig "s/#cfitsio_libraries/cfitsio_libraries/g" setup.cfg
-sed -i.orig "s/#ccfits_libraries/ccfits_libraries/g" setup.cfg
-sed -i.orig "s/#wcslib_libraries/wcslib_libraries/g" setup.cfg
+sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xspec_include_path}|g" setup.cfg
 sed -i.orig "s|#gfortran_libraries = gfortran|gfortran_libraries= ${libgfortran_name}|g" setup.cfg
-
-case "${XSPECVER}" in
-  12.9.1)
-      xspec_version_string="12.9.1"
-      ;;
-  12.9.10e)  # I misspelled the version string, should have been 12.10.0
-      xspec_version_string="12.10.0"
-      ;;
-  *)
-      xspec_version_string="12.9.0"
-      ;;
-esac
-
 sed -i.orig "s|#xspec_version = 12.9.0|xspec_version = ${xspec_version_string}|g" setup.cfg
 
 


### PR DESCRIPTION
This PR introduces the following changes in the Travis build:

  * Two XSPEC 12.10.0e jobs with Python 3.6 and 3.7 are added.
  * The XSPEC/Py27 job is removed.
  * Travis build matrix now includes XSPEC 12.9.1 and 12.10.0 for Python 3.5, 3.6, and 3.7.
  * As the build configuration with 12.9.1 and 12.10.0 is drastically different, some changes were made to the configuration scripts.
  * Conda is now verbose again. At first this was a mistake, I just forgot to roll back a debugging change, but it seems to work fine. We had made conda less verbose because the jobs would hit the log file size limitations, but it does not looks like they are anymore, at least for now. On the other hand very often the quietness of conda makes the jobs time out, so hopefully that won't happen anymore either.
  * The XSPEC 12.10.0/Python 3.7 job also tests against Matplotlib 3.
  * Rather than always installing Matplotlib 2.0, the Travis jobs now correctly install the latest version of the 2 series.

Also, since a regression (thread) test started to fail with 12.10.0, I compensated by applying the changes in #534.

## What's missing

@DougBurke suggested we only test 12.10.1, but we still don't have those conda binaries.

Similary, we still don't have macOS binaries.

Having successful builds with 12.10.0 will demonstrate we are compatible with that version and document the changes in configuration users would require.