### PR TITLE
Fix issue 368, guess needs to update fwhm/sigma bounds

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -726,15 +726,15 @@ class test_threads(SherpaTestCase):
     def test_lev3fft(self):
         self.run_thread('lev3fft', scriptname='bar.py')
         self.assertEqualWithinTol(self.locals['src'].fwhm.val,
-                                  0.044178, 1e-4)
+                                  0.0442234, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].xpos.val,
-                                  150.016, 1e-4)
+                                  150.015, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].ypos.val,
-                                  2.66493839, 1e-4)
+                                  2.66494, 1e-4)
         self.assertEqualWithinTol(self.locals['src'].ampl.val,
-                                  1.56090546, 1e-4)
+                                  1.56384, 1e-4)
         self.assertEqualWithinTol(self.locals['bkg'].c0.val,
-                                  -1.513700715, 1e-4)
+                                  -1.51662, 1e-4)
 
         fres = ui.get_fit_results()
         assert fres.istatval == approx(19496.3, rel=1e-4)

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1564,6 +1564,7 @@ class SigmaGauss2D(Gauss2D):
         param_apply_limits(ypos, self.ypos, **kwargs)
         param_apply_limits(fwhm, self.sigma_a, **kwargs)
         param_apply_limits(fwhm, self.sigma_b, **kwargs)
+        param_apply_limits(norm, self.ampl, **kwargs)
 
     def calc(self, *args, **kwargs):
         kwargs['integrate'] = bool_cast(self.integrate)

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2010, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020
+#       Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1478,9 +1479,11 @@ class Gauss2D(RegriddableModel2D):
     def guess(self, dep, *args, **kwargs):
         xpos, ypos = guess_position(dep, *args)
         norm = guess_amplitude2d(dep, *args)
+        fwhm = guess_fwhm(dep, *args)
         param_apply_limits(xpos, self.xpos, **kwargs)
         param_apply_limits(ypos, self.ypos, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
+        param_apply_limits(fwhm, self.fwhm, **kwargs)
 
     def calc(self, *args, **kwargs):
         kwargs['integrate'] = bool_cast(self.integrate)
@@ -1552,6 +1555,15 @@ class SigmaGauss2D(Gauss2D):
                                  (self.sigma_a, self.sigma_b, self.xpos,
                                   self.ypos, self.theta, self.ampl))
         self.cache = 0
+
+    def guess(self, dep, *args, **kwargs):
+        xpos, ypos = guess_position(dep, *args)
+        norm = guess_amplitude2d(dep, *args)
+        fwhm = guess_fwhm(dep, *args)
+        param_apply_limits(xpos, self.xpos, **kwargs)
+        param_apply_limits(ypos, self.ypos, **kwargs)
+        param_apply_limits(fwhm, self.sigma_a, **kwargs)
+        param_apply_limits(fwhm, self.sigma_b, **kwargs)
 
     def calc(self, *args, **kwargs):
         kwargs['integrate'] = bool_cast(self.integrate)
@@ -1640,8 +1652,10 @@ class NormGauss2D(RegriddableModel2D):
     def guess(self, dep, *args, **kwargs):
         xpos, ypos = guess_position(dep, *args)
         ampl = guess_amplitude2d(dep, *args)
+        fwhm = guess_fwhm(dep, *args)
         param_apply_limits(xpos, self.xpos, **kwargs)
         param_apply_limits(ypos, self.ypos, **kwargs)
+        param_apply_limits(fwhm, self.fwhm, **kwargs)
 
         # Apply normalization factor to guessed amplitude
         norm = (numpy.pi / _gfactor) * self.fwhm.val * self.fwhm.val * \

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -2192,12 +2192,12 @@ def get_fwhm(y, x, xhi=None):
     If there are multiple peaks of the same height then
     the first peak is used.
     """
-
-    half_max_val = y.max() / 2.0
-    x_max = x[y.argmax()]
-    for ii, val in enumerate(y[:y.argmax()]):
-        if val >= half_max_val:
-            return 2.0 * numpy.abs(x[ii] - x_max)
+    y_argmax = y.argmax()
+    half_max_val = y[y_argmax] / 2.0
+    x_max = x[y_argmax]
+    for ii, val in enumerate(y[y_argmax:]):
+        if val < half_max_val:
+            return 2.0 * ii
     return x_max
 
 


### PR DESCRIPTION
# Details

Add support for guessing the fwhm or sigma parameters of the Gauss2D, NormGauss2D, and SigmaGauss2D models.

# Note

This PR fixes issue #638 (gauss2d models need to have the fwhm/sigma bounds updated by guess)