### PR TITLE
add warning when chips is selected but cannot be imported

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -55,13 +55,28 @@ if plot_opt == 'none_backend':
 try:
     importlib.import_module('.' + plot_opt, package='sherpa.plot')
     backend = sys.modules['sherpa.plot.' + plot_opt]
-except:
+except ImportError:
     # if the user inputs a malformed backend or it is not found,
     # give a useful warning and fall back on dummy_backend of noops
-    warning('failed to import sherpa.plot.%s;' % plot_opt +
-            ' plotting routines will not be available')
-    from . import dummy_backend as backend
-    plot_opt = 'dummy_backend'
+    if plot_opt == 'chips_backend':
+        warning('chips is not supported in CIAO 4.12+, falling back to matplotlib.')
+        warning('Please consider updating your $HOME/.sherpa.rc file to suppress this warning.')
+        plot_opt = 'pylab_backend'
+
+        try:
+            importlib.import_module('.' + plot_opt, package='sherpa.plot')
+            backend = sys.modules['sherpa.plot.' + plot_opt]
+        except ImportError:
+            warning('failed to import sherpa.plot.%s;' % plot_opt +
+                    ' plotting routines will not be available')
+            from . import dummy_backend as backend
+
+            plot_opt = 'dummy_backend'
+    else:
+        warning('failed to import sherpa.plot.%s;' % plot_opt +
+                ' plotting routines will not be available')
+        from . import dummy_backend as backend
+        plot_opt = 'dummy_backend'
 
 backend.init()
 


### PR DESCRIPTION
# Release Note
Sherpa now warns the user if Chips is selected as a backend but it is not available in the installation. In this case Sherpa will also try and fall back to the pylab backend.

# Notes
This fixes CIAO-283.
This was included in ciao4.12b1 and then dropped from the subsequent beta because I only committed it to the ciao-specific branch. I was supposed to issue a PR, and here it is.