### PR TITLE
Gitlab updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,24 +1,7 @@
 stages:
-  - extract
   - build and package
   - deploy
   - test deploy
-
-extract:
-  stage: extract
-  image: registry.gitlab.com/olaurino/sherpa-docker-build:master
-  variables:
-     GIT_SUBMODULE_STRATEGY: 'none'
-  script:
-     - conda install numpy
-     - python setup.py sdist
-     - python -c "import sherpa; print(sherpa._version.get_versions()['version'])" > dist/version
-     - python -c "import sherpa; print(sherpa._version.get_versions()['full'])" > dist/full
-     - cat dist/version dist/full
-  artifacts:
-     expire_in: "2 weeks"
-     paths:
-         - dist
 
 .template-conda-build: &template_conda_build
   image: registry.gitlab.com/olaurino/sherpa-docker-build:master
@@ -29,11 +12,7 @@ extract:
       - export SHERPA_FULL_VERSION=$(git describe --tags --always)
       - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
       - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
-      - export SHERPA_TARBALL=$(pwd)/$(ls dist/*.tar.gz)
-      - conda build --output-folder /opt/project/packages /opt/project/recipes/sherpa.conda
-      - cp -R /opt/project/packages .
-  dependencies:
-      - extract
+      - conda build --output-folder packages recipes/conda
   artifacts:
     expire_in: "2 weeks"
     paths:
@@ -47,13 +26,7 @@ extract:
       - export SHERPA_FULL_VERSION=$(git describe --tags --always)
       - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
       - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
-      - export SHERPA_TARBALL=$(pwd)/$(ls dist/*.tar.gz)
-      - mkdir ~/packages
-      - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/olaurino/sherpa-docker-build ~/sherpa-docker-build
-      - conda build --output-folder ~/packages ~/sherpa-docker-build/recipes/sherpa.conda
-      - cp -R ~/packages .
-  dependencies:
-      - extract
+      - conda build --output-folder packages recipes/conda
   artifacts:
       expire_in: "2 weeks"
       paths:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,2 @@
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.9.sdk        # [osx]

--- a/recipes/conda/build.sh
+++ b/recipes/conda/build.sh
@@ -1,0 +1,12 @@
+
+sed -i.orig "s|#install_dir=build|install_dir=$PREFIX|" setup.cfg
+
+$PYTHON setup.py clean --all
+
+export PYTHON_LDFLAGS=" "
+
+$PYTHON setup.py install
+
+# This headers are known to collide with astropy's extensions and would prevent astropy from building
+rm -f $PREFIX/include/wcs*.h
+

--- a/recipes/conda/build.sh
+++ b/recipes/conda/build.sh
@@ -5,6 +5,7 @@ $PYTHON setup.py clean --all
 
 export PYTHON_LDFLAGS=" "
 
+$PYTHON setup.py build
 $PYTHON setup.py install
 
 # This headers are known to collide with astropy's extensions and would prevent astropy from building

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -1,0 +1,45 @@
+package:
+ name: sherpa
+ version: {{ environ.get('SHERPA_VERSION') }}
+
+source:
+ url: {{ environ.get('SHERPA_TARBALL') }}
+
+build:
+ number: {{ environ.get('SHERPA_BUILD_NUMBER') }}
+
+requirements:
+ build:
+  - {{ compiler('cxx') }}
+  - {{ compiler('c') }}
+  - make
+  - bison
+  - flex
+
+ host:
+  - python {{ environ.get('SHERPA_PYTHON_VERSION', '2.7.*') }}
+  - numpy 1.11.*
+  - setuptools
+  - six
+
+ run:
+  - python {{ environ.get('SHERPA_PYTHON_VERSION', '2.7.*') }}
+  - numpy >1.11
+  - setuptools
+  - pytest
+  - six
+
+test:
+  imports:
+    - stk
+    - group
+    - sherpa.astro.ui
+ 
+  commands:
+    - sherpa_smoke
+
+about:
+ home: http://cxc.cfa.harvard.edu/sherpa/
+ summary: Sherpa is the CIAO modeling and fitting application. It enables the user to construct complex models from simple definitions and fit those models to data, using a variety of statistics and optimization methods
+ license: GPLv3
+

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -3,7 +3,7 @@ package:
  version: {{ environ.get('SHERPA_VERSION') }}
 
 source:
- url: {{ environ.get('SHERPA_TARBALL') }}
+ path: ../../
 
 build:
  number: {{ environ.get('SHERPA_BUILD_NUMBER') }}


### PR DESCRIPTION
I had to fix some of the infrastructure I use to CI the creation of the conda packages on Gitlab, as the macOS pipeline started failing with Python 3.7 a few weeks ago. I took the opportunity to make a couple of changes to streamline the process, including putting the conda recipe back into Sherpa. I had removed the recipe because the semi-manual approach I had a few years ago made it hard to check that the recipes worked at every merge. But I have had a better, mostly automated setup for a couple of years now, so it makes sense to put the recipes back into the repo.

I won't wait or this PR to be reviewed, as it's purely infrastructural.