### PR TITLE
whitelist new numpy deprecation warning

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -104,7 +104,9 @@ if sys.version_info >= (3, 2):
             [r"invalid value encountered in sqrt",
              # See https://github.com/ContinuumIO/anaconda-issues/issues/6678
              r"numpy.dtype size changed, may indicate binary " +
-             r"incompatibility. Expected 96, got 88"
+             r"incompatibility. Expected 96, got 88",
+             # See https://github.com/numpy/numpy/pull/432
+             r"numpy.ufunc size changed"
              ],
     }
     known_warnings.update(python3_warnings)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -80,6 +80,7 @@ known_warnings = {
          ],
      VisibleDeprecationWarning:
         [r"Passing `normed=True`*",
+         r"sctypeNA and typeNA will be removed.*",
         ],
 }
 


### PR DESCRIPTION
This PR fixes a build issue on master, so I'll merge it when Travis gives me the green light.

As you can see in https://travis-ci.org/sherpa/sherpa/jobs/505739553 our builds started to fail because of a new deprecation warning in numpy. I will issue a PR right after this one with a fix, but I'd prefer that PR to be reviewed.

There is one more warning that looks like benign (we already have a similar item in the whitelist), see https://github.com/numpy/numpy/pull/432

The goal of this PR is just to get master back to green.