### PR TITLE
a fix for /data/lenin2/Test/CIAO4.11/SherpaRegressionBeta1/45

### DIFF
--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -196,9 +196,9 @@ class ARFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.arfargs = ()
 
-    def startup(self):
-        self.model.startup()
-        CompositeModel.startup(self)
+    def startup(self, cache):
+        self.model.startup(cache)
+        CompositeModel.startup(self, cache)
 
     def teardown(self):
         self.model.teardown()
@@ -408,7 +408,7 @@ class ARFModelPHA(ARFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self):
+    def startup(self, cache):
         arf = self._arf  # original
         pha = self.pha
 
@@ -429,7 +429,7 @@ class ARFModelPHA(ARFModel):
         if pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-        ARFModel.startup(self)
+        ARFModel.startup(self, cache)
 
     def teardown(self):
         self.arf = self._arf  # restore original

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -39,8 +39,8 @@ logger = logging.getLogger("sherpa")
 @requires_xspec
 class test_ARFModelPHA(SherpaTestCase):
     _fit_using_ARFModelPHA = {
-        'numpoints': 26786,
-        'dof': 26783
+        'numpoints': 1212,
+        'dof': 1208
     }
     
     def setup(self):
@@ -53,23 +53,19 @@ class test_ARFModelPHA(SherpaTestCase):
 
     def test_ARFModelPHA(self):
         from sherpa.astro import ui
-        ui.load_pha(self.make_path("acis_1597_v2_pha2.fits"))
-        ui.load_arf(4, self.make_path("acis_1597_v2_HEG_1_garf.fits"))
-        ui.load_arf(3, self.make_path("acis_1597_v2_HEG_-1_garf.fits"))
-        ui.load_arf(9, self.make_path("acis_1597_v2_MEG_-1_garf.fits"))
-        ui.load_arf(10, self.make_path("acis_1597_v2_MEG_1_garf.fits"))
-        ui.get_data(4).units="wavelength"
-        ui.get_data(3).units="wavelength"
-        ui.get_data(9).units="wavelength"
-        ui.get_data(10).units="wavelength"
-        ui.set_model(4,"xsphabs.abs1*powlaw1d.p1")
-        ui.set_model(3,"abs1*p1")
-        ui.set_model(9,"abs1*p1")
-        ui.set_model(10,"abs1*p1")
-        ui.notice(2, 30)
+        ui.load_pha(self.make_path("3c120_meg_1.pha"))
+        ui.group_counts(20)
+        ui.notice(0.5, 6)
+        ui.subtract()
+        ui.set_model(ui.xsphabs.abs1 * (ui.xsapec.bubble + ui.powlaw1d.p1))
+        abs1.nh = 0.163
+        abs1.nh.freeze()
+        p1.ampl = 0.017
+        p1.gamma = 1.9
+        bubble.kt = 0.5
+        bubble.norm = 4.2e-5
         tol = 1.0e-2
         ui.set_method_opt('ftol', tol)
-        ui.set_method_opt('gtol', tol)
         ui.fit()
         result = ui.get_fit_results()
         assert result.numpoints == self._fit_using_ARFModelPHA['numpoints']

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -58,6 +58,8 @@ class test_ARFModelPHA(SherpaTestCase):
         ui.notice(0.5, 6)
         ui.subtract()
         ui.set_model(ui.xsphabs.abs1 * (ui.xsapec.bubble + ui.powlaw1d.p1))
+        ui.set_xsabund('angr')
+        ui.set_xsxsect('vern')
         abs1.nh = 0.163
         abs1.nh.freeze()
         p1.ampl = 0.017

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -54,6 +54,11 @@ class test_ARFModelPHA(SherpaTestCase):
     def test_ARFModelPHA(self):
         from sherpa.astro import ui
         ui.load_pha(self.make_path("3c120_meg_1.pha"))
+
+        # remove the RMF to ensure this is an ARF-only analysis
+        # (which is what is needed to trigger the bug that lead to #699)
+        ui.get_data().set_rmf(None)
+
         ui.group_counts(20)
         ui.notice(0.5, 6)
         ui.subtract()

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -21,7 +21,8 @@ from __future__ import print_function
 
 import numpy
 
-from sherpa.utils.testing import SherpaTestCase, requires_data, requires_fits
+from sherpa.utils.testing import SherpaTestCase, requires_data, requires_fits,\
+    requires_xspec
 
 from sherpa.models import Polynom1D, SimulFitModel
 from sherpa.models.basic import Gauss1D
@@ -35,6 +36,7 @@ logger = logging.getLogger("sherpa")
 
 @requires_data
 @requires_fits
+@requires_xspec
 class test_ARFModelPHA(SherpaTestCase):
     _fit_using_ARFModelPHA = {
         'numpoints': 26786,


### PR DESCRIPTION
# Note
PR #616 was written to enable the testers to turn on (or off) caching at runtime to test PR #444  (and possibly PR #503).  This was done by adding the argument ```cache``` to all ```startup``` methods, unfortunately sherpa's tests do not include the instantiation of the ```ARFModelPHA``` class so a recent test by SDS found this bug which is hopefully fixed by this PR.

 SDS has to decide if PR #616, #503 and #699 should be released for public consumption 
