### PR TITLE
Pytest-doctestplus no longer supports python 3.5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ conda:
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
       - export PATH=~/miniconda/bin:$PATH
       - conda update -qq -y --all
-      - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib pytest-openfiles"<=0.4.0" # How to make sure it's the correct version?
+      - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib pytest-openfiles"<=0.4.0" pytest-doctestplus"<=0.5.0" # How to make sure it's the correct version?
       - source activate test35
       - pip install /master.zip
       - sherpa_smoke -f astropy
@@ -113,7 +113,7 @@ conda:
     - cd /tmp
     - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip
     - conda update -qq -y --all
-    - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib pytest-openfiles"<=0.4.0" # How to make sure it's the correct version?
+    - conda create -n test35 --yes -q -c sherpa/label/dev python=3.5 astropy sherpa matplotlib pytest-openfiles"<=0.4.0" pytest-doctestplus"<=0.5.0" # How to make sure it's the correct version?
     - conda activate test35
     - pip install master.zip
     - sherpa_smoke -f astropy

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     # been bumped to "nearly latest" versions
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER="1.17" TRAVIS_PYTHON_VERSION="3.8"
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
-    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0 pytest-doctestplus<=0.5.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
     # As above, Python 3.6, setup.py install, xspec 12.10
     - env: XSPECVER="12.10.1b" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # As above, python 3.7, numpy 1.15, matplotlib 3
@@ -28,10 +28,10 @@ jobs:
     # Also, install matplotlib 2.0 and do not install astropy (checks tests are properly skipped)
     - env: INSTALL_TYPE=install TEST=package MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.6"
     # Install astropy without matplotlib (checks tests are properly skipped)
-    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy pytest-openfiles<=0.4.0" TRAVIS_PYTHON_VERSION="3.5"
+    - env: INSTALL_TYPE=develop TEST=submodule FITS="astropy pytest-openfiles<=0.4.0 pytest-doctestplus<=0.5.0" TRAVIS_PYTHON_VERSION="3.5"
     # A relatively basic installation - NumPy and AstroPy - with no test data; this is similar to the preceeding
     # test, so perhaps could be combined?
-    - env: INSTALL_TYPE=develop TEST=none FITS="astropy pytest-openfiles<=0.4.0" TRAVIS_PYTHON_VERSION="3.5"
+    - env: INSTALL_TYPE=develop TEST=none FITS="astropy pytest-openfiles<=0.4.0 pytest-doctestplus<=0.5.0" TRAVIS_PYTHON_VERSION="3.5"
 
 before_install:
   - source travis/setup_conda.sh

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -22,7 +22,7 @@ smokevars="${XSPECTEST} ${FITSTEST} -v 3"
 
 # Install coverage tooling and run tests using setuptools
 if [ ${TEST} == submodule ]; then
-    conda install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
+    conda install -yq pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
 fi
 
 # Run smoke test

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -22,7 +22,7 @@ smokevars="${XSPECTEST} ${FITSTEST} -v 3"
 
 # Install coverage tooling and run tests using setuptools
 if [ ${TEST} == submodule ]; then
-    pip install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
+    conda install pytest-cov; python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
 fi
 
 # Run smoke test


### PR DESCRIPTION
This is the same issue seen previously for pytest-openfiles (PRs [#805](https://github.com/sherpa/sherpa/pull/805), [#806,](https://github.com/sherpa/sherpa/pull/806) and [#807](https://github.com/sherpa/sherpa/pull/807)). pytest-doctestplus no longer supports Python 3.5, but is still getting installed. 

At the moment, this is an issue with both of pytest-openfiles and pytest-doctestplus Conda packages not having Python>=3.6 and pytest>=4.6 (pytest-openfiles) or 4.0 (pytest-doctestplus) in their run requirements. When we install astropy into our Conda environment, pytest and these packages are also installed. This then manifests as the issue seen in the Travis Jobs when trying to load the Pytest modules.  If the run requirements are updated for these Conda packages, we should no longer need these workarounds. For now, I am implementing the same fix done for pytest-openfiles.

We could try to clean up the version requirements a bit by trying to install pytest with pip instead of Conda, but that may end up complicating things a bit. 