### PR TITLE
Added invitation for native software citation

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -16,7 +16,7 @@ Zenodo: https://zenodo.org/record/3944985
 The Zenodo guide to versioning at http://help.zenodo.org/#versioning
 provides advice on how to cite the correct version.
 
-If you want a general-purpose citation then please either of the
+If you want a general-purpose citation then please use either of the
 following, kindly provided by the SAO/NASA Astrophysics Data System
 service:
 

--- a/CITATION
+++ b/CITATION
@@ -1,63 +1,47 @@
 
-If you are writing a paper and would like to cite Sherpa, we recommend
-the native software citation and the following two papers. Note how it is advisable
-(http://help.zenodo.org/#versioning) to cite the specific version of your record in citation.
+The sherpa module contains an experimental citation() function which
+will return the citation information for the latest release or a given
+release:
 
+   >>> import sherpa
+   >>> sherpa.citation()
+   >>> sherpa.citation('4.12.1')
 
-Doug Burke, Omar Laurino, dtnguyen2, Jamie Budynkiewicz, Tom Aldcroft, Aneta Siemiginowska, … Katrin Leinweber.
-(2019, February 20). sherpa/sherpa: Sherpa 4.11.0 (Version 4.11.0).
-Zenodo. http://doi.org/10.5281/zenodo.2573885
+The output can be saved to a file by setting the filename argument.
 
-Sherpa: a mission-independent data analysis application
-http://adsabs.harvard.edu/abs/2001SPIE.4477...76F
-P. E. Freeman, S. Doe, A. Siemiginowska
-SPIE Proceedings, Vol. 4477, p.76, 2001	
+This will only work if you have internet access (at least for the
+latest query) as it takes the data from the Sherpa record at
+Zenodo: https://zenodo.org/record/3944985
 
-Developing Sherpa with Python
-http://adsabs.harvard.edu/abs/2007ASPC..376..543D
-S. Doe, et al.
-Astronomical Data Analysis Software and Systems XVI, 376, 543
+The Zenodo guide to versioning at http://help.zenodo.org/#versioning
+provides advice on how to cite the correct version.
 
-
-BibTeX entries for LaTeX users are
-
-@misc{doug_burke_2019_2573885,
-  author       = {Doug Burke and
-                  Omar Laurino and
-                  dtnguyen2 and
-                  Jamie Budynkiewicz and
-                  Tom Aldcroft and
-                  Aneta Siemiginowska and
-                  Christoph Deil and
-                  wmclaugh and
-                  Brigitta Sipocz and
-                  Katrin Leinweber},
-  title        = {sherpa/sherpa: Sherpa 4.11.0},
-  month        = feb,
-  year         = 2019,
-  doi          = {10.5281/zenodo.593753},
-  url          = {https://doi.org/10.5281/zenodo. 593753}
-}
+If you want a general-purpose citation then please either of the
+following, kindly provided by the SAO/NASA Astrophysics Data System
+service:
 
 @INPROCEEDINGS{2001SPIE.4477...76F,
-   author = {{Freeman}, P. and {Doe}, S. and {Siemiginowska}, A.},
-    title = "{Sherpa: a mission-independent data analysis application}",
-booktitle = {Astronomical Data Analysis},
-     year = 2001,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 4477,
-   eprint = {astro-ph/0108426},
-   editor = {{Starck}, J.-L. and {Murtagh}, F.~D.},
-    month = nov,
-    pages = {76-87},
-      doi = {10.1117/12.447161},
-   adsurl = {http://adsabs.harvard.edu/abs/2001SPIE.4477...76F},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Freeman}, Peter and {Doe}, Stephen and {Siemiginowska}, Aneta},
+        title = "{Sherpa: a mission-independent data analysis application}",
+     keywords = {Astrophysics},
+    booktitle = {Astronomical Data Analysis},
+         year = 2001,
+       editor = {{Starck}, Jean-Luc and {Murtagh}, Fionn D.},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+       volume = {4477},
+        month = nov,
+        pages = {76-87},
+          doi = {10.1117/12.447161},
+archivePrefix = {arXiv},
+       eprint = {astro-ph/0108426},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2001SPIE.4477...76F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2007ASPC..376..543D,
-   author = {{Doe}, S. and {Nguyen}, D. and {Stawarz}, C. and {Refsdal}, B. and 
-	{Siemiginowska}, A. and {Burke}, D. and {Evans}, I. and {Evans}, J. and 
+   author = {{Doe}, S. and {Nguyen}, D. and {Stawarz}, C. and {Refsdal}, B. and
+	{Siemiginowska}, A. and {Burke}, D. and {Evans}, I. and {Evans}, J. and
 	{McDowell}, J. and {Houck}, J. and {Nowak}, M.},
     title = "{Developing Sherpa with Python}",
 booktitle = {Astronomical Data Analysis Software and Systems XVI},
@@ -70,4 +54,3 @@ booktitle = {Astronomical Data Analysis Software and Systems XVI},
    adsurl = {http://adsabs.harvard.edu/abs/2007ASPC..376..543D},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-

--- a/CITATION
+++ b/CITATION
@@ -1,6 +1,12 @@
 
 If you are writing a paper and would like to cite Sherpa, we recommend
-the following papers:
+the native software citation and the following two papers. Note how it is advisable
+(http://help.zenodo.org/#versioning) to cite the specific version of your record in citation.
+
+
+Doug Burke, Omar Laurino, dtnguyen2, Jamie Budynkiewicz, Tom Aldcroft, Aneta Siemiginowska, … Katrin Leinweber.
+(2019, February 20). sherpa/sherpa: Sherpa 4.11.0 (Version 4.11.0).
+Zenodo. http://doi.org/10.5281/zenodo.2573885
 
 Sherpa: a mission-independent data analysis application
 http://adsabs.harvard.edu/abs/2001SPIE.4477...76F
@@ -12,7 +18,26 @@ http://adsabs.harvard.edu/abs/2007ASPC..376..543D
 S. Doe, et al.
 Astronomical Data Analysis Software and Systems XVI, 376, 543
 
+
 BibTeX entries for LaTeX users are
+
+@misc{doug_burke_2019_2573885,
+  author       = {Doug Burke and
+                  Omar Laurino and
+                  dtnguyen2 and
+                  Jamie Budynkiewicz and
+                  Tom Aldcroft and
+                  Aneta Siemiginowska and
+                  Christoph Deil and
+                  wmclaugh and
+                  Brigitta Sipocz and
+                  Katrin Leinweber},
+  title        = {sherpa/sherpa: Sherpa 4.11.0},
+  month        = feb,
+  year         = 2019,
+  doi          = {10.5281/zenodo.593753},
+  url          = {https://doi.org/10.5281/zenodo. 593753}
+}
 
 @INPROCEEDINGS{2001SPIE.4477...76F,
    author = {{Freeman}, P. and {Doe}, S. and {Siemiginowska}, A.},

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -135,8 +135,28 @@ location of the documentation version **must** be added to the
 ``.gitignore`` file (see the section near the end) to make sure it
 does not accidentally get added.
 
+If the notebook is not placed in ``notebooks/`` then the
+``nbsphinx_prolog`` setting in ``docs/conf.py`` will need updating.
+This sets the text used to indicate the link to the notebook on the
+Sherpa repository.
+
 At present we require that the notebook be fully evaluated as we
 do not run the notebooks while building the documentation.
+
+Add a new test option?
+----------------------
+
+The ``sherpa/conftest.py`` file contains general-purpose testing
+routines, fixtures, and configuration support for the test suite.
+To add a new command-line option:
+
+ - add to the ``pytest_addoption`` routine, to add the option;
+
+ - add to ``pytest_collection_modifyitems`` if the option adds
+   a new mark;
+
+ - and add support in ``pytest_configure``, such as registering
+   a new mark.
 
 Update the XSPEC bindings?
 --------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -421,7 +421,8 @@ section - can be found with::
     python setup.py test -a "--pyargs sherpa --help"
 
 and to pass an argument to the Sherpa test suite (there are currently
-two options, namely ``--test-data`` and ``--runslow``)::
+three options, namely ``--test-data``, ``--runslow``, and
+``-runzenodo``)::
 
     python setup.py test -a "--pyargs sherpa --runslow"
 

--- a/docs/overview/sherpa.rst
+++ b/docs/overview/sherpa.rst
@@ -1,0 +1,17 @@
+*****************
+The sherpa module
+*****************
+
+.. currentmodule:: sherpa
+
+.. automodule:: sherpa
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      citation
+      get_config
+      get_include
+      smoke

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -19,6 +19,7 @@ Reference/API
 .. toctree::
    :maxdepth: 2
 
+   sherpa
    err
    utils
    testing

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -73,9 +73,9 @@ DEFAULT_CITATION = """Please review the Zenodo Sherpa page at
        https://doi.org/10.5281/zenodo.593753
 to identify the latest release of Sherpa. The Zenodo page
 https://help.zenodo.org/#versioning provides information on how to
-cite the specific version.
+cite a specific version.
 
-If you want a general-purpose citation then please either of the
+If you want a general-purpose citation then please use either of the
 following, kindly provided by the SAO/NASA Astrophysics Data System
 service:
 
@@ -462,13 +462,13 @@ def citation(version='latest', filename=None, clobber=False):
 
     The citation information is taken from Zenodo [1]_, using the
     Sherpa "latest release" identifier [2]_, and so requires an
-    internet connection. The message is displaye on screen, using
+    internet connection. The message is displayed on screen, using
     pagination, or can be written to a file.
 
     Parameters
     ----------
     version : str, optional
-        The version to retrieve the citation before. The supported
+        The version to retrieve the citation for. The supported
         values are limited to 'latest' and the current set of
         releases available on Zenodo (this goes back to '4.8.0').
     filename : str or StringIO or None, optional

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -499,9 +499,9 @@ def citation(version='latest', filename=None, clobber=False):
 
     """
 
-    from sherpa.ui.utils import _send_to_pager
+    from sherpa.utils import send_to_pager
     cite = _get_citation(version=version)
-    _send_to_pager(cite, filename=filename, clobber=clobber)
+    send_to_pager(cite, filename=filename, clobber=clobber)
 
 
 def get_include():

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -42,7 +42,7 @@ import subprocess
 import sys
 
 
-__all__ = ('citation', 'get_include',)
+__all__ = ('citation', 'get_config', 'get_include', 'smoke')
 
 from ._version import get_versions
 __version__ = get_versions()['version']
@@ -545,8 +545,7 @@ def citation(version='latest', filename=None, clobber=False):
     If there is no internet connection, or there was a problem in
     downloading the data, or the Zenodo API has started to return
     different informatioon than expected, then the code will return
-    the basic information (that is, as if run with
-    ``download=False``).
+    information on why the call failed and other citation options.
 
     Zenodo only lets you perform a limited number of calls in
     a set time span, so if you call this routine too many times
@@ -558,6 +557,20 @@ def citation(version='latest', filename=None, clobber=False):
     .. [1] https://zenodo.org/
 
     .. [2] https://doi.org/10.5281/zenodo.593753
+
+    Examples
+    --------
+
+    Display the citation information for the latest release on
+    Zenodo. The information is paged to the display:
+
+    >>> import sherpa
+    >>> sherpa.citation()
+
+    Write out the citation information for Sherpa 4.12.1 to the file
+    ``cite.txt``:
+
+    >>> sherpa.citation('4.12.1', outfile='cite.txt')
 
     """
 
@@ -605,28 +618,36 @@ def get_config():
 
 
 def smoke(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):
-    """
-    Run Sherpa's "smoke" test. The smoke test is a simple test that
-        ensures the Sherpa installation is functioning. It is not a complete
-        test suite, but it fails if obvious issues are found.
+    """Run Sherpa's "smoke" test.
+
+    The smoke test is a simple test that ensures the Sherpa
+    installation is functioning. It is not a complete test suite, but
+    it fails if obvious issues are found.
 
     Parameters
     ----------
-    xspec : boolean
-        Require xspec module when running tests. Tests requiring xspec may still run if the xspec module is present.
-    fits : str
-        Require a fits module with this name to be present before running the smoke test.
-        This option makes sure that when the smoke test is run the required modules are present.
-        Note that tests requiring fits may still run if any fits backend is available, and they might
-        still fail on their own.
-    require_failure : boolean
-        For debugging purposes, the smoke test may be required to always fail. Defaults to False.
-    verbosity : int
+    verbosity : int, optional
         The level of verbosity of this test
+    require_failure : boolean, optional
+        For debugging purposes, the smoke test may be required to
+        always fail. Defaults to False.
+    fits : str or None, optional
+        Require a fits module with this name to be present before
+        running the smoke test. This option makes sure that when the
+        smoke test is run the required modules are present.  Note that
+        tests requiring fits may still run if any fits backend is
+        available, and they might still fail on their own.
+    xspec : boolean, optional
+        Require xspec module when running tests. Tests requiring xspec
+        may still run if the xspec module is present.
+    ds9 : boolean, optional
+        Requires DS9 when running tests.
 
-    Returns
-    -------
-    The method raises the SystemExit if errors are found during the smoke test
+    Raises
+    ------
+    SystemExit
+        Raised if any errors are found during the tests.
+
     """
     from sherpa.astro.utils import smoke
     smoke.run(verbosity=verbosity, require_failure=require_failure, fits=fits, xspec=xspec, ds9=ds9)

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2014, 2015, 2016, 2019
+#  Copyright (C) 2007, 2014, 2015, 2016, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -34,7 +34,7 @@ the standard subpackages, use ``import sherpa.all`` or
 
 """
 
-
+import datetime
 import logging
 import os
 import os.path
@@ -42,7 +42,7 @@ import subprocess
 import sys
 
 
-__all__ = ('get_include',)
+__all__ = ('citation', 'get_include',)
 
 from ._version import get_versions
 __version__ = get_versions()['version']
@@ -63,7 +63,445 @@ handler.setFormatter(Formatter())
 log.addHandler(handler)
 log.setLevel(logging.INFO)
 
+dbg = log.debug
+
 del Formatter, log, handler
+
+
+
+DEFAULT_CITATION = """Please review the Zenodo Sherpa page at
+       https://doi.org/10.5281/zenodo.593753
+to identify the latest release of Sherpa. The Zenodo page
+https://help.zenodo.org/#versioning provides information on how to
+cite the specific version.
+
+If you want a general-purpose citation then please either of the
+following, kindly provided by the SAO/NASA Astrophysics Data System
+service:
+
+@INPROCEEDINGS{2001SPIE.4477...76F,
+       author = {{Freeman}, Peter and {Doe}, Stephen and {Siemiginowska}, Aneta},
+        title = "{Sherpa: a mission-independent data analysis application}",
+     keywords = {Astrophysics},
+    booktitle = {Astronomical Data Analysis},
+         year = 2001,
+       editor = {{Starck}, Jean-Luc and {Murtagh}, Fionn D.},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+       volume = {4477},
+        month = nov,
+        pages = {76-87},
+          doi = {10.1117/12.447161},
+archivePrefix = {arXiv},
+       eprint = {astro-ph/0108426},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2001SPIE.4477...76F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2007ASPC..376..543D,
+   author = {{Doe}, S. and {Nguyen}, D. and {Stawarz}, C. and {Refsdal}, B. and
+	{Siemiginowska}, A. and {Burke}, D. and {Evans}, I. and {Evans}, J. and
+	{McDowell}, J. and {Houck}, J. and {Nowak}, M.},
+    title = "{Developing Sherpa with Python}",
+booktitle = {Astronomical Data Analysis Software and Systems XVI},
+     year = 2007,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 376,
+   editor = {{Shaw}, R.~A. and {Hill}, F. and {Bell}, D.~J.},
+    month = oct,
+    pages = {543},
+   adsurl = {http://adsabs.harvard.edu/abs/2007ASPC..376..543D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+"""
+
+
+def _make_citation(version, title, date, authors, idval, latest=True):
+
+    year = date.year
+    month = date.strftime('%b').lower()
+    nicedate = date.strftime('%B %d, %Y')
+
+    authnames = ' and\n                  '.join(authors)
+
+    if latest:
+        out = "The latest release of Sherpa is {}\n".format(title)
+        out += "released on {}.".format(nicedate)
+    else:
+        out = "Sherpa {} was released on {}.".format(version, nicedate)
+
+    out += """
+
+@software{{sherpa_{year}_{idval},
+  author       = {{{authnames}}},
+  title        = {{{title}}},
+  month        = {month},
+  year         = {year},
+  publisher    = {{Zenodo}},
+  version      = {{{version}}},
+  doi          = {{10.5281/zenodo.{idval}}},
+  url          = {{https://doi.org/10.5281/zenodo.{idval}}}
+}}
+
+""".format(authnames=authnames, idval=idval, title=title,
+           version=version, year=year, month=month)
+
+    out += DEFAULT_CITATION
+    return out
+
+
+def _get_citation_hardcoded(version):
+    """Retrieve the citation information.
+
+    Parameters
+    ----------
+    version : str
+        The version to retrieve the citation before. It is expected
+        to be '4.8.0' or higher.
+
+    Returns
+    -------
+    citation : str or None
+        Citation information if known, otherwise None.
+
+    """
+
+    def todate(year, mnum, dnum):
+        return datetime.datetime(year, mnum, dnum)
+
+    db = 'DougBurke'
+    ol = 'Omar Laurino'
+    dn = 'dtnguyen2'
+    ta = 'Tom Aldcroft'
+    an = 'Aneta Siemiginowska'
+
+    jb = 'Jamie Budynkiewicz'
+    cd = 'Christoph Deil'
+    bs = 'Brigitta Sipocz'
+
+    wm = 'wmclaugh'
+
+    kl = 'Katrin Leinweber'
+
+    mt = 'Marie-Terrell'
+    bs2 = 'Brigitta Sipőcz'
+    hm = 'Hans Moritz Günther'
+    td = 'Todd'
+
+    cite = {}
+
+    def add(version, **kwargs):
+        assert version not in cite
+        cite[version] = dict(**kwargs)
+        cite[version]['version'] = version
+
+    add(version='4.8.0', title='sherpa: Sherpa 4.8.0',
+        date=todate(2016, 1, 27),
+        authors=[db, ol, dn, ta, an],
+        idval='45243')
+    add(version='4.8.1', title='sherpa: Sherpa 4.8.1',
+        date=todate(2016, 4, 15),
+        authors=[db, ol, dn, ta, jb, an, cd, bs],
+        idval='49832')
+    add(version='4.8.2', title='sherpa: Sherpa 4.8.2',
+        date=todate(2016, 9, 23),
+        authors=[db, ol, dn, jb, ta, an, cd, wm, bs],
+        idval='154744')
+
+    add(version='4.9.0', title='sherpa/sherpa: Sherpa 4.9.0',
+        date=todate(2017, 1, 27),
+        authors=[db, ol, dn, jb, ta, an, wm, cd, bs],
+        idval='260416')
+    add(version='4.9.1', title='sherpa/sherpa: Sherpa 4.9.1',
+        date=todate(2017, 8, 3),
+        authors=[db, ol, dn, jb, ta, an, wm, cd, bs],
+        idval='838686')
+
+    add(version='4.10.0', title='sherpa/sherpa: Sherpa 4.10.0',
+        date=todate(2018, 5, 1),
+        authors=[db, ol, dn, jb, ta, an, wm, cd, bs],
+        idval='1245678')
+    add(version='4.10.1', title='sherpa/sherpa: Sherpa 4.10.1',
+        date=todate(2018, 10, 16),
+        authors=[db, ol, dn, jb, ta, an, wm, bs, cd, kl],
+        idval='1463962')
+    add(version='4.10.2', title='sherpa/sherpa: Sherpa 4.10.2',
+        date=todate(2018, 12, 14),
+        authors=[db, ol, dn, jb, ta, an, cd, wm, bs, kl],
+        idval='2275738')
+
+    add(version='4.11.0', title='sherpa/sherpa: Sherpa 4.11.0',
+        date=todate(2019, 2, 20),
+        authors=[db, ol, dn, jb, ta, an, cd, wm, bs, kl],
+        idval='2573885')
+    add(version='4.11.1', title='sherpa/sherpa: Sherpa 4.11.1',
+        date=todate(2019, 8, 1),
+        authors=[db, ol, dn, jb, ta, an, cd, wm, bs, kl],
+        idval='3358134')
+
+    add(version='4.12.0', title='sherpa/sherpa: Sherpa 4.12.0',
+        date=todate(2020, 1, 30),
+        authors=[db, ol, dn, wm, jb, ta, an, cd, mt, bs2, hm, td, kl],
+        idval='3631574')
+    add(version='4.12.1', title='sherpa/sherpa: Sherpa 4.12.1',
+        date=todate(2020, 7, 14),
+        authors=[db, ol, wm, dn, mt, hm, jb, an, ta, cd, bs2, kl, td],
+        idval='3944985')
+
+    kwargs = cite.get(version, None)
+    if kwargs is None:
+        return None
+
+    return _make_citation(**kwargs, latest=False)
+
+
+def _download_json(url):
+    """Return the JSON data or None.
+
+    Parameters
+    ----------
+    url : str
+        The URL to process.
+
+    Returns
+    -------
+    response : object or None
+        The data in JSON or None if there was any problem.
+
+    """
+
+    import json
+    import ssl
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError
+
+    # Need to set the Content-Type so it looks like I need
+    # a request. Darn it. Even though https://developers.zenodo.org/#list36
+    # claims you can set the content-type, it just seems to
+    # return JSON.
+    #
+    # req = Request(url,
+    #               headers={'Content-Type': 'application/x-bibtex'})
+    #
+    req = Request(url)
+
+    # This is not ideal, but given the way that we package
+    # CIAO we can end up with issues evaluating SSL certificates,
+    # so as we are not sending secure information we drop
+    # the SSL checks.
+    #
+    context = ssl._create_unverified_context()
+
+    try:
+        res = urlopen(req, context=context)
+    except HTTPError as he:
+        dbg("Unable to access {}: {}".format(url, he))
+        return None
+
+    try:
+        jsdata = json.load(res)
+    except UnicodeDecodeError as ue:
+        dbg("Unable to decode JSON from Zenodo: {}".format(ue))
+        return None
+
+    return jsdata
+
+
+def _make_zenodo_citation(jsdata, latest=True):
+    """Convert Zenodo record to a citation.
+
+    Parameters
+    ----------
+    jsdata : object
+        A Zenodo record.
+
+    Returns
+    -------
+    citation : str or None
+        Citation information, if found.
+
+    """
+
+    try:
+        created = jsdata['created']
+        mdata = jsdata['metadata']
+        idval = jsdata['id']
+    except KeyError as ke:
+        dbg("Unable to find metadata: {}".format(ke))
+        return None
+
+    try:
+        date = datetime.datetime.fromisoformat(created)
+    except ValueError:
+        dbg("Unable to convert created: '{}'".format(created))
+        return None
+
+    try:
+        version = mdata['version']
+        title = mdata['title']
+        creators = mdata['creators']
+    except KeyError as ke:
+        dbg("Unable to find metadata: {}".format(ke))
+        return None
+
+    authors = [c['name'] for c in creators]
+    out = _make_citation(version=version, title=title, date=date,
+                         authors=authors, idval=idval,
+                         latest=latest)
+    return out
+
+
+def _get_citation_zenodo_latest():
+    """Query Zenodo for the latest release.
+
+    Returns
+    -------
+    citation : str or None
+        Citation information, if found.
+    """
+
+    # Can we retrieve the information from Zenodo?
+    #
+    # We do not access the DOI but the Zenodo API
+    # url = 'https://doi.org/10.5281/zenodo.593753'
+    url = 'https://zenodo.org/api/records/593753'
+    jsdata = _download_json(url)
+    if jsdata is None:
+        return None
+
+    return _make_zenodo_citation(jsdata)
+
+
+def _get_citation_zenodo_version(version):
+    """Query Zenodo for the specific release.
+
+    As this has to return all Sherpa records it is slow.
+
+    Returns
+    -------
+    citation : str or None
+        Citation information, if found.
+    """
+
+    # Is there a better way to do this?
+    #
+    url = 'https://zenodo.org/api/records/?q=conceptrecid:"593753"&all_versions=True'
+    jsdata = _download_json(url)
+    if jsdata is None:
+        return None
+
+    try:
+        hits = jsdata['hits']['hits']
+    except KeyError:
+        dbg("Unable to find hits/hits")
+        return None
+
+    data = None
+    try:
+        for hit in hits:
+            if hit['metadata']['version'] == version:
+                data = hit
+                break
+
+    except KeyError:
+        dbg("Record missing version")
+        return None
+
+    except TypeError:
+        dbg('hits/hits is not iterable!')
+        return None
+
+    if data is None:
+        dbg('Version {} not found'.format(version))
+        return None
+
+    return _make_zenodo_citation(data, latest=False)
+
+
+def _get_citation(version='latest'):
+    """Retrieve the citation information.
+
+    Parameters
+    ----------
+    version : str, optional
+        The version to retrieve the citation before. The supported
+        values are limited to 'latest' and the current set of
+        releases available on Zenodo (this goes back to '4.8.0').
+
+    Returns
+    -------
+    citation : str
+        Citation information.
+
+    """
+
+    if version == 'latest':
+        out = _get_citation_zenodo_latest()
+        if out is not None:
+            return out
+
+        return DEFAULT_CITATION
+
+    # If we know this version there's no need to call Zenodo
+    #
+    out = _get_citation_hardcoded(version)
+    if out is not None:
+        return out
+
+    # In case the hardcoded list hasn't been updated.
+    #
+    out = _get_citation_zenodo_version(version)
+    if out is not None:
+        return out
+
+    return DEFAULT_CITATION
+
+
+def citation(version='latest', filename=None, clobber=False):
+    """Return citatation information for Sherpa.
+
+    The citation information is taken from Zenodo [1]_, using the
+    Sherpa "latest release" identifier [2]_, and so requires an
+    internet connection. The message is displaye on screen, using
+    pagination, or can be written to a file.
+
+    Parameters
+    ----------
+    version : str, optional
+        The version to retrieve the citation before. The supported
+        values are limited to 'latest' and the current set of
+        releases available on Zenodo (this goes back to '4.8.0').
+    filename : str or StringIO or None, optional
+        If not None, write the output to the given file or filelike
+        object.
+    clobber : bool, optional
+        If filename is a string, then - when clobber is set - refuse
+        to overwrite the file if it already exists.
+
+    Notes
+    -----
+    If there is no internet connection, or there was a problem in
+    downloading the data, or the Zenodo API has started to return
+    different informatioon than expected, then the code will return
+    the basic information (that is, as if run with
+    ``download=False``).
+
+    Zenodo only lets you perform a limited number of calls in
+    a set time span, so if you call this routine too many times
+    then it may start to fail.
+
+    References
+    ----------
+
+    .. [1] https://zenodo.org/
+
+    .. [2] https://doi.org/10.5281/zenodo.593753
+
+    """
+
+    from sherpa.ui.utils import _send_to_pager
+    cite = _get_citation(version=version)
+    _send_to_pager(cite, filename=filename, clobber=clobber)
 
 
 def get_include():

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -31,8 +31,9 @@ import numpy
 
 import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, create_non_delta_rmf
-from sherpa.ui.utils import _argument_type_error, _check_type, _send_to_pager
-from sherpa.utils import SherpaInt, SherpaFloat, sao_arange
+from sherpa.ui.utils import _argument_type_error, _check_type
+from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
+    send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.data import Data1D, Data1DAsymmetricErrs
@@ -524,7 +525,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
         txt = self._get_show_bkg(id, bkg_id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_bkg_source(self, id=None, bkg_id=None, outfile=None, clobber=False):
         """Display the background model expression for a data set.
@@ -568,7 +569,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
         txt = self._get_show_bkg_source(id, bkg_id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_bkg_model(self, id=None, bkg_id=None, outfile=None, clobber=False):
         """Display the background model expression used to fit a data set.
@@ -613,7 +614,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
         txt = self._get_show_bkg_model(id, bkg_id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     ###########################################################################
     # Data

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -81,16 +81,23 @@ def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False,
                      help="run slow tests")
 
+    parser.addoption("--runzenodo", action="store_true", default=False,
+                     help="run tests that query Zenodo (requires internet)")
+
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
 
+    # Skip tests unless --runxxx given in cli
+    #
+    for label in ["slow", "zenodo"]:
+        opt = "--run{}".format(label)
+        if config.getoption(opt):
+            continue
+
+        skip = pytest.mark.skip(reason="need {} option to run".format(opt))
+        for item in items:
+            if label in item.keywords:
+                item.add_marker(skip)
 
 
 # Whilelist of known warnings. One can associate different warning messages
@@ -261,7 +268,7 @@ def pytest_configure(config):
     This configuration hook overrides the default mechanism for test data self-discovery, if the --test-data command line
     option is provided
 
-    It also adds support for the "slow" test marker
+    It also adds support for the "slow" and "zenodo" test markers.
 
     Parameters
     ----------
@@ -275,6 +282,7 @@ def pytest_configure(config):
         pass
 
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "zenodo: indicates requires internet access to Zenodo")
 
 
 @pytest.fixture(scope="session")

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -65,10 +65,12 @@ def test_citation_hardcoded(tmpdir):
         sherpa.citation('4.8.0', filename=fh, clobber=True)
 
     cts = citefile.read_text('ascii').split('\n')
-    assert cts[0] == 'Sherpa 4.8.0 was released on January 27, 2016.'
+    assert cts[0].startswith('You are using Sherpa ')
     assert cts[1] == ''
-    assert cts[2] == '@software{sherpa_2016_45243,'
-    assert len(cts) == 63
+    assert cts[2] == 'Sherpa 4.8.0 was released on January 27, 2016.'
+    assert cts[3] == ''
+    assert cts[4] == '@software{sherpa_2016_45243,'
+    assert len(cts) == 65
 
 
 @pytest.mark.zenodo

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2018, 2020
+#          Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,31 +19,36 @@
 #
 
 import os.path
+
+import pytest
+
 import sherpa
-from sherpa.utils.testing import SherpaTestCase, requires_data
 from sherpa import ui
+from sherpa.utils.testing import requires_data
+
+
+def test_include_dir():
+    incdir = os.path.join(sherpa.get_include(), 'sherpa')
+    assert os.path.isdir(incdir)
 
 
 @requires_data
-class test_sherpa(SherpaTestCase):
+def test_not_reading_header_without_comment(make_data_path):
+    with pytest.raises(ValueError):
+        ui.load_data(make_data_path('agn2'))
 
-    def test_include_dir(self):
-        incdir = os.path.join(sherpa.get_include(), 'sherpa')
-        self.assertTrue(os.path.isdir(incdir))
 
-    def setUp(self):
-        self.agn2 = self.make_path('agn2')
-        self.agn2_fixed = self.make_path('agn2_fixed')
-        self.template_idx = self.make_path('table.txt')
+@requires_data
+def test_require_float(make_data_path):
+    with pytest.raises(ValueError):
+        ui.load_data(make_data_path('agn2'))
 
-    def test_not_reading_header_without_comment(self):
-        self.assertRaises(ValueError, ui.load_data, self.agn2)
 
-    def test_reading_floats(self):
-        ui.load_data(self.agn2_fixed)
+@requires_data
+def test_reading_floats(make_data_path):
+    ui.load_data(make_data_path('agn2_fixed'))
 
-    def test_reading_strings(self):
-        ui.load_data(self.template_idx, require_floats=False)
 
-    def test_require_float(self):
-        self.assertRaises(ValueError, ui.load_data, self.agn2)
+@requires_data
+def test_reading_strings(make_data_path):
+    ui.load_data(make_data_path('table.txt'), require_floats=False)

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -52,3 +52,25 @@ def test_reading_floats(make_data_path):
 @requires_data
 def test_reading_strings(make_data_path):
     ui.load_data(make_data_path('table.txt'), require_floats=False)
+
+
+# tmp_path is not supported by pytest 3.8.1 which we are using
+# for Python 3.5 tests, so we have to use tmpdir
+#
+def test_citation_hardcoded(tmpdir):
+    """Check citation works for hardcoded queries.
+
+    We do not try to query Zenodo as we don't want to
+    suffer network issues, run out of queries, or
+    unnescessarily overload Zenodo.
+    """
+
+    citefile = tmpdir.mkdir("citation").join("cite.txt")
+    with citefile.open(mode='w') as fh:
+        sherpa.citation('4.8.0', filename=fh, clobber=True)
+
+    cts = citefile.read_text('ascii').split('\n')
+    assert cts[0] == 'Sherpa 4.8.0 was released on January 27, 2016.'
+    assert cts[1] == ''
+    assert cts[2] == '@software{sherpa_2016_45243,'
+    assert len(cts) == 63

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -58,12 +58,7 @@ def test_reading_strings(make_data_path):
 # for Python 3.5 tests, so we have to use tmpdir
 #
 def test_citation_hardcoded(tmpdir):
-    """Check citation works for hardcoded queries.
-
-    We do not try to query Zenodo as we don't want to
-    suffer network issues, run out of queries, or
-    unnescessarily overload Zenodo.
-    """
+    """Check citation works for hardcoded queries."""
 
     citefile = tmpdir.mkdir("citation").join("cite.txt")
     with citefile.open(mode='w') as fh:
@@ -74,3 +69,47 @@ def test_citation_hardcoded(tmpdir):
     assert cts[1] == ''
     assert cts[2] == '@software{sherpa_2016_45243,'
     assert len(cts) == 63
+
+
+@pytest.mark.zenodo
+def test_todo_latest_success(tmpdir):
+    """Check Zenodo knows about the current version.
+
+    Since we don't know what the actual text should be, this
+    is not a full test, but enough to know that the
+    information has been extracted.
+    """
+
+    citefile = tmpdir.mkdir("citation").join("cite.txt")
+    with citefile.open(mode='w') as fh:
+        sherpa.citation('latest', filename=fh)
+
+    cts = citefile.read_text('utf-8').split('\n')
+    assert cts[0].startswith('You are using Sherpa ')
+    assert cts[1] == ''
+    assert cts[2].startswith('The latest release of Sherpa is ')
+    assert cts[3].startswith('released on ')
+    assert cts[4] == ''
+    assert cts[5].startswith('@software{sherpa_')
+    assert 'Please review the Zenodo Sherpa page at' in cts
+    assert '@INPROCEEDINGS{2001SPIE.4477...76F,' in cts
+    assert '@INPROCEEDINGS{2007ASPC..376..543D,' in cts
+
+
+@pytest.mark.zenodo
+def test_todo_version_fail(tmpdir):
+    """Check Zenodo can not found an invalid version"""
+
+    citefile = tmpdir.mkdir("citation").join("cite.txt")
+    with citefile.open(mode='w') as fh:
+        sherpa.citation('4.7.0', filename=fh)
+
+    cts = citefile.read_text('utf-8').split('\n')
+    assert cts[0].startswith('You are using Sherpa ')
+    assert cts[1] == ''
+    assert cts[2] == 'There was a problem retireving the data from Zenodo:'
+    assert cts[3] == 'Zenodo has no information for version 4.7.0.'
+    assert cts[4] == ''
+    assert cts[5] == 'Please review the Zenodo Sherpa page at'
+    assert '@INPROCEEDINGS{2001SPIE.4477...76F,' in cts
+    assert '@INPROCEEDINGS{2007ASPC..376..543D,' in cts

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -25,13 +25,13 @@ import logging
 import sys
 import os
 import inspect
-import pydoc
 
 import numpy
 
 import sherpa.all
 from sherpa.models.basic import TableModel
-from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, export_method
+from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
+    export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     IdentifierErr, IOErr, ModelErr, SessionErr
 
@@ -89,45 +89,6 @@ def _fix_array(arg, argname, ndims=1):
 
 def _is_subclass(t1, t2):
     return inspect.isclass(t1) and issubclass(t1, t2) and (t1 is not t2)
-
-
-def _send_to_pager(txt, filename=None, clobber=False):
-    """Write out the given string, using pagination if supported.
-
-    This used to call out to using less/more but now is handled
-    by pydoc.pager
-
-    Parameters
-    ----------
-    txt : str
-        The text to display
-    filename : str or StringIO or None, optional
-        If not None, write the output to the given file or filelike
-        object.
-    clobber : bool, optional
-        If filename is a string, then - when clobber is set - refuse
-        to overwrite the file if it already exists.
-
-    """
-
-    if filename is None:
-        pydoc.pager(txt)
-        return
-
-    # Have we been sent a StringIO-like object?
-    #
-    if hasattr(filename, 'write'):
-        print(txt, file=filename)
-        return
-
-    # Assume a filename
-    clobber = sherpa.utils.bool_cast(clobber)
-    _check_type(filename, string_types, 'filename', 'a string')
-    if os.path.isfile(filename) and not clobber:
-        raise IOErr('filefound', filename)
-
-    with open(filename, 'w') as fh:
-        print(txt, file=fh)
 
 
 ###############################################################################
@@ -726,7 +687,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_stat()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_method(self, outfile=None, clobber=False):
         """Display the current optimization method and options.
@@ -771,7 +732,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_method()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_fit(self, outfile=None, clobber=False):
         """Summarize the fit results.
@@ -808,7 +769,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_fit()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_data(self, id=None, outfile=None, clobber=False):
         """Summarize the available data sets.
@@ -844,7 +805,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_data(id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_filter(self, id=None, outfile=None, clobber=False):
         """Show any filters applied to a data set.
@@ -883,7 +844,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_filter(id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_model(self, id=None, outfile=None, clobber=False):
         """Display the model expression used to fit a data set.
@@ -925,7 +886,7 @@ class Session(NoNewAttributesAfterInit):
         """
         txt = self._get_show_psf(id)
         txt += self._get_show_model(id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_source(self, id=None, outfile=None, clobber=False):
         """Display the source model expression for a data set.
@@ -965,7 +926,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_source(id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     # DOC-TODO: how and where to describe the PSF/kernel difference
     # as the Notes section below is inadequate
@@ -1020,7 +981,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_kernel(id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     # DOC-TODO: how and where to describe the PSF/kernel difference
     # as the Notes section below is inadequate
@@ -1075,7 +1036,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_psf(id)
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_conf(self, outfile=None, clobber=False):
         """Display the results of the last conf evaluation.
@@ -1108,7 +1069,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_conf()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_proj(self, outfile=None, clobber=False):
         """Display the results of the last proj evaluation.
@@ -1141,7 +1102,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_proj()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_covar(self, outfile=None, clobber=False):
         """Display the results of the last covar evaluation.
@@ -1174,7 +1135,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         txt = self._get_show_covar()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def show_all(self, id=None, outfile=None, clobber=False):
         """Report the current state of the Sherpa session.
@@ -1233,7 +1194,7 @@ class Session(NoNewAttributesAfterInit):
         txt += self._get_show_conf()
         txt += self._get_show_proj()
         txt += self._get_show_covar()
-        _send_to_pager(txt, outfile, clobber)
+        send_to_pager(txt, outfile, clobber)
 
     def get_functions(self):
         """Return the functions provided by Sherpa.
@@ -1288,7 +1249,7 @@ class Session(NoNewAttributesAfterInit):
         for func in funcs_list:
             funcs += '%s\n' % func
 
-        _send_to_pager(funcs, outfile, clobber)
+        send_to_pager(funcs, outfile, clobber)
 
     ###########################################################################
     # IDs and general data management

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -22,13 +22,17 @@
 Objects and utilities used by multiple Sherpa subpackages
 """
 
+import logging
 import operator
+import os
 import inspect
 from types import FunctionType as function
 from types import MethodType as instancemethod
 import string
 import sys
-from configparser import ConfigParser, NoSectionError, NoOptionError
+from configparser import ConfigParser, NoSectionError
+import pydoc
+
 import numpy
 import numpy.random
 import numpy.fft
@@ -42,7 +46,6 @@ from sherpa.utils import _psf
 
 from sherpa import get_config
 
-import logging
 warning = logging.getLogger("sherpa").warning
 debug = logging.getLogger("sherpa").debug
 
@@ -63,7 +66,7 @@ _multi = False
 
 try:
     import multiprocessing
-    
+
     multiprocessing_start_method = config.get('multiprocessing', 'multiprocessing_start_method', fallback='fork')
 
     if multiprocessing_start_method not in ('fork', 'spawn', 'default'):
@@ -73,7 +76,7 @@ try:
         multiprocessing.set_start_method(multiprocessing_start_method, force=True)
 
     _multi = True
-    
+
     if _ncpus is None:
         _ncpus = multiprocessing.cpu_count()
 except Exception as e:
@@ -103,7 +106,8 @@ __all__ = ('NoNewAttributesAfterInit', 'SherpaFloat',
            'pad_bounding_box', 'parallel_map', 'parallel_map_funcs',
            'param_apply_limits', 'parse_expr', 'poisson_noise',
            'print_fields', 'rebin',
-           'sao_arange', 'sao_fcmp', 'set_origin', 'sum_intervals', 'zeroin',
+           'sao_arange', 'sao_fcmp', 'send_to_pager',
+           'set_origin', 'sum_intervals', 'zeroin',
            'multinormal_pdf', 'multit_pdf', 'get_error_estimates', 'quantile')
 
 
@@ -4143,3 +4147,41 @@ def public(f):
     if f.__name__ not in _all:  # Prevent duplicates if run from an IDE.
         _all.append(f.__name__)
     return f
+
+
+def send_to_pager(txt, filename=None, clobber=False):
+    """Write out the given string, using pagination if supported.
+
+    This used to call out to using less/more but now is handled
+    by pydoc.pager
+
+    Parameters
+    ----------
+    txt : str
+        The text to display
+    filename : str or StringIO or None, optional
+        If not None, write the output to the given file or filelike
+        object.
+    clobber : bool, optional
+        If filename is a string, then - when clobber is set - refuse
+        to overwrite the file if it already exists.
+
+    """
+
+    if filename is None:
+        pydoc.pager(txt)
+        return
+
+    # Have we been sent a StringIO-like object?
+    #
+    if hasattr(filename, 'write'):
+        print(txt, file=filename)
+        return
+
+    # Assume a filename
+    clobber = bool_cast(clobber)
+    if os.path.isfile(filename) and not clobber:
+        raise IOErr('filefound', filename)
+
+    with open(filename, 'w') as fh:
+        print(txt, file=fh)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -70,7 +70,7 @@ try:
     multiprocessing_start_method = config.get('multiprocessing', 'multiprocessing_start_method', fallback='fork')
 
     if multiprocessing_start_method not in ('fork', 'spawn', 'default'):
-       raise ValueError('multiprocessing_start method must be one of "fork", "spawn", or "default"')
+        raise ValueError('multiprocessing_start method must be one of "fork", "spawn", or "default"')
 
     if multiprocessing_start_method != 'default':
         multiprocessing.set_start_method(multiprocessing_start_method, force=True)


### PR DESCRIPTION
# Summary

Improve information on how to cite Sherpa in the CITATION file and with a new method, sherpa.citation, which will display the citation information provided by Zenodo.

# Details

The sherpa.citation method can either query Zenodo to get the data or look up a hard-coded table (stored in the sherpa module) for past releases. The output is of the form

 - what version of Sherpa you are using
 - the Zenodo citation or a message saying it couldn't be found (the version isn't known, the Zenodo API has changed and no-longer returns the information we are expecting, there is no internet connection, or a glitch in the download)
 - information on how to cite vresions, linking to the Zenodo help page
 - Two "general purpose" references to Sherpa

# Example

If you were using a released version then the citation method would return something like

```
>>> sherpa.citation()
You are using Sherpa 4.12.1.

Sherpa 4.12.1 was released on July 14, 2020.

@software{sherpa_2020_3944985,
  author       = {DougBurke and
                  Omar Laurino and
                  wmclaugh and
                  dtnguyen2 and
                  Marie-Terrell and
                  Hans Moritz Günther and
                  Jamie Budynkiewicz and
                  Aneta Siemiginowska and
                  Tom Aldcroft and
                  Christoph Deil and
                  Brigitta Sipőcz and
                  Katrin Leinweber and
                  Todd},
  title        = {sherpa/sherpa: Sherpa 4.12.1},
  month        = jul,
  year         = 2020,
  publisher    = {Zenodo},
  version      = {4.12.1},
```

If you are using a random commit then you'll see something like the following, except that the response depends on whether the version number exists on Zenodo (in which case you will get that information - ie the `@citation{sherpa_...}` section from above), or a warning that the version isn't known, such as

```
>>> sherpa.citation()
You are using Sherpa 4.13.0+442.g38fb7ea5 (it is not a released version).

There was a problem retireving the data from Zenodo:
Zenodo has no information for version 4.13.0.

Please review the Zenodo Sherpa page at
       https://doi.org/10.5281/zenodo.593753
to identify the latest release of Sherpa. The Zenodo page
https://help.zenodo.org/#versioning provides information on how to
cite a specific version.

If you want a general-purpose citation then please use either of the
following, kindly provided by the SAO/NASA Astrophysics Data System
service:

@INPROCEEDINGS{2001SPIE.4477...76F,
       author = {{Freeman}, Peter and {Doe}, Stephen and {Siemiginowska}, Aneta},
...
```


# Background

Needing to cite Sherpa in a publication that will hopefully happen soon, I checked the `CITATION` file and realized that there is nothing present for a native software citation.
Trying to establish citation principles that will give everyone due credit, as well as create traceable records of a work unit like a piece of software, the [FORCE11 Software Citation Working Group](https://www.force11.org/about) published a [paper presenting software citation principles](https://www.force11.org/software-citation-principles). This includes the need to cite the software product directly, *additionally* to software papers (see section 6.2):
> 6.2 **Software papers.** Currently, and for the foreseeable future, software papers are being published and cited, in addition to software itself being published and cited, as many community norms and practices are oriented towards citation of papers. [...] **the software itself should be cited on the same basis as any other research product; authors should cite the appropriate set of software products**. If a software paper exists and it contains results (performance, validation, etc.) that are important to the work, then the software paper should also be cited. We believe that a request from the software authors to cite a paper should typically be respected, and the paper cited **in addition** to the software.

This prompted me to submit this PR adding a section to the `CITATION` file that asks to cite the software directly as well, which is easy since `sherpa` has a Zenodo DOI and is hence easily citable.

It would be great to see this included and move towards this as a general standard in citing software. Please do advise though in case this is not wanted or wanted to be done differently.

