### PR TITLE
change how minim handles exceeding boundary limits

### DIFF
--- a/sherpa/optmethods/src/DifEvo.cc
+++ b/sherpa/optmethods/src/DifEvo.cc
@@ -140,11 +140,11 @@ int main( int argc, char* argv[] ) {
 
 g++  -ansi -pedantic -Wall -O3 -I. -I../../include -I.. -DtestDifEvo DifEvo.cc Simplex.cc -o difevo
 
-==1609== Memcheck, a memory error detector
-==1609== Copyright (C) 2002-2009, and GNU GPL'd, by Julian Seward et al.
-==1609== Using Valgrind-3.5.0 and LibVEX; rerun with -h for copyright info
-==1609== Command: tstde
-==1609==
+==2929== Memcheck, a memory error detector
+==2929== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
+==2929== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
+==2929== Command: sherpa/optmethods/src/difevo
+==2929== 
 #
 #:npar = 2
 #:tol=1e-06
@@ -304,15 +304,17 @@ DifEvo_nm_Michalewicz5	1083	-4.68766	-4.64589	2.20292,1.57053,1.2851,1.11375,1.7
 DifEvo_Michalewicz5	13344	-4.68766	-4.68754	2.205,1.57137,1.28544,1.92321,1.72067
 DifEvo_nm_Michalewicz10	12511	-9.66015	-9.61838	2.20326,1.57071,1.28499,1.11359,1.72045,1.57073,1.45438,1.75605,1.65573,1.57082
 DifEvo_Michalewicz10	52873	-9.66015	-9.55588	2.20803,1.57377,1.28519,1.92256,1.72089,1.57051,1.4554,1.75435,1.28298,1.21835
-==1609==
-==1609== HEAP SUMMARY:
-==1609==     in use at exit: 0 bytes in 0 blocks
-==1609==   total heap usage: 919,570 allocs, 919,570 frees, 157,350,820 bytes allocated
-==1609==
-==1609== All heap blocks were freed -- no leaks are possible
-==1609==
-==1609== For counts of detected and suppressed errors, rerun with: -v
-==1609== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 4 from 4)
+DifEvo_nm_McKinnon	-628	-0.25	-2.376e+11	-100,-100
+DifEvo_McKinnon	-546	-0.25	-2.36123e+11	-99.9549,-99.518
+==2929== 
+==2929== HEAP SUMMARY:
+==2929==     in use at exit: 0 bytes in 0 blocks
+==2929==   total heap usage: 918,471 allocs, 918,471 frees, 156,994,792 bytes allocated
+==2929== 
+==2929== All heap blocks were freed -- no leaks are possible
+==2929== 
+==2929== For counts of detected and suppressed errors, rerun with: -v
+==2929== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 */
 
 #endif

--- a/sherpa/optmethods/src/minim.cc
+++ b/sherpa/optmethods/src/minim.cc
@@ -144,16 +144,15 @@ int main( int argc, char* argv[] ) {
   return 0;
 }
 #endif
+
 /*
 g++ -o minim -DtestMinim -Wall -ansi -pedantic -O3 -I../../include -I.. minim.cc
-*/
-/*
-(sherpa3) [dtn@devel12 src]$ valgrind minim
-==2581== Memcheck, a memory error detector
-==2581== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
-==2581== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
-==2581== Command: minim
-==2581==
+
+==3254== Memcheck, a memory error detector
+==3254== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
+==3254== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
+==3254== Command: sherpa/optmethods/src/minim
+==3254== 
 #
 #:npar = 6
 #:tol=1e-08
@@ -164,7 +163,7 @@ S	N	N	N	N
 Minim_Rosenbrock	-961	0	1.29567	0.184248,0.0284826,1.63673,2.68041,0.529682,0.278636
 Minim_FreudensteinRoth	-574	0	146.953	11.4128,-0.896805,11.4128,-0.896805,11.4128,-0.896805
 Minim_PowellBadlyScaled	1003	0	1.63198e-06	1.50587e-05,6.64168,8.25696e-06,12.1085,1.30173e-05,7.68102
-Minim_BrownBadlyScaled	572	0	1.10634e-17	1e+06,1.99977e-06,1e+06,1.99819e-06,1e+06,2e-06
+Minim_BrownBadlyScaled	2151	0	7.60681e-20	1e+06,1.99991e-06,1e+06,2.0001e-06,1e+06,2e-06
 Minim_Beale	399	0	2.70425e-16	3,0.5,3,0.5,3,0.5
 Minim_JennrichSampson	861	373.086	373.087	0.257825,0.257825,0.257825,0.257825,0.257825,0.257825
 Minim_HelicalValley	145	0	1.12431e-16	1,4.47078e-09,6.95162e-09
@@ -194,20 +193,20 @@ Minim_LinearFullRank	326	0	1.77494e-30	-1,-1,-1,-1,-1,-1
 Minim_LinearFullRank1	247	1.15385	1.15385	2.97377,2.2046,2.13584,0.15931,0.59993,-2.8661
 Minim_LinearFullRank0cols0rows	244	2.66667	2.66667	2.14801,1.95638,0.261166,0.8645,-1.56419,2.61241
 Minim_Chebyquad	641	0	8.64238e-06	0.04472,0.205762,0.230925,0.424449,0.491337,0.591077,0.761322,0.804917,0.956254
-Minim_McCormick	1287	-1.91	-nan	-nan,-nan
-Minim_BoxBetts	84	0	1.02735e-14	1,10,1
-Minim_Paviani	-76813	-45.7	-2.75503	5.78989,7.49795,5.06157,7.23616,4.91172,5.56942,7.55769,6.10409,6.90818,7.98112
-Minim_GoldsteinPrice	83	3	3	-2.85576e-11,-1
+Minim_McCormick	93	-1.91	-1.91322	-0.547198,-1.5472
+Minim_BoxBetts	94	0	8.5606e-16	1,10,1
+Minim_Paviani	1497	-45.7	-45.6242	9.32565,9.39821,9.34252,9.46265,9.35731,9.36868,9.28165,9.299,9.40574,9.21271
+Minim_GoldsteinPrice	92	3	3	7.848e-14,-1
 Minim_Shekel5	-171	-10.1532	-5.10077	7.99958,7.99964,7.99958,7.99964
 Minim_Shekel7	-179	-10.4029	-5.12882	7.99951,7.99962,7.9995,7.99961
 Minim_Shekel10	-189	-10.5364	-5.17565	7.99948,7.99945,7.99946,7.99944
 Minim_Levy4	-803	-21.502	9.85125	2.64769,1.99586,0.670413,6.99797
-Minim_Levy5	-312	-11.504	38.8617	3.96386,3.99615,3.99623,3.99624,3.99945
-Minim_Levy6	-300	-11.504	47.8504	3.96386,3.99615,3.99623,3.99623,3.99624,3.99945
-Minim_Levy7	-376	-11.504	56.8392	3.96386,3.99615,3.99623,3.99623,3.99623,3.99624,3.99945
+Minim_Levy5	-317	-11.504	38.8617	3.96386,3.99615,3.99623,3.99624,3.99945
+Minim_Levy6	-306	-11.504	47.8504	3.96386,3.99615,3.99623,3.99623,3.99624,3.99945
+Minim_Levy7	-383	-11.504	56.8392	3.96386,3.99615,3.99623,3.99623,3.99623,3.99624,3.99945
 Minim_Griewank	-79	0	4.91141	100.481,-97.6456
-Minim_SixHumpCamel	86	-1.03	-1.03163	0.089842,-0.712656
-Minim_Branin	77	0.397889	0.397887	9.42478,2.475
+Minim_SixHumpCamel	91	-1.03	-1.03163	0.089842,-0.712656
+Minim_Branin	97	0.397889	0.397887	9.42478,2.475
 Minim_Shubert	-96	-24.06	-14.6909	8.82716,5.79179
 Minim_Hansen	113	-176.54	-176.542	4.97648,4.85806
 Minim_Cola	-866	12.8154	256.203	1.94861,-0.57903,0.373911,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108,0.673911,-0.0382,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108
@@ -215,18 +214,19 @@ Minim_Ackley	-85	0	19.3325	16.9988,16.9988
 Minim_Bohachevsky1	122	0	0	-1.20688e-13,-4.84744e-14
 Minim_Bohachevsky2	122	0	0	4.72187e-13,-1.38867e-13
 Minim_Bohachevsky3	119	0	0	-7.20017e-14,5.35598e-14
-Minim_Easom	-19	-1	-0	25.55,25.55
+Minim_Easom	-4096	-1	-0	25.55,25.55
 Minim_Rastrigin	-97	0	7.95966	1.98991,1.98991
 Minim_Michalewicz2	77	-1.8013	-1.8013	2.20291,1.5708
-Minim_Michalewicz5	-322	-4.68766	-4.3749	2.20291,1.5708,2.21933,1.92306,0.996677
+Minim_Michalewicz5	-323	-4.68766	-4.3749	2.20291,1.5708,2.21933,1.92306,0.996677
 Minim_Michalewicz10	-938	-9.66015	-7.54148	2.20303,1.57081,1.28501,1.39237,1.72048,1.57081,2.22106,1.5867,1.65572,1.5708
-==2581==
-==2581== HEAP SUMMARY:
-==2581==     in use at exit: 0 bytes in 0 blocks
-==2581==   total heap usage: 24,021 allocs, 24,021 frees, 3,682,352 bytes allocated
-==2581==
-==2581== All heap blocks were freed -- no leaks are possible
-==2581==
-==2581== For counts of detected and suppressed errors, rerun with: -v
-==2581== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+Minim_McKinnon	-4098	-0.25	-2.376e+11	-100,-100
+==3254== 
+==3254== HEAP SUMMARY:
+==3254==     in use at exit: 0 bytes in 0 blocks
+==3254==   total heap usage: 93,753 allocs, 93,753 frees, 113,818,312 bytes allocated
+==3254== 
+==3254== All heap blocks were freed -- no leaks are possible
+==3254== 
+==3254== For counts of detected and suppressed errors, rerun with: -v
+==3254== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 */

--- a/sherpa/optmethods/src/minim.hh
+++ b/sherpa/optmethods/src/minim.hh
@@ -29,13 +29,13 @@ namespace sherpa {
       return ifault;
     }
 
-
     void minim( std::vector<real>& P, const std::vector<real>& STEP,
                 int NOP, real& FUNC, int MAXNFEV, int IPRINT, real STOPCR,
                 int IQUAD, real SIMP, std::vector<real>& VC, int& IFAULT,
                 int& NEVAL, const sherpa::Bounds<real>& LIMITS ) {
-      return MINIM( P, STEP, NOP, FUNC, MAXNFEV, IPRINT, STOPCR, IQUAD, SIMP,
-                    VC, IFAULT, NEVAL, LIMITS);
+      MINIM( P, STEP, NOP, FUNC, MAXNFEV, IPRINT, STOPCR, IQUAD,
+             SIMP, VC, IFAULT, NEVAL, LIMITS );
+      return;
     }
 
   private:
@@ -43,12 +43,33 @@ namespace sherpa {
     Func usr_func;
     Data usr_data;
 
+    //
+    // minim has over expanded beyond a free parameter's boundary, need
+    // to move back into allowed space by the same amount that was exceeded.
+    // However, one has to make sure that one does not overshoot the other
+    // boundary in the event that the boundaries are very tight
+    //
+    void reflect_about_boundary( int npar, std::vector<real>& par,
+                                 const sherpa::Bounds<real>& limits )
+      const {
+      const std::vector<real> lb = limits.get_lb();
+      const std::vector<real> ub = limits.get_ub();
+
+      for  ( int ii = 0; ii < npar; ++ii ) {
+        if ( par[ ii ] < lb[ ii ] )
+          par[ ii ] = std::max( lb[ ii ], lb[ ii ] - ( par[ ii ] - lb[ ii ] ) );
+        if ( par[ ii ] > ub[ ii ] )
+          par[ ii ] = std::min( ub[ ii ], ub[ ii ] - ( par[ ii ] - ub[ ii ] ) );
+        // just in case limits are tight and have over-corrected
+        if ( par[ ii ] < lb[ ii ] || par[ ii ] > ub[ ii ] )
+          par[ ii ] = ( lb[ ii ] + ub[ ii ] ) * 0.5;
+      }
+
+    }
+
     void eval_usr_func( int npar, std::vector<real>& par, real& fval,
                         const sherpa::Bounds<real>& limits ) {
-
-      if ( sherpa::Opt<Data, real>::are_pars_outside_limits( npar, par,
-                                                             limits ) )
-        fval = std::numeric_limits< real >::max( );
+      reflect_about_boundary( npar, par, limits );
       int ierr = EXIT_SUCCESS;
       usr_func( npar, &par[0], fval, ierr, usr_data );
       if ( EXIT_SUCCESS != ierr )

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -20,9 +20,11 @@ from __future__ import print_function
 
 from sherpa.utils import _ncpus
 from sherpa.utils.testing import SherpaTestCase
+from sherpa.optmethods import _saoopt
 from sherpa.optmethods import optfcts
 from sherpa.optmethods import _tstoptfct
 
+import numpy as np
 
 class test_optmethods(SherpaTestCase):
 
@@ -115,6 +117,20 @@ class test_optmethods(SherpaTestCase):
         self.tst( optfcts.lmdif, name + self.lm, _tstoptfct.gaussian,
                   fmin, x0, xmin, xmax )
 
+    def test_mccormick(self):
+        from sherpa.optmethods.opt import McCormick
+        init = 0
+        iquad = 1
+        ftol = 1.0e-7
+        simp = 1.0e-2 * ftol
+        xmin = [-1.5, -3.0]
+        xmax = [4.0, 4.0]
+        x = np.asarray([0, 0])
+        step = 0.4 * np.ones(x.shape, np.float_)
+        x, fval, neval, ifalut = _saoopt.minim(0, 1000, init, iquad, simp, ftol, step, xmin, xmax, x, McCormick)
+        fmin = -1.9132229549810362
+        self.assertEqualWithinTol( fval, fmin, self.tolerance )
+        
 ##     # This test actually passed, there is a bug with assertEqualWithinTol
 ##     def test_meyer(self):
 ##         name = 'meyer'


### PR DESCRIPTION
# Note

When the Fortran opt algo  _minim.f_ was translated to C++, it was reported that the number of function evaluations (nfev) had increased (see [sds](https://icxc.harvard.edu/pipe/sherpadev/2018/0597.html) for details).  Previously, _minim_ handles simple boundary limits as _an infinite potential well_, ie the cost function would return very large value which makes it difficult to count nfev.  The C++ _minimh.hh_ now reflects about the boundary limit by the same amount as was exceeded, with the extra care to not exceed the other boundary limit in the even the limits are very small.

This PR replaces PR #557 since it is difficult to rebase and/or cherry pick