### PR TITLE
add plot_fit_ratio and plot_bkg_fit_ratio functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   fast_finish: true
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=2 XSPECVER="12.10.1b" TRAVIS_PYTHON_VERSION="3.7"
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.1b" TRAVIS_PYTHON_VERSION="3.7"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.

--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -288,6 +288,7 @@ burden...
       plot_energy_flux
       plot_fit
       plot_fit_delchi
+      plot_fit_ratio
       plot_fit_resid
       plot_kernel
       plot_model

--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -276,6 +276,7 @@ burden...
       plot_bkg_delchi
       plot_bkg_fit
       plot_bkg_fit_delchi
+      plot_bkg_fit_ratio
       plot_bkg_fit_resid
       plot_bkg_model
       plot_bkg_ratio

--- a/docs/ui/sherpa_ui.rst
+++ b/docs/ui/sherpa_ui.rst
@@ -194,6 +194,7 @@ hidden away. This needs better explanation...
       plot_delchi
       plot_fit
       plot_fit_delchi
+      plot_fit_ratio
       plot_fit_resid
       plot_kernel
       plot_model

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,0 +1,418 @@
+#
+#  Copyright (C) 2019  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Basic tests of the plot functionality in sherpa.astro.ui.
+
+It is based on sherpa/ui/tests/test_ui_plot.py, but focusses on the
+new routines, and "astro-specific" (currently PHA only) capabilities
+that are in the astro layer.
+
+"""
+
+import logging
+import numpy as np
+
+from sherpa.astro import ui
+
+# the chips plot tests mean that we can't test the plot instances
+# from sherpa.plot import DataPlot, FitPlot, ModelPlot
+
+from sherpa.utils.err import IdentifierErr
+# from sherpa.utils.testing import requires_plotting
+
+import pytest
+
+_data_chan = np.linspace(1, 10, 10, dtype=np.int8)
+_data_counts = np.asarray([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                          dtype=np.int8)
+
+_data_bkg = np.asarray([1, 0, 0, 1, 0, 0, 2, 0, 0, 1],
+                       dtype=np.int8)
+
+_arf = np.asarray([0.8, 0.8, 0.9, 1.0, 1.1, 1.1, 0.7, 0.6, 0.6, 0.6])
+
+# using a "perfect" RMF, in that there's a one-to-one mapping
+# from channel to energy
+#
+_energies = np.linspace(0.5, 1.5, 11)
+
+
+def example_pha_data():
+    """Create an example data set."""
+
+    etime = 1201.0
+    d = ui.DataPHA('example', _data_chan.copy(),
+                   _data_counts.copy(),
+                   exposure=etime,
+                   backscal=0.1)
+
+    a = ui.create_arf(_energies[:-1].copy(),
+                      _energies[1:].copy(),
+                      specresp=_arf.copy(),
+                      exposure=etime)
+
+    r = ui.create_rmf(_energies[:-1].copy(),
+                      _energies[1:].copy(),
+                      e_min=_energies[:-1].copy(),
+                      e_max=_energies[1:].copy(),
+                      startchan=1,
+                      fname=None)
+
+    d.set_arf(a)
+    d.set_rmf(r)
+    return d
+
+
+def example_pha_with_bkg_data():
+    """Create an example data set with background
+
+    There is no response for the background.
+    """
+
+    d = example_pha_data()
+
+    b = ui.DataPHA('example-bkg', _data_chan.copy(),
+                   _data_bkg.copy(),
+                   exposure=1201.0 * 2.0,
+                   backscal=0.4)
+
+    d.set_background(b)
+    return d
+
+
+def example_model():
+    """Create an example model."""
+
+    ui.create_model_component('const1d', 'cpt')
+    cpt = ui.get_model_component('cpt')
+    cpt.c0 = 1.02e2
+    return cpt
+
+
+def setup_example(idval):
+    """Set up a simple dataset for use in the tests.
+
+    A *very basic* ARF is used, along with an ideal RMF. The
+    way this is created means the analysis is in channel space
+    by default.
+
+    Parameters
+    ----------
+    idval : None, int, str
+        The dataset identifier.
+
+    See Also
+    --------
+    setup_example_bkg
+    """
+
+    d = example_pha_data()
+    m = example_model()
+    if idval is None:
+        ui.set_data(d)
+        ui.set_source(m)
+
+    else:
+        ui.set_data(idval, d)
+        ui.set_source(idval, m)
+
+
+def setup_example_bkg(idval):
+    """Set up a simple dataset + background for use in the tests.
+
+    Parameters
+    ----------
+    idval : None, int, str
+        The dataset identifier.
+
+    See Also
+    --------
+    setup_example
+    """
+
+    d = example_pha_with_bkg_data()
+    m = example_model()
+    if idval is None:
+        ui.set_data(d)
+        ui.set_source(m)
+
+    else:
+        ui.set_data(idval, d)
+        ui.set_source(idval, m)
+
+
+"""
+Functions that could be tested:
+
+plot_model
+plot_source
+plot_model_component
+plot_source_component
+plot_order
+
+plot_bkg
+plot_bkg_model
+plot_bkg_resid
+plot_bkg_ratio
+plot_bkg_delchi
+plot_bkg_chisqr
+plot_bkg_fit
+plot_bkg_source
+plot_bkg_fit_resid
+plot_bkg_fit_delchi
+
+plot_arf
+
+get_arf_plot                 X
+get_bkg_chisqr_plot
+get_bkg_delchi_plot
+get_bkg_fit_plot
+get_bkg_model_plot
+get_bkg_plot                 X
+get_bkg_ratio_plot
+get_bkg_resid_plot
+get_bkg_source_plot
+get_model_component_plot
+get_model_plot               X
+get_order_plot
+get_source_component_plot
+get_source_plot              X
+
+"""
+
+
+# The following tests do not check whether returned values are
+# of the expected class instance, since the chips plot tests
+# use a mock object and so mess-up simple "isinstance(x, ModelPlot)"
+# checks.
+#
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_arf_plot(idval):
+    """Basic testing of get_arf_plot
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ap = ui.get_arf_plot()
+    else:
+        ap = ui.get_arf_plot(idval)
+
+    assert ap.xlo == pytest.approx(_energies[:-1])
+    assert ap.xhi == pytest.approx(_energies[1:])
+
+    assert ap.y == pytest.approx(_arf)
+
+    assert ap.title == 'test-arf'
+    assert ap.xlabel == 'Energy (keV)'
+
+    # the y label depends on the backend (due to LaTeX)
+    # assert ap.ylabel == 'cm$^2$'
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_bkg_plot(idval):
+    """Basic testing of get_bkg_plot
+    """
+
+    setup_example_bkg(idval)
+    if idval is None:
+        bp = ui.get_bkg_plot()
+    else:
+        bp = ui.get_bkg_plot(idval)
+
+    assert bp.x == pytest.approx(_data_chan)
+
+    # normalise by exposure time and bin width, but bin width here
+    # is 1 (because it is being measured in channels).
+    #
+    yexp = _data_bkg / 1201.0 / 2.0
+    assert bp.y == pytest.approx(yexp)
+
+    assert bp.title == 'example-bkg'
+    assert bp.xlabel == 'Channel'
+    assert bp.ylabel == 'Counts/sec/channel'
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_bkg_plot_energy(idval):
+    """Basic testing of get_bkg_plot: energy
+    """
+
+    # The way I have set up the data means that set_analysis
+    # doesn't seem to change the setting for the background,
+    # which should be tracked down (Sep 2019) but not just now.
+    #
+    setup_example_bkg(idval)
+    if idval is None:
+        ui.set_analysis('energy')
+        ui.get_bkg().units = 'energy'
+        bp = ui.get_bkg_plot()
+    else:
+        # ui.set_analysis(idval, 'energy')
+        ui.get_bkg(idval).units = 'energy'
+        bp = ui.get_bkg_plot(idval)
+
+    # TODO: is this a bug in the plotting code, or does it just
+    # indicate that the test hasn't set up the correct invariants
+    # (which may be true as the code above has to change the units
+    # setting of the background object)?
+    #
+    # I was expecting bp.x to return energy and not channel values
+    #
+    assert bp.x == pytest.approx(_data_chan)
+
+    # normalise by exposure time and bin width, but bin width here
+    # is 1 (because it is being measured in channels).
+    #
+    yexp = _data_bkg / 1201.0 / 2.0
+    assert bp.y == pytest.approx(yexp)
+
+    assert bp.title == 'example-bkg'
+    assert bp.xlabel == 'Energy (keV)'
+    assert bp.ylabel == 'Counts/sec/keV'
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_bkg_plot_no_bkg(idval):
+    """Basic testing of get_bkg_plot when there's no background
+    """
+
+    setup_example(idval)
+    with pytest.raises(IdentifierErr):
+        if idval is None:
+            ui.get_bkg_plot()
+        else:
+            ui.get_bkg_plot(idval)
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_model_plot(idval):
+    """Basic testing of get_model_plot
+    """
+
+    setup_example(idval)
+    if idval is None:
+        mp = ui.get_model_plot()
+    else:
+        mp = ui.get_model_plot(idval)
+
+    assert mp.xlo == pytest.approx(_data_chan)
+    assert mp.xhi == pytest.approx(_data_chan + 1)
+
+    # The model is a constant, but integrated across the energy bin,
+    # so the energy width is important here to get the normalization
+    # right. It should also be divided by the channel width, but in
+    # this case each bin has a channel width of 1.
+    #
+    yexp = _arf * 1.02e2 * (_energies[1:] - _energies[:-1])
+    assert mp.y == pytest.approx(yexp)
+
+    assert mp.title == 'Model'
+    assert mp.xlabel == 'Channel'
+    assert mp.ylabel == 'Counts/sec/channel'
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_model_plot_energy(idval):
+    """Basic testing of get_model_plot: energy
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.set_analysis('energy')
+        mp = ui.get_model_plot()
+    else:
+        ui.set_analysis(idval, 'energy')
+        mp = ui.get_model_plot(idval)
+
+    assert mp.xlo == pytest.approx(_energies[:-1])
+    assert mp.xhi == pytest.approx(_energies[1:])
+
+    # This should be normalized by the bin width, but it is cancelled
+    # out by the fact that the model normalization has to be multiplied
+    # by the bin width (both in energy).
+    #
+    yexp = _arf * 1.02e2
+    assert mp.y == pytest.approx(yexp)
+
+    assert mp.title == 'Model'
+    assert mp.xlabel == 'Energy (keV)'
+    assert mp.ylabel == 'Counts/sec/keV'
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_source_plot_warning(caplog, idval):
+    """Does get_source_plot create a warning about channel space?
+
+    This is a logged warning, not a UserWarning.
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.get_source_plot()
+    else:
+        ui.get_source_plot(idval)
+
+    emsg = 'Channel space is unappropriate for the PHA unfolded ' + \
+           'source model,\nusing energy.'
+
+    assert len(caplog.record_tuples) == 1
+    rec = caplog.record_tuples[0]
+    assert len(rec) == 3
+    loc, lvl, msg = rec
+
+    assert loc == 'sherpa.astro.plot'
+    assert lvl == logging.WARNING
+    assert msg == emsg
+
+
+@pytest.mark.usefixtures("clean_astro_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_source_plot_energy(idval):
+    """Basic testing of get_source_plot: energy
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.set_analysis('energy')
+        sp = ui.get_source_plot()
+    else:
+        ui.set_analysis(idval, 'energy')
+        sp = ui.get_source_plot(idval)
+
+    assert sp.xlo == pytest.approx(_energies[:-1])
+    assert sp.xhi == pytest.approx(_energies[1:])
+
+    yexp = 1.02e2 * np.ones(10)
+    assert sp.y == pytest.approx(yexp)
+
+    assert sp.title == 'Source Model of example'
+    assert sp.xlabel == 'Energy (keV)'
+
+    # y label depends on the backend
+    # assert sp.ylabel == 'f(E)  Photons/sec/cm$^2$/keV'

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11928,6 +11928,7 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg_fit : Plot the fit results (data, model) for the background of a PHA data set.
         plot_bkg_fit_delchi : Plot the fit results, and the residuals, for the background of a PHA data set.
         plot_fit : Plot the fit results (data, model) for a data set.
+        plot_fit_resid : Plot the fit results, and the residuals, for a data set.
         set_analysis : Set the units used when fitting and displaying spectral data.
 
         Examples
@@ -12011,6 +12012,7 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg_fit : Plot the fit results (data, model) for the background of a PHA data set.
         plot_bkg_fit_resid : Plot the fit results, and the residuals, for the background of a PHA data set.
         plot_fit : Plot the fit results (data, model) for a data set.
+        plot_fit_delchi : Plot the fit results, and the residuals, for a data set.
         set_analysis : Set the units used when fitting and displaying spectral data.
 
         Examples

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11604,6 +11604,7 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg : Plot the background values for a PHA data set.
         plot_bkg_model : Plot the model for the background of a PHA data set.
         plot_bkg_fit_delchi : Plot the fit results, and the residuals, for the background of a PHA data set.
+        plot_bkg_fit_ratio : Plot the fit results, and the data/model ratio, for the background of a PHA data set.
         plot_bkg_fit_resid : Plot the fit results, and the residuals, for the background of a PHA data set.
         plot_fit : Plot the fit results (data, model) for a data set.
         set_analysis : Set the units used when fitting and displaying spectral data.
@@ -11937,6 +11938,71 @@ class Session(sherpa.ui.utils.Session):
         else:
             sherpa.plot.end()
 
+    def plot_bkg_fit_ratio(self, id=None, bkg_id=None, replot=False,
+                           overplot=False, clearwindow=True):
+        """Plot the fit results, and the data/model ratio, for the background of
+        a PHA data set.
+
+        This creates two plots - the first from `plot_bkg_fit` and the
+        second from `plot_bkg_ratio` - for a data set.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The data set that provides the data. If not given then the
+           default identifier is used, as returned by `get_default_id`.
+        bkg_id : int or str, optional
+           Identify the background component to use, if there are
+           multiple ones associated with the data set.
+        replot : bool, optional
+           Set to ``True`` to use the values calculated by the last
+           call to `plot_bkg_fit_ratio`. The default is ``False``.
+        overplot : bool, optional
+           If ``True`` then add the data to an exsiting plot, otherwise
+           create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+
+        Raises
+        ------
+        sherpa.utils.err.ArgumentErr
+           If the data set does not contain PHA data.
+        sherpa.utils.err.IdentifierErr
+           If the ``bkg_id`` parameter is invalid.
+        sherpa.utils.err.ModelErr
+           If no model expression has been created for the background
+           data.
+
+        See Also
+        --------
+        get_bkg_fit_plot : Return the data used by plot_bkg_fit.
+        get_bkg_resid_plot : Return the data used by plot_bkg_resid.
+        plot : Create one or more plot types.
+        plot_bkg : Plot the background values for a PHA data set.
+        plot_bkg_model : Plot the model for the background of a PHA data set.
+        plot_bkg_fit : Plot the fit results (data, model) for the background of a PHA data set.
+        plot_bkg_fit_delchi : Plot the fit results, and the residuals, for the background of a PHA data set.
+        plot_bkg_fit_resid : Plot the fit results, and the residuals, for the background of a PHA data set.
+        plot_fit : Plot the fit results (data, model) for a data set.
+        plot_fit_resid : Plot the fit results, and the residuals, for a data set.
+        set_analysis : Set the units used when fitting and displaying spectral data.
+
+        Examples
+        --------
+
+        Plot the background fit and the ratio of the background to
+        this fit for the default data set:
+
+        >>> plot_bkg_fit_ratio()
+
+        """
+
+        self._plot_bkg_jointplot(self._bkgratioplot,
+                                 id=id, bkg_id=bkg_id,
+                                 replot=replot, overplot=overplot,
+                                 clearwindow=clearwindow)
+
     def plot_bkg_fit_resid(self, id=None, bkg_id=None, replot=False,
                            overplot=False, clearwindow=True):
         """Plot the fit results, and the residuals, for the background of
@@ -11981,6 +12047,7 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg : Plot the background values for a PHA data set.
         plot_bkg_model : Plot the model for the background of a PHA data set.
         plot_bkg_fit : Plot the fit results (data, model) for the background of a PHA data set.
+        plot_bkg_fit_ratio : Plot the fit results, and the data/model ratio, for the background of a PHA data set.
         plot_bkg_fit_delchi : Plot the fit results, and the residuals, for the background of a PHA data set.
         plot_fit : Plot the fit results (data, model) for a data set.
         plot_fit_resid : Plot the fit results, and the residuals, for a data set.
@@ -12044,6 +12111,7 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg : Plot the background values for a PHA data set.
         plot_bkg_model : Plot the model for the background of a PHA data set.
         plot_bkg_fit : Plot the fit results (data, model) for the background of a PHA data set.
+        plot_bkg_fit_ratio : Plot the fit results, and the data/model ratio, for the background of a PHA data set.
         plot_bkg_fit_resid : Plot the fit results, and the residuals, for the background of a PHA data set.
         plot_fit : Plot the fit results (data, model) for a data set.
         plot_fit_delchi : Plot the fit results, and the residuals, for a data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11882,6 +11882,61 @@ class Session(sherpa.ui.utils.Session):
         else:
             sherpa.plot.end()
 
+    def _plot_bkg_jointplot(self, plot2, id=None, bkg_id=None,
+                            replot=False, overplot=False,
+                            clearwindow=True):
+        """Create a joint plot for bkg, vertically aligned, fit data on the top.
+
+        Parameters
+        ----------
+        plot2 : sherpa.plot.Plot instance
+           The plot to appear in the bottom panel.
+        id : int or str, optional
+           The data set. If not given then the default identifier is
+           used, as returned by `get_default_id`.
+        bkg_id : int or str, optional
+           Identify the background component to use, if there are
+           multiple ones associated with the data set.
+        replot : bool, optional
+           Set to ``True`` to use the previous values. The default is
+           ``False``.
+        overplot : bool, optional
+           If ``True`` then add the data to an exsiting plot, otherwise
+           create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+
+        """
+
+        # See the comments in sherpa/ui/utils.py::_plot_jointplot()
+        #
+        plot1 = self._bkgfitplot
+        self._jointplot.reset()
+        if not sherpa.utils.bool_cast(replot):
+            plot1 = self._prepare_plotobj(id, plot1, bkg_id=bkg_id)
+            plot2 = self._prepare_plotobj(id, plot2, bkg_id=bkg_id)
+        try:
+            sherpa.plot.begin()
+            self._jointplot.plottop(plot1, overplot=overplot,
+                                    clearwindow=clearwindow)
+
+            oldval = plot2.plot_prefs['xlog']
+            if (('xlog' in self._bkgdataplot.plot_prefs and
+                 self._bkgdataplot.plot_prefs['xlog']) or
+                ('xlog' in self._bkgmodelplot.plot_prefs and
+                 self._bkgmodelplot.plot_prefs['xlog'])):
+                plot2.plot_prefs['xlog'] = True
+
+            self._jointplot.plotbot(plot2, overplot=overplot)
+
+            plot2.plot_prefs['xlog'] = oldval
+        except:
+            sherpa.plot.exceptions()
+            raise
+        else:
+            sherpa.plot.end()
+
     def plot_bkg_fit_resid(self, id=None, bkg_id=None, replot=False,
                            overplot=False, clearwindow=True):
         """Plot the fit results, and the residuals, for the background of
@@ -11939,32 +11994,11 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_fit_resid()
 
         """
-        self._jointplot.reset()
-        fp = self._bkgfitplot
-        rp = self._bkgresidplot
-        if not sherpa.utils.bool_cast(replot):
-            fp = self._prepare_plotobj(id, fp, bkg_id=bkg_id)
-            rp = self._prepare_plotobj(id, rp, bkg_id=bkg_id)
-        try:
-            sherpa.plot.begin()
-            self._jointplot.plottop(fp, overplot=overplot,
-                                    clearwindow=clearwindow)
 
-            oldval = rp.plot_prefs['xlog']
-            if (('xlog' in self._bkgdataplot.plot_prefs and
-                 self._bkgdataplot.plot_prefs['xlog']) or
-                ('xlog' in self._bkgmodelplot.plot_prefs and
-                 self._bkgmodelplot.plot_prefs['xlog'])):
-                rp.plot_prefs['xlog'] = True
-
-            self._jointplot.plotbot(rp, overplot=overplot)
-
-            rp.plot_prefs['xlog'] = oldval
-        except:
-            sherpa.plot.exceptions()
-            raise
-        else:
-            sherpa.plot.end()
+        self._plot_bkg_jointplot(self._bkgresidplot,
+                                 id=id, bkg_id=bkg_id,
+                                 replot=replot, overplot=overplot,
+                                 clearwindow=clearwindow)
 
     def plot_bkg_fit_delchi(self, id=None, bkg_id=None, replot=False,
                             overplot=False, clearwindow=True):
@@ -12024,32 +12058,10 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_bkg_fit_delchi()
 
         """
-        self._jointplot.reset()
-        fp = self._bkgfitplot
-        dp = self._bkgdelchiplot
-        if not sherpa.utils.bool_cast(replot):
-            fp = self._prepare_plotobj(id, fp, bkg_id=bkg_id)
-            dp = self._prepare_plotobj(id, dp, bkg_id=bkg_id)
-        try:
-            sherpa.plot.begin()
-            self._jointplot.plottop(fp, overplot=overplot,
-                                    clearwindow=clearwindow)
-
-            oldval = dp.plot_prefs['xlog']
-            if (('xlog' in self._bkgdataplot.plot_prefs and
-                 self._bkgdataplot.plot_prefs['xlog']) or
-                ('xlog' in self._bkgmodelplot.plot_prefs and
-                 self._bkgmodelplot.plot_prefs['xlog'])):
-                dp.plot_prefs['xlog'] = True
-
-            self._jointplot.plotbot(dp, overplot=overplot)
-
-            dp.plot_prefs['xlog'] = oldval
-        except:
-            sherpa.plot.exceptions()
-            raise
-        else:
-            sherpa.plot.end()
+        self._plot_bkg_jointplot(self._bkgdelchiplot,
+                                 id=id, bkg_id=bkg_id,
+                                 replot=replot, overplot=overplot,
+                                 clearwindow=clearwindow)
 
     ###########################################################################
     # Analysis Functions

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11024,6 +11024,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11123,6 +11126,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -11191,6 +11197,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -11238,6 +11247,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11301,6 +11313,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11351,6 +11366,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11404,6 +11422,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11456,6 +11477,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11508,6 +11532,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11556,6 +11583,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11614,6 +11644,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11697,6 +11730,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -11798,6 +11834,9 @@ class Session(sherpa.ui.utils.Session):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -11866,8 +11905,8 @@ class Session(sherpa.ui.utils.Session):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11949,8 +11988,8 @@ class Session(sherpa.ui.utils.Session):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -256,12 +256,12 @@ def change_fit(idval):
     change_model(idval)
 
 
-def check_example():
+def check_example(xlabel='x'):
     """Check that the data plot has not changed"""
 
     dplot = ui._session._dataplot
 
-    assert dplot.xlabel == 'x'
+    assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
     assert dplot.title == 'example'
     assert dplot.x == pytest.approx(_data_x)
@@ -272,10 +272,10 @@ def check_example():
     assert dplot.yerr == pytest.approx(calc_errors(_data_y))
 
     
-def check_model_plot(plot, title):
+def check_model_plot(plot, title='Model', xlabel='x'):
     """Helper for check_model/source"""
 
-    assert plot.xlabel == 'x'
+    assert plot.xlabel == xlabel
     assert plot.ylabel == 'y'
     assert plot.title == title
     assert plot.x == pytest.approx(_data_x)
@@ -284,25 +284,27 @@ def check_model_plot(plot, title):
     assert plot.yerr is None
 
 
-def check_model():
+def check_model(xlabel='x'):
     """Check that the model plot has not changed"""
 
-    check_model_plot(ui._session._modelplot, 'Model')
+    check_model_plot(ui._session._modelplot,
+                     title='Model', xlabel=xlabel)
 
 
 def check_source():
     """Check that the source plot has not changed"""
 
-    check_model_plot(ui._session._sourceplot, 'Source')
+    check_model_plot(ui._session._sourceplot,
+                     title='Source')
 
     
-def check_resid():
+def check_resid(title='Residuals for example'):
     """Check that the resid plot has not changed"""
 
     rplot = ui._session._residplot
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
-    assert rplot.title == 'Residuals for example'
+    assert rplot.title == title
     assert rplot.x == pytest.approx(_data_x)
     assert rplot.y == pytest.approx([y - 35 for y in _data_y])
     assert rplot.xerr is None
@@ -362,6 +364,14 @@ def check_fit():
     check_model()
 
 
+def check_fit_resid():
+    """Check that the fit + resid plot has not changed"""
+
+    check_example(xlabel='')
+    check_model(xlabel='')
+    check_resid(title='')
+
+
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -374,6 +384,7 @@ def check_fit():
                           (ui.plot_delchi, change_example, check_delchi),
                           (ui.plot_chisqr, change_example, check_chisqr),
                           (ui.plot_fit, change_fit, check_fit),
+                          (ui.plot_fit_resid, change_fit, check_fit_resid),
                          ])
 def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc):
     """Can we plot, change data, plot with reploat and see a difference?

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -110,6 +110,36 @@ def test_get_fit_plot(idval):
 
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
+@pytest.mark.parametrize("get_prefs", [ui.get_data_plot_prefs,
+                                       ui.get_model_plot_prefs])
+def test_plot_prefs_xxx(get_prefs):
+    """Can we change and reset a preference.
+
+    Pick the 'xlog' field, since the assumption is that: a) this
+    defaults to 'False'; b) each plot type has this setting; c) we
+    do not need to check all settings.
+
+    Some tests fail due to missing plot preferences when there's
+    no plotting backend (e.g. missing 'xlog' settings), so skip
+    these tests in this case.
+    """
+
+    prefs1 = get_prefs()
+    assert not prefs1['xlog']
+    prefs1['xlog'] = True
+
+    prefs2 = get_prefs()
+    assert prefs2['xlog']
+
+    ui.clean()
+    prefs3 = get_prefs()
+    assert prefs1['xlog']
+    assert prefs2['xlog']
+    assert not prefs3['xlog']
+
+
+@requires_plotting
+@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("pfunc", [ui.plot_data,
                                    ui.plot_model,

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -232,7 +232,7 @@ def change_example(idval):
     d.y = [12, 45, 33, 49]
 
 
-def check_example(idval):
+def check_example():
     """Check that the data plot has not changed"""
 
     dplot = ui._session._dataplot
@@ -267,19 +267,19 @@ def check_model_plot(plot, title):
     assert plot.yerr is None
 
 
-def check_model(idval):
+def check_model():
     """Check that the model plot has not changed"""
 
     check_model_plot(ui._session._modelplot, 'Model')
 
 
-def check_source(idval):
+def check_source():
     """Check that the source plot has not changed"""
 
     check_model_plot(ui._session._sourceplot, 'Source')
 
     
-def check_resid(idval):
+def check_resid():
     """Check that the resid plot has not changed"""
 
     rplot = ui._session._residplot
@@ -292,7 +292,7 @@ def check_resid(idval):
     assert rplot.yerr == pytest.approx(Chi2Gehrels.calc_staterror(_data_y))
 
     
-def check_ratio(idval):
+def check_ratio():
     """Check that the ratio plot has not changed"""
 
     rplot = ui._session._ratioplot
@@ -306,7 +306,7 @@ def check_ratio(idval):
     assert rplot.yerr == pytest.approx(dy)
 
     
-def check_delchi(idval):
+def check_delchi():
     """Check that the delchi plot has not changed"""
 
     rplot = ui._session._delchiplot
@@ -322,7 +322,7 @@ def check_delchi(idval):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_y])
 
     
-def check_chisqr(idval):
+def check_chisqr():
     """Check that the chisqr plot has not changed"""
 
     rplot = ui._session._chisqrplot
@@ -341,16 +341,16 @@ def check_chisqr(idval):
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-@pytest.mark.parametrize("setupfunc,plotfunc,changefunc,checkfunc",
-                         [(setup_example, ui.plot_data, change_example, check_example),
-                          (setup_example, ui.plot_model, change_model, check_model),
-                          (setup_example, ui.plot_source, change_model, check_source),
-                          (setup_example, ui.plot_resid, change_model, check_resid),
-                          (setup_example, ui.plot_ratio, change_example, check_ratio),
-                          (setup_example, ui.plot_delchi, change_example, check_delchi),
-                          (setup_example, ui.plot_chisqr, change_example, check_chisqr),
+@pytest.mark.parametrize("plotfunc,changefunc,checkfunc",
+                         [(ui.plot_data, change_example, check_example),
+                          (ui.plot_model, change_model, check_model),
+                          (ui.plot_source, change_model, check_source),
+                          (ui.plot_resid, change_model, check_resid),
+                          (ui.plot_ratio, change_example, check_ratio),
+                          (ui.plot_delchi, change_example, check_delchi),
+                          (ui.plot_chisqr, change_example, check_chisqr),
                          ])
-def test_plot_xxx_replot(idval, setupfunc, plotfunc, changefunc, checkfunc):
+def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc):
     """Can we plot, change data, plot with reploat and see a difference?
 
     This relies on accessing the undelying session object directly,
@@ -358,15 +358,26 @@ def test_plot_xxx_replot(idval, setupfunc, plotfunc, changefunc, checkfunc):
     ui.get_data_plot always recreates the plot structure) or don't
     exist.
 
+    Parameters
+    ----------
+    idval : None, int, str
+        The dataset identifier to use
+    plotfunc
+        The function to call to create the plot. If idval is None it
+        is called with no argument, otherwise with idval.
+    changefunc
+        The function to call to change the setup (e.g. data or model).
+        It is called with idval.
+    checkfunc
+        The function which performs the checks on the plot. It is called
+        with no argument.
     """
 
-    setupfunc(idval)
+    setup_example(idval)
     if idval is None:
         plotfunc()
-        dset = ui.get_data()
     else:
         plotfunc(idval)
-        dset = ui.get_data(idval)
 
     changefunc(idval)
     
@@ -377,4 +388,4 @@ def test_plot_xxx_replot(idval, setupfunc, plotfunc, changefunc, checkfunc):
     else:
         plotfunc(idval, replot=True)
 
-    checkfunc(idval)
+    checkfunc()

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1,0 +1,93 @@
+#
+#  Copyright (C) 2019  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Basic tests of the plot functionality in sherpa.ui. The idea is that
+these - or most of them - can be run even when there is no plot backend.
+"""
+
+from sherpa import ui
+from sherpa.plot import DataPlot, FitPlot, ModelPlot
+
+import pytest
+
+
+def example_data():
+    """Create an example data set."""
+
+    return ui.Data1D('example', [10, 20, 40, 90], [10, 40, 30, 50])
+
+def example_model():
+    """Create an example model."""
+
+    ui.create_model_component('const1d', 'cpt')
+    cpt = ui.get_model_component('cpt')
+    cpt.c0 = 35
+    return cpt
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_fit_plot(idval):
+    """Basic testing of get_fit_plot
+
+    Ideally would also test ui.plot_fit but that is harder to
+    test.
+    """
+
+    ui.clean()  # TODO: use auto-clean
+    
+    d = example_data()
+    m = example_model()
+    if idval is None:
+        ui.set_data(d)
+        ui.set_source(m)
+        f = ui.get_fit_plot()
+
+    else:
+        ui.set_data(idval, d)
+        ui.set_source(idval, m)
+        f = ui.get_fit_plot(idval)
+
+    # Should we be checking exact class?
+    assert isinstance(f, FitPlot)
+    assert isinstance(f.dataplot, DataPlot)
+    assert isinstance(f.modelplot, ModelPlot)
+    
+    dp = f.dataplot
+    mp = f.modelplot
+
+    # Are we guaranteed that arrays are Numpy arrays?
+    def are_equal(a, b):
+        r = a == b
+        try:
+            return all(r)
+        except TypeError:
+            return r
+        
+    assert are_equal(dp.x, mp.x)
+    assert are_equal(dp.y, [10, 40, 30, 50])
+    assert are_equal(mp.y, [35, 35, 35, 35])
+
+    assert dp.xerr is None
+    assert mp.xerr is None
+    assert mp.yerr is None
+
+    assert dp.title == 'example'
+    assert mp.title == 'Model'
+

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -300,13 +300,13 @@ def check_resid_changed2(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y2))
 
 
-def check_ratio():
+def check_ratio(title='Ratio of Data to Model for example'):
     """Check that the ratio plot has not changed"""
 
     rplot = ui._session._ratioplot
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
-    assert rplot.title == 'Ratio of Data to Model for example'
+    assert rplot.title == title
     assert rplot.x == pytest.approx(_data_x)
     assert rplot.y == pytest.approx([y / 35 for y in _data_y])
     assert rplot.xerr is None
@@ -328,6 +328,23 @@ def check_ratio_changed():
     assert rplot.y == pytest.approx([y / 35 for y in _data_y2])
     assert rplot.xerr is None
     dy = [dy / 35 for dy in calc_errors(_data_y2)]
+    assert rplot.yerr == pytest.approx(dy)
+
+
+def check_ratio_changed2(title='Ratio of Data to Model for example'):
+    """Check that the ratio plot has changed
+
+    Assumes that change_example and change_model has been called
+    """
+
+    rplot = ui._session._ratioplot
+    assert rplot.xlabel == 'x'
+    assert rplot.ylabel == 'Data / Model'
+    assert rplot.title == title
+    assert rplot.x == pytest.approx(_data_x)
+    assert rplot.y == pytest.approx([y / 41 for y in _data_y2])
+    assert rplot.xerr is None
+    dy = [dy / 41 for dy in calc_errors(_data_y2)]
     assert rplot.yerr == pytest.approx(dy)
 
 
@@ -456,6 +473,25 @@ def check_fit_resid_changed():
     check_resid_changed2(title='')
 
 
+def check_fit_ratio():
+    """Check that the fit + ratio plot has not changed"""
+
+    check_example(xlabel='')
+    check_model(xlabel='')
+    check_ratio(title='')
+
+
+def check_fit_ratio_changed():
+    """Check that the fit + ratio plot has changed
+
+    Assumes that change_fit has been called
+    """
+
+    check_example_changed(xlabel='')
+    check_model_changed(xlabel='')
+    check_ratio_changed2(title='')
+
+
 def check_fit_delchi():
     """Check that the fit + delchi plot has not changed"""
 
@@ -494,6 +530,8 @@ _plot_all = [
      'check': check_fit, 'check_changed': check_fit_changed},
     {'plot': ui.plot_fit_resid, 'change': change_fit,
      'check': check_fit_resid, 'check_changed': check_fit_resid_changed},
+    {'plot': ui.plot_fit_ratio, 'change': change_fit,
+     'check': check_fit_ratio, 'check_changed': check_fit_ratio_changed},
     {'plot': ui.plot_fit_delchi, 'change': change_fit,
      'check': check_fit_delchi, 'check_changed': check_fit_delchi_changed}]
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -232,6 +232,20 @@ def change_example(idval):
     d.y = [12, 45, 33, 49]
 
 
+def change_model(idval):
+    """Change the example model values (created by setup_model)"""
+
+    cpt = ui.get_model_component('cpt')
+    cpt.c0 = 41
+
+
+def change_fit(idval):
+    """Change both the model and the data."""
+
+    change_example(idval)
+    change_model(idval)
+
+
 def check_example():
     """Check that the data plot has not changed"""
 
@@ -248,13 +262,6 @@ def check_example():
     assert dplot.yerr == pytest.approx(Chi2Gehrels.calc_staterror(_data_y))
 
     
-def change_model(idval):
-    """Change the example model values (created by setup_model)"""
-
-    cpt = ui.get_model_component('cpt')
-    cpt.c0 = 41
-
-
 def check_model_plot(plot, title):
     """Helper for check_model/source"""
 
@@ -338,6 +345,13 @@ def check_chisqr():
     assert rplot.yerr is None
 
 
+def check_fit():
+    """Check that the fit plot has not changed"""
+
+    check_example()
+    check_model()
+
+
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -349,6 +363,7 @@ def check_chisqr():
                           (ui.plot_ratio, change_example, check_ratio),
                           (ui.plot_delchi, change_example, check_delchi),
                           (ui.plot_chisqr, change_example, check_chisqr),
+                          (ui.plot_fit, change_fit, check_fit),
                          ])
 def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc):
     """Can we plot, change data, plot with reploat and see a difference?

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -325,13 +325,13 @@ def check_ratio():
     assert rplot.yerr == pytest.approx(dy)
 
     
-def check_delchi():
+def check_delchi(title='Sigma Residuals for example'):
     """Check that the delchi plot has not changed"""
 
     rplot = ui._session._delchiplot
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
-    assert rplot.title == 'Sigma Residuals for example'
+    assert rplot.title == title
     assert rplot.x == pytest.approx(_data_x)
 
     dy = calc_errors(_data_y)
@@ -372,6 +372,14 @@ def check_fit_resid():
     check_resid(title='')
 
 
+def check_fit_delchi():
+    """Check that the fit + delchi plot has not changed"""
+
+    check_example(xlabel='')
+    check_model(xlabel='')
+    check_delchi(title='')
+
+
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -385,6 +393,7 @@ def check_fit_resid():
                           (ui.plot_chisqr, change_example, check_chisqr),
                           (ui.plot_fit, change_fit, check_fit),
                           (ui.plot_fit_resid, change_fit, check_fit_resid),
+                          (ui.plot_fit_delchi, change_fit, check_fit_delchi),
                          ])
 def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc):
     """Can we plot, change data, plot with reploat and see a difference?

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -42,13 +42,13 @@ def example_model():
     return cpt
 
 
-@pytest.mark.usefixtures("clean_ui")
-@pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_fit_plot(idval):
-    """Basic testing of get_fit_plot
+def setup_example(idval):
+    """Set up a simple dataset for use in the tests.
 
-    Ideally would also test ui.plot_fit but that is harder to
-    test.
+    Parameters
+    ----------
+    idval : None, int, str
+        The dataset identifier.
     """
 
     d = example_data()
@@ -56,11 +56,22 @@ def test_get_fit_plot(idval):
     if idval is None:
         ui.set_data(d)
         ui.set_source(m)
-        f = ui.get_fit_plot()
 
     else:
         ui.set_data(idval, d)
         ui.set_source(idval, m)
+
+
+@pytest.mark.usefixtures("clean_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_fit_plot(idval):
+    """Basic testing of get_fit_plot
+    """
+
+    setup_example(idval)
+    if idval is None:
+        f = ui.get_fit_plot()
+    else:
         f = ui.get_fit_plot(idval)
 
     # Should we be checking exact class?
@@ -95,3 +106,19 @@ def test_get_fit_plot(idval):
     assert dp.title == 'example'
     assert mp.title == 'Model'
 
+
+@pytest.mark.usefixtures("clean_ui")
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_fit_plot(idval):
+    """How bad do things fail on Travis with this?
+
+    The idea is just to see what the failure modes on Travis are
+    for the "no-plot-backend" cases, so there's no actual test
+    to see if the plot did anything.
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.plot_fit()
+    else:
+        ui.plot_fit(idval)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -24,6 +24,7 @@ these - or most of them - can be run even when there is no plot backend.
 
 from sherpa import ui
 from sherpa.plot import DataPlot, FitPlot, ModelPlot
+from sherpa.utils.testing import requires_plotting
 
 import pytest
 
@@ -107,6 +108,7 @@ def test_get_fit_plot(idval):
     assert mp.title == 'Model'
 
 
+@requires_plotting
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("pfunc", [ui.plot_data,
@@ -123,6 +125,10 @@ def test_fit_plot_xxx(idval, pfunc):
 
     Currently this just tests that the call succeeds. There is no
     test to see if the plot did anything.
+
+    Some tests fail due to missing plot preferences when there's
+    no plotting backend (e.g. missing 'xlog' settings), so skip
+    these tests in this case.
     """
 
     setup_example(idval)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -67,6 +67,16 @@ def setup_example(idval):
         ui.set_source(idval, m)
 
 
+def calc_errors(ys):
+    """Return errors for ys using the default statistic.
+
+    Consolidate this code to make it easier to change if the
+    default statistic ever changes.
+    """
+
+    return Chi2Gehrels.calc_staterror(ys)
+
+
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 def test_get_fit_plot(idval):
@@ -193,7 +203,7 @@ def test_plot_data_change(idval):
     assert pvals1.y == pytest.approx(yold)
     assert pvals1.xerr is None
 
-    assert pvals1.yerr == pytest.approx(Chi2Gehrels.calc_staterror(yold))
+    assert pvals1.yerr == pytest.approx(calc_errors(yold))
 
     # Modify the data values; rely on changing the dataset object
     # directly means that we do not need to call set_data here.
@@ -219,7 +229,7 @@ def test_plot_data_change(idval):
     assert pvals2.xerr is None
 
     # Should use approximate equality here
-    assert pvals2.yerr == pytest.approx(Chi2Gehrels.calc_staterror(ynew))
+    assert pvals2.yerr == pytest.approx(calc_errors(ynew))
 
     # just check that the previous value has been updated too
     assert pvals1.y == pytest.approx(pvals2.y)
@@ -259,7 +269,7 @@ def check_example():
     assert dplot.xerr is None
 
     # Should use approximate equality here
-    assert dplot.yerr == pytest.approx(Chi2Gehrels.calc_staterror(_data_y))
+    assert dplot.yerr == pytest.approx(calc_errors(_data_y))
 
     
 def check_model_plot(plot, title):
@@ -296,7 +306,7 @@ def check_resid():
     assert rplot.x == pytest.approx(_data_x)
     assert rplot.y == pytest.approx([y - 35 for y in _data_y])
     assert rplot.xerr is None
-    assert rplot.yerr == pytest.approx(Chi2Gehrels.calc_staterror(_data_y))
+    assert rplot.yerr == pytest.approx(calc_errors(_data_y))
 
     
 def check_ratio():
@@ -309,7 +319,7 @@ def check_ratio():
     assert rplot.x == pytest.approx(_data_x)
     assert rplot.y == pytest.approx([y / 35 for y in _data_y])
     assert rplot.xerr is None
-    dy = [dy / 35 for dy in Chi2Gehrels.calc_staterror(_data_y)]
+    dy = [dy / 35 for dy in calc_errors(_data_y)]
     assert rplot.yerr == pytest.approx(dy)
 
     
@@ -322,7 +332,7 @@ def check_delchi():
     assert rplot.title == 'Sigma Residuals for example'
     assert rplot.x == pytest.approx(_data_x)
 
-    dy = Chi2Gehrels.calc_staterror(_data_y)
+    dy = calc_errors(_data_y)
     assert rplot.y == pytest.approx([(y - 35) / dy
                                      for y,dy in zip(_data_y, dy)])
     assert rplot.xerr is None
@@ -338,7 +348,7 @@ def check_chisqr():
     assert rplot.title == '$\\chi^2$ for example'
     assert rplot.x == pytest.approx(_data_x)
 
-    dy = Chi2Gehrels.calc_staterror(_data_y)
+    dy = calc_errors(_data_y)
     assert rplot.y == pytest.approx([((y - 35) / dy)**2
                                      for y,dy in zip(_data_y, dy)])
     assert rplot.xerr is None

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -42,6 +42,7 @@ def example_model():
     return cpt
 
 
+@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 def test_get_fit_plot(idval):
     """Basic testing of get_fit_plot
@@ -50,8 +51,6 @@ def test_get_fit_plot(idval):
     test.
     """
 
-    ui.clean()  # TODO: use auto-clean
-    
     d = example_data()
     m = example_model()
     if idval is None:

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -109,16 +109,24 @@ def test_get_fit_plot(idval):
 
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_fit_plot(idval):
-    """How bad do things fail on Travis with this?
+@pytest.mark.parametrize("pfunc", [ui.plot_data,
+                                   ui.plot_model,
+                                   ui.plot_source,
+                                   ui.plot_resid,
+                                   ui.plot_ratio,
+                                   ui.plot_delchi,
+                                   ui.plot_fit,
+                                   ui.plot_fit_resid,
+                                   ui.plot_fit_delchi])
+def test_fit_plot_xxx(idval, pfunc):
+    """Can we call a plot_xxx routine?
 
-    The idea is just to see what the failure modes on Travis are
-    for the "no-plot-backend" cases, so there's no actual test
-    to see if the plot did anything.
+    Currently this just tests that the call succeeds. There is no
+    test to see if the plot did anything.
     """
 
     setup_example(idval)
     if idval is None:
-        ui.plot_fit()
+        pfunc()
     else:
-        ui.plot_fit(idval)
+        pfunc(idval)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -322,6 +322,22 @@ def check_delchi(idval):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_y])
 
     
+def check_chisqr(idval):
+    """Check that the chisqr plot has not changed"""
+
+    rplot = ui._session._chisqrplot
+    assert rplot.xlabel == 'x'
+    assert rplot.ylabel == '$\\chi^2$'
+    assert rplot.title == '$\\chi^2$ for example'
+    assert rplot.x == pytest.approx(_data_x)
+
+    dy = Chi2Gehrels.calc_staterror(_data_y)
+    assert rplot.y == pytest.approx([((y - 35) / dy)**2
+                                     for y,dy in zip(_data_y, dy)])
+    assert rplot.xerr is None
+    assert rplot.yerr is None
+
+
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -332,6 +348,7 @@ def check_delchi(idval):
                           (setup_example, ui.plot_resid, change_model, check_resid),
                           (setup_example, ui.plot_ratio, change_example, check_ratio),
                           (setup_example, ui.plot_delchi, change_example, check_delchi),
+                          (setup_example, ui.plot_chisqr, change_example, check_chisqr),
                          ])
 def test_plot_xxx_replot(idval, setupfunc, plotfunc, changefunc, checkfunc):
     """Can we plot, change data, plot with reploat and see a difference?

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -65,9 +65,14 @@ def test_get_fit_plot(idval):
         f = ui.get_fit_plot(idval)
 
     # Should we be checking exact class?
-    assert isinstance(f, FitPlot)
-    assert isinstance(f.dataplot, DataPlot)
-    assert isinstance(f.modelplot, ModelPlot)
+    #
+    # No - because the mock_chips pytest routine redefines these
+    # classes and so makes the test fail (or at least that's my
+    # assumption).
+    #
+    # assert isinstance(f, FitPlot)
+    # assert isinstance(f.dataplot, DataPlot)
+    # assert isinstance(f.modelplot, ModelPlot)
     
     dp = f.dataplot
     mp = f.modelplot

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -23,7 +23,10 @@ these - or most of them - can be run even when there is no plot backend.
 """
 
 from sherpa import ui
-from sherpa.plot import DataPlot, FitPlot, ModelPlot
+
+# the chips plot tests mean that we can't test the plot instances
+# from sherpa.plot import DataPlot, FitPlot, ModelPlot
+
 from sherpa.stats import Chi2Gehrels
 from sherpa.utils.testing import requires_plotting
 
@@ -33,7 +36,8 @@ import pytest
 _data_x = [10, 20, 40, 90]
 _data_y = [10, 40, 30, 50]
 _data_y2 = [12, 45, 33, 49]
-      
+
+
 def example_data():
     """Create an example data set."""
 
@@ -105,7 +109,7 @@ def test_get_fit_plot(idval):
     # assert isinstance(f, FitPlot)
     # assert isinstance(f.dataplot, DataPlot)
     # assert isinstance(f.modelplot, ModelPlot)
-    
+
     dp = f.dataplot
     mp = f.modelplot
 
@@ -188,7 +192,7 @@ def check_example(xlabel='x'):
     # Should use approximate equality here
     assert dplot.yerr == pytest.approx(calc_errors(_data_y))
 
-    
+
 def check_example_changed(xlabel='x'):
     """Check that the data plot has changed
 
@@ -244,7 +248,7 @@ def check_source():
     check_model_plot(ui._session._sourceplot,
                      title='Source')
 
-    
+
 def check_source_changed():
     """Check that the source plot has changed
 
@@ -267,7 +271,7 @@ def check_resid(title='Residuals for example'):
     assert rplot.xerr is None
     assert rplot.yerr == pytest.approx(calc_errors(_data_y))
 
-    
+
 def check_resid_changed(title='Residuals for example'):
     """Check that the resid plot has changed
 
@@ -359,7 +363,7 @@ def check_delchi(title='Sigma Residuals for example'):
 
     dy = calc_errors(_data_y)
     assert rplot.y == pytest.approx([(y - 35) / dy
-                                     for y,dy in zip(_data_y, dy)])
+                                     for y, dy in zip(_data_y, dy)])
     assert rplot.xerr is None
     assert rplot.yerr == pytest.approx([1.0 for y in _data_y])
 
@@ -378,7 +382,7 @@ def check_delchi_changed(title='Sigma Residuals for example'):
 
     dy = calc_errors(_data_y2)
     assert rplot.y == pytest.approx([(y - 35) / dy
-                                     for y,dy in zip(_data_y2, dy)])
+                                     for y, dy in zip(_data_y2, dy)])
     assert rplot.xerr is None
     assert rplot.yerr == pytest.approx([1.0 for y in _data_x])
 
@@ -397,7 +401,7 @@ def check_delchi_changed2(title='Sigma Residuals for example'):
 
     dy = calc_errors(_data_y2)
     assert rplot.y == pytest.approx([(y - 41) / dy
-                                     for y,dy in zip(_data_y2, dy)])
+                                     for y, dy in zip(_data_y2, dy)])
     assert rplot.xerr is None
     assert rplot.yerr == pytest.approx([1.0 for y in _data_x])
 
@@ -413,7 +417,7 @@ def check_chisqr():
 
     dy = calc_errors(_data_y)
     assert rplot.y == pytest.approx([((y - 35) / dy)**2
-                                     for y,dy in zip(_data_y, dy)])
+                                     for y, dy in zip(_data_y, dy)])
     assert rplot.xerr is None
     assert rplot.yerr is None
 
@@ -432,7 +436,7 @@ def check_chisqr_changed():
 
     dy = calc_errors(_data_y2)
     assert rplot.y == pytest.approx([((y - 35) / dy)**2
-                                     for y,dy in zip(_data_y2, dy)])
+                                     for y, dy in zip(_data_y2, dy)])
     assert rplot.xerr is None
     assert rplot.yerr is None
 
@@ -671,11 +675,14 @@ def test_plot_xxx_change(idval, plotfunc, changefunc, checkfunc):
     checkfunc()
 
 
+_dplot = (ui.get_data_plot_prefs, "_dataplot", ui.plot_data)
+_mplot = (ui.get_model_plot_prefs, "_modelplot", ui.plot_model)
+
+
 @requires_plotting
 @pytest.mark.usefixtures("clean_ui")
-@pytest.mark.parametrize("getprefs,attr, plotfunc",
-                         [(ui.get_data_plot_prefs, "_dataplot", ui.plot_data),
-                          (ui.get_model_plot_prefs, "_modelplot", ui.plot_model)])
+@pytest.mark.parametrize("getprefs,attr,plotfunc",
+                         [_dplot, _mplot])
 def test_prefs_change_session_objects(getprefs, attr, plotfunc):
     """Is a plot-preference change also reflected in the session object?
 
@@ -691,7 +698,7 @@ def test_prefs_change_session_objects(getprefs, attr, plotfunc):
     # the clean_ui fixture.
     #
     session = getattr(ui._session, attr)
-    
+
     # All but the last assert are just to check things are behaving
     # as expected (and stuck into one routine rather than have a
     # bunch of tests that repeat a subset of this test)
@@ -706,7 +713,7 @@ def test_prefs_change_session_objects(getprefs, attr, plotfunc):
 
     setup_example(None)
     plotfunc()
-    
+
     assert session.plot_prefs['xlog']
     assert session.x is not None
 
@@ -732,7 +739,7 @@ def test_prefs_change_session_objects_fit():
     plotobj = ui._session._fitplot
     assert plotobj.dataplot is None
     assert plotobj.modelplot is None
-    
+
     dprefs = ui.get_data_plot_prefs()
     mprefs = ui.get_model_plot_prefs()
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -11901,8 +11901,8 @@ class Session(NoNewAttributesAfterInit):
         include the following list. There are also individual
         functions, with ``plot_`` prepended to the plot type, such as
         `plot_data` (the ``bkg`` variants use a prefix of
-        ``plot_bkg_``). There are also several multiple-plot commands
-        (e.g. `plot_fit_resid` and `plot_fit_delchi`).
+        ``plot_bkg_``). There are also several multiple-plot commands,
+        such as `plot_fit_ratio`, `plot_fit_resid`, and `plot_fit_delchi`.
 
         ``arf``
            The ARF for the data set (only for `DataPHA` data sets).
@@ -12366,6 +12366,7 @@ class Session(NoNewAttributesAfterInit):
         get_default_id : Return the default data set identifier.
         plot : Create one or more plot types.
         plot_fit_delchi : Plot the fit results, and the residuals, for a data set.
+        plot_fit_ratio : Plot the fit results, and the ratio of data to model, for a data set.
         plot_fit_resid : Plot the fit results, and the residuals, for a data set.
         plot_data : Plot the data values.
         plot_model : Plot the model for a data set.
@@ -12816,8 +12817,8 @@ class Session(NoNewAttributesAfterInit):
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
-           Set to ``True`` to use the values calculated by the last
-           call to `plot_fit_resid`. The default is ``False``.
+           Set to ``True`` to use the previous values. The default is
+           ``False``.
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
@@ -12838,8 +12839,10 @@ class Session(NoNewAttributesAfterInit):
         plot : Create one or more plot types.
         plot_fit : Plot the fit results for a data set.
         plot_fit_delchi : Plot the fit results, and the residuals, for a data set.
+        plot_fit_ratio : Plot the fit results, and the ratio of data to model, for a data set.
         plot_data : Plot the data values.
         plot_model : Plot the model for a data set.
+        plot_resid : Plot the residuals (data - model) for a data set.
         set_xlinear : New plots will display a linear X axis.
         set_xlog : New plots will display a logarithmically-scaled X axis.
         set_ylinear : New plots will display a linear Y axis.
@@ -12862,6 +12865,70 @@ class Session(NoNewAttributesAfterInit):
         """
 
         self._plot_jointplot(self._residplot,
+                             id=id, replot=replot, overplot=overplot,
+                             clearwindow=clearwindow)
+
+    def plot_fit_ratio(self, id=None, replot=False, overplot=False,
+                       clearwindow=True):
+        """Plot the fit results, and the ratio of data to model, for a data set.
+
+        This creates two plots - the first from `plot_fit` and the
+        second from `plot_ratio` - for a data set.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The data set. If not given then the default identifier is
+           used, as returned by `get_default_id`.
+        replot : bool, optional
+           Set to ``True`` to use the values calculated by the last
+           call to `plot_fit_ratio`. The default is ``False``.
+        overplot : bool, optional
+           If ``True`` then add the data to an exsiting plot, otherwise
+           create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+
+        Raises
+        ------
+        sherpa.utils.err.IdentifierErr
+           If the data set does not exist or a source expression has
+           not been set.
+
+        See Also
+        --------
+        get_fit_plot : Return the data used to create the fit plot.
+        get_default_id : Return the default data set identifier.
+        plot : Create one or more plot types.
+        plot_fit : Plot the fit results for a data set.
+        plot_fit_resid : Plot the fit results, and the residuals, for a data set.
+        plot_fit_delchi : Plot the fit results, and the residuals, for a data set.
+        plot_data : Plot the data values.
+        plot_model : Plot the model for a data set.
+        plot_ratio : Plot the ratio of data to model for a data set.
+        set_xlinear : New plots will display a linear X axis.
+        set_xlog : New plots will display a logarithmically-scaled X axis.
+        set_ylinear : New plots will display a linear Y axis.
+        set_ylog : New plots will display a logarithmically-scaled Y axis.
+
+        Examples
+        --------
+
+        Plot the results for the default data set:
+
+        >>> plot_fit_ratio()
+
+        Overplot the 'core' results on those from the 'jet' data set,
+        using a logarithmic scale for the X axis:
+
+        >>> set_xlog()
+        >>> plot_fit_ratio('jet')
+        >>> plot_fit_ratio('core', overplot=True)
+
+        """
+
+        self._plot_jointplot(self._ratioplot,
                              id=id, replot=replot, overplot=overplot,
                              clearwindow=clearwindow)
 
@@ -12899,8 +12966,10 @@ class Session(NoNewAttributesAfterInit):
         get_default_id : Return the default data set identifier.
         plot : Create one or more plot types.
         plot_fit : Plot the fit results for a data set.
+        plot_fit_ratio : Plot the fit results, and the ratio of data to model, for a data set.
         plot_fit_resid : Plot the fit results, and the residuals, for a data set.
         plot_data : Plot the data values.
+        plot_delchi : Plot the ratio of residuals to error for a data set.
         plot_model : Plot the model for a data set.
         set_xlinear : New plots will display a linear X axis.
         set_xlog : New plots will display a logarithmically-scaled X axis.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8338,8 +8338,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -11902,7 +11902,7 @@ class Session(NoNewAttributesAfterInit):
         functions, with ``plot_`` prepended to the plot type, such as
         `plot_data` (the ``bkg`` variants use a prefix of
         ``plot_bkg_``). There are also several multiple-plot commands
-        (e.g. `plot_fit_resid`).
+        (e.g. `plot_fit_resid` and `plot_fit_delchi`).
 
         ``arf``
            The ARF for the data set (only for `DataPHA` data sets).
@@ -12025,6 +12025,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -12057,6 +12060,18 @@ class Session(NoNewAttributesAfterInit):
         >>> plot_data("jet")
         >>> plot_data("core", overplot=True)
 
+        The following example requires that the Matplotlib backend
+        is selected, and uses a Matplotlib function to create a
+        subplot (in this case one filling the bottom half of the
+        plot area) and then calls `plot_data` with the `clearwindow`
+        argument set to `False` to use this subplot. If the
+        `clearwindow` argument had not been used then the plot area
+        would have been cleared and the plot would have filled the
+        area.
+
+        >>> plt.subplot(2, 1, 2)
+        >>> plot_data(clearwindow=False)
+
         """
         self._plot(id, self._dataplot, **kwargs)
 
@@ -12079,6 +12094,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -12135,6 +12153,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -12202,6 +12223,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -12273,6 +12297,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -12323,6 +12350,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12378,6 +12408,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12437,6 +12470,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12491,6 +12527,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12544,6 +12583,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12597,6 +12639,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12649,6 +12694,9 @@ class Session(NoNewAttributesAfterInit):
         overplot : bool, optional
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12705,8 +12753,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12789,8 +12837,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         Raises
         ------
@@ -12884,8 +12932,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -12956,8 +13004,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -13031,8 +13079,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------
@@ -13110,8 +13158,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           Should the existing plot area be cleared before creating the
-           plot?
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
 
         See Also
         --------


### PR DESCRIPTION
# Overview

Add the `plot_fit_ratio` function to the `sherpa.ui` layer (to match `plot_fit_resid` and `plot_fit_delchi`) and `plot_bkg_fit_ratio` to the `sherpa.astro.ui` layer. Added tests for a number of plot types.

# Details

Most of the commits are adding tests (and can probably be merged into a smaller number of commits, but I want to leave the existing set of commits for initial review).

The tests are very limited, in that although they tend to require a plotting backend, they don't actually check that the plot was actually created. Instead, they test that the plot data structures (such as `DataPlot`) are populated correctly. The `replot` argument is tested since the preference-handling code in the `plot_fit_xxx` routines looked "interesting", and I wanted a reasonable base of tests in case I decided to refactor things.

I think that the `@requires_plotting` decorator could be removed from many (maybe all) of these tests if we required that the dummy plot backend set up sensible default preferences. That's a call for a different PR. I do believe that I see the same issue here as found in the tests for #622 - the way that the chips mocking works can lead to odd downstream behavior.

The `plot_bkg`-related tests show some odd behavior that needs investigating, but is not due to this PR (it may be due to how the synthetic data used in the tests is created).