### PR TITLE
Add xspec convolution api

### DIFF
--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -11,9 +11,18 @@ The sherpa.astro.xspec module
    .. autosummary::
       :toctree: api
 
+      XSSSS_ice
+      XSTBabs
+      XSTBfeo
+      XSTBgas
+      XSTBgrain
+      XSTBpcf
+      XSTBrel
+      XSTBvarabs
+      XSabsori
+      XSacisabs
       XSagauss
       XSagnsed
-      XSagnslim
       XSapec
       XSbapec
       XSbbody
@@ -37,10 +46,13 @@ The sherpa.astro.xspec module
       XSc6pmekl
       XSc6pvmkl
       XSc6vmekl
+      XScabs
       XScarbatm
       XScemekl
       XScevmkl
       XScflow
+      XScflux
+      XSclumin
       XScompLS
       XScompPS
       XScompST
@@ -49,9 +61,12 @@ The sherpa.astro.xspec module
       XScompmag
       XScomptb
       XScompth
+      XSconstant
+      XScpflux
       XScph
       XScplinear
       XScutoffpl
+      XScyclabs
       XSdisk
       XSdiskbb
       XSdiskir
@@ -60,33 +75,51 @@ The sherpa.astro.xspec module
       XSdisko
       XSdiskpbb
       XSdiskpn
+      XSdust
+      XSedge
       XSeplogpar
       XSeqpair
       XSeqtherm
       XSequil
+      XSexpabs
       XSexpdec
+      XSexpfac
       XSezdiskbb
+      XSgabs
       XSgadem
       XSgaussian
       XSgnei
       XSgrad
       XSgrbcomp
       XSgrbm
+      XSgsmooth
       XShatm
+      XSheilin
+      XShighecut
+      XShrefl
+      XSireflect
+      XSismabs
       XSjet
+      XSkdblur
+      XSkdblur2
       XSkerrbb
+      XSkerrconv
       XSkerrd
       XSkerrdisk
+      XSkyconv
       XSkyrline
       XSlaor
       XSlaor2
       XSlogpar
       XSlorentz
+      XSlsmooth
+      XSlyman
       XSmeka
       XSmekal
       XSmkcflow
       XSnei
       XSnlapec
+      XSnotch
       XSnpshock
       XSnsa
       XSnsagrav
@@ -98,29 +131,48 @@ The sherpa.astro.xspec module
       XSnthComp
       XSoptxagn
       XSoptxagnf
+      XSpartcov
+      XSpcfabs
       XSpegpwrlw
       XSpexmon
       XSpexrav
       XSpexriv
+      XSphabs
+      XSplabs
       XSplcabs
       XSposm
       XSpowerlaw
       XSpshock
+      XSpwab
       XSqsosed
       XSraymond
+      XSrdblur
+      XSredden
       XSredge
+      XSreflect
       XSrefsch
+      XSrfxconv
+      XSrgsxsrc
       XSrnei
       XSsedov
+      XSsimpl
       XSsirf
       XSslimbh
+      XSsmedge
       XSsnapec
+      XSspexpcut
+      XSspline
       XSsrcut
       XSsresc
       XSssa
       XSstep
+      XSswind1
       XStapec
+      XSthcomp
+      XSuvred
       XSvapec
+      XSvarabs
+      XSvashift
       XSvbremss
       XSvcph
       XSvequil
@@ -129,9 +181,11 @@ The sherpa.astro.xspec module
       XSvmcflow
       XSvmeka
       XSvmekal
+      XSvmshift
       XSvnei
       XSvnpshock
       XSvoigt
+      XSvphabs
       XSvpshock
       XSvraymond
       XSvrnei
@@ -145,67 +199,29 @@ The sherpa.astro.xspec module
       XSvvrnei
       XSvvsedov
       XSvvtapec
+      XSwabs
+      XSwndabs
+      XSxilconv
+      XSxion
+      XSxscat
+      XSzTBabs
       XSzagauss
+      XSzashift
+      XSzbabs
       XSzbbody
       XSzbknpower
       XSzbremss
       XSzcutoffpl
-      XSzgauss
-      XSzkerrbb
-      XSzlogpar
-      XSzpowerlw
-      XSSSS_ice
-      XSTBabs
-      XSTBfeo
-      XSTBgas
-      XSTBgrain
-      XSTBpcf
-      XSTBrel
-      XSTBvarabs
-      XSabsori
-      XSacisabs
-      XScabs
-      XSconstant
-      XScyclabs
-      XSdust
-      XSedge
-      XSexpabs
-      XSexpfac
-      XSgabs
-      XSheilin
-      XShighecut
-      XShrefl
-      XSismabs
-      XSismdust
-      XSlog10con
-      XSlogconst
-      XSlyman
-      XSnotch
-      XSolivineabs
-      XSpcfabs
-      XSphabs
-      XSplabs
-      XSpwab
-      XSredden
-      XSsmedge
-      XSspexpcut
-      XSspline
-      XSswind1
-      XSuvred
-      XSvarabs
-      XSvphabs
-      XSwabs
-      XSwndabs
-      XSxion
-      XSxscat
-      XSzTBabs
-      XSzbabs
       XSzdust
       XSzedge
+      XSzgauss
       XSzhighect
       XSzigm
+      XSzlogpar
+      XSzmshift
       XSzpcfabs
       XSzphabs
+      XSzpowerlw
       XSzredden
       XSzsmdust
       XSzvarabs
@@ -222,4 +238,7 @@ Class Inheritance Diagram
    :parts: 1
 
 .. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipcf
+   :parts: 1
+
+.. inheritance-diagram:: XScflux XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift
    :parts: 1

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -12,17 +12,19 @@ the abundance table information. The models provided by XSPEC
 are described in :doc:`astro_xspec`.
 
    .. rubric:: Classes
-               
+
    .. autosummary::
       :toctree: api
 
       XSModel
       XSAdditiveModel
       XSMultiplicativeModel
+      XSConvolutionKernel
+      XSConvolutionModel
       XSTableModel
 
    .. rubric:: Functions
-               
+
    .. autosummary::
       :toctree: api
 
@@ -47,6 +49,5 @@ are described in :doc:`astro_xspec`.
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSModel XSAdditiveModel XSMultiplicativeModel XSTableModel
+.. inheritance-diagram:: XSModel XSAdditiveModel XSMultiplicativeModel XSConvolutionKernel XSConvolutionModel XSTableModel
    :parts: 1
-

--- a/sherpa/astro/ui/__init__.py
+++ b/sherpa/astro/ui/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -47,7 +47,8 @@ _session._add_model_types(sherpa.astro.instrument)
 if hasattr(sherpa.astro, 'xspec'):
     _session._add_model_types(sherpa.astro.xspec,
                               (sherpa.astro.xspec.XSAdditiveModel,
-                               sherpa.astro.xspec.XSMultiplicativeModel))
+                               sherpa.astro.xspec.XSMultiplicativeModel,
+                               sherpa.astro.xspec.XSConvolutionKernel))
 
     from sherpa.astro.xspec import get_xsabund, get_xscosmo, get_xsxsect, \
          set_xsabund, set_xscosmo, set_xsxsect, set_xsxset, get_xsxset, \

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -63,14 +63,11 @@ References
 
 .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/index.html
 
-.. [2] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node131.html
-       (link valid for XSPEC 12.11.0)
+.. [2] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Additive.html
 
-.. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node231.html
-       (link valid for XSPEC 12.11.0)
+.. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Multiplicative.html
 
-.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node279.html
-       (link valid for XSPEC 12.11.0)
+.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Convolution.html
 
 .. [5] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelSmaug.html
 
@@ -215,7 +212,7 @@ def get_xsversion():
     --------
 
     >>> get_xsversion()
-    '12.9.1p'
+    '12.11.0m'
     """
 
     return _xspec.get_xsversion()
@@ -1009,8 +1006,7 @@ class XSAdditiveModel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node131.html
-           (link valid for XSPEC 12.11.0)
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Additive.html
 
     """
 
@@ -1028,8 +1024,7 @@ class XSMultiplicativeModel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node231.html
-           (link valid for XSPEC 12.11.0)
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Multiplivative.html
 
     """
 
@@ -1066,8 +1061,7 @@ class XSConvolutionKernel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node279.html
-           (link valid for XSPEC 12.11.0)
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Convolution.html
 
     Examples
     --------
@@ -11061,6 +11055,8 @@ class XSismabs(XSMultiplicativeModel):
     element name to avoid conflict: that is Si_I and S_I refer to
     the XSPEC SiI and SI parameters respectively.
 
+    This model is only available when used with XSPEC 12.9.1 or later.
+
     References
     ----------
 
@@ -11449,6 +11445,8 @@ class XSTBfeo(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
+    This model is only available when used with XSPEC 12.9.1 or later.
+
     References
     ----------
 
@@ -11491,6 +11489,8 @@ class XSTBgas(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
+    This model is only available when used with XSPEC 12.9.1 or later.
+
     References
     ----------
 
@@ -11531,6 +11531,8 @@ class XSTBpcf(XSMultiplicativeModel):
     -----
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
+
+    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11587,6 +11589,8 @@ class XSTBrel(XSMultiplicativeModel):
     -----
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
+
+    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11694,6 +11698,10 @@ class XSvoigt(XSAdditiveModel):
     --------
     XSgauss, XSlorentz
 
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.9.1 or later.
+
     References
     ----------
 
@@ -11731,6 +11739,10 @@ class XSxscat(XSMultiplicativeModel):
         The radius of the circular extraction region, in arcsec.
     DustModel
         The dust model used: see [1]_ for more information.
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11854,6 +11866,8 @@ class XSclumin(XSConvolutionKernel):
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
     emission component (or components) at 1.
+
+    This model is only available when used with XSPEC 12.9.1 or later.
 
     Examples
     --------
@@ -12550,6 +12564,8 @@ class XSrfxconv(XSConvolutionKernel):
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
 
+    This model is only available when used with XSPEC 12.9.1 or later.
+
     See Also
     --------
     XSxilconv
@@ -12686,6 +12702,8 @@ class XSthcomp(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather then using the multiplication symbol.
 
+    This model is only available when used with XSPEC 12.10.0 or later.
+
     References
     ----------
 
@@ -12730,6 +12748,8 @@ class XSvashift(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather then using the multiplication symbol.
 
+    This model is only available when used with XSPEC 12.9.1 or later.
+
     See Also
     --------
     XSvmshift, XSzashift
@@ -12766,6 +12786,8 @@ class XSvmshift(XSConvolutionKernel):
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather then using the multiplication symbol.
+
+    This model is only available when used with XSPEC 12.9.1 or later.
 
     See Also
     --------
@@ -12821,6 +12843,8 @@ class XSxilconv(XSConvolutionKernel):
     the ``set_xsxset`` function to set the value of the XILCONV_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
+
+    This model is only available when used with XSPEC 12.9.1 or later.
 
     See Also
     --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -64,13 +64,13 @@ References
 .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/index.html
 
 .. [2] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node131.html
-       (link valid for XSPEC 12.10.1)
+       (link valid for XSPEC 12.11.0)
 
-.. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node229.html
-       (link valid for XSPEC 12.10.1)
+.. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node231.html
+       (link valid for XSPEC 12.11.0)
 
-.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node273.html
-       (link valid for XSPEC 12.10.1)
+.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node279.html
+       (link valid for XSPEC 12.11.0)
 
 .. [5] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelSmaug.html
 
@@ -209,7 +209,7 @@ def get_xsversion():
     References
     ----------
 
-    .. [1] http://heasarc.nasa.gov/docs/xanadu/xspec/
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/
 
     Examples
     --------
@@ -285,35 +285,35 @@ def set_xsabund(abundance):
 
     References
     ----------
-    .. [1] http://heasarc.nasa.gov/xanadu/xspec/manual/XSabund.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSabund.html
            Note that this may refer to a newer version than the
            compiled version used by Sherpa; use `get_xsversion` to
            check.
 
     .. [2] Anders E. & Grevesse N. (1989, Geochimica et
            Cosmochimica Acta 53, 197)
-           http://adsabs.harvard.edu/abs/1989GeCoA..53..197A
+           https://adsabs.harvard.edu/abs/1989GeCoA..53..197A
 
     .. [3] Asplund M., Grevesse N., Sauval A.J. & Scott P.
            (2009, ARAA, 47, 481)
-           http://adsabs.harvard.edu/abs/2009ARA%26A..47..481A
+           https://adsabs.harvard.edu/abs/2009ARA%26A..47..481A
 
     .. [4] Feldman U.(1992, Physica Scripta 46, 202)
-           http://adsabs.harvard.edu/abs/1992PhyS...46..202F
+           https://adsabs.harvard.edu/abs/1992PhyS...46..202F
 
     .. [5] Anders E. & Ebihara (1982, Geochimica et Cosmochimica
            Acta 46, 2363)
-           http://adsabs.harvard.edu/abs/1982GeCoA..46.2363A
+           https://adsabs.harvard.edu/abs/1982GeCoA..46.2363A
 
     .. [6] Grevesse, N. & Sauval, A.J. (1998, Space Science
            Reviews 85, 161)
-           http://adsabs.harvard.edu/abs/1998SSRv...85..161G
+           https://adsabs.harvard.edu/abs/1998SSRv...85..161G
 
     .. [7] Wilms, Allen & McCray (2000, ApJ 542, 914)
-           http://adsabs.harvard.edu/abs/2000ApJ...542..914W
+           https://adsabs.harvard.edu/abs/2000ApJ...542..914W
 
     .. [8] Lodders, K (2003, ApJ 591, 1220)
-           http://adsabs.harvard.edu/abs/2003ApJ...591.1220L
+           https://adsabs.harvard.edu/abs/2003ApJ...591.1220L
 
     Examples
     --------
@@ -358,7 +358,7 @@ def set_xschatter(level):
 
     References
     ----------
-    .. [1] http://heasarc.nasa.gov/xanadu/xspec/manual/XSchatter.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSchatter.html
            Note that this may refer to a newer version than the
            compiled version used by Sherpa; use `get_xsversion` to
            check.
@@ -397,7 +397,7 @@ def set_xscosmo(h0, q0, l0):
 
     References
     ----------
-    .. [1] http://heasarc.nasa.gov/xanadu/xspec/manual/XScosmo.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XScosmo.html
            Note that this may refer to a newer version than the
            compiled version used by Sherpa; use `get_xsversion` to
            check.
@@ -438,20 +438,20 @@ def set_xsxsect(name):
 
     References
     ----------
-    .. [1] http://heasarc.nasa.gov/xanadu/xspec/manual/XSxsect.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSxsect.html
            Note that this may refer to a newer version than the
            compiled version used by Sherpa; use `get_xsversion` to
            check.
 
     .. [2] Balucinska-Church & McCammon (1992; Ap.J.400, 699).
-           http://adsabs.harvard.edu/abs/1992ApJ...400..699B
+           https://adsabs.harvard.edu/abs/1992ApJ...400..699B
 
     .. [3] Yan, M., Sadeghpour, H. R., Dalgarno, A. 1998,
            Ap.J. 496, 1044
-           http://adsabs.harvard.edu/abs/1998ApJ...496.1044Y
+           https://adsabs.harvard.edu/abs/1998ApJ...496.1044Y
 
     .. [4] Verner et. al., 1996, Ap.J., 465, 487.
-           http://adsabs.harvard.edu/abs/1996ApJ...465..487V
+           https://adsabs.harvard.edu/abs/1996ApJ...465..487V
 
     Examples
     --------
@@ -467,7 +467,7 @@ def set_xsxsect(name):
 # the strings the user sent as specific XSPEC model strings (if any) during
 # the session.  Only store if setting was successful.
 # See:
-# http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSxset.html
+# https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSxset.html
 modelstrings = {}
 
 # Store any path changes
@@ -547,7 +547,7 @@ def set_xsxset(name, value):
     References
     ----------
 
-    .. [1] http://heasarc.nasa.gov/xanadu/xspec/manual/XSabund.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSabund.html
            Note that this may refer to a newer version than the
            compiled version used by Sherpa; use `get_xsversion` to
            check.
@@ -647,8 +647,8 @@ def set_xspath_manager(path):
 # strings.  The chatter setting is an integer.  Please see the
 # XSPEC manual concerning the following commands: abund, chatter,
 # cosmo, xsect, and xset.
-# http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Control.html
-# http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Setting.html
+# https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Control.html
+# https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/Setting.html
 #
 # The path dictionary contains the manager path, which can be
 # explicitly set. It could also contain the model path, but there
@@ -755,11 +755,11 @@ def read_xstable_model(modelname, filename):
     References
     ----------
 
-    .. [1] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
 
-    .. [2] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
+    .. [2] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
 
-    .. [3] http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
+    .. [3] https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
 
     Examples
     --------
@@ -918,7 +918,7 @@ class XSTableModel(XSModel):
     ----------
 
     .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixLocal.html
-    .. [2] http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
+    .. [2] https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
 
     """
 
@@ -1010,7 +1010,7 @@ class XSAdditiveModel(XSModel):
     ----------
 
     .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node131.html
-           (link valid for XSPEC 12.10.1)
+           (link valid for XSPEC 12.11.0)
 
     """
 
@@ -1028,8 +1028,8 @@ class XSMultiplicativeModel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node229.html
-           (link valid for XSPEC 12.10.1)
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node231.html
+           (link valid for XSPEC 12.11.0)
 
     """
 
@@ -1066,8 +1066,8 @@ class XSConvolutionKernel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node273.html
-           (link valid for XSPEC 12.10.1)
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node279.html
+           (link valid for XSPEC 12.11.0)
 
     Examples
     --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -50,10 +50,25 @@ are now taken from the user's XSPEC configuration file - either
 for these settings. The default value for the photo-ionization table
 in this case is now ``vern`` rather than ``bcmc``.
 
+Supported models
+----------------
+
+The additive [2]_ and multiplicative [3]_ models from the XSPEC model
+library are supported, except for the `smaug` model [4]_, since it
+requires use of information from the XFLT keywords in the data file).
+
 References
 ----------
 
 .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/index.html
+
+.. [2] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node131.html
+       (link valid for XSPEC 12.10.1)
+
+.. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node229.html
+       (link valid for XSPEC 12.10.1)
+
+.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelSmaug.html
 
 """
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -53,9 +53,10 @@ in this case is now ``vern`` rather than ``bcmc``.
 Supported models
 ----------------
 
-The additive [2]_ and multiplicative [3]_ models from the XSPEC model
-library are supported, except for the `smaug` model [4]_, since it
-requires use of information from the XFLT keywords in the data file).
+The additive [2]_, multiplicative [3]_, and convolution [4]_ models
+from the XSPEC model library are supported, except for the `smaug`
+model [5]_, since it requires use of information from the XFLT keywords
+in the data file).
 
 References
 ----------
@@ -68,13 +69,20 @@ References
 .. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node229.html
        (link valid for XSPEC 12.10.1)
 
-.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelSmaug.html
+.. [4] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node273.html
+       (link valid for XSPEC 12.10.1)
+
+.. [5] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelSmaug.html
 
 """
 
 
 import string
-from sherpa.models import Parameter, modelCacher1d, RegriddableModel1D
+
+import numpy as np
+
+from sherpa.models import ArithmeticModel, ArithmeticFunctionModel, \
+    CompositeModel, Parameter, modelCacher1d, RegriddableModel1D
 from sherpa.models.parameter import hugeval
 
 from sherpa.utils import guess_amplitude, param_apply_limits, bool_cast
@@ -1001,7 +1009,8 @@ class XSAdditiveModel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Additive.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node131.html
+           (link valid for XSPEC 12.10.1)
 
     """
 
@@ -1019,11 +1028,250 @@ class XSMultiplicativeModel(XSModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Multiplicative.html
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node229.html
+           (link valid for XSPEC 12.10.1)
 
     """
 
     pass
+
+
+class XSConvolutionKernel(XSModel):
+    """The base class for XSPEC convolution models.
+
+    The XSPEC convolution models are listed at [1]_.
+
+    Notes
+    -----
+
+    As these models are applied to the result of other models, this
+    model class isn't called directly, but creates a wrapper instance
+    (`XSConvolutionModel`) that is. This wrapping is done by applying
+    the kernel to the model expression using normal function
+    application, that is the following creates a model called ``mdl``
+    which aplies the comvolution model (in this case `XScflux`) to the
+    model expression (an absorbed APEC model):
+
+    >>> cmdl = XScflux()
+    >>> src = XSapec()
+    >>> gal = XSphabs()
+    >>> mdl = cmdl(gal  * src)
+
+    These expressions can then be nested, so for instance you can
+    apply a convolution model to only part of the model expression, as
+    in:
+
+    >>> mdl = gal * cmdl(src)
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/node273.html
+           (link valid for XSPEC 12.10.1)
+
+    Examples
+    --------
+
+    Create an instance of the XSPEC cflux convolution model, and set
+    its parameters:
+
+    >>> from sherpa.astro import xspec
+    >>> cmdl = xspec.XScflux()
+    >>> cmdl.emin = 0.5
+    >>> cmdl.emax = 7.0
+    >>> cmdl.lg10flux = -12.1
+    >>> print(cmdl)
+    xscflux
+       Param        Type          Value          Min          Max      Units
+       -----        ----          -----          ---          ---      -----
+       xscflux.Emin frozen          0.5            0        1e+06        keV
+       xscflux.Emax frozen           10            0        1e+06        keV
+       xscflux.lg10Flux thawed          -12         -100          100        cgs
+
+    The convolution models are not evaluated directly. Instead they
+    are applied to a model expression which you specify as the
+    argument to the convolved model. The following creates two
+    different models: mdl1 applies the convolution to the
+    full model expression (absorbed powerlaw), and mdl
+    applies the convolution to the powerlaw component and then
+    multiplies this by the absorption model.
+
+    >>> gal = xspec.XSphabs()
+    >>> pl = xspec.XSpowerlaw()
+    >>> mdl1 = cmdl(gal * pl)
+    >>> mdl2 = gal * cmdl(pl)
+
+    For the XScflux use case it is important to freeze the normalization
+    parameter of the emission model (i.e. additive component) to 1,
+    to ensure the lg10Flux value is calculated correctly. That is:
+
+    >>> pl.norm = 1
+    >>> pl.norm.freeze()
+
+    """
+
+    def __repr__(self):
+        return "<{} kernel instance '{}'>".format(type(self).__name__,
+                                                  self.name)
+
+    def __call__(self, model):
+        return XSConvolutionModel(model, self)
+
+    def calc(self, pars, rhs, *args, **kwargs):
+        """Evaluate the convolved model.
+
+        Note that this method is not cached by
+        sherpa.models.modelCacher1d (may change in the future).
+
+        Parameters
+        ----------
+        pars : sequence of numbers
+            The parameters of the convolved model. The first npars
+            parameters (where npars is the lenth of the objecs pars
+            attribute) are applied to the convolution model, and the
+            remaining are passed to the rhs model.
+        rhs : sherpa.models.model.ArithmeticModel
+            The model that is being convolved.
+        *args
+            The model grid. There should be two arrays (the low and
+            high edges of the bin) to make sure the wrapped model is
+            evaluated correctly. One array can be used but this should
+            only be used when the wrapped model only contains XSPEC
+            models.
+        **kwargs
+            At present all additional keyword arguments are dropped.
+
+        """
+
+        npars = len(self.pars)
+        lpars = pars[:npars]
+        rpars = pars[npars:]
+
+        # We do not pass kwargs on to either rhs or self._calc;
+        # this is needed because when used with regrid support the
+        # kwargs may include keywords like 'integrate' but this
+        # can then cause problems downstream (that is, they then
+        # get sent to the xspec compiled routine, which doesn't
+        # support them). This may be a problem with the XSPEC
+        # interface (i.e. it should not pass on kwargs to the compiled
+        # code), but for now stop it here.
+        #
+        # DJB is worried that if there is a nested set of grids
+        # then this could be a problem, but has no experience or
+        # tests to back this up.
+        #
+        # fluxes = np.asarray(rhs(rpars, *args, **kwargs))
+        fluxes = np.asarray(rhs(rpars, *args))
+        return self._calc(lpars, fluxes, *args)
+
+
+# It makes sense to derive from XSModel to say "this is XSPEC",
+# but does the extra machinery it provides cause a problem here?
+#
+class XSConvolutionModel(CompositeModel, XSModel):
+    """Evaluate a model and pass it to an XSPEC convolution model.
+
+    Calculate the convolved data - that is evaluate the model and then
+    pass it to the wrapper model which applies the convolution model.
+
+    Parameters
+    ----------
+    model : sherpa.models.model.ArithmeticModel instance
+        The model whose results, when evaluated, are passed to
+        the convolution model.
+    wrapper : sherpa.astro.xspec.XSConvolutionKernel instance
+        The XSPEC convolution model.
+
+    Examples
+    --------
+
+    The following evaluates two models (creating the y1 and y2
+    arrays), where y1 applies the `XScfux` convolution model to the
+    combined absorption times powerlaw model, and y2 applies the
+    convolution model to only the power-law model, and then multiples
+    this by the absorption model. In the following mdl1 and mdl2
+    are instances of XSConvolutionModel:
+
+    >>> import numpy as np
+    >>> from sherpa.astro import xspec
+    >>> cmdl = xspec.XScflux()
+    >>> gal = xspec.XSphabs()
+    >>> pl = xspec.XSpowerlaw()
+    >>> pl.norm.freeze()
+    >>> mdl1 = cmdl(gal * pl)
+    >>> mdl2 = gal * cmdl(pl)
+    >>> cmdl.emin = 0.5
+    >>> cmdl.emax = 7.0
+    >>> cmdl.lg10flux = -12.1
+    >>> egrid = np.arange(0.1, 10, 0.01)
+    >>> elo, ehi = egrid[:-1], egrid[1:]
+    >>> y1 = mdl1(elo, ehi)
+    >>> y2 = mdl2(elo, ehi)
+
+    Display the combined model:
+
+    >>> print(mdl1)
+    xscflux((phabs * powerlaw))
+       Param        Type          Value          Min          Max      Units
+       -----        ----          -----          ---          ---      -----
+       xscflux.Emin frozen          0.5            0        1e+06        keV
+       xscflux.Emax frozen           10            0        1e+06        keV
+       xscflux.lg10Flux thawed          -12         -100          100        cgs
+       phabs.nH     thawed            1            0       100000 10^22 atoms / cm^2
+       powerlaw.PhoIndex thawed            1           -2            9
+       powerlaw.norm frozen            1            0        1e+24
+
+    >>> print(mdl2)
+    (phabs * xscflux(powerlaw))
+       Param        Type          Value          Min          Max      Units
+       -----        ----          -----          ---          ---      -----
+       phabs.nH     thawed            1            0       100000 10^22 atoms / cm^2
+       xscflux.Emin frozen          0.5            0        1e+06        keV
+       xscflux.Emax frozen           10            0        1e+06        keV
+       xscflux.lg10Flux thawed          -12         -100          100        cgs
+       powerlaw.PhoIndex thawed            1           -2            9
+       powerlaw.norm frozen            1            0        1e+24
+
+    """
+
+    @staticmethod
+    def wrapobj(obj):
+        if isinstance(obj, ArithmeticModel):
+            return obj
+        else:
+            return ArithmeticFunctionModel(obj)
+
+    def __init__(self, model, wrapper):
+        self.model = self.wrapobj(model)
+        self.wrapper = wrapper
+        CompositeModel.__init__(self,
+                                "{}({})".format(self.wrapper.name,
+                                                self.model.name),
+                                (self.wrapper, self.model))
+
+    # for now this is not cached
+    def calc(self, p, *args, **kwargs):
+        """Evaluate the convolved model on a grid.
+
+        Parameters
+        ----------
+        p : sequence of numbers
+            The parameters of the model, matching the ``pars``
+            field. This will start with the convolution model
+            parameters (if any) and then the model.
+        *args
+            The model grid. There should be two arrays (the low and
+            high edges of the bin) to make sure the wrapped model is
+            evaluated correctly. One array can be used but this should
+            only be used when the wrapped model only contains XSPEC
+            models.
+        **kwargs
+            Additional keyword arguments.
+
+        """
+
+        return self.wrapper.calc(p, self.model.calc,
+                                 *args, **kwargs)
 
 
 @version_at_least("12.10.1")
@@ -1487,7 +1735,7 @@ class XSbexrav(XSAdditiveModel):
 
     See Also
     --------
-    XSbexriv
+    XSbexriv, XSreflect
 
     Notes
     -----
@@ -1562,7 +1810,7 @@ class XSbexriv(XSAdditiveModel):
 
     See Also
     --------
-    XSbexrav
+    XSbexrav, XSireflect
 
     Notes
     -----
@@ -3019,6 +3267,10 @@ class XSdiskline(XSAdditiveModel):
     norm
         The model normalization in photon/cm^2/s.
 
+    See Also
+    --------
+    XSrdblur
+
     References
     ----------
 
@@ -3718,7 +3970,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     See Also
     --------
-    XSdiskline, XSlaor
+    XSdiskline, XSkerrconv, XSlaor
 
     References
     ----------
@@ -3861,7 +4113,7 @@ class XSlaor(XSAdditiveModel):
 
     See Also
     --------
-    XSlaor2
+    XSkdblur, XSlaor2
 
     References
     ----------
@@ -3922,7 +4174,7 @@ class XSlaor2(XSAdditiveModel):
 
     See Also
     --------
-    XSlaor
+    XSkdblur2, XSlaor
 
     References
     ----------
@@ -4757,6 +5009,10 @@ class XSnthComp(XSAdditiveModel):
     norm
         The normalization of the model: see [1]_ for more details.
 
+    See Also
+    --------
+    XSthcomp
+
     References
     ----------
 
@@ -4846,7 +5102,7 @@ class XSpexrav(XSAdditiveModel):
 
     See Also
     --------
-    XSpexriv, XSpexmon
+    XSpexriv, XSpexmon, XSreflect
 
     Notes
     -----
@@ -4911,7 +5167,7 @@ class XSpexriv(XSAdditiveModel):
 
     See Also
     --------
-    XSpexrav, XSpexmon
+    XSireflect, XSpexrav, XSpexmon
 
     Notes
     -----
@@ -11500,5 +11756,1179 @@ class XSxscat(XSMultiplicativeModel):
                                         self.DustModel))
 
 
+class XScflux(XSConvolutionKernel):
+    """The XSPEC cflux convolution model: calculate flux
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Emin
+        Minimum energy over which the flux is calculated.
+    Emax
+        Maximum energy over which the flux is calculated.
+    lg10Flux
+        log (base 10) of the flux in erg/cm^2/s
+
+    See Also
+    --------
+    XSclumin, XScpflux
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See [1]_ for the meaning and restrictions, in particular the
+    necessity of freezing the amplitude, or normalization, of the
+    emission component (or components) at 1.
+
+    Examples
+    --------
+
+    With the following definitions:
+
+    >>> cflux = XScflux()
+    >>> absmdl = XSphabs()
+    >>> plmdl = XSpowerlaw()
+    >>> gmdl = XSgaussian()
+    >>> srcmdl = plmdl + gmdl
+
+    then the model can be applied in a number of ways, such as:
+
+    >>> mdl1 = cflux(absmdl * srcmdl)
+    >>> mdl2 = absmdl * cflux(srcmdl)
+    >>> mdl3 = absmdl * (plmdl + cflux(gmdl))
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCflux.html
+
+    """
+
+    _calc = _xspec.C_cflux
+
+    def __init__(self, name='xscflux'):
+        self.Emin = Parameter(name, 'Emin', 0.5, min=0.0, max=1e6,
+                              hard_min=0.0, hard_max=1e6, frozen=True,
+                              units='keV')
+        self.Emax = Parameter(name, 'Emax', 10.0, min=0.0, max=1e6,
+                              hard_min=0.0, hard_max=1e6, frozen=True,
+                              units='keV')
+        self.lg10Flux = Parameter(name, 'lg10Flux', -12.0, min=-100.0,
+                                  max=100.0, hard_min=-100.0, hard_max=100.0,
+                                  frozen=False, units='cgs')
+        XSConvolutionKernel.__init__(self, name, (self.Emin,
+                                                  self.Emax,
+                                                  self.lg10Flux
+                                                  ))
+
+
+@version_at_least("12.9.1")
+class XSclumin(XSConvolutionKernel):
+    """The XSPEC clumin convolution model: calculate luminosity
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Emin
+        Minimum energy over which the luminosity is calculated.
+    Emax
+        Maximum energy over which the luminosity is calculated.
+    Redshift
+        redshift of the source
+    lg10Lum
+        log (base 10) of the luminosity in erg/s
+
+    See Also
+    --------
+    XSclumin, XScpflux
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See [1]_ for the meaning and restrictions, in particular the
+    necessity of freezing the amplitude, or normalization, of the
+    emission component (or components) at 1.
+
+    Examples
+    --------
+
+    With the following definitions:
+
+    >>> clumin = XSclumin()
+    >>> absmdl = XSphabs()
+    >>> plmdl = XSpowerlaw()
+    >>> gmdl = XSgaussian()
+    >>> srcmdl = plmdl + gmdl
+
+    then the model can be applied in a number of ways, such as:
+
+    >>> mdl1 = clumin(absmdl * srcmdl)
+    >>> mdl2 = absmdl * clumin(srcmdl)
+    >>> mdl3 = absmdl * (plmdl + clumin(gmdl))
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelClumin.html
+
+    """
+
+    __function__ = "C_clumin"
+
+    def __init__(self, name='xsclumin'):
+        self.Emin = Parameter(name, 'Emin', 0.5, min=0.0, max=1e6,
+                              hard_min=0.0, hard_max=1e6, frozen=True,
+                              units='keV')
+        self.Emax = Parameter(name, 'Emax', 10.0, min=0.0, max=1e6,
+                              hard_min=0.0, hard_max=1e6, frozen=True,
+                              units='keV')
+        self.Redshift = Parameter(name, 'Redshift', 0, min=-0.999, max=10,
+                                  hard_min=-0.999, hard_max=10, frozen=True)
+        self.lg10Lum = Parameter(name, 'lg10Lum', -40.0, min=-100.0,
+                                 max=100.0, hard_min=-100.0, hard_max=100.0,
+                                 frozen=False, units='cgs')
+        XSConvolutionKernel.__init__(self, name, (self.Emin,
+                                                  self.Emax,
+                                                  self.Redshift,
+                                                  self.lg10Lum
+                                                  ))
+
+
+class XScpflux(XSConvolutionKernel):
+    """The XSPEC cpflux convolution model: calculate photon flux
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Emin
+        Minimum energy over which the photon flux is calculated.
+    Emax
+        Maximum energy over which the photon flux is calculated.
+    Flux
+        photon flux in photon/cm^2/s
+
+    See Also
+    --------
+    XScflux, XSclumin
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See [1]_ for the meaning and restrictions, in particular the
+    necessity of freezing the amplitude, or normalization, of the
+    emission component (or components) at 1.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCpflux.html
+
+    """
+
+    _calc = _xspec.C_cpflux
+
+    def __init__(self, name='xscpflux'):
+        self.Emin = Parameter(name, 'Emin', 0.5, min=0.0, max=1e6,
+                              hard_min=0.0, hard_max=1e6, frozen=True,
+                              units='keV')
+        self.Emax = Parameter(name, 'Emax', 10.0, min=0.0, max=1e6,
+                              hard_min=0.0, hard_max=1e6, frozen=True,
+                              units='keV')
+        self.Flux = Parameter(name, 'Flux', 1.0, min=0.0, max=1e10,
+                              hard_min=0.0, hard_max=1e10,
+                              frozen=False, units='')
+        XSConvolutionKernel.__init__(self, name, (self.Emin,
+                                                  self.Emax,
+                                                  self.Flux
+                                                  ))
+
+
+class XSgsmooth(XSConvolutionKernel):
+    """The XSPEC gsmooth convolution model: gaussian smoothing
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    SigAt6keV
+        gaussian sigma at 6 keV
+    Index
+        power of energy for sigma variation
+
+    See Also
+    --------
+    XSlsmooth
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGsmooth.html
+
+    """
+
+    _calc = _xspec.C_gsmooth
+
+    def __init__(self, name='xsgsmooth'):
+        self.SigAt6keV = Parameter(name, 'SigAt6keV', 1.0, min=0.0, max=10.0,
+                                   hard_min=0.0, hard_max=20.0,
+                                   frozen=False, units='keV')
+        self.Index = Parameter(name, 'Index', 0.0, min=-1.0, max=1.0,
+                               hard_min=-1.0, hard_max=1.0, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.SigAt6keV, self.Index))
+
+
+class XSireflect(XSConvolutionKernel):
+    """The XSPEC ireflect convolution model: reflection from ionized material
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    rel_refl
+        The reflection scaling factor (1 for isotropic source above disk).
+    Redshift
+        The redshift of the source.
+    abund
+        The abundance of elements heaver than He relative to their solar
+        abundances.
+    Fe_abund
+        The iron abundance relative to the above.
+    cosIncl
+        The cosine of the inclination angle.
+    T_disk
+        The disk temperature in K.
+    xi
+        The disk ionization parameter: see [1]_ for an explanation.
+
+    See Also
+    --------
+    XSbexriv, XSpexriv
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the IREFLECT_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelIreflect.html
+
+    """
+
+    _calc = _xspec.C_ireflct
+
+    def __init__(self, name='xsireflect'):
+        self.rel_refl = Parameter(name, 'rel_refl', 0.0, min=-1.0, max=1e6,
+                                  hard_min=-1.0, hard_max=1e6, frozen=False)
+        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                  hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.abund = Parameter(name, 'abund', 1.0, min=0.0, max=1e6,
+                               hard_min=0.0, hard_max=1e6, frozen=True)
+        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.0, max=1e6,
+                                  hard_min=0.0, hard_max=1e6, frozen=True)
+        self.cosIncl = Parameter(name, 'cosIncl', 0.45, min=0.05, max=0.95,
+                                 hard_min=0.05, hard_max=0.95, frozen=True)
+        self.T_disk = Parameter(name, 'T_disk', 3e4, min=1e4, max=1e6,
+                                hard_min=1e4, hard_max=1e6, frozen=True,
+                                units='K')
+        self.xi = Parameter(name, 'xi', 1.0, min=0.0, max=1e3, hard_min=0.0,
+                            hard_max=5e3, frozen=True, units='erg cm/s')
+        XSConvolutionKernel.__init__(self, name, (self.rel_refl,
+                                                  self.Redshift,
+                                                  self.abund,
+                                                  self.Fe_abund,
+                                                  self.cosIncl,
+                                                  self.T_disk,
+                                                  self.xi
+                                                  ))
+
+
+class XSkdblur(XSConvolutionKernel):
+    """The XSPEC kdblur convolution model: convolve with the laor model
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Index
+        The power law dependence of emissivity (scales as R^-Index).
+    Rin_G
+        The inner radius, in units of GM/c^2.
+    Rout_G
+        The outer radius, in units of GM/c^2.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+
+    See Also
+    --------
+    XSkdblur2, XSlaor
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKdblur.html
+
+    """
+
+    _calc = _xspec.C_kdblur
+
+    def __init__(self, name='xskdblur'):
+        self.Index = Parameter(name, 'Index', 3.0, min=-10.0, max=10.0,
+                               hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 4.5, min=1.235, max=400.0,
+                               hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Rout_G = Parameter(name, 'Rout_G', 100.0, min=1.235, max=400.0,
+                                hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                              hard_min=0.0, hard_max=90.0, frozen=False,
+                              units='deg')
+        XSConvolutionKernel.__init__(self, name, (self.Index,
+                                                  self.Rin_G,
+                                                  self.Rout_G,
+                                                  self.Incl
+                                                  ))
+
+
+class XSkdblur2(XSConvolutionKernel):
+    """The XSPEC kdblur2 convolution model: convolve with the laor2 model
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Index
+        The power law dependence of emissivity (scales as R^-Index).
+    Rin_G
+        The inner radius, in units of GM/c^2.
+    Rout_G
+        The outer radius, in units of GM/c^2.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+    Rbreak
+        The radius at which the emissivity power-law index changes.
+    Index1
+        The emissivity power-law index for r>Rbreak.
+
+    See Also
+    --------
+    XSkdblur, XSlaor2
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKdblur2.html
+
+    """
+
+    _calc = _xspec.C_kdblur2
+
+    def __init__(self, name='xskdblur2'):
+        self.Index = Parameter(name, 'Index', 3.0, min=-10.0, max=10.0,
+                               hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Rin_G = Parameter(name, 'Rin_G', 4.5, min=1.235, max=400.0,
+                               hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Rout_G = Parameter(name, 'Rout_G', 100.0, min=1.235, max=400.0,
+                                hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                              hard_min=0.0, hard_max=90.0, frozen=False,
+                              units='deg')
+        self.Rbreak = Parameter(name, 'Rbreak', 20.0, min=1.235, max=400.0,
+                                hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Index1 = Parameter(name, 'Index1', 3.0, min=-10.0, max=10.0,
+                                hard_min=-10.0, hard_max=10.0, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Index,
+                                                  self.Rin_G,
+                                                  self.Rout_G,
+                                                  self.Incl,
+                                                  self.Rbreak,
+                                                  self.Index1))
+
+
+class XSkerrconv(XSConvolutionKernel):
+    """The XSPEC kerrconv convolution model: accretion disk line shape with BH spin as free parameter
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Index1
+        The emissivity index for the inner disk.
+    Index2
+        The emissivity index for the outer disk.
+    r_br_g
+        The break radius separating the inner and outer portions of the
+        disk, in gravitational radii.
+    a
+        The dimensionless black hole spin.
+    Incl
+        The disk inclination angle, in degrees. A face-on disk has
+        Incl=0.
+    Rin_ms
+        The inner radius of the disk, in units of the radius of
+        marginal stability.
+    Rout_ms
+        The outer radius of the disk, in units of the radius of
+        marginal stability.
+
+    See Also
+    --------
+    XSdiskline, XSkerrdisk, XSlaor
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKerrconv.html
+
+    """
+
+    _calc = _xspec.C_spinconv
+
+    def __init__(self, name='xskerrconv'):
+        self.Index = Parameter(name, 'Index', 3.0, min=-10.0, max=10.0,
+                               hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Index1 = Parameter(name, 'Index1', 3.0, min=-10.0, max=10.0,
+                                hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.r_br_g = Parameter(name, 'r_br_g', 6.0, min=1.0, max=400.0,
+                                hard_min=1.0, hard_max=400.0, frozen=True)
+        self.a = Parameter(name, 'a', 0.998, min=0.0, max=0.998,
+                           hard_min=0.0, hard_max=0.998, frozen=False)
+        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                              hard_min=0.0, hard_max=90.0, frozen=False,
+                              units='deg')
+        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, min=1.0, max=400.0,
+                                hard_min=1.0, hard_max=400.0, frozen=True)
+        self.Rout_ms = Parameter(name, 'Rout_ms', 400.0, min=1.0, max=400.0,
+                                 hard_min=1.0, hard_max=400.0, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Index,
+                                                  self.Index1,
+                                                  self.r_br_g,
+                                                  self.a,
+                                                  self.Incl,
+                                                  self.Rin_ms,
+                                                  self.Rout_ms
+                                                  ))
+
+
+@version_at_least("12.10.1")
+class XSkyconv(XSConvolutionKernel):
+    """The XSPEC kyconv convolution model: convolution using a relativistic line from axisymmetric accretion disk
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    a
+        a/M, the black-hole angular momentum in (GM/c).
+    theta_o
+        The observer inclinitation in degrees (0 is pole on).
+    rin
+        The inner radius, in GM/c^2.
+    ms
+        Flag: 0 means integrate from rin, 1 means integrate the emission
+        from above the marginally-stable orbit only.
+    rout
+        The outer radius, in GM/c^2.
+    alpha
+        The accretion disk emissivity scales as r^-alpha for r < rb.
+    beta
+        The accretion disk emissivity scales as r^-beta for r > rb.
+    rb
+        The boundary radius between inner and outer emissivity laws,
+        in units of GM/c^2.
+    zshift
+        The  overall Doppler shift.
+    limb
+        Flag: 0 means isotropic emission, 1 means Laor's limb darkening
+        (1 + 0.26 \\mu), 2 means Haardt's limb brightening (log(1 + 1 / \\mu)).
+    ne_loc
+        The number of grid points in local energy (energy resolution of
+        local flux, the grid is equidistant in logarithmic scale).
+    normal
+        Flag: 0 means normalize total flux to unity, > 0 means normalize
+        to unity at the energy given by the parameter value, and
+        < 0 means unnormalized.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKyconv.html
+
+    """
+
+    __function__ = "kyconv"
+
+    def __init__(self, name='xskyconv'):
+        self.a = Parameter(name, 'a', 0.9982, min=0.0, max=1.0,
+                           hard_min=0.0, hard_max=1.0, frozen=False,
+                           units='GM/c')
+        self.theta_o = Parameter(name, 'theta_o', 30.0, min=0.0, max=89.0,
+                                 hard_min=0.0, hard_max=89.0, frozen=False,
+                                 units='deg')
+        self.rin = Parameter(name, 'rin', 1.0, min=1.0, max=1000.0,
+                             hard_min=1.0, hard_max=1000.0, frozen=True,
+                             units='GM/c^2')
+        self.ms = Parameter(name, 'ms', 1.0, min=0.0, max=1.0,
+                            hard_min=0.0, hard_max=1.0, frozen=True)
+        self.rout = Parameter(name, 'rout', 400.0, min=1.0, max=1000.0,
+                              hard_min=1.0, hard_max=1000.0, frozen=True,
+                              units='GM/c^2')
+        self.alpha = Parameter(name, 'alpha', 3.0, min=-20.0, max=20.0,
+                               hard_min=-20.0, hard_max=20.0, frozen=True)
+        self.beta = Parameter(name, 'beta', 3.0, min=-20.0, max=20.0,
+                              hard_min=-20.0, hard_max=20.0, frozen=True)
+        self.rb = Parameter(name, 'rb', 400.0, min=1.0, max=1000.0,
+                            hard_min=1.0, hard_max=1000.0, frozen=True,
+                            units='GM/c^2')
+        self.zshift = Parameter(name, 'zshift', 0.0, min=-0.999, max=10.0,
+                                hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.limb = Parameter(name, 'limb', 0.0, min=0.0, max=2.0,
+                              hard_min=0.0, hard_max=2.0, frozen=True)
+        self.ne_loc = Parameter(name, 'ne_loc', 100.0, min=3.0, max=5000.0,
+                                hard_min=3.0, hard_max=5000.0, frozen=True)
+        self.normal = Parameter(name, 'normal', 1.0, min=-1.0, max=100.0,
+                                hard_min=-1.0, hard_max=100.0, frozen=True)
+
+        pars = (self.a, self.theta_o, self.rin, self.ms, self.rout,
+                self.alpha, self.beta, self.rb, self.zshift, self.limb,
+                self.ne_loc, self.normal)
+        XSConvolutionKernel.__init__(self, name, pars)
+
+
+class XSlsmooth(XSConvolutionKernel):
+    """The XSPEC lsmooth convolution model: lorentzian smoothing
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    SigAt6keV
+        lorentzian sigma at 6 keV
+    Index
+        power of energy for sigma variation
+
+    See Also
+    --------
+    XSgsmooth
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLsmooth.html
+
+    """
+
+    _calc = _xspec.C_lsmooth
+
+    def __init__(self, name='xslsmooth'):
+        self.SigAt6keV = Parameter(name, 'SigAt6keV', 1.0, min=0.0, max=10.0,
+                                   hard_min=0.0, hard_max=20.0, frozen=False,
+                                   units='keV')
+        self.Index = Parameter(name, 'Index', 0.0, min=-1.0, max=1.0,
+                               hard_min=-1.0, hard_max=1.0, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.SigAt6keV, self.Index))
+
+
+class XSpartcov(XSConvolutionKernel):
+    """The XSPEC partcov convolution model: partial covering
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    CvrFract
+        The covering fraction (0 to 1).
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelPartcov.html
+
+    """
+    _calc = _xspec.C_PartialCovering
+
+    def __init__(self, name='xspartcov'):
+        self.CvrFract = Parameter(name, 'CvrFract', 0.5, min=0.05, max=0.95,
+                                  hard_min=0.0, hard_max=1.0, frozen=False)
+        XSConvolutionKernel.__init__(self, name, (self.CvrFract,))
+
+
+class XSrdblur(XSConvolutionKernel):
+    """The XSPEC rdblur convolution model: convolve with the diskline model shape
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Betor10
+        The power law dependence of emissivity: see [1]_ for more details.
+    Rin_M
+        The inner radius, in units of GM^2/c.
+    Rout_M
+        The outer radius, in units of GM^2/c.
+    Incl
+        The inclination, in degrees.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See Also
+    --------
+    XSdiskline
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRdblur.html
+
+    """
+    _calc = _xspec.C_rdblur
+
+    def __init__(self, name='xsrdblur'):
+        self.Betor10 = Parameter(name, 'Betor10', -2.0, min=-10.0, max=20.0,
+                                 hard_min=-10.0, hard_max=20.0, frozen=True)
+        self.Rin_M = Parameter(name, 'Rin_M', 10.0, min=6.0, max=1000.0,
+                               hard_min=6.0, hard_max=10000.0, frozen=True)
+        self.Rout_M = Parameter(name, 'Rout_M', 1000.0, min=0.0,
+                                max=1000000.0, hard_min=0.0,
+                                hard_max=10000000.0, frozen=True)
+        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                              hard_min=0.0, hard_max=90.0, frozen=False,
+                              units='deg')
+        XSConvolutionKernel.__init__(self, name, (self.Betor10,
+                                                  self.Rin_M,
+                                                  self.Rout_M,
+                                                  self.Incl
+                                                  ))
+
+
+class XSreflect(XSConvolutionKernel):
+    """The XSPEC reflect convolution model: reflection from neutral material
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    rel_refl
+        The reflection scaling parameter (a value between 0 and 1
+        for an isotropic source above the disk, less than 0 for no
+        reflected component).
+    Redshift
+        The redshift of the source.
+    abund
+        The abundance of the elements heaver than He relative to their
+        solar abundance, as set by the ``set_xsabund`` function.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function.
+    cosIncl
+        The cosine of the inclination angle in degrees.
+
+    See Also
+    --------
+    XSbexrav, XSpexrav
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the REFLECT_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelReflect.html
+
+    """
+    _calc = _xspec.C_reflct
+
+    def __init__(self, name='xsreflect'):
+        self.rel_refl = Parameter(name, 'rel_refl', 0.0, min=-1.0, max=1e6,
+                                  hard_min=-1.0, hard_max=1e6, frozen=False)
+        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                  hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.abund = Parameter(name, 'abund', 1.0, min=0.0, max=1e6,
+                               hard_min=0.0, hard_max=1e6, frozen=True)
+        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.0, max=1e6,
+                                  hard_min=0.0, hard_max=1e6, frozen=True)
+        self.cosIncl = Parameter(name, 'cosIncl', 0.45, min=0.05, max=0.95,
+                                 hard_min=0.05, hard_max=0.95, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.rel_refl,
+                                                  self.Redshift,
+                                                  self.abund,
+                                                  self.Fe_abund,
+                                                  self.cosIncl
+                                                  ))
+
+
+@version_at_least("12.9.1")
+class XSrfxconv(XSConvolutionKernel):
+    """The XSPEC rfxconv convolution model: angle-dependent reflection from an ionized disk
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    rel_refl
+        The relative reflection normalization. If negative then only
+        the reflected component is returned.
+    redshift
+        The redshift of the source.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function. ALl other elements are assumed to
+        have Solar abundances.
+    cosIncl
+        The cosine of the inclination angle in degrees.
+    log_xi
+        The ionization parameter used by the table models.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the RFXCONV_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    See Also
+    --------
+    XSxilconv
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRfxconv.html
+
+    """
+
+    __function__ = "C_rfxconv"
+
+    def __init__(self, name='xsrfxconv'):
+        self.rel_refl = Parameter(name, 'rel_refl', -1.0, min=-1.0, max=1e6,
+                                  hard_min=-1.0, hard_max=1e6)
+        self.redshift = Parameter(name, 'redshift', 0.0, min=0.0, max=4.0,
+                                  hard_min=0.0, hard_max=4.0, frozen=True)
+        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.5, max=3,
+                                  hard_min=0.5, hard_max=3, frozen=True)
+        self.cosIncl = Parameter(name, 'cosIncl', 0.5, min=0.05, max=0.95,
+                                 hard_min=0.05, hard_max=0.95, frozen=True)
+        self.log_xi = Parameter(name, 'log_xi', 1.0, min=1.0, max=6.0,
+                                hard_min=1.0, hard_max=6.0)
+        XSConvolutionKernel.__init__(self, name, (self.rel_refl,
+                                                  self.redshift,
+                                                  self.Fe_abund,
+                                                  self.cosIncl,
+                                                  self.log_xi
+                                                  ))
+
+
+class XSrgsxsrc(XSConvolutionKernel):
+    """The XSPEC rgxsrc convolution model: convolve an RGS spectrum for extended emission.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    order
+        The order, which must be -1 to -3 inclusive.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    The ``set_xsxset`` function must be used to set the RGS_XSOURCE_FILE
+    value to point to a file as described in [1]_.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRgxsrc.html
+
+    """
+
+    _calc = _xspec.rgsxsrc
+
+    def __init__(self, name='xsrgsxsrc'):
+        self.order = Parameter(name, 'order', -1.0, min=-3.0, max=-1,
+                               hard_min=-3.0, hard_max=-1, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.order,))
+
+
+class XSsimpl(XSConvolutionKernel):
+    """The XSPEC simpl convolution model: comptonization of a seed spectrum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Gamma
+        The photon power law index.
+    FracSctr
+        The scattered fraction (between 0 and 1).
+    UpScOnly
+        A flag to switch between up-scattering only (when greater than
+        zero) or both up- and down-scattering (when zero or less).
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSimpl.html
+
+    """
+
+    _calc = _xspec.C_simpl
+
+    def __init__(self, name='xssimpl'):
+        self.Gamma = Parameter(name, 'Gamma', 2.3, min=1.1, max=4.0,
+                               hard_min=1.0, hard_max=5.0, frozen=False)
+        self.FracSctr = Parameter(name, 'FracSctr', 0.05, min=0.0, max=0.4,
+                                  hard_min=0.0, hard_max=1.0, frozen=False)
+        self.UpScOnly = Parameter(name, 'UpScOnly', 1.0, min=0.0, max=100.0,
+                                  hard_min=0.0, hard_max=100.0, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Gamma,
+                                                  self.FracSctr,
+                                                  self.UpScOnly
+                                                  ))
+
+
+@version_at_least("12.11.0")
+class XSthcomp(XSConvolutionKernel):
+    """The XSPEC thcomp convolution model: Thermally comptonized continuum.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    gamma_tau
+        The low-energy power-law photon index when positive and the Thomson
+        optical depth (multiplied by -1) when negative.
+    kT_e
+        The electron temperature (high energy rollover)
+    FracSctr
+        The scattering fraction (between 0 and 1). If 1 then all of the
+        seed photons will be Comptonized, and if 0 then only the original
+        seed photons will be seen.
+    z
+        redshift
+
+    See Also
+    --------
+    XSnthcomp
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelThcomp.html
+
+    """
+
+    __function__ = "thcompf"
+
+    def __init__(self, name='xsthcomp'):
+        # TODO: allow negative
+        self.gamma_tau = Parameter(name, 'gamma_tau', 1.7, min=1.001, max=5.0,
+                                   hard_min=1.001, hard_max=10.0, frozen=False)
+        self.kT_e = Parameter(name, 'kT_e', 50.0, min=0.5, max=150.0,
+                              hard_min=0.5, hard_max=150.0, units='keV',
+                              frozen=False)
+        self.FracStr = Parameter(name, 'FracSctr', 1.0, min=0.0, max=1.0,
+                                  hard_min=0.0, hard_max=1.0, frozen=False)
+        self.z = Parameter(name, 'z', 0.0, min=0.0, max=5.0,
+                           hard_min=0.0, hard_max=5.0, frozen=True)
+
+        XSConvolutionKernel.__init__(self, name, (self.gamma_tau,
+                                                  self.kT_e,
+                                                  self.FracStr,
+                                                  self.z
+                                                  ))
+
+
+@version_at_least("12.9.1")
+class XSvashift(XSConvolutionKernel):
+    """The XSPEC vashift convolution model: velocity shift an additive model.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Velocity
+        The velocity, in km/s.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See Also
+    --------
+    XSvmshift, XSzashift
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVashift.html
+
+    """
+
+    __function__ = "C_vashift"
+
+    def __init__(self, name='xsvashift'):
+        self.Redshift = Parameter(name, 'Velocity', 0.0,
+                                  min=-1e4, max=1e4,
+                                  hard_min=-1e4, hard_max=1e4,
+                                  units='km/s', frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Velocity,))
+
+
+@version_at_least("12.9.1")
+class XSvmshift(XSConvolutionKernel):
+    """The XSPEC vmshift convolution model: velocity shift a multiplicative model.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Velocity
+        The velocity, in km/s.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See Also
+    --------
+    XSvashift, XSzmshift
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVmshift.html
+
+    """
+
+    __function__ = "C_vmshift"
+
+    def __init__(self, name='xsvmshift'):
+        self.Redshift = Parameter(name, 'Velocity', 0.0,
+                                  min=-1e4, max=1e4,
+                                  hard_min=-1e4, hard_max=1e4,
+                                  units='km/s', frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Velocity,))
+
+
+@version_at_least("12.9.1")
+class XSxilconv(XSConvolutionKernel):
+    """The XSPEC xilconv convolution model: angle-dependent reflection from an ionized disk
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    rel_refl
+        The relative reflection normalization. If negative then only
+        the reflected component is returned.
+    redshift
+        The redshift of the source.
+    Fe_abund
+        The iron abundance relative to the solar abundance, as set by
+        the ``set_xsabund`` function. ALl other elements are assumed to
+        have Solar abundances.
+    cosIncl
+        The cosine of the inclination angle in degrees.
+    log_xi
+        The ionization parameter used by the table models.
+    cutoff
+        The exponential cut-off energy, in keV.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    The precision of the numerical integration can be changed by using
+    the ``set_xsxset`` function to set the value of the XILCONV_PRECISION
+    keyword, which defines the fractional precision. The default is 0.01
+    (1%).
+
+    See Also
+    --------
+    XSrfxconv
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelXilconv.html
+
+    """
+
+    __function__ = "C_xilconv"
+
+    def __init__(self, name='xsxilconv'):
+        self.rel_refl = Parameter(name, 'rel_refl', -1.0, min=-1.0, max=1e6,
+                                  hard_min=-1.0, hard_max=1e6)
+        self.redshift = Parameter(name, 'redshift', 0.0, min=0.0, max=4.0,
+                                  hard_min=0.0, hard_max=4.0, frozen=True)
+        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.5, max=3.0,
+                                  hard_min=0.5, hard_max=3.0, frozen=True)
+        self.cosIncl = Parameter(name, 'cosIncl', 0.5, min=0.05, max=0.95,
+                                 hard_min=0.05, hard_max=0.95, frozen=True)
+        self.log_xi = Parameter(name, 'log_xi', 1.0, min=1.0, max=1e6,
+                                hard_min=1.0, hard_max=1e6)
+        self.cutoff = Parameter(name, 'cutoff', 300.0, min=20.0, max=300.0,
+                                hard_min=20.0, hard_max=300.0,
+                                units='keV', frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.rel_refl,
+                                                  self.redshift,
+                                                  self.Fe_abund,
+                                                  self.cosIncl,
+                                                  self.log_xi,
+                                                  self.cutoff
+                                                  ))
+
+
+class XSzashift(XSConvolutionKernel):
+    """The XSPEC zashift convolution model: redshift an additive model.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Redshift
+        The redshift.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See Also
+    --------
+    XSvashift, XSzmshift
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZashift.html
+
+    """
+
+    _calc = _xspec.C_zashift
+
+    def __init__(self, name='xszashift'):
+        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                  hard_min=-0.999, hard_max=10, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Redshift,))
+
+
+class XSzmshift(XSConvolutionKernel):
+    """The XSPEC zmshift convolution model: redshift a multiplicative model.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Redshift
+        The redshift.
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather then using the multiplication symbol.
+
+    See Also
+    --------
+    XSvmshift, XSzashift
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZmshift.html
+
+    """
+
+    _calc = _xspec.C_zmshift
+
+    def __init__(self, name='xszmshift'):
+        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                  hard_min=-0.999, hard_max=10, frozen=True)
+        XSConvolutionKernel.__init__(self, name, (self.Redshift,))
+
+
 # Add model classes to __all__
+#
+# Should this remove the "base" classes, such as
+# XSModel and XSConvolutionModel?
+#
 __all__ += tuple(n for n in globals() if n.startswith('XS'))

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1371,17 +1371,7 @@ static PyMethodDef XSpecMethods[] = {
 
   XSPECMODELFCT_C_NORM(C_carbatm, 4),
   XSPECMODELFCT_C_NORM(C_hatm, 4),
-#ifdef XSPEC_12_10_0
-  XSPECMODELFCT_NORM(jet, 16),
-#endif
   XSPECMODELFCT(ismabs, 31),
-
-#ifdef XSPEC_12_11_0
-  XSPECMODELFCT(ismdust, 3),
-  XSPECMODELFCT(olivineabs, 2),
-  XSPECMODELFCT_C(C_logconst, 1),
-  XSPECMODELFCT_C(C_log10con, 1),
-#endif
 
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),
   XSPECMODELFCT_C_NORM(C_snapec, 7),
@@ -1398,6 +1388,17 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_vmshift, 1),
   XSPECMODELFCT_CON(C_xilconv, 6),
   #endif
+
+#ifdef XSPEC_12_10_0
+  XSPECMODELFCT_NORM(jet, 16),
+#endif
+
+#ifdef XSPEC_12_11_0
+  XSPECMODELFCT(ismdust, 3),
+  XSPECMODELFCT(olivineabs, 2),
+  XSPECMODELFCT_C(C_logconst, 1),
+  XSPECMODELFCT_C(C_log10con, 1),
+#endif
 
   { NULL, NULL, 0, NULL }
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -22,7 +22,7 @@ import numpy
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
-from sherpa.utils.testing import SherpaTestCase, requires_data, \
+from sherpa.utils.testing import requires_data, \
     requires_fits, requires_xspec
 from sherpa.utils.err import ParameterErr
 
@@ -162,364 +162,366 @@ def make_grid_noncontig2():
     return elo[idx], ehi[idx], wlo[idx], whi[idx]
 
 
+# In Sherpa 4.8.0 development, the XSPEC model class included
+# an explicit check that all the bins were finite. This has
+# been removed as testing has shown there are complications when
+# using this with some real-world responses. So add in an
+# explicit - hopefully temporary - test here.
+#
+# Also ensure that at least one bin is > 0
+# (technically we could have a model with all negative
+#  values, or all 0 with the default values, but this
+#  seems unlikely; it is more likely a model evaluates
+#  to 0 - or at least not positive - because a data file
+#  is missing).
+#
+def assert_is_finite(vals, modelcls, label):
+    """modelcls is the model class (e.g. xspec.XSphabs)"""
+
+    import sherpa.astro.xspec as xs
+
+    emsg = "model {} is finite [{}]".format(modelcls, label)
+    assert numpy.isfinite(vals).all(), emsg
+
+    # XSPEC 12.10.0 defaults to ATOMDB version 3.0.7 but
+    # provides files for 3.0.9 (this is okay for the application
+    # as it is automatically over-written by the XSPEC init file,
+    # but not for the models-only build we use). With this
+    # mis-match, APEC-style models return all 0 values, so check
+    # for this.
+    #
+    # Some models seem to return 0's, so skip them for now.
+    #
+    # The *cflow models return 0's because:
+    #     XSVMCF: Require z > 0 for cooling flow models
+    # but the default value is 0 but mkcflox/vmcflow
+    # have a default redshift of 0 in XSPEC 12.10.0 model.dat
+    #
+    if modelcls in [xs.XSmkcflow, xs.XSvmcflow]:
+        # Catch the case when this condition is no longer valid
+        #
+        assert (vals == 0.0).all(), \
+            'Expected {} to evaluate to all zeros [{}]'.format(modelcls, label)
+        return
+
+    emsg = "model {} has a value > 0 [{}]".format(modelcls, label)
+    assert (vals > 0.0).any(), emsg
+
+
 @requires_xspec
-class test_xspec(SherpaTestCase):
+def test_create_model_instances(clean_astro_ui):
+    import sherpa.astro.xspec as xs
+    count = 0
 
-    def setUp(self):
-        from sherpa.astro import xspec
-        ui.clean()
-        self._defaults = xspec.get_xsstate()
+    for cls in dir(xs):
+        if not cls.startswith('XS'):
+            continue
 
-    def tearDown(self):
-        from sherpa.astro import xspec
-        xspec.set_xsstate(self._defaults)
+        cls = getattr(xs, cls)
 
-    # In Sherpa 4.8.0 development, the XSPEC model class included
-    # an explicit check that all the bins were finite. This has
-    # been removed as testing has shown there are complications when
-    # using this with some real-world responses. So add in an
-    # explicit - hopefully temporary - test here.
+        if is_proper_subclass(cls, (xs.XSAdditiveModel,
+                                    xs.XSMultiplicativeModel,
+                                    xs.XSConvolutionKernel)):
+            # Ensure that we can create an instance, but do
+            # nothing with it.
+            cls()
+            count += 1
+
+    assert count == XSPEC_MODELS_COUNT
+
+
+@requires_xspec
+def test_norm_works(clean_astro_ui):
+    # Check that the norm parameter for additive models
+    # works, as it is handled separately from the other
+    # parameters.
+    import sherpa.astro.xspec as xs
+
+    # need an additive model
+    mdl = xs.XSpowerlaw()
+    mdl.PhoIndex = 2
+    egrid = [0.1, 0.2, 0.3, 0.4]
+
+    mdl.norm = 1.2
+    y1 = mdl(egrid)
+
+    mfactor = 2.1
+    mdl.norm = mdl.norm.val * mfactor
+    y2 = mdl(egrid)
+
+    # check that the sum is not 0 and that it
+    # scales as expected.
+    s1 = y1.sum()
+    s2 = y2.sum()
+
+    assert s1 > 0.0, 'powerlaw is positive'
+    assert s2 == pytest.approx(mfactor * s1)
+
+
+@requires_xspec
+def test_evaluate_model(clean_astro_ui):
+    import sherpa.astro.xspec as xs
+    mdl = xs.XSbbody()
+    out = mdl([1, 2, 3, 4])
+    if mdl.calc.__name__.startswith('C_'):
+        otype = numpy.float64
+    else:
+        otype = numpy.float32
+
+    assert out.dtype.type == otype
+    assert int(numpy.flatnonzero(out == 0.0)) == 3
+
+
+@requires_xspec
+def test_checks_input_length(clean_astro_ui):
+    import sherpa.astro.xspec as xs
+    mdl = xs.XSpowerlaw()
+
+    # Check when input array is too small (< 2 elements)
+    with pytest.raises(TypeError):
+        mdl([0.1])
+
+    # Check when input arrays are not the same size (when the
+    # low and high bin edges are given)
+    with pytest.raises(TypeError):
+        mdl([0.1, 0.2, 0.3], [0.2, 0.3])
+
+    with pytest.raises(TypeError):
+        mdl([0.1, 0.2], [0.2, 0.3, 0.4])
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
+def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_path):
+
+    loadfunc('mdl', make_data_path('xspec-tablemodel-RCS.mod'))
+    mdl = ui.get_model_component('mdl')
+
+    # Check when input array is too small (< 2 elements)
+    with pytest.raises(TypeError):
+        mdl([0.1])
+
+    # Check when input arrays are not the same size (when the
+    # low and high bin edges are given)
+    with pytest.raises(TypeError):
+        mdl([0.1, 0.2, 0.3], [0.2, 0.3])
+
+    with pytest.raises(TypeError):
+        mdl([0.1, 0.2], [0.2, 0.3, 0.4])
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
+def test_xspec_xstablemodel(loadfunc, clean_astro_ui, make_data_path):
+    # Just test one table model; use the same scheme as
+    # test_xspec_models_noncontiguous().
     #
-    # Also ensure that at least one bin is > 0
-    # (technically we could have a model with all negative
-    #  values, or all 0 with the default values, but this
-    #  seems unlikely; it is more likely a model evaluates
-    #  to 0 - or at least not positive - because a data file
-    #  is missing).
+    # The table model is from
+    # https://heasarc.gsfc.nasa.gov/xanadu/xspec/models/rcs.html
+    # retrieved July 9 2015. The exact model is irrelevant for this
+    # test, so this was chosen as it's relatively small.
+    loadfunc('tmod', make_data_path('xspec-tablemodel-RCS.mod'))
+
+    # when used in the test suite it appears that the tmod
+    # global symbol is not created, so need to access the component
+    tmod = ui.get_model_component('tmod')
+
+    assert tmod.name == 'xstablemodel.tmod'
+
+    egrid, elo, ehi, wgrid, wlo, whi = make_grid()
+
+    evals1 = tmod(egrid)
+    evals2 = tmod(elo, ehi)
+
+    wvals1 = tmod(wgrid)
+    wvals2 = tmod(wlo, whi)
+
+    assert_is_finite(evals1, tmod, "energy")
+    assert_is_finite(wvals1, tmod, "wavelength")
+
+    emsg = "table model evaluation failed: "
+    assert_array_equal(evals1[:-1], evals2,
+                       err_msg=emsg + "energy comparison")
+
+    assert_allclose(evals1, wvals1,
+                    err_msg=emsg + "single arg")
+    assert_allclose(evals2, wvals2,
+                    err_msg=emsg + "two args")
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
+def test_xspec_xstablemodel_noncontiguous2(loadfunc, clean_astro_ui, make_data_path):
+    loadfunc('tmod', make_data_path('xspec-tablemodel-RCS.mod'))
+    tmod = ui.get_model_component('tmod')
+
+    elo, ehi, wlo, whi = make_grid_noncontig2()
+
+    evals2 = tmod(elo, ehi)
+    wvals2 = tmod(wlo, whi)
+
+    assert_is_finite(evals2, tmod, "energy")
+    assert_is_finite(wvals2, tmod, "wavelength")
+
+    emsg = "table model non-contiguous evaluation failed: "
+    rtol = 1e-3
+    assert_allclose(evals2, wvals2, rtol=rtol,
+                    err_msg=emsg + "energy to wavelength")
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_xpec_tablemodel_outofbound(clean_astro_ui, make_data_path):
+    ui.load_xstable_model('tmod', make_data_path('xspec-tablemodel-RCS.mod'))
+    # when used in the test suite it appears that the tmod
+    # global symbol is not created, so need to access the component
+    tmod = ui.get_model_component('tmod')
+    with pytest.raises(ParameterErr) as e:
+        tmod.calc([0., .2, 1., 1.], numpy.arange(1,5))
+    assert 'minimum' in str(e)
+
+
+@requires_xspec
+def test_convolution_model_cflux(clean_astro_ui):
+    # Use the cflux convolution model, since this gives
+    # an easily-checked result. At present the only
+    # interface to these models is via direct access
+    # to the functions (i.e. there are no model classes
+    # providing access to this functionality).
     #
-    def assertFinite(self, vals, model, label):
-        emsg = "model {} is finite [{}]".format(model, label)
-        self.assertTrue(numpy.isfinite(vals).all(),
-                        msg=emsg)
-
-        # XSPEC 12.10.0 defaults to ATOMDB version 3.0.7 but
-        # provides files for 3.0.9 (this is okay for the application
-        # as it is automatically over-written by the XSPEC init file,
-        # but not for the models-only build we use).
-        #
-        # Some models return 0's, so skip them for now.
-        #
-        # The logic of what gets sent in for the model
-        # argument is unclear (class, object, and strings are
-        # sent in), which makes this more annoying.
-        #
-        smdl = str(model)
-        for n in ["mkcflow", "vmcflow"]:
-            if n in smdl:
-                return
-
-        emsg = "model {} has a value > 0 [{}]".format(model, label)
-        self.assertTrue((vals > 0.0).any(), msg=emsg)
-
-    def test_create_model_instances(self):
-        import sherpa.astro.xspec as xs
-        count = 0
-
-        for cls in dir(xs):
-            if not cls.startswith('XS'):
-                continue
-
-            cls = getattr(xs, cls)
-
-            if is_proper_subclass(cls, (xs.XSAdditiveModel,
-                                        xs.XSMultiplicativeModel,
-                                        xs.XSConvolutionKernel)):
-                # Ensure that we can create an instance, but do
-                # nothing with it.
-                cls()
-                count += 1
-
-        self.assertEqual(count, XSPEC_MODELS_COUNT)
-
-    def test_norm_works(self):
-        # Check that the norm parameter for additive models
-        # works, as it is handled separately from the other
-        # parameters.
-        import sherpa.astro.xspec as xs
-
-        # need an additive model
-        mdl = xs.XSpowerlaw()
-        mdl.PhoIndex = 2
-        egrid = [0.1, 0.2, 0.3, 0.4]
-
-        mdl.norm = 1.2
-        y1 = mdl(egrid)
-
-        mfactor = 2.1
-        mdl.norm = mdl.norm.val * mfactor
-        y2 = mdl(egrid)
-
-        # check that the sum is not 0 and that it
-        # scales as expected.
-        s1 = y1.sum()
-        s2 = y2.sum()
-        self.assertGreater(s1, 0.0, msg='powerlaw is positive')
-        self.assertAlmostEqual(s2, mfactor * s1,
-                               msg='powerlaw norm scaling')
-
-    def test_evaluate_model(self):
-        import sherpa.astro.xspec as xs
-        mdl = xs.XSbbody()
-        out = mdl([1, 2, 3, 4])
-        if mdl.calc.__name__.startswith('C_'):
-            otype = numpy.float64
-        else:
-            otype = numpy.float32
-        self.assertEqual(out.dtype.type, otype)
-        self.assertEqual(int(numpy.flatnonzero(out == 0.0)), 3)
-
-    def test_checks_input_length(self):
-        import sherpa.astro.xspec as xs
-        mdl = xs.XSpowerlaw()
-
-        # Check when input array is too small (< 2 elements)
-        self.assertRaises(TypeError, mdl, [0.1])
-
-        # Check when input arrays are not the same size (when the
-        # low and high bin edges are given)
-        self.assertRaises(TypeError, mdl, [0.1, 0.2, 0.3], [0.2, 0.3])
-        self.assertRaises(TypeError, mdl, [0.1, 0.2], [0.2, 0.3, 0.4])
-
-    # Support for XSPEC support in load_table_model has been deprecated
-    # in Sherpa 4.9.0; use load_xstable_model instead. For now the
-    # tests are run with both functions, which means making the loading
-    # function a parameter of the tests.
-    #
-    def _test_xspec_tablemodel_checks_input_length(self, loadfunc):
-
-        loadfunc('mdl', self.make_path('xspec-tablemodel-RCS.mod'))
-        mdl = ui.get_model_component('mdl')
-
-        # Check when input array is too small (< 2 elements)
-        self.assertRaises(TypeError, mdl, [0.1])
-
-        # Check when input arrays are not the same size (when the
-        # low and high bin edges are given)
-        self.assertRaises(TypeError, mdl, [0.1, 0.2, 0.3], [0.2, 0.3])
-        self.assertRaises(TypeError, mdl, [0.1, 0.2], [0.2, 0.3, 0.4])
-
-    def _test_xspec_tablemodel(self, loadfunc):
-        # Just test one table model; use the same scheme as
-        # test_xspec_models_noncontiguous().
-        #
-        # The table model is from
-        # https://heasarc.gsfc.nasa.gov/xanadu/xspec/models/rcs.html
-        # retrieved July 9 2015. The exact model is irrelevant for this
-        # test, so this was chosen as it's relatively small.
-        loadfunc('tmod', self.make_path('xspec-tablemodel-RCS.mod'))
-
-        # when used in the test suite it appears that the tmod
-        # global symbol is not created, so need to access the component
-        tmod = ui.get_model_component('tmod')
-
-        self.assertEqual(tmod.name, 'xstablemodel.tmod')
-
-        egrid, elo, ehi, wgrid, wlo, whi = make_grid()
-
-        evals1 = tmod(egrid)
-        evals2 = tmod(elo, ehi)
-
-        wvals1 = tmod(wgrid)
-        wvals2 = tmod(wlo, whi)
-
-        self.assertFinite(evals1, tmod, "energy")
-        self.assertFinite(wvals1, tmod, "wavelength")
-
-        emsg = "table model evaluation failed: "
-        assert_array_equal(evals1[:-1], evals2,
-                           err_msg=emsg + "energy comparison")
-
-        assert_allclose(evals1, wvals1,
-                        err_msg=emsg + "single arg")
-        assert_allclose(evals2, wvals2,
-                        err_msg=emsg + "two args")
-
-    def _test_xspec_tablemodel_noncontiguous2(self, loadfunc):
-
-        loadfunc('tmod', self.make_path('xspec-tablemodel-RCS.mod'))
-        tmod = ui.get_model_component('tmod')
-
-        elo, ehi, wlo, whi = make_grid_noncontig2()
-
-        evals2 = tmod(elo, ehi)
-        wvals2 = tmod(wlo, whi)
-
-        self.assertFinite(evals2, tmod, "energy")
-        self.assertFinite(wvals2, tmod, "wavelength")
-
-        emsg = "table model non-contiguous evaluation failed: "
-        rtol = 1e-3
-        assert_allclose(evals2, wvals2, rtol=rtol,
-                        err_msg=emsg + "energy to wavelength")
-
-    @requires_data
-    @requires_fits
-    def test_xstablemodel_checks_input_length(self):
-        self._test_xspec_tablemodel_checks_input_length(
-            ui.load_xstable_model)
-
-    @requires_data
-    @requires_fits
-    def test_tablemodel_checks_input_length(self):
-        self._test_xspec_tablemodel_checks_input_length(
-            ui.load_table_model)
-
-    @requires_data
-    @requires_fits
-    def test_xspec_xstablemodel(self):
-        self._test_xspec_tablemodel(ui.load_xstable_model)
-
-    @requires_data
-    @requires_fits
-    def test_xspec_tablemodel(self):
-        self._test_xspec_tablemodel(ui.load_table_model)
-
-    @requires_data
-    @requires_fits
-    def test_xspec_xstablemodel_noncontiguous2(self):
-        self._test_xspec_tablemodel_noncontiguous2(ui.load_xstable_model)
-
-    @requires_data
-    @requires_fits
-    def test_xspec_tablemodel_noncontiguous2(self):
-        self._test_xspec_tablemodel_noncontiguous2(ui.load_table_model)
-
-    @requires_data
-    @requires_fits
-    def test_xpec_tablemodel_outofbound(self):
-        ui.load_xstable_model('tmod', self.make_path('xspec-tablemodel-RCS.mod'))
-        # when used in the test suite it appears that the tmod
-        # global symbol is not created, so need to access the component
-        tmod = ui.get_model_component('tmod')
-        with pytest.raises(ParameterErr) as e:
-            tmod.calc([0., .2, 1., 1.], numpy.arange(1,5))
-        assert 'minimum' in str(e)
-
-
-    def test_convolution_model_cflux(self):
-        # Use the cflux convolution model, since this gives
-        # an easily-checked result. At present the only
-        # interface to these models is via direct access
-        # to the functions (i.e. there are no model classes
-        # providing access to this functionality).
-        #
-        import sherpa.astro.xspec as xs
-
-        if not hasattr(xs._xspec, 'C_cflux'):
-            self.skipTest('cflux convolution model is missing')
-
-        # The energy grid should extend beyond the energy grid
-        # used to evaluate the model, to avoid any edge effects.
-        # It also makes things easier if the elo/ehi values align
-        # with the egrid bins.
-        elo = 0.55
-        ehi = 1.45
-        egrid = numpy.linspace(0.5, 1.5, 101)
-
-        mdl1 = xs.XSpowerlaw()
-        mdl1.PhoIndex = 2
-
-        # flux of mdl1 over the energy range of interest; converting
-        # from a flux in photon/cm^2/s to erg/cm^2/s, when the
-        # energy grid is in keV.
-        y1 = mdl1(egrid)
-        idx, = numpy.where((egrid >= elo) & (egrid < ehi))
-
-        # To match XSpec, need to multiply by (Ehi^2-Elo^2)/(Ehi-Elo)
-        # which means that we need the next bin to get Ehi. Due to
-        # the form of the where statement, we should be missing the
-        # Ehi value of the last bin
-        e1 = egrid[idx]
-        e2 = egrid[idx + 1]
-
-        f1 = 8.01096e-10 * ((e2 * e2 - e1 * e1) * y1[idx] / (e2 - e1)).sum()
-
-        # The cflux parameters are elo, ehi, and the log of the
-        # flux within this range (this is log base 10 of the
-        # flux in erg/cm^2/s). The parameters chosen for the
-        # powerlaw, and energy range, should have f1 ~ 1.5e-9
-        # (log 10 of this is -8.8).
-        lflux = -5.0
-        pars = [elo, ehi, lflux]
-        y2 = xs._xspec.C_cflux(pars, y1, egrid)
-
-        self.assertFinite(y2, "cflux", "energy")
-
-        elo = egrid[:-1]
-        ehi = egrid[1:]
-        wgrid = _hc / egrid
-        whi = wgrid[:-1]
-        wlo = wgrid[1:]
-
-        expected = y1 * 10**lflux / f1
-        numpy.testing.assert_allclose(expected, y2,
-                                      err_msg='energy, single grid')
-
-        y1 = mdl1(wgrid)
-        y2 = xs._xspec.C_cflux(pars, y1, wgrid)
-        self.assertFinite(y2, "cflux", "wavelength")
-        numpy.testing.assert_allclose(expected, y2,
-                                      err_msg='wavelength, single grid')
-
-        expected = expected[:-1]
-
-        y1 = mdl1(elo, ehi)
-        y2 = xs._xspec.C_cflux(pars, y1, elo, ehi)
-        numpy.testing.assert_allclose(expected, y2,
-                                      err_msg='energy, two arrays')
-
-        y1 = mdl1(wlo, whi)
-        y2 = xs._xspec.C_cflux(pars, y1, wlo, whi)
-        numpy.testing.assert_allclose(expected, y2,
-                                      err_msg='wavelength, two arrays')
-
-    def test_convolution_model_cpflux_noncontiguous(self):
-        # The models should raise an error if given a non-contiguous
-        # grid.
-        import sherpa.astro.xspec as xs
-
-        if not hasattr(xs._xspec, 'C_cpflux'):
-            self.skipTest('cpflux convolution model is missing')
-
-        elo, ehi, wlo, whi = make_grid_noncontig2()
-
-        lflux = -5.0
-        pars = [0.2, 0.8, lflux]
-        y1 = numpy.zeros(elo.size)
-
-        self.assertRaises(ValueError, xs._xspec.C_cpflux, pars, y1, elo, ehi)
-        self.assertRaises(ValueError, xs._xspec.C_cpflux, pars, y1, wlo, whi)
-
-    @requires_data
-    @requires_fits
-    def test_set_analysis_wave_fabrizio(self):
-        rmf = self.make_path('3c273.rmf')
-        arf = self.make_path('3c273.arf')
-
-        ui.set_model("fabrizio", "xspowerlaw.p1")
-        ui.fake_pha("fabrizio", arf, rmf, 10000)
-
-        parvals = [1, 1]
-
-        model = ui.get_model("fabrizio")
-        bare_model, _ = ui._session._get_model_status("fabrizio")
-        y = bare_model.calc(parvals, model.xlo, model.xhi)
-        y_m = numpy.mean(y)
-
-        ui.set_analysis("fabrizio", "wave")
-
-        model2 = ui.get_model("fabrizio")
-        bare_model2, _ = ui._session._get_model_status("fabrizio")
-        y2 = bare_model2.calc(parvals, model2.xlo, model2.xhi)
-        y2_m = numpy.mean(y2)
-
-        self.assertAlmostEqual(y_m, y2_m)
-
-    def test_xsxset_get(self):
-        import sherpa.astro.xspec as xs
-        # TEST CASE #1 Case insentitive keys
-        xs.set_xsxset('fooBar', 'somevalue')
-        self.assertEqual('somevalue', xs.get_xsxset('Foobar'))
+    import sherpa.astro.xspec as xs
+
+    if not hasattr(xs._xspec, 'C_cflux'):
+        pytest.skip('cflux convolution model is missing')
+
+    # The energy grid should extend beyond the energy grid
+    # used to evaluate the model, to avoid any edge effects.
+    # It also makes things easier if the elo/ehi values align
+    # with the egrid bins.
+    elo = 0.55
+    ehi = 1.45
+    egrid = numpy.linspace(0.5, 1.5, 101)
+
+    mdl1 = xs.XSpowerlaw()
+    mdl1.PhoIndex = 2
+
+    # flux of mdl1 over the energy range of interest; converting
+    # from a flux in photon/cm^2/s to erg/cm^2/s, when the
+    # energy grid is in keV.
+    y1 = mdl1(egrid)
+    idx, = numpy.where((egrid >= elo) & (egrid < ehi))
+
+    # To match XSpec, need to multiply by (Ehi^2-Elo^2)/(Ehi-Elo)
+    # which means that we need the next bin to get Ehi. Due to
+    # the form of the where statement, we should be missing the
+    # Ehi value of the last bin
+    e1 = egrid[idx]
+    e2 = egrid[idx + 1]
+
+    f1 = 8.01096e-10 * ((e2 * e2 - e1 * e1) * y1[idx] / (e2 - e1)).sum()
+
+    # The cflux parameters are elo, ehi, and the log of the
+    # flux within this range (this is log base 10 of the
+    # flux in erg/cm^2/s). The parameters chosen for the
+    # powerlaw, and energy range, should have f1 ~ 1.5e-9
+    # (log 10 of this is -8.8).
+    lflux = -5.0
+    pars = [elo, ehi, lflux]
+    y2 = xs._xspec.C_cflux(pars, y1, egrid)
+
+    assert_is_finite(y2, "cflux", "energy")
+
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    wgrid = _hc / egrid
+    whi = wgrid[:-1]
+    wlo = wgrid[1:]
+
+    expected = y1 * 10**lflux / f1
+    numpy.testing.assert_allclose(expected, y2,
+                                  err_msg='energy, single grid')
+
+    y1 = mdl1(wgrid)
+    y2 = xs._xspec.C_cflux(pars, y1, wgrid)
+    assert_is_finite(y2, "cflux", "wavelength")
+    numpy.testing.assert_allclose(expected, y2,
+                                  err_msg='wavelength, single grid')
+
+    expected = expected[:-1]
+
+    y1 = mdl1(elo, ehi)
+    y2 = xs._xspec.C_cflux(pars, y1, elo, ehi)
+    numpy.testing.assert_allclose(expected, y2,
+                                  err_msg='energy, two arrays')
+
+    y1 = mdl1(wlo, whi)
+    y2 = xs._xspec.C_cflux(pars, y1, wlo, whi)
+    numpy.testing.assert_allclose(expected, y2,
+                                  err_msg='wavelength, two arrays')
+
+
+@requires_xspec
+def test_convolution_model_cpflux_noncontiguous(clean_astro_ui):
+    # The models should raise an error if given a non-contiguous
+    # grid.
+    import sherpa.astro.xspec as xs
+
+    if not hasattr(xs._xspec, 'C_cpflux'):
+        pytest.skip('cpflux convolution model is missing')
+
+    elo, ehi, wlo, whi = make_grid_noncontig2()
+
+    lflux = -5.0
+    pars = [0.2, 0.8, lflux]
+    y1 = numpy.zeros(elo.size)
+
+    with pytest.raises(ValueError):
+        xs._xspec.C_cpflux(pars, y1, elo, ehi)
+
+    with pytest.raises(ValueError):
+        xs._xspec.C_cpflux(pars, y1, wlo, whi)
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_set_analysis_wave_fabrizio(clean_astro_ui, make_data_path):
+    rmf = make_data_path('3c273.rmf')
+    arf = make_data_path('3c273.arf')
+
+    ui.set_model("fabrizio", "xspowerlaw.p1")
+    ui.fake_pha("fabrizio", arf, rmf, 10000)
+
+    parvals = [1, 1]
+
+    model = ui.get_model("fabrizio")
+    bare_model, _ = ui._session._get_model_status("fabrizio")
+    y = bare_model.calc(parvals, model.xlo, model.xhi)
+    y_m = numpy.mean(y)
+
+    ui.set_analysis("fabrizio", "wave")
+
+    model2 = ui.get_model("fabrizio")
+    bare_model2, _ = ui._session._get_model_status("fabrizio")
+    y2 = bare_model2.calc(parvals, model2.xlo, model2.xhi)
+    y2_m = numpy.mean(y2)
+
+    assert y2_m == pytest.approx(y_m)
+
+
+@requires_xspec
+def test_xsxset_get(clean_astro_ui):
+    import sherpa.astro.xspec as xs
+    # TEST CASE #1 Case insentitive keys
+    xs.set_xsxset('fooBar', 'somevalue')
+    assert xs.get_xsxset('Foobar') == 'somevalue'
 
 
 @requires_xspec
@@ -595,57 +597,6 @@ def test_old_style_xspec_class():
     expected = XSzbabs()([1, 2, 3])
 
     assert_array_equal(expected, actual)
-
-
-# The following repeats logic in self.assertFinite above.
-# The plan is to move the SherpaTestCase derived tests into
-# plain pytest-style tests, and then self.assertFinite
-# will be removed, but that day is not today.
-#
-# In Sherpa 4.8.0 development, the XSPEC model class included
-# an explicit check that all the bins were finite. This has
-# been removed as testing has shown there are complications when
-# using this with some real-world responses. So add in an
-# explicit - hopefully temporary - test here.
-#
-# Also ensure that at least one bin is > 0
-# (technically we could have a model with all negative
-#  values, or all 0 with the default values, but this
-#  seems unlikely; it is more likely a model evaluates
-#  to 0 - or at least not positive - because a data file
-#  is missing).
-#
-def assert_is_finite(vals, modelcls, label):
-    """modelcls is the model class (e.g. xspec.XSphabs)"""
-
-    import sherpa.astro.xspec as xs
-
-    emsg = "model {} is finite [{}]".format(modelcls, label)
-    assert numpy.isfinite(vals).all(), emsg
-
-    # XSPEC 12.10.0 defaults to ATOMDB version 3.0.7 but
-    # provides files for 3.0.9 (this is okay for the application
-    # as it is automatically over-written by the XSPEC init file,
-    # but not for the models-only build we use). With this
-    # mis-match, APEC-style models return all 0 values, so check
-    # for this.
-    #
-    # Some models seem to return 0's, so skip them for now.
-    #
-    # The *cflow models return 0's because:
-    #     XSVMCF: Require z > 0 for cooling flow models
-    # but the default value is 0 but mkcflox/vmcflow
-    # have a default redshift of 0 in XSPEC 12.10.0 model.dat
-    #
-    if modelcls in [xs.XSmkcflow, xs.XSvmcflow]:
-        # Catch the case when this condition is no longer valid
-        #
-        assert (vals == 0.0).all(), \
-            'Expected {} to evaluate to all zeros [{}]'.format(modelcls, label)
-        return
-
-    emsg = "model {} has a value > 0 [{}]".format(modelcls, label)
-    assert (vals > 0.0).any(), emsg
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -1,0 +1,805 @@
+#
+#  Copyright (C) 2020
+#         Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import pytest
+
+from sherpa.utils.testing import requires_xspec, requires_data
+from sherpa.data import Data1DInt
+from sherpa.models.basic import Box1D, Const1D, PowLaw1D
+from sherpa.models.parameter import Parameter
+from sherpa.models.model import RegridWrappedModel
+
+from sherpa.astro import ui
+
+# Unlike test_xspec.py which tries to evaluate all the additive and
+# multiplicative models, here we just try several ones for which
+# we can easily evaluate the results
+#
+#   - cflux: calculates the flux over an energy range as a parameter
+#   - [zv][am]shift: shift a model
+#
+
+# Identify when new models are added (in case tests should be written),
+# as well as the number of thawed and frozen parameters.
+#
+XSPEC_CON_MODELS = [('cflux', 1, 2),
+                    ('clumin', 1, 3),
+                    ('cpflux', 1, 2),
+                    ('gsmooth', 1, 1),
+                    ('ireflect', 1, 6),
+                    ('kdblur', 1, 3),
+                    ('kdblur2', 1, 5),
+                    ('kerrconv', 2, 5),
+                    ('kyconv', 2, 10),
+                    ('lsmooth', 1, 1),
+                    ('partcov', 1, 0),
+                    ('rdblur', 1, 3),
+                    ('reflect', 1, 4),
+                    ('rfxconv', 2, 3),
+                    ('rgsxsrc', 0, 1),
+                    ('simpl', 2, 1),
+                    ('thcomp', 3, 1),
+                    ('vashift', 0, 1),
+                    ('vmshift', 0, 1),
+                    ('xilconv', 2, 4),
+                    ('zashift', 0, 1),
+                    ('zmshift', 0, 1)]
+
+
+@requires_xspec
+def test_count_xspec_convolution_models():
+    """Do we have all the models we expect"""
+
+    from sherpa.astro import xspec
+
+    for n, _, _ in XSPEC_CON_MODELS:
+        clsname = 'XS{}'.format(n)
+        try:
+            cls = getattr(xspec, clsname)
+        except AttributeError:
+            assert False, 'missing convolution model {}'.format(clsname)
+
+        mdl = cls()
+        assert issubclass(cls, xspec.XSConvolutionKernel), mdl
+
+
+@requires_xspec
+def test_check_no_extra_xspec_convolution_models():
+    """Are we missing any?
+
+    This is for the test suite (check we know about everything)
+    rather than catching any errors in the code.
+    """
+
+    from sherpa.astro import xspec
+
+    exclude = ['XSModel', 'XSAdditiveModel', 'XSMultiplicativeModel',
+               'XSConvolutionModel', 'XSConvolutionKernel']
+
+    names = [(n, getattr(xspec, n))
+             for n in dir(xspec)
+             if n.startswith('XS') and n not in exclude]
+
+    classes = set([])
+    for name, cls in names:
+        try:
+            mdl = cls()
+        except TypeError:
+            pass
+
+        if isinstance(mdl, xspec.XSConvolutionKernel):
+            npars = len(mdl.pars)
+            nfrozen = len([p for p in mdl.pars if p.frozen])
+            classes.add((name[2:], npars - nfrozen, nfrozen))
+
+    assert classes == set(XSPEC_CON_MODELS)
+
+
+def setup_data(elo=0.1, ehi=10.0, ebin=0.01):
+    """Return a data set.
+
+    Parameters
+    ----------
+    elo, ehi : number, optional
+        The start and end energy of the grid, in keV.
+    ebin : number, optional
+        The bin width, in keV.
+
+    Returns
+    -------
+    data : Data1DInt
+        The data object. The Y values are not expected to be used,
+        so are set to 1.
+
+    """
+
+    if elo >= ehi:
+        raise ValueError("elo >= ehi")
+    if elo <= 0:
+        raise ValueError("elo <= 0")
+    if ebin <= 0:
+        raise ValueError("ebin <= 0")
+
+    x = np.arange(elo, ehi + ebin, ebin)
+    if x.size < 2:
+        raise ValueError("elo, ehi, ebin not sensible")
+
+    y = np.ones(x.size - 1)
+    return Data1DInt('dummy', x[:-1], x[1:], y)
+
+
+def _check_pars(label, mdl, parvals):
+    """Check that we have the expected parameters.
+
+    Parameters
+    ----------
+    label : str
+        The label to use in the assertions
+    mdl
+        The model object. It must have a pars attribute.
+    parvals : sequence of tuples
+        Each entry gives the parameter name, value, frozen flag,
+        and units field.
+    """
+
+    nexp = len(parvals)
+    ngot = len(mdl.pars)
+    assert nexp == ngot, '{}: number of parameters'.format(label)
+
+    for i, vals in enumerate(parvals):
+
+        par = mdl.pars[i]
+        plbl = '{} param {}: '.format(label, i + 1)
+        assert isinstance(par, Parameter), plbl + 'is a parameter'
+        assert par.name == vals[0], plbl + 'name'
+        assert par.val == vals[1], plbl + 'value'
+        assert par.frozen == vals[2], plbl + 'frozen'
+        assert par.units == vals[3], plbl + 'units'
+
+
+@requires_xspec
+def test_cflux_settings():
+    """Do the expected things happen when a model is calculated?"""
+
+    from sherpa.astro import xspec
+
+    kern = xspec.XScflux('cflux')
+    assert isinstance(kern, xspec.XSConvolutionKernel), \
+        "cflux creates XSConvolutionKernel"
+
+    cfluxpars = [('Emin', 0.5, True, 'keV'),
+                 ('Emax', 10.0, True, 'keV'),
+                 ('lg10Flux', -12, False, 'cgs')]
+    _check_pars('cflux', kern, cfluxpars)
+
+    mdl = kern(PowLaw1D('pl'))
+    assert isinstance(mdl, xspec.XSConvolutionModel), \
+        "cflux(mdl) creates XSConvolutionModel"
+
+    plpars = [('gamma', 1.0, False, ''),
+              ('ref', 1.0, True, ''),
+              ('ampl', 1.0, False, '')]
+    _check_pars('model', mdl, cfluxpars + plpars)
+
+
+def _test_cflux_calc(mdl, slope, ampl):
+    """Test the CFLUX convolution model calculation.
+
+    This is a test of the convolution interface, as the results of
+    the convolution can be easily checked.
+
+    Parameters
+    ----------
+    mdl
+        The unconvolved model. It is assumed to be a power law (so
+        either a XSpowerlaw or PowLaw1D instance).
+    slope, ampl : number
+        The slope (gamma or PhoIndex) and amplitude
+        (ampl or norm) of the power law.
+
+    See Also
+    --------
+    test_cflux_calc_sherpa, test_cflux_calc_xspec
+
+    """
+
+    from sherpa.astro import xspec
+
+    d = setup_data()
+
+    kern = xspec.XScflux('cflux')
+
+    mdl_unconvolved = mdl
+    mdl_convolved = kern(mdl)
+
+    # As it's just a power law, we can evaluate analytically
+    #
+    pterm = 1.0 - slope
+    emin = d.xlo[0]
+    emax = d.xhi[-1]
+    counts_expected = ampl * (emax**pterm - emin**pterm) / \
+        pterm
+
+    # Could evaluate the model directly, but check that it's working
+    # with the Sherpa setup. It is not clear that going through
+    # the eval_model method really buys us much testing since the
+    # main check we would really want to do is with the DataPHA
+    # class, but that requires a lot of set up; the idea is that
+    # the interface is abstract enough that going through
+    # Data1DInt's eval_model API is sufficient.
+    #
+    y_unconvolved = d.eval_model(mdl_unconvolved)
+    nbins_unconvolved = y_unconvolved.size
+    assert nbins_unconvolved == d.xlo.size, \
+        'unconvolved model has correct # bins'
+
+    counts_unconvolved = y_unconvolved.sum()
+
+    # This is mainly a sanity check of everything, as it is not
+    # directly related to the convolution model. The counts_expected
+    # term is > 0.01 with the chosen settings, so 1e-15
+    # is a hand-wavy term to say "essentially zero". It may need
+    # tweaking depending on platform/setup.
+    #
+    assert np.abs(counts_expected - counts_unconvolved) < 1e-15, \
+        'can integrate a power law'
+
+    # How to verify the convolution model? Well, one way is to
+    # give it a flux, get the model values, and then check that
+    # these values are very close to the expected values for
+    # that flux.
+    #
+    kern.emin = 0.5
+    kern.emax = 7.0
+
+    desired_flux = 3.2e-14
+    kern.lg10flux = np.log10(desired_flux)
+
+    y_convolved = d.eval_model(mdl_convolved)
+    nbins_convolved = y_convolved.size
+    assert nbins_convolved == d.xlo.size, \
+        'convolved model has correct # bins'
+
+    # The model evaluated by mdl_convolved should have a
+    # log_10(flux), over the kern.Emin to kern.Emax energy range,
+    # of kern.lg10Flux, when the flux is in erg/cm^2/s (assuming
+    # the model it is convolving has units of photon/cm^2/s).
+    #
+    # d.xlo and d.xhi are in keV, so need to convert them to
+    # erg.
+    #
+    # Use 1 keV = 1.60218e-9 erg for the conversion, which limits
+    # the accuracy (in part because I don't know how this compares
+    # to the value that XSPEC uses, which could depend on the
+    # version of XSPEC).
+    #
+    econv = 1.60218e-9
+    emid = econv * (d.xlo + d.xhi) / 2.0
+
+    y_signal = emid * y_convolved
+
+    # Do not bother with trying to correct for any partially-filled
+    # bins at the end of this range (there shouldn't be any).
+    #
+    idx = np.where((d.xlo >= kern.emin.val) &
+                   (d.xhi <= kern.emax.val))
+    flux = y_signal[idx].sum()
+
+    # Initial tests had desired_flux = 3.2e-14 and the difference
+    # ~ 1.6e-16. This has been used to determine the tolerance.
+    # Note that 2e-16/3.2e-14 ~ 0.006 ie ~ 0.6%
+    #
+    assert np.abs(flux - desired_flux) < 2e-16, \
+        'flux is not as expected'
+
+    # The cflux model should handle any change in the model amplitude
+    # (I believe; as there's no one definition of what the model
+    # amplitude means in XSPEC). So, increasing the amplitude - assumed
+    # to the last parameter of the input model - should result in
+    # the same flux values. The unconvolved model is checked to make
+    # sure it does scale (as a sanity check).
+    #
+    rescale = 1000.0
+    mdl.pars[-1].val *= rescale
+    y_unconvolved_rescaled = d.eval_model(mdl_unconvolved)
+    y_convolved_rescaled = d.eval_model(mdl_convolved)
+
+    assert_allclose(y_unconvolved, y_unconvolved_rescaled / rescale,
+                    atol=0, rtol=1e-7)
+    assert_allclose(y_convolved, y_convolved_rescaled,
+                    atol=0, rtol=1e-7)
+
+
+@requires_xspec
+def test_cflux_calc_xspec():
+    """Test the CFLUX convolution model calculations (XSPEC model)
+
+    This is a test of the convolution interface, as the results of
+    the convolution can be easily checked. The model being convolved
+    is an XSPEC model.
+
+    See Also
+    --------
+    test_cflux_calc_sherpa
+
+    """
+
+    from sherpa.astro import xspec
+
+    mdl = xspec.XSpowerlaw('xspec')
+    mdl.phoindex = 1.7
+    mdl.norm = 0.025
+    _test_cflux_calc(mdl, mdl.phoindex.val, mdl.norm.val)
+
+
+@requires_xspec
+def test_cflux_calc_sherpa():
+    """Test the CFLUX convolution model calculations (sherpa model)
+
+    This is a test of the convolution interface, as the results of
+    the convolution can be easily checked. The model being convolved
+    is a Sherpa model.
+
+    See Also
+    --------
+    test_cflux_calc_xspec
+
+    """
+
+    mdl = PowLaw1D('sherpa')
+    mdl.gamma = 1.7
+    mdl.ampl = 0.025
+    _test_cflux_calc(mdl, mdl.gamma.val, mdl.ampl.val)
+
+
+@requires_xspec
+def test_cflux_nbins():
+    """Check that the number of bins created by cflux is correct.
+
+    The test_cflux_calc_xxx routines do include a test of the number
+    of bins, but that is just for a Data1DInt dataset, so the model
+    only ever gets called with explicit lo and hi edges. This test
+    calls the model directly to check both 1 and 2 argument variants.
+
+    Notes
+    -----
+    There's no check of a non-contiguous grid.
+    """
+
+    from sherpa.astro import xspec
+
+    spl = PowLaw1D('sherpa')
+    xpl = xspec.XSpowerlaw('xspec')
+
+    spl.gamma = 0.7
+    xpl.phoindex = 0.7
+
+    egrid = np.arange(0.1, 2, 0.01)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    nbins = elo.size
+
+    def check_bins(lbl, mdl):
+        y1 = mdl(egrid)
+        y2 = mdl(elo, ehi)
+
+        assert y1.size == nbins + 1, '{}: egrid'.format(lbl)
+        assert y2.size == nbins, '{}: elo/ehi'.format(lbl)
+
+    # verify assumptions
+    #
+    check_bins('Sherpa model', spl)
+    check_bins('XSPEC model', xpl)
+
+    # Now try the convolved versions
+    #
+    cflux = xspec.XScflux("conv")
+    check_bins('Convolved Sherpa', cflux(spl))
+    check_bins('Convolved XSPEC', cflux(xpl))
+
+
+@requires_xspec
+def test_calc_xspec_regrid():
+    """Test the CFLUX convolution model calculations (XSPEC model)
+
+    Can we regrid the model and get a similar result to the
+    direct version? This uses zashift but with 0 redshift.
+
+    See Also
+    --------
+    test_calc_sherpa_regrid
+
+    """
+
+    from sherpa.astro import xspec
+
+    mdl = xspec.XSpowerlaw('xspec')
+    mdl.phoindex = 1.7
+    mdl.norm = 0.025
+
+    # rather than use the 'cflux' convolution model, try
+    # the redshift model but with 0 redshift.
+    #
+    kern = xspec.XSzashift('zshift')
+    kern.redshift = 0
+    mdl_convolved = kern(mdl)
+
+    d = setup_data(elo=0.2, ehi=5, ebin=0.01)
+
+    dr = np.arange(0.1, 7, 0.005)
+    mdl_regrid = mdl_convolved.regrid(dr[:-1], dr[1:])
+
+    yconvolved = d.eval_model(mdl_convolved)
+    yregrid = d.eval_model(mdl_regrid)
+
+    # Do a per-pixel comparison (this will automatically catch any
+    # difference in the output sizes).
+    #
+    ydiff = np.abs(yconvolved - yregrid)
+    mdiff = ydiff.max()
+    # rdiff = ydiff / yconvolved
+
+    # in testing see the max difference being ~ 3e-17
+    assert mdiff < 1e-15, \
+        'can rebin an XSPEC powerlaw: max diff={}'.format(mdiff)
+
+
+@requires_xspec
+def test_calc_sherpa_regrid():
+    """Test the CFLUX convolution model calculations (Sherpa model)
+
+    Can we redshift a sherpa model and get the expected
+    result, with a regrid applied? In this case a feature
+    is added outside the default energy range, but in the
+    regridded range, to check things are working.
+
+    See Also
+    --------
+    test_calc_xspec_regrid
+
+    """
+
+    from sherpa.astro import xspec
+
+    mdl = Box1D('box')
+    mdl.xlow = 4
+    mdl.xhi = 12
+    # why is the box amplitude restricted like this?
+    mdl.ampl.max = 2
+    mdl.ampl = 2
+
+    kern = xspec.XSzashift('zshift')
+    kern.redshift = 1.0
+    mdl_convolved = kern(mdl)
+
+    d = setup_data(elo=0.1, ehi=10, ebin=0.01)
+    dr = setup_data(elo=0.1, ehi=13, ebin=0.005)
+
+    mdl_regrid = mdl_convolved.regrid(dr.xlo, dr.xhi)
+
+    yconvolved = d.eval_model(mdl_convolved)
+    yregrid = d.eval_model(mdl_regrid)
+
+    # We expect values < 2 keV to be 0
+    #   yconvolved:  > 2 keV to < 5 keV to be 0.02 (ampl / bin width)
+    #   yregrid:     > 2 keV to < 6 keV to be 0.02
+    # above this to be 0, with some fun at the edges.
+    #
+    ehi = d.xhi
+
+    idx = np.where(ehi < 2)
+    ymax = np.abs(yconvolved[idx]).max()
+    assert ymax == 0.0, 'yconvolved < 2 keV: max={}'.format(ymax)
+
+    idx = np.where((ehi >= 2) & (ehi < 5))
+    ymax = np.abs(yconvolved[idx] - 0.02).max()
+    assert ymax < 1e-14, 'yconvolved: 2-5 keV max={}'.format(ymax)
+
+    idx = np.where(ehi >= 5)
+    ymax = np.abs(yconvolved[idx]).max()
+    assert ymax == 0.0, 'yconvolved: > 5 keV max={}'.format(ymax)
+
+    # expect last bin to be ~ 0 but preceeding ones to be zero
+    idx = np.where(ehi < 2)
+    ymax = np.abs(yregrid[idx][:-1]).max()
+    assert ymax == 0, 'yregrid < 2 keV: max={}'.format(ymax)
+
+    ymax = np.abs(yregrid[idx])[-1]
+    assert ymax < 1e-14, 'yregrid < 2 keV: max={}'.format(ymax)
+
+    idx = np.where((ehi >= 2) & (ehi < 6))
+    ymax = np.abs(yregrid[idx] - 0.02).max()
+    assert ymax < 2e-14, 'yregrid: 2-6 keV {}'.format(ymax)
+
+    # expect first bin to be ~ 0 but following ones to be zero
+    idx = np.where(ehi >= 6)
+    ymax = np.abs(yregrid[idx])[0]
+    assert ymax < 2e-14, 'yregrid: > 6 keV max={}'.format(ymax)
+
+    ymax = np.abs(yregrid[idx][1:]).max()
+    assert ymax == 0.0, 'yregrid: > 6 keV max={}'.format(ymax)
+
+
+@requires_xspec
+def test_xspec_con_ui_registered():
+    """Are the convolution models registered for use by the UI layer?"""
+
+    mdls = set(ui.list_models('xspec'))
+    for n, _, _ in XSPEC_CON_MODELS:
+        xsname = "xs{}".format(n)
+        assert xsname in mdls, xsname
+
+
+@requires_xspec
+@requires_data
+def test_xspec_con_ui_cflux(make_data_path, clean_astro_ui, restore_xspec_settings):
+    """Check cflux from the UI layer with a response."""
+
+    from sherpa.astro import xspec
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha('random', infile)
+    ui.subtract('random')
+    ui.ignore(None, 0.5)
+    ui.ignore(7, None)
+
+    ui.set_source('random', 'xsphabs.gal * xscflux.sflux(powlaw1d.pl)')
+    mdl = ui.get_source('random')
+
+    assert mdl.name == '(xsphabs.gal * xscflux.sflux(powlaw1d.pl))'
+    assert len(mdl.pars) == 7
+    assert mdl.pars[0].fullname == 'gal.nH'
+    assert mdl.pars[1].fullname == 'sflux.Emin'
+    assert mdl.pars[2].fullname == 'sflux.Emax'
+    assert mdl.pars[3].fullname == 'sflux.lg10Flux'
+    assert mdl.pars[4].fullname == 'pl.gamma'
+    assert mdl.pars[5].fullname == 'pl.ref'
+    assert mdl.pars[6].fullname == 'pl.ampl'
+
+    assert isinstance(mdl.lhs, xspec.XSphabs)
+    assert isinstance(mdl.rhs, xspec.XSConvolutionModel)
+
+    gal = ui.get_model_component('gal')
+    sflux = ui.get_model_component('sflux')
+    pl = ui.get_model_component('pl')
+    assert isinstance(gal, xspec.XSphabs)
+    assert isinstance(sflux, xspec.XScflux)
+    assert isinstance(pl, PowLaw1D)
+
+    # the convolution model needs the normalization to be fixed
+    # (not for this example, as we are not fitting, but do this
+    # anyway for reference)
+    pl.ampl.frozen = True
+
+    sflux.emin = 1
+    sflux.emax = 5
+    sflux.lg10Flux = -12.3027
+
+    pl.gamma = 2.03
+    gal.nh = 0.039
+
+    ui.set_xsabund('angr')
+    ui.set_xsxsect('vern')
+
+    # check we get the "expected" statistic (so this is a regression
+    # test).
+    #
+    ui.set_stat('chi2gehrels')
+    sinfo = ui.get_stat_info()
+
+    assert len(sinfo) == 1
+    sinfo = sinfo[0]
+    assert sinfo.numpoints == 40
+    assert sinfo.dof == 37
+    assert sinfo.statval == pytest.approx(21.25762265234619)
+
+    # Do we get the same flux from Sherpa's calc_energy_flux?
+    #
+    cflux = ui.calc_energy_flux(id='random', model=sflux(pl), lo=1, hi=5)
+    lcflux = np.log10(cflux)
+    assert lcflux == pytest.approx(sflux.lg10Flux.val)
+
+
+@requires_xspec
+@requires_data
+def test_xspec_con_ui_shift(make_data_path, clean_astro_ui, restore_xspec_settings):
+    """Check shifted models from the UI layer with a response.
+
+    There is no regrid here, so we see the issue with the upper edge of the
+    RMF cutting off the source.
+    """
+
+    from sherpa.astro import xspec
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+    ui.subtract()
+    ui.ignore(None, 0.5)
+    ui.ignore(7, None)
+
+    msource = ui.box1d.box + ui.const1d.bgnd
+    ui.set_source(ui.xsphabs.gal * ui.xszashift.zsh(msource))
+    mdl = ui.get_source()
+
+    assert mdl.name == '(xsphabs.gal * xszashift.zsh((box1d.box + const1d.bgnd)))'
+    assert len(mdl.pars) == 6
+    assert mdl.pars[0].fullname == 'gal.nH'
+    assert mdl.pars[1].fullname == 'zsh.Redshift'
+    assert mdl.pars[2].fullname == 'box.xlow'
+    assert mdl.pars[3].fullname == 'box.xhi'
+    assert mdl.pars[4].fullname == 'box.ampl'
+    assert mdl.pars[5].fullname == 'bgnd.c0'
+
+    assert isinstance(mdl.lhs, xspec.XSphabs)
+    assert isinstance(mdl.rhs, xspec.XSConvolutionModel)
+
+    gal = ui.get_model_component('gal')
+    zsh = ui.get_model_component('zsh')
+    box = ui.get_model_component('box')
+    bgnd = ui.get_model_component('bgnd')
+    assert isinstance(gal, xspec.XSphabs)
+    assert isinstance(zsh, xspec.XSzashift)
+    assert isinstance(box, Box1D)
+    assert isinstance(bgnd, Const1D)
+
+    zsh.redshift = 1
+
+    # turn off the absorption to make the comparison easier
+    gal.nh = 0
+
+    # pick an energy range that exceeds the RMF maximum energy (11 keV)
+    box.xlow = 10
+    box.xhi = 13
+    box.ampl = 0.5
+
+    bgnd.c0 = 0.001
+    bgnd.integrate = False
+
+    mplot = ui.get_source_plot()
+
+    # Expect, as z = 1
+    #
+    #    0.1 for E < 5 keV     (10 / (1+z))
+    #    0       E > 5.5 keV   (11 / (1+z))  due to RMF cut off
+    #    0.6     5 - 5.5 keV
+    #
+    idx1 = mplot.xhi <= 5
+    idx2 = mplot.xlo >= 5.5
+
+    # ensure we pick the "expected" range
+    assert idx1.sum() == 490
+    assert idx2.sum() == 550
+
+    assert mplot.xhi[idx1].max() == pytest.approx(5)
+    assert mplot.xlo[idx2].min() == pytest.approx(5.5)
+
+    # use the inverse of the two index arrays to ensure we are not
+    # missing any bins.
+    #
+    idx3 = ~(idx1 | idx2)
+
+    # The tolerance has to be relatively large otherwise things fail
+    assert mplot.y[idx1] == pytest.approx(0.1, rel=3e-5)
+    assert mplot.y[idx2] == pytest.approx(0)
+    assert mplot.y[idx3] == pytest.approx(0.6, rel=1e-5)
+
+
+@requires_xspec
+@requires_data
+def test_xspec_con_ui_shift_regrid(make_data_path, clean_astro_ui, restore_xspec_settings):
+    """Check shifted models from the UI layer with a response and regrid.
+
+    Unlike test_xspec_con_ui_shift, the convolution model is run on an extended
+    grid compared to the RMF.
+    """
+
+    from sherpa.astro import xspec
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+    ui.subtract()
+    ui.ignore(None, 0.5)
+    ui.ignore(7, None)
+
+    # Ensure the grid contains the RMF grid (0.1-11 keV).
+    # Really we should have emax to be > 11 * (1+z) but
+    # I purposefully pick a smaller maximum to check we
+    # get 0 values in the output
+    #
+    rgrid = np.arange(0.1, 20, 0.01)
+    rlo = rgrid[:-1]
+    rhi = rgrid[1:]
+
+    msource = ui.box1d.box + ui.const1d.bgnd
+    csource = ui.xszashift.zsh(msource)
+    ui.set_source(ui.xsphabs.gal * csource.regrid(rlo, rhi))
+    mdl = ui.get_source()
+
+    # What should the string representation be?
+    #
+    assert mdl.name == '(xsphabs.gal * regrid1d(xszashift.zsh((box1d.box + const1d.bgnd))))'
+
+    assert len(mdl.pars) == 6
+    assert mdl.pars[0].fullname == 'gal.nH'
+    assert mdl.pars[1].fullname == 'zsh.Redshift'
+    assert mdl.pars[2].fullname == 'box.xlow'
+    assert mdl.pars[3].fullname == 'box.xhi'
+    assert mdl.pars[4].fullname == 'box.ampl'
+    assert mdl.pars[5].fullname == 'bgnd.c0'
+
+    assert isinstance(mdl.lhs, xspec.XSphabs)
+    assert isinstance(mdl.rhs, RegridWrappedModel)
+
+    gal = ui.get_model_component('gal')
+    zsh = ui.get_model_component('zsh')
+    box = ui.get_model_component('box')
+    bgnd = ui.get_model_component('bgnd')
+    assert isinstance(gal, xspec.XSphabs)
+    assert isinstance(zsh, xspec.XSzashift)
+    assert isinstance(box, Box1D)
+    assert isinstance(bgnd, Const1D)
+
+    zsh.redshift = 1
+
+    # turn off the absorption to make the comparison easier
+    gal.nh = 0
+
+    # pick an energy range that exceeds the RMF maximum energy (11 keV)
+    box.xlow = 10
+    box.xhi = 13
+    box.ampl = 0.5
+
+    bgnd.c0 = 0.001
+    bgnd.integrate = False
+
+    mplot = ui.get_source_plot()
+
+    # Expect, as z = 1
+    #
+    #    0.1 for E < 5 keV  or  6.5 - 10 keV
+    #    0.6     5 - 6.5 keV
+    #    0       > 10 keV
+    #
+    idx1 = (mplot.xhi <= 5) | ((mplot.xlo >= 6.5) & (mplot.xhi <= 10))
+    idx2 = (mplot.xlo >= 5) & (mplot.xhi <= 6.5)
+    idx3 = mplot.xlo >= 10
+
+    # ensure we pick the "expected" range (there are 1090 bins in the
+    # RMF energy grid)
+    assert idx1.sum() == 840
+    assert idx2.sum() == 150
+    assert idx3.sum() == 100
+
+    # The tolerance has to be relatively large otherwise things fail
+    #
+    # It appears that the very-last bin of idx1 is actually ~ 0.05,
+    # so separate that out here. It is the last bin of the "valid"
+    # array, and so at z=1 may only have been half-filled by the
+    # convolution.
+    #
+    assert mplot.y[idx1][:-1] == pytest.approx(0.1, rel=1e-5)
+    assert mplot.y[idx1][-1] == pytest.approx(0.05, rel=3e-5)
+
+    assert mplot.y[idx2] == pytest.approx(0.6, rel=3e-5)
+    assert mplot.y[idx3] == pytest.approx(0)


### PR DESCRIPTION
# Summary

Add support for [XSPEC convolution-style models](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/node273.html) - this link is valid for XSPEC 12.10.1 documentation, it may need changing once the next version is released - such as [`cflux`](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCflux.html)  and [`reflect`](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelReflect.html).

Fixes #68 

# Notes

Since these models change the results of other models they are applied to models rather than combined with the +, *, -, or / operators. That is, you say `xscflux.cfl(mdlexpr)` to create a model instance called `cfl` which is applied to the model stored in `mdlexpr` (which could be a single component or multiple components). You can **not** use a model instance (e.g. `cfl`) directly - that is `cfl * xspowerlaw.pl` will not work.

# Examples

The following were run with

```python
>>> from sherpa.astro import xspec                                          
>>> print(xspec.get_xsversion())                                            
12.11.0
```

Previous versions used version 12.10.1

## Example: cflux

The [`cflux` model](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelCflux.html) is a "hack" that lets a user find out the integrated flux for a model (over the emin to emax range of the `cflux` component) via the models `lg10Flux` parameter. It can be applied to multiple components but here I show it calculating the unabsorbed flux for a powerlaw fit. Note that you need to freeze the amplitude of the model expression it convolves (otherwise the parameters are degenerate and the optimiser will have a fit if you try to fit).

In the following I get the unabsorbed flux for the 0.5-7 keV range from `cflux` and then from Sherpa's `calc_energy_flux` command. I haven't tried any of the other "sherpa flux" functionality, which might be interesting to look at how the errors compare, but that is outside of this PR, as I just want to show that `cflux` is behaving sensibly here.

```python
>>> from sherpa.astro import ui
>>> ui.load_pha('sherpa-test-data/sherpatest/3c273.pi')
>>> ui.subtract()
>>> ui.ignore(None, 0.5)
>>> ui.ignore(7, None)
>>> ui.set_source(ui.xsphabs.gal * ui.xscflux.cfl(ui.powlaw1d.pl))
>>> pl.ampl.frozen = True
>>> cfl.emin = 0.5
>>> cfl.emax = 7
>>> print(ui.get_source())
(xsphabs.gal * xscflux.cfl(powlaw1d.pl))
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   gal.nH       thawed            1            0       100000 10^22 atoms / cm^2
   cfl.Emin     frozen          0.5            0        1e+06        keV
   cfl.Emax     frozen            7            0        1e+06        keV
   cfl.lg10Flux thawed          -12         -100          100        cgs
   pl.gamma     thawed            1          -10           10           
   pl.ref       frozen            1 -3.40282e+38  3.40282e+38           
   pl.ampl      frozen            1            0  3.40282e+38           

>>> print(ui.get_model().name)                                             
apply_rmf(apply_arf((38564.608926889 * (xsphabs.gal * xscflux.cfl(powlaw1d.pl)))))
>>> ui.fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 307.417
Final fit statistic   = 20.9832 at function evaluation 29
Data points           = 40
Degrees of freedom    = 37
Probability [Q-value] = 0.984159
Reduced statistic     = 0.567113
Change in statistic   = 286.434
   gal.nH         0.0110431    +/- 0.0582018   
   cfl.lg10Flux   -12.1021     +/- 0.0409627   
   pl.gamma       1.98732      +/- 0.155614    

>>> ui.conf()
gal.nH lower bound:	-----
gal.nH upper bound:	0.060225
pl.gamma lower bound:	-0.101081
pl.gamma upper bound:	0.15686
cfl.lg10Flux lower bound:	-0.0292446
cfl.lg10Flux upper bound:	0.0419616
Dataset               = 1
Confidence Method     = confidence
Iterative Fit Method  = None
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   gal.nH          0.0110431        -----     0.060225
   cfl.lg10Flux     -12.1021   -0.0292446    0.0419616
   pl.gamma          1.98732    -0.101081      0.15686

```

which can be compared to the Sherpa fit without the component:

```python
>>> ui.set_source(gal * pl)
>>> pl.ampl.frozen = False
>>> ui.fit()                                                               
Dataset               = 1
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 1.03755e+10
Final fit statistic   = 20.9832 at function evaluation 17
Data points           = 40
Degrees of freedom    = 37
Probability [Q-value] = 0.984159
Reduced statistic     = 0.567113
Change in statistic   = 1.03755e+10
   gal.nH         0.0110321    +/- 0.0581733   
   pl.gamma       1.98731      +/- 0.155599    
   pl.ampl        0.000185457  +/- 3.28374e-05 

>>> ui.conf()
gal.nH lower bound:	-----
gal.nH upper bound:	0.0602362
pl.ampl lower bound:	-1.806e-05
pl.ampl upper bound:	3.5531e-05
pl.gamma lower bound:	-0.101072
pl.gamma upper bound:	0.156001
Dataset               = 1
Confidence Method     = confidence
Iterative Fit Method  = None
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   gal.nH          0.0110321        -----    0.0602362
   pl.gamma          1.98731    -0.101072     0.156001
   pl.ampl       0.000185457   -1.806e-05   3.5531e-05

```

We can see that `nH` and `gamma` are essentially the same, and the reduced statistic is the same (0.567), which you would hope if `cflux` is working correctly. We can compare the flux too

```python
>>> flux = ui.calc_energy_flux(lo=0.5, hi=7, model=pl)
>>> import numpy as np
>>> print(np.log10(flux))
-12.102113047531182
>>> print(cfl.lg10Flux.val)                                                
-12.102111949073732
```

So they agree to the third decimal place (after rounding).

## Example: zashift

The [`zashift` model](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZashift.html) redshifts an "additive" style model. Here we use it to redshift a flat background plus box (10-14 keV) from a redshift of 1 to the observed band. I chose these limits since the RMF cuts off at 11 keV, so we can see the need for the "regrid" support (and check how this works).

```python
>>> ui.set_source(ui.xszashift.zsh(ui.box1d.box + ui.const1d.bgnd))
>>> print(ui.get_source())                                                 
xszashift.zsh((box1d.box + const1d.bgnd))
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   zsh.Redshift frozen            0       -0.999           10           
   box.xlow     thawed            0 -3.40282e+38  3.40282e+38           
   box.xhi      thawed            0 -3.40282e+38  3.40282e+38           
   box.ampl     thawed            1           -1            1           
   bgnd.c0      thawed            1 -3.40282e+38  3.40282e+38           

>>> zsh.redshift = 1
>>> box.xlo = 10
>>> box.xhi = 14
```

We can see what these look like (manually using matplotlib to create two plots since `ui.plot` does not handle PHA plots well, which is an issue somewhere but I'm not going to look for it as it's irrelevant to this PR):

```python
>>> from matplotlib import pyplot as plt
>>> plt.subplot(2, 1, 1)
>>> ui.plot_source(clearwindow=False)
>>> plt.subplot(2, 1, 2)
>>> ui.plot_model(clearwindow=False)
```

![plots](https://user-images.githubusercontent.com/224638/75913845-af86cc00-5e21-11ea-9b91-6803a13065e5.png)

You can see that the box model has been redshifted from 10-14 keV to 5-7 keV (the background is a constant so it appears unshifted), except that the RMF cut off at 11 keV means that there's no signal above 11/(1+z)=5.5 keV. This is not an issue with this PR, but is my original driver for the regrid code.

## Example: zshift + regrid

Can we use the regrid support to extend the array over which the convolution is performed? To avoid known issues with the current regrid support when there's partial overlap of the grid (which are being worked on) I am going to make sure the "regrid" grid covers the RMF grid (which is 0.1 to 11 keV with a spacing of 0.01 keV).

I think this example - namely how `regrid` is used to create a new model - has a certain amount of logic behind it, but I am not convinced it is the best API for users of the UI layer, but this is related to the `regrid` support and is not part of this PR (i.e. I don't want bike-shedding on this part of Sherpa to slow down this PR :-)

```python
>>> rmf = ui.get_rmf()
>>> print((rmf.energ_lo[0], rmf.energ_hi[-1]))                             
(0.10000000149011612, 11.0)
>>> print(rmf.energ_hi[0] - rmf.energ_lo[0])                               
0.009999997913837433
```

```python
>>> rgrid = np.arange(0.1, 24, 0.01)
>>> print(ui.get_source())                                                 
xszashift.zsh((box1d.box + const1d.bgnd))
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   zsh.Redshift frozen            1       -0.999           10           
   box.xlow     thawed           10 -3.40282e+38  3.40282e+38           
   box.xhi      thawed           14 -3.40282e+38  3.40282e+38           
   box.ampl     thawed            1           -1            1           
   bgnd.c0      thawed            1 -3.40282e+38  3.40282e+38           

>>> orig_mdl = ui.get_source()
>>> shifted_model = orig_mdl.regrid(rgrid[:-1], rgrid[1:])
>>> ui.set_source(shifted_model)
>>> print(ui.get_source())                                                
regrid1d(xszashift.zsh((box1d.box + const1d.bgnd)))
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   zsh.Redshift frozen            1       -0.999           10           
   box.xlow     thawed           10 -3.40282e+38  3.40282e+38           
   box.xhi      thawed           14 -3.40282e+38  3.40282e+38           
   box.ampl     thawed            1           -1            1           
   bgnd.c0      thawed            1 -3.40282e+38  3.40282e+38           

```

After this we can see that the source is evaluated "correctly", in that the box is defined over the 5-7 keV range, and the background is still there at higher energies (this is **not** meant to be a realistic model, which is why the `plot_model` output looks strange):

```python
>>> plt.subplot(2, 1, 1)
>>> ui.plot_source(clearwindow=False)
>>> plt.subplot(2, 1, 2)
>>> ui.plot_model(clearwindow=False)
```

![plots](https://user-images.githubusercontent.com/224638/75915434-7b60da80-5e24-11ea-98c1-193f2874c36d.png)

# What happens when the models are used incorrectly

That is, how useful are the error messages? I am going to try and compare to existing behavior where possible.

## Do not supply an instance name

We see the same error as with the existing models:
 
```python
>>> ui.set_source(ui.powlaw1d)
...
ArgumentTypeErr: 'source model' must be a model object or model expression string
>>> ui.set_source(ui.xscflux)
...
ArgumentTypeErr: 'source model' must be a model object or model expression string 
```

and

```python
>>> ui.set_source(ui.xsphabs.gal * ui.powlaw1d)
...
TypeError: float() argument must be a string or a number, not 'ModelWrapper'
>>> ui.set_source(ui.xsphabs.gal * ui.xscflux)
...
TypeError: float() argument must be a string or a number, not 'ModelWrapper'
```

## Do not include a model instance

The following is incorrect, since `fluxmodel` has no model expression to work with, but there's no error when we call `set_source`. Instead, we see the error when the model is evaluated (e.g. `plot_source`, `calc_stat`, `fit`, ...), and unfortunately they are different, and neither are particularly useful.

```python
>>> ui.set_source(ui.xscflux.fluxmodel)
>>> ui.plot_source()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-15-43d3ac1dbe0f> in <module>
----> 1 ui.plot_source()

<string> in plot_source(id, lo, hi, replot, overplot, clearwindow, **kwargs)

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/astro/ui/utils.py in plot_source(self, id, lo, hi, replot, overplot, clearwindow, **kwargs)
  11211             self._plot(id, self._astrosourceplot, None, None, lo, hi,
  11212                        replot=replot, overplot=overplot,
> 11213                        clearwindow=clearwindow, **kwargs)
  11214         else:
  11215             self._plot(id, self._sourceplot, replot=replot,

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/ui/utils.py in _plot(self, id, plotobj, *args, **kwargs)
  11693 
  11694         if not sherpa.utils.bool_cast(kwargs.pop('replot', False)):
> 11695             obj = self._prepare_plotobj(id, plotobj, *args)
  11696         try:
  11697             sherpa.plot.begin()

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/astro/ui/utils.py in _prepare_plotobj(self, id, plotobj, resp_id, bkg_id, lo, hi, orders, model)
  10955             data = self.get_data(id)
  10956             src = self.get_source(id)
> 10957             plotobj.prepare(data, src, lo, hi)
  10958         elif isinstance(plotobj, sherpa.plot.SourcePlot):
  10959             data = self.get_data(id)

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/astro/plot.py in prepare(self, data, src, lo, hi)
    144         self.xlo, self.xhi = data._get_indep(filter=False)
    145         self.mask = filter_bins((lo,), (hi,), (self.xlo,))
--> 146         self.y = src(self.xlo, self.xhi)
    147         prefix_quant = 'E'
    148         quant = 'keV'

TypeError: __call__() takes 2 positional arguments but 3 were given

>>> ui.calc_stat()                                                         
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-16-94340e5b917e> in <module>
----> 1 ui.calc_stat()

<string> in calc_stat(id, *otherids)

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/ui/utils.py in calc_stat(self, id, *otherids)
   8072         """
   8073         ids, f = self._get_fit(id, otherids)
-> 8074         return f.calc_stat()
   8075 
   8076     def calc_chisqr(self, id=None, *otherids):

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/fit.py in calc_stat(self)
   1114         """
   1115 
-> 1116         return self._calc_stat()[0]
   1117 
   1118     def calc_chisqr(self):

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/fit.py in _calc_stat(self)
   1095         # TODO: is there anything missing here that
   1096         #       self._iterfit.get_extra_args calculates?
-> 1097         return self.stat.calc_stat(self.data, self.model)
   1098 
   1099     def calc_stat(self):

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/stats/__init__.py in calc_stat(self, data, model)
    544 
    545     def calc_stat(self, data, model):
--> 546         fitdata, modeldata = self._get_fit_model_data(data, model)
    547 
    548         return self._calc(fitdata[0], modeldata,

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/stats/__init__.py in _get_fit_model_data(self, data, model)
    204         data, model = self._validate_inputs(data, model)
    205         fitdata = data.to_fit(staterrfunc=self.calc_staterror)
--> 206         modeldata = data.eval_model_to_fit(model)
    207 
    208         return fitdata, modeldata

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/data.py in eval_model_to_fit(self, modelfuncs)
    885 
    886         for func, data in zip(modelfuncs, self.datasets):
--> 887             total_model.append(data.eval_model_to_fit(func))
    888 
    889         return numpy.concatenate(total_model)

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/astro/data.py in eval_model_to_fit(self, modelfunc)
   1691 
   1692     def eval_model_to_fit(self, modelfunc):
-> 1693         return self.apply_filter(modelfunc(*self.get_indep(filter=True)))
   1694 
   1695     def sum_background_data(self,

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/models/model.py in __call__(self, *args, **kwargs)
    262         if (len(args) == 0 and len(kwargs) == 0):
    263             return self
--> 264         return self.calc([p.val for p in self.pars], *args, **kwargs)
    265 
    266     def _get_thawed_pars(self):

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/astro/instrument.py in calc(self, p, x, xhi, *args, **kwargs)
    567         else:
    568             xhi = self.xhi
--> 569         src = self.model.calc(p, xlo, xhi)
    570         bin_mask = self.rmf.bin_mask
    571         if bin_mask is not None and \

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/models/model.py in calc(self, p, *args, **kwargs)
    614         nlhs = len(self.lhs.pars)
    615         lhs = self.lhs.calc(p[:nlhs], *args, **kwargs)
--> 616         rhs = self.rhs.calc(p[nlhs:], *args, **kwargs)
    617         try:
    618             val = self.op(lhs, rhs)

/lagado2.real/local/anaconda/envs/sherpa-add-xspec-convolution-api/lib/python3.7/site-packages/sherpa-4.7+2194.g06d19b0.dirty-py3.7-linux-x86_64.egg/sherpa/astro/xspec/__init__.py in calc(self, pars, rhs, *args, **kwargs)
   1076         #
   1077         # fluxes = np.asarray(rhs(rpars, *args, **kwargs))
-> 1078         fluxes = np.asarray(rhs(rpars, *args))
   1079         return self._calc(lpars, fluxes, *args)
   1080 

TypeError: 'numpy.ndarray' object is not callable

>>> ui.fit()
... same error as from calc_stat ...
```

It looks like more-complicated incorrect expressions such as

```python
>>> ui.set_source(ui.xsphabs.gal * ui.xscflux.cfl * ui.xspowerlaw.pl)
```

return the "`numpy.ndarray`" type error even for `ui.plot_source`.

# Details

Sherpa contains "C level" bindings to the XSPEC convolution models, but we have not provided "python level" access to these from Sherpa. I have maintained such an interface in the SDS contributed code, but now that the regrid support is in (needed to use a number of XSPEC convolution models), it makes sense to move the code into Sherpa.

Originally I had added a number of "load" routines (based on `load_psf`), one for each convolution model, to create an instance of the model, but in this PR I have decided not to provide this interface, as it isn't needed. There's nothing in this PR that means we couldn't add in such routines (or a single load routine that takes the convolution-model name as an argument, for instance), if we think it's useful (but I'd rather not as I don't think it helps users and just gives us more things to document/test and increases the API).

Each model is an instance of the `XSConvolutionKernel` class, and when applied to other models it creates a `XSConvolutionModel` instance. I based this on how the PSF convolution kernel is set up. It works, but is an area of the design that needs checking (ie that it makes sense). The code changes are quite small however, which suggests that it fits into Sherpa's "design".