### PR TITLE
Add warning about masked array to sherpa.astro.ui.load_arrays

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -777,6 +777,13 @@ class Session(sherpa.ui.utils.Session):
            Two or more arrays, followed by the type of data set to
            create.
 
+        Warnings
+        --------
+        Sherpa currently does not support numpy masked arrays. Use the
+        set_filter function and note that it follows a different convention by
+        default (a positive value or True for a "bad" channel, 0 or False for
+        a good channel).
+
         See Also
         --------
         copy_data : Copy a data set to a new identifier.


### PR DESCRIPTION
This adds the warning from PR #698 for sherpa.ui.load_arrays
to the sherpa.astro.ui version, as they don't share a docstring.

The warning notes that Sherpa does not currently support masked arrays for input, and that its way of masking is the inverse to that of masked arrays).