### PR TITLE
Support an "ideal" RMF where MATRIX is a scalar (pyfits backend, fix #862)

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -738,13 +738,24 @@ def get_rmf_data(arg, make_copy=False):
             # Need a RMF which ng>1 to test this with.
             if ng == 1:
                 ncs = [ncs]
+
             start = 0
             for nc in ncs:
                 # n_chan can be an unsigned integer. Adding a Python
                 # integer to a NumPy unsigned integer appears to return
                 # a float.
                 end = start + numpy.int(nc)
-                rowdata.append(mrow[start:end])
+
+                # "perfect" RMFs may have mrow as a scalar
+                try:
+                    rdata = mrow[start:end]
+                except IndexError:
+                    if start != 0 or end != 1:
+                        raise IOErr('bad', 'format', 'MATRIX column formatting')
+
+                    rdata = [mrow]
+
+                rowdata.append(rdata)
                 start = end
 
         data['matrix'] = numpy.concatenate(rowdata)


### PR DESCRIPTION
# Summary

The AstroPy (pyfits) backend could not handle the case of an ideal RMF when the MATRIX column was specified as a scalar and not a 1-element array.

# Details

This is to support issue #862 where a MATRIX column is a scalar, not an array. This is aready supported by Crates, so the Astropy backend needs updating. The change is small (if you can't access the first element of an array then treat it as a scalar), and is an extension to the changes in PRs #358 and #412 which dealt with Swift and ROSAT responses.

A test is added, but rather than adding a file to the Sherpa data corpus, we instead just create the file when needed. It also means that we can easily test the values read in as the data can be made to be easily tested (i.e. a small number of bins).