### PR TITLE
Add parameter-clipping strategy to routines that generate samples (fix #846)

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -177,7 +177,7 @@ def _sample_flux_get_samples_with_scales(fit, src, correlated, scales,
         The dimensions are num by mfree. The ordering of the parameter
         values in each row matches that of the free parameters in
         fit.model.  The clipped array indicates whether a row had one
-        or more clipped paraneters.
+        or more clipped parameters.
 
     Raises
     ------
@@ -298,7 +298,7 @@ def _sample_flux_get_samples(fit, src, correlated, num, clip='hard'):
         The dimensions are num by mfree. The ordering of the parameter
         values in each row matches that of the free parameters in
         fit.model. The clipped array indicates whether a row
-        had one or more clipped paraneters.
+        had one or more clipped parameters.
 
     Notes
     -----
@@ -368,7 +368,7 @@ def decompose(mdl):
 def sample_flux(fit, data, src,
                 method=calc_energy_flux, correlated=False,
                 num=1, lo=None, hi=None, numcores=None, samples=None,
-                clip="hard"):
+                clip='hard'):
     """Calculate model fluxes from a sample of parameter values.
 
     Draw parameter values from a normal distribution and then calculate
@@ -494,7 +494,7 @@ def sample_flux(fit, data, src,
         samples, clipped = _sample_flux_get_samples_with_scales(fit, src, correlated,
                                                                 scales, num, clip=clip)
 
-    # When a subset of the full model is use we need to know how
+    # When a subset of the full model is used we need to know how
     # to select which rows in the samples array refer to the
     # parameters of interest. We could compare on fullname,
     # but is not sufficient to guarantee the match.

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -34,10 +34,13 @@ import logging
 
 warning = logging.getLogger(__name__).warning
 
-__all__ = ('DataPHAPlot', 'SourcePlot', 'ARFPlot', 'BkgDataPlot', 'BkgModelHistogram',
-           'BkgFitPlot', 'BkgSourcePlot', 'BkgDelchiPlot', 'BkgResidPlot',
-           'BkgRatioPlot', 'BkgChisqrPlot',
-           'OrderPlot', 'ModelHistogram')
+__all__ = ('DataPHAPlot', 'ModelHistogram', 'SourcePlot', 'ComponentModelPlot',
+           'ComponentSourcePlot', 'ARFPlot', 'BkgDataPlot',
+           'BkgSourcePlot',
+           'BkgFitPlot', 'BkgDelchiPlot', 'BkgResidPlot',
+           'BkgRatioPlot', 'BkgChisqrPlot', 'BkgSourcePlot',
+           'OrderPlot', 'BkgModelHistogram',
+           'FluxHistogram', 'EnergyFluxHistogram', 'PhotonFluxHistogram')
 
 
 def to_latex(txt):

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -34,12 +34,11 @@ import logging
 
 warning = logging.getLogger(__name__).warning
 
-__all__ = ('DataPHAPlot', 'ModelHistogram', 'SourcePlot', 'ComponentModelPlot',
+__all__ = ('DataPHAPlot', 'SourcePlot', 'ComponentModelPlot',
            'ComponentSourcePlot', 'ARFPlot', 'BkgDataPlot',
-           'BkgSourcePlot',
-           'BkgFitPlot', 'BkgDelchiPlot', 'BkgResidPlot',
-           'BkgRatioPlot', 'BkgChisqrPlot', 'BkgSourcePlot',
-           'OrderPlot', 'BkgModelHistogram',
+           'BkgFitPlot', 'BkgSourcePlot', 'BkgDelchiPlot', 'BkgResidPlot',
+           'BkgRatioPlot', 'BkgChisqrPlot',
+           'OrderPlot', 'ModelHistogram', 'BkgModelHistogram',
            'FluxHistogram', 'EnergyFluxHistogram', 'PhotonFluxHistogram')
 
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -539,8 +539,10 @@ class OrderPlot(ModelHistogram):
 #
 class FluxHistogram(ModelHistogram):
     "Derived class for creating 1D flux distribution plots"
+
     def __init__(self):
         self.modelvals = None
+        self.clipped = None
         self.flux = None
         ModelHistogram.__init__(self)
 
@@ -559,9 +561,26 @@ class FluxHistogram(ModelHistogram):
                           ModelHistogram.__str__(self)])
 
     def prepare(self, fluxes, bins):
-        y = asarray(fluxes[:, 0])
+        """Define the histogram plot.
+
+        Parameter
+        ---------
+        fluxes : numpy array
+            The data, stored in a niter by (npar + 2) matrix, where
+            each row is an iteration, the first column is the flux for
+            that row, the next npar columns are the parameter values,
+            and the last column indicates whether the row was clipped
+            (1) or not (0).
+        bins : int
+            The number of bins to split the flux data into.
+
+        """
+
+        fluxes = asarray(fluxes)
+        y = fluxes[:, 0]
         self.flux = y
-        self.modelvals = asarray(fluxes[:, 1:])
+        self.modelvals = fluxes[:, 1:-1]
+        self.clipped = fluxes[:, -1]
         self.xlo, self.xhi = dataspace1d(y.min(), y.max(),
                                          numbins=bins + 1)[:2]
         y = histogram1d(y, self.xlo, self.xhi)

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -552,12 +552,21 @@ class FluxHistogram(ModelHistogram):
             vals = array2string(asarray(self.modelvals), separator=',',
                                 precision=4, suppress_small=False)
 
+        clip = self.clipped
+        if self.clipped is not None:
+            # Could convert to boolean, but it is surprising for
+            # anyone trying to access the clipped field
+            clip = array2string(asarray(self.clipped), separator=',',
+                                precision=4, suppress_small=False)
+
         flux = self.flux
         if self.flux is not None:
             flux = array2string(asarray(self.flux), separator=',',
                                 precision=4, suppress_small=False)
 
-        return '\n'.join(['modelvals = %s' % vals, 'flux = %s' % flux,
+        return '\n'.join(['modelvals = {}'.format(vals),
+                          'clipped = {}'.format(clip),
+                          'flux = {}'.format(flux),
                           ModelHistogram.__str__(self)])
 
     def prepare(self, fluxes, bins):

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -943,6 +943,81 @@ def test_sample_foo_flux_params(multi, correlated, lnh0, gamma0, lampl0,
     assert ans[:, 0].min() > 0
 
 
+@requires_data
+@requires_fits
+@requires_xspec
+@pytest.mark.parametrize("multi", [ui.sample_energy_flux, ui.sample_photon_flux])
+@pytest.mark.parametrize("id", [None, "foo"])
+def test_sample_foo_flux_clip_soft(multi, id,
+                                   make_data_path, clean_astro_ui):
+    """Can we clip with soft limits?
+    """
+
+    gal, pl = setup_sample(id, make_data_path)
+
+    nh0 = gal.nh.val
+    gamma0 = pl.gamma.val
+    ampl0 = pl.ampl.val
+
+    niter = 100
+
+    # make this even more obvious than test_sample_foo_flux_params
+    pl.gamma.min = 1.9
+    pl.gamma.max = 2.1
+
+    ans = multi(lo=0.5, hi=7, id=id, num=niter, clip='soft')
+    assert ans.shape == (niter, 5)
+
+    # check clipped is 0/1; expect just under 50% clipped but just check
+    # we have some clipped, not the number
+    #
+    clipped = ans[:, 4]
+    v0 = clipped == 0
+    v1 = clipped == 1
+    v = v0 | v1
+    assert v.all()
+    assert v0.any()
+    assert v1.any()
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+@pytest.mark.parametrize("multi", [ui.sample_energy_flux, ui.sample_photon_flux])
+@pytest.mark.parametrize("id", [None, "foo"])
+def test_sample_foo_flux_clip_none(multi, id,
+                                   make_data_path, clean_astro_ui):
+    """We get no clipping.
+
+    Same setup as test_sample_foo_flux_clip_soft
+    """
+
+    gal, pl = setup_sample(id, make_data_path)
+
+    nh0 = gal.nh.val
+    gamma0 = pl.gamma.val
+    ampl0 = pl.ampl.val
+
+    niter = 100
+
+    # make this even more obvious than test_sample_foo_flux_params
+    pl.gamma.min = 1.9
+    pl.gamma.max = 2.1
+
+    ans = multi(lo=0.5, hi=7, id=id, num=niter, clip='none')
+    assert ans.shape == (niter, 5)
+
+    # check clipped is 0/1
+    #
+    clipped = ans[:, 4]
+    v0 = clipped == 0
+    v1 = clipped == 1
+    v = v0 | v1
+    assert v.all()
+    assert v0.all()
+    assert not(v1.any())
+
+
 # The covariance matrix should be close to the following
 # (found from running the code):
 #

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -828,7 +828,7 @@ def test_sample_foo_flux_niter(multi, single, id, niter, correlated,
         assert ans[i, 0] == flux
 
     # check clipped is 0/1; ideally this is a boolean and not a
-    # float represention
+    # float representation
     #
     clipped = ans[:, 4]
     v0 = clipped == 0

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1728,7 +1728,7 @@ def validate_flux_histogram(fhist):
     # Very minimal checks.
     #
     assert fhist.flux.shape == (200,)
-    assert fhist.modelvals.shape == (200, 3)
+    assert fhist.modelvals.shape == (200, 4)
     assert fhist.xlo.shape == (21,)
     assert fhist.xhi.shape == (21,)
     assert fhist.y.shape == (21,)
@@ -1968,7 +1968,7 @@ def test_pha1_plot_foo_flux_scales(plotfunc, getfunc, scale,
     pvals = res.modelvals
 
     assert res.flux.shape == (1000,)
-    assert res.modelvals.shape == (1000, 2)
+    assert res.modelvals.shape == (1000, 3)
     assert res.xlo.shape == (21,)
     assert res.xhi.shape == (21,)
     assert res.y.shape == (21,)
@@ -2035,7 +2035,7 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
     res = getfunc(recalc=False)
 
     avals = res.modelvals
-    assert avals.shape == (1000, 3)
+    assert avals.shape == (1000, 4)
 
     std1 = np.std(avals[:, 1])
     std2 = np.log10(np.std(avals[:, 2]))
@@ -2052,7 +2052,7 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
     res = getfunc(recalc=False)
 
     uvals = res.modelvals
-    assert uvals.shape == (1000, 3)
+    assert uvals.shape == (1000, 4)
 
     std1 = np.std(uvals[:, 1])
     std2 = np.log10(np.std(uvals[:, 2]))
@@ -2129,9 +2129,9 @@ def test_pha1_plot_foo_flux_multi(plotfunc, getfunc,
     assert res.y.shape == (20,)
     cvals = res.modelvals.copy()
 
-    assert avals.shape == (n, 2)
-    assert bvals.shape == (n, 2)
-    assert cvals.shape == (n, 2)
+    assert avals.shape == (n, 3)
+    assert bvals.shape == (n, 3)
+    assert cvals.shape == (n, 3)
 
     # Let's just check the standard deviation of the gamma parameter,
     # which should be similar for avals and bvals, and larger for cvals.
@@ -2184,7 +2184,7 @@ def test_pha1_get_foo_flux_hist_model(getfunc, ratio,
     res = getfunc(lo=0.5, hi=2, num=1000, bins=19, correlated=False)
 
     avals = res.modelvals
-    assert avals.shape == (1000, 3)
+    assert avals.shape == (1000, 4)
 
     std1 = np.std(avals[:, 1])
     std2 = np.log10(np.std(avals[:, 2]))
@@ -2200,7 +2200,7 @@ def test_pha1_get_foo_flux_hist_model(getfunc, ratio,
                   correlated=False)
 
     uvals = res.modelvals
-    assert uvals.shape == (1000, 3)
+    assert uvals.shape == (1000, 4)
 
     std1 = np.std(uvals[:, 1])
     std2 = np.log10(np.std(uvals[:, 2]))

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -2078,6 +2078,154 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
 @pytest.mark.parametrize("plotfunc,getfunc",
                          [(ui.plot_energy_flux, ui.get_energy_flux_hist),
                           (ui.plot_photon_flux, ui.get_photon_flux_hist)])
+def test_pha1_plot_foo_flux_soft(plotfunc, getfunc, clean_astro_ui, basic_pha1):
+    """Check we can send clip=soft
+    """
+
+    orig_mdl = ui.get_source('tst')
+    gal = ui.create_model_component('xswabs', 'gal')
+    gal.nh = 0.04
+    ui.set_source('tst', gal * orig_mdl)
+
+    # Ensure near the minimum
+    ui.fit()
+
+    # Since the results are not being inspected here, the "quality"
+    # of the results isn't important, so we can use a relatively-low
+    # number of iterations.
+    #
+    plotfunc(lo=0.5, hi=2, num=200, bins=20, correlated=True, clip='soft')
+
+    # check we can access these results (relying on the fact that the num
+    # and bins arguments have been changed from their default values).
+    #
+    res = getfunc(recalc=False)
+    validate_flux_histogram(res)
+
+    # check we have clip information and assume at least one bin is
+    # clipped (expect ~ 40 of 200 from testing this)
+    clip = res.modelvals[:, 3]
+    c0 = clip == 0
+    c1 = clip == 1
+    assert (c0 | c1).all()
+    assert c0.any()
+    assert c1.any()
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@requires_xspec
+@pytest.mark.parametrize("plotfunc,getfunc",
+                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
+def test_pha1_plot_foo_flux_none(plotfunc, getfunc, clean_astro_ui, basic_pha1):
+    """Check we can send clip=none
+
+    Copy of test_pha1_plot_foo_flux_none
+    """
+
+    orig_mdl = ui.get_source('tst')
+    gal = ui.create_model_component('xswabs', 'gal')
+    gal.nh = 0.04
+    ui.set_source('tst', gal * orig_mdl)
+
+    # Ensure near the minimum
+    ui.fit()
+
+    # Since the results are not being inspected here, the "quality"
+    # of the results isn't important, so we can use a relatively-low
+    # number of iterations.
+    #
+    plotfunc(lo=0.5, hi=2, num=200, bins=20, correlated=True, clip='none')
+
+    # check we can access these results (relying on the fact that the num
+    # and bins arguments have been changed from their default values).
+    #
+    res = getfunc(recalc=False)
+    validate_flux_histogram(res)
+
+    # check we have clip information but that it's all zeros
+    clip = res.modelvals[:, 3]
+    c0 = clip == 0
+    c1 = clip == 1
+    assert (c0 | c1).all()
+    assert c0.all()
+    assert not(c1.any())
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@requires_xspec
+@pytest.mark.parametrize("getfunc", [ui.get_energy_flux_hist,
+                                     ui.get_photon_flux_hist])
+def test_pha1_get_foo_flux_soft(getfunc, clean_astro_ui, basic_pha1):
+    """Can we send clip=soft?
+    """
+
+    orig_mdl = ui.get_source('tst')
+    gal = ui.create_model_component('xswabs', 'gal')
+    gal.nh = 0.04
+    ui.set_source('tst', gal * orig_mdl)
+
+    # Ensure near the minimum
+    ui.fit()
+
+    res = getfunc(lo=0.5, hi=2, num=200, bins=20, correlated=False,
+                  clip='soft')
+    validate_flux_histogram(res)
+
+    # check we have clip information and assume at least one bin is
+    # clipped (expect ~ 40 of 200 from testing this)
+    clip = res.modelvals[:, 3]
+    c0 = clip == 0
+    c1 = clip == 1
+    assert (c0 | c1).all()
+    assert c0.any()
+    assert c1.any()
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@requires_xspec
+@pytest.mark.parametrize("getfunc", [ui.get_energy_flux_hist,
+                                     ui.get_photon_flux_hist])
+def test_pha1_get_foo_flux_none(getfunc, clean_astro_ui, basic_pha1):
+    """Can we send clip=none?
+
+    Copy of test_pha1_get_foo_flux_soft
+    """
+
+    orig_mdl = ui.get_source('tst')
+    gal = ui.create_model_component('xswabs', 'gal')
+    gal.nh = 0.04
+    ui.set_source('tst', gal * orig_mdl)
+
+    # Ensure near the minimum
+    ui.fit()
+
+    res = getfunc(lo=0.5, hi=2, num=200, bins=20, correlated=False,
+                  clip='none')
+    validate_flux_histogram(res)
+
+    # check we have clip information and all are 0
+    clip = res.modelvals[:, 3]
+    c0 = clip == 0
+    c1 = clip == 1
+    assert (c0 | c1).all()
+    assert c0.all()
+    assert not(c1.any())
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+@requires_xspec
+@pytest.mark.parametrize("plotfunc,getfunc",
+                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
 def test_pha1_plot_foo_flux_multi(plotfunc, getfunc,
                                   make_data_path, clean_astro_ui,
                                   hide_logging, reset_seed):

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1728,7 +1728,7 @@ def validate_flux_histogram(fhist):
     # Very minimal checks.
     #
     assert fhist.flux.shape == (200,)
-    assert fhist.modelvals.shape == (200, 4)
+    assert fhist.modelvals.shape == (200, 3)
     assert fhist.xlo.shape == (21,)
     assert fhist.xhi.shape == (21,)
     assert fhist.y.shape == (21,)
@@ -1968,7 +1968,7 @@ def test_pha1_plot_foo_flux_scales(plotfunc, getfunc, scale,
     pvals = res.modelvals
 
     assert res.flux.shape == (1000,)
-    assert res.modelvals.shape == (1000, 3)
+    assert res.modelvals.shape == (1000, 2)
     assert res.xlo.shape == (21,)
     assert res.xhi.shape == (21,)
     assert res.y.shape == (21,)
@@ -2035,12 +2035,14 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
     res = getfunc(recalc=False)
 
     avals = res.modelvals
-    assert avals.shape == (1000, 4)
+    assert avals.shape == (1000, 3)
 
     std1 = np.std(avals[:, 1])
     std2 = np.log10(np.std(avals[:, 2]))
     assert std1 == pytest.approx(0.1330728846451271, rel=1e-3)
     assert std2 == pytest.approx(-4.54079387550295, rel=1e-3)
+
+    assert res.clipped.shape == (1000,)
 
     assert res.y.shape == (20,)
 
@@ -2052,7 +2054,7 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
     res = getfunc(recalc=False)
 
     uvals = res.modelvals
-    assert uvals.shape == (1000, 4)
+    assert uvals.shape == (1000, 3)
 
     std1 = np.std(uvals[:, 1])
     std2 = np.log10(np.std(uvals[:, 2]))
@@ -2104,7 +2106,7 @@ def test_pha1_plot_foo_flux_soft(plotfunc, getfunc, clean_astro_ui, basic_pha1):
 
     # check we have clip information and assume at least one bin is
     # clipped (expect ~ 40 of 200 from testing this)
-    clip = res.modelvals[:, 3]
+    clip = res.clipped
     c0 = clip == 0
     c1 = clip == 1
     assert (c0 | c1).all()
@@ -2146,7 +2148,7 @@ def test_pha1_plot_foo_flux_none(plotfunc, getfunc, clean_astro_ui, basic_pha1):
     validate_flux_histogram(res)
 
     # check we have clip information but that it's all zeros
-    clip = res.modelvals[:, 3]
+    clip = res.clipped
     c0 = clip == 0
     c1 = clip == 1
     assert (c0 | c1).all()
@@ -2178,7 +2180,7 @@ def test_pha1_get_foo_flux_soft(getfunc, clean_astro_ui, basic_pha1):
 
     # check we have clip information and assume at least one bin is
     # clipped (expect ~ 40 of 200 from testing this)
-    clip = res.modelvals[:, 3]
+    clip = res.clipped
     c0 = clip == 0
     c1 = clip == 1
     assert (c0 | c1).all()
@@ -2211,7 +2213,7 @@ def test_pha1_get_foo_flux_none(getfunc, clean_astro_ui, basic_pha1):
     validate_flux_histogram(res)
 
     # check we have clip information and all are 0
-    clip = res.modelvals[:, 3]
+    clip = res.clipped
     c0 = clip == 0
     c1 = clip == 1
     assert (c0 | c1).all()
@@ -2277,9 +2279,9 @@ def test_pha1_plot_foo_flux_multi(plotfunc, getfunc,
     assert res.y.shape == (20,)
     cvals = res.modelvals.copy()
 
-    assert avals.shape == (n, 3)
-    assert bvals.shape == (n, 3)
-    assert cvals.shape == (n, 3)
+    assert avals.shape == (n, 2)
+    assert bvals.shape == (n, 2)
+    assert cvals.shape == (n, 2)
 
     # Let's just check the standard deviation of the gamma parameter,
     # which should be similar for avals and bvals, and larger for cvals.
@@ -2332,12 +2334,14 @@ def test_pha1_get_foo_flux_hist_model(getfunc, ratio,
     res = getfunc(lo=0.5, hi=2, num=1000, bins=19, correlated=False)
 
     avals = res.modelvals
-    assert avals.shape == (1000, 4)
+    assert avals.shape == (1000, 3)
 
     std1 = np.std(avals[:, 1])
     std2 = np.log10(np.std(avals[:, 2]))
     assert std1 == pytest.approx(0.13478302893162564, rel=1e-3)
     assert std2 == pytest.approx(-4.518960679037794, rel=1e-3)
+
+    assert res.clipped.shape == (1000,)
 
     assert res.y.shape == (20,)
 
@@ -2348,7 +2352,7 @@ def test_pha1_get_foo_flux_hist_model(getfunc, ratio,
                   correlated=False)
 
     uvals = res.modelvals
-    assert uvals.shape == (1000, 4)
+    assert uvals.shape == (1000, 3)
 
     std1 = np.std(uvals[:, 1])
     std2 = np.log10(np.std(uvals[:, 2]))

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1764,6 +1764,13 @@ def test_pha1_plot_foo_flux(plotfunc, getfunc, correlated, clean_astro_ui, basic
     # Ensure near the minimum
     ui.fit()
 
+    # At this point the return should be None
+    res = getfunc(recalc=False)
+    assert isinstance(res, FluxHistogram)
+    assert res.flux is None
+    assert res.xlo is None
+    assert res.y is None
+
     # Since the results are not being inspected here, the "quality"
     # of the results isn't important, so we can use a relatively-low
     # number of iterations.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11126,25 +11126,34 @@ class Session(sherpa.ui.utils.Session):
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
                                   correlated, numcores, bkg_id,
-                                  scales=None, model=None, otherids=()):
+                                  scales=None, model=None, otherids=(),
+                                  clip='hard'):
+        """Run sample_energy_flux and convert to a plot.
+        """
         dist = self.sample_energy_flux(lo, hi, id=id, otherids=otherids,
                                        num=num, scales=scales, model=model,
-                                       correlated=correlated, numcores=numcores, bkg_id=bkg_id)
+                                       correlated=correlated, numcores=numcores,
+                                       bkg_id=bkg_id, clip=clip)
         plot.prepare(dist, bins)
         return plot
 
     def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins,
                                   correlated, numcores, bkg_id,
-                                  scales=None, model=None, otherids=()):
+                                  scales=None, model=None, otherids=(),
+                                  clip='hard'):
+        """Run sample_photon_flux and convert to a plot.
+        """
         dist = self.sample_photon_flux(lo, hi, id=id, otherids=otherids,
                                        num=num, scales=scales, model=model,
-                                       correlated=correlated, numcores=numcores, bkg_id=bkg_id)
+                                       correlated=correlated, numcores=numcores,
+                                       bkg_id=bkg_id, clip=clip)
         plot.prepare(dist, bins)
         return plot
 
     def get_energy_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
-                             scales=None, model=None, otherids=(), recalc=True):
+                             scales=None, model=None, otherids=(), recalc=True,
+                             clip='hard'):
         """Return the data displayed by plot_energy_flux.
 
         The get_energy_flux_hist() function calculates a histogram of
@@ -11154,7 +11163,8 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model and otherids parameters have been added.
+           model and otherids parameters have been added. The clip
+           argument has been added.
 
         Parameters
         ----------
@@ -11212,6 +11222,12 @@ class Session(sherpa.ui.utils.Session):
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
            run.
+        clip : {'hard', 'soft', 'none'}, optional
+            What clipping strategy should be applied to the sampled
+            parameters. The default ('hard') is to fix values at their
+            hard limits if they exceed them. A value of 'soft' uses
+            the soft limits instead, and 'none' applies no
+            clipping.
 
         Returns
         -------
@@ -11266,13 +11282,14 @@ class Session(sherpa.ui.utils.Session):
             self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
-                                           otherids=otherids,
+                                           otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
         return self._energyfluxplot
 
     def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
-                             scales=None, model=None, otherids=(), recalc=True):
+                             scales=None, model=None, otherids=(), recalc=True,
+                             clip='hard'):
         """Return the data displayed by plot_photon_flux.
 
         The get_photon_flux_hist() function calculates a histogram of
@@ -11340,6 +11357,12 @@ class Session(sherpa.ui.utils.Session):
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
            run.
+        clip : {'hard', 'soft', 'none'}, optional
+            What clipping strategy should be applied to the sampled
+            parameters. The default ('hard') is to fix values at their
+            hard limits if they exceed them. A value of 'soft' uses
+            the soft limits instead, and 'none' applies no
+            clipping.
 
         Returns
         -------
@@ -11394,7 +11417,7 @@ class Session(sherpa.ui.utils.Session):
             self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
-                                           otherids=otherids,
+                                           otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
         return self._photonfluxplot
 
@@ -12139,7 +12162,8 @@ class Session(sherpa.ui.utils.Session):
     def plot_energy_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
                          scales=None, model=None, otherids=(),
-                         recalc=True, overplot=False, clearwindow=True,
+                         recalc=True, clip='hard',
+                         overplot=False, clearwindow=True,
                          **kwargs):
         """Display the energy flux distribution.
 
@@ -12153,7 +12177,8 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model and otherids parameters have been added.
+           model and otherids parameters have been added. The clip
+           argument has been added.
 
         Parameters
         ----------
@@ -12211,6 +12236,12 @@ class Session(sherpa.ui.utils.Session):
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
            run.
+        clip : {'hard', 'soft', 'none'}, optional
+            What clipping strategy should be applied to the sampled
+            parameters. The default ('hard') is to fix values at their
+            hard limits if they exceed them. A value of 'soft' uses
+            the soft limits instead, and 'none' applies no
+            clipping.
         overplot : bool, optional
            If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
@@ -12279,14 +12310,15 @@ class Session(sherpa.ui.utils.Session):
         efplot = self.get_energy_flux_hist(lo=lo, hi=hi, id=id, num=num, bins=bins,
                                            correlated=correlated, numcores=numcores,
                                            bkg_id=bkg_id, scales=scales, model=model,
-                                           otherids=otherids, recalc=recalc)
+                                           otherids=otherids, clip=clip, recalc=recalc)
         self._plot(efplot, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
     def plot_photon_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
                          correlated=False, numcores=None, bkg_id=None,
                          scales=None, model=None, otherids=(),
-                         recalc=True, overplot=False, clearwindow=True,
+                         recalc=True, clip='hard',
+                         overplot=False, clearwindow=True,
                          **kwargs):
         """Display the photon flux distribution.
 
@@ -12300,7 +12332,8 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
-           model and otherids parameters have been added.
+           model and otherids parameters have been added. The clip
+           argument has been added.
 
         Parameters
         ----------
@@ -12358,6 +12391,12 @@ class Session(sherpa.ui.utils.Session):
            If ``True``, the default, then re-calculate the values rather
            than use the values from the last time the function was
            run.
+        clip : {'hard', 'soft', 'none'}, optional
+            What clipping strategy should be applied to the sampled
+            parameters. The default ('hard') is to fix values at their
+            hard limits if they exceed them. A value of 'soft' uses
+            the soft limits instead, and 'none' applies no
+            clipping.
         overplot : bool, optional
            If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
@@ -12426,7 +12465,7 @@ class Session(sherpa.ui.utils.Session):
         pfplot = self.get_photon_flux_hist(lo=lo, hi=hi, id=id, num=num, bins=bins,
                                            correlated=correlated, numcores=numcores,
                                            bkg_id=bkg_id, scales=scales, model=model,
-                                           otherids=otherids, recalc=recalc)
+                                           otherids=otherids, clip=clip, recalc=recalc)
         self._plot(pfplot, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
@@ -12801,7 +12840,7 @@ class Session(sherpa.ui.utils.Session):
     def sample_photon_flux(self, lo=None, hi=None, id=None, num=1,
                            scales=None, correlated=False,
                            numcores=None, bkg_id=None, model=None,
-                           otherids=()):
+                           otherids=(), clip='hard'):
         """Return the photon flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12811,7 +12850,8 @@ class Session(sherpa.ui.utils.Session):
         The units for the flux are as returned by `calc_photon_flux`.
 
         .. versionchanged:: 4.12.2
-           The model and otherids parameters were added.
+           The model, otherids, and clip parameters were added and
+           the return value has an extra column.
 
         Parameters
         ----------
@@ -12863,17 +12903,26 @@ class Session(sherpa.ui.utils.Session):
         otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
            calculating the errors to draw values from.
+        clip : {'hard', 'soft', 'none'}, optional
+            What clipping strategy should be applied to the sampled
+            parameters. The default ('hard') is to fix values at their
+            hard limits if they exceed them. A value of 'soft' uses
+            the soft limits instead, and 'none' applies no
+            clipping. The last column in the returned arrays indicates
+            if the row had any clipped parameters (even when clip is
+            set to 'none').
 
         Returns
         -------
         vals
-           The return array has the shape ``(num, N+1)``, where ``N``
+           The return array has the shape ``(num, N+2)``, where ``N``
            is the number of free parameters in the fit and num is the
            `num` parameter.  The rows of this array contain the flux
            value, as calculated by `calc_photon_flux`, followed by the
-           values of the thawed parameters used for that
-           iteration. The order of the parameters matches the data
-           returned by `get_fit_results`.
+           values of the thawed parameters used for that iteration,
+           and then a flag column indicating if the parameters were
+           clipped (1) or not (0).  The order of the parameters
+           matches the data returned by `get_fit_results`.
 
         See Also
         --------
@@ -12983,6 +13032,22 @@ class Session(sherpa.ui.utils.Session):
         >>> vals = sample_photon_flux(0.5, 10, id=1, otherids=[2],
         ...                           model=clus, num=10000)
 
+        Generate two sets of parameter values, where the parameter
+        values in v1 are generated from a random distribution and then
+        clipped to the hard limits of the parameters, and the values
+        in v2 use the soft limits of the parameters. The last column
+        in both v1 and v2 indicates whether the row had any clipped
+        parameters. The flux1_filt and flux2_filt arrays indicate the
+        photon-flux distribution after it has been filtered to remove
+        any row with clipped parameters:
+
+        >>> v1 = sample_photon_flux(0.5, 2, num=1000)
+        >>> v2 = sample_photon_flux(0.5, 2, num=1000, clip='soft')
+        >>> flux1 = v1[:, 0]
+        >>> flux2 = v2[:, 0]
+        >>> flux1_filt = flux1[v1[:, -1] == 0]
+        >>> flux2_filt = flux2[v2[:, -1] == 0]
+
         """
         ids, fit = self._get_fit(id, otherids=otherids)
 
@@ -13002,12 +13067,12 @@ class Session(sherpa.ui.utils.Session):
                                              correlated=correlated,
                                              num=num, lo=lo, hi=hi,
                                              numcores=numcores,
-                                             samples=scales)
+                                             samples=scales, clip=clip)
 
     def sample_energy_flux(self, lo=None, hi=None, id=None, num=1,
                            scales=None, correlated=False,
                            numcores=None, bkg_id=None, model=None,
-                           otherids=()):
+                           otherids=(), clip='hard'):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -13017,7 +13082,8 @@ class Session(sherpa.ui.utils.Session):
         The units for the flux are as returned by `calc_energy_flux`.
 
         .. versionchanged:: 4.12.2
-           The model and otherids parameters were added.
+           The model, otherids, and clip parameters were added and
+           the return value has an extra column.
 
         Parameters
         ----------
@@ -13069,17 +13135,26 @@ class Session(sherpa.ui.utils.Session):
         otherids : sequence of integer and string ids, optional
            The list of other datasets that should be included when
            calculating the errors to draw values from.
+        clip : {'hard', 'soft', 'none'}, optional
+            What clipping strategy should be applied to the sampled
+            parameters. The default ('hard') is to fix values at their
+            hard limits if they exceed them. A value of 'soft' uses
+            the soft limits instead, and 'none' applies no
+            clipping. The last column in the returned arrays indicates
+            if the row had any clipped parameters (even when clip is
+            set to 'none').
 
         Returns
         -------
         vals
-           The return array has the shape ``(num, N+1)``, where ``N``
+           The return array has the shape ``(num, N+2)``, where ``N``
            is the number of free parameters in the fit and num is the
            `num` parameter.  The rows of this array contain the flux
            value, as calculated by `calc_energy_flux`, followed by the
-           values of the thawed parameters used for that
-           iteration. The order of the parameters matches the data
-           returned by `get_fit_results`.
+           values of the thawed parameters used for that iteration,
+           and then a flag column indicating if the parameters were
+           clipped (1) or not (0).  The order of the parameters
+           matches the data returned by `get_fit_results`.
 
         See Also
         --------
@@ -13189,6 +13264,21 @@ class Session(sherpa.ui.utils.Session):
         >>> vals = sample_energy_flux(0.5, 10, id=1, otherids=[2],
         ...                           model=clus, num=10000)
 
+        Generate two sets of parameter values, where the parameter
+        values in v1 are generated from a random distribution and then
+        clipped to the hard limits of the parameters, and the values
+        in v2 use the soft limits of the parameters. The last column
+        in both v1 and v2 indicates whether the row had any clipped
+        parameters. The flux1_filt and flux2_filt arrays indicate the
+        energy-flux distribution after it has been filtered to remove
+        any row with clipped parameters:
+
+        >>> v1 = sample_energy_flux(0.5, 2, num=1000)
+        >>> v2 = sample_energy_flux(0.5, 2, num=1000, clip='soft')
+        >>> flux1 = v1[:, 0]
+        >>> flux2 = v2[:, 0]
+        >>> flux1_filt = flux1[v1[:, -1] == 0]
+        >>> flux2_filt = flux2[v2[:, -1] == 0]
 
         """
         ids, fit = self._get_fit(id, otherids=otherids)
@@ -13209,7 +13299,7 @@ class Session(sherpa.ui.utils.Session):
                                              correlated=correlated,
                                              num=num, lo=lo, hi=hi,
                                              numcores=numcores,
-                                             samples=scales)
+                                             samples=scales, clip=clip)
 
 
     # DOC-NOTE: are scales the variance or standard deviation?

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -517,7 +517,7 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
             This defines the thawed parameters that are used to generate
             the samples, along with any possible error analysis.
         dof : int
-            The degrees of freedon of the distribution.
+            The degrees of freedom of the distribution.
         num : int, optional
             The number of samples to return.
 
@@ -727,7 +727,7 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
         num : int, optional
             The number of samples to return.
         dof : int
-            The degrees of freedon of the distribution.
+            The degrees of freedom of the distribution.
         numcores : int or None, optional
             Should the calculation be done on multiple CPUs?
             The default (None) is to rely on the parallel.numcores


### PR DESCRIPTION
# Summary

The addition of the clip parameter lets users control how parameter values are clipped before use in  sample_energy_flux, sample_photon_flux, plot_energy_flux, plot_photon_flux, get_energy_flux_hist, and get_photon_flux_hist.


# Details

At present only sherpa.astro.flux.sample_flux supports the `clip` parameter. The sherpa.astro.flux.calc_sample_flux is waiting on #754 before it is worth updating (this means that we can not add a clip parameter to sample_flux yet).