### PR TITLE
fix 'tuple index out of range' error in the fit.est_errors method

### DIFF
--- a/docs/_examples/fit/index.py
+++ b/docs/_examples/fit/index.py
@@ -150,12 +150,6 @@ report("coverrs.extra_output")
 print([p.split('.')[1] for p in coverrs.parnames])
 
 
-# HACK due to https://github.com/sherpa/sherpa/issues/342
-
-f.thaw_indices = tuple(i for i, p in enumerate(f.model.pars)
-                       if not p.frozen)
-
-
 from sherpa.estmethods import Confidence
 f.estmethod = Confidence()
 print("*** about to start confidence run")

--- a/docs/fit/index.rst
+++ b/docs/fit/index.rst
@@ -160,7 +160,7 @@ fit the model to the data
    statval   = 840.2511999999999
    numpoints = 6
    dof       = 4
-   qval      = 1.46616165292e-180
+   qval      = 1.4661616529226985e-180
    rstat     = 210.06279999999998
 
 The fields in the :py:class:`~sherpa.fit.StatInfoResults` depend on
@@ -229,8 +229,8 @@ provides a summary of the fit:
    Probability [Q-value] = 4.67533e-20
    Reduced statistic     = 24.2048
    Change in statistic   = 743.432
-      polynom1d.c0   -11.0742    
-      polynom1d.c2   0.503612    
+      polynom1d.c0   -11.0742     +/- 2.91223     
+      polynom1d.c2   0.503612     +/- 0.0311568   
 
 The information is also available directly as fields of the
 :py:class:`~sherpa.fit.FitResults` object:
@@ -242,13 +242,13 @@ The information is also available directly as fields of the
    statname       = chi2
    succeeded      = True
    parnames       = ('polynom1d.c0', 'polynom1d.c2')
-   parvals        = (-11.074165156709268, 0.50361247735062253)
+   parvals        = (-11.074165156709268, 0.5036124773506225)
    statval        = 96.8190901009578
    istatval       = 840.2511999999999
-   dstatval       = 743.432109899
+   dstatval       = 743.4321098990422
    numpoints      = 6
    dof            = 4
-   qval           = 4.67533320771e-20
+   qval           = 4.675333207707564e-20
    rstat          = 24.20477252523945
    message        = successful termination
    nfev           = 6
@@ -342,9 +342,9 @@ solution, with a reduced chi square value of :math:`\simeq 1.3`:
    Probability [Q-value] = 0.259653
    Reduced statistic     = 1.33894
    Change in statistic   = 92.8023
-      polynom1d.c0   -9.38489    
-      polynom1d.c1   -2.41692    
-      polynom1d.c2   0.478273       
+      polynom1d.c0   -9.38489     +/- 2.91751     
+      polynom1d.c1   -2.41692     +/- 0.250889    
+      polynom1d.c2   0.478273     +/- 0.0312677   
 
 The previous plot objects can be used, but the model plot has to be
 updated to reflect the new model values. Three new plot styles are used:
@@ -410,14 +410,14 @@ be able to find the best-fit location.
    
    >>> print(mdl.pars[1])
    val         = 10.0
-   min         = -3.40282346639e+38
-   max         = 3.40282346639e+38
+   min         = -3.4028234663852886e+38
+   max         = 3.4028234663852886e+38
    units       = 
    frozen      = False
    link        = None
    default_val = 10.0
-   default_min = -3.40282346639e+38
-   default_max = 3.40282346639e+38
+   default_min = -3.4028234663852886e+38
+   default_max = 3.4028234663852886e+38
 
 How did the optimiser vary the parameters?
 ------------------------------------------
@@ -440,9 +440,9 @@ to make sure that any existing file is overwritten):
    Probability [Q-value] = 0.259653
    Reduced statistic     = 1.33894
    Change in statistic   = 196013
-      polynom1d.c0   -9.38489    
-      polynom1d.c1   -2.41692    
-      polynom1d.c2   0.478273    
+      polynom1d.c0   -9.38489     +/- 2.91751     
+      polynom1d.c1   -2.41692     +/- 0.250889    
+      polynom1d.c2   0.478273     +/- 0.0312677   
 
 The output file is a simple ASCII file where the columns give the
 function evaluation number, the statistic, and the parameter values::
@@ -498,7 +498,7 @@ see if freeing up :math:`c_1` is statistically meaningful.
 
    >>> from sherpa.utils import calc_mlr
    >>> calc_mlr(res.dof - res2.dof, res.statval - res2.statval)
-   5.7788876325820937e-22
+   5.778887632582094e-22
 
 This provides evidence that the three-term model (with :math:`c_1`
 free) is a statistically better fit, but
@@ -566,9 +566,9 @@ by ``fit``):
    sigma       = 1
    percent     = 68.2689492137
    parnames    = ('polynom1d.c0', 'polynom1d.c1', 'polynom1d.c2')
-   parvals     = (-9.3848895072689729, -2.4169154937357664, 0.47827334260997567)
-   parmins     = (-2.9175079401565722, -0.25088931712955043,-0.031267664298717336)
-   parmaxes    = (2.9175079401565722, 0.25088931712955043, 0.031267664298717336)
+   parvals     = (-9.384889507268973, -2.4169154937357664, 0.47827334260997567)
+   parmins     = (-2.917507940156572, -0.2508893171295504, -0.031267664298717336)
+   parmaxes    = (2.917507940156572, 0.2508893171295504, 0.031267664298717336)
    nfits       = 0
 
 The default is to calculate the one-sigma (68.3%) limits for
@@ -652,26 +652,6 @@ The order of these rows and columns matches that of the
 
 Changing the estimator
 ----------------------
-
-.. note::
-
-   There appears to be a
-   `bug in Sherpa <https://github.com/sherpa/sherpa/issues/342>`_
-   whereby calling ``est_errors`` with the ``Confidence``
-   method here will fail with the message::
-
-       IndexError: tuple index out of range
-
-   If you see this message then it appears that the ``thaw_indices``
-   attribute of the fit object has got out of synchronization and
-   needs to be reset with:
-   
-   >>> f.thaw_indices = tuple(i for i, p in enumerate(f.model.pars)
-   ...                        if not p.frozen)
-
-   It should not be needed in most cases (it is only needed here
-   because of the
-   :ref:`earlier change to thaw c1 <fit_thaw_c1>`).
 
 .. _fit_confidence_call:
 
@@ -771,7 +751,7 @@ errors on just :math:`c_1` can be evaluated with the following:
    fitname     = levmar
    statname    = chi2gehrels
    sigma       = 1
-   percent     = 68.2689492137
+   percent     = 68.26894921370858
    parnames    = ('polynom1d.c1',)
    parvals     = (-2.4169154937357664,)
    parmins     = (-0.25088931712955054,)

--- a/sherpa/estmethods/tests/test_conf.py
+++ b/sherpa/estmethods/tests/test_conf.py
@@ -1,0 +1,113 @@
+#
+#  Copyright (C) 2019  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import numpy as np
+import logging
+
+from sherpa.fit import Fit
+from sherpa.data import Data1D
+from sherpa.models.basic import Polynom1D
+from sherpa.estmethods import Confidence
+from sherpa.utils.testing import SherpaTestCase
+from sherpa import ui
+
+logger = logging.getLogger("sherpa")
+
+class test_estmethods(SherpaTestCase):
+
+    _x = [-13, -5, -3, 2, 7, 12]
+    _y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]
+    _e = np.ones(6) * 5
+
+    _conf_bench = {
+        'parnames' : ('mdl.c0', 'mdl.c1', 'mdl.c2'),
+        'parvals' : np.array([-9.384889507344322, -2.4169154937347925,
+                              0.47827334261018023]),
+        'parmins' : np.array([-2.917507940156449, -0.250889317129555,
+                              -0.03126766429871808]),
+        'parmaxes' : np.array([2.91750794015645, 0.250889317129555,
+                               0.03126766429871808])
+        }
+    
+    def setUp(self):
+        # defensive programming (one of the tests has been seen to fail
+        # when the whole test suite is run without this)
+        ui.clean()
+        self._old_logger_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
+        self.data = Data1D('tst', self._x, self._y, self._e)
+        self.mdl = Polynom1D('mdl')
+        
+    def tearDown(self):
+        ui.clean()
+
+        try:
+            logger.setLevel(self._old_logger_level)
+        except AttributeError:
+            pass
+
+    def cmp_results(self, result, tol=1.0e-3):
+        for ii in range(len(self._conf_bench['parnames'])):
+            assert self._conf_bench['parnames'][ii] == result.parnames[ii]
+        self.assertEqualWithinTol(self._conf_bench['parvals'],
+                                  result.parvals, tol)
+        self.assertEqualWithinTol(self._conf_bench['parmins'],
+                                  result.parmins, tol)
+        self.assertEqualWithinTol(self._conf_bench['parmaxes'],
+                                  result.parmaxes, tol)
+        
+    def tst_low_level(self, thaw_c1):
+        if thaw_c1:
+            self.mdl.c1.thaw()
+        self.mdl.c2.thaw()
+        f = Fit(self.data, self.mdl, estmethod=Confidence())
+        self.mdl.c2 = 1
+        f.fit()
+        if not thaw_c1:
+            self.mdl.c1.thaw()
+            f.fit()
+        result = f.est_errors()
+        self.cmp_results(result)
+        
+    def tst_ui(self, thaw_c1):
+        ui.load_arrays(1, self._x, self._y, self._e)
+        ui.set_source(1, ui.polynom1d.mdl)
+        if  thaw_c1:
+            ui.thaw(mdl.c1)
+        ui.thaw(mdl.c2)
+        mdl.c2 = 1
+        ui.fit()
+        if not thaw_c1:
+            ui.thaw(mdl.c1)
+            ui.fit()
+        ui.conf()
+        result = ui.get_conf_results()
+        self.cmp_results(result)
+        
+    def test_low_level_True(self):
+        self.tst_low_level(True)
+
+    def test_low_level_False(self):
+        self.tst_low_level(False)
+
+    def test_ui_True(self):
+        self.tst_ui(True)
+
+    def test_ui_False(self):
+        self.tst_ui(False)        

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1046,14 +1046,9 @@ class Fit(NoNewAttributesAfterInit):
         NoNewAttributesAfterInit.__init__(self)
 
     def calc_thaw_indices(self):
-        iter = 0
-        self.thaw_indices = ()
-        for current_par in self.model.pars:
-            if current_par.frozen:
-                pass
-            else:
-                self.thaw_indices = self.thaw_indices + (iter,)
-            iter = iter + 1
+        self.thaw_indices = \
+            tuple([i for i, par in enumerate(self.model.pars) if not \
+                   par.frozen])
         
     def __setstate__(self, state):
         self.__dict__.update(state)

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1030,14 +1030,7 @@ class Fit(NoNewAttributesAfterInit):
         # that is, in case an exception is raised and
         # this parameter needs to be thawed in the
         # exception handler.
-        self.thaw_indices = ()
-        iter = 0
-        for current_par in self.model.pars:
-            if current_par.frozen:
-                pass
-            else:
-                self.thaw_indices = self.thaw_indices + (iter,)
-            iter = iter + 1
+        self.calc_thaw_indices()
         self.current_frozen = -1
 
         # The number of times that reminimization has occurred
@@ -1052,6 +1045,16 @@ class Fit(NoNewAttributesAfterInit):
                                 itermethod_opts)
         NoNewAttributesAfterInit.__init__(self)
 
+    def calc_thaw_indices(self):
+        iter = 0
+        self.thaw_indices = ()
+        for current_par in self.model.pars:
+            if current_par.frozen:
+                pass
+            else:
+                self.thaw_indices = self.thaw_indices + (iter,)
+            iter = iter + 1
+        
     def __setstate__(self, state):
         self.__dict__.update(state)
 
@@ -1260,6 +1263,11 @@ class Fit(NoNewAttributesAfterInit):
             print(' '.join(vals), file=self._iterfit._file)
             self._iterfit._file.close()
             self._iterfit._file = None
+
+        # if a re-fit was performed with more/less thawed pars then
+        # self.thaw_indices must be re-calculated otherwise Confidence
+        # will get IndexError, see issue #342 for details
+        self.calc_thaw_indices()
 
         return FitResults(self, output, init_stat, param_warnings.strip("\n"))
 

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2009, 2015, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2018, 2019
+#     Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #
-#  Copyright (C) 2009, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
# Release Note

A fix for issue #342.

Sherpa's ```Confidence``` class is confused if a parameter is frozen then thawed after a fit resulting with an exception of the form: ```IndexError: tuple index out of range```.  The error does not show up if conf is called from the ui level