### PR TITLE
Clean up of the XSPEC interface code

### DIFF
--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -419,6 +419,22 @@ static void finalize_grid(int nelem,
 } /* finalize_grid */
 
 
+template <typename T>
+static bool create_output(int nbins, T &a, T &b) {
+
+  npy_intp dims[1] = { nbins };
+
+  if ( EXIT_SUCCESS != a.zeros( 1, dims ) )
+    return false;
+
+  if ( EXIT_SUCCESS != b.zeros( 1, dims ) )
+    return false;
+
+  return true;
+
+} /* create_output */
+
+
 template <npy_intp NumPars, bool HasNorm,
 void (*XSpecFunc)( float* ear, int* ne, float* param, int* ifl,
 		float* photar, float* photer )>
@@ -479,22 +495,14 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
         std::transform(std::begin(ear), std::end(ear), std::begin(fear),
                        [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
-        // Although the XSpec model expects the flux/fluxerror arrays
-        // to have size ngrid-1, the return array has to match the
-        // input size.
-        npy_intp dims[1] = { ngrid };
-        if (xhi)
-          dims[0]--;
+	// Number of bins to send to XSPEC
+	int nout = ngrid;
+	if (xhi) nout--;
 
-	FloatArray result;
-	if ( EXIT_SUCCESS != result.zeros( 1, dims ) )
-          return NULL;
-
-        // Since the flux error is discarded, it does not need to be a
-        // NumPy array. Should be set to zeros for safety.
-        FloatArray error;
-	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
-          return NULL;
+	FloatArray result, error;
+	if (!create_output(nout, result, error)) {
+	  return NULL;
+	}
 
 	// Even though the XSPEC model function is Fortran, it could call
 	// C++ functions, so swallow exceptions here
@@ -576,22 +584,14 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
 	int ngrid = ear.size();
         int ifl = 1;
 
-        // Although the XSpec model expects the flux/fluxerror arrays
-        // to have size ngrid-1, the return array has to match the
-        // input size.
-        npy_intp dims[1] = { ngrid };
-        if (xhi)
-          dims[0]--;
+	// Number of bins to send to XSPEC
+	int nout = ngrid;
+	if (xhi) nout--;
 
-	DoubleArray result;
-	if ( EXIT_SUCCESS != result.zeros( 1, dims ) )
-          return NULL;
-
-        // Since the flux error is discarded, it does not need to be a
-        // NumPy array. Should be set to zeros for safety.
-	DoubleArray error;
-	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
-          return NULL;
+	DoubleArray result, error;
+	if (!create_output(nout, result, error)) {
+	  return NULL;
+	}
 
 	try {
 
@@ -692,26 +692,18 @@ PyObject* xspecmodelfct_con( PyObject* self, PyObject* args )
           return NULL;
         }
 
-        // Although the XSpec model expects the flux/fluxerror arrays
-        // to have size ngrid-1, the return array has to match the
-        // input size.
-        npy_intp dims[1] = { ngrid };
-        if (xhi)
-          dims[0]--;
+	// Number of bins to send to XSPEC
+	int nout = ngrid;
+	if (xhi) nout--;
 
-	DoubleArray result;
-	if ( EXIT_SUCCESS != result.zeros( 1, dims ) )
-          return NULL;
+	DoubleArray result, error;
+	if (!create_output(nout, result, error)) {
+	  return NULL;
+	}
 
         // Copy over the flux array
-        for (int i = 0; i < dims[0]; i++)
+        for (int i = 0; i < nout; i++)
           result[i] = fluxes[i];
-
-        // Since the flux error is discarded, it does not need to be a
-        // NumPy array. Should be set to zeros for safety.
-	DoubleArray error;
-	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
-          return NULL;
 
 	try {
 
@@ -807,26 +799,18 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args )
         std::transform(std::begin(ear), std::end(ear), std::begin(fear),
                        [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
-        // Although the XSpec model expects the flux/fluxerror arrays
-        // to have size ngrid-1, the return array has to match the
-        // input size.
-        npy_intp dims[1] = { ngrid };
-        if (xhi)
-          dims[0]--;
+	// Number of bins to send to XSPEC
+	int nout = ngrid;
+	if (xhi) nout--;
 
-	FloatArray result;
-	if ( EXIT_SUCCESS != result.zeros( 1, dims ) )
-          return NULL;
+	FloatArray result, error;
+	if (!create_output(nout, result, error)) {
+	  return NULL;
+	}
 
         // Copy over the flux array
-        for (int i = 0; i < dims[0]; i++)
+        for (int i = 0; i < nout; i++)
           result[i] = fluxes[i];
-
-        // Since the flux error is discarded, it does not need to be a
-        // NumPy array. Should be set to zeros for safety.
-	FloatArray error;
-	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
-          return NULL;
 
 	try {
 
@@ -917,22 +901,14 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
         std::transform(std::begin(ear), std::end(ear), std::begin(fear),
                        [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
-        // Although the XSpec model expects the flux/fluxerror arrays
-        // to have size ngrid-1, the return array has to match the
-        // input size.
-        npy_intp dims[1] = { ngrid };
-        if (xhi)
-          dims[0]--;
+	// Number of bins to send to XSPEC
+	int nout = ngrid;
+	if (xhi) nout--;
 
-	FloatArray result;
-	if ( EXIT_SUCCESS != result.zeros( 1, dims ) )
-          return NULL;
-
-        // Since the flux error is discarded, it does not need to be a
-        // NumPy array. Should be set to zeros for safety.
-        FloatArray error;
-	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
-          return NULL;
+	FloatArray result, error;
+	if (!create_output(nout, result, error)) {
+	  return NULL;
+	}
 
 	// Swallow exceptions here
 
@@ -1028,22 +1004,14 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
         std::transform(std::begin(ear), std::end(ear), std::begin(fear),
                        [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
-        // Although the XSpec model expects the flux/fluxerror arrays
-        // to have size ngrid-1, the return array has to match the
-        // input size.
-        npy_intp dims[1] = { ngrid };
-        if (xhi)
-          dims[0]--;
+	// Number of bins to send to XSPEC
+	int nout = ngrid;
+	if (xhi) nout--;
 
-	FloatArray result;
-	if ( EXIT_SUCCESS != result.zeros( 1, dims ) )
-          return NULL;
-
-        // Since the flux error is discarded, it does not need to be a
-        // NumPy array. Should be set to zeros for safety.
-        FloatArray error;
-	if ( EXIT_SUCCESS != error.zeros( 1, dims ) )
-          return NULL;
+	FloatArray result, error;
+	if (!create_output(nout, result, error)) {
+	  return NULL;
+	}
 
 	// Swallow exceptions here
 

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -28,6 +28,7 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 #include "sherpa/fcmp.hh"
 
 // Prior to XSPEC 12.10.1, the table models were split into different
@@ -290,9 +291,8 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        for (int i = 0; i < ngrid; i++) {
-          fear[i] = (FloatArrayType) ear[i];
-        }
+        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
+                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
         // Although the XSpec model expects the flux/fluxerror arrays
         // to have size ngrid-1, the return array has to match the
@@ -1011,9 +1011,8 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        for (int i = 0; i < ngrid; i++) {
-          fear[i] = (FloatArrayType) ear[i];
-        }
+        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
+                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
         // Although the XSpec model expects the flux/fluxerror arrays
         // to have size ngrid-1, the return array has to match the
@@ -1245,9 +1244,8 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        for (int i = 0; i < ngrid; i++) {
-          fear[i] = (FloatArrayType) ear[i];
-        }
+        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
+                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
         // Although the XSpec model expects the flux/fluxerror arrays
         // to have size ngrid-1, the return array has to match the
@@ -1498,9 +1496,8 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        for (int i = 0; i < ngrid; i++) {
-          fear[i] = (FloatArrayType) ear[i];
-        }
+        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
+                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
 
         // Although the XSpec model expects the flux/fluxerror arrays
         // to have size ngrid-1, the return array has to match the

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -41,16 +41,18 @@
 // In XSPEC 12.11.0 (the next one after 12.10.1), the tabint function
 // was moved into C scope.
 //
-#if defined (XSPEC_12_10_1) && !defined(XSPEC_12_11_0)
-void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
-             const char* tabtyp, float* photar, float* photer);
-#endif
-
+#ifdef XSPEC_12_10_1
 #ifdef XSPEC_12_11_0
 extern "C" {
-void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
-             const char* tabtyp, float* photar, float* photer);
+#endif
+
+  void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
+	      const char* tabtyp, float* photar, float* photer);
+
+#ifdef XSPEC_12_11_0
 }
+#endif
+
 #endif
 
 

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -196,35 +196,30 @@ static bool create_grid(const sherpa::Array<CType, ArrayType> &xlo,
   //
   ear.assign(ngrid, 0);
 
-  // The grid is created, converted from Angstrom to Energy
-  // (if required), and then checked for being monotonic.
-  // The multiple loops are not necessarily as efficient
-  // as a single loop, but simpler to write.
-  //
-  {
-    // Process the contiguous sections by looping through
-    // the gaps_index/edges arrays.
-    int start = 0;
-    for (int j = 0 ; j < ngaps; j++) {
-      int end = gaps_index[j] + 1;
-      for(int i = start; i < end; i++) {
-        ear[i + j] = (*x1)[i];
-      }
-      ear[end + j] = gaps_edges[j];
-      start = end;
+  // Process the contiguous sections by looping through
+  // the gaps_index/edges arrays.
+  int start = 0;
+  for (int j = 0 ; j < ngaps; j++) {
+    int end = gaps_index[j] + 1;
+    for(int i = start; i < end; i++) {
+      ear[i + j] = (*x1)[i];
     }
-
-    // need to do the last contiguous grid
-    for(int i = start; i < nelem; i++) {
-      ear[i + ngaps] = (*x1)[i];
-    }
-
-    // Add on the last bin value if needed
-    if (xhi) {
-      ear[ngrid - 1] = (*x2)[nelem - 1];
-    }
+    ear[end + j] = gaps_edges[j];
+    start = end;
   }
 
+  // need to do the last contiguous grid
+  for(int i = start; i < nelem; i++) {
+    ear[i + ngaps] = (*x1)[i];
+  }
+
+  // Add on the last bin value if needed
+  if (xhi) {
+    ear[ngrid - 1] = (*x2)[nelem - 1];
+  }
+
+  // Convert from wavelength (Angstrom) to energy (keV)
+  //
   if (is_wave) {
     CType hc = (sherpa::constants::c_ang<CType>() *
                  sherpa::constants::h_kev<CType>());
@@ -333,17 +328,16 @@ static bool create_contiguous_grid(const sherpa::Array<CType, ArrayType> &xlo,
   // (if required), and then checked for being monotonic.
   // The code has been kept similar to create_grid.
   //
-  {
-    for(int i = 0; i < nelem; i++) {
-      ear[i] = (*x1)[i];
-    }
-
-    // Add on the last bin value if needed
-    if (xhi) {
-      ear[ngrid - 1] = (*x2)[nelem - 1];
-    }
+  for(int i = 0; i < nelem; i++) {
+    ear[i] = (*x1)[i];
   }
 
+  // Add on the last bin value if needed
+  if (xhi) {
+    ear[ngrid - 1] = (*x2)[nelem - 1];
+  }
+
+  // Convert from Angstrom to keV
   if (is_wave) {
     CType hc = (sherpa::constants::c_ang<CType>() *
                  sherpa::constants::h_kev<CType>());


### PR DESCRIPTION
# Summary

Internal changes to the XSPEC interface code, which reduces the amount of similar (sometimes identical) code. There is no change to the behavior of the XSPEC models.


# Details

Noted by @dtnguyen2 in a review of #772

 - [X] Switch to using std::transform in XSPEC Fortran-style models
 - [X] Reduce duplication (but there is more, eg #860)

I'm not likely to work on this anymore (modulo PR review) so we can either review this or through it.