### PR TITLE
Add default config options

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -55,19 +55,12 @@ import importlib
 
 config = ConfigParser()
 config.read(get_config())
-io_opt = config.get('options', 'io_pkg')
+
+# What should we use for the default package?
+io_opt = config.get('options', 'io_pkg', fallback='pyfits')
 io_opt = str(io_opt).strip().lower()
 
-# Python 3 allows the following (although should move to the dictionary
-# style provided by the mapping protocal access.
-#
-# ogip_emin = config.get('ogip', 'minimum_energy', fallback='1.0e-10')
-if config.has_option('ogip', 'minimum_energy'):
-    ogip_emin = config.get('ogip', 'minimum_energy')
-else:
-    # The original version of minimum_energy is 1e-10 keV, so use it as
-    # the default value.
-    ogip_emin = '1.0e-10'
+ogip_emin = config.get('ogip', 'minimum_energy', fallback='1.0e-10')
 
 if ogip_emin.upper() == 'NONE':
     ogip_emin = None

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -45,7 +45,8 @@ _ = numpy.seterr(invalid='ignore')
 config = ConfigParser()
 config.read(get_config())
 
-plot_opt = config.get('options', 'plot_pkg')
+# Choose the dummy backend as the default backend
+plot_opt = config.get('options', 'plot_pkg', fallback='none')
 plot_opt = str(plot_opt).strip().lower() + '_backend'
 if plot_opt == 'matplotlib_backend':
     plot_opt = 'pylab_backend'

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -46,8 +46,10 @@ config.read(get_config())
 # truncation_flag indicates whether or not model truncation
 # should be performed.  If true, use the truncation_value from
 # the config file.
-truncation_flag = config.get('statistics', 'truncate').upper()
-truncation_value = float(config.get('statistics', 'trunc_value'))
+truncation_flag = config.get('statistics', 'truncate',
+                             fallback='True').upper()
+truncation_value = float(config.get('statistics', 'trunc_value',
+                                    fallback=1.0e-25))
 if (bool(truncation_flag) is False or truncation_flag == "FALSE" or
         truncation_flag == "NONE" or truncation_flag == "0"):
     truncation_value = 1.0e-25

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -50,10 +50,7 @@ string_types = (str, )
 
 __all__ = ('ModelWrapper', 'Session')
 
-try:  # Python2
-    BUILTINS = sys.modules["__builtin__"]
-except KeyError:  # Python3
-    BUILTINS = sys.modules["builtins"]
+BUILTINS = sys.modules["builtins"]
 _builtin_symbols_ = tuple(BUILTINS.__dict__.keys())
 
 
@@ -341,7 +338,7 @@ class Session(NoNewAttributesAfterInit):
         self._projection_results = None
 
         self._pyblocxs = sherpa.sim.MCMC()
-        
+
         self._splitplot = sherpa.plot.SplitPlot()
         self._jointplot = sherpa.plot.JointPlot()
         self._dataplot = sherpa.plot.DataPlot()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -44,7 +44,9 @@ warning = logging.getLogger(__name__).warning
 config = ConfigParser()
 config.read(get_config())
 
-numpy.set_printoptions(threshold=int(config.get('verbosity', 'arraylength')))
+numpy.set_printoptions(threshold=int(config.get('verbosity',
+                                                'arraylength',
+                                                fallback=1000000)))
 
 string_types = (str, )
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -51,11 +51,8 @@ debug = logging.getLogger("sherpa").debug
 config = ConfigParser()
 config.read(get_config())
 
-_ncpu_val = "NONE"
-try:
-    _ncpu_val = config.get('parallel', 'numcores').strip().upper()
-except NoSectionError:
-    pass
+_ncpu_val = config.get('parallel', 'numcores',
+                       fallback='None').strip().upper()
 
 _ncpus = None
 if not _ncpu_val.startswith('NONE'):


### PR DESCRIPTION
# Summary

Whenever an option is read from the configuration file (e..g. `~/.sherpa.rc`) provide a default option in case the configuration file is missing (or is missing this option).

# Details

Dropping python 2.7 means that we can now take advantage of the fallback keyword when accessing configuration data. This makes it easier for users to switch between versions of Sherpa with the same configuration file (e.g. if moving to a new version of Sherpa that introduces a new option, but the user's config file has not been updated).

There is a maintenance cost, in that a user would expect the default values to be the same (whether from our sherpa*rc file or from the code), but I think it's worth it.

Addresses #623 and #490 (I think)