### PR TITLE
a fix for /data/lenin2/Test/CIAO4.11/SherpaRegressionBeta1/45 (rebase of #699)

### DIFF
--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -196,9 +196,9 @@ class ARFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.arfargs = ()
 
-    def startup(self):
-        self.model.startup()
-        CompositeModel.startup(self)
+    def startup(self, cache):
+        self.model.startup(cache)
+        CompositeModel.startup(self, cache)
 
     def teardown(self):
         self.model.teardown()
@@ -408,7 +408,7 @@ class ARFModelPHA(ARFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self):
+    def startup(self, cache):
         arf = self._arf  # original
         pha = self.pha
 
@@ -429,7 +429,7 @@ class ARFModelPHA(ARFModel):
         if pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-        ARFModel.startup(self)
+        ARFModel.startup(self, cache)
 
     def teardown(self):
         self.arf = self._arf  # restore original

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -42,11 +42,11 @@ class test_ARFModelPHA(SherpaTestCase):
         'numpoints': 1212,
         'dof': 1208
     }
-    
+
     def setup(self):
         self._old_logger_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)
-        
+
     def tearDown(self):
         if hasattr(self, "_old_logger_level"):
             logger.setLevel(self._old_logger_level)
@@ -54,6 +54,11 @@ class test_ARFModelPHA(SherpaTestCase):
     def test_ARFModelPHA(self):
         from sherpa.astro import ui
         ui.load_pha(self.make_path("3c120_meg_1.pha"))
+
+        # remove the RMF to ensure this is an ARF-only analysis
+        # (which is what is needed to trigger the bug that lead to #699)
+        ui.get_data().set_rmf(None)
+
         ui.group_counts(20)
         ui.notice(0.5, 6)
         ui.subtract()


### PR DESCRIPTION
Note
PR #616 was written to enable the testers to turn on (or off) caching at runtime to test PR #444 (and possibly PR #503). This was done by adding the argument cache to all startup methods, unfortunately sherpa's tests do not include the instantiation of the ARFModelPHA class so a recent test by SDS found this bug which is hopefully fixed by this PR.

SDS has to decide if PR #616, #503 and #699 should be released for public consumption

# Notes for rebase

This is a rebase of #699 to fix the test so that it shows the bug, squashing the commits down to avoid the need to change the test-data submodule, and to add the test first and then the fix (so we can see it fail on travis).

Well, the hope was to avoid an un-needed change to `sherpa-test-data` but that doesn't seem to have worked.