### PR TITLE
Improve documentation and testing for get_source_plot when sent lo/hi arguments

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10094,7 +10094,10 @@ class Session(sherpa.ui.utils.Session):
         instance
            An object representing the data used to create the plot by
            `plot_source`. The return value depends on the data
-           set (e.g. PHA, 1D binned, 1D un-binned).
+           set (e.g. PHA, 1D binned, 1D un-binned). If ``lo`` or ``hi``
+           were set then the ``mask`` attribute of the object can be
+           used to apply the filter to the ``xlo``, ``xhi``, and ``y``
+           attributes.
 
         See Also
         --------
@@ -10125,10 +10128,18 @@ class Session(sherpa.ui.utils.Session):
         >>> splot1.plot()
         >>> splot2.overplot()
 
+        Access the plot data (for a PHA data set) and select only the
+        bins corresponding to the 2-7 keV range defined in the call:
+
+        >>> splot = get_source_plot(lo=2, hi=7)
+        >>> xlo = splot.xlo[splot.mask]
+        >>> xhi = splot.xhi[splot.mask]
+        >>> y = splot.y[splot.mask]
+
         For a PHA data set, the units on both the X and Y axes of the
         plot are controlled by the `set_analysis` command. In this
-        case the Y axis will be in units of photons/s/cm^2 and the X
-        axis in keV:
+        case the Y axis will be in units of photon/s/cm^2/keV x Energy
+        and the X axis in keV:
 
         >>> set_analysis('energy', factor=1)
         >>> splot = get_source_plot()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10912,54 +10912,53 @@ class Session(sherpa.ui.utils.Session):
         elif isinstance(plotobj, sherpa.plot.FitContour):
             plotobj.prepare(self._prepare_plotobj(id, self._datacontour),
                             self._prepare_plotobj(id, self._modelcontour))
+        elif isinstance(plotobj, sherpa.astro.plot.ARFPlot):
+            plotobj.prepare(self._get_pha_data(id).get_arf(resp_id),
+                            self._get_pha_data(id))
+        elif(isinstance(plotobj, sherpa.plot.ComponentModelPlot) or
+             isinstance(plotobj, sherpa.plot.ComponentSourcePlot)):
+            plotobj.prepare(self.get_data(id), model, self.get_stat())
+        elif isinstance(plotobj, sherpa.astro.plot.BkgDataPlot):
+            plotobj.prepare(self.get_bkg(id, bkg_id),
+                            self.get_stat())
+        elif isinstance(plotobj, (sherpa.astro.plot.BkgModelPlot,
+                                  sherpa.astro.plot.BkgRatioPlot,
+                                  sherpa.astro.plot.BkgResidPlot,
+                                  sherpa.astro.plot.BkgDelchiPlot,
+                                  sherpa.astro.plot.BkgChisqrPlot,
+                                  sherpa.astro.plot.BkgModelHistogram)):
+            plotobj.prepare(self.get_bkg(id, bkg_id),
+                            self.get_bkg_model(id, bkg_id),
+                            self.get_stat())
+        elif isinstance(plotobj, sherpa.astro.plot.BkgSourcePlot):
+            plotobj.prepare(self.get_bkg(id, bkg_id),
+                            self.get_bkg_source(id, bkg_id), lo, hi)
+        elif isinstance(plotobj, sherpa.astro.plot.SourcePlot):
+            data = self.get_data(id)
+            src = self.get_source(id)
+            plotobj.prepare(data, src, lo, hi)
+        elif isinstance(plotobj, sherpa.plot.SourcePlot):
+            data = self.get_data(id)
+            src = self.get_source(id)
+            plotobj.prepare(data, src)
+        elif (isinstance(plotobj, sherpa.plot.PSFPlot) or
+              isinstance(plotobj, sherpa.plot.PSFContour) or
+              isinstance(plotobj, sherpa.plot.PSFKernelPlot) or
+              isinstance(plotobj, sherpa.plot.PSFKernelContour)):
+            plotobj.prepare(self.get_psf(id), self.get_data(id))
+        elif(isinstance(plotobj, sherpa.plot.DataPlot) or
+             isinstance(plotobj, sherpa.plot.DataContour)):
+            plotobj.prepare(self.get_data(id), self.get_stat())
+        elif isinstance(plotobj, sherpa.astro.plot.OrderPlot):
+            plotobj.prepare(self._get_pha_data(id),
+                            self.get_model(id), orders)
         else:
-            if isinstance(plotobj, sherpa.astro.plot.ARFPlot):
-                plotobj.prepare(self._get_pha_data(id).get_arf(resp_id),
-                                self._get_pha_data(id))
-            elif(isinstance(plotobj, sherpa.plot.ComponentModelPlot) or
-                 isinstance(plotobj, sherpa.plot.ComponentSourcePlot)):
-                plotobj.prepare(self.get_data(id), model, self.get_stat())
-            elif isinstance(plotobj, sherpa.astro.plot.BkgDataPlot):
-                plotobj.prepare(self.get_bkg(id, bkg_id),
-                                self.get_stat())
-            elif isinstance(plotobj, (sherpa.astro.plot.BkgModelPlot,
-                                      sherpa.astro.plot.BkgRatioPlot,
-                                      sherpa.astro.plot.BkgResidPlot,
-                                      sherpa.astro.plot.BkgDelchiPlot,
-                                      sherpa.astro.plot.BkgChisqrPlot,
-                                      sherpa.astro.plot.BkgModelHistogram)):
-                plotobj.prepare(self.get_bkg(id, bkg_id),
-                                self.get_bkg_model(id, bkg_id),
-                                self.get_stat())
-            elif isinstance(plotobj, sherpa.astro.plot.BkgSourcePlot):
-                plotobj.prepare(self.get_bkg(id, bkg_id),
-                                self.get_bkg_source(id, bkg_id), lo, hi)
-            elif isinstance(plotobj, sherpa.astro.plot.SourcePlot):
-                data = self.get_data(id)
-                src = self.get_source(id)
-                plotobj.prepare(data, src, lo, hi)
-            elif isinstance(plotobj, sherpa.plot.SourcePlot):
-                data = self.get_data(id)
-                src = self.get_source(id)
-                plotobj.prepare(data, src)
-            elif (isinstance(plotobj, sherpa.plot.PSFPlot) or
-                  isinstance(plotobj, sherpa.plot.PSFContour) or
-                  isinstance(plotobj, sherpa.plot.PSFKernelPlot) or
-                  isinstance(plotobj, sherpa.plot.PSFKernelContour)):
-                plotobj.prepare(self.get_psf(id), self.get_data(id))
-            elif(isinstance(plotobj, sherpa.plot.DataPlot) or
-                 isinstance(plotobj, sherpa.plot.DataContour)):
-                plotobj.prepare(self.get_data(id), self.get_stat())
-            elif isinstance(plotobj, sherpa.astro.plot.OrderPlot):
-                plotobj.prepare(self._get_pha_data(id),
-                                self.get_model(id), orders)
-            else:
-                # Using _get_fit becomes very complicated using simulfit
-                # models and datasets
-                #
-                # ids, f = self._get_fit(id)
-                plotobj.prepare(self.get_data(id), self.get_model(id),
-                                self.get_stat())
+            # Using _get_fit becomes very complicated using simulfit
+            # models and datasets
+            #
+            # ids, f = self._get_fit(id)
+            plotobj.prepare(self.get_data(id), self.get_model(id),
+                            self.get_stat())
 
         return plotobj
 


### PR DESCRIPTION
# Summary

Improve the documentation for the sherpa.astro.ui.get_source_plot routine, describing how to
use the result when the lo or hi arguments are sent.

# Details

This PR just documents the current behavior and adds a test for it (see #316 for a discussion).

A fix is very easy (move the `mask` step from `plot` to `prepare`) but this would be a breaking change.