### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/evaluation/astro_background.rst
+++ b/docs/evaluation/astro_background.rst
@@ -1,0 +1,19 @@
+**********************************
+The sherpa.astro.background module
+**********************************
+
+.. currentmodule:: sherpa.astro.background
+
+.. automodule:: sherpa.astro.background
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      BackgroundSumModel
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram:: BackgroundSumModel

--- a/docs/evaluation/index.rst
+++ b/docs/evaluation/index.rst
@@ -52,7 +52,7 @@ evaluation:
    stored in the model itself. This can be useful when a model is to
    be embedded within another one, as shown in the
    :ref:`two-dimensional user model <example-usermodel-2d>`
-   example. 
+   example.
 
 .. _evaluation_data:
 
@@ -70,3 +70,17 @@ not a simple one-to-one relation, such as when analyzing
 astronomical X-ray spectral data with an associated response
 (i.e. a :term:`RMF` file), or
 :ref:`when using a PSF <convolution-psf2d-evaluate>`.
+
+.. _evaluation-reference-api:
+
+Reference/API
+=============
+
+This section describes some of the classes used to evaluate the
+models, in particular in supporting models evaluated against
+:py:class:`~sherpa.astro.data.DataPHA` objects.
+
+.. toctree::
+   :maxdepth: 2
+
+   astro_background

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -31,7 +31,7 @@ class BackgroundSumModel(CompositeModel, ArithmeticModel):
     """Combine multiple background datasets.
 
     Define the model expression to be applied to the source
-    region accounting for the backgroud models.
+    region accounting for the background models.
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ class BackgroundSumModel(CompositeModel, ArithmeticModel):
     bkgmodels : dict
         The background components, where the key is the identifier
         in this dataset and the value is the model. This dictionary
-        is not empty.
+        cannot be empty.
 
     """
 

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -1,5 +1,5 @@
-# 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#
+#  Copyright (C) 2007, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,6 +17,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""Support multiple background components for a PHA dataset.
+
+"""
+
 from sherpa.models.model import CompositeModel, ArithmeticModel
 from sherpa.utils.err import DataErr
 
@@ -24,6 +28,21 @@ __all__ = ('BackgroundSumModel',)
 
 
 class BackgroundSumModel(CompositeModel, ArithmeticModel):
+    """Combine multiple background datasets.
+
+    Define the model expression to be applied to the source
+    region accounting for the backgroud models.
+
+    Parameters
+    ----------
+    srcdata : sherpa.astro.data.DataPHA instance
+        The source dataset.
+    bkgmodels : dict
+        The background components, where the key is the identifier
+        in this dataset and the value is the model. This dictionary
+        is not empty.
+
+    """
 
     def __init__(self, srcdata, bkgmodels):
         self.srcdata = srcdata
@@ -43,4 +62,4 @@ class BackgroundSumModel(CompositeModel, ArithmeticModel):
             # of p)
             return bmodel(*args, **kwargs)
 
-        return self.srcdata.sum_background_data(eval_bkg_model)            
+        return self.srcdata.sum_background_data(eval_bkg_model)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1137,7 +1137,7 @@ class DataPHA(Data1D):
     def get_backscal(self, group=True, filter=False):
         """Return the area scaling of the PHA data set.
 
-        Return the BACKSCAL setting [1]_ for the PHA data set.
+        Return the BACKSCAL setting [BSCAL]_ for the PHA data set.
 
         Parameters
         ----------
@@ -1169,7 +1169,7 @@ class DataPHA(Data1D):
         References
         ----------
 
-        .. [1] "The OGIP Spectral File Format", Arnaud, K. & George, I.
+        .. [BSCAL] "The OGIP Spectral File Format", Arnaud, K. & George, I.
                http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
 
         Examples
@@ -1187,7 +1187,7 @@ class DataPHA(Data1D):
     def get_areascal(self, group=True, filter=False):
         """Return the fractional area factor of the PHA data set.
 
-        Return the AREASCAL setting [1]_ for the PHA data set.
+        Return the AREASCAL setting [ASCAL]_ for the PHA data set.
 
         Parameters
         ----------
@@ -1213,7 +1213,7 @@ class DataPHA(Data1D):
         References
         ----------
 
-        .. [1] "The OGIP Spectral File Format", Arnaud, K. & George, I.
+        .. [ASCAL] "The OGIP Spectral File Format", Arnaud, K. & George, I.
                http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
 
         Examples

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1102,6 +1102,25 @@ class DataPHA(Data1D):
         return self.sum_background_data(lambda key, bkg: 1.)
 
     def _check_scale(self, scale, group=True, filter=False):
+        """Ensure the scale value is positive and filtered/grouped.
+
+        Parameters
+        ----------
+        scale : number or numpy array
+            The scale factor.
+        group : bool, optional
+            Is any grouping applied to the data? This is only
+            relevant for an array.
+        filter : bool, optional
+            Is any filter applied? This is only checked if group
+            is True.
+
+        Returns
+        -------
+        scale : number or numpy array
+            Negative values are replaced by 1.0.
+
+        """
         if numpy.isscalar(scale) and scale <= 0.0:
             scale = 1.0
         elif numpy.iterable(scale):

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3297,7 +3297,7 @@ class XSdiskm(XSAdditiveModel):
 
     Attributes
     ----------
-    NSmass
+    accrate
         The accretion rate, in Eddington luminosities.
     NSmass
         The central mass, in solar mass units.
@@ -3338,7 +3338,7 @@ class XSdisko(XSAdditiveModel):
 
     Attributes
     ----------
-    NSmass
+    accrate
         The accretion rate, in Eddington luminosities.
     NSmass
         The central mass, in solar mass units.
@@ -10411,7 +10411,7 @@ class XSzbabs(XSMultiplicativeModel):
         The H column density, in 10^22 atoms/cm^2.
     nHeI
         The He I column density, in 10^22 atoms/cm^2.
-    nHeI
+    nHeII
         The He II column density, in 10^22 atoms/cm^2.
     z
         The redshift of the absorber.


### PR DESCRIPTION
# Summary

Several documentation fixes: XSPEC parameter names, avoiding confusion over links on references (Sphinx pages), and adding some basic documentation to the sherpa.astro.background module.

# Details

This is a documentation-only PR.

I noticed these when working on an issue. They are all minor changes, but the XSPEC changes do fix a documentation bug (and are the only changes users of the sherpa.astro.ui layer would note).