### PR TITLE
Fix numpy hist warning

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -96,7 +96,7 @@ known_warnings = {
          r"numpy.ufunc size changed, may indicate binary ",
          ],
      VisibleDeprecationWarning:
-        [r"Passing `normed=True`*",
+        [
          r"sctypeNA and typeNA will be removed.*",
         ],
 }

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -96,9 +96,7 @@ known_warnings = {
          r"numpy.ufunc size changed, may indicate binary ",
          ],
      VisibleDeprecationWarning:
-        [
-         r"sctypeNA and typeNA will be removed.*",
-        ],
+        [],
 }
 
 if sys.version_info >= (3, 2):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -294,7 +294,7 @@ class PDFPlot(HistogramPlot):
 
     def prepare(self, points, bins=12, normed=True, xlabel="x", name="x"):
         self.points = points
-        self.y, xx = numpy.histogram(points, bins=bins, normed=normed)
+        self.y, xx = numpy.histogram(points, bins=bins, density=normed)
         self.xlo = xx[:-1]
         self.xhi = xx[1:]
         self.ylabel = "probability density"

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -482,5 +482,11 @@ def test_numpy_histogram_density_vs_normed(make_data_path):
     c = ui.get_model_component('c')
     ui.fit()
     res = ui.eqwidth(c, c+c, error=True)
-    ui.get_pdf_plot()
     ui.plot_pdf(res[4])
+    plot = ui.get_pdf_plot()
+    expected_x = numpy.linspace(2.5, 3.5, 13)
+    expected_xlo, expected_xhi = expected_x[:-1], expected_x[1:]
+    expected_y = [0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0]
+    assert plot.y == pytest.approx(expected_y)
+    assert plot.xlo == pytest.approx(expected_xlo)
+    assert plot.xhi == pytest.approx(expected_xhi)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -474,7 +474,7 @@ def test_source_component_arbitrary_grid_int():
     numpy.testing.assert_array_equal(ui._compsrcplot.y, [10, 10, 10, 100, 100, 100])
 
 
-def test_numpy_histogram_density_vs_normed(make_data_path):
+def test_numpy_histogram_density_vs_normed():
     from sherpa.astro import ui
 
     ui.load_arrays(1, [1, 2, 3], [1, 2, 3])

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -22,6 +22,9 @@ import numpy
 import pytest
 
 import sherpa.all as sherpa
+from sherpa.astro.ui.utils import Session
+from sherpa.models import Const1D
+from sherpa.data import Data1DInt
 from sherpa.utils.testing import SherpaTestCase, requires_data, requires_plotting
 
 _datax = numpy.array(
@@ -405,9 +408,6 @@ class test_confidence(SherpaTestCase):
 
 @requires_plotting
 def test_source_component_arbitrary_grid():
-    from sherpa.astro.ui.utils import  Session
-    from sherpa.models import Const1D
-
     ui = Session()
 
     x = [1, 2, 3]
@@ -429,10 +429,6 @@ def test_source_component_arbitrary_grid():
 
 @requires_plotting
 def test_plot_model_arbitrary_grid_integrated():
-    from sherpa.astro.ui.utils import Session
-    from sherpa.models import Const1D
-    from sherpa.data import Data1DInt
-
     ui = Session()
 
     x = [1, 2, 3], [2, 3, 4]
@@ -455,10 +451,6 @@ def test_plot_model_arbitrary_grid_integrated():
 
 @requires_plotting
 def test_source_component_arbitrary_grid_int():
-    from sherpa.astro.ui.utils import Session
-    from sherpa.models import Const1D
-    from sherpa.data import Data1DInt
-
     ui = Session()
 
     x = numpy.array([1, 2, 3]), numpy.array([2, 3, 4])

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -472,3 +472,15 @@ def test_source_component_arbitrary_grid_int():
 
     numpy.testing.assert_array_equal(ui._compsrcplot.x, points)
     numpy.testing.assert_array_equal(ui._compsrcplot.y, [10, 10, 10, 100, 100, 100])
+
+
+def test_numpy_histogram_density_vs_normed(make_data_path):
+    from sherpa.astro import ui
+
+    ui.load_arrays(1, [1, 2, 3], [1, 2, 3])
+    ui.set_source('const1d.c')
+    c = ui.get_model_component('c')
+    ui.fit()
+    res = ui.eqwidth(c, c+c, error=True)
+    ui.get_pdf_plot()
+    ui.plot_pdf(res[4])


### PR DESCRIPTION
# Release Note
When plotting a PDF Sherpa now calls `numpy.histogram` with `density=True|False` rather than `normed=True|False`. There is no change visible to the user other than a warning that will not be issued anymore. `normed=True` was broken for non uniform bins, but our code always produces uniform bins, so we should never hit the problematic case.

# Notes
@anetasie @DougBurke it would be good if you could confirm the change does not produce any differences in real world cases.