### PR TITLE
Fix ignore/notice error-ing out when all bins have been set bad #790

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -48,6 +48,7 @@ except ImportError:
     # no need to create one here
     pass
 
+info = logging.getLogger(__name__).info
 warning = logging.getLogger(__name__).warning
 
 groupstatus = False
@@ -1016,6 +1017,12 @@ class DataPHA(Data1D):
 
     def _energy_to_channel(self, val):
         elo, ehi = self._get_ebins()
+
+        # special case handling no noticed data (e.g. ignore_bad
+        # removes all bins); assume if elo is empty then so is ehi.
+        #
+        if len(elo) == 0:
+            raise DataErr('notmask')
 
         val = numpy.asarray(val)
         res = []
@@ -2269,9 +2276,16 @@ class DataPHA(Data1D):
         for bid in bkg_id:
             bkg = self.get_background(bid)
             old_bkg_units = bkg.units
-            bkg.units = self.units
-            bkg.notice(lo, hi, ignore)
-            bkg.units = old_bkg_units
+            try:
+                bkg.units = self.units
+                try:
+                    bkg.notice(lo, hi, ignore)
+                except DataErr as de:
+                    info("Skipping background {} for {}: {}".format(bid,
+                                                                    self.name,
+                                                                    de))
+            finally:
+                bkg.units = old_bkg_units
 
         # If we're only supposed to filter backgrounds, return
         if filter_background_only:
@@ -2284,10 +2298,26 @@ class DataPHA(Data1D):
             self.notice_response(False)
 
         elo, ehi = self._get_ebins()
+
+        # We do not want a "all data are masked out" error to cause
+        # this to fail; it should just do nothing (as trying to set
+        # a noticed range to include masked-out ranges would also
+        # be ignored).
+        #
         if lo is not None and type(lo) != str:
-            lo = self._to_channel(lo)
+            try:
+                lo = self._to_channel(lo)
+            except DataErr as de:
+                info("Skipping dataset {}: {}".format(self.name,
+                                                      de))
+                return
         if hi is not None and type(hi) != str:
-            hi = self._to_channel(hi)
+            try:
+                hi = self._to_channel(hi)
+            except DataErr as de:
+                info("Skipping dataset {}: {}".format(self.name,
+                                                      de))
+                return
 
         if ((self.units == "wavelength" and
              elo[0] < elo[-1] and ehi[0] < ehi[-1]) or

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2278,12 +2278,10 @@ class DataPHA(Data1D):
             old_bkg_units = bkg.units
             try:
                 bkg.units = self.units
-                try:
-                    bkg.notice(lo, hi, ignore)
-                except DataErr as de:
-                    info("Skipping background {} for {}: {}".format(bid,
-                                                                    self.name,
-                                                                    de))
+                # If the background is all ignored then bkg.notice will
+                # do nothing (other than display an INFO message).
+                #
+                bkg.notice(lo, hi, ignore)
             finally:
                 bkg.units = old_bkg_units
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -706,3 +706,146 @@ def test_list_pileup_ids_multi(clean_astro_ui):
 
     ans = ui.list_pileup_model_ids()
     assert ans == [1, "2"]
+
+
+def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
+    """Common tests from test_grouped_pha_all_badXXX
+
+    Sending in two ranges is a bit excessive but easiest
+    thing to implement
+    """
+
+    cts = ui.get_counts()
+    assert cts == pytest.approx([exp_counts])
+
+    dplot = ui.get_data_plot()
+    assert dplot.x == pytest.approx([exp_xmid])
+    assert dplot.y == pytest.approx([exp_counts])
+
+    # ignore all the data
+    ui.ignore(lo1, hi1)
+
+    # can still plot
+    cts = ui.get_counts()
+    assert cts == pytest.approx([exp_counts])
+
+    cts = ui.get_counts(filter=True)
+    assert len(cts) == 0
+
+    dplot = ui.get_data_plot()
+    assert len(dplot.x) == 0
+    assert len(dplot.y) == 0
+
+    # ignore does not fail
+    #
+    ui.ignore(lo2, hi2)
+
+    # we can restore the data
+    ui.notice(None, None)
+
+    cts = ui.get_counts()
+    assert cts == pytest.approx([exp_counts])
+
+    dplot = ui.get_data_plot()
+    assert dplot.x == pytest.approx([exp_xmid])
+    assert dplot.y == pytest.approx([exp_counts])
+
+    # now ignore the bad channels (ie everything)
+    #
+    ui.ignore_bad()
+
+    cts = ui.get_counts()
+    assert len(cts) == 0
+
+    dplot = ui.get_data_plot()
+    assert len(dplot.x) == 0
+    assert len(dplot.y) == 0
+
+    # there's nothing to notice (this line is an example of #790)
+    ui.notice(lo1, hi1)
+
+    cts = ui.get_counts()
+    assert len(cts) == 0
+
+    dplot = ui.get_data_plot()
+    assert len(dplot.x) == 0
+    assert len(dplot.y) == 0
+
+
+def test_grouped_pha_all_bad_channel():
+    """Helpdesk ticket: low-count data had no valid bins after grouping #790
+
+    A simple PHA dataset is created, with no response, which has no
+    "good" grouped data (1 group, but with a quality of 2). Several
+    checks are made to ensure we can filter/notice/plot the data even
+    when it is empty.  This is in channel space.
+
+    See also test_grouped_pha_all_bad_response which is essentially the
+    same test but with a response model.
+
+    """
+    chans = numpy.arange(1, 6, dtype=numpy.int16)
+    counts = numpy.asarray([0, 1, 2, 0, 1], dtype=numpy.int16)
+    grouping = numpy.asarray([1, -1, -1, -1, -1], dtype=numpy.int16)
+    quality = numpy.asarray([2, 2, 2, 2, 2], dtype=numpy.int16)
+
+    dset = ui.DataPHA('low', chans, counts, grouping=grouping, quality=quality)
+    ui.set_data(dset)
+
+    # Run tests
+    check_bad_grouping(3, 0.8, 0, 6, 2, 10)
+
+
+@pytest.mark.parametrize("arf,rmf", [(True, False), (False, True), (True, True)])
+@pytest.mark.parametrize("chantype,exp_counts,exp_xmid,lo1,hi1,lo2,hi2",
+                         [("channel", 0.8, 3, 0, 7, 2, 6),
+                          pytest.param("energy", 8.0, 0.35, 0.05, 1.0, 0.2, 0.8,
+                                       marks=pytest.mark.xfail),
+                          pytest.param("wave", 0.03871461, 52.59935223, 20, 90, 30, 85,
+                                       marks=pytest.mark.xfail),
+                         ])
+def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xmid, lo1, hi1, lo2, hi2):
+    """Helpdesk ticket: low-count data had no valid bins after grouping #790
+
+    A simple PHA dataset is created, which has no "good" grouped data
+    (1 group, but with a quality of 2). Several checks are made to
+    ensure we can filter/notice/plot the data even when it is empty.
+
+    Checks are done for
+      - arf-only
+      - rmf-only
+      - arf+rmf
+    analysis in case there's a difference in the code paths
+
+    """
+
+    chans = numpy.arange(1, 6, dtype=numpy.int16)
+    counts = numpy.asarray([0, 1, 2, 0, 1], dtype=numpy.int16)
+    grouping = numpy.asarray([1, -1, -1, -1, -1], dtype=numpy.int16)
+    quality = numpy.asarray([2, 2, 2, 2, 2], dtype=numpy.int16)
+
+    dset = ui.DataPHA('low', chans, counts, grouping=grouping, quality=quality)
+    ui.set_data(dset)
+
+    egrid = numpy.asarray([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    # it is required that at least one of arf or rmf is set but this
+    # is not enforced
+    #
+    if arf:
+        ui.set_arf(ui.create_arf(elo, ehi))
+
+    if rmf:
+        # NOTE: need to set e_min/max otherwise get a 'noenergybins'
+        #       error from sherpa.astro.data.DataPHA._get_ebins
+        #
+        ui.set_rmf(ui.create_rmf(elo, ehi, e_min=elo, e_max=ehi))
+
+    # plot units depend on analysis type;
+    #
+    ui.set_analysis(chantype)
+
+    # Run tests
+    check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -799,10 +799,8 @@ def test_grouped_pha_all_bad_channel():
 @pytest.mark.parametrize("arf,rmf", [(True, False), (False, True), (True, True)])
 @pytest.mark.parametrize("chantype,exp_counts,exp_xmid,lo1,hi1,lo2,hi2",
                          [("channel", 0.8, 3, 0, 7, 2, 6),
-                          pytest.param("energy", 8.0, 0.35, 0.05, 1.0, 0.2, 0.8,
-                                       marks=pytest.mark.xfail),
-                          pytest.param("wave", 0.03871461, 52.59935223, 20, 90, 30, 85,
-                                       marks=pytest.mark.xfail),
+                          ("energy", 8.0, 0.35, 0.05, 1.0, 0.2, 0.8),
+                          ("wave", 0.03871461, 52.59935223, 20, 90, 30, 85)
                          ])
 def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xmid, lo1, hi1, lo2, hi2):
     """Helpdesk ticket: low-count data had no valid bins after grouping #790


### PR DESCRIPTION
# Aim

Allow notice and ignore to be called on a dataset which has no "good" bins after ignore_bad has been called. The calls do not change anything (a screen message is displayed), which is similar to how you can call ignore multiple times.

# Details

The fix is simple: an internal method now raises a `DataErr` if there are no bins, and this error is caught by notice/ignore (well, a lower level class method) and a screen message is created to say the dataset is being ignored. I am hoping that there are no unforseen consequences, but the main change is that we now get a slightly-more useful error raised in problem cases.

Add test cases for bug #790 (Unable to filter PHA data sets with no "good" groups). These test out channel, energy, and wavelength handling.