### PR TITLE
calculate_photon_flux/calculate_energy_flux fix and improvement

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -27,7 +27,6 @@ import pytest
 from sherpa.utils import _ncpus
 from sherpa.utils.testing import SherpaTestCase, requires_data, \
     requires_fits, requires_xspec, requires_group
-from sherpa import get_config
 import sherpa.astro.ui as ui
 from sherpa.astro.data import DataPHA
 
@@ -113,17 +112,20 @@ class test_threads(SherpaTestCase):
             assert calc == approx(-0.57731725, rel=1e-4)
 
             calc = ui.calc_kcorr([1, 1.2, 1.4, 1.6, 1.8, 2], 0.5, 2)
-            expected = [0.93341286, 0.93752836, 0.94325233,
-                        0.94990140, 0.95678054, 0.96393515]
+            # Prior to fixing #619 the expected values were
+            # expected = [0.93341286, 0.93752836, 0.94325233,
+            #             0.94990140, 0.95678054, 0.96393515]
+            expected = [0.93132747, 0.9352768, 0.94085917,
+                        0.94738472, 0.95415463, 0.96121113]
             assert calc == approx(expected, rel=1e-4)
-            
+
         self.run_thread('pha_intro')
         # astro.ui imported as ui, instead of
         # being in global namespace
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_pha_intro(fit_results, self.locals['p1'], covarerr)
-        
+
         self.run_thread('pha_intro_ncpus')
         # astro.ui imported as ui, instead of
         # being in global namespace
@@ -134,7 +136,7 @@ class test_threads(SherpaTestCase):
             assert fit_results.extra_output['num_parallel_map'] > 0
         else:
             assert fit_results.extra_output['num_parallel_map'] == 0
-            
+
     @requires_fits
     def test_pha_read(self):
         self.run_thread('pha_read')
@@ -160,8 +162,7 @@ class test_threads(SherpaTestCase):
             self.assertEqual(fit_results.nfev, 9)
             self.assertEqual(fit_results.numpoints, 11)
             self.assertEqual(fit_results.dof, 9)
-          
-            
+
         # In data1.dat for this test, there is a comment with one
         # word at the beginning -- deliberately would break when reading
         # with DM ASCII kernel, but passes because we have Sherpa code
@@ -171,7 +172,7 @@ class test_threads(SherpaTestCase):
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_test_basic(fit_results, self.locals, covarerr)
         self.assertEqual(0, fit_results.extra_output['num_parallel_map'])
-        
+
         self.run_thread('basic_ncpus')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -180,7 +181,7 @@ class test_threads(SherpaTestCase):
             assert fit_results.extra_output['num_parallel_map'] > 0
         else:
             assert fit_results.extra_output['num_parallel_map'] == 0
-        
+
     @requires_fits
     @requires_xspec
     def test_simultaneous(self):
@@ -188,7 +189,7 @@ class test_threads(SherpaTestCase):
         def cmp_simultaneous(fit_results, mylocals, covarerr):
             abs1 = mylocals['abs1']
             pl1 = mylocals['pl1']
-            pl2 = mylocals['pl2']            
+            pl2 = mylocals['pl2']
             assert covarerr[0] == approx(0.397769, rel=1e-3)
             assert covarerr[1] == approx(0.486058, rel=1e-3)
             assert covarerr[2] == approx(1.48213e-05, rel=1e-3)
@@ -202,13 +203,13 @@ class test_threads(SherpaTestCase):
             self.assertEqualWithinTol(pl2.ampl.val, 2.44585e-05, 1e-3)
             self.assertEqual(fit_results.numpoints, 18)
             self.assertEqual(fit_results.dof, 14)
-           
+
         self.run_thread('simultaneous')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_simultaneous(fit_results, self.locals, covarerr)
         self.assertEqual(0, fit_results.extra_output['num_parallel_map'])
-        
+
         self.run_thread('simultaneous_ncpus')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -217,7 +218,7 @@ class test_threads(SherpaTestCase):
             assert fit_results.extra_output['num_parallel_map'] > 0
         else:
             assert fit_results.extra_output['num_parallel_map'] == 0
-        
+
     @requires_fits
     @requires_xspec
     def test_sourceandbg(self):
@@ -241,13 +242,13 @@ class test_threads(SherpaTestCase):
             self.assertEqualWithinTol(b2.norm.val, 1.16118e-05, 1e-2)
             self.assertEqual(fit_results.numpoints, 1330)
             self.assertEqual(fit_results.dof, 1325)
-            
+
         self.run_thread('sourceandbg')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_sourceanddbg(fit_results, self.locals, covarerr)
         self.assertEqual(0, fit_results.extra_output['num_parallel_map'])
-        
+
         self.run_thread('sourceandbg_ncpus')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -256,7 +257,7 @@ class test_threads(SherpaTestCase):
             fit_results.extra_output['num_parallel_map'] > 0
         else:
             assert fit_results.extra_output['num_parallel_map'] == 0
-        
+
     @requires_fits
     def test_spatial(self):
         self.run_thread('spatial')
@@ -292,13 +293,13 @@ class test_threads(SherpaTestCase):
             self.assertEqual(fit_results.nfev, 92)
             self.assertEqual(fit_results.numpoints, 38)
             self.assertEqual(fit_results.dof, 35)
-            
+
         self.run_thread('radpro')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_radpro(fit_results, self.locals, covarerr)
         self.assertEqual(0, fit_results.extra_output['num_parallel_map'])
-        
+
         self.run_thread('radpro_ncpus')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -385,7 +386,7 @@ class test_threads(SherpaTestCase):
 
     @requires_fits
     def test_linepro(self):
-        
+
         def cmp_linepro(fit_results, mylocals, covarerr):
             b1 = mylocals['b1']
             assert covarerr[0] == approx(0.176282, rel=1e-4)
@@ -398,13 +399,13 @@ class test_threads(SherpaTestCase):
             self.assertEqual(fit_results.nfev, 17)
             self.assertEqual(fit_results.numpoints, 75)
             self.assertEqual(fit_results.dof, 72)
-            
+
         self.run_thread('linepro')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_linepro(fit_results, self.locals, covarerr)
         self.assertEqual(0, fit_results.extra_output['num_parallel_map'])
-        
+
         self.run_thread('linepro_ncpus')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -413,7 +414,7 @@ class test_threads(SherpaTestCase):
             assert fit_results.extra_output['num_parallel_map'] > 0
         else:
             assert fit_results.extra_output['num_parallel_map'] == 0
-            
+
     @requires_fits
     def test_kernel(self):
 
@@ -429,13 +430,13 @@ class test_threads(SherpaTestCase):
             self.assertEqual(fit_results.nfev, 21)
             self.assertEqual(fit_results.numpoints, 75)
             self.assertEqual(fit_results.dof, 72)
-            
+
         self.run_thread('kernel')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         cmp_kernel(fit_results, self.locals, covarerr)
         self.assertEqual(0, fit_results.extra_output['num_parallel_map'])
-        
+
         self.run_thread('kernel_ncpus')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -444,7 +445,7 @@ class test_threads(SherpaTestCase):
             assert fit_results.extra_output['num_parallel_map'] > 0
         else:
             assert fit_results.extra_output['num_parallel_map'] == 0
-            
+
     @requires_fits
     @requires_xspec
     def test_spectrum(self):
@@ -466,13 +467,13 @@ class test_threads(SherpaTestCase):
             assert mek2.norm.val == approx(1.03724, rel=1e-4)
             self.assertEqual(fres.numpoints, 446)
             self.assertEqual(fres.dof, 441)
-            
+
         self.run_thread('spectrum')
         fres = ui.get_fit_results()
         covarerr = sqrt(fres.extra_output['covar'].diagonal())
         cmp_spectrum(fres, self.locals, covarerr)
         self.assertEqual(0, fres.extra_output['num_parallel_map'])
-        
+
         self.run_thread('spectrum_ncpus')
         fres = ui.get_fit_results()
         covarerr = sqrt(fres.extra_output['covar'].diagonal())
@@ -481,7 +482,7 @@ class test_threads(SherpaTestCase):
             assert fres.extra_output['num_parallel_map'] > 0
         else:
             assert fres.extra_output['num_parallel_map'] == 0
-            
+
     @requires_fits
     def test_histo(self):
         self.run_thread('histo')
@@ -509,13 +510,13 @@ class test_threads(SherpaTestCase):
             self.assertEqual(fres.nfev, 95)
             self.assertEqual(fres.numpoints, 162)
             self.assertEqual(fres.dof, 159)
-            
+
         self.run_thread('xmm')
         fres = ui.get_fit_results()
         covarerr = sqrt(fres.extra_output['covar'].diagonal())
         cmp_xmm(fres, self.locals, covarerr)
         self.assertEqual(0, fres.extra_output['num_parallel_map'])
-        
+
         self.run_thread('xmm_ncpus')
         fres = ui.get_fit_results()
         covarerr = sqrt(fres.extra_output['covar'].diagonal())
@@ -545,7 +546,7 @@ class test_threads(SherpaTestCase):
         covarerr = sqrt(fres.extra_output['covar'].diagonal())
         cmp_grouped_ciao4_5(fres, self.locals, covarerr)
         self.assertEqual(0, fres.extra_output['num_parallel_map'])
-        
+
         self.run_thread('grouped_ciao4.5_ncpus')
         fres = ui.get_fit_results()
         covarerr = sqrt(fres.extra_output['covar'].diagonal())
@@ -554,7 +555,7 @@ class test_threads(SherpaTestCase):
             assert fres.extra_output['num_parallel_map'] > 0
         else:
             assert fres.extra_output['num_parallel_map'] == 0
-        
+
     @requires_fits
     @requires_xspec
     def test_proj(self):
@@ -649,7 +650,7 @@ class test_threads(SherpaTestCase):
             assert conf.parmaxes[0] == approx(62.0585, rel=0.01)
             assert conf.parmins[1] == approx(-9.5568e-07, rel=0.01)
             assert conf.parmaxes[1] == approx(2.39937e-06, rel=0.01)
-            
+
         self.run_thread('proj_bubble')
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
@@ -661,10 +662,9 @@ class test_threads(SherpaTestCase):
         fit_results = ui.get_fit_results()
         covarerr = sqrt(fit_results.extra_output['covar'].diagonal())
         proj = ui.get_proj_results()
-        conf = ui.get_conf_results()        
+        conf = ui.get_conf_results()
         cmp_proj_bubble(self.locals, covarerr, proj, conf)
-        
-        
+
         # # Fit -- Results from reminimize
 
         # # The fit results change in XSPEC 12.10.0 since the mekal model
@@ -680,7 +680,6 @@ class test_threads(SherpaTestCase):
         # assert covar.parmins[1] == approx(-8.847916e-7, rel=0.01)
         # assert covar.parmaxes[0] == approx(0.328832, rel=0.01)
         # assert covar.parmaxes[1] == approx(8.847916e-7, rel=0.01)
-
 
     # New tests based on SDS threads -- we should catch these errors
     # (if any occur) so SDS doesn't waste time tripping over them.

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -78,7 +78,6 @@ def test_calc_flux_pha_invalid_model(func, make_data_path, clean_astro_ui):
         func(0.5, 7, model='pl')
 
 
-@pytest.mark.xfail(reason='bug #619')
 def test_calc_flux_pha_bin_edges(clean_astro_ui):
     """What happens when filter edges partially overlap bins?
 
@@ -150,7 +149,6 @@ def test_calc_flux_pha_bin_edges(clean_astro_ui):
     assert eflux == pytest.approx(expected_eflux)
 
 
-@pytest.mark.xfail(reason='bug #619')
 def test_calc_flux_pha_density_bin_edges(clean_astro_ui):
     """What happens when filter edges partially overlap bins? flux density
 
@@ -360,13 +358,13 @@ def test_calc_flux_pha_analysis(elo, ehi, setting, lo, hi, make_data_path, clean
 @pytest.mark.parametrize("id", [None, 1, "foo"])
 @pytest.mark.parametrize("energy", [0.05,
                                     0.1,
-                                    fails_619(0.109),
+                                    0.109,
                                     0.11,
                                     1,
-                                    fails_619(1.015),
+                                    1.015,
                                     5,
                                     10.99,
-                                    fails_619(10.991),
+                                    10.991,
                                     11,
                                     15])
 def test_calc_flux_density_pha(id, energy, make_data_path, clean_astro_ui):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -12838,13 +12838,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        lo : number, optional
-           The minimum limit of the band. Use ``None``, the default,
-           to use the low value of the data set.
-        hi : number, optional
-           The maximum limit of the band, which must be larger than
-           `lo`. Use ``None``, the default, to use the upper value of
-           the data set.
+        lo, hi : number, optional
+           If both are None or both are set then calculate the flux
+           over the given band. If only one is set then calculate
+           the flux density at that point. The units for `lo` and `hi`
+           are given by the current analysis setting.
         id : int or str, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
@@ -12856,14 +12854,10 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         flux : number
-           The flux from the source model integrated over the given
-           band. This represents the flux from the model without any
-           instrument response (i.e. the intrinsic flux of the
-           source). For X-Spec style models the units will be
-           photon/cm^2/s. If `hi` is ``None`` but `lo` is set the
-           the flux density is returned at that point: photon/cm^2/s/keV
-           or photon/cm^2/s/Angstrom depending on the analysis
-           setting.
+           The flux or flux density.  For X-Spec style models the
+           flux units will be photon/cm^2/s and the flux density units
+           will be either photon/cm^2/s/keV or photon/cm^2/s/Angstrom,
+           depending on the analysis setting.
 
         See Also
         --------
@@ -12952,13 +12946,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        lo : number, optional
-           The minimum limit of the band. Use ``None``, the default,
-           to use the low value of the data set.
-        hi : number, optional
-           The maximum limit of the band, which must be larger than
-           `lo`. Use ``None``, the default, to use the upper value of
-           the data set.
+        lo, hi : number, optional
+           If both are None or both are set then calculate the flux
+           over the given band. If only one is set then calculate
+           the flux density at that point. The units for `lo` and `hi`
+           are given by the current analysis setting.
         id : int or str, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
@@ -12970,13 +12962,10 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         flux : number
-           The flux from the source model integrated over the given
-           band. This represents the flux from the model without any
-           instrument response (i.e. the intrinsic flux of the
-           source). For X-Spec style models the units will be
-           erg/cm^2/s. If ``hi`` is ``None`` but ``lo`` is set then the
-           flux density is returned at that point: erg/cm^2/s/keV or
-           erg/cm^2/s/Angstrom depending on the analysis setting.
+           The flux or flux density.  For X-Spec style models the
+           flux units will be erg/cm^2/s and the flux density units
+           will be either erg/cm^2/s/keV or erg/cm^2/s/Angstrom,
+           depending on the analysis setting.
 
         See Also
         --------
@@ -13055,17 +13044,14 @@ class Session(sherpa.ui.utils.Session):
         """Sum up the data values over a pass band.
 
         This function is for one-dimensional data sets: use
-        `calc_model_sum` for two-dimensional data sets.
+        `calc_data_sum2d` for two-dimensional data sets.
 
         Parameters
         ----------
-        lo : number, optional
-           The minimum limit of the band. Use ``None``, the default,
-           to use the low value of the data set.
-        hi : number, optional
-           The maximum limit of the band, which must be larger than
-           ``lo``. Use ``None``, the default, to use the upper value of
-           the data set.
+        lo, hi : number, optional
+           If both are None or both are set then sum up the data
+           over the given band. If only one is set then return
+           the data count in the given bin.
         id : int or str, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
@@ -13077,9 +13063,6 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         dsum : number
-           The sum of the data values that lie within the given
-           limits.  If ``hi`` is ``None`` but ``lo`` is set then the data
-           value of the bin containing the ``lo`` value are returned.
            If a background estimate has been subtracted from the data
            set then the calculation will use the background-subtracted
            values.
@@ -13166,13 +13149,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        lo : number, optional
-           The minimum limit of the band. Use ``None``, the default,
-           to use the low value of the data set.
-        hi : number, optional
-           The maximum limit of the band, which must be larger than
-           ``lo``. Use ``None``, the default, to use the upper value of
-           the data set.
+        lo, hi : number, optional
+           If both are None or both are set then sum up over the given
+           band. If only one is set then use the model value in the
+           selected bin. The units for `lo` and `hi` are given by the
+           current analysis setting.
         id : int or str, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
@@ -13184,7 +13165,7 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         signal : number
-           The sum of the model values over the requested axis range.
+           The model value (sum or individual bin).
 
         See Also
         --------
@@ -13507,13 +13488,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        lo : number, optional
-           The minimum limit of the band. Use ``None``, the default,
-           to use the low value of the data set.
-        hi : number, optional
-           The maximum limit of the band, which must be larger than
-           ``lo``. Use ``None``, the default, to use the upper value of
-           the data set.
+        lo, hi : number, optional
+           If both are None or both are set then sum up over the given
+           band. If only one is set then use the model value in the
+           selected bin. The units for `lo` and `hi` are given by the
+           current analysis setting.
         id : int or str, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
@@ -13525,10 +13504,7 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         signal : number
-           The source model summed up over the given band. This does
-           *not* include the bin width when using histogram-style
-           ('integrated' data spaces), such as used with X-Spec
-           emission - also known as additive - models.
+           The model value (sum or individual bin).
 
         See Also
         --------

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2008, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2008, 2016, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -214,21 +214,19 @@ def calc_energy_flux(data, src, lo=None, hi=None):
     src
        The source expression: this should not include any instrument
        responses.
-    lo : number, optional
-       The minimum limit of the band. Use `None`, the default,
-       to use the low value of the data set.
-    hi : number, optional
-       The maximum limit of the band, which must be larger than
-       `lo`. Use ``None``, the default, to use the upper value of
-       the data set.
+    lo, hi : number, optional
+       If both are None or both are set then calculate the flux
+       over the given band. If only one is set then calculate
+       the flux density at that point. The units for `lo` and `hi`
+       are given by the current analysis setting of the `data`
+       parameter.
 
     Returns
     -------
     flux
-       The flux from the source model integrated over the given
-       band. For X-Spec style models the units will be erg/cm^2/s. If
-       `hi` is ``None`` but `lo` is set then the flux density is
-       returned at that point: erg/cm^2/s/keV or erg/cm^2/s/Angstrom
+       The flux or flux density of the source model. For X-Spec
+       models the flux units will be erg/cm^2/s and the flux
+       density is either erg/cm^2/s/keV or erg/cm^2/s/Angstrom,
        depending on the analysis setting.
 
     See Also
@@ -288,22 +286,20 @@ def calc_photon_flux(data, src, lo=None, hi=None):
     src
        The source expression: this should not include any instrument
        responses.
-    lo : number, optional
-       The minimum limit of the band. Use `None`, the default,
-       to use the low value of the data set.
-    hi : number, optional
-       The maximum limit of the band, which must be larger than
-       `lo`. Use ``None``, the default, to use the upper value of
-       the data set.
+    lo, hi : number, optional
+       If both are None or both are set then calculate the flux
+       over the given band. If only one is set then calculate
+       the flux density at that point. The units for `lo` and `hi`
+       are given by the current analysis setting of the `data`
+       parameter.
 
     Returns
     -------
     flux
-       The flux from the source model integrated over the given
-       band. For X-Spec style models the units will be
-       photon/cm^2/s. If `hi` is ``None`` but `lo` is set then the flux
-       density is returned at that point: photon/cm^2/s/keV or
-       photon/cm^2/s/Angstrom depending on the analysis setting.
+       The flux or flux density of the source model. For X-Spec
+       models the flux units will be photon/cm^2/s and the flux
+       density is either photon/cm^2/s/keV or
+       photon/cm^2/s/Angstrom, depending on the analysis setting.
 
     See Also
     --------
@@ -365,22 +361,19 @@ def calc_source_sum(data, src, lo=None, hi=None):
     data
        The data object to use.
     src
-       The source expression.
-    lo : number, optional
-       The minimum limit of the band. Use ``None``, the default, to use
-       the low value of the data set.
-    hi : number, optional
-       The maximum limit of the band, which must be larger than
-       `lo`. Use ``None``, the default, to use the upper value of the
-       data set.
+       The source expression. This must not include the instrumental
+       responses.
+    lo, hi : number, optional
+       If both are None or both are set then sum up over the given
+       band. If only one is set then use the model value in the
+       selected bin. The units for `lo` and `hi` are given by the
+       current analysis setting of the `data` object.
 
     Returns
     -------
     signal : number
-       The source model summed up over the given band. This does
-       *not* include the bin width when using histogram-style
-       (integrated) data spaces, such as used with X-Spec
-       emission - also known as additive - models.
+       The source model summed up over the given band or for
+       a single bin.
 
     See Also
     --------
@@ -423,22 +416,18 @@ def calc_data_sum(data, lo=None, hi=None):
     ----------
     data
        The data object to use.
-    lo : number, optional
-       The minimum limit of the band. Use ``None``, the default, to use
-       the low value of the data set.
-    hi : number, optional
-       The maximum limit of the band, which must be larger than
-       `lo`. Use ``None``, the default, to use the upper value of the
-       data set.
+    lo, hi : number, optional
+       If both are None or both are set then use the full dataset.
+       If only one is set then use the data count for that bin.
+       The units for `lo` and `hi` are given by the current analysis
+       setting of the `data` parameter.
 
     Returns
     -------
     dsum : number
        The sum of the data values that lie within the given limits.
-       If `hi` is ``None`` but `lo` is set then the data value of the
-       bin containing the `lo` value are returned.  If a background
-       estimate has been subtracted from the data set then the
-       calculation will use the background-subtracted values.
+       If a background estimate has been subtracted from the data set
+       then the calculation will use the background-subtracted values.
 
     See Also
     --------
@@ -526,21 +515,20 @@ def calc_model_sum(data, model, lo=None, hi=None):
     ----------
     data
        The data object to use.
-    src
-       The source expression, which should not include the
-       instrumental responses.
-    lo : number, optional
-       The minimum limit of the band. Use ``None``, the default, to use
-       the low value of the data set.
-    hi : number, optional
-       The maximum limit of the band, which must be larger than
-       `lo`. Use ``None``, the default, to use the upper value of the
-       data set.
+    model
+       The source expression, which should include the instrumental
+       responses.
+    lo, hi : number, optional
+       If both are None or both are set then sum up over the given
+       band. If only one is set then use the model value in the
+       selected bin. The units for `lo` and `hi` are given by the
+       current analysis setting of the `data` object.
 
     Returns
     -------
     signal : number
-       The sum of the model values used to fit the data.
+       The source model summed up over the given band or for
+       a single bin.
 
     See Also
     --------

--- a/sherpa/astro/utils/tests/test_astro_utils.py
+++ b/sherpa/astro/utils/tests/test_astro_utils.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2008, 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2008, 2016, 2018, 2020
+#       Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,36 +18,29 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import pytest
 
-from sherpa.utils.testing import SherpaTestCase
 from sherpa.astro.utils import is_in
 
+LONGVALS = [100, 249, 400, 450, 500, 601, 1024]
+SHORTVALS = [100, 249, 601, 1024]
 
-class test_utils(SherpaTestCase):
 
-    def setUp(self):
-        self.long  = [100, 249, 400, 450, 500, 601, 1024]
-        self.short = [100, 249, 601, 1024]
+# test_is_in_long and test_not_in_short were originally a
+# single test case called test_response_filter_logic
+#
+@pytest.mark.parametrize("lo, hi",
+                         [(50, 2400),  # outside case
+                          (100, 200),  # lo case
+                          (50, 1024),  # hi case
+                          (250, 2000),  # 'hidden' lo case
+                          (50, 250),  # 'hidden' hi case
+                          (250, 600)  # 'hidden' interval case w/ noticed channels inside
+                         ])
+def test_is_in_long(lo, hi):
+    assert is_in(LONGVALS, lo, hi)
 
-    def test_response_filter_logic(self):
 
-        # outside case
-        self.assertTrue( is_in(self.long, 50, 2400) )
-
-        # lo case
-        self.assertTrue( is_in(self.long, 100, 200) )
-
-        # hi case
-        self.assertTrue( is_in(self.long, 50, 1024) )
-
-        # 'hidden' lo case
-        self.assertTrue( is_in(self.long, 250, 2000) )
-
-        # 'hidden' hi case
-        self.assertTrue( is_in(self.long, 50, 250) )
-
-        # 'hidden' interval case w/ noticed channels inside
-        self.assertTrue( is_in(self.long, 250, 600) )
-
-        # 'hidden' interval case w/ *no* noticed channels inside
-        self.assertTrue( not is_in(self.short, 250, 600) )
+def test_not_in_short():
+    # 'hidden' interval case w/ *no* noticed channels inside
+    assert not is_in(SHORTVALS, 250, 600)

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,10 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import numpy as np
 import pytest
 
 from sherpa.astro import ui
-from sherpa.astro.utils import filter_resp
+from sherpa.astro.utils import filter_resp, range_overlap_1dint
 from sherpa.utils.testing import requires_data, requires_fits
 
 
@@ -60,3 +61,85 @@ def test_rmf_filter_no_chans(make_data_path):
 
     emsg = "There are no noticed channels"
     assert str(excinfo.value) == emsg
+
+
+@pytest.mark.parametrize("lo, hi, expected",
+                         [(None, None, [1] * 5),
+                          (0, 100, [1] * 5),
+                          (20, 90, [1] * 5),
+                          (1, 10, None),
+                          (1, 20, None),
+                          (90, 100, None),
+                          (100, 110, None),
+                          (10, 19, None),
+                          (10, 10, None),
+                          (91, 91, None),
+                          # edge handling for densities is different at
+                          # low and high ends
+                          (20, 20, [1, 0, 0, 0, 0]),
+                          (30, 30, [0, 1, 0, 0, 0]),
+                          (44, 44, [0, 0, 1, 0, 0]),
+                          (60, 60, [0, 0, 0, 1, 0]),
+                          (80, 80, [0, 0, 0, 0, 1]),
+                          (90, 0, None),
+                          # limits fall within each bin
+                          (21, 21, [1, 0, 0, 0, 0]),
+                          (32, 32, [0, 1, 0, 0, 0]),
+                          (54, 54, [0, 0, 1, 0, 0]),
+                          (79, 79, [0, 0, 0, 1, 0]),
+                          (85, 85, [0, 0, 0, 0, 1]),
+                          # ranges - single bin (exact)
+                          (20, 30, [1, 0, 0, 0, 0]),
+                          (30, 44, [0, 1, 0, 0, 0]),
+                          (44, 60, [0, 0, 1, 0, 0]),
+                          (60, 80, [0, 0, 0, 1, 0]),
+                          (80, 90, [0, 0, 0, 0, 1]),
+                          # ranges - single bin (subset)
+                          (21, 29, [0.8, 0, 0, 0, 0]),
+                          (30, 37, [0, 0.5, 0, 0, 0]),
+                          (51, 60, [0, 0, 0.5625, 0, 0]),
+                          (68, 72, [0, 0, 0, 0.2, 0]),
+                          (81, 82, [0, 0, 0, 0, 0.1]),
+                          # ranges - partial overlap, all within grid
+                          (27, 84, [0.3, 1, 1, 1, 0.4]),
+                          (32, 78, [0, 12 / 14, 1, 0.9, 0]),
+                          (20, 24, [0.4, 0, 0, 0, 0]),
+                          (83, 90, [0, 0, 0, 0, 0.7]),
+                          # partial overlap, but lo or hi past grid
+                          (0, 26, [0.6, 0, 0, 0, 0]),
+                          (0, 30, [1.0, 0, 0, 0, 0]),
+                          (0, 37, [1.0, 0.5, 0, 0, 0]),
+                          (0, 44, [1.0, 1.0, 0, 0, 0]),
+                          (26, 100, [0.4, 1, 1, 1, 1]),
+                          (30, 100, [0, 1, 1, 1, 1]),
+                          (44, 100, [0, 0, 1, 1, 1]),
+                          # partial overlap, starting/ending on grid
+                          (20, 61, [1.0, 1.0, 1.0, 0.05, 0]),
+                          (20, 80, [1.0, 1.0, 1.0, 1.0, 0]),
+                          (20, 81, [1.0, 1.0, 1.0, 1.0, 0.1]),
+                          (20, 50, [1, 1, 0.375, 0, 0]),
+                          (75, 90, [0, 0, 0, 0.25, 1]),
+                          (46, 90, [0, 0, 0.875, 1, 1])
+                          ])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_range_overlap_1dint_ascending(lo, hi, expected, reverse):
+
+    grid = np.asarray([20, 30, 44, 60, 80, 90])
+
+    # wavelength grids are in descending order, but first/second
+    # elements of axes are still in low/high order.
+    #
+    if reverse:
+        grid = grid[::-1]
+        axes = (grid[1:], grid[:-1])
+        if expected is not None:
+            expected = expected[::-1]
+    else:
+        axes = (grid[:-1], grid[1:])
+
+    got = range_overlap_1dint(axes, lo, hi)
+    if expected is None:
+        assert got is None
+        return
+
+    assert got == pytest.approx(expected)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -235,10 +235,10 @@ def calc_ftest(dof1, stat1, dof2, stat2):
 
     Examples
     --------
-    >>> calc_ftest(11, 16.3, 10, 10.2) 
+    >>> calc_ftest(11, 16.3, 10, 10.2)
     0.03452352914891555
 
-    >>> calc_ftest([11, 11], [16.3, 16.3], [10, 9], [10.2, 10.5]) 
+    >>> calc_ftest([11, 11], [16.3, 16.3], [10, 9], [10.2, 10.5])
     array([0.03452353, 0.13819987])
     """
 
@@ -1003,9 +1003,10 @@ def filter_bins(mins, maxes, axislist):
 
     Returns
     -------
-    mask : ndarray
+    mask : ndarray or None
        A mask indicating whether the values are included (True) or
-       excluded (False).
+       excluded (False). If any of the input sequences are empty then
+       None will be returned.
 
     Examples
     --------

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -281,3 +281,110 @@ def test_parallel_map(num_tasks, num_segments):
         pararesult = utils.parallel_map(f, iterable, num_tasks)
 
         assert_equal(result, numpy.asarray(pararesult))
+
+
+@pytest.mark.parametrize("los, his, axis", [([], [], [0,1,2,3,4]),
+                                            ([], [1], [0,1,2,3,4]),
+                                            ([1], [], [0,1,2,3,4]),
+                                            ([], [], [])])
+def test_filter_bins_empty(los, his, axis):
+    """Ensure filter_bins returns None if one input is empty."""
+
+    # just check the input parameters include an empty array
+    assert len(los) == 0 or len(his) == 0 or len(axis) == 0
+
+    assert utils.filter_bins(los, his, [axis]) is None
+
+
+def test_filter_bins_scalar_array_empty():
+    """Edge case: do we care about this result?"""
+
+    f = utils.filter_bins([1], [2], [[]])
+    assert f.dtype == numpy.bool
+    assert len(f) == 0
+
+
+@pytest.mark.parametrize("axval, flag", [(0, False),
+                                         (0.99, False),
+                                         (1 - 1e-7, True),
+                                         (1, True),
+                                         (2.34, True),
+                                         (5, True),
+                                         (5 + 1e-7, True),
+                                         (5.01, False),
+                                         (7, False)])
+def test_filter_bins_scalar_array(axval, flag):
+    """Edge case: do we care about this result?"""
+
+    f = utils.filter_bins([1], [5], [axval])
+    assert f == flag
+
+
+@pytest.mark.parametrize("lo, hi, res",
+                         [(0, 10, [True] * 5),
+                          (1, 5, [True] * 5),
+                          (2, 5, [False, True, True, True, True]),
+                          (2, None, [False, True, True, True, True]),
+                          (1, 4, [True, True, True, True, False]),
+                          (None, 4, [True, True, True, True, False]),
+                          (1.1, 4.9, [False, True, True, True, False]),
+                          (2, 4, [False, True, True, True, False]),
+                          # Have minimum > maximum, so nothing is selected
+                          (4, 3, [False, False, False, False, False]),
+                          # Have minimum = maximum = bin value
+                          (4, 4, [False, False, False, True, False]),
+                          # Have minimum = maximum, not equal to a bin value
+                          (3.1, 3.1, [False, False, False, False, False])
+                         ])
+def test_filter_bins_one(lo, hi, res):
+    """Can we filter the array between lo and hi?"""
+
+    dvals = numpy.asarray([1, 2, 3, 4, 5])
+    flags = utils.filter_bins([lo], [hi], [dvals])
+    assert (flags == res).all()
+
+
+def test_filter_bins_two_none():
+    """Use two different arrays for filtering with no filter.
+    """
+
+    y1 = [1, 2, 3, 4, 5]
+    y2 = [10, 20, 30, 40, 50]
+
+    flags = utils.filter_bins((None, None), (None, None), (y1, y2))
+    assert flags is None
+
+
+@pytest.mark.parametrize("lo1, lo2, hi1, hi2, expected",
+                         [ (1.5, 21, 3.6, 44, [False, False, True, False, False]),
+                           (1.5, None, None, 44, [False, True, True, True, False]),
+                           (None, None, None, 44, [True, True, True, True, False]),
+                           (1.5, None, None, None, [False, True, True, True, True])
+                         ])
+def test_filter_bins_two(lo1, lo2, hi1, hi2, expected):
+    """Use two different arrays for filtering.
+
+    This version uses tuples rather than arrays as the
+    input arguments to filter_bins.
+
+    """
+
+    y1 = [1, 2, 3, 4, 5]
+    y2 = [10, 20, 30, 40, 50]
+
+    flags = utils.filter_bins((lo1, lo2), (hi1, hi2), (y1, y2))
+    assert len(flags) == 5
+    for i in range(5):
+        assert flags[i] == expected[i], i
+
+
+def test_filter_bins_unordered():
+    """What happens if the array is unordered?"""
+
+    flags = utils.filter_bins((3, ), (8, ), [[1,4,3,7,8,10,5]])
+
+    expected = [False, True, True, True, True, False, True]
+
+    assert len(flags) == len(expected)
+    for got, exp in zip(flags, expected):
+        assert got == exp


### PR DESCRIPTION
# Summary

Bug fixes and improvements for calculate_photon_flux and calculate_energy_flux:

 - address flux and flux-density calculation issues discussed (fix #619)
 - fix documentation of the lo and hi arguments (fix #308)
 - add model parameter to calc_photon/energy_flux which allows users to easily calculate "unabsorbed" fluxes

# Details

Not listed in the summary section is that new tests have been added, both for the new functionality (checking the ability to calculate the flux of a model component), and for the existing functionality (to show the issues raised in #619).

## flux/flux density calculation (#619)

The problem with the existing code is that it doesn't really handle the case of 1D integrated cases (i.e. bins with low and high edges). The instrument grid would be filtered to select the bins to use for the calculation, but this did not include bins which were partially filled (e.g. for a grid of 0.5-0.6, 0.6-0.7, ... and a low edge of 0.55, the first bin would not be included). You can see the problems this causes in the PDF contained within https://github.com/sherpa/sherpa/issues/619#issuecomment-485779739 - in the test comments I note that before this change I have seen cases where the calculated fluxes were 80 to 90% of the expected value, and after the change are within 5% of the correct value (it depends very much on bin width and range).

For flux density calculations it was worse, since it only seems to have selected a value when the selected energy fell on a bin edge (so with the above grid you could get values for 0.5 or 0.6, but not for 0.55, when the routines would calculate 0).

The current approach taken in this PR is to treat partially filled bins via linear interpolation - that is, for a bin 0.5-0.6 and a low edge of 0.51 or 0.58, 90% or 20% of the flux would be included. To do this I have implemented my own routine for selecting bins from a 1D "integrated" grid (sherpa.astro.utils.range_overlap_1dint). I don't believe this functionality exists elsewhere, but I may be wrong. I also have written this with an over-abundance of caution (a lot of asserts) to ensure the preconitions I believe to be true are in fact true. The logic for searching for which bins the user limits fall within has been left to the numpy.digitize routine; this has the advantage of being a pre-canned routine, but does mean we lose the ability to use sao_fcmp to compare if a value is close to a bin edge (for example, the 3c273.pi RMF we use in many of our tests is nominally defined over the range 0.1 to 11 keV but the first bin actually starts at 0.10000000149011612 keV, which sao_fcmp thinks is the same, but numpy.digitize doesn't). This is primarily an issue for users who request a flux density at the very edge of the response.

The flux density calculation is now constant within a bin of the instrument response, rather than only being defined at the bin edges. This is not ideal, and can be improved upon as discussed in the NOTE section below (note 1).

Since these changes mean that the calc_photon/energy_flux results are different, the calc_kcorr test results need tweaking slightly to account for these changes.

**NOTE 1** I believe a better approach would be to ignore the instrument grid and create an appropriate one based on the user limits (i.e. essentially what is suggested in https://github.com/sherpa/sherpa/issues/619#issuecomment-499412354 ). This completely side steps edge effects and worrying about partial overlap of bins, as well as allowing the calculation of fluxes for energy ranges outside the instrument grid. It would however require changes to the API, since we would need a way of specifying the grid to use (both for fluxes and flux density, and you'd probably want to do different things for these two cases). I decided to try an improve the results first, so we can get an improved test suite, and then we can look at changing the method in a later PR.

**NOTE 2** I am generally unsure about the flux-density calculation (particularly for analysis=angstrom), as it is strongly dependent on the bin size.

**NOTE 3** if the user gave limits that fell within a single bin, the old code would turn that into a flux density, rather than a flux. This is *to me* exceedingly surprising (you don't always remember the binning of the response and we currently don't provide much guidance or information to the user about this grid). I have therefore switched this case to calculate a flux (using linear interpolation within the bin), and only calculatr a flux density when one of these conditions hold: lo=hi and it is not None, lo=value and hi is None, hi=value and lo is None (when lo/hi are within the instrument range).

**NOTE 4** I am pretty sure that eqwidth suffers from the same problems, but I have not looked at this. 

**NOTE 5** I wonder if we should just make calc_energy_flux and calc_photon_flux error out if called on anything but a DataPHA dataset. I have not added any testing of the 1D (non integrated) case here (as this code path shouldn't have changed), so don't know what it actually calculates in this case (particularly for the energy flux case). The calc_photon_flux routine is technically correct (in that it doesn't really make any assumptions about the axis units), it is just named confusingly for the generic case.

**NOTE 6** I don't understand the expected behavior when analysis=channel is selected. It looks like the band limits (or value at which to calculate the flux density) are taken to be in keV, but that surprises me (I expected channel). The tests for analysis=channel are therefore rather limited.

## Addition of the model argument

The addition of the model parameter will be useful for sample_flux, but that is not addressed here. Note that sample_flux uses the long argument name of modelcomponent but model is used here (which I am going to suggest sample_flux change to, and better matches the existing API).

This was an easy change, as it really only needed adding the user argument; the actual code that does the calculation did not need to be changed.

**Note** this functionality (i.e. the model argument) could be added to calc_source_sum (should be easy) and calc_model_sum (significantly harder).