### PR TITLE
fix a bug with fit(cache=False) passing the runtime option while fitting

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2010, 2016, 2017, 2018, 2019
+#  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -543,6 +543,7 @@ class ArithmeticModel(Model):
     def startup(self, cache):
         self._queue = ['']
         self._cache = {}
+        self._use_caching = cache
         if int(self.cache) > 0:
             self._queue = [''] * int(self.cache)
             frozen = numpy.array([par.frozen for par in self.pars], dtype=bool)

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -549,7 +549,7 @@ class MyCacheTestModel(ArithmeticModel):
         self.counter = 0
         ArithmeticModel.__init__(self, name, (self.A, self.mylambda, self.b))
 
-@pytest.mark.usefixtures("clean_ui")
+
 def test_cache():
     """To make sure that the runtime fit(cache=???) works"""
 


### PR DESCRIPTION
# Note

This PR fixes the issue at the following comment https://github.com/sherpa/sherpa/issues/731#issuecomment-576873292
of issue #731