### PR TITLE
Fix for plot_cdf: plot() got an unexpected keyword argument 'clearwindpw'

### DIFF
--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -770,3 +770,15 @@ def test_prefs_change_session_objects_fit():
     #
     assert plotobj.dataplot is ui._session._dataplot
     assert plotobj.modelplot is ui._session._modelplot
+
+
+
+@pytest.mark.parametrize("plotfunc", [ui.plot_cdf, ui.plot_pdf])
+def test_plot_xdf(plotfunc):
+    """Very basic check we can call plot_cdf/pdf
+
+    This can be run even without a plotting backend available.
+    """
+
+    pvals = [0.1, 0.2, 0.1, 0.4, 0.3, 0.2, 0.1, 0.6]
+    plotfunc(pvals)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13327,7 +13327,7 @@ class Session(NoNewAttributesAfterInit):
         try:
             sherpa.plot.begin()
             self._cdfplot.plot(overplot=overplot,
-                               clearwindpw=clearwindow, **kwargs)
+                               clearwindow=clearwindow, **kwargs)
         except:
             sherpa.plot.exceptions()
             raise


### PR DESCRIPTION
Recent changes broke `plot-cdf` - calling it would return the error

```plot() got an unexpected keyword argument 'clearwindpw'```

due to a one-character typo. This PR fixes the typo.

# Details

First commit is to add a test showing the faiulre, and then the second commit fixes it. The error came about from my commit at https://github.com/sherpa/sherpa/commit/3efb1e7d6c2980d5c591d6876c8475fab9148cf8

(the rebase will lose the test failure from the first commit, but you can see them at https://travis-ci.org/sherpa/sherpa/builds/623314472)