### PR TITLE
No error for no-ops in `ungroup` and friends

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2017, 2018
+#  Copyright (C) 2007, 2015, 2017, 2018, 2020
 #        Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -877,3 +877,53 @@ def test_rmf_get_x_unit():
     expected_rmf_x = (rmf_x_hi + rmf_x_lo)/2
     actual_rmf_x = rmf.get_x()
     np.testing.assert_array_almost_equal(expected_rmf_x, actual_rmf_x)
+
+# https://github.com/sherpa/sherpa/pull/766
+def test_ungroup():
+    '''Make sure that ungrouped data can be ungrouped.
+
+    This test just groups and ungroups a few times.
+    '''
+    session = Session()
+    testdata = DataPHA('testdata', np.arange(50, dtype=float) + 1.,
+                                   np.zeros(50),
+                                   bin_lo=1,
+                                   bin_hi=10)
+    session.set_data(1, testdata)
+    session.ungroup(1)
+    session.group_bins(1, 5)
+    assert np.all(session.get_grouping(1)[::10] == 1)
+    assert testdata.grouped
+    # test it can be ungrouped
+    session.ungroup(1)
+    assert not testdata.grouped
+    # test ungrouped data can be ungrouped without altering
+    # the grouping
+    session.ungroup(1)
+    assert not testdata.grouped
+
+# https://github.com/sherpa/sherpa/pull/766
+def test_unsubtract():
+    '''Make sure that unsubtracted data can be unsubtracted.
+
+    This test just subtracts and unsubtracts a few times.
+    '''
+    session = Session()
+    testdata = DataPHA('testdata', np.arange(50, dtype=float) + 1.,
+                       np.zeros(50),
+                       bin_lo=1, bin_hi=10)
+    testbkg = DataPHA('testbkg', np.arange(50, dtype=float) + .5,
+                      np.zeros(50),
+                      bin_lo=1, bin_hi=10)
+    session.set_data(1, testdata)
+    session.set_bkg(1, testbkg)
+    session.unsubtract(1)
+    session.subtract(1)
+    assert testdata.subtracted
+    # test it can be ungrouped
+    session.unsubtract(1)
+    assert not testdata.subtracted
+    # test ungrouped data can be ungrouped without altering
+    # the grouping
+    session.unsubtract(1)
+    assert not testdata.subtracted

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -7169,8 +7169,6 @@ class Session(sherpa.ui.utils.Session):
         ------
         sherpa.utils.err.ArgumentErr
            If the data set does not contain a PHA data set.
-        sherpa.utils.err.DataErr
-           If the data set is already grouped.
 
         See Also
         --------
@@ -7257,17 +7255,8 @@ class Session(sherpa.ui.utils.Session):
 
             # Now check if data is already grouped, and send error message
             # if so
-            if (data.grouped is True):
-                raise DataErr(
-                    'groupset', 'data set', str(self._fix_id(id)), 'True')
-        else:
-            # Just grouping one particular background here
-            if (data.grouped is True):
-                raise DataErr(
-                    'groupset', 'background', str(self._fix_id(bkg_id)), 'True')
-
-        # If we get here, checks showed data not grouped, so set group flag
-        data.group()
+        if not (data.grouped is True):
+            data.group()
 
     def set_grouping(self, id, val=None, bkg_id=None):
         """Apply a set of grouping flags to a PHA data set.
@@ -7635,8 +7624,6 @@ class Session(sherpa.ui.utils.Session):
         ------
         sherpa.utils.err.ArgumentErr
            If the data set does not contain a PHA data set.
-        sherpa.utils.err.DataErr
-           If the data set is not grouped.
 
         See Also
         --------
@@ -7705,17 +7692,8 @@ class Session(sherpa.ui.utils.Session):
 
             # Now check if data is already ungrouped, and send error message
             # if so
-            if (data.grouped is False):
-                raise DataErr(
-                    'groupset', 'data set', str(self._fix_id(id)), 'False')
-        else:
-            if (data.grouped is False):
-                # Just ungrouping one particular background here
-                raise DataErr(
-                    'groupset', 'background', str(self._fix_id(bkg_id)), 'False')
-
-        # If we get here, checks showed data grouped, so set ungroup flag
-        data.ungroup()
+        if (data.grouped is True):
+            data.ungroup()
 
     # DOC-TODO: need to document somewhere that this ignores existing
     # quality flags and how to use tabStops to include
@@ -8376,8 +8354,6 @@ class Session(sherpa.ui.utils.Session):
         ------
         sherpa.utils.err.ArgumentErr
            If the data set does not contain a PHA data set.
-        sherpa.utils.err.DataErr
-           If the data set is already subtracted.
 
         See Also
         --------
@@ -8441,10 +8417,8 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_data(overplot=True)
 
         """
-        if (self._get_pha_data(id).subtracted is True):
-            raise DataErr(
-                'subtractset', 'data set', str(self._fix_id(id)), 'True')
-        self._get_pha_data(id).subtract()
+        if (self._get_pha_data(id).subtracted is False):
+            self._get_pha_data(id).subtract()
 
     def unsubtract(self, id=None):
         """Undo any background subtraction for the data set.
@@ -8466,8 +8440,6 @@ class Session(sherpa.ui.utils.Session):
         ------
         sherpa.utils.err.ArgumentErr
            If the data set does not contain a PHA data set.
-        sherpa.utils.err.DataErr
-           If the data set does not have its background subtracted.
 
         See Also
         --------
@@ -8496,10 +8468,8 @@ class Session(sherpa.ui.utils.Session):
         False
 
         """
-        if (self._get_pha_data(id).subtracted is False):
-            raise DataErr(
-                'subtractset', 'data set', str(self._fix_id(id)), 'False')
-        self._get_pha_data(id).unsubtract()
+        if (self._get_pha_data(id).subtracted is True):
+            self._get_pha_data(id).unsubtract()
 
     def fake_pha(self, id, arf, rmf, exposure, backscal=None, areascal=None,
                  grouping=None, grouped=False, quality=None, bkg=None):


### PR DESCRIPTION
Currently, `ungroup` and `unsubtract` throw a `DataErr`, if a dataset is not
grouped or not subtracted. Why is this necessary?
For purely interactive use if just one or two datasets, an Exception is one way
of providing feedback to the user and remind him "hey, you did not even group
 this before, are you sure you know what you are doing?".
However, when working with more datasets, it gets annoying and it's even worse
when I have a long-running script. Why does the script fail, if all I'm doing is
to accidentally ungroup something that was ungrouped before.
Here is what I do: I play around interactively, group with or that and then I
want to ungroup or unsubtract everything. Currently, I have to go one by one,
with code like this:
```
for i in ui.list_data_ids():
        try:
            ui.ungroup(i)
        except sherpa.utils.err.DataErr:
            # It's already ungrouped
            pass
```

That's clunky, so I wonder: Why is it necessary to throw an Exception when a
dataset is already ungrouped or unsubtracted?
If I want to ungroup, why would it matter to me if data was previously grouped
or not? What matters is that it's ungrouped after.

This PR removes some of those (in my opinion) annoying exceptions.

Note that this needs a through review not just for the approach, but also for the implementation. I'm new to the Sherpa internals and the fact that no test needed to be changed to make it pass locally indicates that the exceptions are not covered by tests.
(If there is agreement to proceed with this, I'll add a test.)