### PR TITLE
ensure that min/max limits are applied to linked parameters before use

### DIFF
--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -146,13 +146,23 @@ class Parameter(NoNewAttributesAfterInit):
     #
     # 'val' property
     #
-
+    # Note that _get_val has to check the parameter value when it
+    # is a link, to ensure that it isn't outside the parameter's
+    # min/max range. See issue #742.
+    #
     def _get_val(self):
         if hasattr(self, 'eval'):
             return self.eval()
-        if self.link is not None:
-            return self.link.val
-        return self._val
+        if self.link is None:
+            return self._val
+
+        val = self.link.val
+        if val < self.min:
+            raise ParameterErr('edge', self.fullname, 'minimum', self.min)
+        if val > self.max:
+            raise ParameterErr('edge', self.fullname, 'maximum', self.max)
+
+        return val
 
     def _set_val(self, val):
         if isinstance(val, Parameter):

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -154,10 +154,10 @@ class test_parameter(SherpaTestCase):
     def test_link(self):
         self.p.link = None
         self.assertTrue(self.p.link is None)
-        self.assertNotEqual(self.p.val, 17.3)
-        self.afp.val = 17.3
+        self.assertNotEqual(self.p.val, 7.3)
+        self.afp.val = 7.3
         self.p.link = self.afp
-        self.assertEqual(self.p.val, 17.3)
+        self.assertEqual(self.p.val, 7.3)
         self.p.unlink()
         self.assertTrue(self.p.link is None)
         self.assertRaises(ParameterErr, setattr, self.afp, 'link', self.p)
@@ -250,13 +250,19 @@ def test_link_parameter_setting():
     # What happens when we set lmdl.c0 to a value outside
     # the valid range for mdl?
     #
-    # The current behavior is the bug; it is not clear
-    # yet when an error should be raised - probably
-    # when mdl.gamma.val is checked, and not when
-    # lmdl.c0 is set.
+    # The error is raised when we try to access the value
+    # of the parameter with the link, and *not* when we set
+    # the parameter that is linked to.
     #
     lmdl.c0 = 23
-    assert mdl.gamma.val == pytest.approx(23)
+    emsg = 'parameter powlaw1d.gamma has a maximum of 10'
+    with pytest.raises(ParameterErr, match=emsg):
+        mdl.gamma.val
+
+    lmdl.c0 = -23
+    emsg = 'parameter powlaw1d.gamma has a minimum of -10'
+    with pytest.raises(ParameterErr, match=emsg):
+        mdl.gamma.val
 
     lmdl.c0 = -2
     assert mdl.gamma.val == pytest.approx(-2)
@@ -280,5 +286,6 @@ def test_link_parameter_evaluation():
     assert (y2 > 0).all()
 
     lmdl.c0 = 12
-    y12 = mdl(grid)
-    assert (y12 > 0).all()
+    emsg = 'parameter powlaw1d.gamma has a maximum of 10'
+    with pytest.raises(ParameterErr, match=emsg):
+        mdl(grid)

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -269,7 +269,11 @@ def test_link_parameter_setting():
 
 
 def test_link_parameter_evaluation():
-    """See also test_link_parameter_setting"""
+    """See also test_link_parameter_setting
+
+    A version of this test, using an XSPEC table model, is found
+    in sherpa/astro/xspec/tests/test_xspec_unit::test_xstbl_link_parameter_evaluation
+    """
 
     # What happens when we try to evaluate a model whose
     # parameter is out-of-range thanks to a link?


### PR DESCRIPTION
# Summary

Enforce parameter restrictions (that they must lie within their min/max range) even when the parameter is linked to another (which has a different range). This fixes #742.

# Important note

With this PR, and a model called `mdl` containing a parameter with an invalid value,

    mdl(grid)

will raise a `ParameterErr`. 
However, you can still call the model with any parameter values by using the `call` method, e.g.

    mdl.call(parvals, egrid)

where the `parvals` sequence is not checked. PR #743 would catch this case (but only for XSPEC table models). Note that the `call` method is not expected to be commonly used.

# Details

The first commit adds tests that show the current behavior (that is, the parameter can be evaluated outside it's min/max range). Then the fix is made, but the tests are not updated (so are expected to fail). This picks up an existing test which decided to use an out-of-band value for the link. Examples of these failures can be seen at https://travis-ci.org/sherpa/sherpa/jobs/654689948#L4127  (from an earlier version of this PR before a rebase). The third commit updates the tests to use a more-sensible value (for the existing test), or to check for the `ParameterErr` in the new tests. The fourth commit adds an explicit XSPEC table-model test (to verify the original bug fix).

The check is made when the parameter value is accessed, not when the linked-to parameter is changed, since this is the simplest way to address the issue. Any other way would likely be fragile and *much* more complicated. The implementation can lead to slightly-surprising error messages - e.g. evaluating the model will raise a `ParameterErr` as shown in the example below - but I believe this is reasonable.

```
In [1]: from sherpa.models.basic import PowLaw1D, Const1D                       

In [2]: m1, m2 = PowLaw1D(), Const1D()                                          

In [3]: m1.gamma = m2.c0                                                        

In [4]: print(m1.gamma)                                                         
val         = 1.0
min         = -10.0
max         = 10.0
units       = 
frozen      = True
link        = const1d.c0
default_val = 1.0
default_min = -10.0
default_max = 10.0

In [5]: print(m2.c0)                                                            
val         = 1.0
min         = -3.4028234663852886e+38
max         = 3.4028234663852886e+38
units       = 
frozen      = False
link        = None
default_val = 1.0
default_min = -3.4028234663852886e+38
default_max = 3.4028234663852886e+38

In [6]: m2.c0 = 20                                                              

In [7]: m1([1, 2, 3])                                                           
---------------------------------------------------------------------------
ParameterErr                              Traceback (most recent call last)
<ipython-input-7-bfe3cdbf28bf> in <module>
----> 1 m1([1, 2, 3])

/lagado.real/sherpa/sherpa-playground/sherpa/models/model.py in __call__(self, *args, **kwargs)
    262         if (len(args) == 0 and len(kwargs) == 0):
    263             return self
--> 264         return self.calc([p.val for p in self.pars], *args, **kwargs)
    265 
    266     def _get_thawed_pars(self):

/lagado.real/sherpa/sherpa-playground/sherpa/models/model.py in <listcomp>(.0)
    262         if (len(args) == 0 and len(kwargs) == 0):
    263             return self
--> 264         return self.calc([p.val for p in self.pars], *args, **kwargs)
    265 
    266     def _get_thawed_pars(self):

/lagado.real/sherpa/sherpa-playground/sherpa/models/parameter.py in _get_val(self)
    161             raise ParameterErr('edge', self.fullname, 'minimum', self.min)
    162         if val > self.max:
--> 163             raise ParameterErr('edge', self.fullname, 'maximum', self.max)
    164 
    165         return val

ParameterErr: parameter powlaw1d.gamma has a maximum of 10
```