### PR TITLE
Remove the unused parameter in sherpa.astro.optical.LogEmission model

### DIFF
--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -1122,8 +1122,6 @@ class LogEmission(RegriddableModel1D):
         The normalisation of the gaussian.
     skew
         The skew of the gaussian.
-    limit
-        This is a hidden parameter and is unused by the model.
 
     See Also
     --------

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -1164,12 +1164,10 @@ class LogEmission(RegriddableModel1D):
                              units='angstroms')
         self.flux = Parameter(name, 'flux', 1.)
         self.skew = Parameter(name, 'skew', 1., tinyval, frozen=True)
-        self.limit = Parameter(name, 'limit', 4., alwaysfrozen=True,
-                               hidden=True )
 
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.pos, self.flux,
-                                  self.skew, self.limit))
+                                  self.skew))
 
     # @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):


### PR DESCRIPTION
# Release Note
Remove the unused parameter in the sherpa.astro.optical.LogEmission model. The LogEmission model only has four parameters _(fwhm, pos, flux and skew)_ consistent within the ```calc``` method.  The hidden parameter _limit_ and it doc were removed.

# Note
This PR is a fix for issue #219