### PR TITLE
Link boundary of 1 parameter to another par's value (issue #362)

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -152,8 +152,15 @@ class Model(NoNewAttributesAfterInit):
 
             if tp == 'linked':
                 linkstr = 'expr: %s' % p.link.fullname
-                s += ('\n   %-12s %-6s %12g %24s %10s' %
-                      (p.fullname, tp, p.val, linkstr, p.units))
+                s += ('\n   %-12s %-6s %12g %24s' %
+                      (p.fullname, tp, p.val, linkstr))
+                if p.link_min is not None:
+                    linkminstr = 'expr: %s' % p.link_min.fullname
+                    s += linkminstr
+                if p.link_max is not None:
+                    linkmaxstr = 'expr: %s' % p.link_max.fullname
+                    s += linkmaxstr
+                s += p.units
             else:
                 s += ('\n   %-12s %-6s %12g %12g %12g %10s' %
                       (p.fullname, tp, p.val, p.min, p.max, p.units))

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -22,11 +22,154 @@ from numpy import arange
 from sherpa.utils import SherpaFloat
 from sherpa.utils.testing import SherpaTestCase
 from sherpa.models.parameter import Parameter, UnaryOpParameter, \
-    BinaryOpParameter, ConstantParameter
+    BinaryOpParameter, ConstantParameter, hugeval
 from sherpa.utils.err import ParameterErr
 
+from sherpa.models.basic import Gauss1D
+from sherpa import ui
 
 class test_parameter(SherpaTestCase):
+
+    class TestParBase:
+
+        def __init__(self, pos1, pos2):
+            self.src1 = Gauss1D()
+            self.src1.pos = pos1
+            self.src1_pos = pos1
+            self.src2 = Gauss1D()
+            self.src2.pos = pos2
+            self.src2_pos = pos2
+            self.tst_pos(self.src1.pos, self.src1_pos)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+            return
+
+        def __del__(self):
+            self.src1.pos.unlink()
+            self.tst_pos(self.src1.pos, self.src1.pos.default_val,
+                         min=self.src1.pos.min, max=self.src1.pos.max,
+                         link_min=self.src1.pos.link_min,
+                         link_max=self.src1.pos.link_max)
+            self.src2.pos.unlink()
+            self.tst_pos(self.src2.pos, self.src2_pos, min=self.src2.pos.min,
+                         max=self.src2.pos.max,
+                         link_min=self.src2.pos.link_min,
+                         link_max=self.src2.pos.link_max)
+            return
+
+        def tst_pos(self, gauss, pos, min=-hugeval, max=hugeval, frozen=False,
+                    link=None, link_min=None, link_max=None):
+            assert gauss.val == pos
+            assert gauss.min == min
+            assert gauss.max == max
+            assert gauss.frozen == frozen
+            if gauss.link is None or link is None:
+                assert gauss.link == link
+            else:
+                self.tst_pos(gauss.link, pos)
+            if gauss.link_min is None:
+                assert gauss.link_min == link_min
+            else:
+                assert gauss.link_min.eval() == link_min.eval()
+            if gauss.link_max is None:
+                assert gauss.link_max == link_max
+            else:
+                assert gauss.link_max.eval() == link_max.eval()
+            assert gauss.default_val == pos
+            assert gauss.default_min == min
+            assert gauss.default_max == max
+
+
+    class TestParVal(TestParBase):
+
+        def __init__(self, pos1, pos2):
+            test_parameter.TestParBase.__init__(self, pos1, pos2)
+            return
+
+        def tst(self):
+            self.tst_pos(self.src1.pos, self.src2_pos, frozen=True,
+                         link=self.src1.pos)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+
+        def tst_low_level_val_link(self):
+            self.src1.pos.val = self.src2.pos.val
+            self.src1.pos.link = self.src2.pos
+            self.tst()
+
+        def tst_ui_val_link(self):
+            ui.link(self.src1.pos, self.src2.pos)
+            self.tst()
+
+
+    class TestParMin(TestParBase):
+
+        def __init__(self, pos1, pos2):
+            test_parameter.TestParBase.__init__(self, pos1, pos2)
+            return
+
+        def tst(self):
+            self.tst_pos(self.src1.pos, self.src2_pos + 2, frozen=True,
+                         min=self.src2.pos.val - 5, link=self.src1.pos,
+                         link_min=self.src2.pos - 5)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+
+        def tst_low_level_min_link(self):
+            self.src1.pos.link = self.src2.pos + 2
+            self.src1.pos.link_min = self.src2.pos - 5
+            self.tst()
+
+        def tst_ui_min_link(self):
+            ui.link(self.src1.pos, self.src2.pos + 2, min=self.src2.pos - 5)
+            self.tst()
+
+
+    class TestParMax(TestParBase):
+
+        def __init__(self, pos1, pos2):
+            test_parameter.TestParBase.__init__(self, pos1, pos2)
+            return
+
+        def tst(self):
+            self.tst_pos(self.src1.pos, self.src2_pos + 2, frozen=True,
+                         max=self.src2.pos.val +8, link=self.src1.pos,
+                         link_max=self.src2.pos + 8)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+
+        def tst_low_level_max_link(self):
+            self.src1.pos.link = self.src2.pos + 2
+            self.src1.pos.link_max = self.src2.pos + 8
+            self.tst()
+
+        def tst_ui_max_link(self):
+            ui.link(self.src1.pos, self.src2.pos + 2, max=self.src2.pos + 8)
+            self.tst()
+
+
+    class TestParMinMax(TestParBase):
+
+        def __init__(self, pos1, pos2):
+            test_parameter.TestParBase.__init__(self, pos1, pos2)
+            return
+
+        def tst(self):
+            self.tst_pos(self.src1.pos, self.src2_pos + 2, frozen=True,
+                         min=self.src2.pos.val - 5,
+                         max=self.src2.pos.val + 8,
+                         link=self.src1.pos,
+                         link_min=self.src2.pos - 5,
+                         link_max=self.src2.pos + 8)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+
+        def tst_low_level_min_max_link(self):
+            self.src1.pos.link = self.src2.pos + 2
+            self.src1.pos.link_min = self.src2.pos - 5
+            self.src1.pos.link_max = self.src2.pos + 8
+            self.tst()
+
+        def tst_ui_min_max_link(self):
+            ui.link(self.src1.pos, self.src2.pos + 2, min=self.src2.pos - 5,
+            max=self.src2.pos + 8)
+            self.tst()
+
 
     def setUp(self):
         self.p = Parameter('model', 'name', 0, -10, 10, -100, 100, 'units')
@@ -144,3 +287,39 @@ class test_composite_parameter(SherpaTestCase):
         p = self.p.val
         p2 = self.p2.val
         self.assertEqual(cmplx.val, (3 * p + p2) / (p ** 3.2))
+
+    def test_link_unlink_val(self):
+        test_parameter.TestParVal(4, 5)
+        return
+
+    def test_link_unlink_val_low_level(self):
+        tst = test_parameter.TestParVal(4, 5)
+        tst.tst_low_level_val_link()
+
+    def test_link_unlink_val_ui(self):
+        tst = test_parameter.TestParVal(4, 5)
+        tst.tst_ui_val_link()
+
+    def test_link_unlink_min_ui(self):
+        tst = test_parameter.TestParMin(-1, 0)
+        tst.tst_ui_min_link()
+
+    def test_link_unlink_min_low_level(self):
+        tst = test_parameter.TestParMin(-1, 0)
+        tst.tst_low_level_min_link()
+
+    def test_link_unlink_max_ui(self):
+        tst = test_parameter.TestParMax(-1, 0)
+        tst.tst_ui_max_link()
+
+    def test_link_unlink_max_low_level(self):
+        tst = test_parameter.TestParMax(-1, 0)
+        tst.tst_low_level_max_link()
+
+    def test_link_unlink_min_max_ui(self):
+        tst = test_parameter.TestParMinMax(-1, 0)
+        tst.tst_ui_min_max_link()
+
+    def test_link_unlink_min_max_low_level(self):
+        tst = test_parameter.TestParMinMax(-1, 0)
+        tst.tst_low_level_min_max_link()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -7417,12 +7417,12 @@ class Session(NoNewAttributesAfterInit):
         for p in par:
             self._freeze_thaw_par_or_model(p, 'thaw')
 
-    def link(self, par, val):
+    def link(self, par, val, min=None, max=None):
         """Link a parameter to a value.
 
-        A parameter can be linked to another parameter value, or
-        function of that value, rather than be an independent value.
-        As the linked-to values change, the parameter value will
+        A parameter and its limits can be linked to another parameter
+        value, or function of that value, rather than be an independent
+        value. As the linked-to values change, the parameter value will
         change.
 
         Parameters
@@ -7432,6 +7432,13 @@ class Session(NoNewAttributesAfterInit):
         val
            The value - wihch can be a numeric value or a function
            of other model parameters, to set `par` to.
+        min : None
+           The minimum - wihch can be a numeric value or a function
+           of other model minimum parameters, to set `min` to.
+        max : None
+           The maximum - wihch can be a numeric value or a function
+           of other model parameters, to set `max` to.
+
 
         See Also
         --------
@@ -7483,11 +7490,32 @@ class Session(NoNewAttributesAfterInit):
         >>> g2.pos.val
         14.399999999999999
 
+
+        The min and max limits of the ``pos`` parameter of the ``src1`` is
+        set to be line the min -5  and max  + 8 of the ``pos`` parameter of
+        ``src2`` model, respectively.
+
+        >>> gauss1d.src1
+        >>> gauss1d.src2
+        >>> src2.pos.val = -1
+        >>> link(src1.pos, src2.pos + 2, min=src2.pos - 5, max=src2.pos + 8)
+        >>> src1.pos.min
+        -6.0
+        >>> src2.pos.min
+        -3.4028234663852886e+38
+        >>> src1.pos.max
+        7.0
+        >>> src2.pos.max
+        3.4028234663852886e+38
         """
         par = self._check_par(par)
         if isinstance(val, string_types):
             val = self._eval_model_expression(val, 'parameter link')
         par.link = val
+        if min is not None:
+            par.link_min = min
+        if max is not None:
+            par.link_max = max
 
     def unlink(self, par):
         """Unlink a parameter value.


### PR DESCRIPTION
# Release Note

This PR enables sherpa to link a parameter's boundary limit(s) to another parameter's value (issue #362).  One can either link a parameter limit(s) to another's parameter's value separately:
 
```
>>> from sherpa.astro.ui import *
>>> gauss1d.src1
<Gauss1D model instance 'gauss1d.src1'>
>>> gauss1d.src2
<Gauss1D model instance 'gauss1d.src2'>
>>> src2.pos.val = -1
>>> print(src1.pos)
val         = 0.0
min         = -3.4028234663852886e+38
max         = 3.4028234663852886e+38
units       = 
frozen      = False
link        = None
link_min    = None
link_max    = None
default_val = 0.0
default_min = -3.4028234663852886e+38
default_max = 3.4028234663852886e+38
>>> link(src1.pos, src2.pos + 2, min=src2.pos - 5)
>>> print(src1.pos)
val         = 1.0
min         = -6.0
max         = 3.4028234663852886e+38
units       = 
frozen      = True
link        = (src2.pos + 2)
link_min    = (src2.pos - 5)
link_max    = None
default_val = 1.0
default_min = -6.0
default_max = 3.4028234663852886e+38
>>> link(src1.pos, src2.pos + 2, max=src2.pos + 8)
>>> print(src1.pos)
val         = 1.0
min         = -6.0
max         = 7.0
units       = 
frozen      = True
link        = (src2.pos + 2)
link_min    = (src2.pos - 5)
link_max    = (src2.pos + 8)
default_val = 1.0
default_min = -6.0
default_max = 7.0
```
or link the boundary parameter limits to another's parameter's value together:

```
>>> gauss1d.src1
<Gauss1D model instance 'gauss1d.src1'>
>>> gauss1d.src2
<Gauss1D model instance 'gauss1d.src2'>
>>> src2.pos.val = -1
>>> print(src1.pos)
val         = 0.0
min         = -3.4028234663852886e+38
max         = 3.4028234663852886e+38
units       = 
frozen      = False
link        = None
link_min    = None
link_max    = None
default_val = 0.0
default_min = -3.4028234663852886e+38
default_max = 3.4028234663852886e+38
>>> link(src1.pos, src2.pos + 2, min=src2.pos - 5, max=src2.pos + 8)
>>> print(src1.pos)
val         = 1.0
min         = -6.0
max         = 7.0
units       = 
frozen      = True
link        = (src2.pos + 2)
link_min    = (src2.pos - 5)
link_max    = (src2.pos + 8)
default_val = 1.0
default_min = -6.0
default_max = 7.0
```
# Note

I think a parameter's boundary limits wil be linked as requested by issue #362;  However, using this PR to fit is entirely different matter.  My understanding of the optimization routines shipped with sherpa (probably best to ask the residential expert to be sure) do not update the boundary limits of the free parameters at each iteration of the fit, that is the boundary limits are fixed at the start of the optimization and stay that way until the end.  I have looked into rectifying this but it got very messy very fast. 

