### PR TITLE
add warning when chips is selected but cannot be imported (rebase of #648)

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -57,13 +57,28 @@ if plot_opt == 'none_backend':
 try:
     importlib.import_module('.' + plot_opt, package='sherpa.plot')
     backend = sys.modules['sherpa.plot.' + plot_opt]
-except (ImportError, KeyError):
+except ImportError:
     # if the user inputs a malformed backend or it is not found,
     # give a useful warning and fall back on dummy_backend of noops
-    warning('failed to import sherpa.plot.{};'.format(plot_opt) +
-            ' plotting routines will not be available')
-    from . import dummy_backend as backend
-    plot_opt = 'dummy_backend'
+    if plot_opt == 'chips_backend':
+        warning('chips is not supported in CIAO 4.12+, falling back to matplotlib.')
+        warning('Please consider updating your $HOME/.sherpa.rc file to suppress this warning.')
+        plot_opt = 'pylab_backend'
+
+        try:
+            importlib.import_module('.' + plot_opt, package='sherpa.plot')
+            backend = sys.modules['sherpa.plot.' + plot_opt]
+        except ImportError:
+            warning('failed to import sherpa.plot.%s;' % plot_opt +
+                    ' plotting routines will not be available')
+            from . import dummy_backend as backend
+
+            plot_opt = 'dummy_backend'
+    else:
+        warning('failed to import sherpa.plot.%s;' % plot_opt +
+                ' plotting routines will not be available')
+        from . import dummy_backend as backend
+        plot_opt = 'dummy_backend'
 
 backend.init()
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -55,8 +55,7 @@ if plot_opt == 'none_backend':
     plot_opt = 'dummy_backend'
 
 try:
-    importlib.import_module('.' + plot_opt, package='sherpa.plot')
-    backend = sys.modules['sherpa.plot.' + plot_opt]
+    backend = importlib.import_module('.' + plot_opt, package='sherpa.plot')
 except ImportError:
     # if the user inputs a malformed backend or it is not found,
     # give a useful warning and fall back on dummy_backend of noops
@@ -66,8 +65,7 @@ except ImportError:
         plot_opt = 'pylab_backend'
 
         try:
-            importlib.import_module('.' + plot_opt, package='sherpa.plot')
-            backend = sys.modules['sherpa.plot.' + plot_opt]
+            backend = importlib.import_module('.' + plot_opt, package='sherpa.plot')
         except ImportError:
             warning('failed to import sherpa.plot.%s;' % plot_opt +
                     ' plotting routines will not be available')


### PR DESCRIPTION
# Release Note

Sherpa now warns the user if Chips is selected as a backend but it is not available in the installation. In this case Sherpa will also try and fall back to the pylab backend. The user will see the message

```
WARNING: chips is not supported in CIAO 4.12+, falling back to matplotlib.
WARNING: Please consider updating your $HOME/.sherpa.rc file to suppress this warning.
```

and (as long as matplotlib is installed) will be able to create plots.

# Notes

This fixes CIAO-283.
This was included in ciao4.12b1 and then dropped from the subsequent beta because I only committed it to the ciao-specific branch. I was supposed to issue a PR, and here it is.

This is a rebased version of #648, dealing with the conflict over how the backend is imported. The version from #648 was taken. A follow up simplification of the code was made, taking advantage of the fact that `import_module` returns the module, so there is no need to look it up in `sys.modules` (presumably an artifact from python 2.7 support).