### PR TITLE
Support building with NumPy 1.19

### DIFF
--- a/helpers/develop.py
+++ b/helpers/develop.py
@@ -36,7 +36,7 @@ try:
                 shutil.copyfile(sherpa_config.group_location, os.path.join(os.getcwd(), 'group.so'))
 
 except ImportError:
-    from distutils.core import Command
+    from distutils.cmd import Command
 
     class develop(Command):
 

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 #
-#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 from .extensions import build_ext, build_lib_arrays
 from .deps import build_deps
 
-from numpy.distutils.core import Command
+from distutils.cmd import Command
 import os
 import sys
 

--- a/helpers/test.py
+++ b/helpers/test.py
@@ -56,7 +56,7 @@ try:
             sys.exit(errno)
 
 except ImportError:
-    from distutils.core import Command
+    from distutils.cmd import Command
 
     class PyTest(Command):
         user_options = []

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -21,7 +21,7 @@ import sys
 import os
 
 from distutils.version import LooseVersion
-from numpy.distutils.core import Command
+from distutils.cmd import Command
 from .extensions import build_ext, build_lib_arrays
 
 def clean(xs):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -55,10 +55,11 @@ def modelCacher1d(func):
         digest = ''
         if use_caching:
 
-            data = [numpy.array(pars).tostring(), boolean_to_byte(kwargs.get('integrate', False)),
-                    numpy.asarray(xlo).tostring()]
+            data = [numpy.array(pars).tobytes(),
+                    boolean_to_byte(kwargs.get('integrate', False)),
+                    numpy.asarray(xlo).tobytes()]
             if args:
-                data.append(numpy.asarray(args[0]).tostring())
+                data.append(numpy.asarray(args[0]).tobytes())
 
             token = b''.join(data)
             digest = hashlib.sha256(token).digest()


### PR DESCRIPTION
# Summary

Support NumPy 1.19. Note that this version of NumPy drops support for version Python 3.5.

# Details

It looks like NumPy 1.19 has changed some things

- numpy.distutils no longer exports Comnand, so get it from distutils (where it came from anyway); it's not clear whether this used to behave differently in the past
- tostring now generates deprecation warnings, so we switch to tobytes (which has been available since NumPy 1.9, which predates Python version 3.5)
