### PR TITLE
Pytest openfiles travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     # been bumped to "nearly latest" versions
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER="1.17" TRAVIS_PYTHON_VERSION="3.8"
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy pytest-openfiles'<=0.4.0'" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
     # As above, Python 3.6, setup.py install, xspec 12.10
     - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # As above, python 3.7, numpy 1.15, matplotlib 3
@@ -28,10 +28,10 @@ jobs:
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # Install astropy without matplotlib (checks tests are properly skipped)
-    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
+    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy pytest-openfiles'<=0.4.0'" TRAVIS_PYTHON_VERSION="3.5"
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
     # test, so perhaps could be combined?
-    - env: INSTALL_TYPE=develop TEST=none FITS="astropy" TRAVIS_PYTHON_VERSION="3.5"
+    - env: INSTALL_TYPE=develop TEST=none FITS="astropy pytest-openfiles'<=0.4.0'" TRAVIS_PYTHON_VERSION="3.5"
 
 before_install:
   - source travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     # been bumped to "nearly latest" versions
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER="1.17" TRAVIS_PYTHON_VERSION="3.8"
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy pytest-openfiles'<=0.4.0'" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
     # As above, Python 3.6, setup.py install, xspec 12.10
     - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # As above, python 3.7, numpy 1.15, matplotlib 3
@@ -28,10 +28,10 @@ jobs:
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # Install astropy without matplotlib (checks tests are properly skipped)
-    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy pytest-openfiles'<=0.4.0'" TRAVIS_PYTHON_VERSION="3.5"
+    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy pytest-openfiles<=0.4.0" TRAVIS_PYTHON_VERSION="3.5"
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
     # test, so perhaps could be combined?
-    - env: INSTALL_TYPE=develop TEST=none FITS="astropy pytest-openfiles'<=0.4.0'" TRAVIS_PYTHON_VERSION="3.5"
+    - env: INSTALL_TYPE=develop TEST=none FITS="astropy pytest-openfiles<=0.4.0" TRAVIS_PYTHON_VERSION="3.5"
 
 before_install:
   - source travis/setup_conda.sh


### PR DESCRIPTION
The pytest-openfiles issue that was seen in the GitLab tests ([PR#805](https://github.com/sherpa/sherpa/pull/805) and [PR#806](https://github.com/sherpa/sherpa/pull/806)) has now made its way into the Travis tests. This is still only an issue for the Python 3.5 when astropy is installed, as such, the fix was to append this to the "FITS" setting for the Python 3.5 Travis jobs. 