### PR TITLE
Update travis build matrix for 4.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,19 @@ matrix:
     - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
       sudo: required
       dist: trusty
-    # As above, python 3.7, numpy 1.14, matplotlib 3
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.14" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=3 TRAVIS_PYTHON_VERSION="3.7"
+    # As above, python 3.7, numpy 1.15, matplotlib 3
+    - env: XSPECVER="12.10.1b" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=3 TRAVIS_PYTHON_VERSION="3.7"
       sudo: required
       dist: trusty
     # Experimental support for using Sphinx to build the documentation
     # should we not run tests with this build (to save time); i.e. have
     # a specific build just for the documentation and nothing else?
-    - env: DOCS=true INSTALL_TYPE=build_sphinx TEST=none TRAVIS_PYTHON_VERSION="3.6"
+    - env: DOCS=true INSTALL_TYPE=build_sphinx TEST=none TRAVIS_PYTHON_VERSION="3.7"
       sudo: required
       dist: trusty
     # Install sherpatest package rather than relying on relative location of the submodule
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
-    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="2.7"
+    - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # Install astropy without matplotlib (checks tests are properly skipped)
     - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding


### PR DESCRIPTION
I didn't get input from @DougBurke yet, but this is my guess of how I think I'll be asked to change the build matrix on Travis and @DougBurke can confirm or comment. Note I removed one of the 2.7 builds as we are starting to deprecate support for 2.7. Other than that I updated the most up to date version of numpy to 1.15 and the docs build to the most recent version of Python (has 3.8 come out yet?)