### PR TITLE
WIP: Redo sherpa installation and CI with PEP 518 and tox

### DIFF
--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -21,7 +21,7 @@
 import shlex
 import os
 
-from numpy.distutils.core import Extension
+from distutils.extension import Extension
 
 # Include directory for Sherpa headers
 sherpa_inc = ['sherpa/include', 'sherpa/utils/src']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools",
+            "setuptools_scm",
+            "wheel",
+            "oldest-supported-numpy",
+            ]
+build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,68 @@
-[aliases]
-build = sherpa_config xspec_config build
-build_ext = sherpa_config xspec_config build_ext
-develop = sherpa_config xspec_config develop
-install = sherpa_config xspec_config install
-test = develop test
-bdist_wheel = sherpa_config bdist_wheel
+[metadata]
+name = sherpa
+author = Smithsonian Astrophysical Observatory / Chandra X-Ray Center
+author_email = cxchelp@head.cfa.harvard.edu
+license = GNU GPL v3
+license_file = COPYRIGHT
+url = http://cxc.harvard.edu/sherpa/
+description = Modeling and fitting package for scientific data analysis
+long_description = file: README.md
+keywords = astronomy, astrophysics, modeling, models, fitting, X-ray, data analysis
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+
+    Operating System :: OS Independent
+    Programming Language :: C
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Scientific/Engineering :: Astronomy
+    Topic :: Scientific/Engineering :: Physics
+
+[options]
+# We set packages to find: to automatically find all sub-packages
+packages = find:
+requires = numpy
+zip_safe = False
+tests_require =
+    pytest>=3.3
+    pytest-xvfb
+setup_requires = setuptools_scm
+install_requires = numpy>=1.10
+python_requires = >=3.5
+
+[options.entry_points]
+console_scripts =
+    sherpa_test = sherpa:clitest
+    sherpa_smoke = sherpa:_smoke_cli
+
+[options.extras_require]
+test =
+    coverage
+docs =
+    sphinx-astropy
+    pytest
+
+[options.data_files]
+sherpa = sherpa/sherpa.rc, sherpa/sherpa-standalone.rc
+
+
+[options.package_data]
+* = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*
+astropy = s
+astropy.utils.tests = data/.hidden_file.txt
+astropy.wcs = include/*/*.h
+astropy.wcs.tests = extension/*.c
+sherpa = include/sherpa/*.hh, include/sherpa/astro/*.hh, tests/*
+sherpa.astro.ui = tests/data/*
+
+[tool:pytest]
+minversion = 3.1
+testpaths = "sherpa" "docs"
+norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern"
+doctest_plus = enabled
+text_file_format = rst
+
+
 
 [sherpa_config]
 
@@ -103,3 +161,42 @@ source-dir = docs
 #wcslib_libraries = wcs
 #gfortran_lib_dirs = None
 #gfortran_libraries = gfortran
+
+
+[coverage:run]
+omit =
+  astropy/__init__*
+  astropy/conftest.py
+  astropy/*setup*
+  astropy/*/tests/*
+  astropy/tests/test_*
+  astropy/extern/*
+  astropy/utils/compat/*
+  astropy/version*
+  astropy/wcs/docstrings*
+  astropy/_erfa/*
+  */astropy/__init__*
+  */astropy/conftest.py
+  */astropy/*setup*
+  */astropy/*/tests/*
+  */astropy/tests/test_*
+  */astropy/extern/*
+  */astropy/utils/compat/*
+  */astropy/version*
+  */astropy/wcs/docstrings*
+  */astropy/_erfa/*
+
+[coverage:report]
+exclude_lines =
+  # Have to re-enable the standard pragma
+  pragma: no cover
+  # Don't complain about packages we have installed
+  except ImportError
+  # Don't complain if tests don't hit assertions
+  raise AssertionError
+  raise NotImplementedError
+  # Don't complain about script hooks
+  def main\(.*\):
+  # Ignore branches that don't pertain to this version of Python
+  pragma: py{ignore_python_version}
+

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+#!/usr/bin/env python
 #
 # Copyright (C) 2014, 2017, 2018, 2019 Smithsonian Astrophysical Observatory
 #
@@ -18,131 +18,67 @@ from __future__ import print_function
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# NOTE: The configuration for the package, including the name, version, and
+# other information are set in the setup.cfg file.
+
+import os
 import sys
 
-# python_requires will stop pip, but also let users who are using
-# 'python setup.py develop'.
-#
-if sys.version_info < (3, 5):
-    sys.stderr.write("Sherpa 4.12 (and later) requires Python 3.5 or later.\n\n")
-    sys.stderr.write("Please use Sherpa 4.11.1 if you need to use Python 2.7\n")
-    sys.exit(1)
-
-try:
-    import setuptools
-except:
-    print((
-        "WARNING\n"
-        "Could not import setuptools.\n"
-        "This might lead to an incomplete installation\n"
-    ), file=sys.stderr)
-
-# The module used to try to find the numpy module and error out if
-# that could not be found, but it seems simpler to just error out
-# here.
-#
-try:
-    from numpy.distutils import core
-
-except ImportError:
-    import sys
-
-    print((
-        "You need to install NUMPY in order to build Sherpa\n"
-        "Other dependencies will be automatically installed\n"
-        "Please install NUMPY (e.g. pip install numpy) and try again."
-    ), file=sys.stderr)
-    sys.exit(2)
+from setuptools import setup
 
 from helpers.extensions import static_ext_modules
 
-import versioneer
+# First provide helpful messages if contributors try and run legacy commands
+# for tests or docs.
 
-versioneer.VCS = 'git'
-versioneer.versionfile_source = 'sherpa/_version.py'
-versioneer.versionfile_build = 'sherpa/_version.py'
-versioneer.tag_prefix = ''
-versioneer.parentdir_prefix = 'sherpa-'
+TEST_HELP = """
+Note: running tests is no longer done using 'python setup.py test'. Instead
+you will need to run:
+    tox -e test
+If you don't already have tox installed, you can install it with:
+    pip install tox
+If you only want to run part of the test suite, you can also use pytest
+directly with::
+    pip install -e .[test]
+    pytest
+For more information, see:
+  http://docs.astropy.org/en/latest/development/testguide.html#running-tests
+"""
 
-# Restrict to python 3.5 or later for pip, but see
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-# for limitations
-#
-meta = dict(name='sherpa',
-            version=versioneer.get_version(),
-            author='Smithsonian Astrophysical Observatory / Chandra X-Ray Center',
-            author_email='cxchelp@head.cfa.harvard.edu',
-            url='http://cxc.harvard.edu/sherpa/',
-            description='Modeling and fitting package for scientific data analysis',
-            license='GNU GPL v3',
-            long_description=open('README.md', 'rt').read(),
-            long_description_content_type='text/markdown',
-            platforms='Linux, Mac OS X',
-            python_requires='~=3.5',
-            install_requires=['numpy'],
-            tests_require=['pytest-xvfb', 'pytest>=3.3'],
-            packages=['sherpa',
-                      'sherpa.estmethods',
-                      'sherpa.image',
-                      'sherpa.models',
-                      'sherpa.optmethods',
-                      'sherpa.plot',
-                      'sherpa.sim',
-                      'sherpa.stats',
-                      'sherpa.ui',
-                      'sherpa.utils',
-                      'sherpa.astro',
-                      'sherpa.astro.datastack',
-                      'sherpa.astro.datastack.plot_backend',
-                      'sherpa.astro.io',
-                      'sherpa.astro.models',
-                      'sherpa.astro.optical',
-                      'sherpa.astro.sim',
-                      'sherpa.astro.ui',
-                      'sherpa.astro.utils',
-                      'sherpa.astro.xspec',
-                      ],
-            package_data={'sherpa': ['include/sherpa/*.hh',
-                                     'include/sherpa/astro/*.hh',
-                                     'tests/*'],
-                          'sherpa.estmethods': ['tests/test_*.py'],
-                          'sherpa.image': ['tests/test_*.py'],
-                          'sherpa.models': ['tests/test_*.py'],
-                          'sherpa.optmethods': ['tests/test_*.py'],
-                          'sherpa.plot': ['tests/test_*.py'],
-                          'sherpa.sim': ['tests/test_*.py'],
-                          'sherpa.stats': ['tests/test_*.py'],
-                          'sherpa.ui': ['tests/test_*.py'],
-                          'sherpa.utils': ['tests/test_*.py'],
-                          'sherpa.astro': ['tests/test_*.py'],
-                          'sherpa.astro.datastack': ['tests/data/*', 'tests/*.py'],
-                          'sherpa.astro.io': ['tests/test_*.py'],
-                          'sherpa.astro.models': ['tests/test_*.py'],
-                          'sherpa.astro.optical': ['tests/test_*.py'],
-                          'sherpa.astro.sim': ['tests/test_*.py'],
-                          'sherpa.astro.ui': ['tests/data/*', 'tests/test_*.py'],
-                          'sherpa.astro.utils': ['tests/test_*.py'],
-                          },
-            data_files=[('sherpa',
-                         ['sherpa/sherpa.rc', 'sherpa/sherpa-standalone.rc']), ],
-            ext_modules=static_ext_modules, cmdclass=versioneer.get_cmdclass(),
-            entry_points={
-                'console_scripts': [
-                    'sherpa_test = sherpa:clitest',
-                    'sherpa_smoke = sherpa:_smoke_cli',
-                ]
-            },
-            classifiers=[
-                'Intended Audience :: Science/Research',
-                'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-                'Programming Language :: C',
-                'Programming Language :: Python :: 3.5',
-                'Programming Language :: Python :: 3.6',
-                'Programming Language :: Python :: 3.7',
-                'Programming Language :: Python :: Implementation :: CPython',
-                'Topic :: Scientific/Engineering :: Astronomy',
-                'Topic :: Scientific/Engineering :: Physics'
-                ],
-            )
+if 'test' in sys.argv:
+    print(TEST_HELP)
+    sys.exit(1)
 
-core.setup(**meta)
+DOCS_HELP = """
+Note: building the documentation is no longer done using
+'python setup.py build_docs'. Instead you will need to run:
+    tox -e build_docs
+If you don't already have tox installed, you can install it with:
+    pip install tox
+You can also build the documentation with Sphinx directly using::
+    pip install -e .[docs]
+    cd docs
+    make html
+For more information, see:
+  http://docs.astropy.org/en/latest/install.html#builddocs
+"""
+
+if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
+    print(DOCS_HELP)
+    sys.exit(1)
+
+VERSION_TEMPLATE = """
+# Note that we need to fall back to the hard-coded version if either
+# setuptools_scm can't be imported or setuptools_scm can't determine the
+# version, so we catch the generic 'Exception'.
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+except Exception:
+    version = '{version}'
+""".lstrip()
+
+setup(use_scm_version={'write_to': os.path.join('sherpa', 'version.py'),
+                       'write_to_template': VERSION_TEMPLATE},
+      ext_modules=static_ext_modules)
+


### PR DESCRIPTION
In this PR, I'm changing sherpa's setup scripts and CI setup to follow PEP 518 and astropy's examples.
**This is not functional right now.** I'm posting it here to get some feedback from the Sherpa developers to see if this is a route they are interested in. Getting it all right, especially with the binary components requires some work and probably help from core developers.

This largely follows what astropy does.

- [x] replace versioneer with setuptools_scm (not strictly required, but since this relies on setuptools now seems like a small step to take)
- [x] Install python files
- [ ] compile and install extensions
- [x] run tests for python with tox 
- [ ] run tests using compiled extensions with tox
- [ ] run CI with tox
- [ ] write / update contributor docs (currently referring to astropy docs)
