### PR TITLE
sample_flux now returns statistic values for each row

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -527,7 +527,7 @@ def sample_flux(fit, data, src,
     return numpy.concatenate((vals, numpy.expand_dims(clipped, 1)), axis=1)
 
 
-def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
+def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
                      confidence):
     """Given a set of parameter samples, estimate the flux distribution.
 
@@ -542,21 +542,17 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
     .. versionchanged:: 4.13.1
        The clipping now includes parameters at the soft limits;
        previously they were excluded which could cause problems with
-       parameters for which we can only calculate an upper limit.
+       parameters for which we can only calculate an upper limit. The
+       id and session arguments have been removed.
 
     Parameters
     ----------
-    id : int or str
-        The dataset identifier. It must exist and have an associated model in
-        session.
     lo : number or None, optional
         The lower edge of the dataspace range for the flux calculation.
         If None then the lower edge of the data grid is used.
     hi : number or None, optional
         The upper edge of the dataspace range for the flux calculation.
         If None then the upper edge of the data grid is used.
-    session : sherpa.ui.utils.Session instance
-        Defines the data, model, and fit.
     fit : sherpa.fit.Fit instance
         The fit object. The src parameter is assumed to be a subset of
         the fit.model expression (to allow for calculating the flux of
@@ -665,11 +661,10 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
             oflx[nn] = mysim[nn, 0]
 
             for par, parval in zip(thawedpars, mysim[nn, 1:]):
-                session.set_par(par.fullname, parval)
+                par.set(parval)
 
             iflx[nn] = calc_energy_flux(data, modelcomponent, lo=lo, hi=hi)
-
-            mystat.append(session.calc_stat(id))
+            mystat.append(fit.calc_stat())
 
         logger.setLevel(orig_log_level)
 

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -641,22 +641,8 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
     #
     orig_model_vals = fit.model.thawedpars
 
-    logger = logging.getLogger("sherpa")
-    orig_log_level = logger.level
-
-    # only change the log level if it is less than error
-    #
-    if orig_log_level < logging.ERROR:
-        logger.setLevel(logging.ERROR)
-
-    # With the move to calling calc_energy_flux directly there should
-    # be no need to change the logging level, but leave in for now.
-    #
+    mystat = []
     try:
-
-        logger.setLevel(logging.ERROR)
-
-        mystat = []
         for nn in range(size):
             oflx[nn] = mysim[nn, 0]
 
@@ -666,17 +652,13 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
             iflx[nn] = calc_energy_flux(data, modelcomponent, lo=lo, hi=hi)
             mystat.append(fit.calc_stat())
 
-        logger.setLevel(orig_log_level)
-
     finally:
-
         fit.model.thawedpars = orig_model_vals
-        logger.setLevel(orig_log_level)
 
     hwidth = confidence / 2
     result = []
-    for x in [oflx, iflx]:
-        result.append(numpy.percentile(x, [50, 50 + hwidth, 50 - hwidth]))
+    for flx in [oflx, iflx]:
+        result.append(numpy.percentile(flx, [50, 50 + hwidth, 50 - hwidth]))
 
     for lbl, arg in zip(['original model', 'model component'], result):
         med, usig, lsig = arg
@@ -689,7 +671,6 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
     for index in range(size):
         samples[index][-1] = mystat[index]
 
-    # samples = numpy.delete( samples, (size), axis=0 )
     result.append(samples)
 
     return result

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -630,16 +630,12 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
     softmins = fit.model.thawedparmins
     softmaxs = fit.model.thawedparmaxes
 
-    def simulated_pars_within_ranges(mysamples, mysoftmins, mysoftmaxs):
+    # We have to use columns 1 to n-1 of samples
+    valid = numpy.ones(samples.shape[0], dtype=numpy.bool)
+    for col, pmin, pmax in zip(samples.T[1:-1], softmins, softmaxs):
+        valid &= (col >= pmin) & (col <= pmax)
 
-        for i, (pmin, pmax) in enumerate(zip(mysoftmins, mysoftmaxs), 1):
-            parvals = mysamples[:, i]
-            tmp = (parvals >= pmin) & (parvals <= pmax)
-            mysamples = mysamples[tmp]
-
-        return mysamples
-
-    mysim = simulated_pars_within_ranges(samples, softmins, softmaxs)
+    mysim = samples[valid]
 
     size = len(mysim[:, 0])
     oflx = numpy.zeros(size)  # observed/absorbed flux

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -655,11 +655,8 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
                 else:
                     par.set(parval)
 
-            # This will calculate fluxes we do not use (when valid has
-            # False values in it) but the assumption is that this is
-            # a small number of rows.
-            #
-            iflx[nn] = calc_energy_flux(data, modelcomponent, lo=lo, hi=hi)
+            if valid[nn]:
+                iflx[nn] = calc_energy_flux(data, modelcomponent, lo=lo, hi=hi)
 
             mystat[nn, 0] = fit.calc_stat()
 

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -2034,11 +2034,11 @@ def test_sample_flux_751_752(idval, make_data_path, clean_astro_ui,
     clips = vals[:, -2]
     assert (clips == 0).all()
 
-    # All the statistic values should be set (> 0). This is #751.
+    # All the statistic values should be set (> 0). This wasn't until #751
+    # was addressed.
     #
     stats = vals[:, -1]
-    # assert (stats > 0).all()
-    assert (stats > 0).sum() == 81
+    assert (stats > 0).all()
 
 
 @requires_xspec

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13260,7 +13260,9 @@ class Session(sherpa.ui.utils.Session):
            controlled by the Sherpa logging setup. The flux
            calculation no-longer excludes samples at the parameter
            soft limits, as this could cause an over-estimation of the
-           flux when a parameter is only an upper limit.
+           flux when a parameter is only an upper limit. The statistic
+           value is now returned for each row, even those that were
+           excluded from the flux calculation.
 
         Parameters
         ----------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13433,7 +13433,7 @@ class Session(sherpa.ui.utils.Session):
                                               numcores=numcores,
                                               bkg_id=bkg_id)
 
-        return sherpa.astro.flux.calc_sample_flux(id=id, lo=lo, hi=hi, session=self,
+        return sherpa.astro.flux.calc_sample_flux(lo=lo, hi=hi,
                                                   fit=fit, data=data, samples=samples,
                                                   modelcomponent=modelcomponent,
                                                   confidence=confidence)


### PR DESCRIPTION
# Summary

The sample_flux command now returns a statistic value for each iteration, even if those rows are not used in the reported flux distribution. Fixes #751.

# Details

There are some associated code clean ups that reduce the amount of information sent to sherpa.astro.flux.calc_sample_flux, and reduce the complexity of the code. The main functional change is that we now loop through all samples, so we can calculate the statistic for each sample. Previously this was only done for those rows that were not "clipped", and so the mapping from parameter row to sample was lost (i.e. you could only guarantee that this held was when no rows were "clipped").

# Not addressed here

Just to remind myself of what still needs looking at (this was my original PR which was much larger and complex but has slowly been merged in pieces thanks to @hamogu so it's now much simpler).

 - Xrays=False (#755)
 - you can't get the flux distribution when modelcomponent is set (#795)
 - work on multiple datasets (#404)
 - what happens with background data sets (e.g flux for a background model); #1048 probably needs fixing first
 - what happens if you've used set_full_model (for this and the *_energy/photon_flux routines)?
