### PR TITLE
WIP: fix primini iterated fit case

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -704,9 +704,20 @@ class IterFit(NoNewAttributesAfterInit):
         staterror_original = []
 
         for d in self.data.datasets:
+            # This loop is only concerned about user-specified
+            # statistical error, not tnat calculated by the
+            # statistic, so the staterrfunc argument is left as None
+            # in the get_staterror call.
+            #
             st = d.get_staterror(filter=False)
             staterror_original.append(st)
-            d.staterror = ones_like(st)
+
+            # could probably use the 'st is None' logic in all
+            # cases
+            if st is None:
+                d.staterror = ones_like(d.get_dep(filter=False))
+            else:
+                d.staterror = ones_like(st)
 
         # Keep record of current and previous statistics;
         # when these are within some tolerace, Primini's method

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2811,7 +2811,6 @@ def test_fit_dof_neg1(stat, method, success):
 @requires_data
 @requires_fits
 @pytest.mark.usefixtures("clean_astro_ui")
-@pytest.mark.xfail(raises=TypeError)
 def test_bug_431(make_data_path):
     """does primini iterated-fit work with PHA data
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2819,6 +2819,10 @@ def test_bug_431(make_data_path):
     out the example as given.
 
     Note: this is really a regression test rather than a unit test.
+
+    The values (e.g. statistic and parameter values) were evaluated
+    with a commit from before the breakage:
+    2235e1c738f85a6f675cb295510b9a5d98d30714
     """
 
     from sherpa.astro import ui
@@ -2847,18 +2851,13 @@ def test_bug_431(make_data_path):
     assert s0[0].dof == 40
 
     # The relative tolerance used in the numeric checks below has
-    # been guessed at 1 per cent.
+    # been guessed at 1 per cent. May need to change this now
+    # I have added in values from before the fix.
 
-    # value calculated with CIAO 4.12 development branch
     assert s0[0].statval == pytest.approx(22.392398974457006, rel=0.01)
 
     ui.set_iter_method('primini')
     ui.fit()
-
-    # not sure what good values to test here are
-    # so at the moment just check the code runs to completion
-    # (once #431 is fixed that is)
-    #
 
     # Ensure the staterror is still None (the primini fit changes
     # this during the evaluation, so check it has been restored).
@@ -2873,10 +2872,6 @@ def test_bug_431(make_data_path):
     assert s1[0].numpoints == 42
     assert s1[0].dof == 40
 
-    # values calculated with CIAO 4.12 development branch (after
-    # fixing #413) and are just to check that the fit changed
-    # something; there has been no attempt to validate these new values.
-    #
-    assert s1[0].statval == pytest.approx(24.469394979244473, rel=0.01)
-    assert pl.gamma.val == pytest.approx(1.9047630946173293, rel=0.01)
-    assert pl.ampl.val == pytest.approx(1.838231409413269e-4, rel=0.01)
+    assert s1[0].statval == pytest.approx(22.392132075293787, rel=0.01)
+    assert pl.gamma.val == pytest.approx(1.931138404465634, rel=0.01)
+    assert pl.ampl.val == pytest.approx(1.7413534602287168e-4, rel=0.01)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2879,3 +2879,24 @@ def test_bug_431(make_data_path):
     assert s1[0].statval == pytest.approx(22.392132075293787, rel=0.01)
     assert pl.gamma.val == pytest.approx(1.931138404465634, rel=0.01)
     assert pl.ampl.val == pytest.approx(1.7413534602287168e-4, rel=0.01)
+
+    s1 = None
+
+    # Ensure we can "remove" the primini fit and get a fit
+    #
+    # The best-fit values should be the same as with the primini
+    # fit (as reported by 2235e1c738f85a6f675cb295510b9a5d98d30714)
+    #
+    ui.set_iter_method('none')
+    ui.fit()
+
+    fr = ui.get_fit_results()
+
+    assert fr.itermethodname == 'none'
+    assert fr.methodname == 'levmar'
+    assert fr.statname == 'chi2gehrels'
+    assert fr.numpoints == 42
+    assert fr.dof == 40
+    assert fr.succeeded
+    assert fr.nfev == 4
+    assert fr.dstatval == pytest.approx(0)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2832,8 +2832,13 @@ def test_bug_431(make_data_path):
     ui.notice(0.5, 7.0)
     ui.set_source(ui.powlaw1d.pl)
     pl = ui.get_model_component('pl')
-    pl.ampl = 1.74e-4
-    pl.gamma = 1.93
+
+    # pick values that are far enough away from the empirically-determined
+    # "best fit" that using a simple relative, like 0.01, should be good
+    # enough.
+    #
+    pl.ampl = 2.5e-4
+    pl.gamma = 1.7
 
     # pre-condition (just to check if the input data file, or
     # data structure) is ever changed
@@ -2851,10 +2856,9 @@ def test_bug_431(make_data_path):
     assert s0[0].dof == 40
 
     # The relative tolerance used in the numeric checks below has
-    # been guessed at 1 per cent. May need to change this now
-    # I have added in values from before the fix.
+    # been guessed at 1 per cent.
 
-    assert s0[0].statval == pytest.approx(22.392398974457006, rel=0.01)
+    assert s0[0].statval == pytest.approx(214.17266245704036, rel=0.01)
 
     ui.set_iter_method('primini')
     ui.fit()


### PR DESCRIPTION
Darn it - this isn't getting the same values as you got from before the break.

# Summary

Allow the iterated method to be set to the `primini` method when analysing PHA data. This is to address bug #431

# Details

Thanks to @olaurino initial analysis to track down the problem. This fix "looks sensible" to me, but I don't understand why the code originally worked, or what commit 637aa33a5d78fbbb85c78f1eef1d1663e049de49 did to cause the problem.