### PR TITLE
Add warnings in documentation about masked arrays loaded into Sherpa

### DIFF
--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -471,6 +471,11 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
     def __init__(self, name, indep, y, staterror=None, syserror=None):
         """
+        Warning: Currently, Data objects ignore any masks on input data. If you have masked data,
+        set ``data.mask`` after initialization - and note that the Sherpa convention for masking
+        is OPPOSITE to numpy, i.e. in Sherpa True marks a valid value and False an invalid,
+        to-be-ignored value.
+
         Parameters
         ----------
         name : basestring

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -3741,6 +3741,13 @@ class Session(NoNewAttributesAfterInit):
            Two or more arrays, followed by the type of data set to
            create.
 
+        Warnings
+        --------
+        Sherpa currently does not support numpy masked arrays. Use the
+        set_filter function and note that it follows a different convention by
+        default (a positive value or True for a "bad" channel, 0 or False for
+        a good channel).
+
         See Also
         --------
         copy_data : Copy a data set to a new identifier.


### PR DESCRIPTION
Sherpa currently does not support numpy masked arrays. See #346
and #695 for related bug reports. This does not fix the issue, but
adds documentation to make users more aware of this issue and point
to work-arounds.