### PR TITLE
update ciao default plotter to matplotlib

### DIFF
--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -1,7 +1,7 @@
 # SHERPA_VERSION 4.10.0
 [options]
 # Plotting packages available- pylab, chips
-plot_pkg   : chips
+plot_pkg   : pylab
 
 # IO packages available- pyfits, crates
 io_pkg     : crates


### PR DESCRIPTION
# Release Note
The default Sherpa plotting package has been changed to `matplotlib` for CIAO users as well (it had been the default for standalone users for several years).

# Notes
This does not have any impact on Standalone users at all. I don't expect any review on this and I'll just merge it so it will be in the upcoming CIAOX builds.

As a matter of fact I meant to add `[skip ci]` to the commit message, as the tests aren't really exercising anything other than rerunning the master branch tests... I'll leave them be as sometimes we get errors from the free-floating dependencies in some of the jobs.