### PR TITLE
Residual-style plots ignore the ylog setting (fix #586)

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11401,6 +11401,9 @@ class Session(sherpa.ui.utils.Session):
         Display the residuals for the background of a PHA data set
         when it is being fit, rather than subtracted from the source.
 
+        .. versionchanged:: 4.12.0
+           The Y axis is now always drawn using a linear scale.
+
         Parameters
         ----------
         id : int or str, optional
@@ -11437,6 +11440,11 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg_ratio : Plot the ratio of data to model values for the background of a PHA data set.
         set_bkg_model : Set the background model expression for a PHA data set.
 
+        Notes
+        -----
+        The ylog setting is ignored, and the Y axis is drawn using a
+        linear scale.
+
         Examples
         --------
 
@@ -11458,6 +11466,9 @@ class Session(sherpa.ui.utils.Session):
         Display the ratio of data to model values for the background
         of a PHA data set when it is being fit, rather than subtracted
         from the source.
+
+        .. versionchanged:: 4.12.0
+           The Y axis is now always drawn using a linear scale.
 
         Parameters
         ----------
@@ -11495,6 +11506,11 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg_resid : Plot the residual (data-model) values for the background of a PHA data set.
         set_bkg_model : Set the background model expression for a PHA data set.
 
+        Notes
+        -----
+        The ylog setting is ignored, and the Y axis is drawn using a
+        linear scale.
+
         Examples
         --------
 
@@ -11515,6 +11531,9 @@ class Session(sherpa.ui.utils.Session):
         Display the ratio of the residuals (data-model) to the error
         values for the background of a PHA data set when it is being
         fit, rather than subtracted from the source.
+
+        .. versionchanged:: 4.12.0
+           The Y axis is now always drawn using a linear scale.
 
         Parameters
         ----------
@@ -11551,6 +11570,11 @@ class Session(sherpa.ui.utils.Session):
         plot_bkg_ratio : Plot the ratio of data to model values for the background of a PHA data set.
         plot_bkg_resid : Plot the residual (data-model) values for the background of a PHA data set.
         set_bkg_model : Set the background model expression for a PHA data set.
+
+        Notes
+        -----
+        The ylog setting is ignored, and the Y axis is drawn using a
+        linear scale.
 
         Examples
         --------
@@ -12058,6 +12082,11 @@ class Session(sherpa.ui.utils.Session):
         plot_fit_resid : Plot the fit results, and the residuals, for a data set.
         set_analysis : Set the units used when fitting and displaying spectral data.
 
+        Notes
+        -----
+        For the residual plot, the ylog setting is ignored, and the Y axis
+        is drawn using a linear scale.
+
         Examples
         --------
 
@@ -12080,6 +12109,10 @@ class Session(sherpa.ui.utils.Session):
 
         This creates two plots - the first from `plot_bkg_fit` and the
         second from `plot_bkg_resid` - for a data set.
+
+        .. versionchanged:: 4.12.0
+           The Y axis of the residual plot is now always drawn using a
+           linear scale.
 
         Parameters
         ----------
@@ -12123,6 +12156,11 @@ class Session(sherpa.ui.utils.Session):
         plot_fit_resid : Plot the fit results, and the residuals, for a data set.
         set_analysis : Set the units used when fitting and displaying spectral data.
 
+        Notes
+        -----
+        For the residual plot, the ylog setting is ignored, and the Y axis
+        is drawn using a linear scale.
+
         Examples
         --------
 
@@ -12144,6 +12182,10 @@ class Session(sherpa.ui.utils.Session):
 
         This creates two plots - the first from `plot_bkg_fit` and the
         second from `plot_bkg_delchi` - for a data set.
+
+        .. versionchanged:: 4.12.0
+           The Y axis of the residual plot is now always drawn using a
+           linear scale.
 
         Parameters
         ----------
@@ -12186,6 +12228,11 @@ class Session(sherpa.ui.utils.Session):
         plot_fit : Plot the fit results (data, model) for a data set.
         plot_fit_delchi : Plot the fit results, and the residuals, for a data set.
         set_analysis : Set the units used when fitting and displaying spectral data.
+
+        Notes
+        -----
+        For the residual plot, the ylog setting is ignored, and the Y axis
+        is drawn using a linear scale.
 
         Examples
         --------

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -474,7 +474,7 @@ class HistogramPlot(Histogram):
            match the names of the keys of the object's
            plot_prefs dictionary.
 
-        See Also        
+        See Also
         --------
         prepare, overplot
 
@@ -1743,6 +1743,11 @@ class DelchiPlot(ModelPlot):
     xlabel, ylabel, title : str
        Plot labels.
 
+    Notes
+    -----
+    The ylog setting is ignored, whether given as a preference or
+    a keyword argument, so the Y axis is always drawn with a
+    linear scale.
     """
 
     plot_prefs = backend.get_resid_plot_defaults()
@@ -1765,6 +1770,8 @@ class DelchiPlot(ModelPlot):
         self.title = _make_title('Sigma Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
+        self.plot_prefs['ylog'] = False
+        kwargs.pop('ylog', True)
         Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
                   title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
                   overplot=overplot, clearwindow=clearwindow, **kwargs)
@@ -1836,6 +1843,11 @@ class ResidPlot(ModelPlot):
     xlabel, ylabel, title : str
        Plot labels.
 
+    Notes
+    -----
+    The ylog setting is ignored, whether given as a preference or
+    a keyword argument, so the Y axis is always drawn with a
+    linear scale.
     """
 
     plot_prefs = backend.get_resid_plot_defaults()
@@ -1873,6 +1885,8 @@ class ResidPlot(ModelPlot):
         self.title = _make_title('Residuals', data.name)
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
+        self.plot_prefs['ylog'] = False
+        kwargs.pop('ylog', True)
         Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
                   title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
                   overplot=overplot, clearwindow=clearwindow, **kwargs)
@@ -1920,6 +1934,11 @@ class RatioPlot(ModelPlot):
     xlabel, ylabel, title : str
        Plot labels.
 
+    Notes
+    -----
+    The ylog setting is ignored, whether given as a preference or
+    a keyword argument, so the Y axis is always drawn with a
+    linear scale.
     """
 
     plot_prefs = backend.get_ratio_plot_defaults()
@@ -1957,6 +1976,8 @@ class RatioPlot(ModelPlot):
         self.title = _make_title('Ratio of Data to Model', data.name)
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
+        self.plot_prefs['ylog'] = False
+        kwargs.pop('ylog', True)
         Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
                   title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
                   overplot=overplot, clearwindow=clearwindow, **kwargs)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -148,6 +148,19 @@ def test_ratioplot(setup_plot):
     # tp.plot()
 
 
+@requires_plotting
+@pytest.mark.parametrize("plottype", [sherpa.DelchiPlot,
+                                      sherpa.RatioPlot,
+                                      sherpa.ResidPlot])
+def test_ignore_ylog_prefs(setup_plot, plottype):
+    """Do we ignore the ylog preference setting?"""
+    tp = plottype()
+    tp.plot_prefs['ylog'] = True
+    tp.prepare(setup_plot.data, setup_plot.g1, setup_plot.f.stat)
+    tp.plot()
+    assert not tp.plot_prefs['ylog']
+
+
 def test_fitplot(setup_plot):
     dp = sherpa.DataPlot()
     dp.prepare(setup_plot.data, setup_plot.f.stat)

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -66,3 +66,24 @@ def test_ignore_ylog_prefs(plottype):
     ax = plt.gca()
     assert ax.get_xscale() == 'log'
     assert ax.get_yscale() == 'linear'
+
+
+@requires_pylab
+@pytest.mark.parametrize("plottype", [DelchiPlot, RatioPlot, ResidPlot])
+def test_ignore_ylog_kwarg(plottype):
+    """Do the "residual" style plots ignore the ylog keyword argument?"""
+
+    data = Data1D('tst', np.asarray([1, 2, 3]), np.asarray([10, 12, 10.5]))
+    mdl = Const1D('tst-model')
+    mdl.c0 = 11.1
+
+    plot = plottype()
+    plot.prepare(data, mdl, stat=Chi2DataVar())
+    plot.plot(xlog=True, ylog=True)
+
+    fig = plt.gcf()
+    assert len(fig.axes) == 1
+
+    ax = plt.gca()
+    assert ax.get_xscale() == 'log'
+    assert ax.get_yscale() == 'linear'

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -19,15 +19,13 @@
 
 import numpy as np
 
-from matplotlib import pyplot as plt
+import pytest
 
 from sherpa.utils.testing import requires_pylab
 from sherpa.data import Data1D
 from sherpa.models.basic import Const1D
 from sherpa.stats import Chi2DataVar
 from sherpa.plot import DelchiPlot, RatioPlot, ResidPlot
-
-import pytest
 
 
 @requires_pylab
@@ -49,6 +47,8 @@ def test_axes_default():
 @pytest.mark.parametrize("plottype", [DelchiPlot, RatioPlot, ResidPlot])
 def test_ignore_ylog_prefs(plottype):
     """Do the "residual" style plots ignore the ylog preference setting?"""
+
+    from matplotlib import pyplot as plt
 
     data = Data1D('tst', np.asarray([1, 2, 3]), np.asarray([10, 12, 10.5]))
     mdl = Const1D('tst-model')
@@ -72,6 +72,8 @@ def test_ignore_ylog_prefs(plottype):
 @pytest.mark.parametrize("plottype", [DelchiPlot, RatioPlot, ResidPlot])
 def test_ignore_ylog_kwarg(plottype):
     """Do the "residual" style plots ignore the ylog keyword argument?"""
+
+    from matplotlib import pyplot as plt
 
     data = Data1D('tst', np.asarray([1, 2, 3]), np.asarray([10, 12, 10.5]))
     mdl = Const1D('tst-model')

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -775,3 +775,68 @@ def test_plot_xdf(plotfunc):
 
     pvals = [0.1, 0.2, 0.1, 0.4, 0.3, 0.2, 0.1, 0.6]
     plotfunc(pvals)
+
+
+@requires_plotting
+@pytest.mark.usefixtures("clean_ui")
+@pytest.mark.parametrize("plotobj,plotfunc",
+                         [("_residplot", ui.plot_resid),
+                          ("_delchiplot", ui.plot_delchi)
+                          ])
+def test_plot_resid_ignores_ylog(plotobj, plotfunc):
+    """Do the plot_resid-family of routines ignore the ylog setting?
+
+    Note that plot_chisqr is not included in support for ignoring
+    ylog (since the data should be positive in this case).
+    """
+
+    # access it this way to ensure have access to the actual
+    # object used by the session object in this test (as the
+    # clean call done by the clean_ui fixture will reset the
+    # plot objects).
+    #
+    prefs = getattr(ui._session, plotobj).plot_prefs
+
+    setup_example(None)
+
+    ui.set_ylog()
+    assert prefs['ylog']
+
+    plotfunc(ylog=True)
+
+    # Note that the ylog setting has been removed (to reflect
+    # what was displayed).
+    #
+    assert not prefs['ylog']
+
+
+@requires_plotting
+@pytest.mark.usefixtures("clean_ui")
+@pytest.mark.parametrize("plotobj,plotfunc",
+                         [("_residplot", ui.plot_fit_resid),
+                          ("_delchiplot", ui.plot_fit_delchi)
+                          ])
+def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc):
+    """Do the plot_resid-family of routines ignore the ylog setting?"""
+
+    # access it this way to ensure have access to the actual
+    # object used by the session object in this test (as the
+    # clean call done by the clean_ui fixture will reset the
+    # plot objects).
+    #
+    rprefs = getattr(ui._session, plotobj).plot_prefs
+    dprefs = ui._session._dataplot.plot_prefs
+
+    setup_example(None)
+
+    ui.set_ylog()
+    assert rprefs['ylog']
+    assert dprefs['ylog']
+
+    plotfunc(ylog=True)
+
+    # Note that the ylog setting has been removed (to reflect
+    # what was displayed), for the residual-style component only.
+    #
+    assert not rprefs['ylog']
+    assert dprefs['ylog']

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12501,6 +12501,9 @@ class Session(NoNewAttributesAfterInit):
         This function displays the residuals (data - model) for a data
         set.
 
+        .. versionchanged:: 4.12.0
+           The Y axis is now always drawn using a linear scale.
+
         Parameters
         ----------
         id : int or str, optional
@@ -12532,13 +12535,14 @@ class Session(NoNewAttributesAfterInit):
         plot_ratio : Plot the ratio of data to model for a data set.
         set_xlinear : New plots will display a linear X axis.
         set_xlog : New plots will display a logarithmically-scaled X axis.
-        set_ylinear : New plots will display a linear Y axis.
-        set_ylog : New plots will display a logarithmically-scaled Y axis.
 
         Notes
         -----
         The additional arguments supported by `plot_resid` are the same
         as the keywords of the dictionary returned by `get_data_plot_prefs`.
+
+        The ylog setting is ignored, and the Y axis is drawn using a
+        linear scale.
 
         Examples
         --------
@@ -12636,6 +12640,9 @@ class Session(NoNewAttributesAfterInit):
         This function displays the residuals (data - model) divided by
         the error, for a data set.
 
+        .. versionchanged:: 4.12.0
+           The Y axis is now always drawn using a linear scale.
+
         Parameters
         ----------
         id : int or str, optional
@@ -12657,11 +12664,6 @@ class Session(NoNewAttributesAfterInit):
            If the data set does not exist or a source expression has
            not been set.
 
-        Notes
-        -----
-        The additional arguments supported by `plot_delchi` are the same
-        as the keywords of the dictionary returned by `get_data_plot_prefs`.
-
         See Also
         --------
         get_delchi_plot : Return the data used by plot_delchi.
@@ -12672,8 +12674,14 @@ class Session(NoNewAttributesAfterInit):
         plot_resid : Plot the residuals (data - model) for a data set.
         set_xlinear : New plots will display a linear X axis.
         set_xlog : New plots will display a logarithmically-scaled X axis.
-        set_ylinear : New plots will display a linear Y axis.
-        set_ylog : New plots will display a logarithmically-scaled Y axis.
+
+        Notes
+        -----
+        The additional arguments supported by `plot_delchi` are the same
+        as the keywords of the dictionary returned by `get_data_plot_prefs`.
+
+        The ylog setting is ignored, and the Y axis is drawn using a
+        linear scale.
 
         Examples
         --------
@@ -12707,6 +12715,9 @@ class Session(NoNewAttributesAfterInit):
 
         This function displays the ratio data / model for a data set.
 
+        .. versionchanged:: 4.12.0
+           The Y axis is now always drawn using a linear scale.
+
         Parameters
         ----------
         id : int or str, optional
@@ -12738,13 +12749,14 @@ class Session(NoNewAttributesAfterInit):
         plot_resid : Plot the residuals (data - model) for a data set.
         set_xlinear : New plots will display a linear X axis.
         set_xlog : New plots will display a logarithmically-scaled X axis.
-        set_ylinear : New plots will display a linear Y axis.
-        set_ylog : New plots will display a logarithmically-scaled Y axis.
 
         Notes
         -----
         The additional arguments supported by `plot_ratio` are the same
         as the keywords of the dictionary returned by `get_data_plot_prefs`.
+
+        The ylog setting is ignored, and the Y axis is drawn using a
+        linear scale.
 
         Examples
         --------
@@ -12966,6 +12978,10 @@ class Session(NoNewAttributesAfterInit):
         This creates two plots - the first from `plot_fit` and the
         second from `plot_resid` - for a data set.
 
+        .. versionchanged:: 4.12.0
+           The Y axis of the residual plot is now always drawn using a
+           linear scale.
+
         Parameters
         ----------
         id : int or str, optional
@@ -13008,6 +13024,9 @@ class Session(NoNewAttributesAfterInit):
         The additional arguments supported by `plot_fit_resid` are the same
         as the keywords of the dictionary returned by `get_data_plot_prefs`,
         and are applied to both plots.
+
+        For the residual plot, the ylog setting is ignored, and the Y axis
+        is drawn using a linear scale.
 
         Examples
         --------
@@ -13090,6 +13109,9 @@ class Session(NoNewAttributesAfterInit):
         as the keywords of the dictionary returned by `get_data_plot_prefs`,
         and are applied to both plots.
 
+        For the ratio plot, the ylog setting is ignored, and the Y axis
+        is drawn using a linear scale.
+
         Examples
         --------
 
@@ -13125,6 +13147,10 @@ class Session(NoNewAttributesAfterInit):
 
         This creates two plots - the first from `plot_fit` and the
         second from `plot_delchi` - for a data set.
+
+        .. versionchanged:: 4.12.0
+           The Y axis of the delchi plot is now always drawn using a
+           linear scale.
 
         Parameters
         ----------
@@ -13168,6 +13194,9 @@ class Session(NoNewAttributesAfterInit):
         The additional arguments supported by `plot_fit_delchi` are the same
         as the keywords of the dictionary returned by `get_data_plot_prefs`,
         and are applied to both plots.
+
+        For the delchi plot, the ylog setting is ignored, and the Y axis
+        is drawn using a linear scale.
 
         Examples
         --------


### PR DESCRIPTION
Residual, ratio, and delchi plots always use a linear scale for the y axis, no matter what the `ylog` setting is.
    
This address #586
    
The plot method for these classes has been over-ridden to force the
`ylog` preference setting to be `False`, and to drop the `ylog` keyword
argument if specified. This means that a command like (from the
ui layer)
    
    set_ylog()
    plot_fit_resid()
    
will use a logarithmic Y axis for the top plot but a linear one for
the bottom plot.

Notes
--------
    
This might be better done as a Mixin / Multi-Inheritance class, since
the logic is the same for all three cases, but I have not looked into
this approach.

This was originally part of the WSTAT plot fix (PR #694) but has been pulled out as it is a separate issue and fix.
