### PR TITLE
add basic cache tracking

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021
-#     Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -48,11 +48,9 @@ def evaluates_model(func):
     """
     @wraps(func)
     def run(fit, *args, **kwargs):
-        if 'cache' in kwargs:
-            fit.model.startup(kwargs['cache'])
-            kwargs.pop('cache', None)
-        else:
-            fit.model.startup(True)
+
+        cache = kwargs.pop('cache', True)
+        fit.model.startup(cache=cache)
         result = func(fit, *args, **kwargs)
         fit.model.teardown()
         return result

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -137,7 +137,6 @@ def modelCacher1d(func):
             digest = hashfunc(token).digest()
             if digest in cache:
                 cache_ctr['hits'] += 1
-                cache_ctr['record'].append({'pars': pars, 'hit': True})
                 return cache[digest].copy()
 
         vals = func(cls, pars, xlo, *args, **kwargs)
@@ -152,7 +151,6 @@ def modelCacher1d(func):
             cache[digest] = vals.copy()
 
             cache_ctr['misses'] += 1
-            cache_ctr['record'].append({'pars': pars, 'hit': False})
 
         return vals
 
@@ -691,14 +689,13 @@ class ArithmeticModel(Model):
         # It is not obvious what to set the queue length to
         self._queue = ['']
         self._cache = {}
-        self._cache_ctr = {'hits': 0, 'misses': 0, 'record': [], 'check': 0}
+        self._cache_ctr = {'hits': 0, 'misses': 0, 'check': 0}
 
     def cache_status(self):
         """Display the cache status."""
         c = self._cache_ctr
         print(f" {self.name:30s}  size: {len(self._queue):4d}  " +
               f"hits: {c['hits']:5d}  misses: {c['misses']:5d}  " +
-              f"nrecords: {len(c['record']):5d}  " +
               f"check={c['check']:5d}"
         )
 
@@ -727,7 +724,7 @@ class ArithmeticModel(Model):
 
         if '_cache' not in state:
             self.__dict__['_cache'] = {}
-            self.__dict__['_cache_ctr'] = {'hits': 0, 'misses': 0, 'record': [], 'check': 0}
+            self.__dict__['_cache_ctr'] = {'hits': 0, 'misses': 0, 'check': 0}
 
         if 'cache' not in state:
             self.__dict__['cache'] = 5

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -525,11 +525,19 @@ class CompositeModel(Model):
     def teardown(self):
         pass
 
-    def _cache_status(self):
-        """Report the cache status"""
+    def cache_clear(self):
+        """Clear the cache for each component."""
         for p in self.parts:
             try:
-                p._cache_status()
+                p.cache_clear()
+            except AttributeError:
+                pass
+
+    def cache_status(self):
+        """Display the cache status of each component."""
+        for p in self.parts:
+            try:
+                p.cache_status()
             except AttributeError:
                 pass
 
@@ -675,13 +683,18 @@ class ArithmeticModel(Model):
         # Model caching ability
         self.cache = 5  # repeat the class definition
         self._use_caching = True  # FIXME: reduce number of variables?
+        self.cache_clear()
+        Model.__init__(self, name, pars)
+
+    def cache_clear(self):
+        """Clear the cache."""
+        # It is not obvious what to set the queue length to
         self._queue = ['']
         self._cache = {}
         self._cache_ctr = {'hits': 0, 'misses': 0, 'record': [], 'check': 0}
-        Model.__init__(self, name, pars)
 
-    def _cache_status(self):
-        """Report the cache status"""
+    def cache_status(self):
+        """Display the cache status."""
         c = self._cache_ctr
         print(f" {self.name:30s}  size: {len(self._queue):4d}  " +
               f"hits: {c['hits']:5d}  misses: {c['misses']:5d}  " +
@@ -723,10 +736,7 @@ class ArithmeticModel(Model):
         return FilterModel(self, filter)
 
     def startup(self, cache=False):
-        # NOTE: this resets the existing cache
-        self._queue = ['']
-        self._cache = {}
-        self._cache_ctr = {'hits': 0, 'misses': 0, 'record': [], 'check': 0}
+        self.cache_clear()
         self._use_caching = cache
         if int(self.cache) > 0:
             self._queue = [''] * int(self.cache)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -19,6 +19,7 @@
 #
 
 
+import functools
 import logging
 import hashlib
 import warnings
@@ -82,6 +83,7 @@ def modelCacher1d(func):
 
     """
 
+    @functools.wraps(func)
     def cache_model(cls, pars, xlo, *args, **kwargs):
         use_caching = cls._use_caching
         cache = cls._cache
@@ -145,8 +147,6 @@ def modelCacher1d(func):
 
         return vals
 
-    cache_model.__name__ = func.__name__
-    cache_model.__doc__ = func.__doc__
     return cache_model
 
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -21,7 +21,6 @@
 
 import functools
 import logging
-import hashlib
 import warnings
 
 import numpy
@@ -33,6 +32,16 @@ from sherpa.utils import formatting
 
 from .parameter import Parameter
 
+# What routine do we use for the hash in modelCacher1d?  As we do not
+# need cryptographic security go for a "quick" algorithm, but md5 is
+# not guaranteed to always be present.  There has been no attempt to
+# check the run times of these routines for the expected data sizes
+# they will be used with.
+#
+try:
+    from hashlib import md5 as hashfunc
+except ImportError:
+    from hashlib import sha256 as hashfunc
 
 warning = logging.getLogger(__name__).warning
 
@@ -125,7 +134,7 @@ def modelCacher1d(func):
                 data.append(numpy.asarray(args[0]).tobytes())
 
             token = b''.join(data)
-            digest = hashlib.sha256(token).digest()
+            digest = hashfunc(token).digest()
             if digest in cache:
                 cache_ctr['hits'] += 1
                 cache_ctr['record'].append({'pars': pars, 'hit': True})

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -116,6 +116,7 @@ try:
 except ImportError:
     from hashlib import sha256 as hashfunc
 
+info = logging.getLogger(__name__).info
 warning = logging.getLogger(__name__).warning
 
 
@@ -605,7 +606,19 @@ class CompositeModel(Model):
                 pass
 
     def cache_status(self):
-        """Display the cache status of each component."""
+        """Display the cache status of each component.
+
+        Information on the cache - the number of "hits", "misses", and
+        "requests" - is displayed at the INFO logging level.
+
+        Example
+        -------
+
+        >>> mdl.cache_status()
+         xsphabs.gal                size:    5  hits:   715  misses:   158  check=  873
+         powlaw1d.pl                size:    5  hits:   633  misses:   240  check=  873
+
+        """
         for p in self.parts:
             try:
                 p.cache_status()
@@ -765,12 +778,22 @@ class ArithmeticModel(Model):
         self._cache_ctr = {'hits': 0, 'misses': 0, 'check': 0}
 
     def cache_status(self):
-        """Display the cache status."""
+        """Display the cache status.
+
+        Information on the cache - the number of "hits", "misses", and
+        "requests" - is displayed at the INFO logging level.
+
+        Example
+        -------
+
+        >>> pl.cache_status()
+         powlaw1d.pl                size:    5  hits:   633  misses:   240  check=  873
+
+        """
         c = self._cache_ctr
-        print(f" {self.name:30s}  size: {len(self._queue):4d}  " +
-              f"hits: {c['hits']:5d}  misses: {c['misses']:5d}  " +
-              f"check={c['check']:5d}"
-        )
+        info(f" {self.name:25s}  size: {len(self._queue):4d}  " +
+             f"hits: {c['hits']:5d}  misses: {c['misses']:5d}  " +
+             f"check: {c['check']:5d}")
 
     # Unary operations
     __neg__ = _make_unop(numpy.negative, '-')

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -18,10 +18,16 @@
 #
 
 from collections import namedtuple
-import hashlib
 import logging
 import operator
 import warnings
+
+# Repeat the logic from sherpa/models/model.py
+#
+try:
+    from hashlib import md5 as hashfunc
+except ImportError:
+    from hashlib import sha256 as hashfunc
 
 import numpy
 
@@ -642,7 +648,7 @@ def check_cache(mdl, expected, x, xhi=None):
         data.append(xhi.tobytes())
 
     token = b''.join(data)
-    digest = hashlib.sha256(token).digest()
+    digest = hashfunc(token).digest()
     assert digest in cache
     assert cache[digest] == pytest.approx(expected)
 
@@ -880,7 +886,7 @@ def test_cache_integrate_fall_through_no_integrate():
             x.tobytes()]
 
     token = b''.join(data)
-    digest = hashlib.sha256(token).digest()
+    digest = hashfunc(token).digest()
     assert digest in cache
     assert cache[digest] == pytest.approx(expected)
 
@@ -907,7 +913,7 @@ def test_cache_integrate_fall_through_integrate_true():
             x.tobytes()]
 
     token = b''.join(data)
-    digest = hashlib.sha256(token).digest()
+    digest = hashfunc(token).digest()
     assert digest in cache
     assert cache[digest] == pytest.approx(expected)
 
@@ -934,6 +940,6 @@ def test_cache_integrate_fall_through_integrate_false():
             x.tobytes()]
 
     token = b''.join(data)
-    digest = hashlib.sha256(token).digest()
+    digest = hashfunc(token).digest()
     assert digest in cache
     assert cache[digest] == pytest.approx(expected)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1026,3 +1026,99 @@ def test_cache_status_multiple(caplog):
     assert toks[0] == 'box1d'
     assert toks[4] == '0'
     assert toks[6] == '0'
+
+
+def test_cache_clear_single(caplog):
+    """Check cache_clear for a single model."""
+
+    p = Polynom1D()
+
+    # There's no official API for accessing the cache data,
+    # so do it directly.
+    #
+    assert len(p._cache) == 0
+    assert p._cache_ctr['check'] == 0
+    assert p._cache_ctr['hits'] == 0
+    assert p._cache_ctr['misses'] == 0
+
+    p([1, 2, 3])
+    p([1, 2, 3])
+    p([1, 2, 3, 4])
+
+    assert len(p._cache) == 1
+    assert p._cache_ctr['check'] == 3
+    assert p._cache_ctr['hits'] == 1
+    assert p._cache_ctr['misses'] == 2
+
+    p.cache_clear()
+
+    assert len(p._cache) == 0
+    assert p._cache_ctr['check'] == 0
+    assert p._cache_ctr['hits'] == 0
+    assert p._cache_ctr['misses'] == 0
+
+
+def test_cache_clear_multiple(caplog):
+    """Check cache_clear for a combined model."""
+
+    p = Polynom1D()
+    b = Box1D()
+    c = Const1D()
+    mdl = c * (p + 2 * b)
+
+    # Ensure one component doesn't use the cache
+    c._use_caching = False
+
+    # There's no official API for accessing the cache data,
+    # so do it directly.
+    #
+    assert len(p._cache) == 0
+    assert p._cache_ctr['check'] == 0
+    assert p._cache_ctr['hits'] == 0
+    assert p._cache_ctr['misses'] == 0
+
+    assert len(b._cache) == 0
+    assert b._cache_ctr['check'] == 0
+    assert b._cache_ctr['hits'] == 0
+    assert b._cache_ctr['misses'] == 0
+
+    assert len(c._cache) == 0
+    assert c._cache_ctr['check'] == 0
+    assert c._cache_ctr['hits'] == 0
+    assert c._cache_ctr['misses'] == 0
+
+    mdl([1, 2, 3])
+    mdl([1, 2, 3])
+    mdl([1, 2, 3, 4])
+
+    assert len(p._cache) == 1
+    assert p._cache_ctr['check'] == 3
+    assert p._cache_ctr['hits'] == 1
+    assert p._cache_ctr['misses'] == 2
+
+    assert len(b._cache) == 1
+    assert b._cache_ctr['check'] == 3
+    assert b._cache_ctr['hits'] == 1
+    assert b._cache_ctr['misses'] == 2
+
+    assert len(c._cache) == 0
+    assert c._cache_ctr['check'] == 3
+    assert c._cache_ctr['hits'] == 0
+    assert c._cache_ctr['misses'] == 0
+
+    mdl.cache_clear()
+
+    assert len(p._cache) == 0
+    assert p._cache_ctr['check'] == 0
+    assert p._cache_ctr['hits'] == 0
+    assert p._cache_ctr['misses'] == 0
+
+    assert len(b._cache) == 0
+    assert b._cache_ctr['check'] == 0
+    assert b._cache_ctr['hits'] == 0
+    assert b._cache_ctr['misses'] == 0
+
+    assert len(c._cache) == 0
+    assert c._cache_ctr['check'] == 0
+    assert c._cache_ctr['hits'] == 0
+    assert c._cache_ctr['misses'] == 0

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -845,6 +845,7 @@ class DoNotUseModel(Model):
     # We need this for modelCacher1d
     _use_caching = True
     _cache = {}
+    _cache_ctr = {'hits': 0, 'misses': 0, 'check': 0, 'record': []}
     _queue = ['']
 
     @modelCacher1d

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -851,7 +851,7 @@ class DoNotUseModel(Model):
     # We need this for modelCacher1d
     _use_caching = True
     _cache = {}
-    _cache_ctr = {'hits': 0, 'misses': 0, 'check': 0, 'record': []}
+    _cache_ctr = {'hits': 0, 'misses': 0, 'check': 0}
     _queue = ['']
 
     @modelCacher1d


### PR DESCRIPTION
# Summary

Adds the cache_status and cache_clear methods to models for verifying the cache behavior (this is only expected to be used in rare cases). The cache code has seen documentation improvements.

# Details

This was originally a "for testing only" PR but I think it's worth accepting as it is useful, and I don't believe (but have not tested) that it would slow things down significantly (the development did add one feature that could have been a bit more of a slowdown but that has since been removed).

The aim is to store basic hit/miss information on the cache, and provides a method to display the current cache status. There have since been some clean-up/minor improvements and documentation additions. The algorithm used to calculate the cache contents has been changed from sha256 to md5 as this appears to be faster, and we do not need strong cryprographic strantgh here. I have not tried to optimise this more (i.e. test other algorighms); if we went to a CRC style check we could be even faster, but that is likely a step too far.

The cache count does not give reliable results when using the multi-threading features of Sherpa (at present mainly an issue when you do error analysis). Use numcores=1 or set the parallel=False option to avoid this. Note that `functools.lru_cache` has the same warning, so we're in good company. I have thought about switching over to `lru_cache` but it is not a simple change, as numpy arrays are not hashable.

An example of use (this is for fitting the `gal * pl` model to three datasets with the same grid so there's plenty of calls that should be cached):

```
In [1]: %run ../trial.py 1
...

In [2]: ui.get_source()._cache_status()
 xsphabs.gal                size:    5  hits:   715  misses:   158  check:   873
 powlaw1d.pl                size:    5  hits:   633  misses:   240  check:   873
```

For this dataset the run-time without the cache is 6 - 6.5s and with the cache it's 2.2 - 2.4s (this is the full runtime of the script, so including loading code and data).

# Notes

## A list is used to act as a LRU

The _queue attribute makes the cache act as LRU - so we only store the recently accessed - and constrains the amount of data stored. However, there's a bit of an oddity as the length of the queue is changed by the startup method of the model. I think this is an area that could be looked at and potentially improved (maybe dropping the special case of the startup code and always setting the queue to the cache size?), but not in this PR.

## Evaluating the cache key

I've long been concerned that the way we send arrays to models is less-than-optimal - it makes sense for one-off calls but in a fit there is repeated work (e.g. internal to the XSPEC interface we have to massage xlo,xhi into a single array, and playing filtering games with PSF convolution models). The calculation of the cache key requires "static" info - at least for a fit - as the integrate setting and grid(s) don't change - along with the parameter values (which do change). There is the possibility that we could improve the code for this, but this is again out-of-scope for this PR.

## Example program

With '../trial.py' being

```
import logging
import sys

import numpy as np
from sherpa.astro import ui

cache = len(sys.argv) > 1
print(f"Fit with cache={cache}")

logging.getLogger('sherpa').setLevel(logging.WARN)
ui.load_pha(1, '/home/dburke/sherpa/sherpa-master/sherpa-test-data/sherpatest/obs1.pi')
ui.load_pha(3, '/home/dburke/sherpa/sherpa-master/sherpa-test-data/sherpatest/obs3.pi')
ui.load_pha(4, '/home/dburke/sherpa/sherpa-master/sherpa-test-data/sherpatest/obs4.pi')
logging.getLogger('sherpa').setLevel(logging.INFO)

ui.notice(0.5, 7)

mdl = ui.xsphabs.gal * ui.powlaw1d.pl

for i in [1, 3, 4]:
    ui.group_counts(i, 15)
    ui.subtract(i)
    ui.set_source(i, mdl)

mdl._cache_status()

ui.fit(cache=cache)

mdl._cache_status()

# NOTE: everything from here is no-longer supported in the PR as the record entry has been removed;
#            I've left the code for reference.
record = pl._cache_ctr['record']

if cache:
    # look at pl.gamma parameter
    gammas = np.asarray([rs['pars'][0] for rs in record])
    flags = np.asarray([rs['hit'] for rs in record])

    # assume ordered as 1, 3, 4 (although actually doesn't matter what order they are
    # done, just that they follow the same order)
    #
    idx1 = np.arange(0, gammas.size, 3)
    idx2 = np.arange(1, gammas.size, 3)
    idx3 = np.arange(2, gammas.size, 3)

    print("Are the gamma values repeated?")
    print(np.all(gammas[idx2] == gammas[idx1]))
    print(np.all(gammas[idx3] == gammas[idx1]))

    print("Are the second and third set of values cached?")
    print(np.all(flags[idx2] == flags[idx3]))
    print(np.all(flags[idx2]))

    # We don't expect flags[idx1] == flags[idx2] since the idx1 values
    # will include "new" parameter values.
    #
    print("Are some of the first set un-cached?")
    print(np.any(flags[idx1] == False))

else:
    assert len(record) == 0
```

then we get the run-time for un-cached:

```
% time python ../trial.py
time python ../trial.py
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
Fit with cache=False
 xsphabs.gal                     size:    1  hits:     0  misses:     0  nrecords:     0  check=    0
 powlaw1d.pl                     size:    1  hits:     0  misses:     0  nrecords:     0  check=    0
Datasets              = 1, 3, 4
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 4.14929e+13
Final fit statistic   = 3.43238 at function evaluation 287
Data points           = 12
Degrees of freedom    = 9
Probability [Q-value] = 0.944665
Reduced statistic     = 0.381376
Change in statistic   = 4.14929e+13
   gal.nH         0.00057023   +/- 0.0752482
   pl.gamma       1.53513      +/- 0.610621
   pl.ampl        5.51651e-07  +/- 2.76327e-07
 xsphabs.gal                     size:    5  hits:     0  misses:     0  nrecords:     0  check=  873
 powlaw1d.pl                     size:    5  hits:     0  misses:     0  nrecords:     0  check=  873

real    0m6.420s
user    0m6.854s
sys     0m0.691s
```

and for cached the run-time along with some simple checks to show that the model evaluation - which follows a "evaluate for dataset a then b then c and repeat" shows this behavior - we can see the run-time improvement:

```
% time python ../trial.py 1
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
Fit with cache=True
 xsphabs.gal                     size:    1  hits:     0  misses:     0  nrecords:     0  check=    0
 powlaw1d.pl                     size:    1  hits:     0  misses:     0  nrecords:     0  check=    0
Datasets              = 1, 3, 4
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 4.14929e+13
Final fit statistic   = 3.43238 at function evaluation 287
Data points           = 12
Degrees of freedom    = 9
Probability [Q-value] = 0.944665
Reduced statistic     = 0.381376
Change in statistic   = 4.14929e+13
   gal.nH         0.00057023   +/- 0.0752482
   pl.gamma       1.53513      +/- 0.610621
   pl.ampl        5.51651e-07  +/- 2.76327e-07
 xsphabs.gal                     size:    5  hits:   715  misses:   158  nrecords:   873  check=  873
 powlaw1d.pl                     size:    5  hits:   633  misses:   240  nrecords:   873  check=  873
Are the gamma values repeated?
True
True
Are the second and third set of values cached?
True
True
Are some of the first set un-cached?
True

real    0m2.364s
user    0m2.799s
sys     0m0.686s
``` 

## Calculating the cache key

This is a bit long as my understanding of the code improved while writing this and I haven't taken the time to re-write this text.

I noticed that we were using `sha256` when `md5` is likely to be quicker, as shown below: 10 vs 17 microseconds.

Of course, this is not the only bit of computation, since we also have to bundle up the data into a byte array to pass to the hash function, and if you include this them you see that that time actually dominated (and in fact can end up with the sha256 run being faster).

```
In [1]: import numpy as np

In [2]: from hashlib import md5, sha256

In [3]: from zlib import crc32

In [4]: egrid = np.arange(0.1, 11, 0.01)

In [5]: %timeit crc32(egrid)
5.55 µs ± 52.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [6]: edata = b''.join(egrid)

In [7]: %timeit md5(edata).digest()
10.7 µs ± 34.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [8]: %timeit md5(edata).hexdigest()
10.7 µs ± 81.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [9]: %timeit sha256(edata).digest()
16.7 µs ± 118 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [10]: %timeit sha256(edata).hexdigest()
17.4 µs ± 572 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [11]: %timeit edata1 = b''.join(egrid); md5(edata1).digest()
540 µs ± 7.93 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [12]: %timeit edata1 = b''.join(egrid); md5(edata1).digest()
541 µs ± 2.32 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [13]: %timeit edata1 = b''.join(egrid); md5(edata1).digest()
567 µs ± 2.13 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [14]: %timeit edata1 = b''.join(egrid); sha256(edata1).digest()
511 µs ± 4.24 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [15]: %timeit edata1 = b''.join(egrid); sha256(edata1).digest()
514 µs ± 6.06 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [16]: %timeit edata1 = b''.join(egrid); sha256(edata1).digest()
500 µs ± 1.71 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [17]: %timeit edata1 = b''.join(egrid); md5(edata1).digest()
510 µs ± 13.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [18]: %timeit edata1 = b''.join(egrid); md5(edata1).digest()
501 µs ± 2.34 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [19]: %timeit edata1 = b''.join(egrid); sha256(edata1).digest()
482 µs ± 2.52 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

So, things to note

- the hash function is not the time sink here
- if we used zlib.crc32 instead then we'd be a lot faster (as we don't have to go through the "make a byte string" step), **BUT** crc32 is explicitly not intended as a general-purpose hash
- the example has not tested other methods in `hashlib` (but as we're already dominated by the pre-processing step it's doesn't seem worth it)
- is there a better (i.e. faster) way to turn the numpy array to a byte string?
- in reality we have to combine parameters, grid, integreate setting, and potentially another grid, and so there are plenty of places where efficiencies  in one approach could get lost when you do the whole process

An answer to "is there a faster way" is: yes (`.tobytes` requires numpy 1.9.0 and I can't remember what are current minimum is):

```
In [25]: %timeit edata1 = b''.join(egrid); val1 = sha256(edata1).digest()
501 µs ± 10.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [26]: %timeit edata1 = egrid.tobytes(); val1 = sha256(edata1).digest()
18.1 µs ± 187 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

which gives us back the "MD5 is quicker than sha256" approach:

```
In [31]: %timeit edata1 = egrid.tobytes(); val1 = sha256(edata1).digest()
17.1 µs ± 148 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [32]: %timeit edata1 = egrid.tobytes(); val1 = md5(edata1).digest()
11.2 µs ± 50.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

[it turns out we already make use of `todigest` so some of this is moot, but there is still some cleanup we can do].
 