### PR TITLE
xspec table models: add out-of-bound check to avoid segfault

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -951,6 +951,10 @@ class XSTableModel(XSModel):
         # logic could be in __init__, but that can be changed
         # at a later date.
         #
+        
+        assert all((param.min <= value <= param.max 
+            for value, param in zip(self.pars, p))), "model parameters outside bounds"
+        
         if hasattr(_xspec, 'tabint'):
             tabtype = 'add' if self.addmodel else 'mul'
             return _xspec.tabint(p,

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -62,6 +62,7 @@ from sherpa.models import Parameter, modelCacher1d, RegriddableModel1D
 from sherpa.models.parameter import hugeval
 
 from sherpa.utils import guess_amplitude, param_apply_limits, bool_cast
+from sherpa.utils.err import ParameterErr
 from sherpa.astro.utils import get_xspec_position
 
 from .utils import ModelMeta, version_at_least, equal_or_greater_than
@@ -951,10 +952,12 @@ class XSTableModel(XSModel):
         # logic could be in __init__, but that can be changed
         # at a later date.
         #
-        
-        assert all((param.min <= value <= param.max 
-            for param, value in zip(self.pars, p))), "model parameters outside bounds"
-        
+        for param, value in zip(self.pars, p):
+            if value < param._hard_min:
+                raise ParameterErr('edge', self.name, 'minimum', param._hard_min)
+            if value > param._hard_max:
+                raise ParameterErr('edge', self.name, 'maximum', param._hard_max)
+
         if hasattr(_xspec, 'tabint'):
             tabtype = 'add' if self.addmodel else 'mul'
             return _xspec.tabint(p,

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -953,7 +953,7 @@ class XSTableModel(XSModel):
         #
         
         assert all((param.min <= value <= param.max 
-            for value, param in zip(self.pars, p))), "model parameters outside bounds"
+            for param, value in zip(self.pars, p))), "model parameters outside bounds"
         
         if hasattr(_xspec, 'tabint'):
             tabtype = 'add' if self.addmodel else 'mul'

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -24,6 +24,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from sherpa.astro import ui
 from sherpa.utils.testing import SherpaTestCase, requires_data, \
     requires_fits, requires_xspec
+from sherpa.utils.err import ParameterErr
 
 # How many models should there be?
 # This number includes all additive and multiplicative models, even the ones
@@ -375,6 +376,18 @@ class test_xspec(SherpaTestCase):
     @requires_fits
     def test_xspec_tablemodel_noncontiguous2(self):
         self._test_xspec_tablemodel_noncontiguous2(ui.load_table_model)
+
+    @requires_data
+    @requires_fits
+    def test_xpec_tablemodel_outofbound(self):
+        ui.load_xstable_model('tmod', self.make_path('xspec-tablemodel-RCS.mod'))
+        # when used in the test suite it appears that the tmod
+        # global symbol is not created, so need to access the component
+        tmod = ui.get_model_component('tmod')
+        with pytest.raises(ParameterErr) as e:
+            tmod.calc([0., .2, 1., 1.], numpy.arange(1,5))
+        assert 'minimum' in str(e)
+
 
     def test_convolution_model_cflux(self):
         # Use the cflux convolution model, since this gives


### PR DESCRIPTION
This PR superceeds #743. See there for discussion.

Once the CI passes here, I will transfer the meta-information from #743 (requested reviewers, milestone etc.) to this PR and close #743.

## Summary
Passing an parameter that is out of bounds to an XSPEC table model can segfault the Sherpa session. This was originally discovered with parameters linked to other models, but can happen in other ways, too. This PR adds an explicit out-of-bounds check.