### PR TITLE
Docs: fix typo in docstring for calc_kcorr

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -13712,7 +13712,7 @@ class Session(sherpa.ui.utils.Session):
         0.82799195070436793
 
         Calculate the K correction for a range of redshifts (0 to 2)
-        using an observed frame of 0. to 2 keV and a rest frame of 0.1
+        using an observed frame of 0.5 to 2 keV and a rest frame of 0.1
         to 10 keV (the energy grid is set to ensure that it covers the
         full energy range; that is the rest-frame band and the
         observed frame band multiplied by the smallest and largest


### PR DESCRIPTION
Fix a typo in the documentation for calc_kcorr: change "0." to "0.5" in one of the examples.