### PR TITLE
Update 4.11.1 docs

### DIFF
--- a/docs/data/astrodata.rst
+++ b/docs/data/astrodata.rst
@@ -16,9 +16,10 @@ The sherpa.astro.data module
       DataRMF
       DataIMG
       DataIMGInt
+      DataRosatRMF
    
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: DataPHA DataARF DataRMF DataIMG DataIMGInt
+.. inheritance-diagram:: DataPHA DataARF DataRMF DataIMG DataIMGInt DataRosatRMF
    :parts: 1

--- a/docs/data/data.rst
+++ b/docs/data/data.rst
@@ -11,17 +11,26 @@ The sherpa.data module
    .. autosummary::
       :toctree: api
    
-      BaseData
       Data
-      DataND
       Data1D
+      Data1DAsymmetricErrs
       Data1DInt
       Data2D
       Data2DInt
       DataSimulFit
+      BaseData
+      DataSpace1D
+      DataSpace2D
+      DataSpaceND
+      Filter
+      IntegratedDataSpace1D
+      IntegratedDataSpace2D
 
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: BaseData Data DataND Data1D Data1DInt Data2D Data2DInt DataSimulFit
+.. inheritance-diagram:: BaseData Data Data1D Data1DAsymmetricErrs Data1DInt Data2D Data2DInt DataSimulFit
+   :parts: 1
+
+.. inheritance-diagram:: DataSpace1D DataSpace2D DataSpaceND IntegratedDataSpace1D IntegratedDataSpace2D
    :parts: 1

--- a/docs/model_classes/regrid.rst
+++ b/docs/model_classes/regrid.rst
@@ -23,7 +23,8 @@ The sherpa.models.regrid module
       :toctree: api
 
       rebin_2d
-      rebin_flux
+      rebin_int
+      rebin_no_int
 
 Class Inheritance Diagram
 =========================

--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -235,6 +235,7 @@ burden...
       load_arf
       load_arrays
       load_ascii
+      load_ascii_with_errors
       load_bkg
       load_bkg_arf
       load_bkg_rmf
@@ -306,6 +307,7 @@ burden...
       projection
       reg_proj
       reg_unc
+      resample_data
       reset
       restore
       sample_energy_flux

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1336,6 +1336,7 @@ class Session(sherpa.ui.utils.Session):
         load_arrays : Create a data set from array values.
         load_table : Load a FITS binary file as a data set.
         load_image : Load an image as a data set.
+        resample_data : Resample data with asymmetric error bars.
         set_data : Set a data set.
         unpack_ascii : Unpack an ASCII file into a data structure.
 
@@ -12013,7 +12014,9 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
 
     def resample_data(self, id=None, niter=1000, seed=None):
-        """The function performs a parametric bootstrap assuming a skewed
+        """Resample data with asymmetric error bars.
+
+        The function performs a parametric bootstrap assuming a skewed
         normal distribution centered on the observed data point with the
         variance given by the low and high measurement errors. The function
         simulates niter realizations of the data and fits each realization
@@ -12030,14 +12033,18 @@ class Session(sherpa.ui.utils.Session):
         seed : int, optional
            The seed for the random number generator. The default is ```None```.
 
+        See Also
+        --------
+        load_ascii_with_errors : Load an ASCII file with asymmetric errors as a data set.
+
         Example
         -------
         Account for of asymmetric errors when calculating parameter
         uncertainties:
 
-        >>> load_ascii_with_errors(1,'test.dat')
+        >>> load_ascii_with_errors(1, 'test.dat')
         >>> set_model('polynom1d.p0')
-        >>>  thaw(p0.c1)
+        >>> thaw(p0.c1)
         >>> fit()
         Dataset               = 1
         Method                = levmar
@@ -12049,7 +12056,7 @@ class Session(sherpa.ui.utils.Session):
         Change in statistic   = 4074.79
         p0.c0          3.2661       +/- 0.193009
         p0.c1          2162.19      +/- 65.8445
-        >>> result = resample_data(1,niter=10)
+        >>> result = resample_data(1, niter=10)
         p0.c0 : avg = 4.159973865314249 , std = 1.0575403309799554
         p0.c1 : avg = 1943.5489865678633 , std = 268.64478808013547
         >>> print(result)
@@ -12074,14 +12081,14 @@ class Session(sherpa.ui.utils.Session):
         2185.418945147045,
         2235.9753113309894]}
 
-        # For a large number of realizations the output can be stored in
-        # the dictionary and accessed, for example, to visualize the
-        # distributions.
+        For a large number of realizations the output can be stored in
+        the dictionary and accessed, for example, to visualize the
+        distributions.
 
-        >>> sample = resample_data(1,5000)
+        >>> sample = resample_data(1, 5000)
         p0.c0 : avg = 3.966543284267264 , std = 0.9104639711036427
         p0.c1 : avg = 1988.8417667057342 , std = 220.21903089622705
-        >>> plot_pdf(sample['p0.c0'],bins=40)
+        >>> plot_pdf(sample['p0.c0'], bins=40)
         """
         data = self.get_data(id)
         model = self.get_model(id)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1156,6 +1156,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
+        load_ascii_with_errors : Load an ASCII file with asymmetric errors as a data set.
         load_table : Load a FITS binary file as a data set.
         load_image : Load an image as a data set.
         set_data : Set a data set.
@@ -1300,7 +1301,7 @@ class Session(sherpa.ui.utils.Session):
 
         return data
 
-    def load_ascii_with_errors(self, id, filename=None, colkeys=None, sep=' ', 
+    def load_ascii_with_errors(self, id, filename=None, colkeys=None, sep=' ',
                                comment='#', func=numpy.average, delta=False):
         """Load an ASCII file with asymmetric errors as a data set.
 
@@ -1319,16 +1320,24 @@ class Session(sherpa.ui.utils.Session):
         comment : str, optional
            The comment character. The default is ``'#'``.
         func: python function, optional
-           A python function shall be used to populate the errors, it is of
-           the form:
-                 def avg(lo, hi):
-                     return 0.5 * (lo + hi)
-           The default is the numpy average function.
+           The function used to combine the lo and hi values to estimate
+           an error. The function should take two arguments ``(lo, hi)``
+           and return a single NumPy array, giving the per-bin error.
+           The default function used is numpy.average.
         delta: boolean, optional
            The flag is used to indicate if the asymmetric errors for the
            third and fourth columns are delta values from the second (y)
            column or not.
            The default value is False
+
+        See Also
+        --------
+        load_ascii: Load an ASCII file as a data set.
+        load_arrays : Create a data set from array values.
+        load_table : Load a FITS binary file as a data set.
+        load_image : Load an image as a data set.
+        set_data : Set a data set.
+        unpack_ascii : Unpack an ASCII file into a data structure.
 
         Notes
         -----
@@ -1347,7 +1356,7 @@ class Session(sherpa.ui.utils.Session):
         +----------------------+-----------------+--------------------+
         | Identifier           | Required Fields |   Optional Fields  |
         +======================+=================+====================+
-        | Data1DAsymmetricErrs | x, y, elo, ehi  |                    | 
+        | Data1DAsymmetricErrs | x, y, elo, ehi  |                    |
         +----------------------+-----------------+--------------------+
 
         Examples
@@ -1367,25 +1376,15 @@ class Session(sherpa.ui.utils.Session):
         Read in the first four columns (x, y, elo, ehi) where elo and ehi
         are of the form delta_lo and delta_hi, respectively.
 
+        >>> def rms(lo, hi):
+        ...     return numpy.sqrt(lo * lo + hi * hi)
+        ...
         >>> load_ascii_with_errors('sources.dat', func=rms)
 
         Read in the first four columns (x, y, elo, ehi) where elo and ehi
-        are of the form delta_lo and delta_hi, respectively. The optional
-        function rms is of the form:
-
-        def rms(lo, hi):
-           return numpy.sqrt(lo * lo + hi * hi)
-
-        shall be used to define the elo and ehi.
-
-        See Also
-        --------
-        load_ascii: Load an ASCII file as a data set.
-        load_arrays : Create a data set from array values.
-        load_table : Load a FITS binary file as a data set.
-        load_image : Load an image as a data set.
-        set_data : Set a data set.
-        unpack_ascii : Unpack an ASCII file into a data structure.
+        are of the form delta_lo and delta_hi, respectively. The `func`
+        argument is used to calculate the error based on the elo and ehi
+        column values.
         """
 
         if filename is None:
@@ -1403,7 +1402,7 @@ class Session(sherpa.ui.utils.Session):
                 return func([data.elo, data.ehi], axis=0)
             else:
                 return func(data.elo, data.ehi)
-            
+
         if type(datas) is list:
             for data in datas:
                 if delta is False:
@@ -12012,7 +12011,7 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
     # Analysis Functions
     ###########################################################################
-    
+
     def resample_data(self, id=None, niter=1000, seed=None):
         """The function performs a parametric bootstrap assuming a skewed
         normal distribution centered on the observed data point with the
@@ -12048,7 +12047,7 @@ class Session(sherpa.ui.utils.Session):
         Data points           = 61
         Degrees of freedom    = 59
         Change in statistic   = 4074.79
-        p0.c0          3.2661       +/- 0.193009    
+        p0.c0          3.2661       +/- 0.193009
         p0.c1          2162.19      +/- 65.8445
         >>> result = resample_data(1,niter=10)
         p0.c0 : avg = 4.159973865314249 , std = 1.0575403309799554
@@ -12079,16 +12078,16 @@ class Session(sherpa.ui.utils.Session):
         # the dictionary and accessed, for example, to visualize the
         # distributions.
 
-        >>> sample = resample_data(1,5000)                                  
+        >>> sample = resample_data(1,5000)
         p0.c0 : avg = 3.966543284267264 , std = 0.9104639711036427
         p0.c1 : avg = 1988.8417667057342 , std = 220.21903089622705
-        >>> plot_pdf(sample['p0.c0'],bins=40) 
+        >>> plot_pdf(sample['p0.c0'],bins=40)
         """
         data = self.get_data(id)
         model = self.get_model(id)
         resampledata = sherpa.sim.ReSampleData(data, model)
         return resampledata(niter=niter, seed=seed)
-        
+
     # DOC-TODO: should this accept the confidence parameter?
     def sample_photon_flux(self, lo=None, hi=None, id=None, num=1, scales=None,
                            correlated=False, numcores=None, bkg_id=None):


### PR DESCRIPTION
# Summary

Minor update to the documentation for the 4.11.1 release, to ensure that the ReadTheDocs version contains the latest classes and functions.
 
# Details

Update the Sphinx documentation for some of the changes made in the 4.11.1 release. It is just a case of cleaning-up the existing documentation rather than adding any extra text to explain how the regrid functionality works. There are related minor changes to the docstrings for new functions in this release (`load_ascii_with_errors` and `resample_data`).

Note that I made this against the master branch, rather than the 4.11.1 release branch.

This is a re-submission of #650 to try and avoid branch-related shenanighans. Unfortunately github is too clever to fall for this ...