### PR TITLE
Add requires_fits to test_astro_sim tests and switch to pytest

### DIFF
--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2015, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2018, 2020
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -33,8 +34,6 @@ logger = logging.getLogger('sherpa')
 
 class test_sim(SherpaTestCase):
 
-    @requires_fits
-    @requires_xspec
     def setUp(self):
         from sherpa.astro.io import read_pha
         from sherpa.astro.xspec import XSwabs, XSpowerlaw
@@ -67,6 +66,7 @@ class test_sim(SherpaTestCase):
 
     @requires_xspec
     @requires_data
+    @requires_fits
     def test_pragbayes_simarf(self):
         mcmc = sim.MCMC()
 
@@ -93,6 +93,7 @@ class test_sim(SherpaTestCase):
 
     @requires_xspec
     @requires_data
+    @requires_fits
     def test_pragbayes_pcaarf(self):
         mcmc = sim.MCMC()
 


### PR DESCRIPTION
# Summary

Fixes an uncommon error with a simulation test, which would fail if
XSPEC support is built but there is no support for FITS files (i.e. AstroPy
or Pycrates is not installed)

# Details

In the unlikely case you have XSPEC support but do not have astropy
the tests would fail. This fixes this. It also updates the test to use pytest
rather than SherpaTestCase (and in doing cleans up the code a little bit
to remove some repeated code).
