### PR TITLE
modelCacher1d needs to have a couple of deep instead of shallow copy()

### DIFF
--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 #
-#  Copyright (C) 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2018, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,7 @@ from sherpa.data import Data1D, DataSimulFit
 from sherpa.optmethods import NelderMead, LevMar
 from sherpa.stats import Cash, LeastSq
 from sherpa.fit import Fit
+from sherpa.astro import ui
 
 import logging
 logger = logging.getLogger("sherpa")
@@ -157,3 +158,47 @@ class test_cache(SherpaTestCase):
         sfit = Fit(sdata, smodel, method=LevMar(), stat=LeastSq())
         result = sfit.fit()
         self.compare_results(self._fit_g2g2_bench, result)
+
+    def test_cache_copy(self):
+        # fake up a PHA data set
+        chans = numpy.arange(1, 11, dtype=numpy.int8)
+        counts = numpy.ones(chans.size)
+
+        # bin width is not 0.1 but something slightly different
+        ebins = numpy.linspace(0.1, 1.2, num=chans.size + 1)
+        elo = ebins[:-1]
+        ehi = ebins[1:]
+
+        dset = ui.DataPHA('test', chans, counts)
+
+        # make sure ARF isn't 1 to make sure it's being applied
+        arf = ui.create_arf(elo, ehi, specresp=0.7 * numpy.ones(chans.size))
+
+        rmf = ui.create_rmf(elo, ehi, e_min=elo, e_max=ehi)
+
+        ui.set_data(1, dset)
+        ui.set_arf(1, arf)
+        ui.set_rmf(1, rmf)
+
+        ui.set_source(ui.const1d.mdl)
+
+        # again not 1
+        mdl.c0 = 8
+
+
+        # Copy the values from the plot structures, since get_xxx_plot
+        # returns the same object so m1.y == m2.y will not note a difference.
+        #
+
+        d1y = ui.get_data_plot().y.copy()
+        m1y = ui.get_model_plot().y.copy()
+        s1y = ui.get_source_plot().y.copy()
+
+        d2y = ui.get_data_plot().y.copy()
+        m2y = ui.get_model_plot().y.copy()
+        s2y = ui.get_source_plot().y.copy()
+        rtol = 1.0e-4
+        atol = 1.0e-4
+        numpy.testing.assert_allclose(d1y, d2y, rtol, atol)
+        numpy.testing.assert_allclose(m1y, m2y, rtol, atol)
+        numpy.testing.assert_allclose(s1y, s2y, rtol, atol)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -63,7 +63,7 @@ def modelCacher1d(func):
             token = b''.join(data)
             digest = hashlib.sha256(token).digest()
             if digest in cache:
-                return cache[digest]
+                return cache[digest].copy()
 
         vals = func(cls, pars, xlo, *args, **kwargs)
 
@@ -74,7 +74,7 @@ def modelCacher1d(func):
 
             # append newest model values to queue
             queue.append(digest)
-            cache[digest] = vals
+            cache[digest] = vals.copy()
 
         return vals
 
@@ -526,7 +526,7 @@ class ArithmeticModel(Model):
         self.__dict__.update(state)
 
         if '_use_caching' not in state:
-            self.__dict__['_use_caching'] = False
+            self.__dict__['_use_caching'] = True
 
         if '_queue' not in state:
             self.__dict__['_queue'] = ['']


### PR DESCRIPTION
# Release Note
The function ```modelCacher1d``` makes shallow copy of the cached function values, this PR added a couple of ```.copy()`` to make sure deep copies are made instead.  This PR is a fix to issue #673 

# Note
In re-reading the code I also noticed that the setting of the ```_use_caching``` member of the class ```ArithmeticModel``` was not set consistently in the member function ```__set_state__```