### PR TITLE
Remove chips from the documentation

### DIFF
--- a/docs/ciao.rst
+++ b/docs/ciao.rst
@@ -13,13 +13,12 @@ from the
 `Sherpa GitHub page <https://github.com/sherpa/sherpa>`_,
 with the following modifications:
 
-* the plotting and I/O backends use the CIAO versions, namely
-  :term:`ChIPS` and :term:`Crates`, rather than
-  :term:`matplotlib` and :term:`astropy`;
+* the I/O backend uses the CIAO library :term:`Crates` rather than
+  :term:`astropy`;
 
 * a set of customized IPython routines are provided as part of
-  CIAO that automatically load Sherpa and related packages, as well
-  as tweak the IPython look and feel;
+  CIAO that automatically loads Sherpa and adjusts the appearance
+  of IPython (mainly changes to the prompt);
 
 * and the CIAO version of Sherpa includes the optional XSPEC model
   library (:py:mod:`sherpa.astro.xspec`).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,9 +70,9 @@ class XSPECMock(Mock):
         return "999.999.999"
 
 
-# It's not clear if pylab is needed here. Should ChIPS and Crates be
-# mocked too? That is, do we care if the *_backend.py modules are
-# documented?
+# It's not clear if pylab is needed here. At present non of the
+# CIAO-related modules (e.g. the crates I/O backend) are mocked;
+# should they be?
 #
 sys.modules['astropy.io.fits'] = Mock()
 sys.modules['pylab'] = PylabMock()

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -23,11 +23,6 @@ Glossary
        A community Python library for Astronomy:
        https://www.astropy.org/.
        
-   ChIPS
-       The Chandra Imaging and Plotting System, ChIPS, is one of
-       the plotting backends supported by Sherpa. It is the default
-       choice when using Sherpa as part of :term:`CIAO`.
-       
    CIAO
        The data reduction and analysis provided by the :term:`CXC`
        for users of the Chandra X-ray telescope. Sherpa is provided

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -17,11 +17,11 @@ Glossary
        and detector tabulated as a function of energy. The
        :term:`FITS` format used to represent ARFs is defined in
        the :term:`OGIP` Calibration Memo
-       `CAL/GEN/02-002 <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
+       `CAL/GEN/02-002 <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
 
    Astropy
        A community Python library for Astronomy:
-       http://www.astropy.org/.
+       https://www.astropy.org/.
        
    ChIPS
        The Chandra Imaging and Plotting System, ChIPS, is one of
@@ -67,16 +67,16 @@ Glossary
        https://heasarc.gsfc.nasa.gov/.
 
    matplotlib
-       The matplotlib plotting package is is one of the plotting backends
-       supported by Sherpa. More information can be found at
-       http://matplotlib.org/.
+       The matplotlib plotting package, which is documented at
+       https://matplotlib.org/, is used to provide the plotting support
+       in Sherpa.
 
    OGIP
        The Office for Guest Investigator Programs (OGIP) was a division of
        the Laboratory for High Energy Astrophysics at Goddard Space Flight
        Center. The activities of that group have now become the responsibility
        of the `HEASARC FITS Working Group (HFWG)
-       <http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/ofwg_intro.html>`_,
+       <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/ofwg_intro.html>`_,
        and supports the use of high-energy astrophysics data through
        multimission standards and archive access. Of particular note for
        users of Sherpa are the standard documents produced by this group
@@ -111,7 +111,7 @@ Glossary
        given detector channel.  The :term:`FITS` format used to
        represent RMFs is defined in the
        :term:`OGIP` Calibration Memo
-       `CAL/GEN/02-002 <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
+       `CAL/GEN/02-002 <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
 
    WCS
        The phrase World Coordinate System for an Astronomical data set

--- a/docs/plots/index.rst
+++ b/docs/plots/index.rst
@@ -11,11 +11,10 @@ Visualisation
 Overview
 ========
 
-Sherpa has support for different plot backends, at present limited
-to
-:term:`matplotlib` and
-:term:`ChIPS`. Interactive visualizations of images is
-provided by
+Sherpa has support for different plot backends, although
+at present there is only one, which uses the
+:term:`matplotlib` package.
+Interactive visualizations of images is provided by
 :term:`DS9` - an Astronomical image viewer - if installed, whilst
 there is limited support for visualizing two-dimensional data sets
 with matplotlib. The classes described in this document do not

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -105,13 +105,10 @@ The steps taken are normally:
 
 3. and then call the :py:meth:`~sherpa.plot.DataPlot.plot` method.
 
-Sherpa has two plotting backends:
-:term:`matplotlib`, which is used by
-default for the standalone version, and
-:term:`ChIPS`, which is used by :term:`CIAO`.
-Limited support for customizing these plots - such as
-always drawing the Y axis with a logarithmic scale - is provided,
-but extensive changes will require calling the plotting back-end
+Sherpa has one plotting backend, :term:`matplotlib`, which is used
+to display plots. There is limited support for customizing these
+plots - such as always drawing the Y axis with a logarithmic
+scale - but extensive changes will require calling the plotting back-end
 directly.
 
 As an example of the :py:class:`~sherpa.plot.DataPlot` output::

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -114,7 +114,7 @@ always drawing the Y axis with a logarithmic scale - is provided,
 but extensive changes will require calling the plotting back-end
 directly.
 
-As an example of the :py:class:`~shrepa.plot.DataPlot` output::
+As an example of the :py:class:`~sherpa.plot.DataPlot` output::
    
    >>> from sherpa.plot import DataPlot
    >>> dplot = DataPlot()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11866,8 +11866,8 @@ class Session(sherpa.ui.utils.Session):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         Raises
         ------
@@ -11949,8 +11949,8 @@ class Session(sherpa.ui.utils.Session):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         Raises
         ------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10423,7 +10423,7 @@ class Session(NoNewAttributesAfterInit):
     #
 
     # DOC-TODO: how is this used? simple testing didn't seem to make any
-    # difference with chips
+    # difference (using the chips backend)
     def get_split_plot(self):
         """Return the plot attributes for displays with multiple plots.
 
@@ -10467,7 +10467,6 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: discussion of preferences needs better handling
     # of how it interacts with the chosen plot backend.
     #
-    # DOC-TODO-CHIPS: replace backend-specific options
     def get_data_plot_prefs(self):
         """Return the preferences for plot_data.
 
@@ -10495,15 +10494,21 @@ class Session(NoNewAttributesAfterInit):
         `plot_ratio`, and the "fit" variants, such as `plot_fit`,
         `plot_fit_resid`, and `plot_bkg_fit`.
 
-        ``errcolor``
+        The following preferences are recognized by the matplotlib
+        backend:
+
+        ``barsabove``
+           The barsabove argument for the matplotlib errorbar function.
+
+        ``capsize``
+           The capsize argument for the matplotlib errorbar function.
+
+        ``color``
+           The color to use (will be over-ridden by more-specific
+           options below). The default is ``None``.
+
+        ``ecolor``
            The color to draw error bars. The default is ``None``.
-
-        ``errstyle``
-           How to draw errors. The default is ``line``.
-
-        ``errthickness``
-           What thickness of line to draw error bars. The default is
-           ``None``.
 
         ``linecolor``
            What color to use for the line connecting the data points.
@@ -10511,29 +10516,22 @@ class Session(NoNewAttributesAfterInit):
 
         ``linestyle``
            How should the line connecting the data points be drawn.
-           The default is ``0``, which means no line is drawn.
+           The default is 'None', which means no line is drawn.
 
-        ``linethickness``
-           What thickness should be used to draw the line connecting
-           the data points. The default is ``None``.
+        ``marker``
+           What style is used for the symbols. The default is ``'.'``
+           which indicates a point.
+
+        ``markerfacecolor``
+           What color to draw the symbol representing the data points.
+           The default is ``None``.
+
+        ``markersize``
+           What size is the symbol drawn. The default is ``None``.
 
         ``ratioline``
            Should a horizontal line be drawn at y=1?  The default is
            ``False``.
-
-        ``symbolcolor``
-           What color to draw the symbol representing the data points.
-           The default is ``None``.
-
-        ``symbolfill``
-           Should the symbol be drawn filled? The default is ``False``.
-
-        ``symbolsize``
-           What size is the symbol drawn. The default is ``3``.
-
-        ``symbolstyle``
-           What style is used for the symbols. The default is ``4``
-           which means circle for the ChIPS back end.
 
         ``xaxis``
            The default is ``False``
@@ -10563,7 +10561,7 @@ class Session(NoNewAttributesAfterInit):
         and not display Y error bars.
 
         >>> prefs = get_data_plot_prefs()
-        >>> prefs['symbolcolor'] = 'green'
+        >>> prefs['color'] = 'green'
         >>> prefs['yerrorbars'] = False
 
         """
@@ -10808,66 +10806,8 @@ class Session(NoNewAttributesAfterInit):
         `plot_bkg_model`, and the "fit" variants, such as `plot_fit`,
         `plot_fit_resid`, and `plot_bkg_fit`.
 
-        ``errcolor``
-           The color to draw error bars. The default is ``None``.
-
-        ``errstyle``
-           How to draw errors. The default is ``None``.
-
-        ``errthickness``
-           What thickness of line to draw error bars. The default is
-           ``None``.
-
-        ``linecolor``
-           What color to use for the line connecting the data points.
-           The default is ``red``.
-
-        ``linestyle``
-           How should the line connecting the data points be drawn.
-           The default is ``1``, which means a solid line is drawn.
-
-        ``linethickness``
-           What thickness should be used to draw the line connecting
-           the data points. The default is ``3``.
-
-        ``ratioline``
-           Should a horizontal line be drawn at y=1?  The default is
-           ``False``.
-
-        ``symbolcolor``
-           What color to draw the symbol representing the data points.
-           The default is ``None``.
-
-        ``symbolfill``
-           Should the symbol be drawn filled? The default is ``True``.
-
-        ``symbolsize``
-           What size is the symbol drawn. The default is ``None``.
-
-        ``symbolstyle``
-           What style is used for the symbols. The default is ``0``,
-           which means no symbol is used.
-
-        ``xaxis``
-           The default is ``False``
-
-        ``xerrorbars``
-           Should error bars be drawn for the X axis. The default is
-           ``False``.
-
-        ``xlog``
-           Should the X axis be drawn with a logarithmic scale? The
-           default is ``False``. This field can also be changed with the
-           `set_xlog` and `set_xlinear` functions.
-
-        ``yerrorbars``
-           Should error bars be drawn for the Y axis. The default is
-           ``False``.
-
-        ``ylog``
-           Should the Y axis be drawn with a logarithmic scale? The
-           default is ``False``. This field can also be changed with the
-           `set_ylog` and `set_ylinear` functions.
+        The preferences recognized by the matplotlib backend are the
+        same as for `get_data_plot_prefs`.
 
         Examples
         --------
@@ -10876,7 +10816,7 @@ class Session(NoNewAttributesAfterInit):
         to display the model:
 
         >>> prefs = get_model_plot_prefs()
-        >>> prefs['linecolor'] = 'green'
+        >>> prefs['color'] = 'green'
 
         """
         return self._modelplot.plot_prefs

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8338,8 +8338,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         Raises
         ------
@@ -10466,6 +10466,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: discussion of preferences needs better handling
     # of how it interacts with the chosen plot backend.
+    #
+    # DOC-TODO-CHIPS: replace backend-specific options
     def get_data_plot_prefs(self):
         """Return the preferences for plot_data.
 
@@ -12763,8 +12765,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         Raises
         ------
@@ -12847,8 +12849,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         Raises
         ------
@@ -12942,8 +12944,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         See Also
         --------
@@ -13014,8 +13016,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         See Also
         --------
@@ -13065,7 +13067,6 @@ class Session(NoNewAttributesAfterInit):
         return self._cdfplot
 
     # DOC-TODO: what does xlabel do?
-    # DOC-TODO: is clearwindow a ChIPS-only setting?
     def plot_trace(self, points, name="x", xlabel="x",
                    replot=False, overplot=False, clearwindow=True):
         """Create a trace plot of row number versus value.
@@ -13090,8 +13091,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         See Also
         --------
@@ -13169,8 +13170,8 @@ class Session(NoNewAttributesAfterInit):
            If ``True`` then add the data to an exsiting plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
-           When using ChIPS for plotting, should the existing frame
-           be cleared before creating the plot?
+           Should the existing plot area be cleared before creating the
+           plot?
 
         See Also
         --------


### PR DESCRIPTION
# Summary

Remove mention of ChIPS from the documentation (both on read the docs and in the sherpa.astro.ui and sherpa.ui modules), replacing with matplotlib where appropriate.

# Details

Remove mention of ChIPS from the documentation. There is no change to the code in this PR (i.e. the chips backend is still present and included in the config files).

- [X] from the sphinx build 
- [x] from the docstrings
  - [X] from the description of the `clearwindow` parameter
  - [x] review the examples to see if chips commands are being used
  - [x] the `get_data_plot_prefs` routine includes chips defaults, these should either be replaced
        with matplotlib values or just removed (the latter is "technically better" but not actually
        useful to the user)

There are also some minor un-related doc fixes that have come along for the ride. They could be pulled out into a separate PR but it didn't seem worth it at this time.

This is ready for review.