### PR TITLE
pytest-openfiles no longer supports python 3.5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ conda:
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
       - export PATH=~/miniconda/bin:$PATH
       - conda update -qq -y --all
-      - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib pytest-openfiles"<=0.4.0" # How to make sure it's the correct version?
       - source activate test35
       - pip install /master.zip
       - sherpa_smoke -f astropy


### PR DESCRIPTION
It looks like there is now an issue in the Python 3.5 Conda jobs due to the recent release of pytest-openfiles 0.5.0. This version dropped Python 3.5 support, but it looks like the Conda run requirements were not updated to reflect that. As such, the message is the following:

>     pytest-openfiles 0.5.0 has requirement pytest>=4.6, but you'll have pytest 3.8.1 which is incompatible.

Another aspect of this issue is that pytest>3.8.1 is not available for Python 3.5 (as seen from the error). pytest-openfiles is installed because we install astropy for the Sherpa Conda tests.

This does not show up for the Python 3.5 Travis job, pytest-openfiles 0.4.0 is picked up, so this is not an issue there. For now, we can impose a pytest-openfiles<=0.4.0 requirement for the Python 3.5 jobs and release this as a caveat for the users. I do also note that another way to fix this is to pick up from "-c anaconda" as this new version is not in the "anaconda" channel, but in pkgs/main. 