### PR TITLE
Tweak test for issue 717 to be repeatable

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -615,7 +615,7 @@ def test_bug_316(make_data_path):
 @requires_fits
 def test_load_multi_arfsrmfs(make_data_path, clean_astro_ui):
     """Added in #728 to ensure cache parameter is sent along by
-    MultiResponseSumModel.
+    MultiResponseSumModel (fix #717).
 
     This has since been simplified to switch from xsapec to
     powlaw1d as it drops the need for XSPEC and is a simpler
@@ -650,9 +650,17 @@ def test_load_multi_arfsrmfs(make_data_path, clean_astro_ui):
     ui.set_model(1, src)
     ui.set_model(2, src)
 
+    # ensure the test is repeatable by running with a known
+    # statistic and method
+    #
     ui.set_method('levmar')
     ui.set_stat('chi2datavar')
 
+    # Really what we care about for fixing #717 is that
+    # fit does not error out, but it's useful to know that
+    # the fit has changed the parameter values (which were
+    # both 1 before the fit).
+    #
     ui.fit()
     fr = ui.get_fit_results()
     assert fr.succeeded

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -613,7 +613,7 @@ def test_bug_316(make_data_path):
 
 @requires_data
 @requires_fits
-def test_load_multi_arfsrmfs(make_data_path):
+def test_load_multi_arfsrmfs(make_data_path, clean_astro_ui):
     """Added in #728 to ensure cache parameter is sent along by
     MultiResponseSumModel.
 
@@ -650,7 +650,9 @@ def test_load_multi_arfsrmfs(make_data_path):
     ui.set_model(1, src)
     ui.set_model(2, src)
 
+    ui.set_method('levmar')
     ui.set_stat('chi2datavar')
+
     ui.fit()
     fr = ui.get_fit_results()
     assert fr.succeeded


### PR DESCRIPTION
# Summay

Make a test more robust. 

# Details

The following is from before #772 was merged (adding XSPEC 12.11.0), which ended up making most of the changes that were in this PR.

While working on other issues I found that the fix for issue #717 - added in #728 - was not sufficiently isolated, so that adding other tests (or running tests in parallel) could cause this test to fail because of changes to the Sherpa state made by other tests.

There are two commits that

a) ensure that the test is run with a "known" environment (e.g. statistic)
b) switches from an APEC model (from the XSPEC library) to a power-law model (from Sherpa's model library), which means the test can be run without XSPEC, and has benefits because the powerlaw model is a much-better description of the data, and is also much-less likely to change over time (the APEC model depends on external data tables and other things that have been known to change between XSPEC releases)

As the original problem (#717) was to do with evaluating any model - rather than a particular model - the change from APEC to powerlaw shouldn't change the validity of the test.