### PR TITLE
Updates the pytest requirement max to 5.2.2.

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -171,7 +171,7 @@ def _install_test_deps():
             """)
             raise
 
-    deps = ['pytest>=3.3']  # List of packages to be installed
+    deps = ['pytest>=3.3,<=5.2.2']  # List of packages to be installed
     pytest_plugins = []  # List of pytest plugins to be installed
 
     # If the plugins are installed "now", pytest won't load them because they are not registered as python packages

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -171,7 +171,7 @@ def _install_test_deps():
             """)
             raise
 
-    deps = ['pytest>=3.3,<=5.2.2']  # List of packages to be installed
+    deps = ['pytest>=3.3,!=5.2.3']  # List of packages to be installed
     pytest_plugins = []  # List of pytest plugins to be installed
 
     # If the plugins are installed "now", pytest won't load them because they are not registered as python packages

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-pytest>=3.3,<=5.2.2
+pytest>=3.3,!=5.2.3
 pytest-xvfb

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-pytest>=3.3
+pytest>=3.3,<=5.2.2
 pytest-xvfb


### PR DESCRIPTION
Pytest has updated to 5.2.3 and this update is causing import errors for the sherpa tests.

Part of the error:

```
==================================== ERRORS ====================================

_ ERROR collecting miniconda/envs/build/lib/python3.6/site-packages/sherpa-4.11.1+246.gd6db323-py3.6-linux-x86_64.egg/sherpa/astro/io/__init__.py _

ImportError while importing test module '/home/travis/miniconda/envs/build/lib/python3.6/site-packages/sherpa-4.11.1+246.gd6db323-py3.6-linux-x86_64.egg/sherpa/astro/io/__init__.py'.

Hint: make sure your test modules/packages have valid Python names.

Traceback:

miniconda/envs/build/lib/python3.6/site-packages/sherpa-4.11.1+246.gd6db323-py3.6-linux-x86_64.egg/sherpa/astro/io/__init__.py:85: in <module>

    importlib.import_module('.' + io_opt, package='sherpa.astro.io')

miniconda/envs/build/lib/python3.6/importlib/__init__.py:126: in import_module

    return _bootstrap._gcd_import(name[level:], package, level)

<frozen importlib._bootstrap>:994: in _gcd_import

    ???

<frozen importlib._bootstrap>:971: in _find_and_load

    ???

<frozen importlib._bootstrap>:955: in _find_and_load_unlocked

    ???

<frozen importlib._bootstrap>:665: in _load_unlocked

    ???

<frozen importlib._bootstrap_external>:678: in exec_module

    ???

<frozen importlib._bootstrap>:219: in _call_with_frames_removed

    ???

miniconda/envs/build/lib/python3.6/site-packages/sherpa-4.11.1+246.gd6db323-py3.6-linux-x86_64.egg/sherpa/astro/io/pyfits_backend.py:42: in <module>

    from astropy.io import fits

E   ModuleNotFoundError: No module named 'astropy'

During handling of the above exception, another exception occurred:

miniconda/envs/build/lib/python3.6/site-packages/sherpa-4.11.1+246.gd6db323-py3.6-linux-x86_64.egg/sherpa/astro/io/__init__.py:91: in <module>

    .format(io_opt))

E   ImportError: Cannot import selected FITS I/O backend pyfits_backend.

E       If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.

E       If you are using Standalone Sherpa, please install astropy.

!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
```

There seems to be others encountering this issue (thank you for finding this Omar): [pytest/issues/6194](https://github.com/pytest-dev/pytest/issues/6194).
