### PR TITLE
Add regrid tests

### DIFF
--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -483,7 +483,10 @@ def test_regrid1d_error_grid_mismatch_2(setup_1d):
 @pytest.mark.parametrize("requested",
                          [ np.arange(2.5, 7, 0.2),
                            np.arange(1, 5.1, 0.2),
-                           np.arange(2.5, 5.1, 0.2)
+                           np.arange(2.5, 5.1, 0.2),
+                           np.arange(2.5, 7, 0.075),
+                           np.arange(1, 5.1, 0.075),
+                           np.arange(2.5, 5.1, 0.075)
                        ])
 def test_low_level_regrid1d_partial_overlap(requested):
     """What happens if there is partial overlap of the grid?

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -456,9 +456,6 @@ def test_ui_regrid1d_non_overlapping_not_allowed():
 def test_low_level_regrid1d_non_overlapping_not_allowed():
     """Integrated data space must not overlap"""
 
-    tmp = np.linspace(1, 100, 10)
-    y = np.ones((9,))
-    d = Data1DInt('tst', tmp[:-1], tmp[1:], np.ones((9,)))
     c = Box1D()
     lo = np.linspace(1,100,600)
     hi = np.linspace(2,101,600)

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -535,7 +535,15 @@ def test_low_level_regrid1d_partial_overlap(requested):
                            np.arange(2.5, 5.1, 0.075),
                            np.arange(2.5, 7, 0.12),
                            np.arange(1, 5.1, 0.12),
-                           np.arange(2.5, 5.1, 0.12)
+                           np.arange(2.5, 5.1, 0.12),
+                           # The bin=0.2 case may need a larger tolerance
+                           # than the other cases
+                           np.arange(2.5, 7, 0.2),
+                           np.arange(1, 5.1, 0.2),
+                           # the following errors out with a bin-size
+                           # does not match error rather than
+                           # creating the wrong answer
+                           np.arange(2.5, 5.1, 0.2)
                        ])
 def test_low_level_regrid1d_int_partial_overlap(requested):
     """What happens if there is partial overlap of the grid?


### PR DESCRIPTION
# NOTE

Replaced by #764, which is this PR rebased onto the fix in #747

# Details

This PR adds tests to the regrid code based on issue #722 - that is, the handling of partial overlap between the output grid and the user-specified "regrid".

The 1D non-integrated tests pass, but the 1D integrated tests - `test_low_level_regrid1d_int_partial_overlap` - fail because the model is evaluated to twice what it should be (and so they are marked as `pytest.mark.xfail`). Actually, the last one errors out with  `TypeError: 1D model evaluation input array sizes do not match, xlo: 49 vs xhi: 48` (both failures were seen in #722).

These tests are not necessarily sufficient for the overlap case:

a) they only cover the 1D case
b) the model chosen for testing is explicitly set to 0 in the areas where the grids fail to overlap, as it is not clear to me what the expected behavior here is (from the warning message I think that the model is expected to be evaluated on the old grid where there is no overlap, but I am not 100% sure of this).

As a "base case" I added tests that check when the regrid grid is larger than the output grid. Surprisingly enough this fails for the 1D non-integrated case when the bin size is larger than the output bin size. In this case the last two bins are not zero but have significant counts in them. I don't know why, so have marked this particular test xfail too.

I've also added a test of the low-level rebin method to show that when it is being asked to do what I think it should be in this case it does. In other words this does seem to be somewhere in the `regrid` method/class structure.

# Where is the bug?

I think the problem is that the evaluation space has both grids in it - so in our case the union of `np.arange(1, 9, 0.5)` and `np.arange(2.1, 8, 0.5)` (or something similar), which means that the model will evaluate x=4-4.5 and x=4.1-4.5, which is going to essentially double the y values once it has been passed to `sherpa.utils._utils.rebin`. '

Notice the repeated elements in the joined grid (I think this is what is happening in the larger example, but haven't guaranteed it completely) - e.g. the low edges go `..., 1.8, 1.9, 2, 2.1, 2.1, 2.2, 2.2, ...`:

```
In [12]: x1grid = np.arange(1, 9, 0.1)                                          

In [13]: x2grid = np.arange(2.1, 8, 0.1)                                        

In [14]: x2space = EvaluationSpace1D(x2grid[:-1], x2grid[1:])                   

In [15]: x1space = EvaluationSpace1D(x1grid[:-1], x1grid[1:])                   

In [16]: x2space in x1space                                                     
Out[16]: True

In [17]: x1space in x2space                                                     
Out[17]: False

In [18]: jspace = x2space.join(x1space)                                         

In [19]: jspace.grid                                                            
Out[19]: 
(array([1. , 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2. , 2.1, 2.1,
        2.2, 2.2, 2.3, 2.3, 2.4, 2.4, 2.5, 2.5, 2.6, 2.6, 2.7, 2.7, 2.8,
        2.8, 2.9, 2.9, 3. , 3. , 3.1, 3.1, 3.2, 3.2, 3.3, 3.3, 3.4, 3.4,
        3.5, 3.5, 3.6, 3.6, 3.7, 3.7, 3.8, 3.8, 3.9, 3.9, 4. , 4. , 4.1,
        4.1, 4.2, 4.2, 4.3, 4.4, 4.4, 4.5, 4.5, 4.6, 4.6, 4.7, 4.8, 4.8,
        4.9, 4.9, 5. , 5. , 5.1, 5.2, 5.2, 5.3, 5.3, 5.4, 5.4, 5.5, 5.6,
        5.6, 5.7, 5.7, 5.8, 5.8, 5.9, 6. , 6. , 6.1, 6.1, 6.2, 6.2, 6.3,
        6.4, 6.4, 6.5, 6.5, 6.6, 6.6, 6.7, 6.8, 6.8, 6.9, 6.9, 7. , 7. ,
        7.1, 7.2, 7.2, 7.3, 7.3, 7.4, 7.4, 7.5, 7.6, 7.6, 7.7, 7.7, 7.8,
        7.8, 7.9, 8. , 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8]),
 array([1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2. , 2.1, 2.2, 2.2,
        2.3, 2.3, 2.4, 2.4, 2.5, 2.5, 2.6, 2.6, 2.7, 2.7, 2.8, 2.8, 2.9,
        2.9, 3. , 3. , 3.1, 3.1, 3.2, 3.2, 3.3, 3.3, 3.4, 3.4, 3.5, 3.5,
        3.6, 3.6, 3.7, 3.7, 3.8, 3.8, 3.9, 3.9, 4. , 4. , 4.1, 4.1, 4.2,
        4.2, 4.3, 4.4, 4.4, 4.5, 4.5, 4.6, 4.6, 4.7, 4.8, 4.8, 4.9, 4.9,
        5. , 5. , 5.1, 5.2, 5.2, 5.3, 5.3, 5.4, 5.4, 5.5, 5.6, 5.6, 5.7,
        5.7, 5.8, 5.8, 5.9, 6. , 6. , 6.1, 6.1, 6.2, 6.2, 6.3, 6.4, 6.4,
        6.5, 6.5, 6.6, 6.6, 6.7, 6.8, 6.8, 6.9, 6.9, 7. , 7. , 7.1, 7.2,
        7.2, 7.3, 7.3, 7.4, 7.4, 7.5, 7.6, 7.6, 7.7, 7.7, 7.8, 7.8, 7.9,
        8. , 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9]))

```
```