### PR TITLE
update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER=1.11 TRAVIS_PYTHON_VERSION="2.7"
-    # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 1.5
-    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=1 TRAVIS_PYTHON_VERSION="3.5"
+    # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
+    - env: XSPECVER="12.9.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
       sudo: required
       dist: trusty
     # As above, Python 3.6, setup.py install, xspec 12.10

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -38,6 +38,7 @@ fi
 
 conda config --add channels ${sherpa_channel}
 conda config --add channels ${xspec_channel}
+conda config --add channels anaconda
 
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi


### PR DESCRIPTION
Anaconda changed their channels and libgfortran=3 was not available anymore. When adding the new `anaconda` channel, which contains libgfortran=3, matplotlib 1 cause a segmentation fault before even running the tests. This PR updates the CI configuration to add the `anaconda` channel as well as to update matplotlib to >=2 on all jobs.