### PR TITLE
Travis build: remove AstroPy < 3.2 restriction

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -37,7 +37,8 @@ if installed:
 
 * :term:`astropy`: for reading and writing files in
   :term:`FITS` format. The minimum required version of astropy
-  is version 1.3, although only versions 2 and higher are used in testing.
+  is version 1.3, although only versions 2 and higher are used in testing
+  (version 3.2 is known to cause problems, but version 3.2.1 is okay).
 * :term:`matplotlib`: for visualisation of
   one-dimensional data or models, one- or two- dimensional
   error analysis, and the results of Monte-Carlo Markov Chain

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -52,11 +52,11 @@ fi
 
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC} ${DOCSBUILD}"
 
-# Hack to force AstroPy < 3.2 (see https://github.com/sherpa/sherpa/issues/632)
-# This is a short-term hack just to get travis tests to pass
-# Should there be better a way of specifying versions for these dependencies?
+# Tests fail with AstroPy 3.2 but not 3.2.1. Since 3.2.1 is now available
+# on conda, we no longer force AstroPy < 3.2 - see
+# https://github.com/sherpa/sherpa/issues/632
 #
-if [ "${FITS}" == astropy ]; then FITSBUILD="'astropy<3.2'"; else FITSBUILD="${FITS}"; fi
+FITSBUILD="${FITS}"
 
 # Create and activate conda build environment
 # We create a new environment so we don't care about the python version in the root environment.


### PR DESCRIPTION
# Summary

AstroPy version 3.2 causes problems but version 3.2.1 is fine, so remove the "pre 3.2" restriction on AstroPy in the Travis tests, and add a note in the documentation that AstroPy 3.2 causes problems.

# Details

It looks like the AstroPy 3.2 problems reported in #632 only occur
with version 3.2, and not the next release (3.2.1) which is now
available. So we can remove the '< 3.2' restriction. I have left in
the separation of "user input" (via FITS) and "run-time" (via
FITSBUILD) behavior, in case it is useful later.

There is no functional change in this PR (it is only the Travis testing scripts and Sphinx documentation that is updated).