### PR TITLE
Updates to the Read-The-Docs build environment

### DIFF
--- a/docs/ciao.rst
+++ b/docs/ciao.rst
@@ -14,7 +14,7 @@ from the
 with the following modifications:
 
 * the I/O backend uses the CIAO library :term:`Crates` rather than
-  :term:`astropy`;
+  :term:`Astropy`;
 
 * a set of customized IPython routines are provided as part of
   CIAO that automatically loads Sherpa and adjusts the appearance
@@ -22,7 +22,7 @@ with the following modifications:
 
 * and the CIAO version of Sherpa includes the optional XSPEC model
   library (:py:mod:`sherpa.astro.xspec`).
-  
+
 The online documentation provided for Sherpa as part of CIAO,
 namely http://cxc.harvard.edu/sherpa/, can be used with the
 standalone version of Sherpa, but note that the focus of this

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 # look at sherpa.utils which provides docstrings for the code in
 # sherpa.utils._utils.
 #
-# The minimum supported version of Sphinx is 1.3.
+# The minimum supported version of Sphinx is 1.8.
 #
 # The minimum requirements are:
 #    numpy  - since setup.py enforces this
@@ -123,10 +123,9 @@ sherpa_version = sherpa_release[:sherpa_release.find('+')]
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# If use napoleon, force 1.3 rather than try and support the external
-# napoleon code.
+# The use of app.add_js_file requires Sphinx 1.8.
 #
-needs_sphinx = '1.3'
+needs_sphinx = '1.8'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -485,4 +484,4 @@ texinfo_documents = [
 #
 
 def setup(app):
-    app.add_javascript('copybutton.js')
+    app.add_js_file('copybutton.js')

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,9 @@ name: sherpa
 
 channels:
   - defaults
+  - astropy
 
 dependencies:
+  - python=3.7
   - numpy
+  - sphinx-astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,7 +36,7 @@ Sherpa has the following requirements:
 Sherpa can take advantage of the following Python packages
 if installed:
 
-* :term:`astropy`: for reading and writing files in
+* :term:`Astropy`: for reading and writing files in
   :term:`FITS` format. The minimum required version of astropy
   is version 1.3, although only versions 2 and higher are used in testing
   (version 3.2 is known to cause problems, but version 3.2.1 is okay).
@@ -441,7 +441,7 @@ additional packages:
 
 * `Sphinx <http://sphinx.pocoo.org/>`_, version 1.8 or later
 * The ``sphinx_rtd_theme``
-* NumPy and `sphinx_astropy <https://github.com/astropy/sphinx-astropy/>`_
+* NumPy and `sphinx-astropy <https://github.com/astropy/sphinx-astropy/>`_
   (the latter can be installed with ``pip``).
 * `Graphviz <https://www.graphviz.org/>`_ (for the inheritance diagrams)
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ Sherpa has the following requirements:
 * NumPy (the exact lower limit has not been determined,
   but it is likely to be 1.7.0 or later)
 * Linux or OS-X (patches to add Windows support are welcome)
-  
+
 Sherpa can take advantage of the following Python packages
 if installed:
 
@@ -86,9 +86,9 @@ Citing Sherpa
 
 Information on citing Sherpa can be found from the
 `CITATION document <https://github.com/sherpa/sherpa/blob/master/CITATION>`_
-in the Sherpa repository, or from the 
+in the Sherpa repository, or from the
 `Sherpa Zenodo page <https://doi.org/10.5281/zenodo.593753>`_.
-    
+
 Installing a pre-compiled version of Sherpa
 ===========================================
 
@@ -111,7 +111,7 @@ significant upgrades to the dependencies, Sherpa can be installed
 using::
 
     conda install -c sherpa sherpa
-    
+
 It is **strongly** suggested that Sherpa is installed into a named
 `conda environment <http://conda.pydata.org/docs/using/envs.html>`_
 (i.e. not the default environment).
@@ -125,7 +125,7 @@ command::
 
     pip install sherpa
 
-The NumPy package must already have been installed for this to work.    
+The NumPy package must already have been installed for this to work.
 
 .. _build-from-source:
 
@@ -256,7 +256,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.26.1 of HEASOFT and
    may need updating with a newer release.
-   
+
 2. If the full XSPEC 12.10.0 system has been built then use::
 
        with-xspec = True
@@ -288,7 +288,7 @@ match the contents of the XSPEC installation.
    flag when building HEASOFT which simplifies the installation of
    these extra libraries, but can cause problems for the Sherpa build.
 
-A common problem is to set one or both of the ``xspec_lib_dirs`` 
+A common problem is to set one or both of the ``xspec_lib_dirs``
 and ``xspec_lib_include`` options to the value of ``$HEADAS`` instead of
 ``$HEADAS/lib`` and ``$HEADAS/include`` (after expanding out the
 environment variable). Doing so will cause the build to fail with
@@ -423,7 +423,7 @@ When both the `DS9 image viewer <http://ds9.si.edu/site/Home.html>`_ and
 test suite will include tests that check that DS9 can be used from
 Sherpa. This causes several copies of the DS9 viewer to be created,
 which can be distracting, as it can cause loss of mouse focus (depending
-on how X-windows is set up). This can be avoided by installing the 
+on how X-windows is set up). This can be avoided by installing the
 `X virtual-frame buffer (Xvfb) <https://en.wikipedia.org/wiki/Xvfb>`_.
 
 .. note::
@@ -431,15 +431,15 @@ on how X-windows is set up). This can be avoided by installing the
    Although the standard Python setuptools approach is used to build
    Sherpa, there may be issues when using some of the other build
    targets, such as ``build_ext``. Please report these to the
-   `Sherpa issues page <https://github.com/sherpa/sherpa/issues/>`_.   
-  
+   `Sherpa issues page <https://github.com/sherpa/sherpa/issues/>`_.
+
 Building the documentation
 --------------------------
 
 Building the documentation requires the Sherpa source code and several
 additional packages:
 
-* `Sphinx <http://sphinx.pocoo.org/>`_, version 1.3 or later
+* `Sphinx <http://sphinx.pocoo.org/>`_, version 1.8 or later
 * The ``sphinx_rtd_theme``
 * NumPy and `sphinx_astropy <https://github.com/astropy/sphinx-astropy/>`_
   (the latter can be installed with ``pip``).
@@ -479,7 +479,7 @@ the ``sherpa_smoke`` executable::
     OK (skipped=5)
 
 or from the Python prompt::
-  
+
     >>> import sherpa
     >>> sherpa.smoke()
     WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
@@ -487,13 +487,13 @@ or from the Python prompt::
     Ran 7 tests in 0.447s
 
     OK (skipped=5)
-    
+
 This provides basic validation that Sherpa has been installed
 correctly, but does not run many functional tests. The screen output
 will include additional warning messages if the ``astropy`` or
 ``matplotlib`` packages are not installed, or Sherpa was built
 without support for the XSPEC model library.
-    
+
 The Sherpa installation also includes the ``sherpa_test`` command-line
 tool which will run through the Sherpa test suite (the number of
 tests depends on what optional packages are available and how
@@ -515,4 +515,3 @@ but it is not set up to do much validation. That is, you need to do something
 quite severe to break this build. Please see
 `issue 491 <https://github.com/sherpa/sherpa/issues/491>`_
 for more information.
-    

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,12 @@
+# readthedocs.yml
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 
-requirements_file: docs/rtd-pip-requirements
+version: 2
 
-# conda:
-#     file: docs/environment.yml
+sphinx:
+  configuration: docs/conf.py
 
-python:
-    version: 3.5
-    setup_py_install: false
+conda:
+  environment: docs/environment.yml
+
+# As using conda, can get away with no python settings


### PR DESCRIPTION
# Summary 

Update the Read-The-Docs configuration to the latest version (2), and switch to a cleaner build (using conda) for the documentation. The minimum Sphinx requirement is now 1.8 (updated from 1.3).

Several minor document fixes have been added, as well as updates to the minimum-required Sphinx version.

# Notes

The build now uses python 3.7 (previously it was using 3.5 which is not sustaiable). The current Sphinx version being used is version 3.1.2 (i.e. much later than the minimum version).