### PR TITLE
Add a pyproject.toml file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft extern
 
 include versioneer.py
+include pyproject.toml
 
 include README.md
 include COPYRIGHT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools",
+            "wheel",
+            "oldest-supported-numpy",
+            ]


### PR DESCRIPTION
PEP 518 specifies the pyproject.toml file and the format is
understood by recent pip versions. On the other hand, there is no
good way to do that in setup.py or setup.cfg.

At the same time, numpy is installed as a wheel for almost all
systems nowadays so getting an extra numpy just for the sherpa
installation is not a big cost any longer.

At a later point, it might makes sense to also move some of the
information in setup.py into setup.cfg but this is a separate
issue.

closes #401
closes #382