### PR TITLE
fixed the compiler warning for the minim.hh file

### DIFF
--- a/sherpa/optmethods/src/minim.hh
+++ b/sherpa/optmethods/src/minim.hh
@@ -95,7 +95,7 @@ namespace sherpa {
       const real FIVE = 5.0;
       real RSQ = 0.0;
       real W = 0.0;
-      int I, J, K;
+      int I=0, J, K;
 
       IFAULT = 1;
       if (N <= 0) goto g100;


### PR DESCRIPTION
# Release Note

A simple fix for the annoying compiler warning in the minim.hh file.

# Details:
The compiler warning:
```
sherpa/optmethods/src/minim.hh:151:10: warning: ‘I’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         R[I-1] = RSQ/W;
          ^
sherpa/optmethods/src/minim.hh:98:11: note: ‘I’ was declared here
       int I, J, K;
           ^
```
should be fixed with the simple change from:
 ```int I, J, K;```
to
```int I=0, J, K;```