### PR TITLE
improve matplotlib plot_fit plots (order of data and model)

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -971,10 +971,11 @@ def test_pha1_plot_model_options(clean_astro_ui, basic_pha1):
 
     # Note that for PHA data sets, the mode is drawn as a histogram,
     # so get_model_plot_prefs doesn't actually work. We need to change
-    # the histogram prefs instead.
+    # the histogram prefs instead. See issue
+    # https://github.com/sherpa/sherpa/issues/672
     #
     # prefs = ui.get_model_plot_prefs()
-    prefs = ui._session._modelhisto.histo_prefs
+    prefs = ui.get_model_plot().histo_prefs
 
     # check the preference are as expected for the boolean cases
     assert not prefs['xlog']

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -24,6 +24,9 @@ It is based on sherpa/ui/tests/test_ui_plot.py, but focusses on the
 new routines, and "astro-specific" (currently PHA only) capabilities
 that are in the astro layer.
 
+There is very-limited checking that the plots are displaying the
+correct data; it is more a check that the routines can be called.
+
 """
 
 import logging
@@ -32,12 +35,15 @@ import numpy as np
 from sherpa.astro import ui
 
 # the chips plot tests mean that we can't test the plot instances
+# (because of the mocking that the chips tests do)
 # from sherpa.plot import DataPlot, FitPlot, ModelPlot
 
 from sherpa.utils.err import IdentifierErr
-from sherpa.utils.testing import requires_plotting
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_plotting, requires_pylab
 
 import pytest
+
 
 _data_chan = np.linspace(1, 10, 10, dtype=np.int8)
 _data_counts = np.asarray([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
@@ -752,3 +758,272 @@ def test_bkg_plot_xxx(idval, plotfunc, checkfuncs):
     #
     for checkfunc in checkfuncs:
         checkfunc(plotfunc)
+
+
+# The following tests were added in a separate PR to those above, and
+# rather than try to work out whether they do the same thing, they
+# have been left separate.
+#
+
+@pytest.fixture
+def basic_pha1(make_data_path):
+    """Create a basic PHA-1 data set/setup"""
+
+    ui.set_default_id('tst')
+    ui.load_pha(make_data_path('3c273.pi'))
+    ui.subtract()
+    ui.notice(0.5, 7)
+    ui.set_source(ui.powlaw1d.pl)
+    pl = ui.get_model_component('pl')
+    pl.gamma = 1.93
+    pl.ampl = 1.74e-4
+    
+
+@pytest.fixture
+def basic_img(make_data_path):
+    """Create a basic image data set/setup"""
+
+    ui.set_default_id(2)
+    ui.load_image(make_data_path('img.fits'))
+    ui.set_source(ui.gauss2d.gmdl)
+    gmdl = ui.get_model_component('gmdl')
+    ui.guess()
+
+
+_basic_plotfuncs = [ui.plot_data,
+                    ui.plot_bkg,
+                    ui.plot_model,
+                    ui.plot_source,
+                    ui.plot_resid,
+                    ui.plot_delchi,
+                    ui.plot_ratio,
+                    ui.plot_fit,
+                    ui.plot_fit_delchi,
+                    ui.plot_fit_resid,
+                    ui.plot_arf,
+                    ui.plot_chisqr]
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_function(clean_astro_ui, basic_pha1):
+    # can we call plot; do not try to be exhaustive
+    ui.plot("data", "bkg", "fit", "arf")
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("plotfunc", _basic_plotfuncs)
+def test_pha1_plot(clean_astro_ui, basic_pha1, plotfunc):
+    plotfunc()
+
+    
+@requires_plotting
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("plotfunc", [ui.int_unc, ui.int_proj])
+def test_pha1_int_plot(clean_astro_ui, basic_pha1, plotfunc):
+    plotfunc('pl.gamma')
+    
+
+@requires_plotting
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("plotfunc", [ui.reg_unc, ui.reg_proj])
+def test_pha1_reg_plot(clean_astro_ui, basic_pha1, plotfunc):
+    plotfunc('pl.gamma', 'pl.ampl')
+    
+
+_img_plotfuncs = [ui.contour_data,
+                  ui.contour_fit,
+                  ui.contour_fit_resid,
+                  ui.contour_model,
+                  ui.contour_ratio,
+                  ui.contour_resid,
+                  ui.contour_source ]
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_img_contour_function(clean_astro_ui, basic_img):
+    # can we call contour; do not try to be exhaustive
+    ui.contour("data", "model", "source", "fit")
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("plotfunc", _img_plotfuncs)
+def test_img_contour(clean_astro_ui, basic_img, plotfunc):
+    plotfunc()
+
+
+# Add in some pylab-specific tests to change default values
+#
+
+@requires_pylab
+@requires_fits
+@requires_data
+def test_pha1_plot_data_options(clean_astro_ui, basic_pha1):
+    """Test that the options have changed things, where easy to do so"""
+
+    from matplotlib import pyplot as plt
+
+    prefs = ui.get_data_plot_prefs()
+
+    # check the preference are as expected for the boolean cases
+    assert not prefs['xerrorbars']
+    assert prefs['yerrorbars']
+    assert not prefs['xlog']
+    assert not prefs['ylog']
+
+    prefs['xerrorbars'] = True
+    prefs['yerrorbars'] = False
+    prefs['xlog'] = True
+    prefs['ylog'] = True
+
+    prefs['color'] = 'orange'
+
+    prefs['linecolor'] = 'brown'
+    prefs['linestyle'] = '-.'
+
+    prefs['marker'] = 's'
+    prefs['markerfacecolor'] = 'cyan'
+    prefs['markersize'] = 10
+
+    ui.plot_data()
+
+    ax = plt.gca()
+    assert ax.get_xscale() == 'log'
+    assert ax.get_yscale() == 'log'
+
+    assert ax.get_xlabel() == 'Energy (keV)'
+    assert ax.get_ylabel() == 'Counts/sec/keV'
+
+    # It is not clear whether an 'exact' check on the value, as
+    # provided by pytest.approx, makes sense, or whether a "softer"
+    # check - e.g.  just check whether it is less- or greater- than a
+    # value - should be used. It depends on how often matplotlib
+    # tweaks the axis settings and how sensitive it is to
+    # platform/backend differences. Let's see how pytest.approx works
+    #
+    xmin, xmax = ax.get_xlim()
+    assert xmin == pytest.approx(0.40110954270367555)
+    assert xmax == pytest.approx(11.495805054836712)
+
+    ymin, ymax = ax.get_ylim()
+    assert ymin == pytest.approx(7.644069935298475e-05)
+    assert ymax == pytest.approx(0.017031102671151491)
+
+    assert len(ax.lines) == 1
+    line = ax.lines[0]
+
+    # Apparently color wins out over linecolor
+    assert line.get_color() == 'orange'
+    assert line.get_linestyle() == '-.'
+    assert line.get_marker() == 's'
+    assert line.get_markerfacecolor() == 'cyan'
+    assert line.get_markersize() == pytest.approx(10.0)
+
+    # assume error bars handled by a collection; test a subset
+    # of values
+    #
+    assert len(ax.collections) == 1
+    coll = ax.collections[0]
+
+    assert len(coll.get_segments()) == 42
+
+    assert coll.get_linestyles() == [(None, None)]
+
+    # looks like the color has been converted to individual channels
+    # - e.g. floating-point values for R, G, B, and alpha.
+    #
+    colors = coll.get_color()
+    assert len(colors) == 1
+    assert len(colors[0]) == 4
+    r, g, b, a = colors[0]
+    assert r == pytest.approx(1)
+    assert g == pytest.approx(0.64705882)
+    assert b == pytest.approx(0)
+    assert a == pytest.approx(1)
+
+
+@requires_pylab
+@requires_fits
+@requires_data
+def test_pha1_plot_model_options(clean_astro_ui, basic_pha1):
+    """Test that the options have changed things, where easy to do so
+
+    In matplotlib 3.1 the plot_model call causes a MatplotlibDeprecationWarning
+    to be created:
+
+    Passing the drawstyle with the linestyle as a single string is deprecated since Matplotlib 3.1 and support will be removed in 3.3; please pass the drawstyle separately using the drawstyle keyword argument to Line2D or set_drawstyle() method (or ds/set_ds()).
+
+    This warning is hidden by the test suite (sherpa/conftest.py) so that
+    it doesn't cause the tests to fail. Note that a number of other tests
+    in this module also cause this warning to be displayed.
+
+    """
+
+    from matplotlib import pyplot as plt
+
+    # Note that for PHA data sets, the mode is drawn as a histogram,
+    # so get_model_plot_prefs doesn't actually work. We need to change
+    # the histogram prefs instead.
+    #
+    # prefs = ui.get_model_plot_prefs()
+    prefs = ui._session._modelhisto.histo_prefs
+
+    # check the preference are as expected for the boolean cases
+    assert not prefs['xlog']
+    assert not prefs['ylog']
+
+    # Only change the X axis here
+    prefs['xlog'] = True
+
+    prefs['color'] = 'green'
+
+    prefs['linecolor'] = 'red'
+    prefs['linestyle'] = 'dashed'
+
+    prefs['marker'] = '*'
+    prefs['markerfacecolor'] = 'yellow'
+    prefs['markersize'] = 8
+
+    ui.plot_model()
+
+    ax = plt.gca()
+    assert ax.get_xscale() == 'log'
+    assert ax.get_yscale() == 'linear'
+
+    assert ax.get_xlabel() == 'Energy (keV)'
+    assert ax.get_ylabel() == 'Counts/sec/keV'
+
+    # It is not clear whether an 'exact' check on the value, as
+    # provided by pytest.approx, makes sense, or whether a "softer"
+    # check - e.g.  just check whether it is less- or greater- than a
+    # value - should be used. It depends on how often matplotlib
+    # tweaks the axis settings and how sensitive it is to
+    # platform/backend differences. Let's see how pytest.approx works
+    #
+    xmin, xmax = ax.get_xlim()
+    assert xmin == pytest.approx(0.40770789163447285)
+    assert xmax == pytest.approx(11.477975806572461)
+
+    ymin, ymax = ax.get_ylim()
+    assert ymin == pytest.approx(-0.00045772936258082011, rel=0.01)
+    assert ymax == pytest.approx(0.009940286575890335, rel=0.01)
+
+    assert len(ax.lines) == 1
+    line = ax.lines[0]
+
+    # Apparently color wins out over linecolor
+    assert line.get_color() == 'green'
+    assert line.get_linestyle() == '--'  # note: input was dashed
+    assert line.get_marker() == '*'
+    assert line.get_markerfacecolor() == 'yellow'
+    assert line.get_markersize() == pytest.approx(8.0)
+
+    assert len(ax.collections) == 0

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -167,8 +167,10 @@ class Plot(NoNewAttributesAfterInit):
 
     def plot(self, x, y, yerr=None, xerr=None, title=None, xlabel=None,
              ylabel=None, overplot=False, clearwindow=True):
-        backend.plot(x, y, yerr, xerr, title, xlabel, ylabel, overplot,
-                     clearwindow, **self.plot_prefs)
+        backend.plot(x, y, yerr=yerr, xerr=xerr,
+                     title=title, xlabel=xlabel, ylabel=ylabel,
+                     overplot=overplot, clearwindow=clearwindow,
+                     **self.plot_prefs)
 
     def overplot(self, *args, **kwargs):
         "Add the data to an existing plot."
@@ -746,8 +748,9 @@ class DataPlot(Plot):
         self.title = data.name
 
     def plot(self, overplot=False, clearwindow=True):
-        Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
-                  self.xlabel, self.ylabel, overplot, clearwindow)
+        Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
+                  title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow)
 
 
 class TracePlot(DataPlot):
@@ -1218,8 +1221,9 @@ class DelchiPlot(ModelPlot):
         self.title = _make_title('Sigma Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
-        Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
-                  self.xlabel, self.ylabel, overplot, clearwindow)
+        Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
+                  title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow)
 
 
 class ChisqrPlot(ModelPlot):
@@ -1325,8 +1329,9 @@ class ResidPlot(ModelPlot):
         self.title = _make_title('Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
-        Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
-                  self.xlabel, self.ylabel, overplot, clearwindow)
+        Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
+                  title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow)
 
 
 class ResidContour(ModelContour):
@@ -1407,8 +1412,9 @@ class RatioPlot(ModelPlot):
         self.title = _make_title('Ratio of Data to Model', data.name)
 
     def plot(self, overplot=False, clearwindow=True):
-        Plot.plot(self, self.x, self.y, self.yerr, self.xerr, self.title,
-                  self.xlabel, self.ylabel, overplot, clearwindow)
+        Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
+                  title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow)
 
 
 class RatioContour(ModelContour):

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -153,9 +153,16 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
           markersize=None):
 
     xmid = 0.5 * (xlo + xhi)
-    plot(xmid, y, yerr, None, title, xlabel, ylabel, overplot, clearwindow,
-         False, yerrorbars, ecolor, capsize, barsabove, xlog, ylog, linestyle,
-         linecolor, color, marker, markerfacecolor, markersize, False, False)
+    plot(xmid, y, yerr=yerr, xerr=None,
+         title=title, xlabel=xlabel, ylabel=ylabel,
+         overplot=overplot, clearwindow=clearwindow,
+         xerrorbars=False, yerrorbars=yerrorbars,
+         ecolor=ecolor, capsize=capsize, barsabove=barsabove,
+         xlog=xlog, ylog=ylog,
+         linestyle=linestyle, linecolor=linecolor,
+         color=color, marker=marker,
+         markerfacecolor=markerfacecolor, markersize=markersize,
+         xaxis=False, ratioline=False)
 
 
 _attr_map = {

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -284,9 +284,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
     #
     try:
         lw = axes.spines['left'].get_linewidth()
-    except:
-        # should restrict to a particular error, but I do not know
-        # the axis structure enough to know what can go wrong
+    except (AttributeError, KeyError):
         lw = 1.0
 
     if xaxis:

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -352,10 +352,13 @@ def set_jointplot(row, col, nrows, ncols, clearaxes=True,
                   top=1,
                   ratio=2):
 
-    # TODO: work out why chips and pylab backends seem to have
-    #       clearaxes logic inverted (comment about it in chips backend)
-    #
-    if not clearaxes:
+    if clearaxes:
+        # need to set axes[1] as current axes.
+        axes = pylab.gca()
+        ax2 = axes.figure.axes[-1]
+        pylab.sca(ax2)
+
+    else:
         # follow the chips backend and set plot number "top" (numbering
         # from 1) as the plot with a height of ratio, and the rest
         # with a value of 1. Note that the chips backend created
@@ -367,16 +370,11 @@ def set_jointplot(row, col, nrows, ncols, clearaxes=True,
         f, axarr = pylab.subplots(nrows, sharex=True, num=1,
                                   gridspec_kw=gs)
         f.subplots_adjust(hspace=0.05)
-        pylab.setp([a.get_xticklabels() for a in f.axes[:-1]], visible=False)
+        pylab.setp([a.get_xticklabels() for a in f.axes[:-1]],
+                   visible=False)
 
         # need to set axes[0] as current axes.
         pylab.sca(axarr[0])
-
-    else:
-        # need to set axes[1] as current axes.
-        axes = pylab.gca()
-        ax2 = axes.figure.axes[-1]
-        pylab.sca(ax2)
 
 
 def get_split_plot_defaults():

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -128,11 +128,11 @@ def point(x, y, overplot=True, clearwindow=False,
     axes = setup_axes(overplot, clearwindow)
 
     if color is None:
-        str = '%s' % (symbol)
+        style = '{}'.format(symbol)
     else:
-        str = '%s%s' % (color, symbol)
+        style = '{}{}'.format(color, symbol)
 
-    axes.plot(numpy.array([x]), numpy.array([y]), str)
+    axes.plot(numpy.array([x]), numpy.array([y]), style)
 
 
 def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -172,12 +172,6 @@ _linestyle_map = {
 }
 
 
-def _check_hex_color(val):
-    if type(val) in (str, numpy.string_) and val.startswith('0x'):
-        val = '#' + str(val).replace('0x', '').rjust(6, '0')
-    return val
-
-
 def _set_line(line, linecolor=None, linestyle=None, linewidth=None):
     """Apply the line attributes, if set.
 
@@ -195,7 +189,7 @@ def _set_line(line, linecolor=None, linestyle=None, linewidth=None):
         func(newval)
 
     if linecolor is not None:
-        set('color', _check_hex_color(linecolor))
+        set('color', linecolor)
 
     if linestyle is not None:
         set('linestyle', _linestyle_map[linestyle])

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -332,16 +332,12 @@ def set_subplot(row, col, nrows, ncols, clearaxes=True,
     plt.subplots_adjust(left=left, right=right, bottom=bottom, top=top,
                         wspace=wspace, hspace=hspace)
 
-    num = row * ncols + col + 1
-
-    # As of numpy 0.9.8, these need to be cast to int to prevent errors
-    # in matplotlib
+    # historically there have been issues with numpy integers here
     nrows = int(nrows)
     ncols = int(ncols)
-    num   = int(num)
+    num = int(row) * ncols + int(col) + 1
 
     plt.subplot(nrows, ncols, num)
-
     if clearaxes:
         plt.cla()
 

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -163,12 +163,6 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
          xaxis=False, ratioline=False)
 
 
-_attr_map = {
-    'linecolor': 'color',
-    'linestyle': 'linestyle',
-    'linewidth': 'linewidth',
-}
-
 _linestyle_map = {
     'noline': ' ',
     'solid': '-',
@@ -184,6 +178,32 @@ def _check_hex_color(val):
     return val
 
 
+def _set_line(line, linecolor=None, linestyle=None, linewidth=None):
+    """Apply the line attributes, if set.
+
+    Parameters
+    ----------
+    line : matplotlib.lines.Line2D
+        The line to change
+    linecolor, linestyle, linewidth : optional
+        The attribute value or None.
+
+    """
+
+    def set(label, newval):
+        func = getattr(line, 'set_' + label)
+        func(newval)
+
+    if linecolor is not None:
+        set('color', _check_hex_color(linecolor))
+
+    if linestyle is not None:
+        set('linestyle', _linestyle_map[linestyle])
+
+    if linewidth is not None:
+        set('linewidth', linewidth)
+
+
 def vline(x, ymin=0, ymax=1,
           linecolor=None,
           linestyle=None,
@@ -193,15 +213,8 @@ def vline(x, ymin=0, ymax=1,
     axes = setup_axes(overplot, clearwindow)
 
     line = axes.axvline(x, ymin, ymax)
-
-    for var in ('linecolor', 'linestyle', 'linewidth'):
-        val = locals()[var]
-        if val is not None:
-            if 'style' in var:
-                val = _linestyle_map[val]
-            elif 'color' in var:
-                val = _check_hex_color(val)
-            getattr(line, 'set_' + _attr_map[var])(val)
+    _set_line(line, linecolor=linecolor, linestyle=linestyle,
+              linewidth=linewidth)
 
 
 def hline(y, xmin=0, xmax=1,
@@ -213,15 +226,8 @@ def hline(y, xmin=0, xmax=1,
     axes = setup_axes(overplot, clearwindow)
 
     line = axes.axhline(y, xmin, xmax)
-
-    for var in ('linecolor', 'linestyle', 'linewidth'):
-        val = locals()[var]
-        if val is not None:
-            if 'style' in var:
-                val = _linestyle_map[val]
-            elif 'color' in var:
-                val = _check_hex_color(val)
-            getattr(line, 'set_' + _attr_map[var])(val)
+    _set_line(line, linecolor=linecolor, linestyle=linestyle,
+              linewidth=linewidth)
 
 
 def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -17,9 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
+# Although this is labelled pylab mode, use the pyplot interface
+# (for the functionlity used here, they are the same).
+#
 import numpy
-import pylab
+from matplotlib import pyplot as plt
 
 from sherpa.utils import get_keyword_defaults
 from sherpa.utils.err import NotImplementedErr
@@ -52,28 +54,24 @@ def begin():
 
 def end():
     set_window_redraw(True)
-    if pylab.isinteractive():
-        pylab.draw()
+    if plt.isinteractive():
+        plt.draw()
 
 
 def exceptions():
     pass
 
 
-# In matplotlib 1.5RC1 the kwargs to pylab.Axes.errorbar are not
-# explictit, but they appear to be set for pybal.errorbar, so
-# switch to that.
-# _errorbar_defaults = get_keyword_defaults(pylab.Axes.errorbar)
-_errorbar_defaults = get_keyword_defaults(pylab.errorbar)
+_errorbar_defaults = get_keyword_defaults(plt.errorbar)
 
 
 def clear_window():
-    pylab.clf()
+    plt.clf()
 
 
 def set_window_redraw(redraw):
     if redraw:
-        pylab.draw()
+        plt.draw()
 
 
 def setup_axes(overplot, clearwindow):
@@ -94,7 +92,7 @@ def setup_axes(overplot, clearwindow):
     if not overplot and clearwindow:
         clear_window()
 
-    return pylab.gca()
+    return plt.gca()
 
 
 def setup_plot(axes, title, xlabel, ylabel, xlog=False, ylog=False):
@@ -331,8 +329,8 @@ def set_subplot(row, col, nrows, ncols, clearaxes=True,
                 wspace=0.3,
                 hspace=0.4):
 
-    pylab.subplots_adjust(left=left, right=right, bottom=bottom, top=top,
-                          wspace=wspace, hspace=hspace)
+    plt.subplots_adjust(left=left, right=right, bottom=bottom, top=top,
+                        wspace=wspace, hspace=hspace)
 
     num = row * ncols + col + 1
 
@@ -342,10 +340,10 @@ def set_subplot(row, col, nrows, ncols, clearaxes=True,
     ncols = int(ncols)
     num   = int(num)
 
-    pylab.subplot(nrows, ncols, num)
+    plt.subplot(nrows, ncols, num)
 
     if clearaxes:
-        pylab.cla()
+        plt.cla()
 
 
 def set_jointplot(row, col, nrows, ncols, clearaxes=True,
@@ -354,9 +352,9 @@ def set_jointplot(row, col, nrows, ncols, clearaxes=True,
 
     if clearaxes:
         # need to set axes[1] as current axes.
-        axes = pylab.gca()
+        axes = plt.gca()
         ax2 = axes.figure.axes[-1]
-        pylab.sca(ax2)
+        plt.sca(ax2)
 
     else:
         # follow the chips backend and set plot number "top" (numbering
@@ -367,14 +365,14 @@ def set_jointplot(row, col, nrows, ncols, clearaxes=True,
         ratios = [1] * nrows
         ratios[top - 1] = ratio
         gs = {'height_ratios': ratios}
-        f, axarr = pylab.subplots(nrows, sharex=True, num=1,
-                                  gridspec_kw=gs)
+        f, axarr = plt.subplots(nrows, sharex=True, num=1,
+                                gridspec_kw=gs)
         f.subplots_adjust(hspace=0.05)
-        pylab.setp([a.get_xticklabels() for a in f.axes[:-1]],
-                   visible=False)
+        plt.setp([a.get_xticklabels() for a in f.axes[:-1]],
+                 visible=False)
 
         # need to set axes[0] as current axes.
-        pylab.sca(axarr[0])
+        plt.sca(axarr[0])
 
 
 def get_split_plot_defaults():

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -45,16 +45,20 @@ name = 'pylab'
 def init():
     pass
 
+
 def begin():
     pass
+
 
 def end():
     set_window_redraw(True)
     if pylab.isinteractive():
         pylab.draw()
 
+
 def exceptions():
     pass
+
 
 def _choose(test, iftrue, iffalse=None):
     if test:
@@ -71,6 +75,7 @@ _errorbar_defaults = get_keyword_defaults(pylab.errorbar)
 
 def clear_window():
     pylab.clf()
+
 
 def set_window_redraw(redraw):
     if redraw:
@@ -89,13 +94,11 @@ def point(x, y, overplot=True, clearwindow=False,
         axes = pylab.gca()
 
     if color is None:
-        str = '%s'%(symbol)
+        str = '%s' % (symbol)
     else:
-        str = '%s%s'%(color,symbol)
+        str = '%s%s' % (color, symbol)
 
-    point = axes.plot(numpy.array([x]),numpy.array([y]),str)[0]
-
-    #pylab.draw()
+    axes.plot(numpy.array([x]), numpy.array([y]), str)
 
 
 def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
@@ -113,31 +116,32 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
           markerfacecolor=None,
           markersize=None):
 
-    plot(0.5*(xlo+xhi), y, yerr, None, title, xlabel, ylabel, overplot, clearwindow,
+    xmid = 0.5 * (xlo + xhi)
+    plot(xmid, y, yerr, None, title, xlabel, ylabel, overplot, clearwindow,
          False, yerrorbars, ecolor, capsize, barsabove, xlog, ylog, linestyle,
          linecolor, color, marker, markerfacecolor, markersize, False, False)
 
 
 _attr_map = {
-    'linecolor' : 'color',
-    'linestyle' : 'linestyle',
-    'linewidth' : 'linewidth',
-    }
+    'linecolor': 'color',
+    'linestyle': 'linestyle',
+    'linewidth': 'linewidth',
+}
 
 _linestyle_map = {
-
-    'noline'  : ' ',
-    'solid'   : '-',
-    'dot'     : ':',
-    'dash'    : '--',
-    'dotdash' : '-.',
-    }
+    'noline': ' ',
+    'solid': '-',
+    'dot': ':',
+    'dash': '--',
+    'dotdash': '-.',
+}
 
 
 def _check_hex_color(val):
     if type(val) in (str, numpy.string_) and val.startswith('0x'):
-        val = '#'+str(val).replace('0x','').rjust(6,'0')
+        val = '#' + str(val).replace('0x', '').rjust(6, '0')
     return val
+
 
 def vline(x, ymin=0, ymax=1,
           linecolor=None,
@@ -248,6 +252,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
                 'markersize'):
         val = locals()[var]
         if val is not None:
+            print(' -- set_{}({})'.format(var, val))
             getattr(line, 'set_' + var)(val)
 
     # Should the color for these lines be taken from the current axes?
@@ -270,7 +275,6 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
     if ratioline:
         axes.axhline(y=1, xmin=0, xmax=1, color='k', linewidth=lw)
 
-    #pylab.draw()
 
 def contour(x0, x1, y, levels=None, title=None, xlabel=None, ylabel=None,
             overcontour=False, clearwindow=True,
@@ -298,7 +302,6 @@ def contour(x0, x1, y, levels=None, title=None, xlabel=None, ylabel=None,
         axes.set_xscale(xscale)
         axes.set_yscale(yscale)
 
-
     x0 = numpy.unique(x0)
     x1 = numpy.unique(x1)
     y  = numpy.asarray(y)
@@ -309,12 +312,10 @@ def contour(x0, x1, y, levels=None, title=None, xlabel=None, ylabel=None,
     y = y.reshape(x1.size, x0.size)
 
     if levels is None:
-        line = axes.contour(x0, x1, y, colors=colors, linewidths=linewidths)
+        axes.contour(x0, x1, y, colors=colors, linewidths=linewidths)
     else:
-        line = axes.contour(x0, x1, y, levels, colors=colors,
-                            linewidths=linewidths)
-
-    #pylab.draw()
+        axes.contour(x0, x1, y, levels, colors=colors,
+                     linewidths=linewidths)
 
 
 def set_subplot(row, col, nrows, ncols, clearaxes=True,
@@ -328,7 +329,7 @@ def set_subplot(row, col, nrows, ncols, clearaxes=True,
     pylab.subplots_adjust(left=left, right=right, bottom=bottom, top=top,
                           wspace=wspace, hspace=hspace)
 
-    num = row*ncols + col + 1
+    num = row * ncols + col + 1
 
     # As of numpy 0.9.8, these need to be cast to int to prevent errors
     # in matplotlib
@@ -367,12 +368,10 @@ def set_jointplot(row, col, nrows, ncols, clearaxes=True,
         pylab.sca(axarr[0])
 
     else:
-
         # need to set axes[1] as current axes.
         axes = pylab.gca()
         ax2 = axes.figure.axes[-1]
         pylab.sca(ax2)
-        #ax2.get_yticklabels()[-1].set_visible(False)
 
 
 def get_split_plot_defaults():
@@ -386,12 +385,14 @@ def get_plot_defaults():
 def get_point_defaults():
     return get_keyword_defaults(point, 2)
 
+
 def get_histo_defaults():
     return get_keyword_defaults(histo, 6)
 
+
 def get_confid_point_defaults():
     d = get_point_defaults()
-    d['symbol']='+'
+    d['symbol'] = '+'
     return d
 
 
@@ -403,9 +404,11 @@ def get_data_plot_defaults():
     d['marker'] = '.'
     return d
 
+
 def get_model_histo_defaults():
     d = get_histo_defaults()
     return d
+
 
 def get_model_plot_defaults():
     d = get_plot_defaults()
@@ -424,7 +427,7 @@ def get_resid_plot_defaults():
     d = get_data_plot_defaults()
     d['xerrorbars'] = True
     d['capsize'] = 0
-    #d['marker'] = '_'
+    # d['marker'] = '_'
     d['xaxis'] = True
     return d
 
@@ -433,7 +436,7 @@ def get_ratio_plot_defaults():
     d = get_data_plot_defaults()
     d['xerrorbars'] = True
     d['capsize'] = 0
-    #d['marker'] = '_'
+    # d['marker'] = '_'
     d['ratioline'] = True
     return d
 
@@ -464,14 +467,17 @@ get_ratio_contour_defaults = get_data_contour_defaults
 get_component_plot_defaults = get_model_plot_defaults
 get_component_histo_defaults = get_model_histo_defaults
 
+
 def get_cdf_plot_defaults():
     d = get_model_plot_defaults()
     d['linecolor'] = 'red'
     return d
 
+
 def get_scatter_plot_defaults():
     d = get_data_plot_defaults()
     return d
+
 
 def get_latex_for_string(txt):
     """Convert to LaTeX form for the matplotlib back end.

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,6 +1,6 @@
 from __future__ import division
 #
-#  Copyright (C) 2007, 2015, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,8 @@ from __future__ import division
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from collections import namedtuple
+
 import numpy
 import pytest
 
@@ -25,7 +27,7 @@ import sherpa.all as sherpa
 from sherpa.astro.ui.utils import Session
 from sherpa.models import Const1D
 from sherpa.data import Data1DInt
-from sherpa.utils.testing import SherpaTestCase, requires_data, requires_plotting
+from sherpa.utils.testing import requires_data, requires_plotting
 
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
@@ -56,354 +58,403 @@ _datay = numpy.array(
 # TODO: many tests in this class do not perform any assertions
 # True, but I am glad they were there despite not performing any assertions
 # as they made me spot some regressions I wouldn't have otherwise spotted (OL)
-class test_plot(SherpaTestCase):
+#
 
-    def setUp(self):
-        self.data = sherpa.Data1D('testdata', _datax, _datay)
-        self.g1 = sherpa.Gauss1D('g1')
-        self.f = sherpa.Fit(self.data, self.g1)
+SetupPlot = namedtuple('SetupPlot',
+                       ['data', 'g1', 'f'])
+SetupContour = namedtuple('SetupContour',
+                          ['data', 'g1', 'f', 'levels'])
+SetupConfidence = namedtuple('SetupConfidence',
+                             ['data', 'g1', 'f', 'ip', 'iu', 'rp', 'ru'])
 
-    def test_dataplot(self):
-        dp = sherpa.DataPlot()
-        dp.prepare(self.data, self.f.stat)
-        # dp.plot()
 
-    def test_modelplot(self):
-        mp = sherpa.ModelPlot()
-        mp.prepare(self.data, self.g1, self.f.stat)
-        # mp.plot()
+@pytest.fixture
+def setup_plot():
 
-    def test_residplot(self):
-        rp = sherpa.ResidPlot()
-        rp.prepare(self.data, self.g1, self.f.stat)
-        # rp.plot()
+    data = sherpa.Data1D('testdata', _datax, _datay)
+    g1 = sherpa.Gauss1D('g1')
+    f = sherpa.Fit(data, g1)
 
-    def test_delchiplot(self):
-        dp = sherpa.DelchiPlot()
-        dp.prepare(self.data, self.g1, self.f.stat)
-        # dp.plot()
+    return SetupPlot(data, g1, f)
 
-    def test_chisqrplot(self):
-        cs = sherpa.ChisqrPlot()
-        cs.prepare(self.data, self.g1, self.f.stat)
-        # cs.plot()
 
-    def test_ratioplot(self):
-        tp = sherpa.RatioPlot()
-        tp.prepare(self.data, self.g1, self.f.stat)
-        # tp.plot()
+@pytest.fixture
+def setup_contour(make_data_path):
 
-    def test_fitplot(self):
-        dp = sherpa.DataPlot()
-        dp.prepare(self.data, self.f.stat)
+    data = sherpa.read_data(make_data_path('gauss2d.dat'),
+                            ncols=3, sep='\t', dstype=sherpa.Data2D)
+    g1 = sherpa.Gauss2D('g1')
+    g1.ellip.freeze()
+    g1.theta.freeze()
+    f = sherpa.Fit(data, g1)
+    levels = numpy.array([0.5, 2, 5, 10, 20])
 
-        mp = sherpa.ModelPlot()
-        mp.prepare(self.data, self.g1, self.f.stat)
+    return SetupContour(data, g1, f, levels)
 
-        fp = sherpa.FitPlot()
-        fp.prepare(dp, mp)
-        # fp.plot()
 
-    def test_splitplot(self):
-        dp = sherpa.DataPlot()
-        dp.prepare(self.data, self.f.stat)
+@pytest.fixture
+def setup_confidence():
+    """Note that this performs a fit, so can be slow"""
 
-        mp = sherpa.ModelPlot()
-        mp.prepare(self.data, self.g1, self.f.stat)
+    data = sherpa.Data1D('testdata', _datax, _datay)
+    g1 = sherpa.Gauss1D('g1')
+    f = sherpa.Fit(data, g1)
+    f.fit()
+    ip = sherpa.IntervalProjection()
+    iu = sherpa.IntervalUncertainty()
+    rp = sherpa.RegionProjection()
+    ru = sherpa.RegionUncertainty()
 
-        rp = sherpa.ResidPlot()
-        rp.prepare(self.data, self.g1, self.f.stat)
+    return SetupConfidence(data, g1, f, ip, iu, rp, ru)
 
-        fp = sherpa.FitPlot()
-        fp.prepare(dp, mp)
 
-        sp = sherpa.SplitPlot(2, 2)
-        # sp.addplot(dp)
-        # sp.addplot(mp)
-        # sp.addplot(fp)
-        # sp.addplot(rp)
+# These tests don't need a backend as there is no "plot" call,
+# and so do not need a @requires_plotting decorator.
+#
+def test_dataplot(setup_plot):
+    dp = sherpa.DataPlot()
+    dp.prepare(setup_plot.data, setup_plot.f.stat)
+    # dp.plot()
+
+
+def test_modelplot(setup_plot):
+    mp = sherpa.ModelPlot()
+    mp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+    # mp.plot()
+
+
+def test_residplot(setup_plot):
+    rp = sherpa.ResidPlot()
+    rp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+    # rp.plot()
+
+
+def test_delchiplot(setup_plot):
+    dp = sherpa.DelchiPlot()
+    dp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+    # dp.plot()
+
+
+def test_chisqrplot(setup_plot):
+    cs = sherpa.ChisqrPlot()
+    cs.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+    # cs.plot()
+
+
+def test_ratioplot(setup_plot):
+    tp = sherpa.RatioPlot()
+    tp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+    # tp.plot()
+
+
+def test_fitplot(setup_plot):
+    dp = sherpa.DataPlot()
+    dp.prepare(setup_plot.data, setup_plot.f.stat)
+
+    mp = sherpa.ModelPlot()
+    mp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+
+    fp = sherpa.FitPlot()
+    fp.prepare(dp, mp)
+    # fp.plot()
+
+
+def test_splitplot(setup_plot):
+    dp = sherpa.DataPlot()
+    dp.prepare(setup_plot.data, setup_plot.f.stat)
+
+    mp = sherpa.ModelPlot()
+    mp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+
+    rp = sherpa.ResidPlot()
+    rp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+
+    fp = sherpa.FitPlot()
+    fp.prepare(dp, mp)
+
+    sp = sherpa.SplitPlot(2, 2)
+    # sp.addplot(dp)
+    # sp.addplot(mp)
+    # sp.addplot(fp)
+    # sp.addplot(rp)
 
 
 @requires_data
-class test_contour(SherpaTestCase):
-
-    def setUp(self):
-        self.data = sherpa.read_data(self.make_path('gauss2d.dat'),
-                                     ncols=3, sep='\t', dstype=sherpa.Data2D)
-        self.g1 = sherpa.Gauss2D('g1')
-        self.g1.ellip.freeze()
-        self.g1.theta.freeze()
-        self.f = sherpa.Fit(self.data, self.g1)
-        self.levels = numpy.array([0.5, 2, 5, 10, 20])
-
-    def test_datacontour(self):
-        dc = sherpa.DataContour()
-        dc.prepare(self.data)
-        dc.levels = self.levels
-        # dc.contour()
-
-    def test_modelcontour(self):
-        mc = sherpa.ModelContour()
-        mc.prepare(self.data, self.g1, self.f.stat)
-        mc.levels = self.levels
-        # mc.contour()
-
-    def test_residcontour(self):
-        rc = sherpa.ResidContour()
-        rc.prepare(self.data, self.g1, self.f.stat)
-        rc.levels = self.levels
-        # rc.contour()
-
-    def test_ratiocontour(self):
-        tc = sherpa.RatioContour()
-        tc.prepare(self.data, self.g1, self.f.stat)
-        tc.levels = self.levels
-        # tc.contour()
-
-    def test_fitcontour(self):
-        dc = sherpa.DataContour()
-        dc.prepare(self.data)
-
-        mc = sherpa.ModelContour()
-        mc.prepare(self.data, self.g1, self.f.stat)
-
-        fc = sherpa.FitContour()
-        fc.prepare(dc, mc)
-        # fc.contour()
-
-    def test_splitcontour(self):
-        dc = sherpa.DataContour()
-        dc.levels = self.levels
-        dc.prepare(self.data)
-
-        mc = sherpa.ModelContour()
-        mc.levels = self.levels
-        mc.prepare(self.data, self.g1, self.f.stat)
-
-        fc = sherpa.FitContour()
-        fc.prepare(dc, mc)
-
-        rc = sherpa.ResidContour()
-        rc.prepare(self.data, self.g1, self.f.stat)
-        rc.levels = self.levels
-
-        sp = sherpa.SplitPlot(2, 2)
-        # sp.addcontour(dc)
-        # sp.addcontour(mc)
-        # sp.addcontour(fc)
-        # sp.addcontour(rc)
+def test_datacontour(setup_contour):
+    dc = sherpa.DataContour()
+    dc.prepare(setup_contour.data)
+    dc.levels = setup_contour.levels
+    # dc.contour()
 
 
-class test_confidence(SherpaTestCase):
+@requires_data
+def test_modelcontour(setup_contour):
+    mc = sherpa.ModelContour()
+    mc.prepare(setup_contour.data, setup_contour.g1, setup_contour.f.stat)
+    mc.levels = setup_contour.levels
+    # mc.contour()
 
-    def setUp(self):
-        self.data = sherpa.Data1D('testdata', _datax, _datay)
-        self.g1 = sherpa.Gauss1D('g1')
-        self.f = sherpa.Fit(self.data, self.g1)
-        self.f.fit()
-        self.ip = sherpa.IntervalProjection()
-        self.iu = sherpa.IntervalUncertainty()
-        self.rp = sherpa.RegionProjection()
-        self.ru = sherpa.RegionUncertainty()
 
-    def test_interval_projection(self):
-        _ipx = numpy.array(
-            [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
-              16.88976119,  17.21040017,  17.53103916,  17.85167814,
-              18.17231712,  18.49295611,  18.81359509,  19.13423407,
-              19.45487306,  19.77551204,  20.09615102,  20.41679001,
-              20.73742899,  21.05806798,  21.37870696,  21.69934594])
-        _ipy = numpy.array(
-            [ 40.09661435,  39.18194614,  38.37963283,  37.68723716,
-              37.10218543,  36.62179549,  36.2432939 ,  35.96383078,
-              35.78049297,  35.69031588,  35.69029438,  35.77739294,
-              35.94855493,  36.20071145,  36.53078937,  36.9357187 ,
-              37.41243938,  37.95790737,  38.56910025,  39.24302218])
+@requires_data
+def test_residcontour(setup_contour):
+    rc = sherpa.ResidContour()
+    rc.prepare(setup_contour.data, setup_contour.g1, setup_contour.f.stat)
+    rc.levels = setup_contour.levels
+    # rc.contour()
 
-        self.ip.fac = 2
-        self.ip.calc(self.f, self.g1.fwhm)
-        self.assertEqualWithinTol(_ipx, self.ip.x, 1e-4)
-        self.assertEqualWithinTol(_ipy, self.ip.y, 1e-4)
-        # self.ip.plot()
 
-    def test_interval_uncertainty(self):
-        _iux = numpy.array(
-            [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
-              16.88976119,  17.21040017,  17.53103916,  17.85167814,
-              18.17231712,  18.49295611,  18.81359509,  19.13423407,
-              19.45487306,  19.77551204,  20.09615102,  20.41679001,
-              20.73742899,  21.05806798,  21.37870696,  21.69934594])
+@requires_data
+def test_ratiocontour(setup_contour):
+    tc = sherpa.RatioContour()
+    tc.prepare(setup_contour.data, setup_contour.g1, setup_contour.f.stat)
+    tc.levels = setup_contour.levels
+    # tc.contour()
 
-        _iuy = numpy.array(
-            [ 42.2582845 ,  40.96299483,  39.80577195,  38.78821363,
-              37.91185112,  37.17815809,  36.58855785,  36.14442877,
-              35.84710827,  35.69789528,  35.69805141,  35.84880111,
-              36.15133085,  36.60678759,  37.21627669,  37.98085933,
-              38.90154977,  39.97931233,  41.21505839,  42.60964342])
 
-        self.iu.fac = 2
-        self.iu.calc(self.f, self.g1.fwhm)
-        self.assertEqualWithinTol(_iux, self.iu.x, 1e-4)
-        self.assertEqualWithinTol(_iuy, self.iu.y, 1e-4)
-        # self.iu.plot()
+@requires_data
+def test_fitcontour(setup_contour):
+    dc = sherpa.DataContour()
+    dc.prepare(setup_contour.data)
 
-    def test_region_projection(self):
-        _rpx0 = numpy.array(
-            [ 11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
-              11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
-              19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146])
+    mc = sherpa.ModelContour()
+    mc.prepare(setup_contour.data, setup_contour.g1, setup_contour.f.stat)
 
-        _rpx1 = numpy.array(
-            [  8.75749218 ,   8.75749218,   8.75749218,   8.75749218, 8.75749218 ,
-               8.75749218 ,   8.75749218,   8.75749218,   8.75749218, 8.75749218 ,
-               10.54556708,  10.54556708,  10.54556708,  10.54556708, 10.54556708,
-               10.54556708,  10.54556708,  10.54556708,  10.54556708, 10.54556708,
-               12.33364199,  12.33364199,  12.33364199,  12.33364199, 12.33364199,
-               12.33364199,  12.33364199,  12.33364199,  12.33364199, 12.33364199,
-               14.12171689,  14.12171689,  14.12171689,  14.12171689, 14.12171689,
-               14.12171689,  14.12171689,  14.12171689,  14.12171689, 14.12171689,
-               15.9097918 ,  15.9097918 ,  15.9097918 ,  15.9097918 , 15.9097918 ,
-               15.9097918 ,  15.9097918 ,  15.9097918 ,  15.9097918 , 15.9097918 ,
-               17.6978667 ,  17.6978667 ,  17.6978667 ,  17.6978667 , 17.6978667 ,
-               17.6978667 ,  17.6978667 ,  17.6978667 ,  17.6978667 , 17.6978667 ,
-               19.48594161,  19.48594161,  19.48594161,  19.48594161, 19.48594161,
-               19.48594161,  19.48594161,  19.48594161,  19.48594161, 19.48594161,
-               21.27401651,  21.27401651,  21.27401651,  21.27401651, 21.27401651,
-               21.27401651,  21.27401651,  21.27401651,  21.27401651, 21.27401651,
-               23.06209142,  23.06209142,  23.06209142,  23.06209142, 23.06209142,
-               23.06209142,  23.06209142,  23.06209142,  23.06209142, 23.06209142,
-               24.85016632,  24.85016632,  24.85016632,  24.85016632, 24.85016632,
-               24.85016632,  24.85016632,  24.85016632,  24.85016632, 24.85016632])
+    fc = sherpa.FitContour()
+    fc.prepare(dc, mc)
+    # fc.contour()
 
-        _rpy = numpy.array(
-            [ 121.18227727,  109.21389788,   98.48751045,   89.15211989,
-              81.31437819,   75.0489422 ,   70.40478381,   67.40903363,
-              66.06931267,   66.37505662,  107.09555406,   93.85962337,
-              82.2173972 ,   72.37069659,   64.46288283,   58.59635882,
-              54.8420303 ,   53.24411902,   53.82255037,   56.57387709,
-              95.08597997,   80.98176715,   68.85606392,   58.97098329,
-              51.51170797,   46.61282359,   44.37139326,   44.85269567,
-              48.09257852,   54.09778178,   85.15342677,   70.58027832,
-              58.4035077 ,   48.95296874,   42.46079117,   39.0982177 ,
-              38.99272007,   42.23460729,   48.87925026,   58.9466444 ,
-              77.29778983,   62.65512325,   50.85972221,   42.31664458,
-              37.31008905,   36.05245858,   38.70590422,   45.38974383,
-              56.18246641,   71.12038263,   71.51901508,   57.20627498,
-              46.22471072,   39.06200464,   36.0595698 ,   37.4754866 ,
-              43.51086985,   54.31802734,   70.00215676,   90.6189382 ,
-              67.81704451,   54.23371422,   44.49847032,   39.18904432,
-              38.70920964,   43.36725746,   53.40756108,   69.01940099,
-              90.33827068,  117.44226953,   66.19183538,   53.73742613,
-              45.68100001,   42.6977601 ,   45.25899046,   53.72773755,
-              68.39593576,   89.49382219,  117.19077045,  151.59034586,
-              66.64335816,   55.71739907,   49.77229917,   49.58814921,
-              55.70889825,   68.55690091,   88.47596148,  115.74125836,
-              150.55962734,  193.06314386,   69.17158712,   60.17362372,
-              56.77236574,   59.86020953,   70.05892198,   87.8547272 ,
-              113.64761294,  147.76168412,  190.44481909,  241.86064553])
 
-        self.rp.fac = 5
-        self.rp.calc(self.f, self.g1.fwhm, self.g1.ampl)
-        self.assertEqualWithinTol(_rpx0, self.rp.x0, 1e-4)
-        self.assertEqualWithinTol(_rpx1, self.rp.x1, 1e-4)
-        self.assertEqualWithinTol(_rpy, self.rp.y, 1e-4)
-        # self.rp.contour()
+@requires_data
+def test_splitcontour(setup_contour):
+    dc = sherpa.DataContour()
+    dc.levels = setup_contour.levels
+    dc.prepare(setup_contour.data)
 
-    def test_region_uncertainty(self):
-        _rux0 = numpy.array(
-            [ 12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
-              12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
-              19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629])
+    mc = sherpa.ModelContour()
+    mc.levels = setup_contour.levels
+    mc.prepare(setup_contour.data, setup_contour.g1, setup_contour.f.stat)
 
-        _rux1 = numpy.array(
-            [ 10.36675959,  10.36675959,  10.36675959,  10.36675959, 10.36675959,
-              10.36675959,  10.36675959,  10.36675959,  10.36675959, 10.36675959,
-              11.79721952,  11.79721952,  11.79721952,  11.79721952, 11.79721952,
-              11.79721952,  11.79721952,  11.79721952,  11.79721952, 11.79721952,
-              13.22767944,  13.22767944,  13.22767944,  13.22767944, 13.22767944,
-              13.22767944,  13.22767944,  13.22767944,  13.22767944, 13.22767944,
-              14.65813936,  14.65813936,  14.65813936,  14.65813936, 14.65813936,
-              14.65813936,  14.65813936,  14.65813936,  14.65813936, 14.65813936,
-              16.08859929,  16.08859929,  16.08859929,  16.08859929, 16.08859929,
-              16.08859929,  16.08859929,  16.08859929,  16.08859929, 16.08859929,
-              17.51905921,  17.51905921,  17.51905921,  17.51905921, 17.51905921,
-              17.51905921,  17.51905921,  17.51905921,  17.51905921, 17.51905921,
-              18.94951914,  18.94951914,  18.94951914,  18.94951914, 18.94951914,
-              18.94951914,  18.94951914,  18.94951914,  18.94951914, 18.94951914,
-              20.37997906,  20.37997906,  20.37997906,  20.37997906, 20.37997906,
-              20.37997906,  20.37997906,  20.37997906,  20.37997906, 20.37997906,
-              21.81043898,  21.81043898,  21.81043898,  21.81043898, 21.81043898,
-              21.81043898,  21.81043898,  21.81043898,  21.81043898, 21.81043898,
-              23.24089891,  23.24089891,  23.24089891,  23.24089891, 23.24089891,
-              23.24089891,  23.24089891,  23.24089891,  23.24089891, 23.24089891])
+    fc = sherpa.FitContour()
+    fc.prepare(dc, mc)
 
-        _ruy = numpy.array(
-            [  96.58117835,   87.02838072,   78.58324208,   71.31800953,
-               65.28984102,   60.54431967,   57.11719555,   55.03459229,
-               54.31255884,   54.95668786,   85.96169801,   75.9815896 ,
-               67.33096852,   60.09842943,   54.35398817,   50.15439725,
-               47.54566158,   46.56317725,   47.23082527,   49.56009821,
-               76.90300053,   66.7116158 ,   58.0882768 ,   51.13947262,
-               45.94928247,   42.58681159,   41.10961032,   41.56372169,
-               43.98222109,   48.38374461,   69.40508592,   59.21845932,
-               50.85516692,   44.4411391 ,   40.07572392,   37.84156267,
-               37.80904175,   40.0362256 ,   44.56674629,   51.42762706,
-               63.46795418,   53.50212017,   45.63163889,   40.00342886,
-               36.73331252,   35.91865051,   37.6439559 ,   41.980689  ,
-               48.98440089,   58.69174556,   59.09160531,   49.56259833,
-               42.41769271,   37.82634191,   35.92204826,   36.8180751 ,
-               40.61435275,   47.39711188,   57.23518487,   70.1761001 ,
-               56.27603931,   47.39989381,   41.21332836,   37.90987826,
-               37.64193114,   40.53983645,   46.7202323 ,   56.28549424,
-               69.31909824,   85.88069069,   55.02125618,   47.01400662,
-               42.01854587,   40.25403789,   41.89296118,   47.08393454,
-               55.96159455,   68.64583609,   85.236141  ,  105.80551733,
-               55.32725591,   48.40493674,   44.83334521,   44.85882081,
-               48.67513836,   56.45036939,   68.33843951,   84.47813741,
-               104.98631314,  129.95058002,   57.19403852,   51.57268419,
-               49.6577264 ,   51.72422701,   57.98846268,   68.63914099,
-               83.85076718,  103.78239821,  128.56961467,  158.31587876])
+    rc = sherpa.ResidContour()
+    rc.prepare(setup_contour.data, setup_contour.g1, setup_contour.f.stat)
+    rc.levels = setup_contour.levels
 
-        self.ru.fac = 4
-        self.ru.calc(self.f, self.g1.fwhm, self.g1.ampl)
-        self.assertEqualWithinTol(_rux0, self.ru.x0, 1e-4)
-        self.assertEqualWithinTol(_rux1, self.ru.x1, 1e-4)
-        self.assertEqualWithinTol(_ruy, self.ru.y, 1e-4)
-        # self.ru.contour()
+    sp = sherpa.SplitPlot(2, 2)
+    # sp.addcontour(dc)
+    # sp.addcontour(mc)
+    # sp.addcontour(fc)
+    # sp.addcontour(rc)
+
+
+def test_interval_projection(setup_confidence):
+    _ipx = numpy.array(
+        [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
+          16.88976119,  17.21040017,  17.53103916,  17.85167814,
+          18.17231712,  18.49295611,  18.81359509,  19.13423407,
+          19.45487306,  19.77551204,  20.09615102,  20.41679001,
+          20.73742899,  21.05806798,  21.37870696,  21.69934594])
+    _ipy = numpy.array(
+        [ 40.09661435,  39.18194614,  38.37963283,  37.68723716,
+          37.10218543,  36.62179549,  36.2432939 ,  35.96383078,
+          35.78049297,  35.69031588,  35.69029438,  35.77739294,
+          35.94855493,  36.20071145,  36.53078937,  36.9357187 ,
+          37.41243938,  37.95790737,  38.56910025,  39.24302218])
+
+    setup_confidence.ip.fac = 2
+    setup_confidence.ip.calc(setup_confidence.f,
+                             setup_confidence.g1.fwhm)
+
+    assert setup_confidence.ip.x == pytest.approx(_ipx, abs=1e-4)
+    assert setup_confidence.ip.y == pytest.approx(_ipy, abs=1e-4)
+    # setup_confidence.ip.plot()
+
+
+def test_interval_uncertainty(setup_confidence):
+    _iux = numpy.array(
+        [ 15.60720526,  15.92784424,  16.24848322,  16.56912221,
+          16.88976119,  17.21040017,  17.53103916,  17.85167814,
+          18.17231712,  18.49295611,  18.81359509,  19.13423407,
+          19.45487306,  19.77551204,  20.09615102,  20.41679001,
+          20.73742899,  21.05806798,  21.37870696,  21.69934594])
+
+    _iuy = numpy.array(
+        [ 42.2582845 ,  40.96299483,  39.80577195,  38.78821363,
+          37.91185112,  37.17815809,  36.58855785,  36.14442877,
+          35.84710827,  35.69789528,  35.69805141,  35.84880111,
+          36.15133085,  36.60678759,  37.21627669,  37.98085933,
+          38.90154977,  39.97931233,  41.21505839,  42.60964342])
+
+    setup_confidence.iu.fac = 2
+    setup_confidence.iu.calc(setup_confidence.f, setup_confidence.g1.fwhm)
+    assert setup_confidence.iu.x == pytest.approx(_iux, abs=1e-4)
+    assert setup_confidence.iu.y == pytest.approx(_iuy, abs=1e-4)
+    # setup_confidence.iu.plot()
+
+
+def test_region_projection(setup_confidence):
+    _rpx0 = numpy.array(
+        [ 11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146,
+          11.03809974,  12.73036104,  14.42262235,  16.11488365, 17.80714495,
+          19.49940625,  21.19166755,  22.88392885,  24.57619016, 26.26845146])
+
+    _rpx1 = numpy.array(
+        [  8.75749218 ,   8.75749218,   8.75749218,   8.75749218, 8.75749218 ,
+           8.75749218 ,   8.75749218,   8.75749218,   8.75749218, 8.75749218 ,
+           10.54556708,  10.54556708,  10.54556708,  10.54556708, 10.54556708,
+           10.54556708,  10.54556708,  10.54556708,  10.54556708, 10.54556708,
+           12.33364199,  12.33364199,  12.33364199,  12.33364199, 12.33364199,
+           12.33364199,  12.33364199,  12.33364199,  12.33364199, 12.33364199,
+           14.12171689,  14.12171689,  14.12171689,  14.12171689, 14.12171689,
+           14.12171689,  14.12171689,  14.12171689,  14.12171689, 14.12171689,
+           15.9097918 ,  15.9097918 ,  15.9097918 ,  15.9097918 , 15.9097918 ,
+           15.9097918 ,  15.9097918 ,  15.9097918 ,  15.9097918 , 15.9097918 ,
+           17.6978667 ,  17.6978667 ,  17.6978667 ,  17.6978667 , 17.6978667 ,
+           17.6978667 ,  17.6978667 ,  17.6978667 ,  17.6978667 , 17.6978667 ,
+           19.48594161,  19.48594161,  19.48594161,  19.48594161, 19.48594161,
+           19.48594161,  19.48594161,  19.48594161,  19.48594161, 19.48594161,
+           21.27401651,  21.27401651,  21.27401651,  21.27401651, 21.27401651,
+           21.27401651,  21.27401651,  21.27401651,  21.27401651, 21.27401651,
+           23.06209142,  23.06209142,  23.06209142,  23.06209142, 23.06209142,
+           23.06209142,  23.06209142,  23.06209142,  23.06209142, 23.06209142,
+           24.85016632,  24.85016632,  24.85016632,  24.85016632, 24.85016632,
+           24.85016632,  24.85016632,  24.85016632,  24.85016632, 24.85016632])
+
+    _rpy = numpy.array(
+        [ 121.18227727,  109.21389788,   98.48751045,   89.15211989,
+          81.31437819,   75.0489422 ,   70.40478381,   67.40903363,
+          66.06931267,   66.37505662,  107.09555406,   93.85962337,
+          82.2173972 ,   72.37069659,   64.46288283,   58.59635882,
+          54.8420303 ,   53.24411902,   53.82255037,   56.57387709,
+          95.08597997,   80.98176715,   68.85606392,   58.97098329,
+          51.51170797,   46.61282359,   44.37139326,   44.85269567,
+          48.09257852,   54.09778178,   85.15342677,   70.58027832,
+          58.4035077 ,   48.95296874,   42.46079117,   39.0982177 ,
+          38.99272007,   42.23460729,   48.87925026,   58.9466444 ,
+          77.29778983,   62.65512325,   50.85972221,   42.31664458,
+          37.31008905,   36.05245858,   38.70590422,   45.38974383,
+          56.18246641,   71.12038263,   71.51901508,   57.20627498,
+          46.22471072,   39.06200464,   36.0595698 ,   37.4754866 ,
+          43.51086985,   54.31802734,   70.00215676,   90.6189382 ,
+          67.81704451,   54.23371422,   44.49847032,   39.18904432,
+          38.70920964,   43.36725746,   53.40756108,   69.01940099,
+          90.33827068,  117.44226953,   66.19183538,   53.73742613,
+          45.68100001,   42.6977601 ,   45.25899046,   53.72773755,
+          68.39593576,   89.49382219,  117.19077045,  151.59034586,
+          66.64335816,   55.71739907,   49.77229917,   49.58814921,
+          55.70889825,   68.55690091,   88.47596148,  115.74125836,
+          150.55962734,  193.06314386,   69.17158712,   60.17362372,
+          56.77236574,   59.86020953,   70.05892198,   87.8547272 ,
+          113.64761294,  147.76168412,  190.44481909,  241.86064553])
+
+    setup_confidence.rp.fac = 5
+    setup_confidence.rp.calc(setup_confidence.f,
+                             setup_confidence.g1.fwhm,
+                             setup_confidence.g1.ampl)
+    assert setup_confidence.rp.x0 == pytest.approx(_rpx0, abs=1e-4)
+    assert setup_confidence.rp.x1 == pytest.approx(_rpx1, abs=1e-4)
+    assert setup_confidence.rp.y == pytest.approx(_rpy, abs=1e-4)
+    # setup_confidence.rp.contour()
+
+
+def test_region_uncertainty(setup_confidence):
+    _rux0 = numpy.array(
+        [ 12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629,
+          12.56113491,  13.91494395,  15.268753  ,  16.62256204, 17.97637108,
+          19.33018012,  20.68398916,  22.0377982 ,  23.39160724, 24.74541629])
+
+    _rux1 = numpy.array(
+        [ 10.36675959,  10.36675959,  10.36675959,  10.36675959, 10.36675959,
+          10.36675959,  10.36675959,  10.36675959,  10.36675959, 10.36675959,
+          11.79721952,  11.79721952,  11.79721952,  11.79721952, 11.79721952,
+          11.79721952,  11.79721952,  11.79721952,  11.79721952, 11.79721952,
+          13.22767944,  13.22767944,  13.22767944,  13.22767944, 13.22767944,
+          13.22767944,  13.22767944,  13.22767944,  13.22767944, 13.22767944,
+          14.65813936,  14.65813936,  14.65813936,  14.65813936, 14.65813936,
+          14.65813936,  14.65813936,  14.65813936,  14.65813936, 14.65813936,
+          16.08859929,  16.08859929,  16.08859929,  16.08859929, 16.08859929,
+          16.08859929,  16.08859929,  16.08859929,  16.08859929, 16.08859929,
+          17.51905921,  17.51905921,  17.51905921,  17.51905921, 17.51905921,
+          17.51905921,  17.51905921,  17.51905921,  17.51905921, 17.51905921,
+          18.94951914,  18.94951914,  18.94951914,  18.94951914, 18.94951914,
+          18.94951914,  18.94951914,  18.94951914,  18.94951914, 18.94951914,
+          20.37997906,  20.37997906,  20.37997906,  20.37997906, 20.37997906,
+          20.37997906,  20.37997906,  20.37997906,  20.37997906, 20.37997906,
+          21.81043898,  21.81043898,  21.81043898,  21.81043898, 21.81043898,
+          21.81043898,  21.81043898,  21.81043898,  21.81043898, 21.81043898,
+          23.24089891,  23.24089891,  23.24089891,  23.24089891, 23.24089891,
+          23.24089891,  23.24089891,  23.24089891,  23.24089891, 23.24089891])
+
+    _ruy = numpy.array(
+        [  96.58117835,   87.02838072,   78.58324208,   71.31800953,
+           65.28984102,   60.54431967,   57.11719555,   55.03459229,
+           54.31255884,   54.95668786,   85.96169801,   75.9815896 ,
+           67.33096852,   60.09842943,   54.35398817,   50.15439725,
+           47.54566158,   46.56317725,   47.23082527,   49.56009821,
+           76.90300053,   66.7116158 ,   58.0882768 ,   51.13947262,
+           45.94928247,   42.58681159,   41.10961032,   41.56372169,
+           43.98222109,   48.38374461,   69.40508592,   59.21845932,
+           50.85516692,   44.4411391 ,   40.07572392,   37.84156267,
+           37.80904175,   40.0362256 ,   44.56674629,   51.42762706,
+           63.46795418,   53.50212017,   45.63163889,   40.00342886,
+           36.73331252,   35.91865051,   37.6439559 ,   41.980689  ,
+           48.98440089,   58.69174556,   59.09160531,   49.56259833,
+           42.41769271,   37.82634191,   35.92204826,   36.8180751 ,
+           40.61435275,   47.39711188,   57.23518487,   70.1761001 ,
+           56.27603931,   47.39989381,   41.21332836,   37.90987826,
+           37.64193114,   40.53983645,   46.7202323 ,   56.28549424,
+           69.31909824,   85.88069069,   55.02125618,   47.01400662,
+           42.01854587,   40.25403789,   41.89296118,   47.08393454,
+           55.96159455,   68.64583609,   85.236141  ,  105.80551733,
+           55.32725591,   48.40493674,   44.83334521,   44.85882081,
+           48.67513836,   56.45036939,   68.33843951,   84.47813741,
+           104.98631314,  129.95058002,   57.19403852,   51.57268419,
+           49.6577264 ,   51.72422701,   57.98846268,   68.63914099,
+           83.85076718,  103.78239821,  128.56961467,  158.31587876])
+
+    setup_confidence.ru.fac = 4
+    setup_confidence.ru.calc(setup_confidence.f,
+                             setup_confidence.g1.fwhm,
+                             setup_confidence.g1.ampl)
+    assert setup_confidence.ru.x0 == pytest.approx(_rux0, abs=1e-4)
+    assert setup_confidence.ru.x1 == pytest.approx(_rux1, abs=1e-4)
+    assert setup_confidence.ru.y == pytest.approx(_ruy, abs=1e-4)
+    # setup_confidence.ru.contour()
 
 
 @requires_plotting
@@ -424,7 +475,7 @@ def test_source_component_arbitrary_grid():
         ui.plot_source_component(regrid_model)
 
     numpy.testing.assert_array_equal(ui._compsrcplot.x, x + re_x)
-    numpy.testing.assert_array_equal(ui._compsrcplot.y, [10, ]*6)
+    numpy.testing.assert_array_equal(ui._compsrcplot.y, [10, ] * 6)
 
 
 @requires_plotting
@@ -466,12 +517,13 @@ def test_source_component_arbitrary_grid_int():
     with pytest.warns(UserWarning):
         ui.plot_source_component(regrid_model)
 
-    x_points = (x[0] + x[1])/2
-    re_x_points = (re_x[0] + re_x[1])/2
+    x_points = (x[0] + x[1]) / 2.0
+    re_x_points = (re_x[0] + re_x[1]) / 2.0
     points = numpy.concatenate((x_points, re_x_points))
 
     numpy.testing.assert_array_equal(ui._compsrcplot.x, points)
-    numpy.testing.assert_array_equal(ui._compsrcplot.y, [10, 10, 10, 100, 100, 100])
+    numpy.testing.assert_array_equal(ui._compsrcplot.y,
+                                     [10, 10, 10, 100, 100, 100])
 
 
 def test_numpy_histogram_density_vs_normed():

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,13 +17,19 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils.testing import SherpaTestCase, requires_pylab
+from sherpa.utils.testing import requires_pylab
 
 
 @requires_pylab
-class pylab_test(SherpaTestCase):
+def test_axes_default():
+    """Have we default values for all the axis settings?"""
 
-    def test_axes_default(self):
-        from sherpa.plot.pylab_backend import _errorbar_defaults
-        # assert all needed defaults have been found
-        assert all(e in _errorbar_defaults for e in ('ecolor', 'capsize', 'barsabove'))
+    from sherpa.plot.pylab_backend import _errorbar_defaults
+
+    # assert all needed defaults have been found, but do not
+    # check the actual values. Split into multiple lines so that
+    # if there's a failure we can see which is False.
+    #
+    fields = ('ecolor', 'capsize', 'barsabove')
+    defs = [e in _errorbar_defaults for e in fields]
+    assert all(defs)


### PR DESCRIPTION
# Summary

Matplotlib 2.0 changed the relative order it draws points and error bars, which makes the output of `plot_fit` much less readable for data with a lot of points - such as high signal-to-noise Chandra grating data - since the model is often obscued. The relative order ("zorder" in matplotlib parlance) of the error bars has been adjusted, which makes the model appear above the points. This can also slightly change the appearance of data plots when multiple data sets are displayed, as points are no-longer guaranteed to be drawn above error bars.

There have also been some minor clean up applied to the code, as well as the addition of tests.

# Details

Given how matplotlib draws points, lines, and error bars, it is not clear that there is an ideal approach for all situations - e.g. a single `plot_fit` call versus multiple calls using `overplot=True` on all-but-the-first call. I believe the following is an improvement for the simple case (single `plot_fit` call), which is likely much-more common than overlaying multiple data sets.

There has been some code clean up that is not directly associated with this change, but done while reviewing the code. Of particular note is the removal of a "color check" that was meant to ensure a hexadecimal value was displayed correctly (and is similar to one in the chips backend) but had problems.

There may be some overlap in the tests that were added here and in recently-merged PRs, but I don't think so (as they are aimed at slightly-different use cases).