### PR TITLE
Remove "dirty" from version string

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,8 @@ stages:
       - export SHERPA_FULL_VERSION=$(git describe --tags --always)
       - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
       - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
-      - conda build --output-folder packages recipes/conda
+      - conda build --output-folder /tmp/packages recipes/conda
+      - cp -r /tmp/packages .
   artifacts:
     expire_in: "2 weeks"
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,8 +102,8 @@ conda:
       # Numpy 1.16 emits a deprecation warning that trips the pytest package pinned by astropy 2.
       # By installing numpy 1.15 we work around the issue, which is the only failure recorded with numpy 1.16
       # Python 2.7 won't be supported for long anyway.
-      - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib numpy=1.15 # How to make sure it's the correct version?
       - conda update -qq -y --all
+      - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib numpy=1.15 # How to make sure it's the correct version?
       - source activate test
       - pip install /master.zip
       - sherpa_smoke -f astropy
@@ -131,23 +131,24 @@ conda:
   script:
     - cd /tmp
     - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip
+    - conda update -qq -y --all
     - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib numpy=1.15 # How to make sure it's the correct version?
-    - source activate test
+    - conda activate test
     - pip install master.zip
     - sherpa_smoke -f astropy
     - sherpa_test
     - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib # How to make sure it's the correct version?
-    - source activate test35
+    - conda activate test35
     - pip install master.zip
     - sherpa_smoke -f astropy
     - sherpa_test
     - conda create -n test36 --yes -q -c sherpa/label/dev python=3.6 astropy sherpa matplotlib # How to make sure it's the correct version?
-    - source activate test36
+    - conda activate test36
     - pip install master.zip
     - sherpa_smoke -f astropy
     - sherpa_test
     - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
-    - source activate test37
+    - conda activate test37
     - pip install master.zip
     - sherpa_smoke -f astropy
     - sherpa_test

--- a/recipes/conda/build.sh
+++ b/recipes/conda/build.sh
@@ -1,5 +1,6 @@
 
 sed -i.orig "s|#install_dir=build|install_dir=$PREFIX|" setup.cfg
+git update-index --assume-unchanged setup.cfg
 
 $PYTHON setup.py clean --all
 


### PR DESCRIPTION
The changes to the infrastructure were resulting in a wrong version string being reported by `sherpa._version.get_versions()`. This PR should fix that. It also uses `conda activate` rather than `source activate` on macOS. For some reason `source activate` was failing (for reasons that have nothing to do with Sherpa).