### PR TITLE
remove python2.7 from gitlab ci config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,11 +28,6 @@ stages:
   tags:
       - sherpa-macos-build
 
-macos-python2.7-conda-build:
-  <<: *template_macos_conda_build
-  variables:
-      SHERPA_PYTHON_VERSION: "2.7.*"
-
 macos-python3.5-conda-build:
   <<: *template_macos_conda_build
   variables:
@@ -47,11 +42,6 @@ macos-python3.7-conda-build:
   <<: *template_macos_conda_build
   variables:
       SHERPA_PYTHON_VERSION: "3.7.*"
-
-linux-python2.7-conda-build:
-  <<: *template_linux_conda_build
-  variables:
-    SHERPA_PYTHON_VERSION: '2.7.*'
 
 linux-python3.5-conda-build:
   <<: *template_linux_conda_build
@@ -74,11 +64,9 @@ conda:
       - sherpa
   image: registry.gitlab.com/olaurino/sherpa-docker-build:master
   dependencies:
-      - linux-python2.7-conda-build
       - linux-python3.5-conda-build
       - linux-python3.6-conda-build
       - linux-python3.7-conda-build
-      - macos-python2.7-conda-build
       - macos-python3.5-conda-build
       - macos-python3.6-conda-build
       - macos-python3.7-conda-build
@@ -104,11 +92,6 @@ conda:
       # By installing numpy 1.15 we work around the issue, which is the only failure recorded with numpy 1.16
       # Python 2.7 won't be supported for long anyway.
       - conda update -qq -y --all
-      - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib numpy=1.15 # How to make sure it's the correct version?
-      - source activate test
-      - pip install /master.zip
-      - sherpa_smoke -f astropy
-      - sherpa_test
       - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test35
       - pip install /master.zip
@@ -133,11 +116,6 @@ conda:
     - cd /tmp
     - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip
     - conda update -qq -y --all
-    - conda create -n test --yes -q -c sherpa/label/dev python=2 astropy sherpa matplotlib numpy=1.15 # How to make sure it's the correct version?
-    - conda activate test
-    - pip install master.zip
-    - sherpa_smoke -f astropy
-    - sherpa_test
     - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test35
     - pip install master.zip


### PR DESCRIPTION
This PR removes the python 2.7 jobs and tests from Gitlab CI (the automated pipeline that tests the creation and usage of the conda packages).