### PR TITLE
Change datastack query_by_header_keyword to not error if keyword is missing

### DIFF
--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 #
-# Copyright (C) 2015, 2016, 2019  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -380,8 +380,11 @@ class DataStack():
         keyword : str
            The keyword to search for (it is looked for in the ``header``
            attribute of each data set, using a case-sensitive search).
+           Data sets are skipped if they do not have a header or the
+           keyword is missing.
         value
-           The value of the keyword.
+           The value of the keyword. Comparison to the header value is
+           done after converting both to a string.
 
         Returns
         -------
@@ -400,17 +403,21 @@ class DataStack():
         [1, 2]
 
         """
+
+        str_value = str(value)
         def func(dataset):
-            if hasattr(dataset, 'header'):
-                str_value = str(value)
-                try:  # Python 3
-                    header_value = str(dataset.header[keyword], "utf-8")
-                except TypeError:  # Python 2
-                    header_value = dataset.header[keyword]
-                if keyword in dataset.header.keys() and \
-                   header_value == str_value:
-                    return True
-            return False
+            try:
+                hdr = dataset.header
+            except AttributeError:
+                return False
+
+            try:
+                keyval = hdr[keyword]
+            except KeyError:
+                return False
+
+            return str(keyval) == str_value
+
         return self.query(func)
 
     def query_by_obsid(self, value):

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2015, 2016, 2018, 2019
+#  Copyright (C) 2014, 2015, 2016, 2018, 2019, 2020
 #       Smithsonian Astrophysical Observatory
 #
 #
@@ -649,8 +649,8 @@ def test_pha_case_6(ds_setup, ds_datadir):
 def test_query_case_7(ds_setup, ds_datadir):
 
     datadir = ds_datadir
-    datastack.load_pha('@' +
-                       '/'.join((datadir, 'pha.lis')))
+    stkname = '@' + '/'.join((datadir, 'pha.lis'))
+    datastack.load_pha(stkname)
 
     f = datastack.query_by_header_keyword('INSTRUME', 'ACIS')
 
@@ -662,7 +662,7 @@ def test_query_case_7(ds_setup, ds_datadir):
 
     ds = datastack.DataStack()
 
-    ds.load_pha('@' + '/'.join((datadir, 'pha.lis')))
+    ds.load_pha(stkname)
 
     f = ds.query_by_obsid('4938')
 
@@ -671,6 +671,28 @@ def test_query_case_7(ds_setup, ds_datadir):
     f = datastack.query_by_obsid(ds, '7867')
 
     assert f == [4]
+
+
+@requires_fits
+@requires_stk
+def test_query_missing_keyword(ds_setup, ds_datadir):
+    """What happens when the keyword does not exist?
+
+    This only checks a case where the keyword is missing in
+    both files.
+    """
+
+    datadir = ds_datadir
+    stkname = '@' + '/'.join((datadir, 'pha.lis'))
+
+    datastack.load_pha(stkname)
+    with pytest.raises(KeyError):
+        datastack.query_by_header_keyword('MISSKEY', 'ACIS')
+
+    ds = datastack.DataStack()
+    ds.load_pha(stkname)
+    with pytest.raises(KeyError):
+        ds.query_by_header_keyword('MISSKEY', 'ACIS')
 
 
 def test_default_instantiation(ds_setup):

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -685,14 +685,34 @@ def test_query_missing_keyword(ds_setup, ds_datadir):
     datadir = ds_datadir
     stkname = '@' + '/'.join((datadir, 'pha.lis'))
 
+    # Note: since there is a conversion between float to string,
+    # there's a possibility this check may fail on some systems
+    #
+    key1 = 'EXPOSUR2'
+    val1 = '50441.752296469'
+    key2 = 'EXPOSUR7'
+    val2 = '21860.439777374'
+
     datastack.load_pha(stkname)
-    with pytest.raises(KeyError):
-        datastack.query_by_header_keyword('MISSKEY', 'ACIS')
+    f = datastack.query_by_header_keyword('MISSKEY', 'ACIS')
+    assert f == []
+
+    f = datastack.query_by_header_keyword(key1, val1)
+    assert f == [1]
+
+    f = datastack.query_by_header_keyword(key2, val2)
+    assert f == [2]
 
     ds = datastack.DataStack()
     ds.load_pha(stkname)
-    with pytest.raises(KeyError):
-        ds.query_by_header_keyword('MISSKEY', 'ACIS')
+    f = ds.query_by_header_keyword('MISSKEY', 'ACIS')
+    assert f == []
+
+    f = ds.query_by_header_keyword(key1, val1)
+    assert f == [3]
+
+    f = ds.query_by_header_keyword(key2, val2)
+    assert f == [4]
 
 
 def test_default_instantiation(ds_setup):


### PR DESCRIPTION
# Summary

Change the sherpa.astro.datastack `query_by_header_keyword` routine so that it skips data sets which do not have the keyword, rather than raising a `KeyError`. This also affects `query_by_obsid`.

# Details

This is a "user routine" and isn't used by the datastack internals. The original code looks like it was meant to do this, but the ordering of the code (access the keyword and then check if the keyword exists) meant that an error was raised. I note that the old code would skip data sets with no header at all, so skipping for missing data doesn't seem far fetched. I also note that I think the new behavior makes more sense.

This follows from #732 (remove python 2.7 code) but was separated out as it is a bit-more involved. The old version attempted to convert from byte string but I have removed this logic as our headers (created by both AstroPy and Crates) use strings (or int/float/bool) and not byte strings. 

The first commit adds a test of the behavior, and then in the second commit I change the behavior and update the test to reflect the new behavior.

I have tested it against crates (CIAO 4.12) and the tests pass there too (Ubuntu).