### PR TITLE
Do not create warnings about error bars in plots if no error bars are to be shown (fix #621)

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -564,6 +564,10 @@ class JointPlot(SplitPlot):
         clearaxes = kwargs.get('clearwindow', True)
         self._clear_window(0, 0, clearaxes)
 
+        print("INTERNAL DEBUGGING: JointPlot")
+        print(" isinstance(plot, FitPlot) = {}".format(isinstance(plot, FitPlot)))
+        print(" type(plot) = {}".format(type(plot)))
+
         # FIXME: should not know about FitPlot, terrible hack to remove label
         if isinstance(plot, FitPlot):
             plot.dataplot.xlabel = ''

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1274,7 +1274,7 @@ class ResidPlot(ModelPlot):
     x : array_like
        The X value for each point.
     y : array_like
-       The Y value for each point: data-model.
+       The Y value for each point: data - model.
     xerr : array_like
        The half-width of each X "bin", if set.
     yerr : array_like
@@ -1349,7 +1349,7 @@ class RatioPlot(ModelPlot):
     x : array_like
        The X value for each point.
     y : array_like
-       The Y value for each point: data-model.
+       The Y value for each point: data / model.
     xerr : array_like
        The half-width of each X "bin", if set.
     yerr : array_like

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -564,12 +564,34 @@ class JointPlot(SplitPlot):
         clearaxes = kwargs.get('clearwindow', True)
         self._clear_window(0, 0, clearaxes)
 
+        """
         # FIXME: should not know about FitPlot, terrible hack to remove label
         if isinstance(plot, FitPlot):
             plot.dataplot.xlabel = ''
             plot.modelplot.xlabel = ''
         else:
             plot.xlabel = ''
+
+        """
+
+        # Slightly-more Pythonic way to clear the labels than checking
+        # the class of the object.
+        #
+        # The order here could matter if things get changed (such as
+        # FitPlot being re-worked to use a common labelling system)
+        #
+        # Unlike the previous version, this will not fail (here at least)
+        # if xlabel doesn't exist.
+        #
+        if hasattr(plot, 'xlabel'):
+            plot.xlabel = ''
+        elif hasattr(plot, 'dataplot') and hasattr(plot, 'modelplot'):
+            dplot = plot.dataplot
+            mplot = plot.modelplot
+            if hasattr(dplot, 'xlabel'):
+                dplot.xlabel = ''
+            if hasattr(mplot, 'xlabel'):
+                mplot.xlabel = ''
 
         kwargs['clearwindow'] = False
         plot.plot(*args, **kwargs)

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -40,7 +40,7 @@ from six.moves.configparser import ConfigParser
 
 warning = logging.getLogger(__name__).warning
 
-# TODO: why is this module globally chaning the invalid mode of NumPy?
+# TODO: why is this module globally changing the invalid mode of NumPy?
 _ = numpy.seterr(invalid='ignore')
 
 config = ConfigParser()
@@ -585,24 +585,9 @@ class JointPlot(SplitPlot):
         clearaxes = kwargs.get('clearwindow', True)
         self._clear_window(0, 0, clearaxes)
 
-        """
-        # FIXME: should not know about FitPlot, terrible hack to remove label
-        if isinstance(plot, FitPlot):
-            plot.dataplot.xlabel = ''
-            plot.modelplot.xlabel = ''
-        else:
-            plot.xlabel = ''
-
-        """
-
-        # Slightly-more Pythonic way to clear the labels than checking
-        # the class of the object.
-        #
-        # The order here could matter if things get changed (such as
-        # FitPlot being re-worked to use a common labelling system)
-        #
-        # Unlike the previous version, this will not fail (here at least)
-        # if xlabel doesn't exist.
+        # The code used to check if the plot was an instance of
+        # FitPlot, which has been updated to check for the presence
+        # of attributes instead.
         #
         if hasattr(plot, 'xlabel'):
             plot.xlabel = ''

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -711,6 +711,17 @@ class DataPlot(Plot):
         # the stat.name is not in _stats_noerr but an exception is
         # raised by get_yerr).
         #
+        # This assumes that the error bars calculated by data.to_plot are
+        # over-ridden once a statistic is given. However, how does this
+        # work if the statistic is a Chi2 variant - e.g. Chi2DataVar -
+        # but the user has given explicit errors (i.e. they are not to
+        # be calcualted by the "DataVar" part but used as is). Does
+        # data.get_yerr handle this for us, or are invalid errors
+        # used here? It appears that the correct answers are being
+        # returned, but should we only call data.get_yerr if yerr
+        # is None/empty/whatever is returned by to_plot? This also
+        # holds for the Resid/RatioPlot classes.
+        #
         try:
             yerrorbars = self.plot_prefs['yerrorbars']
         except KeyError:

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -564,10 +564,6 @@ class JointPlot(SplitPlot):
         clearaxes = kwargs.get('clearwindow', True)
         self._clear_window(0, 0, clearaxes)
 
-        print("INTERNAL DEBUGGING: JointPlot")
-        print(" isinstance(plot, FitPlot) = {}".format(isinstance(plot, FitPlot)))
-        print(" type(plot) = {}".format(type(plot)))
-
         # FIXME: should not know about FitPlot, terrible hack to remove label
         if isinstance(plot, FitPlot):
             plot.dataplot.xlabel = ''

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -218,7 +218,9 @@ def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, fla
 
 
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
-@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
+@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar,
+                                       pytest.param(LeastSq,
+                                                    marks=pytest.mark.xfail)])
 def test_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statClass):
     """Should see no warnings (see #621)
 

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -87,6 +87,7 @@ def check_for_warning(caplog, nwarn, statname=None):
 
 @pytest.mark.parametrize("statClass,flag",
                          [(Chi2DataVar, False),
+                          (Chi2ModVar, False),
                           (LeastSq, True)])
 def test_data_plot_see_errorbar_warnings(caplog, statClass, flag):
     """Do we see the warning when expected - data plot?
@@ -168,6 +169,7 @@ def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
 @pytest.mark.parametrize("statClass,flag",
                          [(Chi2DataVar, False),
+                          (Chi2ModVar, False),
                           (LeastSq, True)])
 def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, flag):
     """Do we see the warning when expected - residual/ratio plots?
@@ -254,6 +256,7 @@ def test_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statC
 
 @pytest.mark.parametrize("statClass,flag",
                          [(Chi2DataVar, False),
+                          (Chi2ModVar, False),
                           (LeastSq, True)])
 def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
     """Do we see the warning when expected - fit plot?
@@ -314,6 +317,7 @@ def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
 @pytest.mark.parametrize("statClass,flag",
                          [(Chi2DataVar, False),
+                          (Chi2ModVar, False),
                           (LeastSq, True)])
 def test_fit_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, flag):
     """Do we see the warning when expected - fit + resid/ratio plot?

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -132,9 +132,7 @@ def test_data_plot_see_errorbar_warnings(caplog, statClass, flag):
     check_for_warning(caplog, nwarn, stat.name)
 
 
-@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar,
-                                       pytest.param(LeastSq,
-                                                    marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
 def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
     """Should not see warnings when no error bars are drawn (See #621).
 

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -288,6 +288,10 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
 
     stat = statClass()
 
+    print("INTERNAL DEBUGGING 1")
+    print(" isinstance(fplot, FitPlot) = {}".format(isinstance(fplot, FitPlot)))
+    print(" type(fplot) = {}".format(type(fplot)))
+
     # Ensure that the logging is set to WARNING since there
     # appears to be some test that changes it to ERROR.
     #
@@ -298,6 +302,10 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
         fplot.prepare(dplot, mplot)
 
         rplot.prepare(d, m, stat)
+
+        print("INTERNAL DEBUGGING 2")
+        print(" isinstance(fplot, FitPlot) = {}".format(isinstance(fplot, FitPlot)))
+        print(" type(fplot) = {}".format(type(fplot)))
 
         jplot.plottop(fplot)
         jplot.plotbot(rplot)

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -143,17 +143,13 @@ def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
 
     Parameters
     ----------
-    stat : sherpa.stats.Stat instance
+    statClass : sherpa.stats.Stat instance
 
     """
 
     d = example_data()
     plot = DataPlot()
 
-    # Internal check: this test requires that either yerrorbars is set
-    # to True, or not included, in the plot preferences. So check this
-    # assumption.
-    #
     prefs = plot.plot_prefs
     prefname = 'yerrorbars'
     prefs[prefname] = False
@@ -219,6 +215,41 @@ def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, fla
         nwarn = 0
         
     check_for_warning(caplog, nwarn, stat.name)
+
+
+@pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
+@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
+def test_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statClass):
+    """Should see no warnings (see #621)
+
+    This is a copy of test_residstyle_plot_see_errorbar_warnings
+    but with yerrorbars preference set to False.
+
+    Parameters
+    ----------
+    plotClass : {sherpa.plot.ResidPlot, sherpa.plot.RatioPlot}
+        The plot to test.
+    statClass : sherpa.stats.Stat instance
+
+    """
+
+    d = example_data()
+    m = example_model()
+    plot = plotClass()
+
+    prefs = plot.plot_prefs
+    prefname = 'yerrorbars'
+    prefs[prefname] = False
+
+    stat = statClass()
+
+    # Ensure that the logging is set to WARNING since there
+    # appears to be some test that changes it to ERROR.
+    #
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        plot.prepare(d, m, stat)
+
+    check_for_warning(caplog, 0, stat.name)
 
 
 @pytest.mark.parametrize("statClass,flag",

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -33,7 +33,8 @@ import numpy as np
 
 from sherpa.data import Data1D
 from sherpa.models.basic import Const1D
-from sherpa.plot import DataPlot, ModelPlot, ResidPlot, FitPlot, JointPlot
+from sherpa.plot import DataPlot, ModelPlot, ResidPlot, RatioPlot, \
+    FitPlot, JointPlot
 from sherpa.stats import LeastSq, Chi2DataVar, Chi2ModVar
 
 def example_data():
@@ -168,11 +169,12 @@ def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
     check_for_warning(caplog, 0, stat.name)
 
 
+@pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
 @pytest.mark.parametrize("statClass,flag",
                          [(Chi2DataVar, False),
                           (LeastSq, True)])
-def test_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
-    """Do we see the warning when expected - residual plot?
+def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, flag):
+    """Do we see the warning when expected - residual/ratio plots?
 
     This looks for the 'The displayed errorbars have been supplied with
     the data or calculated using chi2xspecvar; the errors are not used in
@@ -183,7 +185,9 @@ def test_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
 
     Parameters
     ----------
-    stat : sherpa.stats.Stat instance
+    plotClass : {sherpa.plot.ResidPlot, sherpa.plot.RatioPlot}
+        The plot to test.
+    statClass : sherpa.stats.Stat instance
     flag : bool
         True if the warning should be created, False otherwise
 
@@ -191,7 +195,7 @@ def test_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
 
     d = example_data()
     m = example_model()
-    plot = ResidPlot()
+    plot = plotClass()
 
     # Internal check: this test requires that either yerrorbars is set
     # to True, or not included, in the plot preferences. So check this
@@ -276,11 +280,12 @@ def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
     check_for_warning(caplog, nwarn, stat.name)
 
 
+@pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
 @pytest.mark.parametrize("statClass,flag",
                          [(Chi2DataVar, False),
                           (LeastSq, True)])
-def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
-    """Do we see the warning when expected - fit + resid plot?
+def test_fit_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, flag):
+    """Do we see the warning when expected - fit + resid/ratio plot?
 
     This looks for the 'The displayed errorbars have been supplied with
     the data or calculated using chi2xspecvar; the errors are not used in
@@ -291,7 +296,9 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
 
     Parameters
     ----------
-    stat : sherpa.stats.Stat instance
+    plotClass : {sherpa.plot.ResidPlot, sherpa.plot.RatioPlot}
+        The plot to test.
+    statClass : sherpa.stats.Stat instance
     flag : bool
         True if the warning should be created, False otherwise
 
@@ -306,7 +313,7 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
     dplot = DataPlot()
     mplot = ModelPlot()
     fplot = FitPlot()
-    rplot = ResidPlot()
+    rplot = plotClass()
 
     jplot = JointPlot()
     

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -35,7 +35,7 @@ from sherpa.data import Data1D
 from sherpa.models.basic import Const1D
 from sherpa.plot import DataPlot, ModelPlot, ResidPlot, RatioPlot, \
     FitPlot, JointPlot
-from sherpa.stats import LeastSq, Chi2DataVar, Chi2ModVar
+from sherpa.stats import LeastSq, Cash, Chi2DataVar, Chi2ModVar
 
 def example_data():
     """Create a 1D example dataset"""
@@ -84,11 +84,14 @@ def check_for_warning(caplog, nwarn, statname=None):
 # NOTE: the following tests contain a lot of repeated code but I don't
 #       want to refactor them until things have stabilized
 #
+_stats_with_flags = [(Chi2DataVar, False),
+                     (Chi2ModVar, False),
+                     (Cash, True),
+                     (LeastSq, True)]
+_stats_no_flags = [s[0] for s in _stats_with_flags]
 
-@pytest.mark.parametrize("statClass,flag",
-                         [(Chi2DataVar, False),
-                          (Chi2ModVar, False),
-                          (LeastSq, True)])
+
+@pytest.mark.parametrize("statClass,flag", _stats_with_flags)
 def test_data_plot_see_errorbar_warnings(caplog, statClass, flag):
     """Do we see the warning when expected - data plot?
 
@@ -134,7 +137,7 @@ def test_data_plot_see_errorbar_warnings(caplog, statClass, flag):
     check_for_warning(caplog, nwarn, stat.name)
 
 
-@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
+@pytest.mark.parametrize("statClass", _stats_no_flags)
 def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
     """Should not see warnings when no error bars are drawn (See #621).
 
@@ -167,10 +170,7 @@ def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
 
 
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
-@pytest.mark.parametrize("statClass,flag",
-                         [(Chi2DataVar, False),
-                          (Chi2ModVar, False),
-                          (LeastSq, True)])
+@pytest.mark.parametrize("statClass,flag", _stats_with_flags)
 def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, flag):
     """Do we see the warning when expected - residual/ratio plots?
 
@@ -220,7 +220,7 @@ def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, fla
 
 
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
-@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
+@pytest.mark.parametrize("statClass", _stats_no_flags)
 def test_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statClass):
     """Should see no warnings (see #621)
 
@@ -254,10 +254,7 @@ def test_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statC
     check_for_warning(caplog, 0, stat.name)
 
 
-@pytest.mark.parametrize("statClass,flag",
-                         [(Chi2DataVar, False),
-                          (Chi2ModVar, False),
-                          (LeastSq, True)])
+@pytest.mark.parametrize("statClass,flag", _stats_with_flags)
 def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
     """Do we see the warning when expected - fit plot?
 
@@ -315,10 +312,7 @@ def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
 
 
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
-@pytest.mark.parametrize("statClass,flag",
-                         [(Chi2DataVar, False),
-                          (Chi2ModVar, False),
-                          (LeastSq, True)])
+@pytest.mark.parametrize("statClass,flag", _stats_with_flags)
 def test_fit_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, flag):
     """Do we see the warning when expected - fit + resid/ratio plot?
 
@@ -389,7 +383,7 @@ def test_fit_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass,
 
 
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
-@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
+@pytest.mark.parametrize("statClass", _stats_no_flags)
 def test_fit_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statClass):
     """Should not see warnings when no error bars are drawn (See #621).
 

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -1,0 +1,304 @@
+#
+#  Copyright (C) 2019  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Test the appearance of warnings when plots are created. At present
+# this is restricted to warnings about whether the displayed error bars
+# are used in a fit or not.
+#
+# The tests require a minimum of pytest 3.3 (and may require 3.4, as it
+# is not clear if the changes in the logging handling between 3.3 and 3.4
+# are an issue here; I think they are not but have not tested it).
+#
+
+import logging
+import pytest
+
+import numpy as np
+
+from sherpa.data import Data1D
+from sherpa.models.basic import Const1D
+from sherpa.plot import DataPlot, ModelPlot, ResidPlot, FitPlot, JointPlot
+from sherpa.stats import LeastSq, Chi2DataVar
+
+def example_data():
+    """Create a 1D example dataset"""
+    
+    x = np.array([0, 10, 20])
+    y = np.array([10, 20, 40])
+    return Data1D('exmp', x, y)
+
+
+def example_model():
+    """Create a 1D example model"""
+
+    mdl = Const1D('exmp')
+    mdl.c0 = 25
+    return mdl
+
+
+def check_for_warning(caplog, nwarn, statname=None):
+    """Check that the warning was created ntimes.
+
+    Parameters
+    ----------
+    caplog
+        The caplog fixture sent to the test.
+    nwarn : int
+        The number of times the warning is created (>= 0).
+    statname : None or str
+        The statistic name (must be given if nwarn > 0).
+    """
+
+    assert len(caplog.records) == nwarn
+    if nwarn == 0:
+        return
+
+    # How useful is it to check the exact message?
+    expected = 'The displayed errorbars have been supplied with the ' + \
+               'data or calculated using chi2xspecvar; the errors ' + \
+               'are not used in fits with {}'.format(statname)
+
+    for (log_name, log_level, message) in caplog.record_tuples:
+        assert log_level == logging.WARNING
+        assert log_name == 'sherpa.plot'
+        assert message == expected
+
+
+# NOTE: the following tests contain a lot of repeated code but I don't
+#       want to refactor them until things have stabilized
+#
+
+@pytest.mark.parametrize("statClass,flag",
+                         [(Chi2DataVar, False),
+                          (LeastSq, True)])
+def test_data_plot_see_errorbar_warnings(caplog, statClass, flag):
+    """Do we see the warning when expected - data plot?
+
+    This looks for the 'The displayed errorbars have been supplied with
+    the data or calculated using chi2xspecvar; the errors are not used in
+    fits with <>' message. These are messages displayed to the Sherpa
+    logger at the warning level, rather than using the warnings module,
+    so the Sherpa capture_all_warnings test fixture does not come into
+    play.
+
+    Parameters
+    ----------
+    stat : sherpa.stats.Stat instance
+    flag : bool
+        True if the warning should be created, False otherwise
+
+    """
+
+    d = example_data()
+    plot = DataPlot()
+
+    # Internal check: this test requires that either yerrorbars is set
+    # to True, or not included, in the plot preferences. So check this
+    # assumption.
+    #
+    prefs = plot.plot_prefs
+    prefname = 'yerrorbars'
+    assert (prefname not in prefs) or prefs[prefname]
+
+    stat = statClass()
+
+    # Ensure that the logging is set to WARNING since there
+    # appears to be some test that changes it to ERROR.
+    #
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        plot.prepare(d, stat)
+
+    if flag:
+        nwarn = 1
+    else:
+        nwarn = 0
+        
+    check_for_warning(caplog, nwarn, stat.name)
+
+
+@pytest.mark.parametrize("statClass,flag",
+                         [(Chi2DataVar, False),
+                          (LeastSq, True)])
+def test_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
+    """Do we see the warning when expected - residual plot?
+
+    This looks for the 'The displayed errorbars have been supplied with
+    the data or calculated using chi2xspecvar; the errors are not used in
+    fits with <>' message. These are messages displayed to the Sherpa
+    logger at the warning level, rather than using the warnings module,
+    so the Sherpa capture_all_warnings test fixture does not come into
+    play.
+
+    Parameters
+    ----------
+    stat : sherpa.stats.Stat instance
+    flag : bool
+        True if the warning should be created, False otherwise
+
+    """
+
+    d = example_data()
+    m = example_model()
+    plot = ResidPlot()
+
+    # Internal check: this test requires that either yerrorbars is set
+    # to True, or not included, in the plot preferences. So check this
+    # assumption.
+    #
+    prefs = plot.plot_prefs
+    prefname = 'yerrorbars'
+    assert (prefname not in prefs) or prefs[prefname]
+
+    stat = statClass()
+
+    # Ensure that the logging is set to WARNING since there
+    # appears to be some test that changes it to ERROR.
+    #
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        plot.prepare(d, m, stat)
+
+    if flag:
+        nwarn = 1
+    else:
+        nwarn = 0
+        
+    check_for_warning(caplog, nwarn, stat.name)
+
+
+@pytest.mark.parametrize("statClass,flag",
+                         [(Chi2DataVar, False),
+                          (LeastSq, True)])
+def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
+    """Do we see the warning when expected - fit plot?
+
+    This looks for the 'The displayed errorbars have been supplied with
+    the data or calculated using chi2xspecvar; the errors are not used in
+    fits with <>' message. These are messages displayed to the Sherpa
+    logger at the warning level, rather than using the warnings module,
+    so the Sherpa capture_all_warnings test fixture does not come into
+    play.
+
+    Parameters
+    ----------
+    stat : sherpa.stats.Stat instance
+    flag : bool
+        True if the warning should be created, False otherwise
+
+    """
+
+    d = example_data()
+    m = example_model()
+
+    dplot = DataPlot()
+    mplot = ModelPlot()
+    fplot = FitPlot()
+
+    # Internal check: this test requires that either yerrorbars is set
+    # to True, or not included, in the plot preferences. So check this
+    # assumption.
+    #
+    prefname = 'yerrorbars'
+    for plot in [dplot, mplot, fplot]:
+        prefs = plot.plot_prefs
+        assert (prefname not in prefs) or prefs[prefname]
+
+    stat = statClass()
+
+    # Ensure that the logging is set to WARNING since there
+    # appears to be some test that changes it to ERROR.
+    #
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+
+        dplot.prepare(d, stat)
+        mplot.prepare(d, m, stat)
+        fplot.prepare(dplot, mplot)
+
+    if flag:
+        nwarn = 1
+    else:
+        nwarn = 0
+        
+    check_for_warning(caplog, nwarn, stat.name)
+
+
+@pytest.mark.parametrize("statClass,flag",
+                         [(Chi2DataVar, False),
+                          (LeastSq, True)])
+def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
+    """Do we see the warning when expected - fit + resid plot?
+
+    This looks for the 'The displayed errorbars have been supplied with
+    the data or calculated using chi2xspecvar; the errors are not used in
+    fits with <>' message. These are messages displayed to the Sherpa
+    logger at the warning level, rather than using the warnings module,
+    so the Sherpa capture_all_warnings test fixture does not come into
+    play.
+
+    Parameters
+    ----------
+    stat : sherpa.stats.Stat instance
+    flag : bool
+        True if the warning should be created, False otherwise
+
+    Notes
+    -----
+    Is this an accurate example of how 'plot_fit_resid' is created?
+    """
+
+    d = example_data()
+    m = example_model()
+
+    dplot = DataPlot()
+    mplot = ModelPlot()
+    fplot = FitPlot()
+    rplot = ResidPlot()
+
+    jplot = JointPlot()
+    
+    # Internal check: this test requires that either yerrorbars is set
+    # to True, or not included, in the plot preferences. So check this
+    # assumption.
+    #
+    prefname = 'yerrorbars'
+    for plot in [dplot, mplot, fplot, rplot]:
+        prefs = plot.plot_prefs
+        assert (prefname not in prefs) or prefs[prefname]
+
+    stat = statClass()
+
+    # Ensure that the logging is set to WARNING since there
+    # appears to be some test that changes it to ERROR.
+    #
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+
+        dplot.prepare(d, stat)
+        mplot.prepare(d, m, stat)
+        fplot.prepare(dplot, mplot)
+
+        rplot.prepare(d, m, stat)
+
+        jplot.plottop(fplot)
+        jplot.plotbot(rplot)
+        
+    if flag:
+        nwarn = 2
+    else:
+        nwarn = 0
+        
+    check_for_warning(caplog, nwarn, stat.name)

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -288,10 +288,6 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
 
     stat = statClass()
 
-    print("INTERNAL DEBUGGING 1")
-    print(" isinstance(fplot, FitPlot) = {}".format(isinstance(fplot, FitPlot)))
-    print(" type(fplot) = {}".format(type(fplot)))
-
     # Ensure that the logging is set to WARNING since there
     # appears to be some test that changes it to ERROR.
     #
@@ -302,10 +298,6 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
         fplot.prepare(dplot, mplot)
 
         rplot.prepare(d, m, stat)
-
-        print("INTERNAL DEBUGGING 2")
-        print(" isinstance(fplot, FitPlot) = {}".format(isinstance(fplot, FitPlot)))
-        print(" type(fplot) = {}".format(type(fplot)))
 
         jplot.plottop(fplot)
         jplot.plotbot(rplot)

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -218,9 +218,7 @@ def test_residstyle_plot_see_errorbar_warnings(caplog, plotClass, statClass, fla
 
 
 @pytest.mark.parametrize("plotClass", [ResidPlot, RatioPlot])
-@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar,
-                                       pytest.param(LeastSq,
-                                                    marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar, LeastSq])
 def test_residstyle_plot_no_errors_no_errorbar_warnings(caplog, plotClass, statClass):
     """Should see no warnings (see #621)
 

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -213,8 +213,11 @@ def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
     # to True, or not included, in the plot preferences. So check this
     # assumption.
     #
+    # I am skipping model plot here, since it is assumed that there
+    # are no errors on the model.
+    #
     prefname = 'yerrorbars'
-    for plot in [dplot, mplot, fplot]:
+    for plot in [dplot, fplot]:
         prefs = plot.plot_prefs
         assert (prefname not in prefs) or prefs[prefname]
 
@@ -275,8 +278,11 @@ def test_fit_resid_plot_see_errorbar_warnings(caplog, statClass, flag):
     # to True, or not included, in the plot preferences. So check this
     # assumption.
     #
+    # I am skipping model plot here, since it is assumed that there
+    # are no errors on the model.
+    #
     prefname = 'yerrorbars'
-    for plot in [dplot, mplot, fplot, rplot]:
+    for plot in [dplot, fplot, rplot]:
         prefs = plot.plot_prefs
         assert (prefname not in prefs) or prefs[prefname]
 

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -133,9 +133,8 @@ def test_data_plot_see_errorbar_warnings(caplog, statClass, flag):
 
 
 @pytest.mark.parametrize("statClass", [Chi2DataVar, Chi2ModVar,
-                                       LeastSq])
-#                                       pytest.param(LeastSq,
-#                                                    marks=pytest.mark.xfail)])
+                                       pytest.param(LeastSq,
+                                                    marks=pytest.mark.xfail)])
 def test_data_plot_no_errors_no_errorbar_warnings(caplog, statClass):
     """Should not see warnings when no error bars are drawn (See #621).
 


### PR DESCRIPTION
# Summary

Remove the  `The displayed errorbars have been supplied with the data or calculated using chi2xspecvar...` warnings that appear for data, residual/ratio, and fit plots when the user has explicitly turned off the display of errorbars (by setting the `yerrorbars` plot-preference setting to `False`).

This does **not** address the problem of this message appearing multiple times for "combined" plots like `fit_plot_resid`, as it is not immediately obvious to me how to do this.

# Details

Add several tests to check that we are creating the "The displayed
errorbars have been supplied with the data or calculated using
chi2xspecvar; the errors are not used in fits with ..." warning messages
when creating plots.

These tests do not require a plotting backend. However, given that the
behavior is "stateful", in that the tests could fail if some other
part of the system has changed the plot preferences, then there are
additional checks (beyond those needed to perform the checks) that
indicate whether the system state has been changed.

The caplog fixture, introduced in pytest 3.3, is used to capture the
logging output (which is how the warnings are displayed to the user;
they do not use the warnings module). There are other tests in the
system that change the system logging level, so these tests use the
caplog context mamanger to ensure the tests are run with the standard
logging level.

The tests contain a lot of repeated code, but it's not clear whether it is
worth consolidating it.

There does appear to be repeated calculation of the y error bars in the
plot routines - `data.to_plot` is called and then the errors are re-calculated.
This is outside of the scope of this PR to look at, but I've added some
comments about it.

The development of this PR hit a snag with the existing plot tests, in particular
how the chips setup is mocked. I had to change code to test for attributes
rather than use `isinstance`, as documented below, which is more-idiomatic
Python, but may point to some work needed for the mock code.

The PR should be rebased to clean up the testing code, as I was tracking down
the mock/isinstance issue, but I want to leave the history as is for now. 