### PR TITLE
Fix #609: User Model: unable to change parameter values

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -396,15 +396,16 @@ def clean_astro_ui():
 
     This also resets the XSPEC settings (if XSPEC support is provided).
 
+    See Also
+    --------
+    clean_ui
+
     Notes
     -----
     It does NOT change the logging level; perhaps it should, but the
     screen output is useful for debugging at this time.
     """
     from sherpa.astro import ui
-
-    # old_lgr_level = logger.getEffectiveLevel()
-    # logger.setLevel(logging.CRITICAL)
 
     if has_xspec:
         old_xspec = xspec.get_xsstate()
@@ -418,7 +419,26 @@ def clean_astro_ui():
     if old_xspec is not None:
         xspec.set_xsstate(old_xspec)
 
-    # logger.setLevel(old_lgr_level)
+
+@pytest.fixture
+def clean_ui():
+    """Ensure sherpa.ui.clean is called before AND after the test.
+
+    See Also
+    --------
+    clean_astro_ui
+
+    Notes
+    -----
+    It does NOT change the logging level; perhaps it should, but the
+    screen output is useful for debugging at this time.
+    """
+    from sherpa import ui
+
+    ui.clean()
+    yield
+
+    ui.clean()
 
 
 @pytest.fixture

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1843,7 +1843,8 @@ class UserModel(ArithmeticModel):
             pars = (self.ampl,)
         else:
             for par in pars:
-                self.__dict__[par.name] = par
+                setattr(self, par.name, par)
+
         ArithmeticModel.__init__(self, name, pars)
 
 

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -390,7 +390,6 @@ def test_user_model_create_pars_full():
 # parameter values for a user model using direct access
 #
 @pytest.mark.usefixtures("clean_ui")
-@pytest.mark.xfail(msg="bug 609")
 def test_user_model_change_par():
 
     mname = "test_model"


### PR DESCRIPTION
# Release Note
A regression introduced in Sherpa 4.10.0 presented users from change user-model parameter values through direct access. This issue has been fixed. Several tests were added to reduce the chance of regressions in the future.

# Summary

Fix issue #609 - the inability to change user-model parameter values through direct access - which was broken by some refactoring (probably #255 introduced in Sherpa 4.10.0).

Several tests have been added to exercise simple one-dimensional user models (both for this fix and to check other behavior).