### PR TITLE
Update tests to use ds9 8.0.1

### DIFF
--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -43,7 +43,7 @@ download () {
 
 ### DS9 and XPA
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.0.tar.gz
+ds9_tar=ds9.${ds9_os}.8.0.1.tar.gz
 xpa_tar=xpa.${ds9_os}.2.1.18.tar.gz
 
 # Fetch them


### PR DESCRIPTION
Version 8.0 is no-longer available on the DS9 web site, which causes a number of Travis tests to fail - e.g. https://travis-ci.org/sherpa/sherpa/jobs/571477281#L1030