### PR TITLE
Add link/unlink parameter tests

### DIFF
--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -22,11 +22,70 @@ from numpy import arange
 from sherpa.utils import SherpaFloat
 from sherpa.utils.testing import SherpaTestCase
 from sherpa.models.parameter import Parameter, UnaryOpParameter, \
-    BinaryOpParameter, ConstantParameter
+    BinaryOpParameter, ConstantParameter, hugeval
 from sherpa.utils.err import ParameterErr
+from sherpa.models.basic import Gauss1D
+from sherpa import ui
 
 
 class test_parameter(SherpaTestCase):
+
+    class TestParBase:
+
+        def __init__(self, pos1, pos2):
+            self.src1 = Gauss1D()
+            self.src1.pos = pos1
+            self.src1_pos = pos1
+            self.src2 = Gauss1D()
+            self.src2.pos = pos2
+            self.src2_pos = pos2
+            self.tst_pos(self.src1.pos, self.src1_pos)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+            return
+
+        def __del__(self):
+            self.src1.pos.unlink()
+            self.tst_pos(self.src1.pos, self.src1.pos.default_val,
+                         min=self.src1.pos.min, max=self.src1.pos.max)
+            self.src2.pos.unlink()
+            self.tst_pos(self.src2.pos, self.src2_pos, min=self.src2.pos.min,
+                         max=self.src2.pos.max)
+            return
+
+        def tst_pos(self, gauss, pos, min=-hugeval, max=hugeval, frozen=False,
+                    link=None, link_min=None, link_max=None):
+            assert gauss.val == pos
+            assert gauss.min == min
+            assert gauss.max == max
+            assert gauss.frozen == frozen
+            if gauss.link is None or link is None:
+                assert gauss.link == link
+            else:
+                self.tst_pos(gauss.link, pos)
+            assert gauss.default_val == pos
+            assert gauss.default_min == min
+            assert gauss.default_max == max
+
+
+    class TestParVal(TestParBase):
+
+        def __init__(self, pos1, pos2):
+            test_parameter.TestParBase.__init__(self, pos1, pos2)
+            return
+
+        def tst(self):
+            self.tst_pos(self.src1.pos, self.src2_pos, frozen=True,
+                         link=self.src1.pos)
+            self.tst_pos(self.src2.pos, self.src2_pos)
+
+        def tst_low_level_val_link(self):
+            self.src1.pos.val = self.src2.pos.val
+            self.src1.pos.link = self.src2.pos
+            self.tst()
+
+        def tst_ui_val_link(self):
+            ui.link(self.src1.pos, self.src2.pos)
+            self.tst()
 
     def setUp(self):
         self.p = Parameter('model', 'name', 0, -10, 10, -100, 100, 'units')
@@ -144,3 +203,15 @@ class test_composite_parameter(SherpaTestCase):
         p = self.p.val
         p2 = self.p2.val
         self.assertEqual(cmplx.val, (3 * p + p2) / (p ** 3.2))
+
+    def test_link_unlink_val(self):
+        test_parameter.TestParVal(4, 5)
+        return
+
+    def test_link_unlink_val_low_level(self):
+        tst = test_parameter.TestParVal(4, 5)
+        tst.tst_low_level_val_link()
+
+    def test_link_unlink_val_ui(self):
+        tst = test_parameter.TestParVal(4, 5)
+        tst.tst_ui_val_link()

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -43,7 +43,7 @@ class test_parameter(SherpaTestCase):
             self.tst_pos(self.src2.pos, self.src2_pos)
             return
 
-        def __del__(self):
+        def tst_unlink(self):
             self.src1.pos.unlink()
             self.tst_pos(self.src1.pos, self.src1.pos.default_val,
                          min=self.src1.pos.min, max=self.src1.pos.max)
@@ -82,10 +82,12 @@ class test_parameter(SherpaTestCase):
             self.src1.pos.val = self.src2.pos.val
             self.src1.pos.link = self.src2.pos
             self.tst()
+            self.tst_unlink()
 
         def tst_ui_val_link(self):
             ui.link(self.src1.pos, self.src2.pos)
             self.tst()
+            self.tst_unlink()
 
     def setUp(self):
         self.p = Parameter('model', 'name', 0, -10, 10, -100, 100, 'units')
@@ -205,7 +207,8 @@ class test_composite_parameter(SherpaTestCase):
         self.assertEqual(cmplx.val, (3 * p + p2) / (p ** 3.2))
 
     def test_link_unlink_val(self):
-        test_parameter.TestParVal(4, 5)
+        tst = test_parameter.TestParVal(4, 5)
+        tst.tst_unlink()
         return
 
     def test_link_unlink_val_low_level(self):


### PR DESCRIPTION
# Release Note

This PR adds three tests for sherpa's un/link commands. The tests make sure that _all_ the members of the ```Parameter``` class are correct for the low and ui  levels of sherpa's link function.

# Note

The tests are a subset of the tests for PR #670 (Link boundary of 1 parameter to another par's value).  Tests were added to make sure that by adding functionalities to the link command that the current state of the un/link command is backward compatible.