### PR TITLE
Remove unused Python 2.7 compatibility code

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016, 2019, 2020
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -137,13 +138,10 @@ def _try_key(crate, name, dtype=str):
     if str(key).find('none') != -1:
         return None
 
-    # Python3 (and having the type as a parameter) seems to require some complexity here.
-    # If there is a better way I am not aware of it.
-    if dtype == str and (isinstance(key, string_types) or isinstance(key, bytes)):
-        try:  # Python 3
-            return dtype(key, "utf-8")
-        except TypeError:  # Python 2
-            return dtype(key)
+    # byte strings are to be decoded to strings
+    #
+    if dtype == str and isinstance(key, bytes):
+        return dtype(key, "utf-8")
     else:
         return dtype(key)
 

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2009, 2016  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2016, 2020  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -272,7 +272,6 @@ static PyMethodDef RegionFcts[] = {
 #define PyMODINIT_FUNC void
 #endif
 
-#ifdef PY3
 static struct PyModuleDef module_region = {
 PyModuleDef_HEAD_INIT,
 "_region",
@@ -281,42 +280,24 @@ NULL,
 RegionFcts
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit__region(void)
-
-#else
-#define INITERROR return
-
-PyMODINIT_FUNC
-init_region(void)
-#endif
-
 {
 
   PyObject *m;
 
   if (PyType_Ready(&pyRegion_Type) < 0)
-    INITERROR;
+    return NULL;
 
   import_array();
 
-#ifdef PY3
   m = PyModule_Create(&module_region);
-#else
-  m = Py_InitModule3((char*)"_region", RegionFcts, NULL);
-#endif
-
-if (m == NULL)
-    INITERROR;
+  if (m == NULL)
+    return NULL;
 
   Py_INCREF(&pyRegion_Type);
 
   PyModule_AddObject(m, (char*)"Region", (PyObject *)&pyRegion_Type);
-
-#ifdef PY3
   return m;
-#endif
 
 }

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2010, 2015-2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015-2018, 2019, 2020
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -911,10 +912,15 @@ class XSTableModel(XSModel):
             if nint > 0:
                 isfrozen = False
 
-            try:  # Python 3
-                parname = str(parnames[ii], "utf-8")
-            except TypeError:  # Python 2
+            # We don't explicitly demand this is a string, so support
+            # byte strings (given that the values are read from the
+            # FITS file this is a possibility).
+            #
+            try:
+                parname = str(parnames[ii], 'utf-8')
+            except TypeError:
                 parname = parnames[ii]
+
             parname = parname.strip().lower().translate(tbl)
             par = Parameter(name, parname, initvals[ii],
                             mins[ii], maxes[ii],

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,4 +1,5 @@
-//  Copyright (C) 2007, 2015-2018, 2019  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015-2018, 2019, 2020
+//                Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -1350,9 +1351,6 @@ static PyMethodDef XSpecMethods[] = {
 
 };
 
-
-#ifdef PY3
-
 static struct PyModuleDef xspec_module = {
         PyModuleDef_HEAD_INIT,
         "_xspec",
@@ -1365,12 +1363,3 @@ PyMODINIT_FUNC PyInit__xspec(void) {
   import_array();
   return PyModule_Create(&xspec_module);
 }
-
-#else
-
-PyMODINIT_FUNC
-init_xspec(void) {
-  import_array();
-  Py_InitModule( (char*)"_xspec", XSpecMethods );
-}
-#endif

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -237,26 +237,6 @@ def setup(doRaise=True, debug=False):
         if doRaise:
             raise RuntimeErr('badwin', _ex)
 
-    elif sys.version_info < (3, 2):
-        class _Popen(subprocess.Popen):
-            # Add in the necessary methods so it can be used as a
-            # context manager (for Python 3.1 and earlier).
-            #
-            # See https://stackoverflow.com/a/30421047
-            #
-            def __enter__(self):
-                return self
-
-            def __exit__(self, type, value, traceback):
-                if self.stdout:
-                    self.stdout.close()
-                if self.stderr:
-                    self.stderr.close()
-                if self.stdin:
-                    self.stdin.close()
-                # Wait for the process to terminate, to avoid zombies.
-                self.wait()
-
     else:
         _Popen = subprocess.Popen
 

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2006-2010, 2016, 2017, 2018, 2019
+#  Copyright (C) 2006-2010, 2016, 2017, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -351,15 +351,10 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT) as p:
         try:
-            # Python 2 vs 3 requires some complexity here.
-            try:  # Python 2 bytes (which are actually strings)
-                unicode(data, "ascii")  # unicode does not exist in Python 3
+            try:
                 data = bytearray(data, "UTF-8")
             except:
-                try:  # Python 3 with data passed as string.
-                    data = bytearray(data, "UTF-8")
-                except:  # data is provided as bytes (in Python 3) or is null, so it does not need to be converted.
-                    pass
+                pass
 
             if data:
                 p.stdin.write(data)

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2017, 2020  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -35,12 +35,6 @@ typedef int (*converter)( PyObject*, void* );
 
 #define CONVERTME(arg) ((converter) sherpa::convert_to_contig_array<arg>)
 
-#if PY_MAJOR_VERSION >= 3
-#define PY3
-#endif
-
-#ifdef PY3
-
 #define SHERPAMOD(name, fctlist) \
 static struct PyModuleDef module##name = {\
 PyModuleDef_HEAD_INIT, \
@@ -54,20 +48,6 @@ PyMODINIT_FUNC PyInit_##name(void) { \
   import_array(); \
   return PyModule_Create(&module##name); \
 }
-
-#else
-
-#define SHERPAMOD(name, fctlist) \
-PyMODINIT_FUNC init##name(void);\
-PyMODINIT_FUNC \
-init##name(void) \
-{ \
-  import_array(); \
-  Py_InitModule( (char*)#name, fctlist ); \
-}
-
-#endif
-
 
 #define FCTSPEC(name, func) \
  { (char*)#name, (PyCFunction)func, METH_VARARGS, NULL }

--- a/sherpa/include/sherpa/integration.hh
+++ b/sherpa/include/sherpa/integration.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2020  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify

--- a/sherpa/include/sherpa/integration.hh
+++ b/sherpa/include/sherpa/integration.hh
@@ -87,11 +87,7 @@ static void **Integration_API;
 #define integrate_Nd ((_integrate_Nd)Integration_API[1])
 #define py_integrate_1d ((_py_integrate_1d)Integration_API[2])
 
-#ifdef PY3
 #define PTR( obj ) PyCapsule_GetPointer( obj, NULL )
-#else
-#define PTR( obj ) PyCObject_AsVoidPtr( obj )
-#endif
 
 static int
 import_integration(void)

--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016, 2019 Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2019, 2020 Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -429,8 +429,6 @@ namespace sherpa { namespace models {
 
 }  }  /* namespace models, namespace sherpa */
 
-#if PY_MAJOR_VERSION >= 3
-
 #define SHERPAMODELMOD(name, fctlist) \
 static struct PyModuleDef module##name = {\
 PyModuleDef_HEAD_INIT, \
@@ -446,21 +444,6 @@ PyMODINIT_FUNC PyInit_##name(void) { \
     return NULL; \
   return PyModule_Create(&module##name); \
 }
-
-#else
-
-#define SHERPAMODELMOD(name, fctlist) \
-PyMODINIT_FUNC \
-init##name(void) \
-{ \
-  import_array(); \
-  if ( -1 == import_integration() ) \
-    return; \
-  Py_InitModule( (char*)#name, fctlist );	\
-}
-
-#endif
-
 
 // Allow this to be customized on a per-file basis
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2017, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -142,9 +142,6 @@ class test_composite_model(SherpaTestCase):
         ops = [operator.add, operator.sub, operator.mul,
                operator.floordiv, operator.truediv, operator.mod,
                operator.pow]
-
-        if hasattr(operator, 'div'):  # Python 2
-            ops.append(operator.div)
 
         for op in ops:
             for m in (op(self.m, self.m2.c0.val), op(self.m.c0.val, self.m2),

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2019, 2020
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -182,9 +183,6 @@ class test_composite_parameter(SherpaTestCase):
         ops = [operator.add, operator.sub, operator.mul,
                operator.floordiv, operator.truediv, operator.mod,
                operator.pow]
-
-        if hasattr(operator, 'div'):  # Python 2
-            ops.append(operator.div)
 
         for op in ops:
             for p in (op(self.p, self.p2.val), op(self.p.val, self.p2),

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -61,24 +61,13 @@ import logging
 import math
 import inspect
 
-try:
-    # try lgamma in >= Python 2.7
-    math.lgamma(1)
-
-    lgam = math.lgamma
-except:
-    # default to log(gamma()) in < Python2.7
-    from test.test_random import gamma
-    lgam = lambda x : math.log(gamma(x))
-
 logger = logging.getLogger("sherpa")
 info = logger.info
 debug = logger.debug
 error = logger.error
 
-__all__=['LimitError', 'MetropolisMH', 'MH', 'Sampler',
-         'Walk', 'dmvt', 'dmvnorm']
-         #'Walk', 'dmvt', 'dmvnorm', 'progress_bar']
+__all__ = ('LimitError', 'MetropolisMH', 'MH', 'Sampler',
+           'Walk', 'dmvt', 'dmvnorm')
 
 
 class LimitError(Exception):
@@ -133,6 +122,7 @@ def dmvt(x, mu, sigma, dof, log=True, norm=False):
 
     # log density normalized
     if norm:
+        lgam = math.lgamma
         val += (lgam((dof+p)/2.) - lgam(dof/2.) - (p/2.) *
                 np.log(np.pi) + (dof/2.) * np.log(dof))
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -235,10 +235,10 @@ def calc_ftest(dof1, stat1, dof2, stat2):
 
     Examples
     --------
-    >>> calc_ftest(11, 16.3, 10, 10.2) 
+    >>> calc_ftest(11, 16.3, 10, 10.2)
     0.03452352914891555
 
-    >>> calc_ftest([11, 11], [16.3, 16.3], [10, 9], [10.2, 10.5]) 
+    >>> calc_ftest([11, 11], [16.3, 16.3], [10, 9], [10.2, 10.5])
     array([0.03452353, 0.13819987])
     """
 
@@ -1132,29 +1132,21 @@ def export_method(meth, name=None, modname=None):
 
     # Make an argument list string, removing 'self'
     #
-    argspec = None
-    try:
-        sig = inspect.signature(meth)
-    except AttributeError:
-        argspec = inspect.getargspec(meth)
+    # This code originaly used inspect.getargspec but was
+    # converted to use inspect.signature.
+    #
+    sig = inspect.signature(meth)
 
-    if argspec is None:
-        # is this the best way to emulate the Python 2.7 version?
-        def tostr(p):
-            if p.kind == p.VAR_KEYWORD:
-                return "**{}".format(p.name)
-            elif p.kind == p.VAR_POSITIONAL:
-                return "*{}".format(p.name)
-            else:
-                return p.name
+    def tostr(p):
+        if p.kind == p.VAR_KEYWORD:
+            return "**{}".format(p.name)
+        elif p.kind == p.VAR_POSITIONAL:
+            return "*{}".format(p.name)
+        else:
+            return p.name
 
-        argspec = ",".join([tostr(p) for p in sig.parameters.values()])
-        argspec = "({})".format(argspec)
-
-    else:
-        argspec = inspect.getargspec(meth)
-        argspec[0].pop(0)
-        argspec = inspect.formatargspec(argspec[0], argspec[1], argspec[2])
+    argspec = ",".join([tostr(p) for p in sig.parameters.values()])
+    argspec = "({})".format(argspec)
 
     # Create a wrapper function with no default arguments
     g = {old_name: meth}
@@ -1196,19 +1188,10 @@ def get_keyword_names(func, skip=0):
 
     """
 
-    try:
-        # Python 3+: (it appears that getargspec is not being
-        # removed in Python 3.6, but this should stop the warnings
-        # from earlier versions)
-        sig = inspect.signature(func)
-    except AttributeError:
-        # Python 2.7
-        argspec = inspect.getargspec(func)
-        if argspec[3] is None:
-            return []
-        first = len(argspec[0]) - len(argspec[3])
-        return argspec[0][first + skip:]
-
+    # This used to use getargspec but was changed to use inspect
+    # since the former was removed briefly (circa Python 3.6).
+    #
+    sig = inspect.signature(func)
     kwargs = [p.name
               for p in sig.parameters.values()
               if p.kind == p.POSITIONAL_OR_KEYWORD and
@@ -1239,19 +1222,10 @@ def get_keyword_defaults(func, skip=0):
 
     """
 
-    try:
-        # Python 3+: (it appears that getargspec is not being
-        # removed in Python 3.6, but this should stop the warnings
-        # from earlier versions)
-        sig = inspect.signature(func)
-    except AttributeError:
-        # Python 2.7
-        argspec = inspect.getargspec(func)
-        if argspec[3] is None:
-            return {}
-        first = len(argspec[0]) - len(argspec[3])
-        return dict(zip(argspec[0][first + skip:], argspec[3][skip:]))
-
+    # This used to use getargspec but was changed to use inspect
+    # since the former was removed briefly (circa Python 3.6).
+    #
+    sig = inspect.signature(func)
     kwargs = [(p.name, p.default)
               for p in sig.parameters.values()
               if p.kind == p.POSITIONAL_OR_KEYWORD and
@@ -1280,25 +1254,10 @@ def get_num_args(func):
 
     """
 
-    try:
-        # Python 3+: (it appears that getargspec is not being
-        # removed in Python 3.6, but this should stop the warnings
-        # from earlier versions)
-        sig = inspect.signature(func)
-    except AttributeError:
-        # Python 2.7
-        argspec = inspect.getargspec(func)
-        num_args = 0
-        num_kargs = 0
-
-        if len(argspec[0]) != 0:
-            num_args = len(argspec[0])
-
-        if argspec[3] is not None:
-            num_kargs = len(argspec[3])
-
-        return (num_args, (num_args - num_kargs), num_kargs)
-
+    # This used to use getargspec but was changed to use inspect
+    # since the former was removed briefly (circa Python 3.6).
+    #
+    sig = inspect.signature(func)
     posargs = [True
                for p in sig.parameters.values()
                if p.kind == p.POSITIONAL_OR_KEYWORD and

--- a/sherpa/utils/src/_psf.cc
+++ b/sherpa/utils/src/_psf.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016, 2018  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2018, 2020  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -1050,7 +1050,6 @@ static PyMethodDef PsfFcts[] = {
 
 //// Initialize the module
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef psf = {
     PyModuleDef_HEAD_INIT,
     "_psf",
@@ -1077,25 +1076,3 @@ PyMODINIT_FUNC PyInit__psf(void) {
 
   return m;
 }
-
-#else
-
-PyMODINIT_FUNC init_psf(void) {
-
-  PyObject* m;
-
-  if( PyType_Ready(&tcdPyData_Type) < 0 )
-    return;
-
-  import_array();  // Must be present for NumPy.
-
-  m = Py_InitModule3( (char*)"_psf", PsfFcts, NULL);
-
-  if( m == NULL )
-    return;
-
-  Py_INCREF(&tcdPyData_Type);
-  PyModule_AddObject(m, (char*)"tcdData", (PyObject*)&tcdPyData_Type);
-}
-
-#endif

--- a/sherpa/utils/src/integration.cc
+++ b/sherpa/utils/src/integration.cc
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2020  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -164,14 +164,6 @@ namespace sherpa { namespace integration {
     
 }  }  /* namespace integration, namespace sherpa */
 
-#define INIT_INTEGRATION_API static void *Integration_API[3];\
-Integration_API[0] = (void*)sherpa::integration::integrate_1d;\
-Integration_API[1] = (void*)sherpa::integration::integrate_Nd;\
-Integration_API[2] = (void*)sherpa::integration::py_integrate_1d;
-
-
-#if PY_MAJOR_VERSION >=3
-
 static struct PyModuleDef integration = {
     PyModuleDef_HEAD_INIT,
     "integration",
@@ -182,7 +174,10 @@ static struct PyModuleDef integration = {
 
 PyMODINIT_FUNC PyInit_integration(void) {
 
-  INIT_INTEGRATION_API
+  static void *Integration_API[3];
+  Integration_API[0] = (void*)sherpa::integration::integrate_1d;
+  Integration_API[1] = (void*)sherpa::integration::integrate_Nd;
+  Integration_API[2] = (void*)sherpa::integration::py_integrate_1d;
 
   PyObject *m;
   PyObject *api_cobject;
@@ -201,29 +196,3 @@ PyMODINIT_FUNC PyInit_integration(void) {
 
   return m;
 }
-
-#else
-
-PyMODINIT_FUNC
-initintegration(void)
-{
-
-  INIT_INTEGRATION_API
-
-  PyObject *m;
-  PyObject *api_cobject;
-
-  if ( NULL == ( m = Py_InitModule( (char*)"integration", NULL ) ) )
-    return;
-
-  if ( NULL == ( api_cobject = PyCObject_FromVoidPtr( (void*)Integration_API,
-						      NULL) ) )
-    return;
-
-  // Since the actual data is static, we can let PyModule_AddObject()
-  // steal the reference
-  PyModule_AddObject( m, (char*)"_C_API", api_cobject );
-
-}
-
-#endif


### PR DESCRIPTION
# Summary

Remove unused code from the removal of Python 2.7 support.

# Details

Remove conditional code from Python 2.7 support. This is primarily driven from comments in the code pointing out changes made when adding python 3 support, so this is not guaranteed to catch everything (there is some code in datastack but I'm going to make a separate PR for that as it is more involved).

Changes include:

- remove `inspect.getargspec` as `inspect.signature` is supported by Python >= 3.3
- rework `is_binary_file` to match try/except handling (only catch where we expect an error to be raised) and to use a context manager to handle closing the file; the documentation of this internal routine has also been extended to spell out what "binary" means here
- rework conversion code in crates to be simpler now that there is no need to support Python 2.7
- Remove code that was only run with Python 2.7 (e.g. change "try: py27-call / except: py3-call" to just "py3-call").
- in the DS9 module there was code used only for Python versions earlier than 3.2; this was removed as our minimum supported Python version is 3.5.
- remove conditional compilation for pre-python 3 code from C++ code (both source code and header files)

Note that there is a change to the crates back end which have not been tested (as we don't have crates available in our travis tests). I have tested this off to the side, using the conda CIAO 4.12 CIAO package, and the tests pass.

The increase in coverage is small, but there (note that this doesn't track the minor clean up in the compiled code):

label | statements | missing | excluded | branches | partial | coverage
----- | ---------- | ------- | -------- | -------- | ------- | --------
before | 24304 | 7926 | 0 | 7086 | 1181 | 64%
after | 24246 | 7879 | 0 | 7066 | 1179 | 64%