### PR TITLE
WIP explore test setup as 'python setup.py test' is going away

### DIFF
--- a/travis/test.sh
+++ b/travis/test.sh
@@ -22,7 +22,7 @@ smokevars="${XSPECTEST} ${FITSTEST} -v 3"
 
 # Install coverage tooling and run tests using setuptools
 if [ ${TEST} == submodule ]; then
-    pip install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
+    pip install pytest-cov; py.test --cov sherpa --cov-report term || exit 1;
 fi
 
 # Run smoke test


### PR DESCRIPTION
Support for 'python setup.py test' is going away, so switch to
using py.test here (it is fortunately an easy change).