### PR TITLE
Allow slow tests to be run (not on by default)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -360,10 +360,23 @@ The ``test`` command is a wrapper that calls ``pytest`` under the hood,
 and includes the ``develop`` command.
 
 You can pass additional arguments to ``pytest`` with the ``-a`` or
-``--pytest-args`` arguments.  As an example, a single test can be run
-using the syntax:
+``--pytest-args`` arguments.  As examples, the following two commands
+run all the tests in ``test_data.py`` and then a single named
+test in this file::
 
-    python setup.py test -a sherpa/astro/datastack/tests/test_datastack.py::test_load::test_case3
+    python setup.py test -a sherpa/tests/test_data.py
+    python setup.py test -a sherpa/tests/test_data.py::test_data_eval_model
+
+The full set of options, including those added by the Sherpa test
+suite - which are listed at the end of the ``custom options``
+section - can be found with::
+
+    python setup.py test -a "--pyargs sherpa --help"
+
+and to pass an argument to the Sherpa test suite (there are currently
+two options, namely ``--test-data`` and ``--runslow``)::
+
+    python setup.py test -a "--pyargs sherpa --runslow"
 
 .. note::
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/optmethods/tests/test_ncoresopt.py
+++ b/sherpa/optmethods/tests/test_ncoresopt.py
@@ -20,192 +20,256 @@ from __future__ import print_function
 
 
 from sherpa.utils import _ncpus
-from sherpa import get_config
-from sherpa.utils.testing import SherpaTestCase
-from sherpa.optmethods import optfcts
-from sherpa.optmethods import _tstoptfct
 from sherpa.optmethods.ncoresnm import ncoresNelderMead
 from sherpa.optmethods.ncoresde import ncoresDifEvo
 import sherpa.optmethods.opt as tstopt
 
-class test_optmethods(SherpaTestCase):
+import pytest
 
-    def setUp(self):
-        self.tolerance = 1.0e-2
-        self.ncores_nm = ncoresNelderMead()
-        self.ncores_de = ncoresDifEvo()
-        self.numpar = 10
-        
-    def print_result( self, name, f, x, nfev ):
-        print('%s(%s) = %g in %d nfev' % (name, x, f, nfev))
+NUMPAR = 10
+NCORES_NM = ncoresNelderMead()
+NCORES_DE = ncoresDifEvo()
 
-    def tst_opt(self, opt, fcn, x0, xmin, xmax, fmin):
-        def func(arg):
-            return fcn(arg)[0]
-        nfev, fval, par = opt(func, x0, xmin, xmax)
-        self.assertEqualWithinTol(fval, fmin, self.tolerance)        
 
-    def tst_func(self, opt, func, x0, xmin, xmax, fmin):
-        nfev, fval, par = opt(func, x0, xmin, xmax)
-        self.assertEqualWithinTol(fval, fmin, self.tolerance)        
+def print_result(name, f, x, nfev):
+    print('%s(%s) = %g in %d nfev' % (name, x, f, nfev))
 
-    def test_Ackley(self):
-        xmin = self.numpar * [-32.768]
-        xmax = self.numpar * [32.768]
-        x0 = self.numpar * [12.3]
-        if _ncpus != 1:
-            self.tst_func(self.ncores_nm, tstopt.Ackley, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Ackley, x0, xmin, xmax, 0.0)
 
-    def test_Bohachevsky1(self):
-        xmin = [-100, -100]
-        xmax = [100, 100]
-        x0 = [-12, 10]
-        self.tst_func(self.ncores_nm, tstopt.Bohachevsky1, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Bohachevsky1, x0, xmin, xmax, 0.0)
+# Mapping from SherpaTestCase.assertEqualWithinTol to
+#              pytest.approx
+# and noting that the tolerance is an absolute tolerance,
+# not relative in SherpaTestCase.
+#
+def tst_opt(opt, fcn, x0, xmin, xmax, fmin, tol=1e-2):
+    def func(arg):
+        return fcn(arg)[0]
+    nfev, fval, par = opt(func, x0, xmin, xmax)
+    assert fval == pytest.approx(fmin, abs=tol)
 
-    def test_Bohachevsky2(self):
-        xmin = [-100, -100]
-        xmax = [100, 100]
-        x0 = [12, 10]
-        self.tst_func(self.ncores_nm, tstopt.Bohachevsky2, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Bohachevsky2, x0, xmin, xmax, 0.0)
 
-    def test_Bohachevsky3(self):
-        xmin = [-100, -100]
-        xmax = [100, 100]
-        x0 = [-61.2, 51.0]
-        self.tst_func(self.ncores_nm, tstopt.Bohachevsky3, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Bohachevsky3, x0, xmin, xmax, 0.0)
+def tst_func(opt, func, x0, xmin, xmax, fmin, tol=1e-2):
+    nfev, fval, par = opt(func, x0, xmin, xmax)
+    assert fval == pytest.approx(fmin, abs=tol)
 
-    def test_Booth(self):
-        xmin = [-10, -10]
-        xmax = [10, 10]
-        x0 = [-6.2, 5.0]
-        self.tst_func(self.ncores_nm, tstopt.Booth, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Booth, x0, xmin, xmax, 0.0)
 
-    def test_BoxBetts(self):
-        xmin = [0.9, 9.0, 0.9]
-        xmax = [1.2, 11.2, 1.2]
-        x0 = [(xmin[0] + xmax[0]) * 0.5, (xmin[1] + xmax[1]) * 0.5,
-              (xmin[2] + xmax[2]) * 0.5]
-        self.tst_func(self.ncores_nm, tstopt.BoxBetts, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.BoxBetts, x0, xmin, xmax, 0.0)
+def test_Ackley():
+    xmin = NUMPAR * [-32.768]
+    xmax = NUMPAR * [32.768]
+    x0 = NUMPAR * [12.3]
+    if _ncpus != 1:
+        tst_func(NCORES_NM, tstopt.Ackley, x0, xmin, xmax, 0.0)
 
-    def test_Branin(self):
-        xmin = [-5, 0]
-        xmax = [10, 15]
-        x0 = [-3.2, 5.0]
-        self.tst_func(self.ncores_nm, tstopt.Branin, x0, xmin, xmax, 0.397887)
-        self.tst_func(self.ncores_de, tstopt.Branin, x0, xmin, xmax, 0.397887)
+    tst_func(NCORES_DE, tstopt.Ackley, x0, xmin, xmax, 0.0)
 
-    def test_DixonPrixe(self):
-        xmin = self.numpar * [-10]
-        xmax = self.numpar * [10]
-        x0 = self.numpar * [-1.]
-        self.tst_func(self.ncores_de, tstopt.DixonPrice, x0, xmin, xmax, 0.0)
 
-    def test_Easom(self):
-        xmin = [-100, -100]
-        xmax = [100, 100]
-        x0 = [25.0, 25.0]
-        self.tst_func(self.ncores_de, tstopt.Easom, x0, xmin, xmax, -1.0)
+def test_Bohachevsky1():
+    xmin = [-100, -100]
+    xmax = [100, 100]
+    x0 = [-12, 10]
 
-    def test_FreudensteinRoth(self):
-        xmin = self.numpar * [-1000, -1000]
-        xmax = self.numpar * [1000, 1000]
-        x0 = self.numpar * [0.5, -2]
-        self.tst_func(self.ncores_nm, tstopt.FreudensteinRoth, x0, xmin, xmax,
-                      0.0)
-        self.tst_func(self.ncores_de, tstopt.FreudensteinRoth, x0, xmin, xmax,
-                      0.0)
+    fmin = 0.0
 
-    def test_GoldsteinPrice(self):
-        xmin = [-2, -2]
-        xmax = [2, 2]
-        x0 = [-1, 1]
-        self.tst_func(self.ncores_nm, tstopt.GoldsteinPrice, x0, xmin, xmax,
-                      3.0)
-        self.tst_func(self.ncores_de, tstopt.GoldsteinPrice, x0, xmin, xmax,
-                      3.0)
+    tst_func(NCORES_NM, tstopt.Bohachevsky1, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Bohachevsky1, x0, xmin, xmax, fmin)
 
-    def test_Hump(self):
-        xmin = [-5, -5]
-        xmax = [5, 5]
-        x0 = [-3.2, 5.0]
-        self.tst_func(self.ncores_nm, tstopt.Hump, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Hump, x0, xmin, xmax, 0.0)        
-        
-    def test_Matyas(self):
-        xmin = [-10, -10]
-        xmax = [10, 10]
-        x0 = [-3.2, 5.0]
-        self.tst_func(self.ncores_nm, tstopt.Matyas, x0, xmin, xmax, 0.0)
-        self.tst_func(self.ncores_de, tstopt.Matyas, x0, xmin, xmax, 0.0)
 
-    def test_McCormick(self):
-        xmin = [-1.5, -3.0]
-        xmax = [4.0, 4.0]
-        x0 = [0.0, 0.0]
-        if _ncpus != 1:
-            self.tst_func(self.ncores_nm, tstopt.McCormick, x0, xmin, xmax,
-                          -1.91)
-        # self.tst_func(self.ncores_de, tstopt.McCormick, x0, xmin, xmax, -1.91)
-        
-    def test_Paviani(self):
-        xmin = self.numpar * [2.001]
-        xmax = self.numpar * [9.999]
-        x0 = self.numpar * [5.0]
-        self.tst_func(self.ncores_nm, tstopt.Paviani, x0, xmin, xmax, -45.7)
-        self.tst_func(self.ncores_de, tstopt.Paviani, x0, xmin, xmax, -45.7)
+def test_Bohachevsky2():
+    xmin = [-100, -100]
+    xmax = [100, 100]
+    x0 = [12, 10]
 
-    def test_Rastrigin(self):
-        xmin = self.numpar * [-5.12]
-        xmax = self.numpar * [5.12]
-        x0	 = self.numpar * [-2.0]
-        if _ncpus != 1:
-            self.tst_func(self.ncores_nm, tstopt.Rastrigin, x0, xmin, xmax,
-                          0.0)
-        self.tst_func(self.ncores_de, tstopt.Rastrigin, x0, xmin, xmax, 0.0)
+    fmin = 0.0
 
-    def test_Shubert(self):
-        xmin = [-10, -10]
-        xmax = [10, 10]
-        x0	 = [-2.0, 5.0]
-        if _ncpus != 1:
-            self.tst_func(self.ncores_nm, tstopt.Shubert, x0, xmin, xmax,
-                          -186.7309)
-        self.tst_func(self.ncores_de, tstopt.Shubert, x0, xmin, xmax,
-                      -186.7309)
+    tst_func(NCORES_NM, tstopt.Bohachevsky2, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Bohachevsky2, x0, xmin, xmax, fmin)
 
+
+def test_Bohachevsky3():
+    xmin = [-100, -100]
+    xmax = [100, 100]
+    x0 = [-61.2, 51.0]
+
+    fmin = 0.0
+    tst_func(NCORES_NM, tstopt.Bohachevsky3, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Bohachevsky3, x0, xmin, xmax, fmin)
+
+
+def test_Booth():
+    xmin = [-10, -10]
+    xmax = [10, 10]
+    x0 = [-6.2, 5.0]
+
+    fmin = 0.0
+    tst_func(NCORES_NM, tstopt.Booth, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Booth, x0, xmin, xmax, fmin)
+
+
+def test_BoxBetts():
+    xmin = [0.9, 9.0, 0.9]
+    xmax = [1.2, 11.2, 1.2]
+    x0 = [(xmin[0] + xmax[0]) * 0.5, (xmin[1] + xmax[1]) * 0.5,
+          (xmin[2] + xmax[2]) * 0.5]
+
+    fmin = 0.0
+    tst_func(NCORES_NM, tstopt.BoxBetts, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.BoxBetts, x0, xmin, xmax, fmin)
+
+
+def test_Branin():
+    xmin = [-5, 0]
+    xmax = [10, 15]
+    x0 = [-3.2, 5.0]
+
+    fmin = 0.397887
+    tst_func(NCORES_NM, tstopt.Branin, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Branin, x0, xmin, xmax, fmin)
+
+
+def test_DixonPrixe():
+    xmin = NUMPAR * [-10]
+    xmax = NUMPAR * [10]
+    x0 = NUMPAR * [-1.]
+
+    fmin = 0.0
+
+    tst_func(NCORES_DE, tstopt.DixonPrice, x0, xmin, xmax, fmin)
+
+
+def test_Easom():
+    xmin = [-100, -100]
+    xmax = [100, 100]
+    x0 = [25.0, 25.0]
+
+    fmin = -1.0
+
+    tst_func(NCORES_DE, tstopt.Easom, x0, xmin, xmax, fmin)
+
+
+def test_FreudensteinRoth():
+    xmin = NUMPAR * [-1000, -1000]
+    xmax = NUMPAR * [1000, 1000]
+    x0 = NUMPAR * [0.5, -2]
+
+    fmin = 0.0
+
+    tst_func(NCORES_NM, tstopt.FreudensteinRoth, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.FreudensteinRoth, x0, xmin, xmax, fmin)
+
+
+def test_GoldsteinPrice():
+    xmin = [-2, -2]
+    xmax = [2, 2]
+    x0 = [-1, 1]
+
+    fmin = 3.0
+
+    tst_func(NCORES_NM, tstopt.GoldsteinPrice, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.GoldsteinPrice, x0, xmin, xmax, fmin)
+
+
+def test_Hump():
+    xmin = [-5, -5]
+    xmax = [5, 5]
+    x0 = [-3.2, 5.0]
+
+    fmin = 0.0
+
+    tst_func(NCORES_NM, tstopt.Hump, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Hump, x0, xmin, xmax, fmin)
+
+
+def test_Matyas():
+    xmin = [-10, -10]
+    xmax = [10, 10]
+    x0 = [-3.2, 5.0]
+
+    fmin = 0.0
+
+    tst_func(NCORES_NM, tstopt.Matyas, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Matyas, x0, xmin, xmax, fmin)
+
+
+# TODO: mark this as only-run on multi-core systems
+def test_McCormick():
+    xmin = [-1.5, -3.0]
+    xmax = [4.0, 4.0]
+    x0 = [0.0, 0.0]
+
+    fmin = -1.91
+
+    if _ncpus != 1:
+        tst_func(NCORES_NM, tstopt.McCormick, x0, xmin, xmax, fmin)
+
+    # tst_func(NCORES_DE, tstopt.McCormick, x0, xmin, xmax, fmin)
+
+
+def test_Paviani():
+    xmin = NUMPAR * [2.001]
+    xmax = NUMPAR * [9.999]
+    x0 = NUMPAR * [5.0]
+
+    # ans = -45.7
+
+    # From
+    # http://infinity77.net/global_optimization/test_functions_nd_P.html#go_benchmark.Paviani
+    # which gives -45.7784684040686
     #
-    # comment out a few time consuming tests, anyone
-    # modifying the ncores opt should uncomment the tests
-    #
-    # def test_Levy(self):
-    #     xmin = self.numpar * [-10]
-    #     xmax = self.numpar * [10]
-    #     x0 = self.numpar * [-5.]
-    #     self.tst_func(self.ncores_nm, tstopt.Levy, x0, xmin, xmax, 0.0)
-    #     self.tst_func(self.ncores_de, tstopt.Levy, x0, xmin, xmax, 0.0)
-    # def test_Sphere(self):
-    #     xmin = self.numpar * [-5.12]
-    #     xmax = self.numpar * [5.12]
-    #     x0 = self.numpar * [-2.0]
-    #     self.tst_func(self.ncores_nm, tstopt.Sphere, x0, xmin, xmax, 0.0)
-    #     self.tst_func(self.ncores_de, tstopt.Sphere, x0, xmin, xmax, 0.0)
+    fmin = -45.778
 
-    # def test_SumSquares(self):
-    #     xmin = self.numpar * [-10]
-    #     xmax = self.numpar * [10]
-    #     x0 = self.numpar * [-2.0]
-    #     self.tst_func(self.ncores_nm, tstopt.SumSquares, x0, xmin, xmax, 0.0)
-    #     self.tst_func(self.ncores_de, tstopt.SumSquares, x0, xmin, xmax, 0.0)
+    tst_func(NCORES_NM, tstopt.Paviani, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Paviani, x0, xmin, xmax, fmin)
 
-    # def test_Zakharov(self):
-    #     xmin = self.numpar * [-5, -5]
-    #     xmax = self.numpar * [10, 10]
-    #     x0   = self.numpar * [0.5, -2]
-    #     self.tst_func(self.ncores_nm, tstopt.Zakharov, x0, xmin, xmax, 0.0)
-    #     self.tst_func(self.ncores_de, tstopt.Zakharov, x0, xmin, xmax, 0.0)
+
+def test_Rastrigin():
+    xmin = NUMPAR * [-5.12]
+    xmax = NUMPAR * [5.12]
+    x0 = NUMPAR * [-2.0]
+    if _ncpus != 1:
+        tst_func(NCORES_NM, tstopt.Rastrigin, x0, xmin, xmax, 0.0)
+
+    tst_func(NCORES_DE, tstopt.Rastrigin, x0, xmin, xmax, 0.0)
+
+
+def test_Shubert():
+    xmin = [-10, -10]
+    xmax = [10, 10]
+    x0 = [-2.0, 5.0]
+
+    fmin = -186.7309
+
+    if _ncpus != 1:
+        tst_func(NCORES_NM, tstopt.Shubert, x0, xmin, xmax, fmin)
+
+    tst_func(NCORES_DE, tstopt.Shubert, x0, xmin, xmax, fmin)
+
+
+#
+# comment out a few time consuming tests, anyone
+# modifying the ncores opt should uncomment the tests
+#
+# def test_Levy():
+#     xmin = NUMPAR * [-10]
+#     xmax = NUMPAR * [10]
+#     x0 = NUMPAR * [-5.]
+#     tst_func(NCORES_NM, tstopt.Levy, x0, xmin, xmax, 0.0)
+#     tst_func(NCORES_DE, tstopt.Levy, x0, xmin, xmax, 0.0)
+# def test_Sphere():
+#     xmin = NUMPAR * [-5.12]
+#     xmax = NUMPAR * [5.12]
+#     x0 = NUMPAR * [-2.0]
+#     tst_func(NCORES_NM, tstopt.Sphere, x0, xmin, xmax, 0.0)
+#     tst_func(NCORES_DE, tstopt.Sphere, x0, xmin, xmax, 0.0)
+
+# def test_SumSquares():
+#     xmin = NUMPAR * [-10]
+#     xmax = NUMPAR * [10]
+#     x0 = NUMPAR * [-2.0]
+#     tst_func(NCORES_NM, tstopt.SumSquares, x0, xmin, xmax, 0.0)
+#     tst_func(NCORES_DE, tstopt.SumSquares, x0, xmin, xmax, 0.0)
+
+# def test_Zakharov():
+#     xmin = NUMPAR * [-5, -5]
+#     xmax = NUMPAR * [10, 10]
+#     x0   = NUMPAR * [0.5, -2]
+#     tst_func(NCORES_NM, tstopt.Zakharov, x0, xmin, xmax, 0.0)
+#     tst_func(NCORES_DE, tstopt.Zakharov, x0, xmin, xmax, 0.0)

--- a/sherpa/optmethods/tests/test_ncoresopt.py
+++ b/sherpa/optmethods/tests/test_ncoresopt.py
@@ -243,33 +243,52 @@ def test_Shubert():
     tst_func(NCORES_DE, tstopt.Shubert, x0, xmin, xmax, fmin)
 
 
+# The following tests are slow, so are only run by the user asking
+# to do so, with the --runslow flag.
 #
-# comment out a few time consuming tests, anyone
-# modifying the ncores opt should uncomment the tests
-#
-# def test_Levy():
-#     xmin = NUMPAR * [-10]
-#     xmax = NUMPAR * [10]
-#     x0 = NUMPAR * [-5.]
-#     tst_func(NCORES_NM, tstopt.Levy, x0, xmin, xmax, 0.0)
-#     tst_func(NCORES_DE, tstopt.Levy, x0, xmin, xmax, 0.0)
-# def test_Sphere():
-#     xmin = NUMPAR * [-5.12]
-#     xmax = NUMPAR * [5.12]
-#     x0 = NUMPAR * [-2.0]
-#     tst_func(NCORES_NM, tstopt.Sphere, x0, xmin, xmax, 0.0)
-#     tst_func(NCORES_DE, tstopt.Sphere, x0, xmin, xmax, 0.0)
+@pytest.mark.slow
+def test_Levy():
+    xmin = NUMPAR * [-10]
+    xmax = NUMPAR * [10]
+    x0 = NUMPAR * [-5.]
 
-# def test_SumSquares():
-#     xmin = NUMPAR * [-10]
-#     xmax = NUMPAR * [10]
-#     x0 = NUMPAR * [-2.0]
-#     tst_func(NCORES_NM, tstopt.SumSquares, x0, xmin, xmax, 0.0)
-#     tst_func(NCORES_DE, tstopt.SumSquares, x0, xmin, xmax, 0.0)
+    fmin = 0.0
 
-# def test_Zakharov():
-#     xmin = NUMPAR * [-5, -5]
-#     xmax = NUMPAR * [10, 10]
-#     x0   = NUMPAR * [0.5, -2]
-#     tst_func(NCORES_NM, tstopt.Zakharov, x0, xmin, xmax, 0.0)
-#     tst_func(NCORES_DE, tstopt.Zakharov, x0, xmin, xmax, 0.0)
+    tst_func(NCORES_NM, tstopt.Levy, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Levy, x0, xmin, xmax, fmin)
+
+
+@pytest.mark.slow
+def test_Sphere():
+    xmin = NUMPAR * [-5.12]
+    xmax = NUMPAR * [5.12]
+    x0 = NUMPAR * [-2.0]
+
+    fmin = 0.0
+
+    tst_func(NCORES_NM, tstopt.Sphere, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Sphere, x0, xmin, xmax, fmin)
+
+
+@pytest.mark.slow
+def test_SumSquares():
+    xmin = NUMPAR * [-10]
+    xmax = NUMPAR * [10]
+    x0 = NUMPAR * [-2.0]
+
+    fmin = 0.0
+
+    tst_func(NCORES_NM, tstopt.SumSquares, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.SumSquares, x0, xmin, xmax, fmin)
+
+
+@pytest.mark.slow
+def test_Zakharov():
+    xmin = NUMPAR * [-5, -5]
+    xmax = NUMPAR * [10, 10]
+    x0   = NUMPAR * [0.5, -2]
+
+    fmin = 0.0
+
+    tst_func(NCORES_NM, tstopt.Zakharov, x0, xmin, xmax, fmin)
+    tst_func(NCORES_DE, tstopt.Zakharov, x0, xmin, xmax, fmin)


### PR DESCRIPTION
# Summary

The only changes in this PR are developer changes.

Switches `sherpa/optmethods/tests/test_ncoresopt.py` to pytest style from the previous unit-test style. This requires tweaking the expected result from a test (presumably because of the different ways of expressing tolerances for the approximate check).

Uncomment the slow-running tests, but mark them as slow, so that they are only run if the `--runslow` command-line argument is given. That is, the tests will not be run on Travis or for the standard `python setup.py test` run.

Unfortunately it's not obvious to me how to run the full test suite with this command-line argument. I can run this test with it (so the functionality is now available to run these tests) using

```
% python setup.py test -a 'sherpa/optmethods/tests/test_ncoresopt.py --runslow'
```

# Details

The idea is to address @olaurino comment https://github.com/sherpa/sherpa/pull/649#issuecomment-516409016

 - [x] convert the test to pytest
 - [x] add flag
 - [x] use flag to allow tests to be run

Note the pytest conversion required changing the expected minimum for the
Paviani test from -45.7 to -45.778 (which is closer to the expected value for this optimization, I believe). This will need checking.

You can now run the optional tests with

```
% python setup.py test -a 'sherpa/optmethods/tests/test_ncoresopt.py --runslow'
```

but I can't seem to pass this flag through to the whole test suite (it shouldn't really matter,
but makes like easier, and would be needed if we wanted to use this in other tests). That is,

```
% python setup.py test -a --runslow
```

fails, and I can't work out why. I have had similar issues with trying to get the -D flag (to change the test-data directory), so I wonder if there's something odd with how we have got pytest integrated into our system. 