### PR TITLE
Post 4.11.0 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ extend (whether to other areas of Astronomy or in other domains).
 Release History
 ---------------
 
+4.11.0: 20 February 2019 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2573885.svg)](https://doi.org/10.5281/zenodo.2573885)
+
 4.10.2: 14 December 2018 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2275738.svg)](https://doi.org/10.5281/zenodo.2275738)
 
 4.10.1: 16 October 2018 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1463962.svg)](https://doi.org/10.5281/zenodo.1463962)


### PR DESCRIPTION
This PR updates the pointer to the test data submodule and adds the new Zenodo DOI for 4.11.0, as a result of the 4.11.0 release.