### PR TITLE
Updates to sampling of energy and photon fluxes: bug fixes and calculate unabsorbed components

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -197,9 +197,10 @@ def sample_flux(fit, data, src,
     if npar == 0:
         raise FitErr('nothawedpar')
 
-    sampler = NormalParameterSampleFromScaleVector()
     if correlated:
         sampler = NormalParameterSampleFromScaleMatrix()
+    else:
+        sampler = NormalParameterSampleFromScaleVector()
 
     # Rename samples to scales as it is confusing here (as it does
     # not refer to the samples drawn from the distribution but the

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -105,7 +105,7 @@ def calc_flux(data, src, samples, method=calc_energy_flux,
         Should the analysis be split across multiple CPU cores?
         When set to None all available cores are used.
     subset : list of ints or None, optional
-        This is only used when the sapmles array has more parameters
+        This is only used when the samples array has more parameters
         in it than are free in src. In this case the subset array lists
         the column number of the free parameters in src. So, if the
         samples represented 'nh', 'gamma', and 'ampl' values for each

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -94,6 +94,24 @@ def sample_flux(fit, data, src, method=calc_energy_flux, correlated=False,
     scales = samples
     if scales is not None:
         scales = numpy.asarray(scales)
+
+        # A None value will cause scales to have a dtype of object,
+        # which is not supported by isfinite, so check for this
+        # first.
+        #
+        if None in scales:
+            raise ArgumentErr('bad', 'scales',
+                              'must not contain None values')
+
+        # We require that scales only has finite values in it.
+        # The underlying sample routines are assumed to check other
+        # constraints, or deal with negative values (for the 1D case
+        # uncorrelated case the absolute value is used).
+        #
+        if not numpy.isfinite(scales).all():
+            raise ArgumentErr('bad', 'scales',
+                              'must only contain finite values')
+
         if scales.ndim == 2 and (scales.shape[0] != scales.shape[1]):
             raise ArgumentErr('bad', 'scales',
                               'scales must be square when 2D')

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -213,7 +213,12 @@ def sample_flux(fit, data, src,
         # which is not supported by isfinite, so check for this
         # first.
         #
-        if None in scales:
+        # Numpy circa 1.11 raises a FutureWarning with 'if None in scales:'
+        # about this changing to element-wise comparison (which is what
+        # we want). To avoid this warning I use the suggestion from
+        # https://github.com/numpy/numpy/issues/1608#issuecomment-9618150
+        #
+        if numpy.equal(None, scales).any():
             raise ArgumentErr('bad', 'scales',
                               'must not contain None values')
 

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -39,8 +39,9 @@ __all__ = ['calc_flux', 'sample_flux', 'calc_sample_flux']
 
 
 class CalcFluxWorker():
-    def __init__(self, fit, method, data, src, lo, hi):
-        self.fit = fit
+    """Internal class for use by calc_flux."""
+
+    def __init__(self, method, data, src, lo, hi):
         self.method = method
         self.data = data
         self.src = src
@@ -48,22 +49,23 @@ class CalcFluxWorker():
         self.hi = hi
 
     def __call__(self, sample):
-        self.fit.model.thawedpars = sample
+        self.src.thawedpars = sample
         flux = self.method(self.data, self.src, self.lo, self.hi)
-        return [flux] + list(sample)
+        return numpy.asarray([flux] + list(sample))
 
 
-def calc_flux(fit, data, src, samples, method=calc_energy_flux,
+def calc_flux(data, src, samples, method=calc_energy_flux,
               lo=None, hi=None, numcores=None):
     """Calculate model fluxes from a sample of parameter values.
 
     Given a set of parameter values, calculate the model flux for
     each set.
 
+    .. versionchanged:: 4.12.1
+       The fit parameter was removed.
+
     Parameters
     ----------
-    fit : sherpa.fit.Fit instance
-        The fit object
     data : sherpa.data.Data subclass
         The data object to use.
     src : sherpa.models.Arithmetic instance
@@ -107,14 +109,276 @@ def calc_flux(fit, data, src, samples, method=calc_energy_flux,
 
     """
 
-    old_model_vals = fit.model.thawedpars
-    worker = CalcFluxWorker(fit, method, data, src, lo, hi)
+    old_vals = src.thawedpars
+    npar = len(old_vals)
+    if npar != samples.shape[1]:
+        raise ModelErr('numthawed', npar, samples.shape[1])
+
+    worker = CalcFluxWorker(method, data, src, lo, hi)
     try:
         fluxes = parallel_map(worker, samples, numcores)
     finally:
-        fit.model.thawedpars = old_model_vals
+        src.thawedpars = old_vals
 
     return numpy.asarray(fluxes)
+
+
+def _sample_flux_get_samples_with_scales(fit, src, correlated, scales, num):
+    """Return the parameter samples given the parameter scales.
+
+    Parameters
+    ----------
+    fit : sherpa.fit.Fit instance
+        The fit instance. The fit.model expression is assumed to include
+        any necessary response information. The number of free parameters
+        in fit.model is mfree.
+    src : sherpa.models.ArithmeticModel instance
+        The model for which the flux is being calculated. This must be
+        a subset of the fit.model expression, and should not include the
+        response information. There must be at least one thawed parameter
+        in this model. The number of free parameters in src is sfree.
+    correlated : bool
+        Are the parameters assumed to be correlated or not? If correlated
+        is True then scales must be 2D.
+    scales : 1D or 2D array
+        The parameter scales. When 1D they are the gaussian sigma
+        values for the parameter, and when a 2D array they are
+        the covariance matrix. The scales parameter can either represent
+        the free parameters in fit.model or src; that is have size
+        mfree or sfree (1D) or mfree by mfree or sfree by sfree (2D).
+    num : int
+        Tne number of samples to return. This must be 1 or greater.
+
+    Returns
+    -------
+    samples : 2D NumPy array
+        The dimensions are num by sfree. The ordering of the parameter
+        values in each row matches that of src.
+
+    Raises
+    ------
+    ArgumentErr
+        If the scales argument contains invalid (e.g. None or IEEE
+        non-finite values) values, or is the wrong shape.
+    ModelErr
+        If the scales argument has the wrong size (that is, it
+        does not represent either sfree or mfree parameter values).
+
+    Notes
+    -----
+    The support for src being a subset of the fit.model argument
+    has not been tested for complex models, that is when fit.model
+    is rmf(arf(source_model)) and src is a combination of components
+    in source_model but not all the components of source_model.
+    """
+
+    npar = len(src.thawedpars)
+    mpar = len(fit.model.thawedpars)
+    assert mpar >= npar
+
+    scales = numpy.asarray(scales)
+
+    # A None value will cause scales to have a dtype of object,
+    # which is not supported by isfinite, so check for this
+    # first.
+    #
+    # Numpy circa 1.11 raises a FutureWarning with 'if None in scales:'
+    # about this changing to element-wise comparison (which is what
+    # we want). To avoid this warning I use the suggestion from
+    # https://github.com/numpy/numpy/issues/1608#issuecomment-9618150
+    #
+    if numpy.equal(None, scales).any():
+        raise ArgumentErr('bad', 'scales',
+                          'must not contain None values')
+
+    # We require that scales only has finite values in it.
+    # The underlying sample routines are assumed to check other
+    # constraints, or deal with negative values (for the 1D case
+    # uncorrelated case the absolute value is used).
+    #
+    if not numpy.isfinite(scales).all():
+        raise ArgumentErr('bad', 'scales',
+                          'must only contain finite values')
+
+    if scales.ndim == 2 and (scales.shape[0] != scales.shape[1]):
+        raise ArgumentErr('bad', 'scales',
+                          'scales must be square when 2D')
+
+    # Ensure the scales array matches the correlated parameter:
+    #  - when True it must be the covariance matrix (2D)
+    #  - when False it can be either be a 1D array of sigmas or
+    #    the covariance matrix, which we convert to an array of
+    #    sigmas
+    #
+    if correlated:
+        if scales.ndim != 2:
+            raise ArgumentErr('bad', 'scales',
+                              'when correlated=True, scales must be 2D')
+    elif scales.ndim == 2:
+        # convert from covariance matrix
+        scales = numpy.sqrt(scales.diagonal())
+    elif scales.ndim != 1:
+        raise ArgumentErr('bad', 'scales',
+                          'when correlated=False, scales must be 1D or 2D')
+
+    # At this point either 1D or 2D square array. We require
+    # either npar or mpar values. This unfortunately doesn't
+    # work with the expected semantics of the numthawed error
+    # type (which expects an integer), so use npar as the
+    # error message for now.
+    #
+    if scales.shape[0] not in [npar, mpar]:
+        raise ModelErr('numthawed', npar, scales.shape[0])
+
+    # The scales argument to the sampler.get_sample method has to
+    # match the size of the number of free parameters in the
+    # fit.model expression.
+    #
+    # Possible conditions (npar > mpar is impossible):
+    # a) npar == mpar
+    # b) npar < mpar, scales.shape[0] = npar
+    # c) npar < mpar, scales.shape[0] = mpar
+    #
+    # case a is easy, as nothing has to be done.
+    #
+    # case b is handled by temporarily freezing the "extra" free
+    # parameters in the fit.model expression.
+    #
+    # case c is handled by post-processing the samples to remove
+    # the "extra" parameters.
+    #
+    # At this point we requre that src be a subset of fit.model
+    #
+    frozen_pars = []
+    subset = []
+    if npar < mpar:
+        if scales.shape[0] == npar:
+            # Use a set rather than list to potentially improve
+            # the 'in' check below, although the number of elements
+            # is not assumed to be large.
+            #
+            spars = {p for p in src.pars if not p.frozen}
+            for p in fit.model.pars:
+                if p.frozen or p in spars:
+                    continue
+
+                frozen_pars.append(p)
+
+        else:
+            mpars = [p for p in fit.model.pars if not p.frozen]
+            spars = [p for p in src.pars if not p.frozen]
+            mpars = dict(zip(mpars, range(mpar)))
+            subset = [mpars[p] for p in spars]
+
+    if correlated:
+        sampler = NormalParameterSampleFromScaleMatrix()
+    else:
+        sampler = NormalParameterSampleFromScaleVector()
+
+    try:
+        for p in frozen_pars:
+            p.frozen = True
+
+        samples = sampler.get_sample(fit, scales, num=num)
+    finally:
+        for p in frozen_pars:
+            p.frozen = False
+
+    if subset != []:
+        samples = samples[:, subset]
+
+    return samples
+
+
+def _sample_flux_get_samples(fit, src, correlated, num):
+    """Return the parameter samples, using fit to define the scales.
+
+    The covariance method is used to estimate the errors for the
+    parameter sampling.
+
+    Parameters
+    ----------
+    fit : sherpa.fit.Fit instance
+        The fit instance. The fit.model expression is assumed to include
+        any necessary response information.
+    src : sherpa.models.ArithmeticModel instance
+        The model for which the flux is being calculated. This must be
+        a subset of the fit.model expression, and should not include the
+        response information. There must be at least one thawed parameter
+        in this model. The number of free parameters in src is sfree.
+    correlated : bool
+        Are the parameters assumed to be correlated or not? If correlated
+        is True then scales must be 2D.
+    num : int
+        Tne number of samples to return. This must be 1 or greater.
+
+    Returns
+    -------
+    samples : 2D NumPy array
+        The dimensions are num by sfree. The ordering of the parameter
+        values in each row matches that of src.
+
+    Notes
+    -----
+    The support for src being a subset of the fit.model argument
+    has not been tested for complex models, that is when fit.model
+    is rmf(arf(source_model)) and src is a combination of components
+    in source_model but not all the components of source_model.
+    """
+
+    npar = len(src.thawedpars)
+    mpar = len(fit.model.thawedpars)
+    assert mpar >= npar
+
+    if correlated:
+        sampler = NormalParameterSampleFromScaleMatrix()
+    else:
+        sampler = NormalParameterSampleFromScaleVector()
+
+    samples = sampler.get_sample(fit, num=num)
+
+    # Do we need to remove the free parameters that are in
+    # fit.model but not in src from the samples?
+    #
+    if npar < mpar:
+        mpars = [p for p in fit.model.pars if not p.frozen]
+        spars = [p for p in src.pars if not p.frozen]
+        mpars = dict(zip(mpars, range(mpar)))
+        subset = [mpars[p] for p in spars]
+
+        samples = samples[:, subset]
+
+    return samples
+
+
+def decompose(mdl):
+    """Return the individual instances in the model expression.
+
+    Parameters
+    ----------
+    mdl : sherpa.models.model.ArithmeticModel instance
+        The model expression. This can be a single component
+        or a combination.
+
+    Returns
+    -------
+    cpts : set of sherpa.models.model.Model instances
+        The individual components in mdl
+
+    """
+
+    # The __contains__ behavior of the model class appears to
+    # return the individual components, including sub-expressions,
+    # so we just drop the sub-expressions.
+    #
+    out = set([])
+    for cpt in mdl:
+        if hasattr(cpt, 'parts'):
+            continue
+
+        out.add(cpt)
+
+    return out
 
 
 def sample_flux(fit, data, src,
@@ -130,14 +394,16 @@ def sample_flux(fit, data, src,
     Parameters
     ----------
     fit : sherpa.fit.Fit instance
-        The fit object. The fit.model expression defined the number and
-        ordering of the free parameters used in the sampling.
+        The fit object. The src parameter is assumed to be a subset of
+        the fit.model expression (to allow for calculating the flux of
+        a model component), and the fit.data object matches the data
+        object. The fit.model argument is expected to include instrumental
+        models (for PHA data sets).
     data : sherpa.data.Data subclass
         The data object to use.
     src : sherpa.models.Arithmetic instance
         The source model (without instrument response for PHA data) that
-        is used for calculating the flux. This is expected to be part of
-        the model expression used in the fit object.
+        is used for calculating the flux.
     method : function, optional
         How to calculate the flux: assumed to be one of calc_energy_flux
         or calc_photon_flux
@@ -159,7 +425,7 @@ def sample_flux(fit, data, src,
         the covariance method is used to estimate the parameter errors.
         If given and correlated is True then samples must be a
         2D array, and contain the covariance matrix for the free
-        parameters in the fit. If correlated is False then samples
+        parameters in src. If correlated is False then samples
         can either be sent the covariance matrix or a 1D array
         of the error values (i.e. the sigma of the normal distribution).
         If there are n free parameters then the 1D array has to have
@@ -169,8 +435,8 @@ def sample_flux(fit, data, src,
     -------
     vals : 2D NumPy array
         The shape of samples is (num, nfree + 1), where nfree is the
-        number of free parameters in the fit.model expression. Each
-        row contains one iteration, and the columns are the calculated flux,
+        number of free parameters in src. Each row contains one
+        iteration, and the columns are the calculated flux,
         followed by the free parameters.
 
     See Also
@@ -180,91 +446,60 @@ def sample_flux(fit, data, src,
     Notes
     -----
     The ordering of the samples array, and the columns in the output,
-    matches that of the free parameters in the fit.model expression. That is::
+    matches that of the free parameters in the src expression. That is::
 
-        [p.fullname for p in fit.model..pars if not p.frozen]
+        [p.fullname for p in src.pars if not p.frozen]
 
+    If src is a subset of the full source expression then samples,
+    when not None, can either match the number of free parameters in
+    the full source expression (that given by fit.model), or the src
+    parameter.
     """
 
     if num <= 0:
         raise ArgumentErr('bad', 'num', 'must be a positive integer')
 
-    # Note that we get the number of free parameters from the
-    # fit and not src arguments, due to the way sample_flux is
-    # implemented.
-    #
-    npar = len(fit.model.thawedpars)
+    # Ensure we have free parameters
+    npar = len(src.thawedpars)
     if npar == 0:
         raise FitErr('nothawedpar')
 
-    if correlated:
-        sampler = NormalParameterSampleFromScaleMatrix()
-    else:
-        sampler = NormalParameterSampleFromScaleVector()
+    # Check that src is a "subset" of fit.model. The current approach is
+    # probably not sufficient to capture the requirements, where
+    # ordering of the components is important, but is a start.
+    #
+    cpts_full = decompose(fit.model)
+    for cpt in decompose(src):
+        if cpt in cpts_full:
+            continue
 
-    # Rename samples to scales as it is confusing here (as it does
-    # not refer to the samples drawn from the distribution but the
-    # widths of the parameters used to create the samples).
+        raise ArgumentErr('bad', 'src', 'model contains term not in fit')
+
+    mpar = len(fit.model.thawedpars)
+    if npar > mpar:
+        # This should not be possible given the above check, but leave in.
+        raise ArgumentErr('bad', 'src',
+                          'more free parameters than expected')
+
+    # The argument to sample_flux should really be called scales and
+    # not samples.
     #
     scales = samples
-    if scales is not None:
-        scales = numpy.asarray(scales)
+    if scales is None:
+        samples = _sample_flux_get_samples(fit, src, correlated, num)
+    else:
+        samples = _sample_flux_get_samples_with_scales(fit, src, correlated, scales, num)
 
-        # A None value will cause scales to have a dtype of object,
-        # which is not supported by isfinite, so check for this
-        # first.
-        #
-        # Numpy circa 1.11 raises a FutureWarning with 'if None in scales:'
-        # about this changing to element-wise comparison (which is what
-        # we want). To avoid this warning I use the suggestion from
-        # https://github.com/numpy/numpy/issues/1608#issuecomment-9618150
-        #
-        if numpy.equal(None, scales).any():
-            raise ArgumentErr('bad', 'scales',
-                              'must not contain None values')
-
-        # We require that scales only has finite values in it.
-        # The underlying sample routines are assumed to check other
-        # constraints, or deal with negative values (for the 1D case
-        # uncorrelated case the absolute value is used).
-        #
-        if not numpy.isfinite(scales).all():
-            raise ArgumentErr('bad', 'scales',
-                              'must only contain finite values')
-
-        if scales.ndim == 2 and (scales.shape[0] != scales.shape[1]):
-            raise ArgumentErr('bad', 'scales',
-                              'scales must be square when 2D')
-
-        if correlated:
-            if scales.ndim != 2:
-                raise ArgumentErr('bad', 'scales',
-                                  'when correlated=True, scales must be 2D')
-        else:
-            if scales.ndim == 2:
-                # convert from covariance matrix
-                scales = numpy.sqrt(scales.diagonal())
-            elif scales.ndim != 1:
-                raise ArgumentErr('bad', 'scales',
-                                  'when correlated=False, scales must be 1D or 2D')
-
-        # at this point either 1D or 2D square array
-        #
-        if scales.shape[0] != npar:
-            raise ModelErr('numthawed', npar, scales.shape[0])
-
-    # Create the samples and then ensure the values are limited to
-    # the hard limits of the parameter.
+    # Ensure that samples falls within the hard limits by
+    # clipping the values.
     #
-    samples = sampler.get_sample(fit, scales, num=num)
-
-    hardmins = fit.model.thawedparhardmins
-    hardmaxs = fit.model.thawedparhardmaxes
+    hardmins = src.thawedparhardmins
+    hardmaxs = src.thawedparhardmaxes
     for pvals, pmin, pmax in zip(samples.T, hardmins, hardmaxs):
         # do the clipping in place
         numpy.clip(pvals, pmin, pmax, out=pvals)
 
-    return calc_flux(fit, data, src, samples, method, lo, hi, numcores)
+    return calc_flux(data, src, samples, method, lo, hi, numcores)
 
 
 def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -107,14 +107,10 @@ def calc_flux(fit, data, src, samples, method=calc_energy_flux,
 
     """
 
-    def evaluate(sample):
-        fit.model.thawedpars = sample
-        flux = method(data, src, lo, hi)
-        return [flux] + list(sample)
-
     old_model_vals = fit.model.thawedpars
+    worker = CalcFluxWorker(fit, method, data, src, lo, hi)
     try:
-        fluxes = parallel_map(CalcFluxWorker(fit, method, data, src, lo, hi), samples, numcores)
+        fluxes = parallel_map(worker, samples, numcores)
     finally:
         fit.model.thawedpars = old_model_vals
 

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -382,19 +382,19 @@ def sample_flux(fit, data, src,
     hi : number or None, optional
         The upper edge of the dataspace range for the flux calculation.
         If None then the upper edge of the data grid is used.
-    numcores : int or None, optonal
+    numcores : int or None, optional
         Should the analysis be split across multiple CPU cores?
         When set to None all available cores are used.
     samples : 1D or 2D array, optional
         What are the errors on the parameters? If set to None then
         the covariance method is used to estimate the parameter errors.
-        If given and correlated is True then samples must be a
-        2D array, and contain the covariance matrix for the free
-        parameters in fit.model. If correlated is False then samples
-        can either be sent the covariance matrix or a 1D array
-        of the error values (i.e. the sigma of the normal distribution).
-        If there are n free parameters then the 1D array has to have
-        n elements and the 2D array n by n elements.
+        If given and correlated is True then samples must be a 2D array,
+        and contain the covariance matrix for the free parameters in
+        fit.model, and the matrix must be positive definite. If correlated
+        is False then samples can either be sent the covariance matrix or a
+        1D array of the error values (i.e. the sigma of the normal
+        distribution). If there are n free parameters then the 1D array has
+        to have n elements and the 2D array n by n elements.
 
     Returns
     -------

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -22,6 +22,7 @@ import numpy.random
 import logging
 from sherpa.astro.utils import calc_energy_flux
 from sherpa.utils import parallel_map
+from sherpa.utils.err import ArgumentErr
 from sherpa.sim import NormalParameterSampleFromScaleMatrix, \
     NormalParameterSampleFromScaleVector
 
@@ -62,6 +63,9 @@ def calc_flux(fit, data, src, samples, method=calc_energy_flux,
 
 def sample_flux(fit, data, src, method=calc_energy_flux, correlated=False,
                 num=1, lo=None, hi=None, numcores=None, samples=None):
+
+    if num <= 0:
+        raise ArgumentErr('bad', 'num', 'must be a positive integer')
 
     #
     # The following function should be modified to take advantage of numpy

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -311,8 +311,7 @@ def _sample_flux_get_samples(fit, src, correlated, num):
         response information. There must be at least one thawed parameter
         in this model. The number of free parameters in src is sfree.
     correlated : bool
-        Are the parameters assumed to be correlated or not? If correlated
-        is True then scales must be 2D.
+        Are the parameters assumed to be correlated or not?
     num : int
         Tne number of samples to return. This must be 1 or greater.
 

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -675,7 +675,9 @@ def test_sample_foo_flux_invalid_niter(method, niter, id,
                                                      (ArgumentErr, True, np.ones((3, 3, 3))),
                                                      (ArgumentErr, False, [1, np.inf, 2]),
                                                      (ArgumentErr, False, [1, 2, None]),
-                                                     (ArgumentErr, True, [[0.1, 0.01, 0.02], [0.01, np.nan, 0.05], [0.02, 0.01, 0.08]])
+                                                     (ArgumentErr, True, [[0.1, 0.01, 0.02], [0.01, np.nan, 0.05], [0.02, 0.01, 0.08]]),
+                                                     (ArgumentErr, False, np.ones(3).reshape(1, 3, 1)),
+                                                     (ArgumentErr, True, np.ones(9).reshape(1, 3, 3))
                                               ])
 def test_sample_foo_flux_invalid_scales(method, etype, correlated, scales,
                                         make_data_path, clean_astro_ui):

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -752,13 +752,16 @@ def test_sample_foo_flux_params(multi, correlated,
     # The checks use relatively-large tolerances, as there is
     # no reason the values will match closely
     #
-    assert np.median(nh) == pytest.approx(nh0, rel=0.1)
+    # The nH value, as it bumps against the lower bound of 0, has
+    # been seen to require a larger tolerance than the other parameters.
+    #
+    assert np.median(nh) == pytest.approx(nh0, rel=0.2)
     assert np.median(gamma) == pytest.approx(gamma0, rel=0.1)
     assert np.median(ampl) == pytest.approx(ampl0, rel=0.1)
 
     assert np.std(nh) == pytest.approx(errs.parmaxes[0], rel=0.2)
-    assert np.std(gamma) == pytest.approx(errs.parmaxes[1], rel=0.2)
-    assert np.std(ampl) == pytest.approx(errs.parmaxes[2], rel=0.2)
+    assert np.std(gamma) == pytest.approx(errs.parmaxes[1], rel=0.1)
+    assert np.std(ampl) == pytest.approx(errs.parmaxes[2], rel=0.1)
 
     # Check against the hard limits, although this is not particularly
     # informative since the hard limits for these parameters are
@@ -836,11 +839,9 @@ def test_sample_foo_flux_scales(multi, correlated, scales,
     gamma = ans[:, 2]
     ampl = ans[:, 3]
 
-    # occasionally a large relative tolerance has been needed for nh
-    # so bump up all of them
     assert np.median(nh) == pytest.approx(nh0, rel=0.2)
-    assert np.median(gamma) == pytest.approx(gamma0, rel=0.2)
-    assert np.median(ampl) == pytest.approx(ampl0, rel=0.2)
+    assert np.median(gamma) == pytest.approx(gamma0, rel=0.1)
+    assert np.median(ampl) == pytest.approx(ampl0, rel=0.1)
 
     if scales.ndim == 2:
         errs = np.sqrt(scales.diagonal())
@@ -848,8 +849,8 @@ def test_sample_foo_flux_scales(multi, correlated, scales,
         errs = scales
 
     assert np.std(nh) == pytest.approx(errs[0], rel=0.2)
-    assert np.std(gamma) == pytest.approx(errs[1], rel=0.2)
-    assert np.std(ampl) == pytest.approx(errs[2], rel=0.2)
+    assert np.std(gamma) == pytest.approx(errs[1], rel=0.1)
+    assert np.std(ampl) == pytest.approx(errs[2], rel=0.1)
 
     assert nh.min() >= gal.nh.hard_min
     assert nh.max() <= gal.nh.hard_max
@@ -899,14 +900,14 @@ def test_sample_foo_flux_scales_example(multi, make_data_path, clean_astro_ui):
     gamma = ans[:, 2]
     ampl = ans[:, 3]
 
-    assert np.median(nh) == pytest.approx(nh0, rel=0.1)
+    assert np.median(nh) == pytest.approx(nh0, rel=0.2)
     assert np.median(gamma) == pytest.approx(gamma0, rel=0.1)
     assert np.median(ampl) == pytest.approx(ampl0, rel=0.1)
 
     errs = scales
 
     assert np.std(nh) == pytest.approx(errs[0], rel=0.2)
-    assert np.std(gamma) == pytest.approx(errs[1], rel=0.2)
-    assert np.std(ampl) == pytest.approx(errs[2], rel=0.2)
+    assert np.std(gamma) == pytest.approx(errs[1], rel=0.1)
+    assert np.std(ampl) == pytest.approx(errs[2], rel=0.1)
 
     assert ans[:, 0].min() > 0

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -615,7 +615,7 @@ def setup_sample(id, make_data_path, fit=True):
 @pytest.mark.parametrize("method", [ui.sample_energy_flux,
                                     ui.sample_photon_flux])
 @pytest.mark.parametrize("niter", [0, -1])
-@pytest.mark.parametrize("id", [None, 1, 2, "foo"])
+@pytest.mark.parametrize("id", [None, 1, "foo"])
 def test_sample_foo_flux_invalid_niter(method, niter, id,
                                        make_data_path, clean_astro_ui):
     """What happens for sample_energy/photon_flux when num is <= 0
@@ -768,7 +768,7 @@ def test_sample_foo_flux_invalid_model(method, make_data_path, clean_astro_ui):
                                            ui.calc_energy_flux),
                                           (ui.sample_photon_flux,
                                            ui.calc_photon_flux)])
-@pytest.mark.parametrize("id", [None, 1, 2, "foo"])
+@pytest.mark.parametrize("id", [None, 1, "foo"])
 @pytest.mark.parametrize("niter", [1, 2, 10])
 @pytest.mark.parametrize("correlated", [False, True])
 def test_sample_foo_flux_niter(multi, single, id, niter, correlated,
@@ -1215,7 +1215,7 @@ def test_sample_foo_flux_component_scales(correlated, scales3,
 @requires_fits
 @requires_xspec
 @pytest.mark.parametrize("method", [ui.sample_energy_flux, ui.sample_photon_flux])
-@pytest.mark.parametrize("id", [None, 1, 2, "foo"])
+@pytest.mark.parametrize("id", [None, 1, "foo"])
 def test_sample_foo_flux_component_scales_fitpars(method, id,
                                                   make_data_path, clean_astro_ui):
     """Is the fit unchanged when a component + errors are used?

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1639,9 +1639,9 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
     res = getfunc(recalc=False)
 
     uvals = res.modelvals
-    assert uvals.shape == (1000, 2)
-    assert np.std(uvals[:, 0]) == pytest.approx(errs[1], rel=0.1)
-    assert np.std(uvals[:, 1]) == pytest.approx(errs[2], rel=0.1)
+    assert uvals.shape == (1000, 3)
+    assert np.std(uvals[:, 1]) == pytest.approx(errs[1], rel=0.1)
+    assert np.std(uvals[:, 2]) == pytest.approx(errs[2], rel=0.1)
 
     assert res.y.shape == (22,)
 
@@ -1776,9 +1776,9 @@ def test_pha1_get_foo_flux_hist_model(getfunc, ratio,
                   correlated=False)
 
     uvals = res.modelvals
-    assert uvals.shape == (1000, 2)
-    assert np.std(uvals[:, 0]) == pytest.approx(errs[1], rel=0.1)
-    assert np.std(uvals[:, 1]) == pytest.approx(errs[2], rel=0.1)
+    assert uvals.shape == (1000, 3)
+    assert np.std(uvals[:, 1]) == pytest.approx(errs[1], rel=0.1)
+    assert np.std(uvals[:, 2]) == pytest.approx(errs[2], rel=0.1)
 
     assert res.y.shape == (22,)
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1422,6 +1422,40 @@ def test_pha1_plot_foo_flux(plotfunc, getfunc, correlated, clean_astro_ui, basic
 @requires_fits
 @requires_data
 @requires_xspec
+@pytest.mark.parametrize("plotfunc,getfunc",
+                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
+def test_pha1_plot_foo_flux_recalc(plotfunc, getfunc, clean_astro_ui, basic_pha1):
+    """Just check we can call recalc on the routine
+
+    """
+
+    orig_mdl = ui.get_source('tst')
+    gal = ui.create_model_component('xswabs', 'gal')
+    gal.nh = 0.04
+    ui.set_source('tst', gal * orig_mdl)
+
+    # Ensure near the minimum
+    ui.fit()
+
+    # Since the results are not being inspected here, the "quality"
+    # of the results isn't important, so we can use a relatively-low
+    # number of iterations.
+    #
+    plotfunc(lo=0.5, hi=2, num=200, bins=20, correlated=True)
+    plotfunc(lo=0.5, hi=2, num=200, bins=20, correlated=True, recalc=False)
+
+    # check we can access these results (relying on the fact that the num
+    # and bins arguments have been changed from their default values).
+    #
+    res = getfunc(recalc=False)
+    validate_flux_histogram(res)
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@requires_xspec
 @pytest.mark.parametrize("getfunc", [ui.get_energy_flux_hist,
                                      ui.get_photon_flux_hist])
 @pytest.mark.parametrize("correlated", [False, True])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12492,7 +12492,8 @@ class Session(sherpa.ui.utils.Session):
 
     def sample_photon_flux(self, lo=None, hi=None, id=None, num=1,
                            scales=None, correlated=False,
-                           numcores=None, bkg_id=None, model=None):
+                           numcores=None, bkg_id=None, model=None,
+                           otherids=()):
         """Return the photon flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12502,7 +12503,7 @@ class Session(sherpa.ui.utils.Session):
         The units for the flux are as returned by `calc_photon_flux`.
 
         .. versionchanged:: 4.12.2
-           The model parameter was added.
+           The model and otherids parameters were added.
 
         Parameters
         ----------
@@ -12550,6 +12551,11 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
+        otherids: list of integer and string ids, optional
+           The list of other datasets that should be included when
+           calculating the errors to draw values from. The default
+           value is () which indicates that only a single dataset
+           is used.
 
         Returns
         -------
@@ -12609,6 +12615,12 @@ class Session(sherpa.ui.utils.Session):
 
         >>> vals = sample_photon_flux(0.5, 7, model=pl, num=1000, correlated=True)
 
+        Calculate the 2-10 keV flux for the pl model using a joint fit
+        to the datasets 1, 2, 3, and 4:
+
+        >>> vals = sample_photon_flux(2, 10, model=pl, id=1, otherids=(2,3,4),
+        ...                           num=1000)
+
         Use the given parameter errors for sampling the parameter distribution.
         The fit must have three free parameters, and each parameter is
         sampled independently (in this case parerrs gives the sigma
@@ -12643,7 +12655,7 @@ class Session(sherpa.ui.utils.Session):
         ...                            model=pl, scales=1.1 * cmat)
 
         """
-        ids, fit = self._get_fit(id)
+        ids, fit = self._get_fit(id, otherids=otherids)
 
         if bkg_id is None:
             data = self.get_data(id)
@@ -12665,7 +12677,8 @@ class Session(sherpa.ui.utils.Session):
 
     def sample_energy_flux(self, lo=None, hi=None, id=None, num=1,
                            scales=None, correlated=False,
-                           numcores=None, bkg_id=None, model=None):
+                           numcores=None, bkg_id=None, model=None,
+                           otherids=()):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12675,7 +12688,7 @@ class Session(sherpa.ui.utils.Session):
         The units for the flux are as returned by `calc_energy_flux`.
 
         .. versionchanged:: 4.12.2
-           The model parameter was added.
+           The model and otherids parameters were added.
 
         Parameters
         ----------
@@ -12723,6 +12736,11 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
+        otherids: list of integer and string ids, optional
+           The list of other datasets that should be included when
+           calculating the errors to draw values from. The default
+           value is () which indicates that only a single dataset
+           is used.
 
         Returns
         -------
@@ -12782,6 +12800,12 @@ class Session(sherpa.ui.utils.Session):
 
         >>> vals = sample_energy_flux(0.5, 7, model=pl, num=1000, correlated=True)
 
+        Calculate the 2-10 keV flux for the pl model using a joint fit
+        to the datasets 1, 2, 3, and 4:
+
+        >>> vals = sample_energy_flux(2, 10, model=pl, id=1, otherids=(2,3,4),
+        ...                           num=1000)
+
         Use the given parameter errors for sampling the parameter distribution.
         The fit must have three free parameters, and each parameter is
         sampled independently (in this case parerrs gives the sigma
@@ -12816,7 +12840,7 @@ class Session(sherpa.ui.utils.Session):
         ...                            model=pl, scales=1.1 * cmat)
 
         """
-        ids, fit = self._get_fit(id)
+        ids, fit = self._get_fit(id, otherids=otherids)
 
         if bkg_id is None:
             data = self.get_data(id)
@@ -12831,8 +12855,11 @@ class Session(sherpa.ui.utils.Session):
 
         return sherpa.astro.flux.sample_flux(fit, data, model,
                                              method=sherpa.astro.utils.calc_energy_flux,
-                                             correlated=correlated, num=num, lo=lo, hi=hi,
-                                             numcores=numcores, samples=scales)
+                                             correlated=correlated,
+                                             num=num, lo=lo, hi=hi,
+                                             numcores=numcores,
+                                             samples=scales)
+
 
     # DOC-NOTE: are scales the variance or standard deviation?
     def sample_flux(self, modelcomponent=None, lo=None, hi=None, id=None,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10850,11 +10850,9 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
-        otherids: list of integer and string ids, optional
+        otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
-           calculating the errors to draw values from. The default
-           value is () which indicates that only a single dataset
-           is used.
+           calculating the errors to draw values from.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -10897,6 +10895,16 @@ class Session(sherpa.ui.utils.Session):
 
         >>> aflux = get_energy_flux_hist(0.5, 2, num=1000, bins=20)
         >>> uflux = get_energy_flux_hist(0.5, 2, model=pl, num=1000, bins=20)
+
+        When there are multiple datasets loaded,
+        `get_energy_flux_hist` uses all datasets to evaluate the
+        errors when the `id` parameter is left at its default value of
+        `None`. The `otherids` parameter is used, along with `id`, to
+        specify exactly what datasets are used:
+
+        >>> x = get_energy_flux_hist(2, 10, num=1000, bins=20, model=src)
+        >>> y = get_energy_flux_hist(2, 10, num=1000, bins=20, model=src,
+        ...                          id=1, otherids=(2, 3, 4))
 
         """
         if sherpa.utils.bool_cast(recalc):
@@ -10969,11 +10977,9 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
-        otherids: list of integer and string ids, optional
+        otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
-           calculating the errors to draw values from. The default
-           value is () which indicates that only a single dataset
-           is used.
+           calculating the errors to draw values from.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -11016,6 +11022,16 @@ class Session(sherpa.ui.utils.Session):
 
         >>> aflux = get_photon_flux_hist(0.5, 2, num=1000, bins=20)
         >>> uflux = get_photon_flux_hist(0.5, 2, model=pl, num=1000, bins=20)
+
+        When there are multiple datasets loaded,
+        `get_photon_flux_hist` uses all datasets to evaluate the
+        errors when the `id` parameter is left at its default value of
+        `None`. The `otherids` parameter is used, along with `id`, to
+        specify exactly what datasets are used:
+
+        >>> x = get_photon_flux_hist(2, 10, num=1000, bins=20, model=src)
+        >>> y = get_photon_flux_hist(2, 10, num=1000, bins=20, model=src,
+        ...                          id=1, otherids=(2, 3, 4))
 
         """
         if sherpa.utils.bool_cast(recalc):
@@ -11939,11 +11955,9 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
-        otherids: list of integer and string ids, optional
+        otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
-           calculating the errors to draw values from. The default
-           value is () which indicates that only a single dataset
-           is used.
+           calculating the errors to draw values from.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -11992,7 +12006,28 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_energy_flux(0.5, 2, num=1000, bins=20)
         >>> plot_energy_flux(0.5, 2, model=pl, num=1000, bins=20)
 
+        If you have multiple datasets loaded, each with a model, then
+        all datasets will be used to calculate the errors when the
+        id parameter is not set. A single dataset can be used by
+        specifying a dataset (in this example the overplot is just with
+        dataset 1):
+
+        >>> mdl = xsphabs.gal * xsapec.src
+        >>> set_source(1, mdl)
+        >>> set_source(2, mdl)
+        ...
+        >>> plot_energy_flux(0.5, 2, model=src num=1000, bins=20)
+        >>> plot_energy_flux(0.5, 2, model=src num=1000, bins=20,
+        ...                  id=1, overplot=True)
+
+        If you have multiple datasets then you can use the otherids
+        argument to specify exactly what set of data is used:
+
+        >>> plot_energy_flux(0.5, 2, model=src num=1000, bins=20,
+        ...                  id=1, otherids=(2, 3, 4))
+
         """
+
         efplot = self._energyfluxplot
         if sherpa.utils.bool_cast(recalc):
             efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id=id,
@@ -12077,11 +12112,9 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
-        otherids: list of integer and string ids, optional
+        otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
-           calculating the errors to draw values from. The default
-           value is () which indicates that only a single dataset
-           is used.
+           calculating the errors to draw values from.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -12129,6 +12162,26 @@ class Session(sherpa.ui.utils.Session):
 
         >>> plot_photon_flux(0.5, 2, num=1000, bins=20)
         >>> plot_photon_flux(0.5, 2, model=pl, num=1000, bins=20)
+
+        If you have multiple datasets loaded, each with a model, then
+        all datasets will be used to calculate the errors when the
+        id parameter is not set. A single dataset can be used by
+        specifying a dataset (in this example the overplot is just with
+        dataset 1):
+
+        >>> mdl = xsphabs.gal * xsapec.src
+        >>> set_source(1, mdl)
+        >>> set_source(2, mdl)
+        ...
+        >>> plot_photon_flux(0.5, 2, model=src num=1000, bins=20)
+        >>> plot_photon_flux(0.5, 2, model=src num=1000, bins=20,
+        ...                  id=1, overplot=True)
+
+        If you have multiple datasets then you can use the otherids
+        argument to specify exactly what set of data is used:
+
+        >>> plot_photon_flux(0.5, 2, model=src num=1000, bins=20,
+        ...                  id=1, otherids=(2, 3, 4))
 
         """
         pfplot = self._photonfluxplot
@@ -12577,7 +12630,7 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
-        otherids: list of integer and string ids, optional
+        otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
            calculating the errors to draw values from.
 
@@ -12590,8 +12643,7 @@ class Session(sherpa.ui.utils.Session):
            value, as calculated by `calc_photon_flux`, followed by the
            values of the thawed parameters used for that
            iteration. The order of the parameters matches the data
-           returned by `get_fit_results` (restricted to the model
-           parameter, when set).
+           returned by `get_fit_results`.
 
         See Also
         --------
@@ -12784,7 +12836,7 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
-        otherids: list of integer and string ids, optional
+        otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
            calculating the errors to draw values from.
 
@@ -12797,8 +12849,7 @@ class Session(sherpa.ui.utils.Session):
            value, as calculated by `calc_emergy_flux`, followed by the
            values of the thawed parameters used for that
            iteration. The order of the parameters matches the data
-           returned by `get_fit_results` (restricted to the model
-           parameter, when set).
+           returned by `get_fit_results`.
 
         See Also
         --------
@@ -13116,7 +13167,7 @@ class Session(sherpa.ui.utils.Session):
            The default is None, in which case get_draws shall be called.
            The user can input the parameter array (e.g. from running
            `sample_flux`).
-        otherids: list of integer ids, optional
+        otherids : sequence of integer or strings, optional
            The default value is (). However, if get_draws is called
            internally which may require otherids to be set if more then
            one data set is to be used then otherids must be set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12579,21 +12579,19 @@ class Session(sherpa.ui.utils.Session):
            The model must be part of the source expression.
         otherids: list of integer and string ids, optional
            The list of other datasets that should be included when
-           calculating the errors to draw values from. The default
-           value is () which indicates that only a single dataset
-           is used.
+           calculating the errors to draw values from.
 
         Returns
         -------
         vals
-           The return array has the shape ``(num, N+1)``, where ``N`` is the
-           number of free parameters and num is the `num` parameter.
-           The rows of this array contain the flux value, as
-           calculated by `calc_photon_flux`, followed by the values of
-           the thawed parameters used for that iteration. The order of
-           the parameters matches the data returned by
-           `get_fit_results` (restricted to the model parameter, when
-           set).
+           The return array has the shape ``(num, N+1)``, where ``N``
+           is the number of free parameters in the fit and num is the
+           `num` parameter.  The rows of this array contain the flux
+           value, as calculated by `calc_photon_flux`, followed by the
+           values of the thawed parameters used for that
+           iteration. The order of the parameters matches the data
+           returned by `get_fit_results` (restricted to the model
+           parameter, when set).
 
         See Also
         --------
@@ -12610,11 +12608,16 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        When both the model and scales parameters are set then the
-        size of the scales parameter should either match the number of
-        free parameters in the full source expression or that of
-        the model component. The return value in this case is always
-        limited to the number of free parameters in the model component.
+        There are two ways to use this function to calculate fluxes
+        from multiple sources. The first is to leave the `id` argument
+        as `None`, in which case all available datasets will be used.
+        Alternatively, the `id` and `otherids` arguments can be set to
+        list the exact datasets to use, such as `id=1,
+        otherids=(2,3,4)`.
+
+        The returned value contains all free parameters in the fit,
+        even if they are not included in the model argument (e.g.
+        when calculating an unabsorbed flux).
 
         Examples
         --------
@@ -12637,7 +12640,9 @@ class Session(sherpa.ui.utils.Session):
         calculated using the model argument. For the following case,
         an absorbed power-law was used to fit the data -
         `xsphabs.gal * powerlaw.pl` - and then the flux of just the
-        power-law component is calculated:
+        power-law component is calculated. Note that the returned
+        array has columns 'flux', 'gal.nh', 'pl.gamma', and 'pl.ampl'
+        (that is flux and then the free parameters in the full model).
 
         >>> vals = sample_photon_flux(0.5, 7, model=pl, num=1000, correlated=True)
 
@@ -12662,14 +12667,14 @@ class Session(sherpa.ui.utils.Session):
         >>> parerrs = get_covar_results().parmaxes
         >>> vals = sample_photon_flux(0.5, 2, num=1000, scales=parerrs)
 
-        Run covariance to estimate the parameter errors and then extract
-        the covariance matrix from the results (as the `cmat` variable).
-        This matrix is then used to define the parameter widths - including
-        correlated terms - in the flux sampling, after being increased by
-        ten percent. This is used to calculate both the absorbed
-        (`vals1`) and unabsorbed (`vals2`) fluxes. The shapes of these
-        two arrays will be different: 5000 by 4 for `vals1` and
-        5000 by 3 for `vals2`.
+        Run covariance to estimate the parameter errors and then
+        extract the covariance matrix from the results (as the `cmat`
+        variable).  This matrix is then used to define the parameter
+        widths - including correlated terms - in the flux sampling,
+        after being increased by ten percent. This is used to
+        calculate both the absorbed (`vals1`) and unabsorbed (`vals2`)
+        fluxes. Both arrays have columns: flux, gal.nh, pl.gamma, and
+        pl.ampl.
 
         >>> set_source(xsphabs.gal * powlaw1d.pl)
         >>> fit()
@@ -12679,6 +12684,23 @@ class Session(sherpa.ui.utils.Session):
         ...                            scales=1.1 * cmat)
         >>> vals2 = sample_photon_flux(2, 10, num=5000, correlated=True,
         ...                            model=pl, scales=1.1 * cmat)
+
+        Calculate the flux and error distribution using fits
+        to all datasets:
+
+        >>> set_source(xsphabs.gal * xsapec.clus)
+        >>> set_source(2, gal * clus)
+        >>> set_source(3, gal * clus)
+        ... fit the data
+        >>> vals = sample_photon_flux(0.5, 10, model=clus, num=10000)
+
+        Calculate the flux and error distribution using fits
+        to an explicit set of datasets (in this case datasets
+        1 and 2):
+
+        >>> vals = sample_photon_flux(0.5, 10, id=1, otherids=[2],
+        ...                           model=clus, num=10000)
+
 
         """
         ids, fit = self._get_fit(id, otherids=otherids)
@@ -12764,21 +12786,19 @@ class Session(sherpa.ui.utils.Session):
            The model must be part of the source expression.
         otherids: list of integer and string ids, optional
            The list of other datasets that should be included when
-           calculating the errors to draw values from. The default
-           value is () which indicates that only a single dataset
-           is used.
+           calculating the errors to draw values from.
 
         Returns
         -------
         vals
-           The return array has the shape ``(num, N+1)``, where ``N`` is the
-           number of free parameters and num is the `num` parameter.
-           The rows of this array contain the flux value, as
-           calculated by `calc_energy_flux`, followed by the values of
-           the thawed parameters used for that iteration. The order of
-           the parameters matches the data returned by
-           `get_fit_results` (restricted to the model parameter, when
-           set).
+           The return array has the shape ``(num, N+1)``, where ``N``
+           is the number of free parameters in the fit and num is the
+           `num` parameter.  The rows of this array contain the flux
+           value, as calculated by `calc_emergy_flux`, followed by the
+           values of the thawed parameters used for that
+           iteration. The order of the parameters matches the data
+           returned by `get_fit_results` (restricted to the model
+           parameter, when set).
 
         See Also
         --------
@@ -12795,11 +12815,16 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        When both the model and scales parameters are set then the
-        size of the scales parameter should either match the number of
-        free parameters in the full source expression or that of
-        the model component. The return value in this case is always
-        limited to the number of free parameters in the model component.
+        There are two ways to use this function to calculate fluxes
+        from multiple sources. The first is to leave the `id` argument
+        as `None`, in which case all available datasets will be used.
+        Alternatively, the `id` and `otherids` arguments can be set to
+        list the exact datasets to use, such as `id=1,
+        otherids=(2,3,4)`.
+
+        The returned value contains all free parameters in the fit,
+        even if they are not included in the model argument (e.g.
+        when calculating an unabsorbed flux).
 
         Examples
         --------
@@ -12822,7 +12847,9 @@ class Session(sherpa.ui.utils.Session):
         calculated using the model argument. For the following case,
         an absorbed power-law was used to fit the data -
         `xsphabs.gal * powerlaw.pl` - and then the flux of just the
-        power-law component is calculated:
+        power-law component is calculated. Note that the returned
+        array has columns 'flux', 'gal.nh', 'pl.gamma', and 'pl.ampl'
+        (that is flux and then the free parameters in the full model).
 
         >>> vals = sample_energy_flux(0.5, 7, model=pl, num=1000, correlated=True)
 
@@ -12847,14 +12874,14 @@ class Session(sherpa.ui.utils.Session):
         >>> parerrs = get_covar_results().parmaxes
         >>> vals = sample_energy_flux(0.5, 2, num=1000, scales=parerrs)
 
-        Run covariance to estimate the parameter errors and then extract
-        the covariance matrix from the results (as the `cmat` variable).
-        This matrix is then used to define the parameter widths - including
-        correlated terms - in the flux sampling, after being increased by
-        ten percent. This is used to calculate both the absorbed
-        (`vals1`) and unabsorbed (`vals2`) fluxes. The shapes of these
-        two arrays will be different: 5000 by 4 for `vals1` and
-        5000 by 3 for `vals2`.
+        Run covariance to estimate the parameter errors and then
+        extract the covariance matrix from the results (as the `cmat`
+        variable).  This matrix is then used to define the parameter
+        widths - including correlated terms - in the flux sampling,
+        after being increased by ten percent. This is used to
+        calculate both the absorbed (`vals1`) and unabsorbed (`vals2`)
+        fluxes. Both arrays have columns: flux, gal.nh, pl.gamma, and
+        pl.ampl.
 
         >>> set_source(xsphabs.gal * powlaw1d.pl)
         >>> fit()
@@ -12864,6 +12891,23 @@ class Session(sherpa.ui.utils.Session):
         ...                            scales=1.1 * cmat)
         >>> vals2 = sample_energy_flux(2, 10, num=5000, correlated=True,
         ...                            model=pl, scales=1.1 * cmat)
+
+        Calculate the flux and error distribution using fits
+        to all datasets:
+
+        >>> set_source(xsphabs.gal * xsapec.clus)
+        >>> set_source(2, gal * clus)
+        >>> set_source(3, gal * clus)
+        ... fit the data
+        >>> vals = sample_energy_flux(0.5, 10, model=clus, num=10000)
+
+        Calculate the flux and error distribution using fits
+        to an explicit set of datasets (in this case datasets
+        1 and 2):
+
+        >>> vals = sample_energy_flux(0.5, 10, id=1, otherids=[2],
+        ...                           model=clus, num=10000)
+
 
         """
         ids, fit = self._get_fit(id, otherids=otherids)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12405,15 +12405,22 @@ class Session(sherpa.ui.utils.Session):
            The number of samples to create. The default is 1.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
-           parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
-           of length N, where N is the number of free parameters.
+           parameters. The size and shape of the array depende on the
+           number of free parameters in the fit (n) and the value of
+           the `correlated` parameter. When the parameter is `True`,
+           scales must be given the covariance matrix for the free
+           parameters (a n by n matrix that matches the parameter
+           ordering used by Sherpa). For un-correlated parameters
+           the covariance matrix can be used, or a one-dimensional
+           array of n elements can be used, giving the error on the
+           parameters (e.g. the square root of the diagonal elements
+           of the covariance matrix). If the scales parameter is not
+           given then the covariance matrix is evaluated for the
+           current model and best-fit parameters.
         correlated : bool, optional
-           If ``True`` (the default is ``False``) then ``scales`` is the
-           full covariance matrix, otherwise it is just a 1D array
-           containing the variances of the parameters (the diagonal
-           elements of the covariance matrix).
+           Should the correlation between the parameters be included
+           when sampling the parameters? If not, then each parameter
+           is sampled from a normal distribution.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -12454,14 +12461,32 @@ class Session(sherpa.ui.utils.Session):
         distribution):
 
         >>> vals = sample_photon_flux(0.5, 7, num=1000)
-        >>> plot_cdf(vals[:,0], name='flux')
+        >>> plot_cdf(vals[:, 0], name='flux')
 
         Repeat the above, but allowing the parameters to be
         correlated, and then calculate the 5, 50, and 95 percent
         quantiles of the photon flux distribution:
 
-        >>> cvals = sample_photon_flux(.5, 7, num=1000, correlated=True)
-        >>> np.percentile(cvals[:,0], [5,50,95])
+        >>> cvals = sample_photon_flux(0.5, 7, num=1000, correlated=True)
+        >>> np.percentile(cvals[:, 0], [5, 50, 95])
+
+        Use the given parameter errors for sampling the parameter distribution.
+        The fit must have three free parameters, and each parameter is
+        sampled independently:
+
+        >>> parerrs = [0.25, 1.22, 1.04e-4]
+        >>> vals = sample_photon_flux(2, 10, num=5000, scales=parerrs)
+
+        Run covariance to estimate the parameter errors and then extract
+        the covariance matrix from the results (as the `cmat` variable).
+        This matrix is then used to define the parameter widths - including
+        correlated terms - in the flux sampling, after being increased by
+        ten percent:
+
+        >>> covar()
+        >>> cmat = get_covar_results().extra_output
+        >>> vals = sample_photon_flux(2, 10, num=5000, correlated=True,
+        ...                           scales=1.1 * cmat)
 
         """
         ids, fit = self._get_fit(id)
@@ -12507,15 +12532,22 @@ class Session(sherpa.ui.utils.Session):
            The number of samples to create. The default is 1.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
-           parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
-           of length N, where N is the number of free parameters.
+           parameters. The size and shape of the array depende on the
+           number of free parameters in the fit (n) and the value of
+           the `correlated` parameter. When the parameter is `True`,
+           scales must be given the covariance matrix for the free
+           parameters (a n by n matrix that matches the parameter
+           ordering used by Sherpa). For un-correlated parameters
+           the covariance matrix can be used, or a one-dimensional
+           array of n elements can be used, giving the error on the
+           parameters (e.g. the square root of the diagonal elements
+           of the covariance matrix). If the scales parameter is not
+           given then the covariance matrix is evaluated for the
+           current model and best-fit parameters.
         correlated : bool, optional
-           If ``True`` (the default is ``False``) then ``scales`` is the
-           full covariance matrix, otherwise it is just a 1D array
-           containing the variances of the parameters (the diagonal
-           elements of the covariance matrix).
+           Should the correlation between the parameters be included
+           when sampling the parameters? If not, then each parameter
+           is sampled from a normal distribution.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -12556,14 +12588,32 @@ class Session(sherpa.ui.utils.Session):
         distribution):
 
         >>> vals = sample_energy_flux(0.5, 7, num=1000)
-        >>> plot_cdf(vals[:,0], name='flux')
+        >>> plot_cdf(vals[:, 0], name='flux')
 
         Repeat the above, but allowing the parameters to be
         correlated, and then calculate the 5, 50, and 95 percent
         quantiles of the energy flux distribution:
 
-        >>> cvals = sample_energy_flux(.5, 7, num=1000, correlated=True)
-        >>> np.percentile(cvals[:,0], [5,50,95])
+        >>> cvals = sample_energy_flux(0.5, 7, num=1000, correlated=True)
+        >>> np.percentile(cvals[:, 0], [5, 50, 95])
+
+        Use the given parameter errors for sampling the parameter distribution.
+        The fit must have three free parameters, and each parameter is
+        sampled independently:
+
+        >>> parerrs = [0.25, 1.22, 1.04e-4]
+        >>> vals = sample_energy_flux(2, 10, num=5000, scales=parerrs)
+
+        Run covariance to estimate the parameter errors and then extract
+        the covariance matrix from the results (as the `cmat` variable).
+        This matrix is then used to define the parameter widths - including
+        correlated terms - in the flux sampling, after being increased by
+        ten percent:
+
+        >>> covar()
+        >>> cmat = get_covar_results().extra_output
+        >>> vals = sample_energy_flux(2, 10, num=5000, correlated=True,
+        ...                           scales=1.1 * cmat)
 
         """
         ids, fit = self._get_fit(id)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10799,7 +10799,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
@@ -10885,7 +10885,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
@@ -11822,7 +11822,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
@@ -11930,7 +11930,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
@@ -12403,7 +12403,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
@@ -12576,7 +12576,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
@@ -12749,7 +12749,7 @@ class Session(sherpa.ui.utils.Session):
            given then the lower value of the data grid is used.
         hi : optional
            The upper limit to use when summing up the signal. If not
-           guven then the upper value of the data grid is used.
+           given then the upper value of the data grid is used.
         id : int or string, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12393,7 +12393,7 @@ class Session(sherpa.ui.utils.Session):
         contains the flux and parameter values for each iteration.
         The units for the flux are as returned by `calc_photon_flux`.
 
-        .. versionchanged:: 4.12.1
+        .. versionchanged:: 4.12.2
            The model parameter was added.
 
         Parameters
@@ -12566,7 +12566,7 @@ class Session(sherpa.ui.utils.Session):
         contains the flux and parameter values for each iteration.
         The units for the flux are as returned by `calc_energy_flux`.
 
-        .. versionchanged:: 4.12.1
+        .. versionchanged:: 4.12.2
            The model parameter was added.
 
         Parameters

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10771,22 +10771,24 @@ class Session(sherpa.ui.utils.Session):
         return self._bkgchisqrplot
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
-                                  correlated, numcores, bkg_id, scales=None):
-        dist = self.sample_energy_flux(lo, hi, id=id, num=num, scales=scales,
+                                  correlated, numcores, bkg_id,
+                                  scales=None, model=None):
+        dist = self.sample_energy_flux(lo, hi, id=id, num=num, scales=scales, model=model,
                                        correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
     def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins,
-                                  correlated, numcores, bkg_id, scales=None):
-        dist = self.sample_photon_flux(lo, hi, id=id, num=num, scales=scales,
+                                  correlated, numcores, bkg_id,
+                                  scales=None, model=None):
+        dist = self.sample_photon_flux(lo, hi, id=id, num=num, scales=scales, model=model,
                                        correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
     def get_energy_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
-                             scales=None, recalc=True):
+                             scales=None, model=None, recalc=True):
         """Return the data displayed by plot_energy_flux.
 
         The get_energy_flux_hist() function calculates a histogram of
@@ -10795,7 +10797,8 @@ class Session(sherpa.ui.utils.Session):
         model parameters.
 
         .. versionchanged:: 4.12.2
-           The scales parameter is no longer ignored when set.
+           The scales parameter is no longer ignored when set and the
+           model parameter has been added.
 
         Parameters
         ----------
@@ -10827,10 +10830,24 @@ class Session(sherpa.ui.utils.Session):
            background model.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
-           parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
-           of length N, where N is the number of free parameters.
+           parameters. The size and shape of the array depends on the
+           number of free parameters in the fit (n) and the value of
+           the `correlated` parameter. When the parameter is `True`,
+           scales must be given the covariance matrix for the free
+           parameters (a n by n matrix that matches the parameter
+           ordering used by Sherpa). For un-correlated parameters
+           the covariance matrix can be used, or a one-dimensional
+           array of n elements can be used, giving the width (specified
+           as the sigma value of a normal distribution) for each
+           parameter (e.g. the square root of the diagonal elements
+           of the covariance matrix). If the scales parameter is not
+           given then the covariance matrix is evaluated for the
+           current model and best-fit parameters.
+        model : model, optional
+           The model to integrate. If left as `None` then the source
+           model for the dataset will be used. This can be used to
+           calculate the unabsorbed flux, as shown in the examples.
+           The model must be part of the source expression.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -10866,16 +10883,25 @@ class Session(sherpa.ui.utils.Session):
         >>> ehist1 = get_energy_flux_hist(0.5, 2, id='jet', num=1000)
         >>> ehist2 = get_energy_flux_hist(0.5, 2, id='core', num=1000)
 
+        Compare the flux distribution for the full source expression
+        (aflux) to that for just the pl component (uflux); this can be
+        useful to calculate the unabsorbed flux distribution if the
+        full source model contains an absorption component:
+
+        >>> aflux = get_energy_flux_hist(0.5, 2, num=1000, bins=20)
+        >>> uflux = get_energy_flux_hist(0.5, 2, model=pl, num=1000, bins=20)
+
         """
         if sherpa.utils.bool_cast(recalc):
             self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
-                                           scales=scales, numcores=numcores, bkg_id=bkg_id)
+                                           scales=scales, model=model,
+                                           numcores=numcores, bkg_id=bkg_id)
         return self._energyfluxplot
 
     def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
-                             scales=None, recalc=True):
+                             scales=None, model=None, recalc=True):
         """Return the data displayed by plot_photon_flux.
 
         The get_photon_flux_hist() function calculates a histogram of
@@ -10884,7 +10910,8 @@ class Session(sherpa.ui.utils.Session):
         model parameters.
 
         .. versionchanged:: 4.12.2
-           The scales parameter is no longer ignored when set.
+           The scales parameter is no longer ignored when set and the
+           model parameter has been added.
 
         Parameters
         ----------
@@ -10916,10 +10943,24 @@ class Session(sherpa.ui.utils.Session):
            background model.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
-           parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
-           of length N, where N is the number of free parameters.
+           parameters. The size and shape of the array depends on the
+           number of free parameters in the fit (n) and the value of
+           the `correlated` parameter. When the parameter is `True`,
+           scales must be given the covariance matrix for the free
+           parameters (a n by n matrix that matches the parameter
+           ordering used by Sherpa). For un-correlated parameters
+           the covariance matrix can be used, or a one-dimensional
+           array of n elements can be used, giving the width (specified
+           as the sigma value of a normal distribution) for each
+           parameter (e.g. the square root of the diagonal elements
+           of the covariance matrix). If the scales parameter is not
+           given then the covariance matrix is evaluated for the
+           current model and best-fit parameters.
+        model : model, optional
+           The model to integrate. If left as `None` then the source
+           model for the dataset will be used. This can be used to
+           calculate the unabsorbed flux, as shown in the examples.
+           The model must be part of the source expression.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -10955,11 +10996,20 @@ class Session(sherpa.ui.utils.Session):
         >>> phist1 = get_photon_flux_hist(0.5, 2, id='jet', num=1000)
         >>> phist2 = get_photon_flux_hist(0.5, 2, id='core', num=1000)
 
+        Compare the flux distribution for the full source expression
+        (aflux) to that for just the pl component (uflux); this can be
+        useful to calculate the unabsorbed flux distribution if the
+        full source model contains an absorption component:
+
+        >>> aflux = get_photon_flux_hist(0.5, 2, num=1000, bins=20)
+        >>> uflux = get_photon_flux_hist(0.5, 2, model=pl, num=1000, bins=20)
+
         """
         if sherpa.utils.bool_cast(recalc):
             self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
-                                           scales=scales, numcores=numcores, bkg_id=bkg_id)
+                                           scales=scales, model=model,
+                                           numcores=numcores, bkg_id=bkg_id)
         return self._photonfluxplot
 
     def _prepare_plotobj(self, id, plotobj, resp_id=None, bkg_id=None, lo=None,
@@ -11810,7 +11860,8 @@ class Session(sherpa.ui.utils.Session):
 
     def plot_energy_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
-                         scales=None, recalc=True, overplot=False, clearwindow=True,
+                         scales=None, model=None,
+                         recalc=True, overplot=False, clearwindow=True,
                          **kwargs):
         """Display the energy flux distribution.
 
@@ -11823,7 +11874,8 @@ class Session(sherpa.ui.utils.Session):
         create this plot.
 
         .. versionchanged:: 4.12.2
-           The scales parameter is no longer ignored when set.
+           The scales parameter is no longer ignored when set and the
+           model parameter has been added.
 
         Parameters
         ----------
@@ -11855,10 +11907,24 @@ class Session(sherpa.ui.utils.Session):
            background model.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
-           parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
-           of length N, where N is the number of free parameters.
+           parameters. The size and shape of the array depends on the
+           number of free parameters in the fit (n) and the value of
+           the `correlated` parameter. When the parameter is `True`,
+           scales must be given the covariance matrix for the free
+           parameters (a n by n matrix that matches the parameter
+           ordering used by Sherpa). For un-correlated parameters
+           the covariance matrix can be used, or a one-dimensional
+           array of n elements can be used, giving the width (specified
+           as the sigma value of a normal distribution) for each
+           parameter (e.g. the square root of the diagonal elements
+           of the covariance matrix). If the scales parameter is not
+           given then the covariance matrix is evaluated for the
+           current model and best-fit parameters.
+        model : model, optional
+           The model to integrate. If left as `None` then the source
+           model for the dataset will be used. This can be used to
+           calculate the unabsorbed flux, as shown in the examples.
+           The model must be part of the source expression.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -11899,12 +11965,20 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_energy_flux(0.5, 2, id="jet", num=1000)
         >>> plot_energy_flux(0.5, 2, id="core", num=1000, overplot=True)
 
+        Overplot the flux distribution for just the pl component (which
+        must be part of the source expression) on top of the full model.
+        If the full model was xsphabs.gal * powlaw1d.pl then this will
+        compare the unabsorbed to absorbed flux distributions:
+
+        >>> plot_energy_flux(0.5, 2, num=1000, bins=20)
+        >>> plot_energy_flux(0.5, 2, model=pl, num=1000, bins=20)
+
         """
         efplot = self._energyfluxplot
         if sherpa.utils.bool_cast(recalc):
             efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id=id,
                                                     num=num, bins=bins, scales=scales,
-                                                    correlated=correlated,
+                                                    correlated=correlated, model=model,
                                                     numcores=numcores, bkg_id=bkg_id)
         try:
             sherpa.plot.begin()
@@ -11918,7 +11992,8 @@ class Session(sherpa.ui.utils.Session):
 
     def plot_photon_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
-                         scales=None, recalc=True, overplot=False, clearwindow=True,
+                         scales=None, model=None,
+                         recalc=True, overplot=False, clearwindow=True,
                          **kwargs):
         """Display the photon flux distribution.
 
@@ -11931,7 +12006,8 @@ class Session(sherpa.ui.utils.Session):
         create this plot.
 
         .. versionchanged:: 4.12.2
-           The scales parameter is no longer ignored when set.
+           The scales parameter is no longer ignored when set and the
+           model parameter has been added.
 
         Parameters
         ----------
@@ -11963,10 +12039,24 @@ class Session(sherpa.ui.utils.Session):
            background model.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The form depends on the ``correlated``
-           parameter: when ``True``, the array should be a symmetric
-           positive semi-definite (N,N) array, otherwise a 1D array
-           of length N, where N is the number of free parameters.
+           parameters. The size and shape of the array depends on the
+           number of free parameters in the fit (n) and the value of
+           the `correlated` parameter. When the parameter is `True`,
+           scales must be given the covariance matrix for the free
+           parameters (a n by n matrix that matches the parameter
+           ordering used by Sherpa). For un-correlated parameters
+           the covariance matrix can be used, or a one-dimensional
+           array of n elements can be used, giving the width (specified
+           as the sigma value of a normal distribution) for each
+           parameter (e.g. the square root of the diagonal elements
+           of the covariance matrix). If the scales parameter is not
+           given then the covariance matrix is evaluated for the
+           current model and best-fit parameters.
+        model : model, optional
+           The model to integrate. If left as `None` then the source
+           model for the dataset will be used. This can be used to
+           calculate the unabsorbed flux, as shown in the examples.
+           The model must be part of the source expression.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -12007,12 +12097,20 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_photon_flux(0.5, 2, id="jet", num=1000)
         >>> plot_photon_flux(0.5, 2, id="core", num=1000, overplot=True)
 
+        Overplot the flux distribution for just the pl component (which
+        must be part of the source expression) on top of the full model.
+        If the full model was xsphabs.gal * powlaw1d.pl then this will
+        compare the unabsorbed to absorbed flux distributions:
+
+        >>> plot_photon_flux(0.5, 2, num=1000, bins=20)
+        >>> plot_photon_flux(0.5, 2, model=pl, num=1000, bins=20)
+
         """
         pfplot = self._photonfluxplot
         if sherpa.utils.bool_cast(recalc):
             pfplot = self._prepare_photon_flux_plot(pfplot, lo, hi, id=id,
                                                     num=num, bins=bins, scales=scales,
-                                                    correlated=correlated,
+                                                    correlated=correlated, model=model,
                                                     numcores=numcores, bkg_id=bkg_id)
         try:
             sherpa.plot.begin()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13279,14 +13279,16 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        data = self.get_data(id)
+        if bkg_id is None:
+            data = self.get_data(id)
+        else:
+            data = self.get_bkg(id, bkg_id)
 
         if model is None:
-            if bkg_id is not None:
-                data = self.get_bkg(id, bkg_id)
-                model = self.get_bkg_source(id, bkg_id)
-            else:
+            if bkg_id is None:
                 model = self.get_source(id)
+            else:
+                model = self.get_bkg_source(id, bkg_id)
         else:
             _check_type(model, sherpa.models.Model, 'model',
                         'a model object')
@@ -13397,14 +13399,16 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        data = self.get_data(id)
+        if bkg_id is None:
+            data = self.get_data(id)
+        else:
+            data = self.get_bkg(id, bkg_id)
 
         if model is None:
-            if bkg_id is not None:
-                data = self.get_bkg(id, bkg_id)
-                model = self.get_bkg_source(id, bkg_id)
-            else:
+            if bkg_id is None:
                 model = self.get_source(id)
+            else:
+                model = self.get_bkg_source(id, bkg_id)
         else:
             _check_type(model, sherpa.models.Model, 'model',
                         'a model object')

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12851,7 +12851,7 @@ class Session(sherpa.ui.utils.Session):
            The return array has the shape ``(num, N+1)``, where ``N``
            is the number of free parameters in the fit and num is the
            `num` parameter.  The rows of this array contain the flux
-           value, as calculated by `calc_emergy_flux`, followed by the
+           value, as calculated by `calc_energy_flux`, followed by the
            values of the thawed parameters used for that
            iteration. The order of the parameters matches the data
            returned by `get_fit_results`.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10770,27 +10770,32 @@ class Session(sherpa.ui.utils.Session):
         self._prepare_plotobj(id, self._bkgchisqrplot, bkg_id=bkg_id)
         return self._bkgchisqrplot
 
-    def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins, correlated, numcores, bkg_id):
-        dist = self.sample_energy_flux(lo, hi, id=id, num=num, scales=None,
+    def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
+                                  correlated, numcores, bkg_id, scales=None):
+        dist = self.sample_energy_flux(lo, hi, id=id, num=num, scales=scales,
                                        correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
-    def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins, correlated, numcores, bkg_id):
-        dist = self.sample_photon_flux(lo, hi, id=id, num=num, scales=None,
+    def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins,
+                                  correlated, numcores, bkg_id, scales=None):
+        dist = self.sample_photon_flux(lo, hi, id=id, num=num, scales=scales,
                                        correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
-    # DOC-TODO: See comments about plot_energy_flux.
     def get_energy_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
-                             correlated=False, numcores=None, bkg_id=None, **kwargs):
+                             correlated=False, numcores=None, bkg_id=None,
+                             scales=None, recalc=True):
         """Return the data displayed by plot_energy_flux.
 
         The get_energy_flux_hist() function calculates a histogram of
         simulated energy flux values representing the energy flux probability
         distribution for a model component, accounting for the errors on the
         model parameters.
+
+        .. versionchanged:: 4.12.2
+           The scales parameter is no longer ignored when set.
 
         Parameters
         ----------
@@ -10862,21 +10867,24 @@ class Session(sherpa.ui.utils.Session):
         >>> ehist2 = get_energy_flux_hist(0.5, 2, id='core', num=1000)
 
         """
-        if sherpa.utils.bool_cast(kwargs.pop('recalc', True)):
+        if sherpa.utils.bool_cast(recalc):
             self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
-                                           numcores=numcores, bkg_id=bkg_id)
+                                           scales=scales, numcores=numcores, bkg_id=bkg_id)
         return self._energyfluxplot
 
-    # DOC-TODO: See comments about plot_photon_flux.
     def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
-                             correlated=False, numcores=None, bkg_id=None, **kwargs):
+                             correlated=False, numcores=None, bkg_id=None,
+                             scales=None, recalc=True):
         """Return the data displayed by plot_photon_flux.
 
         The get_photon_flux_hist() function calculates a histogram of
         simulated photon flux values representing the photon flux probability
         distribution for a model component, accounting for the errors on the
         model parameters.
+
+        .. versionchanged:: 4.12.2
+           The scales parameter is no longer ignored when set.
 
         Parameters
         ----------
@@ -10948,10 +10956,10 @@ class Session(sherpa.ui.utils.Session):
         >>> phist2 = get_photon_flux_hist(0.5, 2, id='core', num=1000)
 
         """
-        if sherpa.utils.bool_cast(kwargs.pop('recalc', True)):
+        if sherpa.utils.bool_cast(recalc):
             self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
-                                           numcores=numcores, bkg_id=bkg_id)
+                                           scales=scales, numcores=numcores, bkg_id=bkg_id)
         return self._photonfluxplot
 
     def _prepare_plotobj(self, id, plotobj, resp_id=None, bkg_id=None, lo=None,
@@ -11800,10 +11808,9 @@ class Session(sherpa.ui.utils.Session):
                    replot=replot, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    # DOC-TODO: I am assuming it accepts a scales parameter
     def plot_energy_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
-                         recalc=True, overplot=False, clearwindow=True,
+                         scales=None, recalc=True, overplot=False, clearwindow=True,
                          **kwargs):
         """Display the energy flux distribution.
 
@@ -11814,6 +11821,9 @@ class Session(sherpa.ui.utils.Session):
         returned by `calc_energy_flux`. The `sample_energy_flux` and
         `get_energy_flux_hist` functions return the data used to
         create this plot.
+
+        .. versionchanged:: 4.12.2
+           The scales parameter is no longer ignored when set.
 
         Parameters
         ----------
@@ -11893,7 +11903,7 @@ class Session(sherpa.ui.utils.Session):
         efplot = self._energyfluxplot
         if sherpa.utils.bool_cast(recalc):
             efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id=id,
-                                                    num=num, bins=bins,
+                                                    num=num, bins=bins, scales=scales,
                                                     correlated=correlated,
                                                     numcores=numcores, bkg_id=bkg_id)
         try:
@@ -11906,12 +11916,9 @@ class Session(sherpa.ui.utils.Session):
         else:
             sherpa.plot.end()
 
-    # DOC-TODO: I am assuming it accepts a scales parameter, but
-    # changing it doesn't seem to do anything (see next)
-    # DOC-NOTE: I got a TypeError about the scales option
     def plot_photon_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
-                         recalc=True, overplot=False, clearwindow=True,
+                         scales=None, recalc=True, overplot=False, clearwindow=True,
                          **kwargs):
         """Display the photon flux distribution.
 
@@ -11922,6 +11929,9 @@ class Session(sherpa.ui.utils.Session):
         returned by `calc_photon_flux`. The `sample_photon_flux` and
         `get_photon_flux_hist` functions return the data used to
         create this plot.
+
+        .. versionchanged:: 4.12.2
+           The scales parameter is no longer ignored when set.
 
         Parameters
         ----------
@@ -12001,7 +12011,7 @@ class Session(sherpa.ui.utils.Session):
         pfplot = self._photonfluxplot
         if sherpa.utils.bool_cast(recalc):
             pfplot = self._prepare_photon_flux_plot(pfplot, lo, hi, id=id,
-                                                    num=num, bins=bins,
+                                                    num=num, bins=bins, scales=scales,
                                                     correlated=correlated,
                                                     numcores=numcores, bkg_id=bkg_id)
         try:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12477,6 +12477,13 @@ class Session(sherpa.ui.utils.Session):
         >>> parerrs = [0.25, 1.22, 1.04e-4]
         >>> vals = sample_photon_flux(2, 10, num=5000, scales=parerrs)
 
+        In this case the parameter errors are taken from the covariance
+        analysis, using the `parmaxes` field since these are positive.
+
+        >>> covar()
+        >>> parerrs = get_covar_results().parmaxes
+        >>> vals = sample_photon_flux(0.5, 2, num=1000, scales=parerrs)
+
         Run covariance to estimate the parameter errors and then extract
         the covariance matrix from the results (as the `cmat` variable).
         This matrix is then used to define the parameter widths - including
@@ -12603,6 +12610,13 @@ class Session(sherpa.ui.utils.Session):
 
         >>> parerrs = [0.25, 1.22, 1.04e-4]
         >>> vals = sample_energy_flux(2, 10, num=5000, scales=parerrs)
+
+        In this case the parameter errors are taken from the covariance
+        analysis, using the `parmaxes` field since these are positive.
+
+        >>> covar()
+        >>> parerrs = get_covar_results().parmaxes
+        >>> vals = sample_energy_flux(0.5, 2, num=1000, scales=parerrs)
 
         Run covariance to estimate the parameter errors and then extract
         the covariance matrix from the results (as the `cmat` variable).

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12413,22 +12413,24 @@ class Session(sherpa.ui.utils.Session):
            The model must be part of the source expression.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The size and shape of the array depende on the
+           parameters. The size and shape of the array depends on the
            number of free parameters in the fit (n) and the value of
            the `correlated` parameter. When the parameter is `True`,
            scales must be given the covariance matrix for the free
            parameters (a n by n matrix that matches the parameter
            ordering used by Sherpa). For un-correlated parameters
            the covariance matrix can be used, or a one-dimensional
-           array of n elements can be used, giving the error on the
-           parameters (e.g. the square root of the diagonal elements
+           array of n elements can be used, giving the width (specified
+           as the sigma value of a normal distribution) for each
+           parameter (e.g. the square root of the diagonal elements
            of the covariance matrix). If the scales parameter is not
            given then the covariance matrix is evaluated for the
            current model and best-fit parameters.
         correlated : bool, optional
            Should the correlation between the parameters be included
            when sampling the parameters? If not, then each parameter
-           is sampled from a normal distribution.
+           is sampled from independent distributions. In both cases
+           a normal distribution is used.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -12446,7 +12448,8 @@ class Session(sherpa.ui.utils.Session):
            calculated by `calc_photon_flux`, followed by the values of
            the thawed parameters used for that iteration. The order of
            the parameters matches the data returned by
-           `get_fit_results`.
+           `get_fit_results` (restricted to the model parameter, when
+           set).
 
         See Also
         --------
@@ -12460,6 +12463,14 @@ class Session(sherpa.ui.utils.Session):
         plot_trace : Create a trace plot of row number versus value.
         sample_energy_flux : Return the energy flux distribution of a model.
         sample_flux : Return the flux distribution of a model.
+
+        Notes
+        -----
+        When both the model and scales parameters are set then the
+        size of the scales parameter should either match the number of
+        free parameters in the full source expression or that of
+        the model component. The return value in this case is always
+        limited to the number of free parameters in the model component.
 
         Examples
         --------
@@ -12488,7 +12499,8 @@ class Session(sherpa.ui.utils.Session):
 
         Use the given parameter errors for sampling the parameter distribution.
         The fit must have three free parameters, and each parameter is
-        sampled independently:
+        sampled independently (in this case parerrs gives the sigma
+        values for each parameter):
 
         >>> parerrs = [0.25, 1.22, 1.04e-4]
         >>> vals = sample_photon_flux(2, 10, num=5000, scales=parerrs)
@@ -12504,12 +12516,19 @@ class Session(sherpa.ui.utils.Session):
         the covariance matrix from the results (as the `cmat` variable).
         This matrix is then used to define the parameter widths - including
         correlated terms - in the flux sampling, after being increased by
-        ten percent:
+        ten percent. This is used to calculate both the absorbed
+        (`vals1`) and unabsorbed (`vals2`) fluxes. The shapes of these
+        two arrays will be different: 5000 by 4 for `vals1` and
+        5000 by 3 for `vals2`.
 
+        >>> set_source(xsphabs.gal * powlaw1d.pl)
+        >>> fit()
         >>> covar()
         >>> cmat = get_covar_results().extra_output
-        >>> vals = sample_photon_flux(2, 10, num=5000, correlated=True,
-        ...                           scales=1.1 * cmat)
+        >>> vals1 = sample_photon_flux(2, 10, num=5000, correlated=True,
+        ...                            scales=1.1 * cmat)
+        >>> vals2 = sample_photon_flux(2, 10, num=5000, correlated=True,
+        ...                            model=pl, scales=1.1 * cmat)
 
         """
         ids, fit = self._get_fit(id)
@@ -12567,22 +12586,24 @@ class Session(sherpa.ui.utils.Session):
            The model must be part of the source expression.
         scales : array, optional
            The scales used to define the normal distributions for the
-           parameters. The size and shape of the array depende on the
+           parameters. The size and shape of the array depends on the
            number of free parameters in the fit (n) and the value of
            the `correlated` parameter. When the parameter is `True`,
            scales must be given the covariance matrix for the free
            parameters (a n by n matrix that matches the parameter
            ordering used by Sherpa). For un-correlated parameters
            the covariance matrix can be used, or a one-dimensional
-           array of n elements can be used, giving the error on the
-           parameters (e.g. the square root of the diagonal elements
+           array of n elements can be used, giving the width (specified
+           as the sigma value of a normal distribution) for each
+           parameter (e.g. the square root of the diagonal elements
            of the covariance matrix). If the scales parameter is not
            given then the covariance matrix is evaluated for the
            current model and best-fit parameters.
         correlated : bool, optional
            Should the correlation between the parameters be included
            when sampling the parameters? If not, then each parameter
-           is sampled from a normal distribution.
+           is sampled from independent distributions. In both cases
+           a normal distribution is used.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -12600,7 +12621,8 @@ class Session(sherpa.ui.utils.Session):
            calculated by `calc_energy_flux`, followed by the values of
            the thawed parameters used for that iteration. The order of
            the parameters matches the data returned by
-           `get_fit_results`.
+           `get_fit_results` (restricted to the model parameter, when
+           set).
 
         See Also
         --------
@@ -12614,6 +12636,14 @@ class Session(sherpa.ui.utils.Session):
         plot_trace : Create a trace plot of row number versus value.
         sample_photon_flux : Return the flux distribution of a model.
         sample_flux : Return the flux distribution of a model.
+
+        Notes
+        -----
+        When both the model and scales parameters are set then the
+        size of the scales parameter should either match the number of
+        free parameters in the full source expression or that of
+        the model component. The return value in this case is always
+        limited to the number of free parameters in the model component.
 
         Examples
         --------
@@ -12642,7 +12672,8 @@ class Session(sherpa.ui.utils.Session):
 
         Use the given parameter errors for sampling the parameter distribution.
         The fit must have three free parameters, and each parameter is
-        sampled independently:
+        sampled independently (in this case parerrs gives the sigma
+        values for each parameter):
 
         >>> parerrs = [0.25, 1.22, 1.04e-4]
         >>> vals = sample_energy_flux(2, 10, num=5000, scales=parerrs)
@@ -12658,12 +12689,19 @@ class Session(sherpa.ui.utils.Session):
         the covariance matrix from the results (as the `cmat` variable).
         This matrix is then used to define the parameter widths - including
         correlated terms - in the flux sampling, after being increased by
-        ten percent:
+        ten percent. This is used to calculate both the absorbed
+        (`vals1`) and unabsorbed (`vals2`) fluxes. The shapes of these
+        two arrays will be different: 5000 by 4 for `vals1` and
+        5000 by 3 for `vals2`.
 
+        >>> set_source(xsphabs.gal * powlaw1d.pl)
+        >>> fit()
         >>> covar()
         >>> cmat = get_covar_results().extra_output
-        >>> vals = sample_energy_flux(2, 10, num=5000, correlated=True,
-        ...                           scales=1.1 * cmat)
+        >>> vals1 = sample_energy_flux(2, 10, num=5000, correlated=True,
+        ...                            scales=1.1 * cmat)
+        >>> vals2 = sample_energy_flux(2, 10, num=5000, correlated=True,
+        ...                            model=pl, scales=1.1 * cmat)
 
         """
         ids, fit = self._get_fit(id)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10771,14 +10771,14 @@ class Session(sherpa.ui.utils.Session):
         return self._bkgchisqrplot
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins, correlated, numcores, bkg_id):
-        dist = self.sample_energy_flux(
-            lo, hi, id, num, None, correlated, numcores, bkg_id)
+        dist = self.sample_energy_flux(lo, hi, id=id, num=num, scales=None,
+                                       correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
     def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins, correlated, numcores, bkg_id):
-        dist = self.sample_photon_flux(
-            lo, hi, id, num, None, correlated, numcores, bkg_id)
+        dist = self.sample_photon_flux(lo, hi, id=id, num=num, scales=None,
+                                       correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
@@ -10863,8 +10863,9 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if sherpa.utils.bool_cast(kwargs.pop('recalc', True)):
-            self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id, num,
-                                           bins, correlated, numcores, bkg_id)
+            self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
+                                           num=num, bins=bins, correlated=correlated,
+                                           numcores=numcores, bkg_id=bkg_id)
         return self._energyfluxplot
 
     # DOC-TODO: See comments about plot_photon_flux.
@@ -10948,8 +10949,9 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if sherpa.utils.bool_cast(kwargs.pop('recalc', True)):
-            self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id, num,
-                                           bins, correlated, numcores, bkg_id)
+            self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
+                                           num=num, bins=bins, correlated=correlated,
+                                           numcores=numcores, bkg_id=bkg_id)
         return self._photonfluxplot
 
     def _prepare_plotobj(self, id, plotobj, resp_id=None, bkg_id=None, lo=None,
@@ -11890,9 +11892,10 @@ class Session(sherpa.ui.utils.Session):
         """
         efplot = self._energyfluxplot
         if sherpa.utils.bool_cast(recalc):
-            efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id, num,
-                                                    bins, correlated,
-                                                    numcores, bkg_id)
+            efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id=id,
+                                                    num=num, bins=bins,
+                                                    correlated=correlated,
+                                                    numcores=numcores, bkg_id=bkg_id)
         try:
             sherpa.plot.begin()
             efplot.plot(overplot=overplot, clearwindow=clearwindow,
@@ -11997,9 +12000,10 @@ class Session(sherpa.ui.utils.Session):
         """
         pfplot = self._photonfluxplot
         if sherpa.utils.bool_cast(recalc):
-            pfplot = self._prepare_photon_flux_plot(pfplot, lo, hi, id, num,
-                                                    bins, correlated,
-                                                    numcores, bkg_id)
+            pfplot = self._prepare_photon_flux_plot(pfplot, lo, hi, id=id,
+                                                    num=num, bins=bins,
+                                                    correlated=correlated,
+                                                    numcores=numcores, bkg_id=bkg_id)
         try:
             sherpa.plot.begin()
             pfplot.plot(overplot=overplot, clearwindow=clearwindow,
@@ -12379,8 +12383,8 @@ class Session(sherpa.ui.utils.Session):
         return resampledata(niter=niter, seed=seed)
 
     def sample_photon_flux(self, lo=None, hi=None, id=None, num=1,
-                           model=None, scales=None, correlated=False,
-                           numcores=None, bkg_id=None):
+                           scales=None, correlated=False,
+                           numcores=None, bkg_id=None, model=None):
         """Return the photon flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12406,11 +12410,6 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`, is used.
         num : int, optional
            The number of samples to create. The default is 1.
-        model : model, optional
-           The model to integrate. If left as `None` then the source
-           model for the dataset will be used. This can be used to
-           calculate the unabsorbed flux, as shown in the examples.
-           The model must be part of the source expression.
         scales : array, optional
            The scales used to define the normal distributions for the
            parameters. The size and shape of the array depends on the
@@ -12438,6 +12437,11 @@ class Session(sherpa.ui.utils.Session):
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
+        model : model, optional
+           The model to integrate. If left as `None` then the source
+           model for the dataset will be used. This can be used to
+           calculate the unabsorbed flux, as shown in the examples.
+           The model must be part of the source expression.
 
         Returns
         -------
@@ -12552,8 +12556,8 @@ class Session(sherpa.ui.utils.Session):
                                              samples=scales)
 
     def sample_energy_flux(self, lo=None, hi=None, id=None, num=1,
-                           model=None, scales=None, correlated=False,
-                           numcores=None, bkg_id=None):
+                           scales=None, correlated=False,
+                           numcores=None, bkg_id=None, model=None):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12579,11 +12583,6 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`, is used.
         num : int, optional
            The number of samples to create. The default is 1.
-        model : model, optional
-           The model to integrate. If left as `None` then the source
-           model for the dataset will be used. This can be used to
-           calculate the unabsorbed flux, as shown in the examples.
-           The model must be part of the source expression.
         scales : array, optional
            The scales used to define the normal distributions for the
            parameters. The size and shape of the array depends on the
@@ -12611,6 +12610,11 @@ class Session(sherpa.ui.utils.Session):
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
+        model : model, optional
+           The model to integrate. If left as `None` then the source
+           model for the dataset will be used. This can be used to
+           calculate the unabsorbed flux, as shown in the examples.
+           The model must be part of the source expression.
 
         Returns
         -------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10811,9 +10811,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The identifier of the data set to use. If `None`, the
+           default value, then all datasets with associated models are
+           used to calculate the errors and the model evaluation is
+           done using the default dataset.
         num : int, optional
            The number of samples to create. The default is 7500.
         bins : int, optional
@@ -10938,9 +10939,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The identifier of the data set to use. If `None`, the
+           default value, then all datasets with associated models are
+           used to calculate the errors and the model evaluation is
+           done using the default dataset.
         num : int, optional
            The number of samples to create. The default is 7500.
         bins : int, optional
@@ -11916,9 +11918,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The identifier of the data set to use. If `None`, the
+           default value, then all datasets with associated models are
+           used to calculate the errors and the model evaluation is
+           done using the default dataset.
         num : int, optional
            The number of samples to create. The default is 7500.
         bins : int, optional
@@ -12073,9 +12076,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The identifier of the data set to use. If `None`, the
+           default value, then all datasets with associated models are
+           used to calculate the errors and the model evaluation is
+           done using the default dataset.
         num : int, optional
            The number of samples to create. The default is 7500.
         bins : int, optional
@@ -12593,9 +12597,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The identifier of the data set to use. If `None`, the
+           default value, then all datasets with associated models are
+           used to calculate the errors and the model evaluation is
+           done using the default dataset.
         num : int, optional
            The number of samples to create. The default is 1.
         scales : array, optional
@@ -12753,7 +12758,6 @@ class Session(sherpa.ui.utils.Session):
         >>> vals = sample_photon_flux(0.5, 10, id=1, otherids=[2],
         ...                           model=clus, num=10000)
 
-
         """
         ids, fit = self._get_fit(id, otherids=otherids)
 
@@ -12799,9 +12803,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The identifier of the data set to use. If `None`, the
+           default value, then all datasets with associated models are
+           used to calculate the errors and the model evaluation is
+           done using the default dataset.
         num : int, optional
            The number of samples to create. The default is 1.
         scales : array, optional

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10772,23 +10772,25 @@ class Session(sherpa.ui.utils.Session):
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
                                   correlated, numcores, bkg_id,
-                                  scales=None, model=None):
-        dist = self.sample_energy_flux(lo, hi, id=id, num=num, scales=scales, model=model,
+                                  scales=None, model=None, otherids=()):
+        dist = self.sample_energy_flux(lo, hi, id=id, otherids=otherids,
+                                       num=num, scales=scales, model=model,
                                        correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
     def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins,
                                   correlated, numcores, bkg_id,
-                                  scales=None, model=None):
-        dist = self.sample_photon_flux(lo, hi, id=id, num=num, scales=scales, model=model,
+                                  scales=None, model=None, otherids=()):
+        dist = self.sample_photon_flux(lo, hi, id=id, otherids=otherids,
+                                       num=num, scales=scales, model=model,
                                        correlated=correlated, numcores=numcores, bkg_id=bkg_id)
         plot.prepare(dist, bins)
         return plot
 
     def get_energy_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
-                             scales=None, model=None, recalc=True):
+                             scales=None, model=None, otherids=(), recalc=True):
         """Return the data displayed by plot_energy_flux.
 
         The get_energy_flux_hist() function calculates a histogram of
@@ -10798,7 +10800,7 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model parameter has been added.
+           model and otherids parameters have been added.
 
         Parameters
         ----------
@@ -10848,6 +10850,11 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
+        otherids: list of integer and string ids, optional
+           The list of other datasets that should be included when
+           calculating the errors to draw values from. The default
+           value is () which indicates that only a single dataset
+           is used.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -10896,12 +10903,13 @@ class Session(sherpa.ui.utils.Session):
             self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
+                                           otherids=otherids,
                                            numcores=numcores, bkg_id=bkg_id)
         return self._energyfluxplot
 
     def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
-                             scales=None, model=None, recalc=True):
+                             scales=None, model=None, otherids=(), recalc=True):
         """Return the data displayed by plot_photon_flux.
 
         The get_photon_flux_hist() function calculates a histogram of
@@ -10911,7 +10919,7 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model parameter has been added.
+           model and otherids parameters have been added.
 
         Parameters
         ----------
@@ -10961,6 +10969,11 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
+        otherids: list of integer and string ids, optional
+           The list of other datasets that should be included when
+           calculating the errors to draw values from. The default
+           value is () which indicates that only a single dataset
+           is used.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -11009,6 +11022,7 @@ class Session(sherpa.ui.utils.Session):
             self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
+                                           otherids=otherids,
                                            numcores=numcores, bkg_id=bkg_id)
         return self._photonfluxplot
 
@@ -11860,7 +11874,7 @@ class Session(sherpa.ui.utils.Session):
 
     def plot_energy_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
-                         scales=None, model=None,
+                         scales=None, model=None, otherids=(),
                          recalc=True, overplot=False, clearwindow=True,
                          **kwargs):
         """Display the energy flux distribution.
@@ -11875,7 +11889,7 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model parameter has been added.
+           model and otherids parameters have been added.
 
         Parameters
         ----------
@@ -11925,6 +11939,11 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
+        otherids: list of integer and string ids, optional
+           The list of other datasets that should be included when
+           calculating the errors to draw values from. The default
+           value is () which indicates that only a single dataset
+           is used.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -11979,6 +11998,7 @@ class Session(sherpa.ui.utils.Session):
             efplot = self._prepare_energy_flux_plot(efplot, lo, hi, id=id,
                                                     num=num, bins=bins, scales=scales,
                                                     correlated=correlated, model=model,
+                                                    otherids=otherids,
                                                     numcores=numcores, bkg_id=bkg_id)
         try:
             sherpa.plot.begin()
@@ -11992,7 +12012,7 @@ class Session(sherpa.ui.utils.Session):
 
     def plot_photon_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
-                         scales=None, model=None,
+                         scales=None, model=None, otherids=(),
                          recalc=True, overplot=False, clearwindow=True,
                          **kwargs):
         """Display the photon flux distribution.
@@ -12007,7 +12027,7 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model parameter has been added.
+           model and otherids parameters have been added.
 
         Parameters
         ----------
@@ -12057,6 +12077,11 @@ class Session(sherpa.ui.utils.Session):
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
            The model must be part of the source expression.
+        otherids: list of integer and string ids, optional
+           The list of other datasets that should be included when
+           calculating the errors to draw values from. The default
+           value is () which indicates that only a single dataset
+           is used.
         recalc : bool, optional
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
@@ -12111,6 +12136,7 @@ class Session(sherpa.ui.utils.Session):
             pfplot = self._prepare_photon_flux_plot(pfplot, lo, hi, id=id,
                                                     num=num, bins=bins, scales=scales,
                                                     correlated=correlated, model=model,
+                                                    otherids=otherids,
                                                     numcores=numcores, bkg_id=bkg_id)
         try:
             sherpa.plot.begin()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13158,9 +13158,8 @@ class Session(sherpa.ui.utils.Session):
            `set_analysis` for the data set). The default value (``None``)
            means that the upper range of the data set is used.
         id : int or string, optional
-           The identifier of the data set to use. The default value
-           (``None``) means that the default identifier, as returned by
-           `get_default_id`, is used.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         bkg_id : int or string, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
@@ -13173,9 +13172,7 @@ class Session(sherpa.ui.utils.Session):
            The user can input the parameter array (e.g. from running
            `sample_flux`).
         otherids : sequence of integer or strings, optional
-           The default value is (). However, if get_draws is called
-           internally which may require otherids to be set if more then
-           one data set is to be used then otherids must be set.
+           Other data sets to use in the calculation.
         niter : int, optional
            The number of draws to use. The default is ``1000``.
         covar_matrix : 2D array, optional

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -17,6 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import logging
+
 import numpy
 import numpy.random
 
@@ -24,12 +26,10 @@ from sherpa.estmethods import Covariance, Confidence
 from sherpa.utils.err import EstErr
 from sherpa.utils import parallel_map, NoNewAttributesAfterInit
 
-
-import logging
 warning = logging.getLogger("sherpa").warning
 
 
-__all__ = ['multivariate_t', 'multivariate_cauchy',
+__all__ = ('multivariate_t', 'multivariate_cauchy',
            'normal_sample', 'uniform_sample', 't_sample',
            'ParameterScaleVector', 'ParameterScaleMatrix',
            'UniformParameterSampleFromScaleVector',
@@ -38,7 +38,7 @@ __all__ = ['multivariate_t', 'multivariate_cauchy',
            'StudentTParameterSampleFromScaleMatrix',
            'NormalSampleFromScaleMatrix', 'NormalSampleFromScaleVector',
            'UniformSampleFromScaleVector', 'StudentTSampleFromScaleMatrix',
-           ]
+           )
 
 
 def multivariate_t(mean, cov, df, size=None):

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -113,7 +113,7 @@ class ParameterScaleVector(ParameterScale):
         scales = []
         thawedpars = [par for par in fit.model.pars if not par.frozen]
 
-        if None == myscales:
+        if myscales is None:
 
             oldestmethod = fit.estmethod
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8073,10 +8073,10 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         id : int or str, optional
-           The data set to use. If not given then the default
-           identifier is used, as returned by `get_default_id`.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         *otherids : int or str, optional
-           Include multiple data sets in the calculation.
+           Other data sets to use in the calculation.
 
         Returns
         -------
@@ -8130,10 +8130,10 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         id : int or str, optional
-           The data set to use. If not given then all data sets
-           are used.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         *otherids : int or str, optional
-           Include multiple data sets in the calculation.
+           Other data sets to use in the calculation.
 
         Returns
         -------
@@ -8574,11 +8574,10 @@ class Session(NoNewAttributesAfterInit):
            set by the covariance matrix (``True``) or should a
            uni-variate normal be used (``False``)?
         id : int or str, optional
-           The data set containing the model expression. If not given
-           then the default identifier is used, as returned by
-           `get_default_id`.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
-           For when multiple source expressions are being used.
+           Other data sets to use in the calculation.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -8640,11 +8639,10 @@ class Session(NoNewAttributesAfterInit):
         factor : number, optional
            Multiplier to expand the scale parameter (default is 4).
         id : int or str, optional
-           The data set containing the model expression. If not given
-           then the default identifier is used, as returned by
-           `get_default_id`.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
-           For when multiple source expressions are being used.
+           Other data sets to use in the calculation.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -8696,11 +8694,10 @@ class Session(NoNewAttributesAfterInit):
            The number of degrees of freedom to use (the default
            is to use the number from the current fit).
         id : int or str, optional
-           The data set containing the model expression. If not given
-           then the default identifier is used, as returned by
-           `get_default_id`.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
-           For when multiple source expressions are being used.
+           Other data sets to use in the calculation.
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
@@ -9580,11 +9577,11 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         parameters : optional
            The default is to calculate the confidence limits on all
            thawed parameters of the model, or models, for all the
@@ -9706,11 +9703,11 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         parameters : optional
            The default is to calculate the confidence limits on all
            thawed parameters of the model, or models, for all the
@@ -9909,11 +9906,11 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         parameters : optional
            The default is to calculate the confidence limits on all
            thawed parameters of the model, or models, for all the
@@ -10360,9 +10357,8 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         id : int or str, optional
-           The data set containing the data and model. If not given
-           then the default identifier is used, as returned by
-           `get_default_id`.
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
            Other data sets to use in the calculation.
         niter : int, optional
@@ -14121,10 +14117,10 @@ class Session(NoNewAttributesAfterInit):
            The parameter to plot. This argument is only used if `recalc` is
            set to `True`.
         id : str or int, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+           Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
            last call to `int_proj` (or `get_int_proj`) are returned,
@@ -14227,10 +14223,10 @@ class Session(NoNewAttributesAfterInit):
            The parameter to plot. This argument is only used if `recalc` is
            set to `True`.
         id : str or int, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+           Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
            last call to `int_proj` (or `get_int_proj`) are returned,
@@ -14332,10 +14328,10 @@ class Session(NoNewAttributesAfterInit):
            The parameters to plot on the X and Y axes, respectively.
            These arguments are only used if recalc is set to `True`.
         id : str or int, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+           Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
            last call to `reg_proj` (or `get_reg_proj`) are returned,
@@ -14454,10 +14450,10 @@ class Session(NoNewAttributesAfterInit):
            The parameters to plot on the X and Y axes, respectively.
            These arguments are only used if `recalc` is set to `True`.
         id : str or int, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
         otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+           Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
            last call to `reg_unc` (or `get_reg_unc`) are returned,
@@ -14603,11 +14599,11 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par
            The parameter to plot.
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
            call to `int_proj`. The default is ``False``.
@@ -14720,11 +14716,11 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par
            The parameter to plot.
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
            call to `int_proj`. The default is ``False``.
@@ -14860,11 +14856,11 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par0, par1
            The parameters to plot on the X and Y axes, respectively.
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
            call to `int_proj`. The default is ``False``.
@@ -14988,11 +14984,11 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par0, par1
            The parameters to plot on the X and Y axes, respectively.
-        id : str or int, optional
-        otherids : list of str or int, optional
-           The `id` and `otherids` arguments determine which data set
-           or data sets are used. If not given, all data sets which
-           have a defined source model are used.
+        id : int or str, optional
+           The data set that provides the data. If not given then
+           all data sets with an associated model are used simultaneously.
+        otherids : sequence of int or str, optional
+           Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
            call to `int_proj`. The default is ``False``.


### PR DESCRIPTION
# Summary

Fixes and improvements to the `energy_flux` and `photon_flux` set of commands: `sample_energy_flux`, `sample_photon_flux`, `plot_energy_flux`, `plot_photon_flux`, `get_energy_flux_hist`, and `get_photon_flux_hist`:

 - the routines can now take a model parameter to allow the flux calculation to be made on a component of the full expression. This allows you to get the flux errors for the unabsorbed model component (e.g. if the full source model is xsphabs * powlaw1d then the calculations can just be done for the powlaw1d component now). It extends #756 to the remaining `_energy_`/`_photon_` functions. As discussed below there are some consequences to this change.
 - improve support and documentation for the scales parameter (fix #799)
 - the `plot_` and `get_` functions did not support the scales parameter (fix #801)
 - support for simultaneous fits has been improved for the `sample_energy_flux`, `sample_photon_flux`, `plot_energy_flux`, `plot_photon_flux`, `get_energy_flux_hist`, and `get_photon_flux_hist` functions, as they can now specify a subset of datasets using the `otherids` parameter, as is done with other functions
 - take advantage of NumPy routines where appropriate (no user-visible changes)
 - there are now more checks on parameter values to ensure they are valid (e.g. the correct length or shape for 1D and 2D arrays, or that inputs do not contain invalid values such as None or NaN when appropriate)
 - tests have been added for existing and updated functionality
 - add docstrings to some of the routines in the `sherpa.astro.flux` module (these are not seen by users of the `sherpa.astro.ui` module).

# Details

These commits have been separated out of #754.

## Changes when sampling using a component of the full model expression

This PR now lets you fit a model like `xsphabs.gal * powlaw1d.pl` but just calculate the flux distribution for the `pl` component. 

A previous version of this PR ensured that the return array *only* contain parameter distributions for the thawed parameters in the model component used to calculate the flux. However, I have reverted this part in a later commit.

So, the return value from

    sample_energy_flux(model=pl)

will have 4 columns - that is (`flux`, `gal.nh`, `pl.gamma`, `pl.ampl`) - even though `gal.nh` isn't used to calculate the flux (as `model=pl`).

In this mode, the `scales` parameter requires the full number of parameters (so in this example 4 of them). This is to make it easy to use values calculated by `covar` or `conf`, which will include all parameters, without having to filter them to remove the "extra" parameters. It does mean that if you want to manually create the errors (e.g. to see how things change) you will need to create values for these "unused" parameters too.

## Example of calculating the flux distribution for an unabsorbed component

```
Dataset               = 1
Method                = levmar
Statistic             = chi2datavar
Initial fit statistic = 35.2038
Final fit statistic   = 35.2034 at function evaluation 9
Data points           = 42
Degrees of freedom    = 39
Probability [Q-value] = 0.643742
Reduced statistic     = 0.902651
Change in statistic   = 0.000454546
   gal.nH         0.0391826    +/- 0.036544
   pl.gamma       2.02744      +/- 0.106697
   pl.ampl        0.000196152  +/- 2.3637e-05

In [2]: plot_energy_flux(lo=0.5, hi=2, bins=20, num=2000)

In [3]: plot_energy_flux(lo=0.5, hi=2, bins=20, num=2000, overplot=True, model=pl)

In [4]: calc_energy_flux(lo=0.5, hi=2)
Out[4]: 3.8533350781298754e-13

In [5]: calc_energy_flux(lo=0.5, hi=2, model=pl)
Out[5]: 4.3570819963731163e-13

In [6]: from matplotlib import pyplot as plt

In [7]: plt.axvline(3.853e-13)
Out[7]: <matplotlib.lines.Line2D at 0x7f1dcda14f70>

In [8]: plt.axvline(4.357e-13)
Out[8]: <matplotlib.lines.Line2D at 0x7f1dcda1f8e0>
```

The blue histogram is from the first `plot_energy_flux` call and shows the result for the full source model (in this case `xsphabs * powlaw1d`) whereas the orange histogram shows the result for just the power-law component (this capability is added in this PR). The best-fit absorbed and unabsorbed fluxes are calculated with `calc_energy_flux` and then drawn on as vertical lines, "for fun". The ability to use the `model` parameter with `calc_energy_flux` is a relatively recent addition (post the CIAO 4.12.0 release).

![pr-fluxes](https://user-images.githubusercontent.com/224638/86409507-02b14400-bc87-11ea-874d-07c29f41959a.png)

## Example of parameter distributions

With the above fit (i.e. `xsphabs.gal * powlaw1d.pl`), we can have (s2 is new in this PR)

```
>>> s1 = sample_energy_flux(0.5, 2, num=5000)
>>> s2 = sample_energy_flux(0.5, 2, num=5000, model=pl)
```

and then view (e.g. after a `pip install corner`):

```
>>> corner.corner(s1, labels=['flux', 'nh', 'gamma', 'ampl'])
>>> corner.corner(s2, labels=['flux', 'nh', 'gamma', 'ampl'])
```

### Absorbed fluxes

![pr-pardist-all](https://user-images.githubusercontent.com/224638/86409579-270d2080-bc87-11ea-8283-4e608998f8ef.png)

### Unabsorbed fluxes

![pr-pardist-pl](https://user-images.githubusercontent.com/224638/86409598-33917900-bc87-11ea-83f9-11af5582c01e.png)

### Overplotting (see below for an example of how to do this)

Orange is the unabsorbed flux. so you can see how that distribution has shifted compared to the absorbed flux, but the gamma and pl distributions are the same. Note that the tight correlation between flux and ampl for the unabsorbed case is because of the restricted energy range used here (0.5-2 keV); if I'd used 0.5-7 keV then there would be more variation (as you can see in other examples, I think).

![pr-pardist-overplot](https://user-images.githubusercontent.com/224638/86602537-c3c60b80-bf70-11ea-9726-af56b5d69798.png)

## Example with correlated parameters

This uses the covariance matrix (only thing that is new here is that `model` can be given), but note that it has used the correct sub-matrix just for the `pl` component [you can compare the widths to the previous plot and see they are similar for the parameter distributions]:

```
>>> s3 = sample_energy_flux(0.5, 7, num=5000, model=pl, correlated=True)
>>> corner.corner(s3)
```

![pr-pardist-pl-correlated](https://user-images.githubusercontent.com/224638/86409622-42782b80-bc87-11ea-9fec-3d8b81136402.png)

## Overplotting the distributions

Here I switch to 0.5-7 keV for both uncorrelated and correlated analysis, and overplot the histogram/contours, for fun:

```
>>> x = sample_energy_flux(lo=0.5, hi=7, num=5000, model=pl, correlated=False)
>>> y = sample_energy_flux(lo=0.5, hi=7, num=5000, model=pl, correlated=True)
>>> cplot = corner.corner(x, labels=['flux', 'gamma', 'ampl'])
>>> corner.corner(y, color='orange', hist_kwargs={'ls': 'dashed'}, fig=cplot)
>>> cplot.set_size_inches(8, 8)
```
![pr-overplot](https://user-images.githubusercontent.com/224638/86409651-4dcb5700-bc87-11ea-8379-164f035e63bd.png)

You can see that the gamma and ampl parameter distributions are similar when looked at in 1D (as a histogram), but that the flux distribution is narrower when the correlations between the parameters are included.

## Example using the scales argument

One of the changes is that the scales parameter should now work (and work for all the functions). Here's an example coupled with the use of the model argument, as it provides some interesting choices. In this particular example the `covar` output is:

```
Dataset               = 1
Confidence Method     = covariance
Iterative Fit Method  = None
Fitting Method        = levmar
Statistic             = chi2datavar
covariance 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   gal.nH          0.0391826    -0.035761     0.035761
   pl.gamma          2.02744    -0.104797     0.104797
   pl.ampl       0.000196152 -2.32028e-05  2.32028e-05
```

We can send in these errors explicitly either for all three parameters, even though nh is not used in calculating the flux:

```
>>> s1 = sample_energy_flux(0.5, 2, model=pl, scales=[0.04, 0.11, 2.3e-5], num=1000)
```

The output contains columns for flux, nh, gamma, and ampl:

```
>>> s1.shape
(1000, 4)
```

The `scales` parameter could also be the covariance matrix - so a 3 by 3 matrix in this case. It has to be a matrix when `correlated=True` but can be 1D or 2D when `correlated=False` (if 2D it is correctly converted to a 1D array of sigma values)

## Example with multiple datasets

Note that the support for `otherids` provides more flexibility, and allows you to do somethings you couldn't before, but for many cases it isn't actually necessary. For example, in the following example I say

    f1 = sample_energy_flux(lo=0.5, hi=7, id=1, otherids=(3, 4), num=n)

but we could have used tthe default `id` value (of `None`), which uses **all** available datasets, ie I could have said

    f1 = sample_energy_flux(lo=0.5, hi=7, num=n)

Adding in the `otherids` argument lets you pick a subset of data to use, or use a model/dataset that is not the default one for the calculations.

The example script (here using data from sherpa's test dataset):

```
from sherpa.astro.ui import *

mdl = xsphabs.gal * powlaw1d.spl
bmdl = powlaw1d.bpl

load_pha(1, 'sherpa-test-data/sherpatest/obs1.pi')
load_pha(3, 'sherpa-test-data/sherpatest/obs3.pi')
load_pha(4, 'sherpa-test-data/sherpatest/obs4.pi')

set_source(1, mdl)
set_source(3, mdl)
set_source(4, mdl)

set_bkg_source(1, bmdl)
set_bkg_source(3, bmdl)
set_bkg_source(4, bmdl)

notice(0.5, 7)

set_stat('cstat')

gal.nh = 0.0393
gal.nh.freeze()

spl.gamma = 1.76
spl.ampl = 7.33e-7

bpl.gamma = 1.42
bpl.ampl = 1.-5e-6

fit()

n = 10000

# use all three datasets
f1 = sample_energy_flux(lo=0.5, hi=7, id=1, otherids=(3, 4), num=n)

# only use dataset 1
s1 = sample_energy_flux(lo=0.5, hi=7, id=1, num=n)
```

we can evaluate the flux for the combined dataset (called `f1` below) and just for dataset 1 (`s1`). I draw the single dataset first, so it's in black, and I haven't bothered to fix the scaling to show the range of this tataset; it's focussed on the smaller range of the "combined" dataset. A remider that the three columns in the figure below are flux, gamma, and amplitude.

```
>>> import corner
>>> fig1 = corner.corner(s1, labels=['flux', 'gamma', 'ampl', 'bgamma', 'bampl'])
>>> corner.corner(f1, color='orange', fig=fig1)
```

![multi](https://user-images.githubusercontent.com/224638/86410639-24132f80-bc89-11ea-9cb3-f8af2431ef50.png)

You can see that the distributions are much narrower for the orange (ie combined) dataset. For reference the datasets have times approximately 40ks, 80ks, 40ks, so the `s1` dataset is ~1/4 the length of the combined dataset. It's not obvious to me
why corner has chosen such "interesting" scaling here for the datasets.

## Examples of error messages

For completeness (removing the extra traceback):

```
>>> sample_energy_flux(num=0)
ArgumentErr: Invalid num: 'must be a positive integer'
>>> sample_energy_flux(scales=[0.2])
ModelErr: expected 3 thawed parameters, got 1
>>> sample_energy_flux(scales=[[0.2, 0.1, 0.3], [0.1, 0.2, 0.3]])
ArgumentErr: Invalid scales: 'scales must be square when 2D'
>>> sample_energy_flux(scales=[0.2, None, 0.4])
ArgumentErr: Invalid scales: 'must not contain None values'
>>> sample_energy_flux(scales=np.asarray([0.2, 0.1, np.nan]))
ArgumentErr: Invalid scales: 'must only contain finite values'
```

```
>>> get_source()
<BinaryOpModel model instance '(xswabs.gal * powlaw1d.pl)'>
>>> sample_energy_flux(model=const1d.bgnd)
ArgumentErr: Invalid src: 'model contains term not in fit'
>>> freeze(pl)
>>> sample_energy_flux(model=pl)
FitErr: model has no thawed parameters
```
