### PR TITLE
Accept masked arrays for Data XXX creation

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -514,7 +514,7 @@ def get_column_data(*args):
             # vals = arg.get_values()
             vals = arg.values
 
-        elif arg is None or type(arg) in (numpy.ndarray, list, tuple):
+        elif arg is None or isinstance(arg, (numpy.ndarray, list, tuple)):
             vals = arg
         else:
             raise IOErr('badarray', arg)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -520,8 +520,8 @@ def get_column_data(*args):
             raise IOErr('badarray', arg)
 
         if arg is not None:
-            vals = numpy.asarray(vals)
-            for col in numpy.column_stack(vals):
+            vals = numpy.asanyarray(vals)
+            for col in numpy.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(vals)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -417,8 +417,8 @@ def get_column_data(*args):
         if arg is not None and not isinstance(arg, (numpy.ndarray, list, tuple)):
             raise IOErr('badarray', arg)
         if arg is not None:
-            vals = numpy.asarray(arg)
-            for col in numpy.column_stack(vals):
+            vals = numpy.asanyarray(arg)
+            for col in numpy.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(arg)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -52,7 +52,7 @@ def _check(array):
     return array
 
 
-def _check_indep(array):
+def _check_nomask(array):
     if hasattr(array, 'mask'):
         warnings.warn('Dropping mask attribute for array {}. Masks are supported for dependent variables only.'.format(array))
     return array
@@ -86,7 +86,7 @@ class DataSpace1D(EvaluationSpace1D):
             the x axis of this data space
         """
         self.filter = filter
-        EvaluationSpace1D.__init__(self, _check_indep(x))
+        EvaluationSpace1D.__init__(self, _check_nomask(x))
 
     def get(self, filter=False):
         """
@@ -152,7 +152,7 @@ class IntegratedDataSpace1D(EvaluationSpace1D):
             the higher bounds array of this data space
         """
         self.filter = filter
-        EvaluationSpace1D.__init__(self, _check_indep(xlo), _check_indep(xhi))
+        EvaluationSpace1D.__init__(self, _check_nomask(xlo), _check_nomask(xhi))
 
     def get(self, filter=False):
         """
@@ -219,8 +219,8 @@ class DataSpace2D():
             the second axis of this data space
         """
         self.filter = filter
-        self.x0 = _check(_check_indep(x0))
-        self.x1 = _check(_check_indep(x1))
+        self.x0 = _check(_check_nomask(x0))
+        self.x1 = _check(_check_nomask(x1))
 
     def get(self, filter=False):
         """
@@ -281,10 +281,10 @@ class IntegratedDataSpace2D():
             the higher bounds array of the xhi axis
         """
         self.filter = filter
-        self.x0lo = _check(_check_indep(x0lo))
-        self.x1lo = _check(_check_indep(x1lo))
-        self.x0hi = _check(_check_indep(x0hi))
-        self.x1hi = _check(_check_indep(x1hi))
+        self.x0lo = _check(_check_nomask(x0lo))
+        self.x1lo = _check(_check_nomask(x1lo))
+        self.x0hi = _check(_check_nomask(x0hi))
+        self.x1hi = _check(_check_nomask(x1hi))
 
     def get(self, filter=False):
         """
@@ -339,7 +339,7 @@ class DataSpaceND():
             the tuple of independent axes.
         """
         self.filter = filter
-        self.indep = _check_indep(indep)
+        self.indep = _check_nomask(indep)
 
     def get(self, filter=False):
         """
@@ -504,8 +504,8 @@ class Data(NoNewAttributesAfterInit, BaseData):
         self.name = name
         self._data_space = self._init_data_space(Filter(), *indep)
         self.y, self.mask = _check_dep(y)
-        self.staterror = staterror
-        self.syserror = syserror
+        self.staterror = _check_nomask(staterror)
+        self.syserror = _check_nomask(syserror)
         NoNewAttributesAfterInit.__init__(self)
 
     def _init_data_space(self, filter, *data):

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -108,14 +108,14 @@ def get_column_data(*args):
 
     cols = []
     for arg in args:
-        if arg is None or type(arg) in (numpy.ndarray, list, tuple):
+        if arg is None or isinstance(arg, (numpy.ndarray, list, tuple)):
             vals = arg
         else:
             raise IOErr('badarray', arg)
 
         if arg is not None:
-            vals = numpy.asarray(vals)
-            for col in numpy.column_stack(vals):
+            vals = numpy.asanyarray(vals)
+            for col in numpy.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(vals)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -994,9 +994,9 @@ def test_data_get_indep_masked_numpyarray(Dataclass):
     args = list(INSTANCE_ARGS[Dataclass])
     mask = numpy.random.rand(*(args[1].shape)) > 0.5
     args[1] = numpy.ma.array(args[1], mask=mask)
-    with pytest.warns(UserWarning, match="dropping mask"):
+    with pytest.warns(UserWarning, match="for dependent variables only"):
         data = Dataclass(*args)
-    assert len(data.get_indep(filter=True)) == len(args[1])
+    assert len(data.get_dep(filter=True)) == len(args[POS_Y_ARRAY[Dataclass]])
  
 
 @pytest.mark.parametrize("Dataclass", REALLY_ALL_DATA_CLASSES)
@@ -1007,7 +1007,7 @@ def test_data_get_dep_masked_numpyarray(Dataclass):
     args[posy] = numpy.ma.array(args[posy], mask=mask)
     data = Dataclass(*args)
     assert data.mask.shape == mask.shape
-    assert np.all(data.mask == ~mask)
+    assert numpy.all(data.mask == ~mask)
     assert len(data.get_dep(filter=True)) == (~mask).sum()
 
 
@@ -1029,10 +1029,10 @@ def test_data_get_indep_anyobj_with_mask(Dataclass):
     class DummyMask(list):
         mask = 'whatisthis'
     args[1] = DummyMask(args[1])
-    with pytest.warns(UserWarning, match="dropping mask"):
+    with pytest.warns(UserWarning, match="for dependent variables only"):
         data = Dataclass(*args)
     assert data.mask is True
-    assert len(data.get_indep(filter=True)) == len(args[1])
+    assert len(data.get_dep(filter=True)) == len(args[POS_Y_ARRAY[Dataclass]])
 
 
 @pytest.mark.parametrize("Dataclass", REALLY_ALL_DATA_CLASSES)
@@ -1042,7 +1042,7 @@ def test_data_get_dep_any_obj_with_mask(Dataclass):
     class DummyMask(list):
         mask = 'whatisthis'
     args[posy] = DummyMask(args[posy])
-    with pytest.warns(UserWarning, match="dropping mask"):
+    with pytest.warns(UserWarning, match="Set .mask"):
         data = Dataclass(*args)
     assert data.mask is True
     assert len(data.get_dep(filter=True)) == len(args[1])
@@ -1059,10 +1059,10 @@ def test_data_get_indep_masked_numpyarray_ui(data_for_load_arrays):
     mask = numpy.random.rand(*(args[1].shape)) > 0.5
     args = list(args)
     args[1] = numpy.ma.array(args[1], mask=mask)
-    with pytest.warns(UserWarning, match="dropping mask"):
+    with pytest.warns(UserWarning, match="for dependent wariables only"):
         session.load_arrays(*args)
     new_data = session.get_data(data.name)
-    assert len(new_data.get_indep(filter=True)) == len(args[1])
+    assert len(new_data.get_dep(filter=True)) == len(args[POS_Y_ARRAY[type(data)]])
 
 
 @pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
@@ -1075,7 +1075,7 @@ def test_data_get_dep_masked_numpyarray_ui(data_for_load_arrays):
     session.load_arrays(*args)
     new_data = session.get_data(data.name)
     assert new_data.mask.shape == mask.shape
-    assert np.all(new_data.mask == ~mask)
+    assert numpy.all(new_data.mask == ~mask)
     assert len(new_data.get_dep(filter=True)) == (~mask).sum()
 
 
@@ -1099,10 +1099,10 @@ def test_data_get_indep_anyobj_with_mask_ui(data_for_load_arrays):
         mask = 'whatisthis'
     args = list(args)
     args[1] = DummyMask(args[1])
-    with pytest.warns(UserWarning, match="dropping mask"):
+    with pytest.warns(UserWarning, match="for dependent variables only"):
         session.load_arrays(*args)
     new_data = session.get_data(data.name)
-    assert len(new_data.get_indep(filter=True)) == len(args[1])
+    assert len(new_data.get_indep(filter=True)) == len(args[POS_Y_ARRAY[type(data)]])
 
 
 @pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
@@ -1113,7 +1113,7 @@ def test_data_get_dep_any_obj_with_mask_ui(data_for_load_arrays):
         mask = 'whatisthis'
     args = list(args)
     args[posy] = DummyMask(args[posy])
-    with pytest.warns(UserWarning, match="dropping mask"):
+    with pytest.warns(UserWarning, match="Set .mask"):
         session.load_arrays(*args)
     new_data = session.get_data(data.name)
     assert new_data.mask is True

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -22,6 +22,8 @@ import pytest
 from sherpa.data import Data, Data1D, DataSimulFit, Data1DInt, Data2D, Data2DInt, BaseData
 from sherpa.models import Polynom1D, Polynom2D
 from sherpa.utils.err import NotImplementedErr, DataErr
+from sherpa.ui.utils import Session
+from sherpa.astro.ui.utils import Session as AstroSession
 
 NAME = "data_test"
 X_ARRAY = numpy.arange(0, 10, 1)
@@ -1045,29 +1047,32 @@ def test_data_get_dep_any_obj_with_mask(Dataclass):
     with pytest.warns(UserWarning, match="Set .mask"):
         data = Dataclass(*args)
     assert data.mask is True
-    assert len(data.get_dep(filter=True)) == len(args[1])
+    assert len(data.get_dep(filter=True)) == len(data.get_dep(filter=False))
 
 
-# https://github.com/sherpa/sherpa/issues/346
 # repeat set of tests except now by using ui
 # Results should be idendical, but tests are fast, so we just test again
 # To make sure that there is no heuristic in load_arrays or similar that
 # interferes with the logic
+@pytest.mark.parametrize('Session', [Session, AstroSession])
 @pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
-def test_data_get_indep_masked_numpyarray_ui(data_for_load_arrays):
+def test_data_get_indep_masked_numpyarray_ui(data_for_load_arrays, Session):
     session, args, data = data_for_load_arrays
+    session = Session()
     mask = numpy.random.rand(*(args[1].shape)) > 0.5
     args = list(args)
     args[1] = numpy.ma.array(args[1], mask=mask)
-    with pytest.warns(UserWarning, match="for dependent wariables only"):
+    with pytest.warns(UserWarning, match="for dependent variables only"):
         session.load_arrays(*args)
     new_data = session.get_data(data.name)
     assert len(new_data.get_dep(filter=True)) == len(args[POS_Y_ARRAY[type(data)]])
 
 
+@pytest.mark.parametrize('Session', [Session, AstroSession])
 @pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
-def test_data_get_dep_masked_numpyarray_ui(data_for_load_arrays):
+def test_data_get_dep_masked_numpyarray_ui(data_for_load_arrays, Session):
     session, args, data = data_for_load_arrays
+    session = Session()
     posy = POS_Y_ARRAY[type(data)]
     mask = numpy.random.rand(*(args[posy].shape)) > 0.5
     args = list(args)
@@ -1079,9 +1084,11 @@ def test_data_get_dep_masked_numpyarray_ui(data_for_load_arrays):
     assert len(new_data.get_dep(filter=True)) == (~mask).sum()
 
 
+@pytest.mark.parametrize('Session', [Session, AstroSession])
 @pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
-def test_data_get_dep_masked_numpyarray_nomask_ui(data_for_load_arrays):
+def test_data_get_dep_masked_numpyarray_nomask_ui(data_for_load_arrays, Session):
     session, args, data = data_for_load_arrays
+    session = Session()
     posy = POS_Y_ARRAY[type(data)]
     args = list(args)
     args[posy] = numpy.ma.array(args[posy])
@@ -1090,32 +1097,3 @@ def test_data_get_dep_masked_numpyarray_nomask_ui(data_for_load_arrays):
     # Sherpa's way of saying "mask is not set"
     assert new_data.mask is True
     assert len(new_data.get_dep(filter=True)) == len(args[posy].flatten())
-
-
-@pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
-def test_data_get_indep_anyobj_with_mask_ui(data_for_load_arrays):
-    session, args, data = data_for_load_arrays
-    class DummyMask(list):
-        mask = 'whatisthis'
-    args = list(args)
-    args[1] = DummyMask(args[1])
-    with pytest.warns(UserWarning, match="for dependent variables only"):
-        session.load_arrays(*args)
-    new_data = session.get_data(data.name)
-    assert len(new_data.get_indep(filter=True)) == len(args[POS_Y_ARRAY[type(data)]])
-
-
-@pytest.mark.parametrize("data_for_load_arrays", ALL_DATA_CLASSES, indirect=True)
-def test_data_get_dep_any_obj_with_mask_ui(data_for_load_arrays):
-    session, args, data = data_for_load_arrays
-    posy = POS_Y_ARRAY[type(data)]
-    class DummyMask(list):
-        mask = 'whatisthis'
-    args = list(args)
-    args[posy] = DummyMask(args[posy])
-    with pytest.warns(UserWarning, match="Set .mask"):
-        session.load_arrays(*args)
-    new_data = session.get_data(data.name)
-    assert new_data.mask is True
-    assert len(new_data.get_dep(filter=True)) == len(args[1])
-

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1097,3 +1097,15 @@ def test_data_get_dep_masked_numpyarray_nomask_ui(data_for_load_arrays, Session)
     # Sherpa's way of saying "mask is not set"
     assert new_data.mask is True
     assert len(new_data.get_dep(filter=True)) == len(args[posy].flatten())
+
+# https://github.com/sherpa/sherpa/issues/346
+@pytest.mark.parametrize('Session', [Session, AstroSession])
+def test_regression_346(Session):
+    session = Session()
+    x = numpy.arange(-5, 5.1) 
+    old_y = x*x + 23.2
+    y = numpy.ma.masked_array(old_y,mask=y<35) 
+    e = numpy.ones(x.size) 
+    session.load_arrays("mydata", x, y, e) 
+    filtered_y = session. get_dep("mydata", filter=True)
+    assert numpy.allclose(filtered_y, [48.2, 39.2, 39.2, 48.2])

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1104,7 +1104,7 @@ def test_regression_346(Session):
     session = Session()
     x = numpy.arange(-5, 5.1) 
     old_y = x*x + 23.2
-    y = numpy.ma.masked_array(old_y,mask=y<35) 
+    y = numpy.ma.masked_array(old_y,mask=old_y<35) 
     e = numpy.ones(x.size) 
     session.load_arrays("mydata", x, y, e) 
     filtered_y = session. get_dep("mydata", filter=True)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -3740,13 +3740,6 @@ class Session(NoNewAttributesAfterInit):
            Two or more arrays, followed by the type of data set to
            create.
 
-        Warnings
-        --------
-        Sherpa currently does not support numpy masked arrays. Use the
-        set_filter function and note that it follows a different convention by
-        default (a positive value or True for a "bad" channel, 0 or False for
-        a good channel).
-
         See Also
         --------
         copy_data : Copy a data set to a new identifier.


### PR DESCRIPTION
Accept masked arrays for Data XXX creation
    
This change implements changes to use the mask of numpy arrays
when initializing DataXXX. It warns sensibly for non-numpy objects with
a mask in the OO interface when duck-typing, but not in the session
interface, because that whitelists only specific data types anyway.
Thus, this reverses the warnings added to the docs in #698.
    
fixes #695
fixes #346 
