### PR TITLE
Remove Conda-forge for Xspec and update Travis to Xspec 12.10.1n

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   fast_finish: true
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.1b" TRAVIS_PYTHON_VERSION="3.7"
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.1n" TRAVIS_PYTHON_VERSION="3.7"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.
@@ -15,11 +15,11 @@ jobs:
     # been bumped to "nearly latest" versions
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER="1.17" TRAVIS_PYTHON_VERSION="3.8"
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.10.1n" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
     # As above, Python 3.6, setup.py install, xspec 12.10
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
+    - env: XSPECVER="12.10.1n" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # As above, python 3.7, numpy 1.15, matplotlib 3
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=3 TRAVIS_PYTHON_VERSION="3.7"
+    - env: XSPECVER="12.10.1n" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=3 TRAVIS_PYTHON_VERSION="3.7"
     # Experimental support for using Sphinx to build the documentation
     # should we not run tests with this build (to save time); i.e. have
     # a specific build just for the documentation and nothing else?
@@ -54,5 +54,5 @@ script:
 
 notifications:
   email:
-    - wmclaugh@cfa.harvard.edu
+#    - wmclaugh@cfa.harvard.edu
     - mterrell@cfa.harvard.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,5 @@ script:
 
 notifications:
   email:
-#    - wmclaugh@cfa.harvard.edu
+    - wmclaugh@cfa.harvard.edu
     - mterrell@cfa.harvard.edu

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -14,18 +14,18 @@ else  # osx
 
     #Conda compilers - Comment out to test non-conda compilers
     #Unset the Travis compiler variables
-    #unset CC CFLAGS CXXFLAGS
-    #compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
-    #
-    ##Download and set the location of the macOS 10.9 SDK for the Conda Compilers to work
-    #mkdir -p 10.9SDK
-    #wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz -O MacOSX10.9.sdk.tar.xz
-    #if [[ $? -ne 0 ]]; then
-    #  echo "macOS 10.9 SDK download failed"
-    #fi
-    #tar -C 10.9SDK -xf MacOSX10.9.sdk.tar.xz
-    #export CONDA_BUILD_SYSROOT=$(pwd)/10.9SDK/MacOSX10.9.sdk
-    #echo "CONDA_BUILD_SYROOT=${CONDA_BUILD_SYSROOT}"
+    unset CC CFLAGS CXXFLAGS
+    compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
+    
+    #Download and set the location of the macOS 10.9 SDK for the Conda Compilers to work
+    mkdir -p 10.9SDK
+    wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz -O MacOSX10.9.sdk.tar.xz
+    if [[ $? -ne 0 ]]; then
+      echo "macOS 10.9 SDK download failed"
+    fi
+    tar -C 10.9SDK -xf MacOSX10.9.sdk.tar.xz
+    export CONDA_BUILD_SYSROOT=$(pwd)/10.9SDK/MacOSX10.9.sdk
+    echo "CONDA_BUILD_SYROOT=${CONDA_BUILD_SYSROOT}"
     #End of Conda compilers section
 fi
 

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -11,41 +11,48 @@ then
     compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
 else  # osx
     miniconda_os=MacOSX
-    compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
 
-    # On macOS we also need the conda libx11 libraries used to build xspec
-    # We also need to pin down ncurses, for now only on macos.
-    xorg="xorg-libx11 ncurses=5"
+    #Conda compilers - Comment out to test non-conda compilers
+    #Unset the Travis compiler variables
+    #unset CC CFLAGS CXXFLAGS
+    #compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
+    #
+    ##Download and set the location of the macOS 10.9 SDK for the Conda Compilers to work
+    #mkdir -p 10.9SDK
+    #wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz -O MacOSX10.9.sdk.tar.xz
+    #if [[ $? -ne 0 ]]; then
+    #  echo "macOS 10.9 SDK download failed"
+    #fi
+    #tar -C 10.9SDK -xf MacOSX10.9.sdk.tar.xz
+    #export CONDA_BUILD_SYSROOT=$(pwd)/10.9SDK/MacOSX10.9.sdk
+    #echo "CONDA_BUILD_SYROOT=${CONDA_BUILD_SYSROOT}"
+    #End of Conda compilers section
 fi
 
 # Download and install conda
-wget http://repo.continuum.io/miniconda/Miniconda3-latest-${miniconda_os}-x86_64.sh -O miniconda.sh
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-${miniconda_os}-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b -p $miniconda
-export PATH=$miniconda/bin:$PATH
+
+#Source the Conda profile
+source $miniconda/etc/profile.d/conda.sh
 
 # update and add channels
 conda update --yes conda
 
-# Note the order of the channels matter. We built the xspec conda packages for macos using the conda-forge channel
-# with the highest priority, so we add it with a higher priority than the default channels, but with less priority
-# than our own channels, so that we don't accidentally get conda-forge packages for cfitsio/ccfits.
-#
 # To avoid issues with non-XSPEC builds (e.g.
 # https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )
 # the XSPEC-related channels are only added if needed
 #
-if [ -n "${XSPECVER}" ]; then conda config --add channels conda-forge; fi
-
 conda config --add channels ${sherpa_channel}
 if [ -n "${XSPECVER}" ]; then conda config --add channels ${xspec_channel}; fi
-conda config --add channels anaconda
 
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
 if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
+# Xspec >=12.10.1n Conda package includes wcslib & CCfits and pulls in cfitsio & fftw
 if [ -n "${XSPECVER}" ];
- then export XSPEC="xspec-modelsonly=${XSPECVER} ${xorg}";
+ then export XSPEC="xspec-modelsonly=${XSPECVER}";
 fi
 if [ "${DOCS}" == true ];
  then export DOCSBUILD="sphinx sphinx_rtd_theme graphviz";
@@ -63,7 +70,7 @@ FITSBUILD="${FITS}"
 # We create a new environment so we don't care about the python version in the root environment.
 conda create --yes -n build python=${TRAVIS_PYTHON_VERSION} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
 
-source activate build
+conda activate build
 
 # It looks like on some systems (well, linux) the F90 variable needs to be set. Not sure why
 export F90=${F77}


### PR DESCRIPTION
The changes include:

- Remove the need for conda-forge for xspec (related to libgfortran)
-Update Xspec to 12.10.1n
-fftw in extern is disabled for the Xspec build tests. This is because fftw is now (as of Xspec ~12.10.1n) needed for the "modelsonly" build, so it will already be installed when Sherpa goes to build against Xspec. 
-HEADAS setting is removed because this is now set by the Xspec package itself. If it is not set, the Xspec builds will check for it and exit. 
-macOS Conda compiler cleanup.


The macOS Conda compiler cleanup is related to a few things:

-Differences between conda-forge and defaults
-Building against the Conda compilers vs the Travis compilers.

We are currently building against the Conda compilers (to provide pre-testing for the Conda builds). This has NOT been changed. The issue is that the default Conda and Travis compilers mildly conflict and the Conda compilers from the default channel requires the macOS 10.9 SDK to run (with CONDA_BUILD_SYSROOT set). This two issues have been fixed and anything that is ONLY needed when using the Conda compilers for macOS has been added to a "Conda compilers" section that can easily be commented out in as a block if we ever need/want to test against the macOS Travis compilers instead. The first commit tested using the Travis compilers on macOS and the second commit tested the Conda compilers.