### PR TITLE
Handle files with MJD_OBS or MJD-OBS keywords (datastack module)

### DIFF
--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 #
-# Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,9 +19,9 @@ from __future__ import print_function
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import six
 import numpy
 from sherpa.utils.logging import config_logger
+from sherpa.utils.err import IOErr
 from sherpa.astro import ui
 from .utils import load_error_msg, load_wrapper, model_wrapper, \
     simple_wrapper, fit_wrapper, plot_wrapper
@@ -31,7 +31,7 @@ logger = config_logger(__name__)
 
 try:
     import stk
-except:
+except ImportError:
     logger.warning("could not import stk library. CIAO stack files and syntax will be disabled")
 
 # Global list of dataset ids in use
@@ -74,7 +74,7 @@ class DataStack(object):
         for dataid in self.dataset_ids:
             try:
                 del _all_dataset_ids[dataid]
-            except:
+            except KeyError:
                 pass
 
     @property
@@ -211,10 +211,9 @@ class DataStack(object):
         # File Stacks. If the file argument is a stack file, expand the
         # file and call this function for each file in the stack.
         try:
-            files = stk.build(arg)
-            for file in files:
-                self._load_func(ui.load_pha, file, use_errors)
-        except:
+            for infile in stk.build(arg):
+                self._load_func(ui.load_pha, infile, use_errors)
+        except (NameError, OSError, IOErr):
             self._load_func(ui.load_pha, arg, use_errors)
 
     def thaw(self, *pars):

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -127,26 +127,25 @@ class DataStack(object):
         for dataset in self.filter_datasets():
             obsid = "N/A"
             time = "N/A"
-            timekey = None
-            if hasattr(dataset['data'], 'header'):
+            timekey = 'MJD-OBS'
+            try:
+                hdr = dataset['data'].header
+
                 try:
-                    obsid = dataset['data'].header['OBS_ID']
+                    obsid = hdr['OBS_ID']
                 except KeyError:
                     pass
 
                 for key in ['MJD-OBS', 'MJD_OBS']:
                     try:
-                        time = dataset['data'].header[key]
+                        time = hdr[key]
                         timekey = key
                         break
                     except KeyError:
                         pass
 
-            # This is informational, so do not necessarily need
-            # to report the actual key, but for now try to do so.
-            #
-            if timekey is None:
-                timekey = 'MJD-OBS'
+            except AttributeError:
+                pass
 
             print('{0}: {1} {2}: {3} {4}: {5}'.format(dataset['id'],
                                                       dataset['data'].name,

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -118,22 +118,40 @@ class DataStack(object):
         standard output channel. The information displayed depends on the
         type of each data set.
         """
+
+        # The observation-date (MJD) format keyword was MJD_OBS but
+        # has changed (CIAO 4.12) for Chandra data to MJD-OBS, so
+        # need to look for both. The idea is to use the new key
+        # and then fall back to the old one.
+        #
         for dataset in self.filter_datasets():
             obsid = "N/A"
             time = "N/A"
+            timekey = None
             if hasattr(dataset['data'], 'header'):
                 try:
                     obsid = dataset['data'].header['OBS_ID']
                 except KeyError:
                     pass
-                try:
-                    time = dataset['data'].header['MJD_OBS']
-                except KeyError:
-                    pass
+
+                for key in ['MJD-OBS', 'MJD_OBS']:
+                    try:
+                        time = dataset['data'].header[key]
+                        timekey = key
+                        break
+                    except KeyError:
+                        pass
+
+            # This is informational, so do not necessarily need
+            # to report the actual key, but for now try to do so.
+            #
+            if timekey is None:
+                timekey = 'MJD-OBS'
+
             print('{0}: {1} {2}: {3} {4}: {5}'.format(dataset['id'],
                                                       dataset['data'].name,
                                                       'OBS_ID', obsid,
-                                                      "MJD_OBS", time))
+                                                      timekey, time))
 
     # QUS: should this return a copy of the list?
     def get_stack_ids(self):

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -18,698 +18,632 @@
 #
 
 import os
-import sys
 import tempfile
 import logging
 
 import numpy as np
 
-from sherpa.utils.testing import SherpaTestCase, requires_fits, requires_stk
+from sherpa.utils.testing import requires_fits, requires_stk
 from sherpa.astro import ui
 from sherpa.astro import datastack
 from acis_bkg_model import acis_bkg_model
 
+import pytest
+
 logger = logging.getLogger('sherpa')
 
+DATADIR = os.path.join(os.path.dirname(__file__), 'data')
 
-class test_design(SherpaTestCase):
-    def setUp(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("ID")
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-        datastack.set_stack_verbosity(logging.ERROR)
-        self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
 
-    def tearDown(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        logger.setLevel(self.loggingLevel)
+@pytest.fixture
+def ds_setup():
+    """Setup and teardown code for each test."""
 
-    @requires_fits
-    @requires_stk
-    def test_case_1(self):
-        datadir = '/'.join((self._this_dir, 'data'))
-        ls = '@' + '/'.join((datadir, '3c273.lis'))
-        datastack.load_pha(ls, use_errors=True)
+    # Setup
+    #
+    datastack.clear_stack()
+    ui.clean()
+    loggingLevel = logger.getEffectiveLevel()
+    logger.setLevel(logging.ERROR)
+    datastack.set_stack_verbosity(logging.ERROR)
+    datastack.set_template_id("__ID")
 
-        assert 2 == len(datastack.DATASTACK.datasets)
-        assert 2 == len(ui._session._data)
+    # Run test
+    #
+    yield
 
-        datastack.load_pha("myid", '/'.join((datadir, "3c273.pi")))
+    # Cleanup
+    #
+    datastack.clear_stack()
+    ui.clean()
+    datastack.set_template_id("__ID")
+    logger.setLevel(loggingLevel)
 
-        assert 2 == len(datastack.DATASTACK.datasets)
-        assert 3 == len(ui._session._data)
 
-        datastack.load_pha('/'.join((datadir, "3c273.pi")))
+@pytest.fixture
+def ds_datadir():
+    """Location of the data directory for the DataStack tests."""
 
-        assert 3 == len(datastack.DATASTACK.datasets)
-        assert 4 == len(ui._session._data)
+    return DATADIR
 
-        datastack.load_pha([], '/'.join((datadir, "3c273.pi")))
 
-        assert 4 == len(datastack.DATASTACK.datasets)
-        assert 5 == len(ui._session._data)
+@requires_fits
+@requires_stk
+def test_design_case_1(ds_setup, ds_datadir):
 
-        ds = datastack.DataStack()
+    datastack.set_template_id("ID")
 
-        datastack.load_pha(ds, ls)
-
-        assert 4 == len(datastack.DATASTACK.datasets)
-        assert 7 == len(ui._session._data)
-        assert 2 == len(ds.datasets)
-
-        datastack.load_pha(ds, '/'.join((datadir, "3c273.pi")))
+    datadir = ds_datadir
+    ls = '@' + '/'.join((datadir, '3c273.lis'))
+    datastack.load_pha(ls, use_errors=True)
 
-        assert 4 == len(datastack.DATASTACK.datasets)
-        assert 8 == len(ui._session._data)
-        assert 3 == len(ds.datasets)
+    assert 2 == len(datastack.DATASTACK.datasets)
+    assert 2 == len(ui._session._data)
 
-        dids = datastack.DATASTACK.get_stack_ids()
-        assert dids == [1, 2, 3, 4]
+    datastack.load_pha("myid", '/'.join((datadir, "3c273.pi")))
 
-        sids = set(ui._session._data.keys())
-        assert sids == {1, 2, 3, 4, 5, 6, 7, "myid"}
+    assert 2 == len(datastack.DATASTACK.datasets)
+    assert 3 == len(ui._session._data)
 
-        datastack.set_source([1, 2], "powlaw1d.pID")
-        datastack.set_source([3, 4], "brokenpowerlaw.bpID")
+    datastack.load_pha('/'.join((datadir, "3c273.pi")))
 
-        dsids = ds.get_stack_ids()
-        assert dsids == [5, 6, 7]
+    assert 3 == len(datastack.DATASTACK.datasets)
+    assert 4 == len(ui._session._data)
 
-        p1 = ui._session._model_components['p1']
-        p2 = ui._session._model_components['p2']
-        bp3 = ui._session._model_components['bp3']
-        bp4 = ui._session._model_components['bp4']
+    datastack.load_pha([], '/'.join((datadir, "3c273.pi")))
 
-        assert p1 is not None
-        assert p2 is not None
-        assert bp3 is not None
-        assert bp4 is not None
+    assert 4 == len(datastack.DATASTACK.datasets)
+    assert 5 == len(ui._session._data)
 
-        datastack.set_source(1, "polynom1d.poly1")
-        datastack.set_source([2, 3, 4], "atten.attID")
+    ds = datastack.DataStack()
 
-        poly1 = ui._session._model_components['poly1']
-        a2 = ui._session._model_components['att2']
-        a3 = ui._session._model_components['att3']
-        a4 = ui._session._model_components['att4']
+    datastack.load_pha(ds, ls)
 
-        assert poly1 is not None
-        assert a2 is not None
-        assert a3 is not None
-        assert a4 is not None
+    assert 4 == len(datastack.DATASTACK.datasets)
+    assert 7 == len(ui._session._data)
+    assert 2 == len(ds.datasets)
 
-        datastack.clean()
+    datastack.load_pha(ds, '/'.join((datadir, "3c273.pi")))
 
-        assert 0 == len(datastack.DATASTACK.datasets)
-        assert 0 == len(ui._session._data)
-        assert 3 == len(ds.datasets)
+    assert 4 == len(datastack.DATASTACK.datasets)
+    assert 8 == len(ui._session._data)
+    assert 3 == len(ds.datasets)
 
+    dids = datastack.DATASTACK.get_stack_ids()
+    assert dids == [1, 2, 3, 4]
 
-class test_global(SherpaTestCase):
-    def setUp(self):
-        datastack.clear_stack()
-        ui.clean()
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-        datastack.set_stack_verbosity(logging.ERROR)
-        datastack.set_template_id("__ID")
+    sids = set(ui._session._data.keys())
+    assert sids == {1, 2, 3, 4, 5, 6, 7, "myid"}
 
-    def tearDown(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        logger.setLevel(self.loggingLevel)
+    datastack.set_source([1, 2], "powlaw1d.pID")
+    datastack.set_source([3, 4], "brokenpowerlaw.bpID")
 
-    def test_case_2(self):
-        x1 = np.arange(50) + 100
-        y1 = 2 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
-        x3 = np.arange(50) + 200
-        y3 = 2 * (x3**2 + 3 * x3)
+    dsids = ds.get_stack_ids()
+    assert dsids == [5, 6, 7]
 
-        datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+    p1 = ui._session._model_components['p1']
+    p2 = ui._session._model_components['p2']
+    bp3 = ui._session._model_components['bp3']
+    bp4 = ui._session._model_components['bp4']
 
-        datastack.set_source([], 'const1d.const * polynom1d.poly__ID')
+    assert p1 is not None
+    assert p2 is not None
+    assert bp3 is not None
+    assert bp4 is not None
 
-        poly1 = ui._session._get_model_component('poly1')
-        poly2 = ui._session._get_model_component('poly2')
-        poly3 = ui._session._get_model_component('poly3')
-        const = ui._session._get_model_component('const')
+    datastack.set_source(1, "polynom1d.poly1")
+    datastack.set_source([2, 3, 4], "atten.attID")
 
-        datastack.freeze([], 'poly')
-        datastack.thaw([], 'poly.c0')
-        datastack.thaw([], 'poly.c1')
-        datastack.thaw([], 'poly.c2')
-        datastack.thaw([], 'const')
+    poly1 = ui._session._model_components['poly1']
+    a2 = ui._session._model_components['att2']
+    a3 = ui._session._model_components['att3']
+    a4 = ui._session._model_components['att4']
 
-        assert poly1.c0.frozen is False
-        assert poly1.c1.frozen is False
-        assert poly1.c2.frozen is False
-        assert poly1.c3.frozen is True
+    assert poly1 is not None
+    assert a2 is not None
+    assert a3 is not None
+    assert a4 is not None
 
-        assert poly2.c0.frozen is False
-        assert poly2.c1.frozen is False
-        assert poly2.c2.frozen is False
-        assert poly2.c3.frozen is True
+    datastack.clean()
 
-        assert poly3.c0.frozen is False
-        assert poly3.c1.frozen is False
-        assert poly3.c2.frozen is False
-        assert poly3.c3.frozen is True
+    assert 0 == len(datastack.DATASTACK.datasets)
+    assert 0 == len(ui._session._data)
+    assert 3 == len(ds.datasets)
 
-        datastack.set_par([], 'poly.c1', 0.45)
 
-        assert poly1.c1.val == 0.45
-        assert poly2.c1.val == 0.45
-        assert poly3.c1.val == 0.45
+def test_global_case_2(ds_setup):
 
-        datastack.set_par([1], 'poly.c1', 0.1)
+    x1 = np.arange(50) + 100
+    y1 = 2 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+    x3 = np.arange(50) + 200
+    y3 = 2 * (x3**2 + 3 * x3)
 
-        assert poly1.c1.val == 0.1
-        assert poly2.c1.val == 0.45
-        assert poly3.c1.val == 0.45
+    datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        datastack.set_par([], 'const.c0', 2)
+    datastack.set_source([], 'const1d.const * polynom1d.poly__ID')
 
-        assert const.c0.val == 2
+    poly1 = ui._session._get_model_component('poly1')
+    poly2 = ui._session._get_model_component('poly2')
+    poly3 = ui._session._get_model_component('poly3')
+    const = ui._session._get_model_component('const')
 
-        datastack.set_par([], 'const.integrate', False)
-        datastack.freeze([], 'const.c0')
+    datastack.freeze([], 'poly')
+    datastack.thaw([], 'poly.c0')
+    datastack.thaw([], 'poly.c1')
+    datastack.thaw([], 'poly.c2')
+    datastack.thaw([], 'const')
 
-        vals = datastack.get_par([], 'poly.c1.val')
-        assert ([0.1, 0.45, 0.45] == vals).all()
+    assert poly1.c0.frozen is False
+    assert poly1.c1.frozen is False
+    assert poly1.c2.frozen is False
+    assert poly1.c3.frozen is True
 
-        # QUS: pars is not checked, so is this just
-        # checking that get_par doesn't fail?
-        pars = datastack.get_par([], 'const.c0')
+    assert poly2.c0.frozen is False
+    assert poly2.c1.frozen is False
+    assert poly2.c2.frozen is False
+    assert poly2.c3.frozen is True
 
-        datastack.fit([])
+    assert poly3.c0.frozen is False
+    assert poly3.c1.frozen is False
+    assert poly3.c2.frozen is False
+    assert poly3.c3.frozen is True
 
-        assert round(poly1.c1.val) == 1
-        assert round(poly1.c2.val) == 3
-        assert round(poly2.c1.val) == 3
-        assert round(poly2.c2.val) == 1
-        assert round(poly3.c1.val) == 3
-        assert round(poly3.c2.val) == 1
+    datastack.set_par([], 'poly.c1', 0.45)
 
-        datastack.clear_stack()
+    assert poly1.c1.val == 0.45
+    assert poly2.c1.val == 0.45
+    assert poly3.c1.val == 0.45
 
-        x1 = np.arange(50) + 100
-        y1 = 7 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
-        x3 = np.arange(50) + 200
-        y3 = 2 * (x3**2 + 3 * x3)
+    datastack.set_par([1], 'poly.c1', 0.1)
 
-        datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+    assert poly1.c1.val == 0.1
+    assert poly2.c1.val == 0.45
+    assert poly3.c1.val == 0.45
 
-        datastack.set_template_id("foo")
+    datastack.set_par([], 'const.c0', 2)
 
-        datastack.set_source([], 'const1d.constfoo * polynom1d.polyfoo')
+    assert const.c0.val == 2
 
-        # const1 is not used, so should it be removed?
-        const1 = ui._session._get_model_component('const1')
-        const2 = ui._session._get_model_component('const2')
-        const3 = ui._session._get_model_component('const3')
+    datastack.set_par([], 'const.integrate', False)
+    datastack.freeze([], 'const.c0')
 
-        datastack.link([2, 3], 'const.c0')
+    vals = datastack.get_par([], 'poly.c1.val')
+    assert ([0.1, 0.45, 0.45] == vals).all()
 
-        datastack.set_par([2], 'const.c0', 3)
-        datastack.set_par([1], 'const.c0', 7)
+    # QUS: pars is not checked, so is this just
+    # checking that get_par doesn't fail?
+    pars = datastack.get_par([], 'const.c0')
 
-        datastack.freeze([1], 'const.c0')
+    datastack.fit([])
 
-        assert const2.c0.frozen is False
+    assert round(poly1.c1.val) == 1
+    assert round(poly1.c2.val) == 3
+    assert round(poly2.c1.val) == 3
+    assert round(poly2.c2.val) == 1
+    assert round(poly3.c1.val) == 3
+    assert round(poly3.c2.val) == 1
 
-        datastack.fit([])
+    datastack.clear_stack()
 
-        assert const2.c0.val == const3.c0.val
-        assert const3.c0._link is const2.c0
+    x1 = np.arange(50) + 100
+    y1 = 7 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+    x3 = np.arange(50) + 200
+    y3 = 2 * (x3**2 + 3 * x3)
 
-        datastack.unlink([], "const.c0")
+    datastack.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        assert const3.c0._link is not const2.c0
+    datastack.set_template_id("foo")
 
+    datastack.set_source([], 'const1d.constfoo * polynom1d.polyfoo')
 
-class test_load(SherpaTestCase):
-    def setUp(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
-        self.create_files()
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    # const1 is not used, so should it be removed?
+    const1 = ui._session._get_model_component('const1')
+    const2 = ui._session._get_model_component('const2')
+    const3 = ui._session._get_model_component('const3')
 
-    def tearDown(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        os.remove(self.lisname)
-        os.remove(self.name1)
-        os.remove(self.name2)
-        datastack.set_stack_verbose(False)
-        logger.setLevel(self.loggingLevel)
+    datastack.link([2, 3], 'const.c0')
 
-    @requires_fits
-    @requires_stk
-    def test_case_3(self):
-        datastack.load_ascii("@{}".format(self.lisname))
+    datastack.set_par([2], 'const.c0', 3)
+    datastack.set_par([1], 'const.c0', 7)
+
+    datastack.freeze([1], 'const.c0')
+
+    assert const2.c0.frozen is False
+
+    datastack.fit([])
+
+    assert const2.c0.val == const3.c0.val
+    assert const3.c0._link is const2.c0
+
+    datastack.unlink([], "const.c0")
+
+    assert const3.c0._link is not const2.c0
+
+
+def create_files():
+    fd1, name1 = tempfile.mkstemp()
+    fd2, name2 = tempfile.mkstemp()
+
+    fdlis, lisname = tempfile.mkstemp()
+
+    ascii1 = open(name1, 'w')
+    ascii2 = open(name2, 'w')
+    lis = open(lisname, 'w')
+
+    x1 = np.arange(50) + 100
+    y1 = 2 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+
+    for x, y in zip(x1, y1):
+        ascii1.write("{} {}\n".format(x, y))
+    ascii1.close()
+    os.close(fd1)
+
+    for x, y in zip(x2, y2):
+        ascii2.write("{} {}\n".format(x, y))
+    ascii2.close()
+    os.close(fd2)
+
+    lis.write("{}\n".format(name1))
+    lis.write("{}\n".format(name2))
+    lis.close()
+    os.close(fdlis)
+
+    return [name1, name2, lisname]
+
+
+def remove_files(infiles):
+    for infile in infiles:
+        os.remove(infile)
+
+
+@requires_fits
+@requires_stk
+def test_load_case_3(ds_setup, ds_datadir):
+
+    datadir = ds_datadir
+    name1, name2, lisname = create_files()
+
+    try:
+        datastack.load_ascii("@{}".format(lisname))
         assert len(ui._session._data) == 2
         assert len(datastack.DATASTACK.datasets) == 2
 
-        datastack.load_data("@{}".format(self.lisname))
+        datastack.load_data("@{}".format(lisname))
         assert len(ui._session._data) == 4
         assert len(datastack.DATASTACK.datasets) == 4
 
         datastack.load_data("@" +
-                            "/".join((self._this_dir, 'data', 'pha.lis')))
+                            "/".join((datadir, 'pha.lis')))
         assert len(ui._session._data) == 6
         assert len(datastack.DATASTACK.datasets) == 6
 
-    def create_files(self):
-        fd1, self.name1 = tempfile.mkstemp()
-        fd2, self.name2 = tempfile.mkstemp()
-
-        fdlis, self.lisname = tempfile.mkstemp()
-
-        ascii1 = open(self.name1, 'w')
-        ascii2 = open(self.name2, 'w')
-        lis = open(self.lisname, 'w')
-
-        x1 = np.arange(50) + 100
-        y1 = 2 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
+    except:
+        remove_files([name1, name2, lisname])
+        raise
 
-        for x, y in zip(x1, y1):
-            ascii1.write("{} {}\n".format(x, y))
-        ascii1.close()
-        os.close(fd1)
 
-        for x, y in zip(x2, y2):
-            ascii2.write("{} {}\n".format(x, y))
-        ascii2.close()
-        os.close(fd2)
+def test_partial_oo_case_4(ds_setup):
 
-        lis.write("{}\n".format(self.name1))
-        lis.write("{}\n".format(self.name2))
-        lis.close()
-        os.close(fdlis)
-
-
-class test_partial_oo(SherpaTestCase):
+    ds = datastack.DataStack()
 
-    def setUp(self):
-        self.ds = datastack.DataStack()
-        datastack.set_template_id("__ID")
-        datastack.clear_stack()
-        ui.clean()
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    x1 = np.arange(50) + 100
+    y1 = 2 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+    x3 = np.arange(50) + 200
+    y3 = 2 * (x3**2 + 3 * x3)
 
-    def tearDown(self):
-        self.ds.clear_stack()
-        datastack.clear_stack()
-        datastack.set_template_id("__ID")
-        ui.clean()
-        logger.setLevel(self.loggingLevel)
+    datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
 
-    def test_case_4(self):
-        x1 = np.arange(50) + 100
-        y1 = 2 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
-        x3 = np.arange(50) + 200
-        y3 = 2 * (x3**2 + 3 * x3)
+    datastack.set_source(ds, 'const1d.const * polynom1d.poly__ID')
 
-        ds = self.ds
+    poly1 = ui._session._get_model_component('poly1')
+    poly2 = ui._session._get_model_component('poly2')
+    poly3 = ui._session._get_model_component('poly3')
+    const = ui._session._get_model_component('const')
 
-        datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
+    datastack.freeze(ds, 'poly')
+    datastack.thaw(ds, 'poly.c0')
+    datastack.thaw(ds, 'poly.c1')
+    datastack.thaw(ds, 'poly.c2')
+    datastack.thaw(ds, 'const')
 
-        datastack.set_source(ds, 'const1d.const * polynom1d.poly__ID')
+    assert poly1.c0.frozen is False
+    assert poly1.c1.frozen is False
+    assert poly1.c2.frozen is False
+    assert poly1.c3.frozen is True
 
-        poly1 = ui._session._get_model_component('poly1')
-        poly2 = ui._session._get_model_component('poly2')
-        poly3 = ui._session._get_model_component('poly3')
-        const = ui._session._get_model_component('const')
+    assert poly2.c0.frozen is False
+    assert poly2.c1.frozen is False
+    assert poly2.c2.frozen is False
+    assert poly2.c3.frozen is True
 
-        datastack.freeze(ds, 'poly')
-        datastack.thaw(ds, 'poly.c0')
-        datastack.thaw(ds, 'poly.c1')
-        datastack.thaw(ds, 'poly.c2')
-        datastack.thaw(ds, 'const')
+    assert poly3.c0.frozen is False
+    assert poly3.c1.frozen is False
+    assert poly3.c2.frozen is False
+    assert poly3.c3.frozen is True
 
-        assert poly1.c0.frozen is False
-        assert poly1.c1.frozen is False
-        assert poly1.c2.frozen is False
-        assert poly1.c3.frozen is True
+    datastack.set_par(ds, 'poly.c1', 0.45)
 
-        assert poly2.c0.frozen is False
-        assert poly2.c1.frozen is False
-        assert poly2.c2.frozen is False
-        assert poly2.c3.frozen is True
+    assert poly1.c1.val == 0.45
+    assert poly2.c1.val == 0.45
+    assert poly3.c1.val == 0.45
 
-        assert poly3.c0.frozen is False
-        assert poly3.c1.frozen is False
-        assert poly3.c2.frozen is False
-        assert poly3.c3.frozen is True
+    datastack.set_par(ds[1], 'poly.c1', 0.1)
 
-        datastack.set_par(ds, 'poly.c1', 0.45)
+    assert poly1.c1.val == 0.1
+    assert poly2.c1.val == 0.45
+    assert poly3.c1.val == 0.45
 
-        assert poly1.c1.val == 0.45
-        assert poly2.c1.val == 0.45
-        assert poly3.c1.val == 0.45
+    datastack.set_par(ds, 'const.c0', 2)
 
-        datastack.set_par(ds[1], 'poly.c1', 0.1)
+    assert const.c0.val == 2
 
-        assert poly1.c1.val == 0.1
-        assert poly2.c1.val == 0.45
-        assert poly3.c1.val == 0.45
+    datastack.set_par(ds, 'const.integrate', False)
+    datastack.freeze(ds, 'const.c0')
 
-        datastack.set_par(ds, 'const.c0', 2)
+    vals = datastack.get_par(ds, 'poly.c1.val')
+    assert ([0.1, 0.45, 0.45] == vals).all()
 
-        assert const.c0.val == 2
+    # QUS: pars is not checked, so is this just
+    # checking that get_par doesn't fail?
+    pars = datastack.get_par(ds, 'const.c0')
 
-        datastack.set_par(ds, 'const.integrate', False)
-        datastack.freeze(ds, 'const.c0')
+    datastack.fit(ds)
 
-        vals = datastack.get_par(ds, 'poly.c1.val')
-        assert ([0.1, 0.45, 0.45] == vals).all()
+    assert round(poly1.c1.val) == 1
+    assert round(poly1.c2.val) == 3
+    assert round(poly2.c1.val) == 3
+    assert round(poly2.c2.val) == 1
+    assert round(poly3.c1.val) == 3
+    assert round(poly3.c2.val) == 1
 
-        # QUS: pars is not checked, so is this just
-        # checking that get_par doesn't fail?
-        pars = datastack.get_par(ds, 'const.c0')
+    ds.clear_stack()
 
-        datastack.fit(ds)
+    x1 = np.arange(50) + 100
+    y1 = 7 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+    x3 = np.arange(50) + 200
+    y3 = 2 * (x3**2 + 3 * x3)
 
-        assert round(poly1.c1.val) == 1
-        assert round(poly1.c2.val) == 3
-        assert round(poly2.c1.val) == 3
-        assert round(poly2.c2.val) == 1
-        assert round(poly3.c1.val) == 3
-        assert round(poly3.c2.val) == 1
+    datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
 
-        ds.clear_stack()
+    datastack.set_template_id("foo")
 
-        x1 = np.arange(50) + 100
-        y1 = 7 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
-        x3 = np.arange(50) + 200
-        y3 = 2 * (x3**2 + 3 * x3)
+    datastack.set_source(ds, 'const1d.constfoo * polynom1d.polyfoo')
 
-        datastack.load_arrays(ds, [[x1, y1], [x2, y2], [x3, y3]])
+    const1 = ui._session._get_model_component('const1')
+    const2 = ui._session._get_model_component('const2')
+    const3 = ui._session._get_model_component('const3')
 
-        datastack.set_template_id("foo")
+    datastack.link(ds[2, 3], 'const.c0')
 
-        datastack.set_source(ds, 'const1d.constfoo * polynom1d.polyfoo')
+    datastack.set_par(ds[2], 'const.c0', 3)
+    datastack.set_par(ds[1], 'const.c0', 7)
 
-        const1 = ui._session._get_model_component('const1')
-        const2 = ui._session._get_model_component('const2')
-        const3 = ui._session._get_model_component('const3')
+    datastack.freeze(ds[1], 'const.c0')
 
-        datastack.link(ds[2, 3], 'const.c0')
+    assert const2.c0.frozen is False
 
-        datastack.set_par(ds[2], 'const.c0', 3)
-        datastack.set_par(ds[1], 'const.c0', 7)
+    datastack.fit(ds)
 
-        datastack.freeze(ds[1], 'const.c0')
+    assert const2.c0.val == const3.c0.val
+    assert const3.c0._link is const2.c0
 
-        assert const2.c0.frozen is False
+    datastack.unlink(ds, "const.c0")
 
-        datastack.fit(ds)
+    assert const3.c0._link is not const2.c0
 
-        assert const2.c0.val == const3.c0.val
-        assert const3.c0._link is const2.c0
 
-        datastack.unlink(ds, "const.c0")
+def test_oo_case_5(ds_setup):
 
-        assert const3.c0._link is not const2.c0
+    ds = datastack.DataStack()
 
+    x1 = np.arange(50) + 100
+    y1 = 2 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+    x3 = np.arange(50) + 200
+    y3 = 2 * (x3**2 + 3 * x3)
 
-class test_oo(SherpaTestCase):
+    ds.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-    def setUp(self):
-        datastack.clear_stack()
-        datastack.set_template_id("__ID")
-        ui.clean()
-        self.ds = datastack.DataStack()
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    ds.set_source('const1d.const * polynom1d.poly__ID')
 
-    def tearDown(self):
-        self.ds.clear_stack()
-        datastack.clear_stack()
-        datastack.set_template_id("__ID")
-        ui.clean()
-        logger.setLevel(self.loggingLevel)
+    poly1 = ui._session._get_model_component('poly1')
+    poly2 = ui._session._get_model_component('poly2')
+    poly3 = ui._session._get_model_component('poly3')
+    const = ui._session._get_model_component('const')
 
-    def test_case_5(self):
-        x1 = np.arange(50) + 100
-        y1 = 2 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
-        x3 = np.arange(50) + 200
-        y3 = 2 * (x3**2 + 3 * x3)
+    ds.freeze('poly')
+    ds.thaw('poly.c0')
+    ds.thaw('poly.c1')
+    ds.thaw('poly.c2')
+    ds.thaw('const')
 
-        ds = self.ds
+    assert poly1.c0.frozen is False
+    assert poly1.c1.frozen is False
+    assert poly1.c2.frozen is False
+    assert poly1.c3.frozen is True
 
-        ds.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+    assert poly2.c0.frozen is False
+    assert poly2.c1.frozen is False
+    assert poly2.c2.frozen is False
+    assert poly2.c3.frozen is True
 
-        ds.set_source('const1d.const * polynom1d.poly__ID')
+    assert poly3.c0.frozen is False
+    assert poly3.c1.frozen is False
+    assert poly3.c2.frozen is False
+    assert poly3.c3.frozen is True
 
-        poly1 = ui._session._get_model_component('poly1')
-        poly2 = ui._session._get_model_component('poly2')
-        poly3 = ui._session._get_model_component('poly3')
-        const = ui._session._get_model_component('const')
+    ds.set_par('poly.c1', 0.45)
 
-        ds.freeze('poly')
-        ds.thaw('poly.c0')
-        ds.thaw('poly.c1')
-        ds.thaw('poly.c2')
-        ds.thaw('const')
+    assert poly1.c1.val == 0.45
+    assert poly2.c1.val == 0.45
+    assert poly3.c1.val == 0.45
 
-        assert poly1.c0.frozen is False
-        assert poly1.c1.frozen is False
-        assert poly1.c2.frozen is False
-        assert poly1.c3.frozen is True
+    ds[1].set_par('poly.c1', 0.1)
 
-        assert poly2.c0.frozen is False
-        assert poly2.c1.frozen is False
-        assert poly2.c2.frozen is False
-        assert poly2.c3.frozen is True
+    assert poly1.c1.val == 0.1
+    assert poly2.c1.val == 0.45
+    assert poly3.c1.val == 0.45
 
-        assert poly3.c0.frozen is False
-        assert poly3.c1.frozen is False
-        assert poly3.c2.frozen is False
-        assert poly3.c3.frozen is True
+    ds.set_par('const.c0', 2)
 
-        ds.set_par('poly.c1', 0.45)
+    assert const.c0.val == 2
 
-        assert poly1.c1.val == 0.45
-        assert poly2.c1.val == 0.45
-        assert poly3.c1.val == 0.45
+    ds.set_par('const.integrate', False)
+    ds.freeze('const.c0')
 
-        ds[1].set_par('poly.c1', 0.1)
+    vals = ds.get_par('poly.c1.val')
+    assert ([0.1, 0.45, 0.45] == vals).all()
 
-        assert poly1.c1.val == 0.1
-        assert poly2.c1.val == 0.45
-        assert poly3.c1.val == 0.45
+    # QUS: pars is not checked, so is this just
+    # checking that get_par doesn't fail?
+    pars = ds.get_par('const.c0')
 
-        ds.set_par('const.c0', 2)
+    ds.fit()
 
-        assert const.c0.val == 2
+    assert round(poly1.c1.val) == 1
+    assert round(poly1.c2.val) == 3
+    assert round(poly2.c1.val) == 3
+    assert round(poly2.c2.val) == 1
+    assert round(poly3.c1.val) == 3
+    assert round(poly3.c2.val) == 1
 
-        ds.set_par('const.integrate', False)
-        ds.freeze('const.c0')
+    ds.clear_stack()
 
-        vals = ds.get_par('poly.c1.val')
-        assert ([0.1, 0.45, 0.45] == vals).all()
+    x1 = np.arange(50) + 100
+    y1 = 7 * (3 * x1**2 + x1)
+    x2 = np.arange(50)
+    y2 = 2 * (x2**2 + 3 * x2)
+    x3 = np.arange(50) + 200
+    y3 = 2 * (x3**2 + 3 * x3)
 
-        # QUS: pars is not checked, so is this just
-        # checking that get_par doesn't fail?
-        pars = ds.get_par('const.c0')
+    ds.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
 
-        ds.fit()
+    datastack.set_template_id("foo")
 
-        assert round(poly1.c1.val) == 1
-        assert round(poly1.c2.val) == 3
-        assert round(poly2.c1.val) == 3
-        assert round(poly2.c2.val) == 1
-        assert round(poly3.c1.val) == 3
-        assert round(poly3.c2.val) == 1
+    ds.set_source('const1d.constfoo * polynom1d.polyfoo')
 
-        ds.clear_stack()
+    const1 = ui._session._get_model_component('const1')
+    const2 = ui._session._get_model_component('const2')
+    const3 = ui._session._get_model_component('const3')
 
-        x1 = np.arange(50) + 100
-        y1 = 7 * (3 * x1**2 + x1)
-        x2 = np.arange(50)
-        y2 = 2 * (x2**2 + 3 * x2)
-        x3 = np.arange(50) + 200
-        y3 = 2 * (x3**2 + 3 * x3)
+    ds[2, 3].link('const.c0')
 
-        ds.load_arrays([[x1, y1], [x2, y2], [x3, y3]])
+    ds[2].set_par('const.c0', 3)
+    ds[1].set_par('const.c0', 7)
 
-        datastack.set_template_id("foo")
+    ds[1].freeze('const.c0')
 
-        ds.set_source('const1d.constfoo * polynom1d.polyfoo')
+    assert const2.c0.frozen is False
 
-        const1 = ui._session._get_model_component('const1')
-        const2 = ui._session._get_model_component('const2')
-        const3 = ui._session._get_model_component('const3')
+    ds.fit()
 
-        ds[2, 3].link('const.c0')
+    assert const2.c0.val == const3.c0.val
+    assert const3.c0._link is const2.c0
 
-        ds[2].set_par('const.c0', 3)
-        ds[1].set_par('const.c0', 7)
+    ds.unlink("const.c0")
 
-        ds[1].freeze('const.c0')
+    assert const3.c0._link is not const2.c0
 
-        assert const2.c0.frozen is False
 
-        ds.fit()
+@requires_fits
+@requires_stk
+def test_pha_case_6(ds_setup, ds_datadir):
 
-        assert const2.c0.val == const3.c0.val
-        assert const3.c0._link is const2.c0
+    datadir = ds_datadir
+    ls = '@' + '/'.join((datadir, 'pha.lis'))
+    rmf1 = '/'.join((datadir, "acisf04938_000N002_r0043_rmf3.fits"))
+    rmf2 = '/'.join((datadir, "acisf07867_000N001_r0002_rmf3.fits"))
+    arf1 = '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits"))
+    arf2 = '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits"))
+    datastack.load_pha(ls)
 
-        ds.unlink("const.c0")
+    datastack.load_bkg_rmf([], rmf1)
+    datastack.load_bkg_rmf([], rmf2)
 
-        assert const3.c0._link is not const2.c0
+    datastack.load_bkg_arf([], arf1)
+    datastack.load_bkg_arf([], arf2)
 
+    # Define background models
+    bkg_arfs = datastack.get_bkg_arf([])
+    bkg_scales = datastack.get_bkg_scale([])
+    bkg_models = [ui.const1d.c1 * acis_bkg_model('acis7s'),
+                  ui.const1d.c2 * acis_bkg_model('acis7s')]
+    bkg_rsps = datastack.get_response([], bkg_id=1)
+    for i in range(2):
+        id_ = i + 1
+        # Make the ARF spectral response flat.  This is required for using
+        # the acis_bkg_model.
+        bkg_arfs[i].specresp = bkg_arfs[i].specresp * 0 + 1.
+        datastack.set_bkg_full_model(id_, bkg_rsps[i](bkg_models[i]))
 
-class test_pha(SherpaTestCase):
-    def setUp(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("ID")
-        self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    # Fit background
+    datastack.notice(0.5, 8.)
+    datastack.set_method("neldermead")
+    datastack.set_stat("cash")
 
-    def tearDown(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        logger.setLevel(self.loggingLevel)
+    datastack.thaw(c1.c0)
+    datastack.thaw(c2.c0)
+    datastack.fit_bkg()
+    datastack.freeze(c1.c0)
+    datastack.freeze(c2.c0)
 
-    @requires_fits
-    @requires_stk
-    def test_case_6(self):
-        datadir = '/'.join((self._this_dir, 'data'))
-        ls = '@' + '/'.join((datadir, 'pha.lis'))
-        rmf1 = '/'.join((datadir, "acisf04938_000N002_r0043_rmf3.fits"))
-        rmf2 = '/'.join((datadir, "acisf07867_000N001_r0002_rmf3.fits"))
-        arf1 = '/'.join((datadir, "acisf04938_000N002_r0043_arf3.fits"))
-        arf2 = '/'.join((datadir, "acisf07867_000N001_r0002_arf3.fits"))
-        datastack.load_pha(ls)
+    # Define source models
+    rsps = datastack.get_response([])
+    src_model = ui.powlaw1d.pow1
+    src_models = [src_model,
+                  src_model * ui.const1d.ratio_12]
+    for i in range(2):
+        id_ = i + 1
+        datastack.set_full_model(id_, (rsps[i](src_models[i]) +
+                                       bkg_scales[i] *
+                                       bkg_rsps[i](bkg_models[i])))
 
-        datastack.load_bkg_rmf([], rmf1)
-        datastack.load_bkg_rmf([], rmf2)
+    datastack.fit()
 
-        datastack.load_bkg_arf([], arf1)
-        datastack.load_bkg_arf([], arf2)
 
-        # Define background models
-        bkg_arfs = datastack.get_bkg_arf([])
-        bkg_scales = datastack.get_bkg_scale([])
-        bkg_models = [ui.const1d.c1 * acis_bkg_model('acis7s'),
-                      ui.const1d.c2 * acis_bkg_model('acis7s')]
-        bkg_rsps = datastack.get_response([], bkg_id=1)
-        for i in range(2):
-            id_ = i + 1
-            # Make the ARF spectral response flat.  This is required for using
-            # the acis_bkg_model.
-            bkg_arfs[i].specresp = bkg_arfs[i].specresp * 0 + 1.
-            datastack.set_bkg_full_model(id_, bkg_rsps[i](bkg_models[i]))
+@requires_fits
+@requires_stk
+def test_query_case_7(ds_setup, ds_datadir):
 
-        # Fit background
-        datastack.notice(0.5, 8.)
-        datastack.set_method("neldermead")
-        datastack.set_stat("cash")
+    datadir = ds_datadir
+    datastack.load_pha('@' +
+                       '/'.join((datadir, 'pha.lis')))
 
-        datastack.thaw(c1.c0)
-        datastack.thaw(c2.c0)
-        datastack.fit_bkg()
-        datastack.freeze(c1.c0)
-        datastack.freeze(c2.c0)
+    f = datastack.query_by_header_keyword('INSTRUME', 'ACIS')
 
-        # Define source models
-        rsps = datastack.get_response([])
-        src_model = ui.powlaw1d.pow1
-        src_models = [src_model,
-                      src_model * ui.const1d.ratio_12]
-        for i in range(2):
-            id_ = i + 1
-            datastack.set_full_model(id_, (rsps[i](src_models[i]) +
-                                           bkg_scales[i] *
-                                           bkg_rsps[i](bkg_models[i])))
+    assert f == [1, 2]
 
-        datastack.fit()
+    f = datastack.query_by_obsid(7867)
 
+    assert f == [2]
 
-class test_query(SherpaTestCase):
-    def setUp(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        self._this_dir = os.path.dirname(sys.modules[self.__module__].__file__)
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    ds = datastack.DataStack()
 
-    def tearDown(self):
-        datastack.clear_stack()
-        ui.clean()
-        datastack.set_template_id("__ID")
-        datastack.set_stack_verbose(False)
-        logger.setLevel(self.loggingLevel)
+    ds.load_pha('@' + '/'.join((datadir, 'pha.lis')))
 
-    @requires_fits
-    @requires_stk
-    def test_case_7(self):
-        datastack.load_pha('@' +
-                           '/'.join((self._this_dir, 'data', 'pha.lis')))
+    f = ds.query_by_obsid('4938')
 
-        f = datastack.query_by_header_keyword('INSTRUME', 'ACIS')
+    assert f == [3]
 
-        assert f == [1, 2]
+    f = datastack.query_by_obsid(ds, '7867')
 
-        f = datastack.query_by_obsid(7867)
+    assert f == [4]
 
-        assert f == [2]
 
-        ds = datastack.DataStack()
-
-        ds.load_pha('@' + '/'.join((self._this_dir, 'data', 'pha.lis')))
-
-        f = ds.query_by_obsid('4938')
-
-        assert f == [3]
-
-        f = datastack.query_by_obsid(ds, '7867')
-
-        assert f == [4]
-
-
-def test_default_instantiation():
+def test_default_instantiation(ds_setup):
     datastack.DataStack._default_instantiated = False
     ds = datastack.DataStack()
     assert ds._default_instance
     ds = datastack.DataStack()
     assert not ds._default_instance
-
-if __name__ == '__main__':
-
-    from sherpa.utils import SherpaTest
-
-    if len(sys.argv) > 1:
-        datadir = sys.argv[1]
-    else:
-        datadir = None
-
-    SherpaTest(datastack).test(datadir=datadir)

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -692,10 +692,12 @@ def validate_show_stack(capsys, datadir, key1, key2):
        The capsys pytest object.
     datadir: str
        The directory containing the data files.
-    key1 : str
+    key1 : str or None
        The keyword being used for the "MJD OBS" value: file 1.
-    key2 : str
+       If None the value is missing.
+    key2 : str or None
        The keyword being used for the "MJD OBS" value: file 2.
+       If None the value is missing.
 
     """
 
@@ -709,8 +711,20 @@ def validate_show_stack(capsys, datadir, key1, key2):
     # This depends on the serialization of numeric values, which can
     # vary with Python/system
     #
-    l0 = '1: {}/acisf04938_000N002_r0043_pha3.fits OBS_ID: 4938 {}: 53493.55477826'.format(datadir, key1)
-    l1 = '2: {}/acisf07867_000N001_r0002_pha3.fits OBS_ID: 7867 {}: 54374.009361043'.format(datadir, key2)
+    if key1 is None:
+        val1 = 'N/A'
+        key1 = 'MJD-OBS'
+    else:
+        val1 = '53493.55477826'
+
+    if key2 is None:
+        val2 = 'N/A'
+        key2 = 'MJD-OBS'
+    else:
+        val2 = '54374.009361043'
+
+    l0 = '1: {}/acisf04938_000N002_r0043_pha3.fits OBS_ID: 4938 {}: {}'.format(datadir, key1, val1)
+    l1 = '2: {}/acisf07867_000N001_r0002_pha3.fits OBS_ID: 7867 {}: {}'.format(datadir, key2, val2)
 
     captured = capsys.readouterr()
     lines = captured.out.split('\n')
@@ -777,3 +791,21 @@ def test_show_stack3(ds_setup, ds_datadir, capsys):
         del d.header['MJD_OBS']
 
     validate_show_stack(capsys, ds_datadir, 'MJD_OBS', 'MJD-OBS')
+
+
+@requires_fits
+@requires_stk
+def test_show_stack4(ds_setup, ds_datadir, capsys):
+    """Test the show_stack handling: No MJD_OBS or MJD-OBS keyword
+    """
+
+    ls = '@' + '/'.join((ds_datadir, 'pha.lis'))
+    datastack.load_pha(ls)
+
+    # Remove the MJD-OBS keyword.
+    #
+    for idval in [1, 2]:
+        d = datastack.get_data(idval)
+        del d.header['MJD_OBS']
+
+    validate_show_stack(capsys, ds_datadir, None, None)

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -678,3 +678,36 @@ def test_default_instantiation(ds_setup):
     assert ds._default_instance
     ds = datastack.DataStack()
     assert not ds._default_instance
+
+
+@requires_fits
+@requires_stk
+def test_show_stack(ds_setup, ds_datadir, capsys):
+    """Test the show_stack handling.
+    """
+
+    # These files use MJD_OBS in the header
+    datadir = ds_datadir
+    ls = '@' + '/'.join((datadir, 'pha.lis'))
+    datastack.load_pha(ls)
+
+    # clear out the current output
+    captured = capsys.readouterr()
+
+    datastack.show_stack()
+
+    # Did we get the expected output?
+    #
+    # This depends on the serialization of numeric values, which can
+    # vary with Python/system
+    #
+    l0 = '1: {}/acisf04938_000N002_r0043_pha3.fits OBS_ID: 4938 MJD_OBS: 53493.55477826'.format(datadir)
+    l1 = '2: {}/acisf07867_000N001_r0002_pha3.fits OBS_ID: 7867 MJD_OBS: 54374.009361043'.format(datadir)
+
+    captured = capsys.readouterr()
+    lines = captured.out.split('\n')
+    assert len(lines) == 3
+    assert lines[0] == l0
+    assert lines[1] == l1
+    assert lines[2] == ''
+    assert captured.err == ''

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -61,6 +61,37 @@ def ds_setup():
 
 
 @pytest.fixture
+def ds_setup_object():
+    """Setup and teardown code for each test.
+
+    Could try and be clever and re-use ds_setup here,
+    but just repeat it to be simpler.
+    """
+
+    # Setup
+    #
+    ds = datastack.DataStack()
+    datastack.clear_stack()
+    ui.clean()
+    loggingLevel = logger.getEffectiveLevel()
+    logger.setLevel(logging.ERROR)
+    datastack.set_stack_verbosity(logging.ERROR)
+    datastack.set_template_id("__ID")
+
+    # Run test, returning the stack object
+    #
+    yield ds
+
+    # Cleanup
+    #
+    ds.clear_stack()
+    datastack.clear_stack()
+    ui.clean()
+    datastack.set_template_id("__ID")
+    logger.setLevel(loggingLevel)
+
+
+@pytest.fixture
 def ds_datadir():
     """Location of the data directory for the DataStack tests."""
 
@@ -328,9 +359,9 @@ def test_load_case_3(ds_setup, ds_datadir):
         raise
 
 
-def test_partial_oo_case_4(ds_setup):
+def test_partial_oo_case_4(ds_setup_object):
 
-    ds = datastack.DataStack()
+    ds = ds_setup_object
 
     x1 = np.arange(50) + 100
     y1 = 2 * (3 * x1**2 + x1)
@@ -442,9 +473,9 @@ def test_partial_oo_case_4(ds_setup):
     assert const3.c0._link is not const2.c0
 
 
-def test_oo_case_5(ds_setup):
+def test_oo_case_5(ds_setup_object):
 
-    ds = datastack.DataStack()
+    ds = ds_setup_object
 
     x1 = np.arange(50) + 100
     y1 = 2 * (3 * x1**2 + x1)

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2014, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016, 2018, 2019
+#       Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/io/meta.py
+++ b/sherpa/astro/io/meta.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -33,6 +33,9 @@ class Meta(NoNewAttributesAfterInit):
 
     def __getitem__(self, name):
         return self.__header[name]
+
+    def __delitem__(self, name):
+        del self.__header[name]
 
     def __setitem__(self, name, val):
         self.__header[name] = val

--- a/sherpa/astro/io/tests/test_meta.py
+++ b/sherpa/astro/io/tests/test_meta.py
@@ -17,29 +17,41 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# Although the Meta module does not need a FITS backend, you can not
+# import it unless there's a FITS backend present, thanks to the
+# design of sherpa.astro.io. So all the tests are behind a
+# requires_fits decorator. The import could be done at the top of the
+# file (within a check for ImportError) but leave as is.
+#
+
 import pytest
 
-from sherpa.astro.io.meta import Meta
+from sherpa.utils.testing import requires_fits
 
-
+@requires_fits
 def test_empty():
     """An empty store is empty."""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     assert len(store.keys()) == 0
 
 
+@requires_fits
 def test_key_does_not_exist():
     """We know when a key does not exist"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     assert not store.has_key("key")
 
 
+@requires_fits
 @pytest.mark.parametrize("value", ["", " a string ", 23, 23.0, True, None])
 def test_add_keyword(value):
     """Can add a keyword"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key'] = value
     assert store.keys() == ['key']
@@ -50,9 +62,11 @@ def test_add_keyword(value):
     assert svalue == value
 
 
+@requires_fits
 def test_error_if_missing_key():
     """Raise the correct error on missing key"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key'] = 1
 
@@ -60,9 +74,11 @@ def test_error_if_missing_key():
         store['keykey']
 
 
+@requires_fits
 def test_get_with_known_key():
     """get works on a known key"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key1'] = 2
     store['key2'] = 23
@@ -70,9 +86,11 @@ def test_get_with_known_key():
     assert store.get('key1') == 2
 
 
+@requires_fits
 def test_get_with_unknown_key():
     """the default value is used if no key exists"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key1'] = 2
     store['key2'] = 23
@@ -80,18 +98,22 @@ def test_get_with_unknown_key():
     assert store.get('key3', "unknown") == "unknown"
 
 
+@requires_fits
 def test_overwrite_keyword():
     """We can change a keyword"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['val1'] = True
     store['val1'] = False
     assert not store['val1']
 
 
+@requires_fits
 def test_del_keyword():
     """We can delete a keyword"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['x1'] = 1
     store['u1'] = 2
@@ -101,9 +123,11 @@ def test_del_keyword():
     assert store.values() == [2]
 
 
+@requires_fits
 def test_del_missing_keyword():
     """We can not delete a keyword that doesn't exist"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['x1'] = 1
     store['u1'] = 2
@@ -114,9 +138,11 @@ def test_del_missing_keyword():
     assert store.values() == [2, 1]
 
 
+@requires_fits
 def test_keyword_order():
     """keys are sorted, not based on input order"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key2'] = 1
     store['key1'] = 2
@@ -130,9 +156,11 @@ def test_keyword_order():
     assert vals == [False, True, 2, 1]
 
 
+@requires_fits
 def test_key_pop():
     """Can pop a known value"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key1'] = True
     store['key2'] = False
@@ -141,9 +169,11 @@ def test_key_pop():
     assert store.keys() == ['key2']
 
 
+@requires_fits
 def test_key_pop():
     """Can pop an unknown"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['key1'] = True
     store['key2'] = False
@@ -152,16 +182,20 @@ def test_key_pop():
     assert store.keys() == ['key1', 'key2']
 
 
+@requires_fits
 def test_str_empty():
     """stringification: empty"""
 
+    from sherpa.astro.io.meta import Meta
     s = str(Meta())
     assert s == ''
 
 
+@requires_fits
 def test_str_singleton():
     """stringification: single value"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
 
     # Could loop over this, but a bit easier to check the string
@@ -191,9 +225,11 @@ def test_str_singleton():
         assert str(store) == ''
 
 
+@requires_fits
 def test_str_multi():
     """Multiple keys are displayed as expected"""
 
+    from sherpa.astro.io.meta import Meta
     store = Meta()
     store['Xkey'] = 'X X'
     store['xkey'] = ' y  y'

--- a/sherpa/astro/io/tests/test_meta.py
+++ b/sherpa/astro/io/tests/test_meta.py
@@ -1,0 +1,185 @@
+#
+#  Copyright (C) 2019  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import pytest
+
+from sherpa.astro.io.meta import Meta
+
+
+def test_empty():
+    """An empty store is empty."""
+
+    store = Meta()
+    assert len(store.keys()) == 0
+
+
+def test_key_does_not_exist():
+    """We know when a key does not exist"""
+
+    store = Meta()
+    assert not store.has_key("key")
+
+
+@pytest.mark.parametrize("value", ["", " a string ", 23, 23.0, True, None])
+def test_add_keyword(value):
+    """Can add a keyword"""
+
+    store = Meta()
+    store['key'] = value
+    assert store.keys() == ['key']
+    assert store.has_key('key')
+    assert len(store.values()) == 1
+
+    svalue = store['key']
+    assert svalue == value
+
+
+def test_error_if_missing_key():
+    """Raise the correct error on missing key"""
+
+    store = Meta()
+    store['key'] = 1
+
+    with pytest.raises(KeyError):
+        store['keykey']
+
+
+def test_get_with_known_key():
+    """get works on a known key"""
+
+    store = Meta()
+    store['key1'] = 2
+    store['key2'] = 23
+
+    assert store.get('key1') == 2
+
+
+def test_get_with_unknown_key():
+    """the default value is used if no key exists"""
+
+    store = Meta()
+    store['key1'] = 2
+    store['key2'] = 23
+
+    assert store.get('key3', "unknown") == "unknown"
+
+
+def test_overwrite_keyword():
+    """We can change a keyword"""
+
+    store = Meta()
+    store['val1'] = True
+    store['val1'] = False
+    assert not store['val1']
+
+
+def test_keyword_order():
+    """keys are sorted, not based on input order"""
+
+    store = Meta()
+    store['key2'] = 1
+    store['key1'] = 2
+    store['a'] = True
+    store['A'] = False
+
+    keys = store.keys()
+    assert keys == ['A', 'a', 'key1', 'key2']
+
+    vals = store.values()
+    assert vals == [False, True, 2, 1]
+
+
+def test_key_pop():
+    """Can pop a known value"""
+
+    store = Meta()
+    store['key1'] = True
+    store['key2'] = False
+
+    assert store.pop('key1')
+    assert store.keys() == ['key2']
+
+
+def test_key_pop():
+    """Can pop an unknown"""
+
+    store = Meta()
+    store['key1'] = True
+    store['key2'] = False
+
+    assert store.pop('key') is None
+    assert store.keys() == ['key1', 'key2']
+
+
+def test_str_empty():
+    """stringification: empty"""
+
+    s = str(Meta())
+    assert s == ''
+
+
+def test_str_singleton():
+    """stringification: single value"""
+
+    store = Meta()
+
+    # Could loop over this, but a bit easier to check the string
+    # output this way.
+    #
+    store['key'] = ""
+    assert str(store) == '\n key           = '
+
+    store['key'] = "  "
+    assert str(store) == '\n key           =   '
+
+    store['key'] = " a string "
+    assert str(store) == '\n key           =  a string '
+
+    store['key'] = 23
+    assert str(store) == '\n key           = 23'
+
+    store['key'] = 23.0
+    assert str(store) == '\n key           = 23.0'
+
+    store['key'] = False
+    assert str(store) == '\n key           = False'
+
+    # Now some special cases
+    for val in [None, "None", "NONE", "none"]:
+        store['key'] = val
+        assert str(store) == ''
+
+
+def test_str_multi():
+    """Multiple keys are displayed as expected"""
+
+    store = Meta()
+    store['Xkey'] = 'X X'
+    store['xkey'] = ' y  y'
+    store['a'] = 23
+    store['INFILE'] = 'none'
+    store['outfile'] = '/tmp/b.fits'
+
+    lines = str(store).split('\n')
+    assert len(lines) == 5
+    assert lines[0] == ''
+    assert lines[1] == ' Xkey          = X X'
+    assert lines[2] == ' a             = 23'
+    assert lines[3] == ' outfile       = /tmp/b.fits'
+    assert lines[4] == ' xkey          =  y  y'

--- a/sherpa/astro/io/tests/test_meta.py
+++ b/sherpa/astro/io/tests/test_meta.py
@@ -89,6 +89,31 @@ def test_overwrite_keyword():
     assert not store['val1']
 
 
+def test_del_keyword():
+    """We can delete a keyword"""
+
+    store = Meta()
+    store['x1'] = 1
+    store['u1'] = 2
+    del store['x1']
+
+    assert store.keys() == ['u1']
+    assert store.values() == [2]
+
+
+def test_del_missing_keyword():
+    """We can not delete a keyword that doesn't exist"""
+
+    store = Meta()
+    store['x1'] = 1
+    store['u1'] = 2
+    with pytest.raises(KeyError):
+        del store['y1']
+
+    assert store.keys() == ['u1', 'x1']
+    assert store.values() == [2, 1]
+
+
 def test_keyword_order():
     """keys are sorted, not based on input order"""
 


### PR DESCRIPTION
Summary
=======

The `sherpa.astro.datastack` module has been updated to deal with files that use the `MJD-OBS` keyword instead of `MJD_OBS`. This is only used by the `show_stack` routine, which prints out
several keywords from each file in the stack (that is, it is not used when fitting the data, and is only in an "informational" routine).

Chandra data has historically used the `MJD_OBS` keyword, but will be switching to using `MJD-OBS`.

Details
=======

The test suite has been updated from SherpaTestCase to pytest style, and a basic test of `show_stack` has been added. A test suite for the `sherpa.astro.io.meta.Meta` class was added, along with a `__delitem__` method for the class (this was to make it easy to edit the header of the PHA files in memory rather than on disk).

The PR could be cleaned up to merge some of the initial commits, but it is ready for review now.