### PR TITLE
Reduce integration tol

### DIFF
--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <limits>
 
-#define TOL (std::numeric_limits< double >::epsilon());
+#define TOL (std::numeric_limits< float >::epsilon());
 
 template <typename ArrayType>
 class FunctionWithParams {

--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2019 Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
opt routines have tol ~ 1.0e-7 so it doesn't make sense use ~1.0e-16 for tolerance for integration routines so the following change was made:

std::numeric_limits< double >::epsilon()  --> std::numeric_limits< float >::epsilon()