### PR TITLE
stop using numpy.typeNA which is now deprecated

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -46,6 +46,20 @@ except ImportError:
     has_xspec = False
 
 
+# In some instances, if some xvfb processes did not stop cleanly
+# pytest-xfvb starts complaining that a virtual screen is already on
+# the following code works around that. The issue is hard to reproduce
+# but I (OL) tested it locally as it reappeared on my workstation.
+try:
+    import random
+    from pyvirtualdisplay import abstractdisplay
+    abstractdisplay.RANDOMIZE_DISPLAY_NR = True
+    abstractdisplay.random = random
+    random.seed()
+except ImportError:
+    pass
+
+
 TEST_DATA_OPTION = "--test-data"
 
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -117,7 +117,9 @@ if sys.version_info >= (3, 2):
             [r"invalid value encountered in sqrt",
              # See https://github.com/ContinuumIO/anaconda-issues/issues/6678
              r"numpy.dtype size changed, may indicate binary " +
-             r"incompatibility. Expected 96, got 88"
+             r"incompatibility. Expected 96, got 88",
+             # See https://github.com/numpy/numpy/pull/432
+             r"numpy.ufunc size changed"
              ],
     }
     known_warnings.update(python3_warnings)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1330,12 +1330,16 @@ def print_fields(names, vals, converters=None):
 
     """
 
+    # This is the part of the deprecated typeNA dictionary Sherpa
+    # would use up to v4.11.0. We included the dictionaty verbatim,
+    # excluding the complex mapping which where wrong in typeNA.
+    # Note only the class -> string mappings have been copied over.
     if converters is None:
         converters = {numpy.bool_: 'Bool',
                       numpy.bytes_: 'Bytes0',
-                      numpy.complex128: 'Complex64',
-                      numpy.complex256: 'Complex128',
-                      numpy.complex64: 'Complex32',
+                      numpy.complex128: 'Complex128',
+                      numpy.complex256: 'Complex256',
+                      numpy.complex64: 'Complex64',
                       numpy.datetime64: 'Datetime64',
                       numpy.float128: 'Float128',
                       numpy.float16: 'Float16',

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1319,7 +1319,7 @@ def get_num_args(func):
     return (npos + nkw, npos, nkw)
 
 
-def print_fields(names, vals, converters={}):
+def print_fields(names, vals, converters=None):
     """
 
     Given a list of strings names and mapping vals, where names is a
@@ -1330,23 +1330,39 @@ def print_fields(names, vals, converters={}):
 
     """
 
+    if converters is None:
+        converters = {numpy.bool_: 'Bool',
+                      numpy.bytes_: 'Bytes0',
+                      numpy.complex128: 'Complex64',
+                      numpy.complex256: 'Complex128',
+                      numpy.complex64: 'Complex32',
+                      numpy.datetime64: 'Datetime64',
+                      numpy.float128: 'Float128',
+                      numpy.float16: 'Float16',
+                      numpy.float32: 'Float32',
+                      numpy.float64: 'Float64',
+                      numpy.int16: 'Int16',
+                      numpy.int32: 'Int32',
+                      numpy.int64: 'Int64',
+                      numpy.int8: 'Int8',
+                      numpy.object_: 'Object0',
+                      numpy.str_: 'Str0',
+                      numpy.timedelta64: 'Timedelta64',
+                      numpy.uint16: 'UInt16',
+                      numpy.uint32: 'UInt32',
+                      numpy.uint64: 'UInt64',
+                      numpy.uint8: 'UInt8',
+                      numpy.void: 'Void0'
+                      }
+
     width = max(len(n) for n in names)
     fmt = '%%-%ds = %%s' % width
     lines = []
     for n in names:
         v = vals[n]
 
-        conv = None
-        if converters:
-            for t in converters:
-                if isinstance(v, t):
-                    conv = converters[t]
-                    break
-
-        if conv is not None:
-            v = conv(v)
-        elif isinstance(v, numpy.ndarray):
-            v = '%s[%d]' % (numpy.typeNA[v.dtype.type], v.size)
+        if isinstance(v, numpy.ndarray):
+            v = '%s[%d]' % (converters[v.dtype.type], v.size)
         else:
             v = str(v)
         lines.append(fmt % (n, v))


### PR DESCRIPTION
# Release Note
A `numpy` deprecation warning was fixed by removing the usage of `typeNA`, which was not documented and will be removed in a future release of `numpy`. The `print_fields` function has been changed to include a default mapping using the current `typeNA` implementation.

# Notes
First of all, `print_fields` is one of the functions mentioned in #87.

The fix solves the issue described in #605.

This PR changes the logic in `print_fields` because it looks like the `converters` argument is never used in Sherpa, so I simplified the function by removing the logic associated with `converters` altogether. I used the current implementation of `typeNA` to generate a default dictionary of `numpy` array types and their string representation. Anything that is not a `numpy` array is printed as its `str` representation.

There is a small unit test in `test_utils`, which passes with this change. Some tests would fail with a buggy fix, so hopefully the tests are covering enough of the functionality to prevent regressions.