### PR TITLE
Remove all __future__ imports

### DIFF
--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
 #

--- a/helpers/test.py
+++ b/helpers/test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 # Copyright (C) 2014, 2017, 2018, 2019 Smithsonian Astrophysical Observatory
 #

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2007, 2014, 2015, 2016, 2019
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/_version.py
+++ b/sherpa/_version.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag

--- a/sherpa/astro/datastack/__init__.py
+++ b/sherpa/astro/datastack/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 # Copyright (c) 2010,2014,2015 Smithsonian Astrophysical Observatory
 # All rights reserved.
 #

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 #
 # Copyright (C) 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/astro/datastack/plot_backend/__init__.py
+++ b/sherpa/astro/datastack/plot_backend/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 # Copyright (C) 2015, 2016, 2019, 2020
 #               Smithsonian Astrophysical Observatory

--- a/sherpa/astro/datastack/utils.py
+++ b/sherpa/astro/datastack/utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 # Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2009, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -18,7 +18,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import absolute_import
 
 import numpy
 from sherpa.models.parameter import Parameter, tinyval

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,4 +1,3 @@
-from __future__ import division
 #
 #  Copyright (C) 2010, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 #
 #  Copyright (C) 2018, 2019  Smithsonian Astrophysical Observatory

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2012, 2015, 2016, 2017, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2008, 2016, 2020  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -56,7 +56,6 @@ References
 
 """
 
-from __future__ import absolute_import
 
 import string
 from sherpa.models import Parameter, modelCacher1d, RegriddableModel1D

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2009, 2015, 2016, 2018, 2019
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -135,7 +135,6 @@ History:
 2008-05-28 Stephen Doe  Always raise exception on error (doRaise=True always)
 2008-11-25 Stephen Doe  Search PATH for access to application, rather than shell out to use 'which' -- PATH sometimes not correctly inherited by shell via Popen, for csh on some Mac, Solaris machines.
 """
-from __future__ import print_function
 
 import numpy as np
 import os

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2016, 2017  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -1,4 +1,3 @@
-from __future__ import division
 #
 #  Copyright (C) 2008, 2016, 2018, 2019, 2020
 #        Smithsonian Astrophysical Observatory

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2010, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
 #  Copyright (C) 2017, 2018, 2019, 2020
 #         Smithsonian Astrophysical Observatory
 #

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 #  Copyright (C) 2011, 2016, 2019  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2016, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory

--- a/sherpa/optmethods/tests/test_ncoresopt.py
+++ b/sherpa/optmethods/tests/test_ncoresopt.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2019  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -22,8 +22,6 @@
 A visualization interface to Sherpa
 """
 
-from __future__ import division
-from __future__ import absolute_import
 import numpy
 import logging
 import importlib

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,4 +1,3 @@
-from __future__ import division
 #
 #  Copyright (C) 2007, 2015, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2011, 2016, 2018  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -18,7 +18,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import absolute_import
 
 import warnings
 from configparser import ConfigParser

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2007, 2015, 2016, 2018  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2012, 2015, 2016, 2018, 2019, 2020
 #      Smithsonian Astrophysical Observatory

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020
 #       Smithsonian Astrophysical Observatory

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 #
 #  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
 #     Smithsonian Astrophysical Observatory

--- a/sherpa/utils/logging.py
+++ b/sherpa/utils/logging.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #
 # Copyright (C) 2015  Smithsonian Astrophysical Observatory
 #

--- a/sherpa/utils/tests/test_psf_rebinning_unit.py
+++ b/sherpa/utils/tests/test_psf_rebinning_unit.py
@@ -1,4 +1,3 @@
-from __future__ import division
 #
 #  Copyright (C) 2019  Smithsonian Astrophysical Observatory
 #

--- a/versioneer.py
+++ b/versioneer.py
@@ -283,7 +283,6 @@ public domain. The `_version.py` that it creates is also in the public
 domain.
 
 """
-from __future__ import print_function
 
 import errno
 import os


### PR DESCRIPTION
It's mid-2020 and we dropped support for Python 2 in 4.11,
so I don't see a reason to keep those old imports around.
(Note that I'm not updating every copyright year just for removing
that import line.)