### PR TITLE
Add XSPEC 12.11.0 support (HEAsoft 6.27)

### DIFF
--- a/docs/bugs.rst
+++ b/docs/bugs.rst
@@ -7,8 +7,8 @@ is to create a new issue on the Sherpa
 `GitHub issue page <https://github.com/sherpa/sherpa/issues/>`_; that
 requires creating a free account on GitHub if you do not have one.
 For those using Sherpa as part of
-`CIAO <http://cxc.harvard.edu/ciao/>`_, please use the
-`CXC HelpDesk system <http://cxc.harvard.edu/helpdesk/>`_.
+`CIAO <https://cxc.harvard.edu/ciao/>`_, please use the
+`CXC HelpDesk system <https://cxc.harvard.edu/helpdesk/>`_.
 
 Please include an example that demonstrates the issue that will allow
 the developers to reproduce and fix the problem. You may be asked to

--- a/docs/ciao.rst
+++ b/docs/ciao.rst
@@ -24,7 +24,7 @@ with the following modifications:
   library (:py:mod:`sherpa.astro.xspec`).
 
 The online documentation provided for Sherpa as part of CIAO,
-namely http://cxc.harvard.edu/sherpa/, can be used with the
+namely https://cxc.harvard.edu/sherpa/, can be used with the
 standalone version of Sherpa, but note that the focus of this
 documentation is the
 :doc:`session-based API <ui/index>`

--- a/docs/code/trap.py
+++ b/docs/code/trap.py
@@ -26,7 +26,7 @@ def _trap1d(pars, x):
     Notes
     -----
     This is based on the interface described at
-    http://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Trapezoid1D.html
+    https://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Trapezoid1D.html
     but implemented without looking at the code, so any errors
     are not due to AstroPy.
     """

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -14,7 +14,7 @@ problems or feature requests on github
 At present we do not have any explicit documentation on how
 to contribute to Sherpa, but it is similar to other open-source
 packages such as
-`AstroPy <http://docs.astropy.org/en/stable/index.html#contributing>`_.
+`AstroPy <https://docs.astropy.org/en/stable/index.html#contributing>`_.
 
 The developer documentation is also currently lacking.
 
@@ -39,7 +39,7 @@ Conda can be used to install all the dependencies for Sherpa.
     conda install -n sherpaciao -c anaconda -c astropy sphinx graphviz sphinx-astropy sphinx_rtd_theme
 
 The first line installes the full `CIAO release
-<http://cxc.harvard.edu/ciao/>`_ and astropy, required for building
+<https://cxc.harvard.edu/ciao/>`_ and astropy, required for building
 and running tests locally. The last line adds all requirements for
 building the documentation.  Sherpa can use either astropy or crates
 as backend for reading and writing files. The default configuration in

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,16 +1,15 @@
-==================================
+**********************************
 Contributing to Sherpa development
-==================================
+**********************************
 
 .. todo::
 
    Needs work.
-   
+
 Contributions to Sherpa - whether it be bug reports, documentation
 updates, or new code - are highly encouraged.  Please `report any
 problems or feature requests on github
 <https://github.com/sherpa/sherpa/issues/>`_.
-
 
 At present we do not have any explicit documentation on how
 to contribute to Sherpa, but it is similar to other open-source
@@ -104,3 +103,281 @@ can be activated and Sherpa can be build from source.
 
     conda activate sherpaciao
     python setup.py develop
+
+How do I ...
+============
+
+Update the XSPEC bindings?
+--------------------------
+
+The :py:mod:`sherpa.astro.xspec` module currently supports
+:term:`XSPEC` versions 12.11.0 down to 12.9.0. It may build against
+newer versions, but if it does it will not provide access
+to any new models in the release. The following steps are needed
+to update to a newer version, and assume that you have the new version
+of XSPEC, or its model library, available. The following
+sections of the
+`XSPEC manual <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__
+should be reviewed:
+"Appendix F: Using the XSPEC Models Library in Other Programs",
+and
+"Appendix C: Adding Models to XSPEC"
+(direct links are not provided as there are no obvious stable URIs for
+them).
+
+#. Add a new version define in ``helpers/xspec_config.py``.
+
+   Current version: `helpers/xspec_config.py <https://github.com/sherpa/sherpa/blob/master/helpers/xspec_config.py>`_.
+
+   When adding support for XSPEC 12.11.0, the code in the ``run``
+   method was changed to include::
+
+       if xspec_version >= LooseVersion("12.11.0"):
+           macros += [('XSPEC_12_11_0', None)]
+
+   and the version check to::
+
+       # Since there are patches (e.g. 12.10.0c), look for the
+       # "next highest version.
+       if xspec_version >= LooseVersion("12.11.1"):
+           self.warn("XSPEC Version is greater than 12.11.0, which is the latest supported version for Sherpa")
+
+   The define should be named ``XSPEC_<a>_<b>_<c>`` for XSPEC release
+   ``<a>.<b>.<c>`` (the XSPEC patch level is not included). This define
+   is used when compiling the XSPEC model interface, to select which
+   functions to include.
+
+   .. note:: The Sherpa build system requires that the user indicate the
+	     version of XSPEC being used, via the ``xspec_config.xspec_version``
+	     setting in their ``setup.cfg`` file (as attempts to identify
+	     this value automatically were not successful). This version is
+	     the value used in the checks in ``helpers/xspec_config.py``.
+
+#. Attempt to build the XSPEC interface with::
+
+     python setup.py develop
+
+   This requires that the ``xspec_config`` section of the ``setup.cfg``
+   file has been set up correctly for the new XSPEC release. The exact
+   settings depend on how XSPEC was built (e.g. model only or as a
+   full application), and are described in the
+   :ref:`building XSPEC <build-xspec>` documentation. The most-common
+   changes are that the version numbers of the ``CCfits``, ``wcslib``,
+   and ``hdsp`` libraries need updating, and these can be checked by
+   looking in ``$HEADAS/lib``.
+
+   If the build succeeds, you can check that it has worked by directly
+   importing the XSPEC module, such as with the following, which should
+   print out the correct version::
+
+     python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
+
+   It may however fail, due to changes in the XSPEC interface (unfortunately,
+   such changes are often not included in the release notes).
+
+#. Identify changes in the XSPEC models.
+
+   A new XSPEC release can add models, change parameter settings in
+   existing models, change how a model is called, or even delete a
+   model (the last case is rare, and may require a discussion on
+   how to proceed). The
+   `XSPEC release notes <https://heasarc.gsfc.nasa.gov/xanadu/xspec/CHANGELOG.txt>`_
+   page provides an overview, but the ``model.dat`` file - found
+   in ``headas-<version>/Xspec/src/manager/model.dat`` (build) or
+   ``$HEADAS/../spectral/manager/model.dat`` (install) - provides
+   the details. It greatly simplifies things if you have a copy of
+   this file from the previous XSPEC version, since then a command
+   like::
+
+     diff heasoft-6.26.1/spectral/manager/model.dat heasoft-6.27/spectral/manager/model.dat
+
+   will tell you the differences. If you do not have the previous
+   version then the release notes will tell you which models to
+   look for in the ``model.dat`` file.
+
+   The ``model.dat`` is an ASCII file which is described in
+   Appendix C: Adding Models to XSPEC of the
+   `XSPEC manual <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`_.
+   The Sherpa interface to XSPEC only supports models labelled
+   as ``add``, ``mul``, and ``con`` (additive, multiplicative,
+   and convolution, respectively).
+
+   Each model is represented by a set of consecutive lines in
+   the file, and as of XSPEC 12.11.0, the file begins with::
+
+     % head -5 heasoft-6.27/Xspec/src/manager/model.dat
+     agauss         2   0.         1.e20          C_agauss  add  0
+     LineE   A      10.0   0.      0.      1.e6      1.e6      0.01
+     Sigma   A      1.0    0.      0.      1.e6      1.e6      0.01
+
+     agnsed        15   0.03       1.e20          agnsed    add  0
+
+   The important parts of the model definition are the first line,
+   which give the XSPEC model name (first parameter), number of
+   parameters (second parameter), two numbers which we ignore, the
+   name of the function that evaluates the model, the type
+   (e.g. ``add``), and then 1 or more values which we ignore. Then
+   there are lines which define the model parameters (the number match
+   the second argument of the first line), and then one or more blank
+   lines. In the output above we see that the XSPEC ``agauss`` model
+   has 2 parameters, is an additive model provided by the ``C_agauss``
+   function, and that the parameters are ``LineE`` and ``Sigma``.
+   The ``agnsed`` model is then defined (which uses the ``agnsed``
+   routines), but its 15 parameters have been cut off from the output.
+
+   The parameter lines will mostly look like this: parameter name,
+   unit string (is often ``" "``), the default value, the hard and then
+   soft minimum, then the soft ahd hard maximum, and then a value used
+   by the XSPEC optimiser, but we only care about if it is negative
+   (which indicates that the parameter should be frozen by default).
+   The other common variant is the "flag" parameter - that is, a
+   parameter that should never be thawed in a fit - which is indicated
+   by starting the parameter name with a ``$`` symbol (although the
+   documentation says these should only be followed by a single value,
+   you'll see a variety of formats in the ``model.dat`` file). These
+   parameters are marked by setting the ``alwaysfrozen`` argument of
+   the :py:class:`~sherpa.models.parameter.Parameter` constructor
+   to ``True``. Another option is the "scale" parameter, which is
+   labelled with a ``*`` prefix, and these are treated as normal
+   parameter values.
+
+   a. ``sherpa/astro/xspec/src/_xspec.cc``
+
+      Current version: `sherpa/astro/xspec/src/_xspec.cc <https://github.com/sherpa/sherpa/blob/master/sherpa/astro/xspec/src/_xspec.cc>`_.
+
+      New functions are added to the ``XspecMethods`` array,
+      using macros defined in ``sherpa/include/sherpa/astro/xspec_extension.hh``,
+      and should be surrounded by a pre-processor check for the
+      version symbol added to ``helpers/xspec_config.py``.
+
+      As an example::
+
+        #ifdef XSPEC_12_10_1
+          XSPECMODELFCT_NORM( agnsed, 16 ),
+        #endif
+
+      adds support for the ``agnsed`` function, but only for XSPEC
+      12.10.1 and later. Note that the symbol name used here is
+      **not** the XSPEC model name (the first argument of the model
+      definition from ``model.dat``), but the function name (the fifth
+      argument of the model definition (although for the ``agnsed``
+      example they are the same).
+
+      Some models have changed the name of the function over time,
+      so the pre-processor directive may need to be more complex, such
+      as::
+
+        #ifdef XSPEC_12_10_0
+          XSPECMODELFCT_C_NORM( C_nsmaxg, 6 ),
+        #else
+          XSPECMODELFCT_NORM( nsmaxg, 6 ),
+        #endif
+
+      The remaining pieces are the choice of macro
+      (e.g. ``XSPECMODELFCT_NORM`` or ``XSPECMODELFCT_C_NORM``) and
+      the value for the second argument.  The macro depends on the
+      model type and the name of the function (which defines the
+      interface that XSPEC provides for the model, such as single- or
+      double- precision, and Fortran- or C- style linking). Additive
+      models use the suffix ``_NORM`` and convolution models use the
+      suffix ``_CON``. Model functions which begin with ``C_`` use the
+      ``_C`` variant, while those which begin with ``c_`` currently
+      require treating them as if they have no prefix.
+
+      The numeric argument to the template defines the number of
+      parameters supported by the model once in Sherpa, and should
+      equal the value given in the ``model.dat`` file for
+      multiplicative and convolution style models, and one larger than
+      this for additive models (i.e. those which use a macro that ends
+      in ``_NORM``).
+
+      As an example, the following three models from ``model.dat``::
+
+        apec           3  0.         1.e20           C_apec    add  0
+        phabs          1  0.03       1.e20           xsphab    mul  0
+        gsmooth        2  0.         1.e20           C_gsmooth    con  0
+
+      are encoded as (ignoring any pre-processor directives)::
+
+        XSPECMODELFCT_C_NORM( C_apec, 4 ),
+        XSPECMODELFCT( xsphab, 1 ),
+        XSPECMODELFCT_CON(C_gsmooth, 2),
+
+      Those models that do not use the ``_C`` version of the macro (or,
+      for convolution-style models, have to use
+      ``XSPECMODELFCT_CON_F77``), also have to declare the function
+      within the ``extern "C" {}`` block. For FORTRAN models, the
+      declaration should look like (replacing ``func`` with the
+      function name, and note the trailing underscore)::
+
+        void func_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+
+      and for model functions called ``c_func``, the prefixless
+      version should be declared as::
+
+        void func(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+      If you are unsure, do not add a declaration and then try to
+      build Sherpa: the compiler should fail with an indication of
+      what symbol names are missing.
+
+      .. note:: Ideally we would have a sensible ordering for the declarations in this
+		file, but at present it is ad-hoc.
+
+   b. ``sherpa/astro/xspec/__init__.py``
+
+      Current version: `sherpa/astro/xspec/__init__.py <https://github.com/sherpa/sherpa/blob/master/sherpa/astro/xspec/__init__.py>`_.
+
+      This is where the Python classes are added for additive and multiplicative
+      models. The code additions are defined by the model and parameter
+      specifications from the ``model.dat`` file, and the existing classes
+      should be used for inspiration. The model class should be called
+      ``XS<name>``, where ``<name>`` is the XSPEC model name, and the
+      ``name`` argument to its constructor be set to the XSPEC model name.
+
+      The two main issues are:
+
+      * Documentation: there is no machine-readable version of the text, and
+	so the documentation for the XSPEC model is used for inspiration.
+
+        The idea is to provide minimal documentation, such as the
+	model name and parameter descriptions, and then to point users to
+	the XSPEC model page for more information.
+
+	One wrinkle is that the
+	`XSPEC manual <https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/manual.html>`__
+	does not provide a stable URI for a model (as it can change with XSPEC
+	version). However, it appears that you can use the following pattern:
+
+	  https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodel<Name>.html
+
+	where ``<Name>`` is the capitalised version of the model name (e.g.
+	``Agnsed``).
+
+      * Models that are not in older versions of XSPEC should be marked with
+	the ``version_at_least`` decorator (giving it the minimum supported
+	XSPEC version as a string), and the function (added to ``_xspec.cc``)
+	is specified as a string using the ``__function__`` attribute. The
+	:py:class:`sherpa.astro.xspec.utils.ModelMeta` metaclass performs
+	a runtime check to ensure that the model can be used.
+
+   c. ``sherpa/astro/xspec/tests/test_xspec.py``
+
+      Current version: `sherpa/astro/xspec/tests/test_xspec.py <https://github.com/sherpa/sherpa/blob/master/sherpa/astro/xspec/tests/test_xspec.py>`_.
+
+      The ``XSPEC_MODELS_COUNT`` version should be increased by the number
+      of models classes added to ``__init__.py``.
+
+      Additive and multiplicative models will be run as part of the test
+      suite - using a simple test which runs on a default grid and
+      uses the default parameter values - whereas convolution models
+      are not (since their pre-conditions are harder to set up
+      automatically).
+
+   d. ``docs/model_classes/astro_xspec.rst``
+
+      Current version: `docs/model_classes/astro_xspec.rst <https://github.com/sherpa/sherpa/blob/master/docs/model_classes/astro_xspec.rst>`_.
+
+      New models should be added to both the ``Classes`` rubric - sorted
+      by addtive and then multiplicative models, using an alphabetical
+      sorting - and to the appropriate ``inheritance-diagram`` rule.

--- a/docs/evaluation/combine.rst
+++ b/docs/evaluation/combine.rst
@@ -56,7 +56,7 @@ Example
 The following example fits two one-dimensional gaussians to a
 simulated dataset.
 It is based on the `AstroPy modelling documentation
-<http://docs.astropy.org/en/stable/modeling/#compound-models>`_,
+<https://docs.astropy.org/en/stable/modeling/#compound-models>`_,
 but has :ref:`linked the positions of the two gaussians <params-link>`
 during the fit.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,15 +10,15 @@ Welcome to Sherpa's documentation
 .. image:: _static/sherpa_logo.png
     :width: 350px
     :height: 132px
-    :target: http://cxc.harvard.edu/contrib/sherpa/
+    :target: https://cxc.harvard.edu/contrib/sherpa/
 
 Welcome to the Sherpa documentation.
-`Sherpa <http://cxc.harvard.edu/contrib/sherpa/>`_
+`Sherpa <https://cxc.harvard.edu/contrib/sherpa/>`_
 is a Python package for
 modeling and fitting data. It was originally developed by the
-`Chandra X-ray Center <http://cxc.harvard.edu/>`_ for use in
+`Chandra X-ray Center <https://cxc.harvard.edu/>`_ for use in
 `analysing X-ray data (both spectral and imaging)
-<http://cxc.harvard.edu/sherpa>`_
+<https://cxc.harvard.edu/sherpa>`_
 from the  Chandra X-ray telescope, but it is designed to be a
 general-purpose package, which can be enhanced with domain-specific
 tasks (such as X-ray Astronomy).

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -22,7 +22,7 @@ Glossary
    Astropy
        A community Python library for Astronomy:
        https://www.astropy.org/.
-       
+
    CIAO
        The data reduction and analysis provided by the :term:`CXC`
        for users of the Chandra X-ray telescope. Sherpa is provided
@@ -35,7 +35,7 @@ Glossary
        speciality support for X-ray data formats that follow
        :term:`OGIP` standards (such as :term:`ARF` and :term:`RMF`
        files).
-       
+
    CXC
        The `Chandra X-ray Center <http://cxc.harvard.edu/>`_.
 
@@ -45,9 +45,9 @@ Glossary
        image data, and is available from http://ds9.si.edu/. It uses
        the :term:`XPA` messaging system to communicate with external
        processes.
-       
+
    FITS
-       The `Flexible Image Transport System 
+       The `Flexible Image Transport System
        <https://en.wikipedia.org/wiki/FITS>`_ is a common data format in
        Astronomy, originally defined to represent imaging data from radio
        telescopes, but has since been extended to contain a mixture of
@@ -85,7 +85,7 @@ Glossary
        `OGIP/92-007
        <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
        and
-       `OGIP/92-007a 
+       `OGIP/92-007a
        <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007a/ogip_92_007a.html>`_.
        Confusingly, PHA can also refer to the Pulse Height Amplitude (the
        amount of charge detected) of an event, which is one of the
@@ -98,7 +98,7 @@ Glossary
        dependent on the optical design of the system but can also be
        influenced by other factors (e.g. for ground-based observatories
        the atmosphere can add additional blurring).
-       
+
    RMF
        The Redistribution Matrix Function used to describe the response
        of an Astronomical X-ray detector. It is a matrix containing the
@@ -119,7 +119,7 @@ Glossary
        coordinates)
        for a given image pixel, but it can also be used to map between
        row on a spectrograph and the corresponding wavelength of light.
-       
+
    XPA
        The `XPA messaging system
        <http://hea-www.harvard.edu/saord/xpa/>`_
@@ -134,7 +134,7 @@ Glossary
        <https://packages.ubuntu.com/xenial/xpa-tools>`_,
        or they can be
        `built from source <https://github.com/ericmandel/xpa>`_.
-   
+
    XSPEC
        This can refer to either the X-ray Spectral fitting package,
        or the models from this package. XSPEC is distributed by
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.10.1 (patch level `a`
+       Sherpa can be built to use XSPEC versions 12.11.0, 12.10.1 (patch level `a`
        or later), 12.10.0, 12.9.1, or 12.9.0.

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -27,7 +27,7 @@ Glossary
        The data reduction and analysis provided by the :term:`CXC`
        for users of the Chandra X-ray telescope. Sherpa is provided
        as part of CIAO, but can also be used separately. The
-       CIAO system is available from http://cxc.harvard.edu/ciao/.
+       CIAO system is available from https://cxc.harvard.edu/ciao/.
 
    Crates
        The Input/Output library provided as part of :term:`CIAO`.
@@ -37,12 +37,12 @@ Glossary
        files).
 
    CXC
-       The `Chandra X-ray Center <http://cxc.harvard.edu/>`_.
+       The `Chandra X-ray Center <https://cxc.harvard.edu/>`_.
 
    DS9
        An external image viewer designed to allow users to interact with
        gridded data sets (2D and 3D). Is is used by Sherpa to display
-       image data, and is available from http://ds9.si.edu/. It uses
+       image data, and is available from https://ds9.si.edu/. It uses
        the :term:`XPA` messaging system to communicate with external
        processes.
 
@@ -122,7 +122,7 @@ Glossary
 
    XPA
        The `XPA messaging system
-       <http://hea-www.harvard.edu/saord/xpa/>`_
+       <https://hea-www.harvard.edu/saord/xpa/>`_
        is used by :term:`DS9` to communicate
        with external programs. Sherpa uses this functionality to
        control DS9 - by sending it images to display and retriving

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -65,7 +65,7 @@ Releases and version numbers
 The Sherpa release policy has a major release at the start of
 the year, corresponding to the code that is released in the
 previous December as part of the
-`CIAO release <http://cxc.harvard.edu/ciao/>`_, followed by
+`CIAO release <https://cxc.harvard.edu/ciao/>`_, followed by
 several smaller releases throughout the year.
 
 Information on the Sherpa releases is available from the
@@ -113,7 +113,7 @@ using::
     conda install -c sherpa sherpa
 
 It is **strongly** suggested that Sherpa is installed into a named
-`conda environment <http://conda.pydata.org/docs/using/envs.html>`_
+`conda environment <https://conda.pydata.org/docs/using/envs.html>`_
 (i.e. not the default environment).
 
 Using pip
@@ -336,7 +336,7 @@ Other options
 
 The remaining options in the ``setup.cfg`` file allow Sherpa to be
 built in specific environments, such as when it is built as part
-of the `CIAO analysis system <http://cxc.harvard.edu/ciao/>`_. Please
+of the `CIAO analysis system <https://cxc.harvard.edu/ciao/>`_. Please
 see the comments in the ``setup.cfg`` file for more information on
 these options.
 
@@ -351,7 +351,7 @@ Building and Installing
 
 It is highly recommended that some form of virtual environment,
 such as a
-`conda environment <http://conda.pydata.org/docs/using/envs.html>`_
+`conda environment <https://conda.pydata.org/docs/using/envs.html>`_
 or that provided by
 `Virtualenv <https://virtualenv.pypa.io/en/stable/>`_,
 be used when building and installing Sherpa.
@@ -433,8 +433,8 @@ which used ``git`` to access the source code)::
     git submodule init
     git submodule update
 
-When both the `DS9 image viewer <http://ds9.si.edu/site/Home.html>`_ and
-`XPA toolset <http://hea-www.harvard.edu/RD/xpa/>`_ are installed, the
+When both the `DS9 image viewer <https://ds9.si.edu/>`_ and
+`XPA toolset <https://hea-www.harvard.edu/RD/xpa/>`_ are installed, the
 test suite will include tests that check that DS9 can be used from
 Sherpa. This causes several copies of the DS9 viewer to be created,
 which can be distracting, as it can cause loss of mouse focus (depending
@@ -454,7 +454,7 @@ Building the documentation
 Building the documentation requires the Sherpa source code and several
 additional packages:
 
-* `Sphinx <http://sphinx.pocoo.org/>`_, version 1.8 or later
+* `Sphinx <https://sphinx.pocoo.org/>`_, version 1.8 or later
 * The ``sphinx_rtd_theme``
 * NumPy and `sphinx-astropy <https://github.com/astropy/sphinx-astropy/>`_
   (the latter can be installed with ``pip``).

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -51,7 +51,7 @@ if installed:
 The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
 functions from the :term:`XSPEC`.
-The supported versions of XSPEC are 12.10.1 (patch level `a` or later),
+The supported versions of XSPEC are 12.11.0, 12.10.1 (patch level `a` or later),
 12.10.0, 12.9.1, and 12.9.0.
 
 Interactive display and manipulation of two-dimensional images
@@ -213,7 +213,7 @@ XSPEC
    to support changes made in XSPEC 12.10.0.
 
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC` versions 12.10.1 (patch level `a` or later), 12.10.0,
+:term:`XSPEC` versions 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
 12.9.1, and 12.9.0. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
@@ -244,7 +244,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.5`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.10.1 system has been built then use::
+1. If the full XSPEC 12.11.0 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.11.0
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.27
+       ccfits_libraries = CCfits_2.5
+       wcslib_libraries = wcs-5.19.1
+
+   where the version numbers were taken from version 6.27 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.10.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.1
@@ -257,7 +270,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.26.1 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.10.0 system has been built then use::
+3. If the full XSPEC 12.10.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.0
@@ -267,7 +280,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
 
-3. If the full XSPEC 12.9.x system has been built then use::
+4. If the full XSPEC 12.9.x system has been built then use::
 
        with-xspec = True
        xspec_version = 12.9.1
@@ -279,7 +292,7 @@ match the contents of the XSPEC installation.
 
    changing ``12.9.1`` to ``12.9.0`` as appropriate.
 
-4. If the model-only build of XSPEC has been installed, then
+5. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may
    not need version numbers and locations, depending on how the
    ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
@@ -307,7 +320,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.10.1n
+    12.11.0
 
 .. warning::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -202,6 +202,8 @@ the ``fftw`` options in the ``sherpa_config`` section of the
 The ``fftw`` option must be set to ``local`` and then the remaining
 options changed to match the location of the local installation.
 
+.. _build-xspec:
+
 XSPEC
 ^^^^^
 

--- a/docs/mcmc/index.rst
+++ b/docs/mcmc/index.rst
@@ -13,7 +13,7 @@ Sherpa provides a
 method designed for Poisson-distributed data.
 It was originally developed as the
 `Bayesian Low-Count X-ray Spectral (BLoCXS)
-<http://hea-www.harvard.edu/astrostat/pyblocxs/>`_
+<https://hea-www.harvard.edu/astrostat/pyblocxs/>`_
 package, but has since been incorporated into Sherpa.
 It is developed from the work presented in
 `Analysis of Energy Spectra with Low Photon Counts

--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -7,11 +7,13 @@ The sherpa.astro.xspec module
 .. automodule:: sherpa.astro.xspec
 
    .. rubric:: Classes
-               
+
    .. autosummary::
       :toctree: api
-   
+
       XSagauss
+      XSagnsed
+      XSagnslim
       XSapec
       XSbapec
       XSbbody
@@ -22,11 +24,15 @@ The sherpa.astro.xspec module
       XSbknpower
       XSbmc
       XSbremss
+      XSbrnei
       XSbtapec
       XSbvapec
+      XSbvrnei
       XSbvtapec
       XSbvvapec
+      XSbvvrnei
       XSbvvtapec
+      XSbwcycl
       XSc6mekl
       XSc6pmekl
       XSc6pvmkl
@@ -43,6 +49,7 @@ The sherpa.astro.xspec module
       XScompmag
       XScomptb
       XScompth
+      XScph
       XScplinear
       XScutoffpl
       XSdisk
@@ -63,11 +70,14 @@ The sherpa.astro.xspec module
       XSgaussian
       XSgnei
       XSgrad
+      XSgrbcomp
       XSgrbm
       XShatm
+      XSjet
       XSkerrbb
       XSkerrd
       XSkerrdisk
+      XSkyrline
       XSlaor
       XSlaor2
       XSlogpar
@@ -96,6 +106,7 @@ The sherpa.astro.xspec module
       XSposm
       XSpowerlaw
       XSpshock
+      XSqsosed
       XSraymond
       XSredge
       XSrefsch
@@ -106,10 +117,12 @@ The sherpa.astro.xspec module
       XSsnapec
       XSsrcut
       XSsresc
+      XSssa
       XSstep
       XStapec
       XSvapec
       XSvbremss
+      XSvcph
       XSvequil
       XSvgadem
       XSvgnei
@@ -134,8 +147,12 @@ The sherpa.astro.xspec module
       XSvvtapec
       XSzagauss
       XSzbbody
+      XSzbknpower
       XSzbremss
+      XSzcutoffpl
       XSzgauss
+      XSzkerrbb
+      XSzlogpar
       XSzpowerlw
       XSSSS_ice
       XSTBabs
@@ -159,8 +176,12 @@ The sherpa.astro.xspec module
       XShighecut
       XShrefl
       XSismabs
+      XSismdust
+      XSlog10con
+      XSlogconst
       XSlyman
       XSnotch
+      XSolivineabs
       XSpcfabs
       XSphabs
       XSplabs
@@ -193,14 +214,12 @@ The sherpa.astro.xspec module
       XSzwabs
       XSzwndabs
       XSzxipcf
-             
+
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSagauss XSapec XSbapec XSbbody XSbbodyrad XSbexrav XSbexriv XSbkn2pow XSbknpower XSbmc XSbremss XSbtapec XSbvapec XSbvtapec XSbvvapec XSbvvtapec XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScevmkl XScflow XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeplogpar XSeqpair XSeqtherm XSequil XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbm XShatm XSkerrbb XSkerrd XSkerrdisk XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSstep XStapec XSvapec XSvbremss XSvequil XSvgadem XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSzagauss XSzbbody XSzbremss XSzgauss XSzpowerlw
+.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbexrav XSbexriv XSbkn2pow XSbknpower XSbmc XSbremss XSbrnei XSbtapec XSbvapec XSbvrnei XSbvtapec XSbvvapec XSbvvrnei XSbvvtapec XSbwcycl XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScevmkl XScflow XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeplogpar XSeqpair XSeqtherm XSequil XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSstep XStapec XSvapec XSvbremss XSvcph XSvequil XSvgadem XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzgauss XSzkerrbb XSzlogpar XSzpowerlw
    :parts: 1
 
-.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSlyman XSnotch XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipcf
+.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipcf
    :parts: 1
-
-

--- a/docs/model_classes/index.rst
+++ b/docs/model_classes/index.rst
@@ -5,7 +5,7 @@ Available Models
 ****************
 
 .. todo::
-   
+
    I am not convinced separating the models out here from the
    API below is a good idea, as we end up with multiple pages
    describing the `sherpa.astro.xspec` module (for instance).
@@ -14,7 +14,7 @@ Available Models
    at the auto-generated index or module-list pages).
 
 .. note::
-   
+
    The models in :py:mod:`sherpa.astro.xspec` are only available if
    Sherpa was built with support for the
    `XSPEC model library
@@ -53,4 +53,4 @@ contains the classes that implement various models.
    template
    astro_instrument
    xspec_model
-   
+   xspec_utils

--- a/docs/model_classes/usermodel.rst
+++ b/docs/model_classes/usermodel.rst
@@ -25,7 +25,7 @@ A one-dimensional model
 =======================
 
 An example is the
-`AstroPy trapezoidal model <http://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Trapezoid1D.html>`_,
+`AstroPy trapezoidal model <https://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Trapezoid1D.html>`_,
 which has four parameters: the amplitude of the central region, the center
 and width of this region, and the slope. The following model class,
 which was not written for efficiancy or robustness, implements this
@@ -105,7 +105,7 @@ of the ``calc`` method.
 It also shows one way of embedding models from a different system,
 in this case the
 `two-dimemensional polynomial model 
-<http://docs.astropy.org/en/stable/api/astropy.modeling.polynomial.Polynomial2D.html>`_
+<https://docs.astropy.org/en/stable/api/astropy.modeling.polynomial.Polynomial2D.html>`_
 from the AstroPy package.
 
 .. literalinclude:: ../code/poly.py

--- a/docs/model_classes/xspec_utils.rst
+++ b/docs/model_classes/xspec_utils.rst
@@ -1,0 +1,25 @@
+***********************************
+The sherpa.astro.xspec.utils module
+***********************************
+
+.. currentmodule:: sherpa.astro.xspec.utils
+
+.. automodule:: sherpa.astro.xspec.utils
+
+This module provides routines useful for the
+:doc:`XSPEC model <xspec_model>` interface.
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      ModelMeta
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      include_if
+      version_at_least

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -47,7 +47,7 @@ The parameter values have a current value, a valid range
 and a units field. The units field is a string, describing the
 expected units for the parameter; there is currently *no support* for
 using `astropy.units
-<http://docs.astropy.org/en/stable/units/index.html>`_ to set a
+<https://docs.astropy.org/en/stable/units/index.html>`_ to set a
 parameter value.  The "Type" column refers to whether the parameter is
 fixed, (``frozen``) or can be varied during a fit (``thawed``),
 as described below, in the :ref:`params-freeze` section.

--- a/docs/optimisers/index.rst
+++ b/docs/optimisers/index.rst
@@ -39,7 +39,7 @@ field.
 Additional optimisers can be built by extending from the
 :py:class:`sherpa.optmethods.OptMethod` class. This can be used
 to provide access to external packages such as
-`CERN's MINUIT optimisation library <http://iminuit.readthedocs.io>`_.
+`CERN's MINUIT optimisation library <https://iminuit.readthedocs.io>`_.
 
 Choosing an optimiser
 =====================

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -4,7 +4,7 @@ A quick guide to modeling and fitting in Sherpa
 
 Here are some examples of using Sherpa to model and fit data.
 It is based on some of the examples used in the `astropy.modelling
-documentation <http://docs.astropy.org/en/stable/modeling/>`_.
+documentation <https://docs.astropy.org/en/stable/modeling/>`_.
 
 .. _getting-started:
 
@@ -851,7 +851,7 @@ and then displaying it::
 
    The :py:mod:`sherpa.image` model provides support for *interactive*
    image visualization, but this only works if the
-   `DS9 <http://ds9.si.edu/site/Home.html>`_ image viewer is installed.
+   `DS9 <https://ds9.si.edu/site/Home.html>`_ image viewer is installed.
    For the examples in this document, matplotlib plots will be
    created to view the data directly.
    

--- a/docs/ui/index.rst
+++ b/docs/ui/index.rst
@@ -22,7 +22,7 @@ to identify data sets and model components. The Astronomy-specific
 version adds domain-specific functionality; in this case support
 for Astronomical data analysis, with a strong focus on high-energy (X-ray)
 data. It is currently documented on the
-http://cxc.harvard.edu/sherpa/ web site.
+https://cxc.harvard.edu/sherpa/ web site.
 
 The :py:class:`~sherpa.ui.utils.Session` object provides methods
 that allow you to:
@@ -49,7 +49,7 @@ Examples
 
 The following examples are *very* basic, since they are
 intended to highlight how the Sesssion API is used.
-The CIAO documentation for Sherpa at http://cxc.harvard.edu/sherpa/
+The CIAO documentation for Sherpa at https://cxc.harvard.edu/sherpa/
 provides more documentation and examples.
 
 There are two examples which show the same process -

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2014-2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014-2017, 2018, 2020
+#       Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -125,10 +126,13 @@ class xspec_config(Command):
                 if xspec_version >= LooseVersion("12.10.1"):
                     macros += [('XSPEC_12_10_1', None)]
 
+                if xspec_version >= LooseVersion("12.11.0"):
+                    macros += [('XSPEC_12_11_0', None)]
+
                 # Since there are patches (e.g. 12.10.0c), look for the
                 # "next highest version.
-                if xspec_version >= LooseVersion("12.10.2"):
-                    self.warn("XSPEC Version is greater than 12.10.1, which is the latest supported version for Sherpa")
+                if xspec_version >= LooseVersion("12.11.1"):
+                    self.warn("XSPEC Version is greater than 12.11.0, which is the latest supported version for Sherpa")
 
             extension = build_ext('xspec', ld, inc, l, define_macros=macros)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,8 +81,13 @@ source-dir = docs
 #
 # If you are using a full XSPEC build, then add the correct version
 # numbers to the cfitsio, CCfits, and wcs libraries used in the build,
-# if necessary. For XSPEC 12.9.1 this means using CCfits_2.5 and
-# wcs-5.16.
+# if necessary. For XSPEC 12.11.0 (HEAsoft 6.27) this means using
+# CCfits_2.5, wcs-5.19.1, and hdsp_6.27.
+#
+# For XSPEC 12.10.0 and later, the xspec_libraries line should
+# be changed to
+#
+#   xspec_libraries = XSFunctions XSUtil XS hdsp_<version>
 #
 # If you are using the models-only XSPEC build, then the cfitsio_lib_dirs,
 # ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -614,25 +614,48 @@ def test_bug_316(make_data_path):
 
 @requires_data
 @requires_fits
-@requires_xspec
 def test_load_multi_arfsrmfs(make_data_path):
+    """Added in #728 to ensure cache parameter is sent along by
+    MultiResponseSumModel.
+
+    This has since been simplified to switch from xsapec to
+    powlaw1d as it drops the need for XSPEC and is a simpler
+    model, so is less affected by changes in the model code.
+
+    A fit of the Sherpa powerlaw-model to 3c273.pi with a
+    single response in CIAO 4.11 (background subtracted,
+    0.5-7 keV) returns gamma = 1.9298, ampl = 1.73862e-4
+    so doubling the response should halve the amplitude but
+    leave the gamma value the same when using two responses,
+    as below. This is with chi2datavar.
+    """
+
     pha_pi = make_data_path("3c273.pi")
     ui.load_pha(1, pha_pi)
     ui.load_pha(2, pha_pi)
-    bkg_pi = make_data_path("3c273_bg.pi")
-    ui.load_bkg(1, bkg_pi)
-    ui.load_bkg(2, bkg_pi)
 
     arf = make_data_path("3c273.arf")
+    rmf = make_data_path("3c273.rmf")
+
     ui.load_multi_arfs(1, [arf, arf], [1, 2])
     ui.load_multi_arfs(2, [arf, arf], [1, 2])
 
-    rmf = make_data_path("3c273.rmf")
     ui.load_multi_rmfs(1, [rmf, rmf], [1, 2])
     ui.load_multi_rmfs(2, [rmf, rmf], [1, 2])
-    ui.set_model(1, ui.xsapec.src)
-    ui.set_model(2, ui.xsapec.src)
+
+    ui.notice(0.5, 7)
+    ui.subtract(1)
+    ui.subtract(2)
+
+    src = ui.create_model_component('powlaw1d', 'src')
+    ui.set_model(1, src)
+    ui.set_model(2, src)
+
+    ui.set_stat('chi2datavar')
     ui.fit()
-    parvals = ui.get_fit_results().parvals
-    assert(parvals[0] == pytest.approx(1.03364, rel=1.0e-3))
-    assert(parvals[1] == pytest.approx(4.56712e-05, rel=1.03e-3))
+    fr = ui.get_fit_results()
+    assert fr.succeeded
+    assert fr.datasets == (1, 2)
+
+    assert src.gamma.val == pytest.approx(1.9298, rel=1.0e-4)
+    assert src.ampl.val == pytest.approx(1.73862e-4 / 2, rel=1.0e-4)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1110,7 +1110,7 @@ class XSagnsed(XSAdditiveModel):
         self.logrout = Parameter(name, 'logrout', -1, -3, 7, -3, 7,
                                  '(_selfg)', frozen=True)
 
-        self.Htmax = Parameter(name, 'Htmax', 100, 6, 200, 6, 200,
+        self.Htmax = Parameter(name, 'Htmax', 10, 6, 10, 6, 10,
                                'Rg', frozen=True)
 
         self.reprocess = Parameter(name, 'reprocess', 1, 0, 1, 0, 1,
@@ -3223,7 +3223,7 @@ class XSgrad(XSAdditiveModel):
 
     See Also
     --------
-    XSkerbb
+    XSkerrbb
 
     References
     ----------
@@ -3417,8 +3417,8 @@ class XSkerrbb(XSAdditiveModel):
         self.Mdd = Parameter(name, 'Mdd', 1., 0., 1000., 0.0, hugeval, 'Mdd0')
         self.Dbh = Parameter(name, 'Dbh', 10., 0., 10000., 0.0, hugeval, 'kpc', True)
         self.hd = Parameter(name, 'hd', 1.7, 1., 10., 0.0, hugeval, frozen=True)
-        self.rflag = Parameter(name, 'rflag', 1., -100., 100., -hugeval, hugeval, frozen=True)
-        self.lflag = Parameter(name, 'lflag', 0., -100., 100., -hugeval, hugeval, frozen=True)
+        self.rflag = Parameter(name, 'rflag', 1., -100., 100., -hugeval, hugeval, alwaysfrozen=True)
+        self.lflag = Parameter(name, 'lflag', 0., -100., 100., -hugeval, hugeval, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.eta, self.a, self.i, self.Mbh, self.Mdd, self.Dbh, self.hd, self.rflag, self.lflag, self.norm))
 
@@ -11103,8 +11103,8 @@ class XSxscat(XSMultiplicativeModel):
 
     def __init__(self, name='xscat'):
         self.NH = Parameter(name, 'NH', 1., 0., 1000.0, 0.0, 1000.0, '10^22')
-        self.Xpos = Parameter(name, 'Xpos', 0.5, 0, 0.95, 0, 0.95)
-        self.Rext = Parameter(name, 'Rext', 10.0, 0, 115.0, 0, 119.0, 'arcsec',
+        self.Xpos = Parameter(name, 'Xpos', 0.5, 0, 0.99, 0, 0.999)
+        self.Rext = Parameter(name, 'Rext', 10.0, 0, 235.0, 0, 240.0, 'arcsec',
                               frozen=True)
         # The maxmimum number of models depends on the data file, so pick
         # a value that is unlikely to be exceeded (the max at the time

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -31,7 +31,7 @@ XSPEC version - including patch level - the module is using::
 
    >>> from sherpa.astro import xspec
    >>> xspec.get_xsversion()
-   '12.10.1b'
+   '12.11.0'
 
 Initializing XSPEC
 ------------------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -10859,6 +10859,56 @@ class XSismdust(XSMultiplicativeModel):
                                         self.redshift))
 
 
+@version_at_least("12.11.0")
+class XSlogconst(XSMultiplicativeModel):
+    """The XSPEC logconst model: Constant in log units.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    logfact
+        The constant factor in natural log.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLogconst.html
+
+    """
+
+    __function__ = "C_logconst"
+
+    def __init__(self, name='logconst'):
+        self.logfact = Parameter(name, 'logfact', 0.0, -20.0, 20, -20, 20)
+        XSMultiplicativeModel.__init__(self, name, (self.logfact, ))
+
+
+@version_at_least("12.11.0")
+class XSlog10con(XSMultiplicativeModel):
+    """The XSPEC log10con model: Constant in base 10 log units.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    log10fac
+        The constant factor in base 10 log.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLog10con.html
+
+    """
+
+    __function__ = "C_log10con"
+
+    def __init__(self, name='log10con'):
+        self.log10fac = Parameter(name, 'log10fac', 0.0, -20.0, 20, -20, 20)
+        XSMultiplicativeModel.__init__(self, name, (self.log10fac, ))
+
+
 @version_at_least("12.9.1")
 class XSslimbh(XSAdditiveModel):
     """The XSPEC slimbh model: Stationary slim accretion disk.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -10825,6 +10825,40 @@ class XSismabs(XSMultiplicativeModel):
                                         self.Fe, self.redshift))
 
 
+@version_at_least("12.11.0")
+class XSismdust(XSMultiplicativeModel):
+    """The XSPEC ismdust model: Extinction due to a power-law distribution of dust grains.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    msil
+        The dust mass column for silicate (in units of 10^-4).
+    mgra
+        The dust mass column for graphite (in units of 10^-4).
+    redshift
+        The redshift of the absorber.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelIsmdust.html
+
+    """
+
+    __function__ = "ismdust"
+
+    def __init__(self, name='ismdust'):
+        self.msil = Parameter(name, 'msil', 1.0, 0.0, 1e4, 0, 1e5, '10^-4')
+        self.mgra = Parameter(name, 'mgra', 1.0, 0.0, 1e4, 0, 1e5, '10^-4')
+        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                  frozen=True)
+        XSMultiplicativeModel.__init__(self, name,
+                                       (self.msil, self.mgra,
+                                        self.redshift))
+
+
 @version_at_least("12.9.1")
 class XSslimbh(XSAdditiveModel):
     """The XSPEC slimbh model: Stationary slim accretion disk.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -10840,6 +10840,10 @@ class XSismdust(XSMultiplicativeModel):
     redshift
         The redshift of the absorber.
 
+    See Also
+    --------
+    XSolivineabs
+
     References
     ----------
 
@@ -10907,6 +10911,40 @@ class XSlog10con(XSMultiplicativeModel):
     def __init__(self, name='log10con'):
         self.log10fac = Parameter(name, 'log10fac', 0.0, -20.0, 20, -20, 20)
         XSMultiplicativeModel.__init__(self, name, (self.log10fac, ))
+
+
+@version_at_least("12.11.0")
+class XSolivineabs(XSMultiplicativeModel):
+    """The XSPEC olivineabs model: Absorption due to olivine.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    moliv
+        The dust mass column for olivine grains (in units of 10^-4).
+    redshift
+        The redshift of the absorber.
+
+    See Also
+    --------
+    XSismdust
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelOlivineabs.html
+
+    """
+
+    __function__ = "olivineabs"
+
+    def __init__(self, name='olivineabs'):
+        self.moliv = Parameter(name, 'moliv', 1.0, 0.0, 1e4, 0, 1e5, '10^-4')
+        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                  frozen=True)
+        XSMultiplicativeModel.__init__(self, name,
+                                       (self.moliv, self.redshift))
 
 
 @version_at_least("12.9.1")

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1934,6 +1934,77 @@ class XSbvrnei(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.Redshift, self.Velocity, self.norm))
 
 
+@version_at_least("12.11.0")
+class XSbwcycl(XSAdditiveModel):
+    """The XSPEC bwcycl model: Becker-Wolff self-consistent cyclotron line model.
+
+    The model is described at [1]_. Please review the restrictions
+    on the model and parameter values at this reference before using
+    the model.
+
+    Attributes
+    ----------
+    Radius
+        The radius of the Neutron star, in km. Keep frozen.
+    Mass
+        The mass of the Neutron star, in solar units. Keep frozen.
+    csi
+        Parameter linked to the photon escape time (order of some
+        unities).
+    delta
+        Ratio between bulk and thermal Comptonization importances.
+    B
+        The magnetic field in units of 10^12 G.
+    Mdot
+        The mass accretion rate, in 10^17 g/s.
+    Te
+        The electron temperature in units of keV.
+    r0
+        The column radius in m.
+    D
+        The source distance in kpc. Keep frozen.
+    BBnorm
+        The normalization of the blackbody seed photon component
+        (fix it to zero at first).
+    CYCnorm
+        The normalization of the cyclotron emission seed photon
+        component (fix it to one).
+    FFnorm
+        The normalization of the Bremsstrahlung emission seed photon
+        component (fix it to one).
+    norm
+        The normalization of the model (fix it to one).
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelBwcycl.html
+
+    """
+
+    __function__ = "beckerwolff"  # "c_beckerwolff"  do not have a direct interface to c_xxx
+
+    def __init__(self, name='bwcycl'):
+        self.Radius = Parameter(name, 'Radius', 10, 5, 20, 5, 20, units='km', frozen=True)
+        self.Mass = Parameter(name, 'Mass', 1.4, 1, 3, 1, 3, units='Solar', frozen=True)
+        self.csi = Parameter(name, 'csi', 1.5, 0.01, 20, 0.01, 20)
+        self.delta = Parameter(name, 'delta', 1.8, 0.01, 20, 0.01, 20)
+        self.B = Parameter(name, 'B', 4, 0.01, 100, 0.01, 100, units='1e12G')
+        self.Mdot = Parameter(name, 'Mdot', 1, 1e-6, 1e6, 1e-6, 1e6, units='1e17g/s')
+        self.Te = Parameter(name, 'Te', 5, 0.1, 100, 0.1, 100, units='keV')
+        self.r0 = Parameter(name, 'r0', 44, 10, 1000, 10, 1000, units='m')
+        self.D = Parameter(name, 'D', 5, 1, 20, 1, 20, units='km', frozen=True)
+        self.BBnorm = Parameter(name, 'BBnorm', 0.0, 0, 100, 0, 100, frozen=True)
+        self.CYCnorm = Parameter(name, 'CYCnorm', 1.0, -1, 100, -1, 100, frozen=True)
+        self.FFnorm = Parameter(name, 'FFnorm', 1.0, -1, 100, -1, 100, frozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
+
+        XSAdditiveModel.__init__(self, name, (self.Radius, self.Mass, self.csi, self.delta,
+                                              self.B, self.Mdot, self.Te, self.r0, self.D,
+                                              self.BBnorm, self.CYCnorm, self.FFnorm,
+                                              self.norm))
+
+
 class XSc6mekl(XSAdditiveModel):
     """The XSPEC c6mekl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3478,7 +3478,7 @@ class XSkerrbb(XSAdditiveModel):
         [1]_ for more details.
     a
         The specific angular momentum of the black hole in units of the
-        black hole mass M (when G=c=1). It should be in the range [0, 1).
+        black hole mass M (when G=c=1). It should be in the range [-1, 1).
     i
         The disk inclination angle, in degrees. A face-on disk has
         i=0. It must be less than or equal to 85 degrees.
@@ -3507,7 +3507,7 @@ class XSkerrbb(XSAdditiveModel):
 
     See Also
     --------
-    XSgrad
+    XSgrad, XSzkerrbb
 
     References
     ----------
@@ -6793,6 +6793,74 @@ class XSzgauss(XSAdditiveModel):
         XSAdditiveModel.guess(self, dep, *args, **kwargs)
         pos = get_xspec_position(dep, *args)
         param_apply_limits(pos, self.LineE, **kwargs)
+
+
+@version_at_least("12.11.0")
+class XSzkerrbb(XSAdditiveModel):
+    """The XSPEC zkerrbb model: multi-temperature blackbody model for thin accretion disk around a Kerr black hole.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    eta
+        The ratio of the disk power produced by a torque at the disk
+        inner boundary to the disk power arising from accretion. See
+        [1]_ for more details.
+    a
+        The specific angular momentum of the black hole in units of the
+        black hole mass M (when G=c=1). It should be in the range [-1, 1).
+    i
+        The disk inclination angle, in degrees. A face-on disk has
+        i=0. It must be less than or equal to 85 degrees.
+    Mbh
+        The mass of the black hole, in solar masses.
+    Mdd
+        The "effective" mass accretion rate in units of M_solar/year.
+        See [1]_ for more details.
+    z
+        The redshift of the black hole
+    fcol
+        The spectral hardening factor, Tcol/Teff. See [1]_ for more
+        details.
+    rflag
+        A flag to switch on or off the effect of self irradiation:
+        when greater than zero the self irradition is included,
+        otherwise it is not. This parameter can not be thawed.
+    lflag
+        A flag to switch on or off the effect of limb darkening:
+        when greater than zero the disk emission is assumed to be
+        limb darkened, otherwise it is isotropic.
+        This parameter can not be thawed.
+    norm
+        The normalization of the model. It should be fixed to 1
+        if the inclination, mass, and distance are frozen.
+
+    See Also
+    --------
+    XSkerrbb
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelKerrbb.html
+
+    """
+
+    __function__ = "C_zkerrbb"
+
+    def __init__(self, name='zkerrbb'):
+        self.eta = Parameter(name, 'eta', 0., 0., 1.0, 0.0, hugeval, frozen=True)
+        self.a = Parameter(name, 'a', 0., -1., 0.9999, -hugeval, hugeval)
+        self.i = Parameter(name, 'i', 30., 0., 85., 0.0, hugeval, 'deg', True)
+        self.Mbh = Parameter(name, 'Mbh', 1., 0., 100., 0.0, hugeval, 'M_sun')
+        self.Mdd = Parameter(name, 'Mdd', 1., 0., 1000., 0.0, hugeval, 'M0yr')
+        self.z = Parameter(name, 'z', 0.01, 0., 10., 0.0, 10, frozen=True)
+        self.fcol = Parameter(name, 'hd', 1.7, 1., 10., 0.0, hugeval, frozen=True)
+        self.rflag = Parameter(name, 'rflag', 1., -100., 100., -hugeval, hugeval, alwaysfrozen=True)
+        self.lflag = Parameter(name, 'lflag', 0., -100., 100., -hugeval, hugeval, alwaysfrozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
+        XSAdditiveModel.__init__(self, name, (self.eta, self.a, self.i, self.Mbh, self.Mdd, self.z, self.fcol, self.rflag, self.lflag, self.norm))
 
 
 @version_at_least("12.10.1")

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -118,6 +118,10 @@ void agnsed_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void qsosed_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 
+#ifdef XSPEC_12_11_0
+void agnslim_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+
 #ifndef XSPEC_12_9_1
 void xsaped_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -961,6 +965,10 @@ static PyMethodDef XSpecMethods[] = {
 #ifdef XSPEC_12_10_1
   XSPECMODELFCT_NORM( agnsed, 16 ),
   XSPECMODELFCT_NORM( qsosed, 7 ),
+#endif
+
+#ifdef XSPEC_12_11_0
+  XSPECMODELFCT_NORM( agnslim, 15 ),
 #endif
 
 #ifdef XSPEC_12_9_1

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -319,7 +319,13 @@ void slimbbmodel(const double* energy, int nFlux, const double* params, int spec
 #ifdef XSPEC_12_11_0
 void ismdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void olivineabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+
+// Note: have dropped the leading 'c_' for this model
+// TODO: should look at whether we want to fix this as now have a
+//       number of c_xxx functions in model.dat
+void beckerwolff(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 #endif
+
 
 // XSPEC table models; in XSPEC 12.10.1 these have been consolidated
 // into the tabint routine, but that is only available to C++, and
@@ -1292,6 +1298,14 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_vvnpshock, 36 ),
   XSPECMODELFCT_C_NORM( C_vvpshock, 35 ),
   XSPECMODELFCT_C_NORM( C_vvsedov, 35 ),
+
+#ifdef XSPEC_12_11_0
+  // We do not have a direct interface to the c_func routines, so
+  // take advantage of the fact XSPEC provides multiple APIs
+  // and use the C one.
+  // XSPECMODELFCT_C_NORM( c_beckerwolff, 13 ),
+  XSPECMODELFCT_C_NORM( beckerwolff, 13 ),
+#endif
 
   //multiplicative
   XSPECMODELFCT( xsphei, 3 ),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,5 +1,5 @@
 //  Copyright (C) 2007, 2015-2018, 2019, 2020
-//                Smithsonian Astrophysical Observatory
+//      Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -138,7 +138,7 @@ void c6pmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float*
 void c6pvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void c6vmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void cemekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void compbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void compls_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -147,7 +147,7 @@ void xstitg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void disk_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void diskir_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsdskb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#ifndef XSPEC_12_10_1  
+#ifndef XSPEC_12_10_1
 void xsdili_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 void diskm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -159,7 +159,7 @@ void ezdiskbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float
 
 #ifndef XSPEC_12_9_1
 void xsgaul_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif  
+#endif
 
 void grad_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
@@ -169,7 +169,7 @@ void xsgrbcomp(const double* energy, int nFlux, const double* params, int spectr
 
 void jet_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xsgrbm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void spin_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
@@ -182,7 +182,7 @@ void xslorz_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void xsmeka_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void nsa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsagrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsatmos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -190,7 +190,7 @@ void nsatmos_(float* ear, int* ne, float* param, int* ifl, float* photar, float*
 #ifndef XSPEC_12_10_0
 void nsmax_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xspegp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsp1tr_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsposm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -198,12 +198,12 @@ void xsposm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 #ifndef XSPEC_12_9_1
 void xsrays_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xredge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsrefsch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void srcut_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void sresc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
 void ssa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 void xsstep_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -211,25 +211,25 @@ void xsstep_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 #ifndef XSPEC_12_9_1
 void xsvape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xsbrmv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
 #ifndef XSPEC_12_9_1
 void xsvmek_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 #ifndef XSPEC_12_9_1
 void xsvrys_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xszbod_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszbrm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
-#ifndef XSPEC_12_10_0  
+#ifndef XSPEC_12_10_0
 void acisabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xscnst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xscabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xscycl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -248,10 +248,10 @@ void xssmdg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void xsspln_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xssssi_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
-#ifndef XSPEC_12_10_0  
+#ifndef XSPEC_12_10_0
 void swind1_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xsred_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsabsv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsvphb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -267,7 +267,7 @@ void xszphb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 #ifndef XSPEC_12_10_0
 void zxipcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 void xszcrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void msldst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszvab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -300,7 +300,7 @@ void xscomptb(const double* energy, int nFlux, const double* params, int spectru
 void nsmaxg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsx_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
-  
+
 //multiplicative
 void xsphei_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xslyman_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -313,12 +313,16 @@ void slimbbmodel(const double* energy, int nFlux, const double* params, int spec
 #endif
 
 // XSPEC table models; in XSPEC 12.10.1 these have been consolidated
-// into the tabint routine.
+// into the tabint routine, but that is only available to C++, and
+// so is defined in sherpa/include/sherpa/astro/xspec_extension.hh
+// In XSPEC 12.11.0 tabint is available in C scope (but is again
+// defined in xspec_extension.hh as it doesn't need to be visible
+// here).
 //
 #ifndef XSPEC_12_10_1
-void xsatbl(float* ear, int ne, float* param, const char* filenm, int ifl, 
+void xsatbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 	    float* photar, float* photer);
-void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl, 
+void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 	    float* photar, float* photer);
 #endif
 
@@ -355,7 +359,7 @@ int _sherpa_init_xspec_library()
 		     "HEADAS environment variable is not set" );
     return EXIT_FAILURE;
   }
-  
+
   // Stream buffer for redirected stdout
   std::streambuf* cout_sbuf = NULL;
   std::ofstream fout;
@@ -379,7 +383,7 @@ int _sherpa_init_xspec_library()
 
     // Note:  since we are *not* redirecting std::cerr, any error
     // messages are still seen; if, for example, HEADAS is not set,
-    // user will still see error message printed to stderr (i.e., to 
+    // user will still see error message printed to stderr (i.e., to
     // screen by default).  We still want such error messages to be
     // seen!  So do *not* redirect std::cerr.
     //
@@ -389,23 +393,23 @@ int _sherpa_init_xspec_library()
     // Perhaps the screen output could be saved, rather than redirected
     // to /dev/null, and checked for the string '***Error: ', which
     // appears to be used in the error messages from XSPEC.
-    
+
     cout_sbuf = std::cout.rdbuf();
     fout.open("/dev/null");
     if (cout_sbuf != NULL && fout.is_open())
       std::cout.rdbuf(fout.rdbuf()); // temporary redirect stdout to /dev/null
-    
+
     // Initialize XSPEC model library
     FNINIT();
-    
+
     // Get back original std::cout
     if (cout_sbuf != NULL) {
       std::cout.clear();
-      std::cout.rdbuf(cout_sbuf); 
+      std::cout.rdbuf(cout_sbuf);
     }
     fout.clear();
     fout.close();
-    
+
     // Try to minimize model chatter for normal operation.
     FPCHAT( 0 );
 
@@ -450,7 +454,7 @@ int _sherpa_init_xspec_library()
 }
 
 static PyObject* get_version( PyObject *self )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -459,7 +463,7 @@ static PyObject* get_version( PyObject *self )
   int retval;
 
   try {
-    
+
     retval = xs_getVersion(version, 256);
 
   } catch(...) {
@@ -469,19 +473,19 @@ static PyObject* get_version( PyObject *self )
     return NULL;
 
   }
-  
+
   if( retval < 0 ) {
     PyErr_SetString( PyExc_LookupError,
 		     (char*)"XSPEC version string was truncated" );
     return NULL;
   }
-  
+
   return Py_BuildValue( (char*)"s", version );
 
 }
 
 static PyObject* get_chatter( PyObject *self )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -506,7 +510,7 @@ static PyObject* get_chatter( PyObject *self )
 
 
 static PyObject* get_abund( PyObject *self, PyObject *args )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -533,46 +537,46 @@ static PyObject* get_abund( PyObject *self, PyObject *args )
   if( !element ) {
 
     retval = (PyObject*) Py_BuildValue( (char*)"s", abund );
-  
+
   } else {
 
     float abundVal = 0.0;
     std::streambuf *cerr_sbuf = NULL;
     std::ostringstream fout;
-    
+
     try {
-      
+
       cerr_sbuf = std::cerr.rdbuf();
-      
+
       if (cerr_sbuf != NULL)
 	std::cerr.rdbuf(fout.rdbuf());
-      
+
       abundVal = FGABND(element);
-      
-      // Get back original std::cerr
-      if (cerr_sbuf != NULL)
-	std::cerr.rdbuf(cerr_sbuf); 
-      
-      
-    } catch(...) {
-      
+
       // Get back original std::cerr
       if (cerr_sbuf != NULL)
 	std::cerr.rdbuf(cerr_sbuf);
-      
+
+
+    } catch(...) {
+
+      // Get back original std::cerr
+      if (cerr_sbuf != NULL)
+	std::cerr.rdbuf(cerr_sbuf);
+
       PyErr_Format( PyExc_ValueError,
 		    (char*)"could not get XSPEC abundance for '%s'",
 		  element);
       return NULL;
-      
+
     }
-    
+
     if( fout.str().size() > 0 ) {
       PyErr_Format( PyExc_TypeError,
 		    (char*)"could not find element '%s'", element);
       return NULL;
     }
-    
+
     retval = (PyObject*) Py_BuildValue( (char*)"f", abundVal );
   }
 
@@ -581,7 +585,7 @@ static PyObject* get_abund( PyObject *self, PyObject *args )
 
 
 static PyObject* get_cosmo( PyObject *self )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -610,7 +614,7 @@ static PyObject* get_cosmo( PyObject *self )
 
 
 static PyObject* get_cross( PyObject *self )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -635,7 +639,7 @@ static PyObject* get_cross( PyObject *self )
 
 
 static PyObject* set_chatter( PyObject *self, PyObject *args )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -650,7 +654,7 @@ static PyObject* set_chatter( PyObject *self, PyObject *args )
     FPCHAT( chatter );
 
   } catch(...) {
-    
+
     PyErr_Format( PyExc_ValueError,
                   (char*)"could not set XSPEC chatter level to %d",
                   chatter);
@@ -664,7 +668,7 @@ static PyObject* set_chatter( PyObject *self, PyObject *args )
 
 
 static PyObject* set_abund( PyObject *self, PyObject *args )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -680,7 +684,7 @@ static PyObject* set_abund( PyObject *self, PyObject *args )
     FPSOLR( table, &status );
 
   } catch(...) {
-    
+
     status = 1;
 
   }
@@ -693,38 +697,38 @@ static PyObject* set_abund( PyObject *self, PyObject *args )
     size_t count(0);
 
     try {
-      
+
       float element;
       fileStream.exceptions(std::ios_base::failbit);
-      
+
       while (count < ABUND_SIZE && fileStream >> element) {
 	vals[count] = element;
 	++count;
       }
-      
+
       status = 0;
     }
     catch ( std::exception& ) {
-     
+
       if( !fileStream.eof() ) {
-      	PyErr_Format( PyExc_ValueError, 
+      	PyErr_Format( PyExc_ValueError,
                       (char*)"Cannot read file '%s'.  It may not exist or contains invalid data",
                       table);
 	return NULL;
       }
-      
+
       status = 1;
     }
 
     try {
-      
+
       FPSOLR((char*)"file", &status);
       FPSLFL( &vals[0], ABUND_SIZE, &status );
-      
+
     } catch(...) {
-      
+
       status = 1;
-      
+
     }
   }
 
@@ -741,7 +745,7 @@ static PyObject* set_abund( PyObject *self, PyObject *args )
 
 
 static PyObject* set_cosmo( PyObject *self, PyObject *args )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -775,7 +779,7 @@ static PyObject* set_cosmo( PyObject *self, PyObject *args )
 
 
 static PyObject* set_cross( PyObject *self, PyObject *args )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -810,7 +814,7 @@ static PyObject* set_cross( PyObject *self, PyObject *args )
 
 
 static PyObject* set_xset( PyObject *self, PyObject *args )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -844,7 +848,7 @@ static PyObject* set_xset( PyObject *self, PyObject *args )
 }
 
 static PyObject* get_xset( PyObject *self, PyObject *args  )
-{ 
+{
 
   if ( EXIT_SUCCESS != _sherpa_init_xspec_library() )
     return NULL;
@@ -980,7 +984,7 @@ static PyMethodDef XSpecMethods[] = {
 #endif
 #ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_bvapec, 17 ),
-#else  
+#else
   XSPECMODELFCT_NORM( xsbvpe, 17 ),
 #endif
 #ifdef XSPEC_12_10_0
@@ -989,12 +993,12 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_c6pmekl, 11 ),
   XSPECMODELFCT_C_NORM( C_c6pvmkl, 24 ),
   XSPECMODELFCT_C_NORM( C_c6vmekl, 24 ),
-#else  
+#else
   XSPECMODELFCT_NORM( c6mekl, 11 ),
   XSPECMODELFCT_NORM( c6pmekl, 11 ),
   XSPECMODELFCT_NORM( c6pvmkl, 24 ),
   XSPECMODELFCT_NORM( c6vmekl, 24 ),
-#endif  
+#endif
   XSPECMODELFCT_NORM( cemekl, 7 ),
   XSPECMODELFCT_C_NORM( C_cemVMekal, 20 ),
   XSPECMODELFCT_C_NORM( C_xscflw, 6 ),
@@ -1026,9 +1030,9 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT_C_NORM( C_gnei, 6 ),
   XSPECMODELFCT_NORM( grad, 7 ),
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( xsgrbcomp, 10 ),
-#endif  
+#endif
   XSPECMODELFCT_NORM( xsgrbm, 4 ),
   XSPECMODELFCT_C_NORM( C_kerrbb, 10 ),
 #ifdef XSPEC_12_10_0
@@ -1060,7 +1064,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( xslorz, 3 ),
   XSPECMODELFCT_NORM( xsmeka, 5 ),
   XSPECMODELFCT_NORM( xsmekl, 6 ),
-#endif  
+#endif
   XSPECMODELFCT_C_NORM( C_xsmkcf, 6 ),
   XSPECMODELFCT_C_NORM( C_nei, 5 ),
   XSPECMODELFCT_C_NORM( C_nlapec, 4 ),
@@ -1068,7 +1072,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( nsa, 5 ),
   XSPECMODELFCT_NORM( nsagrav, 4 ),
   XSPECMODELFCT_NORM( nsatmos, 5 ),
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_nsmax, 4 ),
 #else
   XSPECMODELFCT_NORM( nsmax, 4 ),
@@ -1086,23 +1090,23 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_raysmith, 4 ),
 #else
   XSPECMODELFCT_NORM( xsrays, 4 ),
-#endif  
+#endif
   XSPECMODELFCT_NORM( xredge, 3 ),
   XSPECMODELFCT_NORM( xsrefsch, 14 ),
 
   XSPECMODELFCT_C_NORM( C_sedov, 6 ),
   XSPECMODELFCT_NORM( srcut, 3 ),
   XSPECMODELFCT_NORM( sresc, 3 ),
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_NORM( ssa, 3 ),
-#endif  
+#endif
   XSPECMODELFCT_NORM( xsstep, 3 ),
 
 #ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vapec, 16 ),
-#else  
+#else
   XSPECMODELFCT_NORM( xsvape, 16 ),
-#endif  
+#endif
   XSPECMODELFCT_NORM( xsbrmv, 3 ),
 
 #ifdef XSPEC_12_10_1
@@ -1117,7 +1121,7 @@ static PyMethodDef XSpecMethods[] = {
 #else
   XSPECMODELFCT_NORM( xsvmek, 18 ),
   XSPECMODELFCT_NORM( xsvmkl, 19 ),
-#endif  
+#endif
   XSPECMODELFCT_C_NORM( C_xsvmcf, 19 ),
   XSPECMODELFCT_C_NORM( C_vnei, 17 ),
   XSPECMODELFCT_C_NORM( C_vnpshock, 19 ),
@@ -1126,7 +1130,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_vraysmith, 15 ),
 #else
   XSPECMODELFCT_NORM( xsvrys, 15 ),
-#endif  
+#endif
   XSPECMODELFCT_C_NORM( C_vsedov, 18 ),
   XSPECMODELFCT_NORM( xszbod, 3 ),
 
@@ -1152,7 +1156,7 @@ static PyMethodDef XSpecMethods[] = {
 #else
   XSPECMODELFCT( acisabs, 8 ),
 #endif
-  
+
   XSPECMODELFCT( xscnst, 1 ),
   XSPECMODELFCT( xscabs, 1 ),
   XSPECMODELFCT( xscycl, 5 ),
@@ -1174,12 +1178,12 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT( xsspln, 6 ),
   XSPECMODELFCT( xssssi, 1 ),
 
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C( C_swind1, 4 ),
 #else
   XSPECMODELFCT( swind1, 4 ),
 #endif
-  
+
   XSPECMODELFCT_C( C_tbabs, 1 ),
   XSPECMODELFCT_C( C_tbgrain, 6 ),
   XSPECMODELFCT_C( C_tbvabs, 42 ),
@@ -1200,7 +1204,7 @@ static PyMethodDef XSpecMethods[] = {
 #else
   XSPECMODELFCT( zxipcf, 4 ),
 #endif
-  
+
   XSPECMODELFCT( xszcrd, 2 ),
   XSPECMODELFCT( msldst, 4 ),
   XSPECMODELFCT_C( C_ztbabs, 2 ),
@@ -1221,7 +1225,7 @@ static PyMethodDef XSpecMethods[] = {
 #ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_bvvapec, 34 ),
   XSPECMODELFCT_C_NORM( C_vvapec, 33 ),
-#else  
+#else
   XSPECMODELFCT_NORM( xsbvvp, 34 ),
   XSPECMODELFCT_NORM( xsvvap, 33 ),
 #endif
@@ -1235,9 +1239,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( eplogpar, 3 ),
 #ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_logpar, 4 ),
-#else  
+#else
   XSPECMODELFCT_NORM( logpar, 4 ),
-#endif  
+#endif
   XSPECMODELFCT_NORM( optxagn, 14 ),
   XSPECMODELFCT_NORM( optxagnf, 12 ),
   XSPECMODELFCT_NORM( pexmon, 8 ),
@@ -1250,14 +1254,14 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( xscompmag, 9 ), // DJB thinks it's okay to use the C++ wrapper for C
   XSPECMODELFCT_C_NORM( xscomptb, 7 ), // DJB thinks it's okay to use the C++ wrapper for C
 
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_nsmaxg, 6 ),
   XSPECMODELFCT_C_NORM( C_nsx, 6 ),
 #else
   XSPECMODELFCT_NORM( nsmaxg, 6 ),
   XSPECMODELFCT_NORM( nsx, 6 ),
 #endif
-  
+
   XSPECMODELFCT_C_NORM( C_rnei, 6 ),
   XSPECMODELFCT_C_NORM( C_vrnei, 18 ),
   XSPECMODELFCT_C_NORM( C_vvrnei, 35 ),
@@ -1284,12 +1288,12 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_cflux, 3),
   XSPECMODELFCT_CON(C_cpflux, 3),
 
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_CON(C_gsmooth, 2),
 #else
   XSPECMODELFCT_CON(C_xsgsmt, 2),
 #endif
-  
+
   XSPECMODELFCT_CON(C_ireflct, 7),
   XSPECMODELFCT_CON(C_kdblur, 4),
   XSPECMODELFCT_CON(C_kdblur2, 6),
@@ -1299,12 +1303,12 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON_F77(kyconv, 12),
 #endif
 
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_CON(C_lsmooth, 2),
 #else
   XSPECMODELFCT_CON(C_xslsmt, 2),
 #endif
-  
+
   XSPECMODELFCT_CON(C_PartialCovering, 1),
   XSPECMODELFCT_CON(C_rdblur, 4),
   XSPECMODELFCT_CON(C_reflct, 5),
@@ -1327,7 +1331,7 @@ static PyMethodDef XSpecMethods[] = {
 
   XSPECMODELFCT_C_NORM(C_carbatm, 4),
   XSPECMODELFCT_C_NORM(C_hatm, 4),
-#ifdef XSPEC_12_10_0  
+#ifdef XSPEC_12_10_0
   XSPECMODELFCT_NORM(jet, 16),
 #endif
   XSPECMODELFCT(ismabs, 31),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1043,6 +1043,11 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT_NORM( xsgrbm, 4 ),
   XSPECMODELFCT_C_NORM( C_kerrbb, 10 ),
+
+#ifdef XSPEC_12_11_0
+  XSPECMODELFCT_C_NORM( C_zkerrbb, 10 ),
+#endif
+
 #ifdef XSPEC_12_10_0
   /* From an email from Craig Gordon at HEASARC:
      12.10.0 and later: for kerrd call C_kerrd. For earlier versions kerrd should call C_kerrdisk.

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -344,6 +344,10 @@ void rgsxsrc_(float* ear, int* ne, float* param, int* ifl, float* photar, float*
 void kyconv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 
+#ifdef XSPEC_12_11_0
+void thcompf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+
 }
 
 // This routine could be called when the module is being initialized,
@@ -1335,6 +1339,10 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_simpl, 3),
   XSPECMODELFCT_CON(C_zashift, 1),
   XSPECMODELFCT_CON(C_zmshift, 1),
+
+#ifdef XSPEC_12_11_0
+  XSPECMODELFCT_CON_F77(thcompf, 4),
+#endif
 
   // Models from 12.9.1
   //

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -316,6 +316,10 @@ void ismabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void slimbbmodel(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 #endif
 
+#ifdef XSPEC_12_11_0
+void ismdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+
 // XSPEC table models; in XSPEC 12.10.1 these have been consolidated
 // into the tabint routine, but that is only available to C++, and
 // so is defined in sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1348,6 +1352,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM(jet, 16),
 #endif
   XSPECMODELFCT(ismabs, 31),
+
+#ifdef XSPEC_12_11_0
+  XSPECMODELFCT(ismdust, 3),
+#endif
+
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),
   XSPECMODELFCT_C_NORM(C_snapec, 7),
   XSPECMODELFCT_C(C_tbfeo, 4),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1355,6 +1355,8 @@ static PyMethodDef XSpecMethods[] = {
 
 #ifdef XSPEC_12_11_0
   XSPECMODELFCT(ismdust, 3),
+  XSPECMODELFCT_C(C_logconst, 1),
+  XSPECMODELFCT_C(C_log10con, 1),
 #endif
 
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -318,6 +318,7 @@ void slimbbmodel(const double* energy, int nFlux, const double* params, int spec
 
 #ifdef XSPEC_12_11_0
 void ismdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+void olivineabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 
 // XSPEC table models; in XSPEC 12.10.1 these have been consolidated
@@ -1355,6 +1356,7 @@ static PyMethodDef XSpecMethods[] = {
 
 #ifdef XSPEC_12_11_0
   XSPECMODELFCT(ismdust, 3),
+  XSPECMODELFCT(olivineabs, 2),
   XSPECMODELFCT_C(C_logconst, 1),
   XSPECMODELFCT_C(C_log10con, 1),
 #endif

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -33,7 +33,7 @@ from sherpa.utils.err import ParameterErr
 # '(XSAdditiveModel)' and adding it to the number of occurrences of the
 # string '(XSMultiplicativeModel)' in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 197
+XSPEC_MODELS_COUNT = 198
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020
 #         Smithsonian Astrophysical Observatory
 #
 #
@@ -33,7 +33,7 @@ from sherpa.utils.err import ParameterErr
 # '(XSAdditiveModel)' and adding it to the number of occurrences of the
 # string '(XSMultiplicativeModel)' in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 196
+XSPEC_MODELS_COUNT = 197
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -33,7 +33,7 @@ from sherpa.utils.err import ParameterErr
 # '(XSAdditiveModel)' and adding it to the number of occurrences of the
 # string '(XSMultiplicativeModel)' in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 202
+XSPEC_MODELS_COUNT = 203
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -33,7 +33,7 @@ from sherpa.utils.err import ParameterErr
 # '(XSAdditiveModel)' and adding it to the number of occurrences of the
 # string '(XSMultiplicativeModel)' in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 198
+XSPEC_MODELS_COUNT = 199
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -33,7 +33,7 @@ from sherpa.utils.err import ParameterErr
 # '(XSAdditiveModel)' and adding it to the number of occurrences of the
 # string '(XSMultiplicativeModel)' in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 201
+XSPEC_MODELS_COUNT = 202
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -33,7 +33,7 @@ from sherpa.utils.err import ParameterErr
 # '(XSAdditiveModel)' and adding it to the number of occurrences of the
 # string '(XSMultiplicativeModel)' in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 199
+XSPEC_MODELS_COUNT = 201
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1,5 +1,5 @@
-// 
-//  Copyright (C) 2009, 2015, 2017  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2009, 2015, 2017, 2020  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -30,16 +30,26 @@
 #include <iostream>
 #include "sherpa/fcmp.hh"
 
-// This symbol is exported from C++ not C scope in early versions
-// of XSPEC 12.10.1
+// Prior to XSPEC 12.10.1, the table models were split into different
+// functions. These functions are defined in _xspec.cc.
 //
-// XSPEC 12.10.1 up to 12.10.1b only have this as C++ linkage (ie no
-// C linkage). It is expected that this will be made available to
-// C soon.
+// In 12.10.1 they were consolidated into a single function, tabint,
+// and so the declaration was moved here. The function was only
+// available in C++ scope.
 //
-#ifdef XSPEC_12_10_1
+// In XSPEC 12.11.0 (the next one after 12.10.1), the tabint function
+// was moved into C scope.
+//
+#if defined (XSPEC_12_10_1) && !defined(XSPEC_12_11_0)
 void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
              const char* tabtyp, float* photar, float* photer);
+#endif
+
+#ifdef XSPEC_12_11_0
+extern "C" {
+void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
+             const char* tabtyp, float* photar, float* photer);
+}
 #endif
 
 
@@ -67,7 +77,7 @@ typedef float FloatArrayType;
 // the models, the excess bins are removed. This has been discussed
 // with Keith Arnaud as a sensible approach. An alternative would be
 // to call the model on each contiguous section, but the issue here
-// is that there may be a non-negligible set-up cost within the models.      
+// is that there may be a non-negligible set-up cost within the models.
 
 // When creating the flux and flux error arrays to be sent to
 // the XSpec routines, the arrays are filled with 0's - that is
@@ -87,7 +97,7 @@ typedef float FloatArrayType;
 // e.g. xlo = 112.7, 103.3, 95.4, ...
 //      xhi = 124.0, 112.7, 103.3, ...
 // where the values are in Angstroms.
-      
+
 // The spectrum number is set to 1. It used to be 0, but some code
 // (a user model, so not included in the XSpec model library being
 // built against) has been seen to behave strangely with a value of 0,
@@ -283,7 +293,7 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
         for (int i = 0; i < ngrid; i++) {
           fear[i] = (FloatArrayType) ear[i];
         }
-        
+
         // Although the XSpec model expects the flux/fluxerror arrays
         // to have size ngrid-1, the return array has to match the
         // input size.
@@ -300,7 +310,7 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
         FloatArray error;
 	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
           return NULL;
-        
+
 	// Even though the XSPEC model function is Fortran, it could call
 	// C++ functions, so swallow exceptions here
 
@@ -347,7 +357,7 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
             result[i] *= pars[NumPars - 1];
 
 	return result.return_new_ref();
-          
+
 }
 
 
@@ -404,7 +414,7 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
         }
 
         int ifl = 1;
-        
+
         bool is_wave = (xlo[0] > xlo[nelem-1]) ? true : false;
         DoubleArray *x1 = &xlo;
         DoubleArray *x2 = &xhi;
@@ -661,7 +671,7 @@ PyObject* xspecmodelfct_con( PyObject* self, PyObject* args )
         }
 
         int ifl = 1;
-        
+
         bool is_wave = (xlo[0] > xlo[nelem-1]) ? true : false;
         DoubleArray *x1 = &xlo;
         DoubleArray *x2 = &xhi;
@@ -889,7 +899,7 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args )
         }
 
         int ifl = 1;
-        
+
         bool is_wave = (xlo[0] > xlo[nelem-1]) ? true : false;
         DoubleArray *x1 = &xlo;
         DoubleArray *x2 = &xhi;
@@ -1491,7 +1501,7 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
         for (int i = 0; i < ngrid; i++) {
           fear[i] = (FloatArrayType) ear[i];
         }
-        
+
         // Although the XSpec model expects the flux/fluxerror arrays
         // to have size ngrid-1, the return array has to match the
         // input size.


### PR DESCRIPTION
# Summary

Add support for XSPEC 12.11.0 (released March 31 2020).

## New models

### Additive

- `XSagnslim`
- `XSzkerrbb`
- `XSbwcycl`

### Multiplicative

- `XSismdust`
- `XSolivineabs`
- `XSlogconst`
- `XSlog10con`

## Model parameter values

Updates the following parameter settings for changes made to the
model.dat file in XSPEC 12.11.0. There is no way to make these
settings depend on the XSPEC model library in use, so we chose to
use the latest values (in many cases these will be compatible
but there may be cases where the values are not valid with older
XSPEC libraries):

 - `XSagnsed`: `Htmax` parameter has changed to lie within the range
   6 to 10, and defaults to 10 (previously you could use 6 to 200
   and the default was 100).

 - `XSkerrbb`: `rflag` and `lflag` are now marked as `alwaysfrozen`
   (they have been changed to '$' parameters in model.dat)

 - `XSxscat`: `Xpos` and `Rext` soft and hard limits have increased;
   they were 0.95/0.95 and 115/119 and are now 0.99/0.999 and
   235/240 respectively

---

# Details

 - [X] support compiling against 12.11.0 (only tested on Linux)
 - [X] check this fix still works with 12.10.1 (ie get a green from Travis CI tests)
 - [X] fix failing test with 12.11.0: `sherpa/astro/ui/tests/test_astro_ui.py::sherpa/astro/ui/tests/test_astro_ui.py`  (it's a regression test that uses APEC and the APEC code has been changed in XSPEC 12.11.0) - see 7c4d4a0 (this is marked as failed because the macOS build timed out and for some reason I can't re-run just that test; you can see it passed in the next commit 62adf64)
 - [X] add support for new models in XSPEC 12.11.0
    - [X] agnslim
    - [X] zkerrbb
    - [X] ismdust
    - [X] olivineabs
    - [X] thcomp (only direct access, no Python class as waiting for #68 to be resolved)
    - [X] logconst
    - [X] log10con
    - [X] bwcycl
    (mixing models not supported)
 - [X] update documentation to include 12.11.0 in supported XSPEC versions
 - [X] update `setup.cfg` comments to include `hdsp` library component (as this is needed in recent versions of XSPEC)
 - [X] add a developer guide for how to handle an XSPEC version increase