### PR TITLE
Update macOS Travis job to use XSPEC 12.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   fast_finish: true
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.0e" TRAVIS_PYTHON_VERSION="3.7"
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=2 XSPECVER="12.10.0e" TRAVIS_PYTHON_VERSION="3.7"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   fast_finish: true
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=2 XSPECVER="12.9.1" TRAVIS_PYTHON_VERSION="3.6"
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.0e" TRAVIS_PYTHON_VERSION="3.7"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -3,7 +3,7 @@
 # Environment
 libgfortranver="3.0"
 sherpa_channel=sherpa
-xspec_channel=cxc/channel/dev
+xspec_channel=xspec/channel/dev
 miniconda=$HOME/miniconda
 
 if [[ ${TRAVIS_OS_NAME} == linux ]];


### PR DESCRIPTION
This PR updates the macOS Travis job to use XSPEC 12.10.0.

We will soon update it again to use 12.10.1, but I'd like to make sure there is trace of a successful 12.10.0 build. Also, we are changing the channel from which we download xspec, so I'd like to make sure that works as well before proceeding further. I branched off #588 and I'll need to rebase after that one is merged.