### PR TITLE
Use TRAVIS_NUMCORES for Travis jobs (number of npus)

### DIFF
--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -91,5 +91,5 @@ export PYTHON_LDFLAGS=" "
 ncores=`python -c 'import multiprocessing; print(multiprocessing.cpu_count());'`
 echo "# Python thinks we have ${ncores} cores"
 echo "# Forcing the number of cores to be 2"
-sed -e "s/^numcore *: *None *$/numcore : 2/" sherpa/sherpa-standalone.rc > .sherpa-standalone.rc
+sed -e "s/^numcore : None/numcore : 2/" sherpa/sherpa-standalone.rc > .sherpa-standalone.rc
 grep numcore .sherpa-standalone.rc  # DBG

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -16,7 +16,7 @@ else  # osx
     #Unset the Travis compiler variables
     unset CC CFLAGS CXXFLAGS
     compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
-    
+
     #Download and set the location of the macOS 10.9 SDK for the Conda Compilers to work
     mkdir -p 10.9SDK
     wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz -O MacOSX10.9.sdk.tar.xz
@@ -77,3 +77,17 @@ export F90=${F77}
 
 # This is required to make sure that the CIAO python extensions being built pick the correct flags
 export PYTHON_LDFLAGS=" "
+
+# Create a customized configuration file where the number of CPU cores
+# can be fixed: on VMs like on Travis the CPU detection logic we use
+# picks up the total number of CPUS on the host machine, not the
+# virtual machine we are running, as described at
+# https://github.com/travis-ci/travis-ci/issues/4696
+#
+# TRAVIS_NUMCORES is from https://github.com/travis-ci/travis-build/pull/1079
+#
+if [ -n "${TRAVIS_NUMCORES}" ]; then
+    echo "Restricting numcores to $TRAVIS_NUMCORES"  # DBG
+    sed -e "s/^numcore *: *None *$/numcore : $TRAVIS_NUMCORES/" sherpa/sherpa-standalone.rc > .sherpa-standalone.rc
+    grep numcore .sherpa-standalone.rc  # DBG
+fi

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -85,9 +85,11 @@ export PYTHON_LDFLAGS=" "
 # https://github.com/travis-ci/travis-ci/issues/4696
 #
 # TRAVIS_NUMCORES is from https://github.com/travis-ci/travis-build/pull/1079
+# but doesn't seem to exist. I am hard-coding to 2 based on
+# https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
 #
-if [ -n "${TRAVIS_NUMCORES}" ]; then
-    echo "Restricting numcores to $TRAVIS_NUMCORES"  # DBG
-    sed -e "s/^numcore *: *None *$/numcore : $TRAVIS_NUMCORES/" sherpa/sherpa-standalone.rc > .sherpa-standalone.rc
-    grep numcore .sherpa-standalone.rc  # DBG
-fi
+ncores=`python -c 'import multiprocessing; print(multiprocessing.cpu_count());'`
+echo "# Python thinks we have ${ncores} cores"
+echo "# Forcing the number of cores to be 2"
+sed -e "s/^numcore *: *None *$/numcore : 2/" sherpa/sherpa-standalone.rc > .sherpa-standalone.rc
+grep numcore .sherpa-standalone.rc  # DBG


### PR DESCRIPTION
It looks like the information I found is no-longer valid, since Travis seems to think we only have 2 cores, so there's no need for the following (which I ended up not getting quite right anyway).

# Details

It is possible that out multi-processing code on Travis is picking
the wrong number of CPUS: the Python multiprocessing module reads
the number from a value which is not guaranteed to be correct on
a VM, as described at
https://github.com/travis-ci/travis-ci/issues/4696

This is fixed by setting up a configuration file, for the Travis
tests, which uses the TRAVIS_NUMCORES environment variable to
fix the number of CPUs.