### PR TITLE
Update copyright year for the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Sherpa'
-copyright = '2019, Chandra X-ray Center, Smithsonian Astrophysical Observatory.'
+copyright = '2019-2020, Chandra X-ray Center, Smithsonian Astrophysical Observatory.'
 author = 'Chandra X-ray Center, Smithsonian Astrophysical Observatory'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This information is displayed at the bottom of each page of the
documentation at https://sherpa.readthedocs.io/en/latest/