### PR TITLE
ignore numpy warning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,10 @@ conda:
       - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip # Hack, gitlab can't checkout the submodule from github
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
       - export PATH=~/miniconda/bin:$PATH
-      - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib # How to make sure it's the correct version?
+      # Numpy 1.16 emits a deprecation warning that trips the pytest package pinned by astropy 2.
+      # By installing numpy 1.15 we work around the issue, which is the only failure recorded with numpy 1.16
+      # Python 2.7 won't be supported for long anyway.
+      - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib numpy=1.15 # How to make sure it's the correct version?
       - source activate test
       - pip install /master.zip
       - sherpa_smoke -f astropy

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -91,7 +91,9 @@ known_warnings = {
         [r"invalid value encountered in sqrt",
          # See https://github.com/ContinuumIO/anaconda-issues/issues/6678
          r"numpy.dtype size changed, may indicate binary " +
-         r"incompatibility. Expected 96, got 88"
+         r"incompatibility. Expected 96, got 88",
+         # I am getting the following from astropy with at least python 2.7 during the conda tests
+         r"numpy.ufunc size changed, may indicate binary ",
          ],
      VisibleDeprecationWarning:
         [r"Passing `normed=True`*",


### PR DESCRIPTION
Gitlab's conda package tests are failing with an unexpected warning triggered by astropy for a suspected incompatibility with numpy. This is similar to See https://github.com/ContinuumIO/anaconda-issues/issues/6678.

It seems safe to whitelist the warning.