### PR TITLE
Get linux libgfortran from conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: c
 
-sudo: false
+dist: trusty
+os: linux
 
-matrix:
+jobs:
   fast_finish: true
   include:
     # macOS build
@@ -15,22 +16,14 @@ matrix:
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER="1.17" TRAVIS_PYTHON_VERSION="3.8"
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
     - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
-      sudo: required
-      dist: trusty
     # As above, Python 3.6, setup.py install, xspec 12.10
     - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
-      sudo: required
-      dist: trusty
     # As above, python 3.7, numpy 1.15, matplotlib 3
     - env: XSPECVER="12.10.1b" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=3 TRAVIS_PYTHON_VERSION="3.7"
-      sudo: required
-      dist: trusty
     # Experimental support for using Sphinx to build the documentation
     # should we not run tests with this build (to save time); i.e. have
     # a specific build just for the documentation and nothing else?
     - env: DOCS=true INSTALL_TYPE=build_sphinx TEST=none TRAVIS_PYTHON_VERSION="3.7"
-      sudo: required
-      dist: trusty
     # Install sherpatest package rather than relying on relative location of the submodule
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
@@ -52,7 +45,7 @@ before_install:
   - if [ "${DOCS}" == "true" ];
      then pip install --requirement docs/rtd-pip-requirements;
     fi
-  
+
 install:
     - python setup.py $INSTALL_TYPE
 
@@ -63,4 +56,3 @@ notifications:
   email:
     - wmclaugh@cfa.harvard.edu
     - mterrell@cfa.harvard.edu
-

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash -e
 
 # Environment
-libgfortranver="3.0"
 sherpa_channel=sherpa
 xspec_channel=xspec/channel/dev
 miniconda=$HOME/miniconda
@@ -31,10 +30,15 @@ conda update --yes conda
 # Note the order of the channels matter. We built the xspec conda packages for macos using the conda-forge channel
 # with the highest priority, so we add it with a higher priority than the default channels, but with less priority
 # than our own channels, so that we don't accidentally get conda-forge packages for cfitsio/ccfits.
-conda config --add channels conda-forge
+#
+# To avoid issues with non-XSPEC builds (e.g.
+# https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )
+# the XSPEC-related channels are only added if needed
+#
+if [ -n "${XSPECVER}" ]; then conda config --add channels conda-forge; fi
 
 conda config --add channels ${sherpa_channel}
-conda config --add channels ${xspec_channel}
+if [ -n "${XSPECVER}" ]; then conda config --add channels ${xspec_channel}; fi
 conda config --add channels anaconda
 
 # Figure out requested dependencies
@@ -57,8 +61,7 @@ FITSBUILD="${FITS}"
 
 # Create and activate conda build environment
 # We create a new environment so we don't care about the python version in the root environment.
-conda create --yes -n build python=${TRAVIS_PYTHON_VERSION} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}\
-  libgfortran=${libgfortranver}
+conda create --yes -n build python=${TRAVIS_PYTHON_VERSION} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
 
 source activate build
 

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -31,10 +31,7 @@ conda update --yes conda
 # Note the order of the channels matter. We built the xspec conda packages for macos using the conda-forge channel
 # with the highest priority, so we add it with a higher priority than the default channels, but with less priority
 # than our own channels, so that we don't accidentally get conda-forge packages for cfitsio/ccfits.
-if [[ ${TRAVIS_OS_NAME} == osx ]];
-then
-    conda config --add channels conda-forge
-fi
+conda config --add channels conda-forge
 
 conda config --add channels ${sherpa_channel}
 conda config --add channels ${xspec_channel}

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -2,6 +2,18 @@
 
 # variable $miniconda is defined in a previous script (setup_conda.sh)
 
+# To build against XSPEC we need libgfortran (it is not needed if the XSPEC
+# module is not being used), so only install it here.
+#
+# At present (April 2020) this requires the use of the conda-forge
+# channel, to get libfortran (due to the way the XSPEC model library
+# was built).
+#
+libgfortranver="3.0"
+
+echo "** Requesting libgfortran=${libgfortranver}"
+conda install --yes libgfortran=${libgfortranver}
+
 ds9_base_url=http://ds9.si.edu/download/
 
 if [[ ${TRAVIS_OS_NAME} == linux ]];


### PR DESCRIPTION
Update the Travis build setup so that libgfortran is picked up from the conda-forge channel for both Linux and macOS builds (previously it was only done for macOS). This is needed since libgfortran is no-longer provided for Linux builds on the conda channel, causing the tests to fail on Travis (issue #792).

As libgfortran is only needed when building against the CXC-provided XSPEC model-only library conda package, the changes are only done for the XSPEC builds. This should hopefully speed up the non-XSPEC runs slightly (as there's no need to download libgfortran).

This PR only changes files related to the Travis-CI testing.