### PR TITLE
change calc_ftest from delta dof to dof (similar to XSPEC)

### DIFF
--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -51,8 +51,11 @@ debug = logging.getLogger("sherpa").debug
 config = ConfigParser()
 config.read(get_config())
 
-_ncpu_val = config.get('parallel', 'numcores',
-                       fallback='None').strip().upper()
+_ncpu_val = "NONE"
+try:
+    _ncpu_val = config.get('parallel', 'numcores').strip().upper()
+except NoSectionError:
+    pass
 
 _ncpus = None
 if not _ncpu_val.startswith('NONE'):
@@ -178,13 +181,13 @@ def calc_ftest(dof1, stat1, dof2, stat2):
 
     Parameters
     ----------
-    dof1 : int
+    dof1 : int or array/list/tuple of int
        degrees of freedom of the simple model
-    stat1 : number
+    stat1 : number or array/list/tuple of number
        best-fit chi-square statistic value of the simple model
-    dof2 : int
+    dof2 : int or array/list/tuple of int
        degrees of freedom of the complex model
-    stat2 : number
+    stat2 : number or array/list/tuple of number
        best-fit chi-square statistic value of the complex model
 
     Returns
@@ -232,16 +235,11 @@ def calc_ftest(dof1, stat1, dof2, stat2):
 
     Examples
     --------
+    >>> calc_ftest(11, 16.3, 10, 10.2) 
+    0.03452352914891555
 
-    In this example, the simple model has 5 degrees of freedom and
-    a chi-square statistic of 7.73, while the complex model has 8
-    degrees of freedom and a chi-square statistic of 8.94. The
-    F test does not provide any evidence that the complex model
-    is a better fit to the data than the simple model since the
-    result is much larger than 0.
-
-    >>> calc_ftest(5, 7.73, 8, 8.94)
-    0.32480691622314933
+    >>> calc_ftest([11, 11], [16.3, 16.3], [10, 9], [10.2, 10.5]) 
+    array([0.03452353, 0.13819987])
     """
 
     return _utils.calc_ftest(dof1, stat1, dof2, stat2)

--- a/sherpa/utils/src/_utils.cc
+++ b/sherpa/utils/src/_utils.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -84,13 +84,38 @@ static PyObject* ftest( PyObject* self, PyObject* args )
   if ( EXIT_SUCCESS != result.create( dof_1.get_ndim(), dof_1.get_dims() ) )
     return NULL;
 
-  double f, x;
-
   for ( npy_intp ii = 0; ii < nelem; ii++ ) {
 
-    f = ( chisq_1[ii] / dof_1[ii] ) / ( chisq_2[ii] / dof_2[ii] );
-    x = dof_2[ii] / ( dof_2[ii] + dof_1[ii] * f );    
-    result[ii] = incbet( dof_2[ii] / 2.0, dof_1[ii] / 2.0, x);
+    const double delta_dof = dof_1[ii] - dof_2[ii];
+    if ( 0.0 == chisq_2[ii] ) {
+      std::ostringstream err;
+      err << "chisq_2[" << ii << "] cannot be equal to 0: ";
+      PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+      return NULL;
+    }
+    if ( 0.0 == dof_2[ii] ) {
+      std::ostringstream err;
+      err << "dof_2[" << ii << "] cannot be equal to 0: ";
+      PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+      return NULL;
+    }
+    if ( 0.0 == delta_dof ) {
+      std::ostringstream err;
+      err << "dof_1[" << ii << "] cannot be equal to dof_2[" << ii << "]: ";
+      PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+      return NULL;
+    }
+    const double delta_chi = chisq_1[ii] - chisq_2[ii];
+    const double f = delta_chi / delta_dof / (chisq_2[ii] / dof_2[ii]);
+    const double tmp = dof_2[ii] + delta_dof * f;
+    if ( 0.0 == tmp ) {
+      std::ostringstream err;
+      err << "dof_2[" << ii << "] + delta_dof * f cannot be equal to 0,\nwhere f = delta_chi / delta_dof / (chisq_2[" << ii << "] / dof_2[" << ii << " ]: ";
+      PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+      return NULL;
+    }
+    result[ii] = incbet( dof_2[ii] * 0.5 , delta_dof * 0.5,
+                         (dof_2[ii] / ( tmp ) ) );
 
   }
   

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,15 +21,37 @@ import numpy
 
 from sherpa.utils import _utils, is_binary_file, pad_bounding_box
 from sherpa.utils.testing import requires_data
-from numpy.testing import assert_almost_equal, assert_array_equal
+from numpy.testing import assert_almost_equal, assert_array_equal, \
+    assert_array_almost_equal
 
 
 def test_calc_ftest():
     """
     this test was created using sherpa 4.8.1 (2507414) as an oracle for the python 3 migration
     """
-    assert_almost_equal(0.475500468, _utils.calc_ftest(10, 1.0, 20, 2.0))
+    assert_almost_equal(0.03452352914891555,
+                        _utils.calc_ftest(11, 16.3, 10, 10.2))
 
+
+def test_calc_ftest2():
+    assert_array_almost_equal(2 * [0.03452352914891555],
+                              _utils.calc_ftest(2 * [11], 2 * [16.3],
+                                                2 * [10], 2 * [10.2]))
+    
+def test_calc_ftest_chi2_equal_0():
+    with pytest.raises(TypeError) as excinfo:
+        _utils.calc_ftest(11, 16.3, 10, 0.0)
+    assert 'chisq_2[0] cannot be equal to 0:' in str(excinfo.value)
+
+def test_calc_ftest_dof2_equal_0():
+    with pytest.raises(TypeError) as excinfo:
+        _utils.calc_ftest(11, 16.3, 0, 10.0)
+    assert 'dof_2[0] cannot be equal to 0:' in str(excinfo.value)
+    
+def test_calc_ftest_dof1_equal_dof2():
+    with pytest.raises(TypeError) as excinfo:
+        _utils.calc_ftest(11, 16.3, 11, 10.0)
+    assert 'dof_1[0] cannot be equal to dof_2[0]:' in str(excinfo.value)
 
 def test_calc_mlr():
     """


### PR DESCRIPTION
# Release Notes
Sherpa calc_ftest does not give the same results as XSPEC's ftest command; Moreover current docs is not entirely correct

# Note
This PR should be considered if sherpa's calc_ftest is to give the same results as XSPEC's ftest, otherwise reject it.  The PR is a 'fix' for issue https://github.com/sherpa/sherpa/issues/641