### PR TITLE
Cache code: make the parameter optional and fix some missing cases

### DIFF
--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -148,7 +148,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.rmfargs = ()
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
@@ -197,7 +197,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.arfargs = ()
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
@@ -250,7 +250,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
         self.rmfargs = ()
         self.arfargs = ()
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
@@ -310,7 +310,7 @@ class RMFModelPHA(RMFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         rmf = self._rmf  # original
 
         # Create a view of original RMF
@@ -409,7 +409,7 @@ class ARFModelPHA(ARFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         arf = self._arf  # original
         pha = self.pha
 
@@ -523,7 +523,7 @@ class RSPModelPHA(RSPModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         arf = self._arf
         rmf = self._rmf
 
@@ -850,7 +850,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.elo, self.ehi, self.table = compile_energy_grid(grid)
         self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         pha = self.pha
         if numpy.iterable(pha.mask):
             pha.notice_response(True)
@@ -983,7 +983,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
                                 ('%s(%s)' % ('apply_rmf', self.model.name)),
                                 (self.model,))
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         pha = self.pha
         pha.notice_response(False)
         self.channel = pha.get_noticed_channels()

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1879,10 +1879,10 @@ class Integrator1D(CompositeModel, RegriddableModel1D):
                                 ('integrate1d(%s)' % self.model.name),
                                 (self.model,))
 
-    def startup(self):
-        self.model.startup()
+    def startup(self, cache=False):
+        self.model.startup(cache)
         self._errflag = 1
-        CompositeModel.startup(self)
+        CompositeModel.startup(self, cache)
 
     def teardown(self):
         self.model.teardown()

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -206,8 +206,13 @@ class Model(NoNewAttributesAfterInit):
                     for alias in val.aliases:
                         self._par_index[alias] = val
 
-    def startup(self):
+    def startup(self, cache=False):
         """Called before a model may be evaluated multiple times.
+
+        Parameters
+        ----------
+        cache : bool, optional
+            Should a cache be used when evaluating the models.
 
         See Also
         --------
@@ -406,7 +411,7 @@ class CompositeModel(Model):
 
         return parts
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         pass
 
     def teardown(self):
@@ -450,7 +455,7 @@ class SimulFitModel(CompositeModel):
     def __iter__(self):
         return iter(self.parts)
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         for part in self:
             part.startup(cache)
         CompositeModel.startup(self, cache)
@@ -470,7 +475,7 @@ class ArithmeticConstantModel(Model):
         self.val = SherpaFloat(val)
         Model.__init__(self, self.name)
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         pass
 
     def calc(self, p, *args, **kwargs):
@@ -541,7 +546,7 @@ class ArithmeticModel(Model):
     def __getitem__(self, filter):
         return FilterModel(self, filter)
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         self._queue = ['']
         self._cache = {}
         self._use_caching = cache
@@ -619,7 +624,7 @@ class BinaryOpModel(CompositeModel, ArithmeticModel):
                                  (self.lhs.name, opstr, self.rhs.name)),
                                 (self.lhs, self.rhs))
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         self.lhs.startup(cache)
         self.rhs.startup(cache)
         CompositeModel.startup(self, cache)
@@ -692,7 +697,7 @@ class ArithmeticFunctionModel(Model):
     def calc(self, p, *args, **kwargs):
         return self.func(*args, **kwargs)
 
-    def startup(self):
+    def startup(self, cache=False):
         pass
 
     def teardown(self):
@@ -717,7 +722,7 @@ class NestedModel(CompositeModel, ArithmeticModel):
                                  (self.outer.name, self.inner.name)),
                                 (self.outer, self.inner))
 
-    def startup(self, cache):
+    def startup(self, cache=False):
         self.inner.startup(cache)
         self.outer.startup(cache)
         CompositeModel.startup(self, cache)


### PR DESCRIPTION
The cache argument to startup has been made optional, to try and
avoid issues like #728, #733, #759

All startup methods have now been adjusted to take the cache
argument (which should also fix the issue).

The default is to not cache the results (as a safety precaution).