### PR TITLE
Add delete_pileup_model (fix #441), list_pileup_model_ids, list_psf_ids functions, fix list_models (fix #749)

### DIFF
--- a/sherpa/astro/datastack/__init__.py
+++ b/sherpa/astro/datastack/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010,2014,2015 Smithsonian Astrophysical Observatory
+# Copyright (c) 2010, 2014, 2015, 2020 Smithsonian Astrophysical Observatory
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -218,14 +218,14 @@ __all__ = ['set_template_id', 'DataStack']
 
 import sys
 import types
+import logging
+
 from sherpa.astro import ui
 from sherpa.utils.logging import config_logger
 from sherpa.utils import public
 from sherpa.astro.datastack.ds import DataStack
-import logging
-from . import plot_backend as backend
-from .utils import model_wrapper, set_template_id, load_wrapper,\
-    load_error_msg, simple_wrapper, fit_wrapper, plot_wrapper
+
+from .utils import set_template_id
 
 logger = config_logger(__name__)
 

--- a/sherpa/astro/datastack/plot_backend/__init__.py
+++ b/sherpa/astro/datastack/plot_backend/__init__.py
@@ -18,8 +18,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.plot import plotter
 from importlib import import_module
+
+from sherpa.plot import plotter
 from sherpa.utils.logging import config_logger
 
 logger = config_logger(__name__)

--- a/sherpa/astro/datastack/utils.py
+++ b/sherpa/astro/datastack/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015, 2016  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -16,10 +16,12 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+import re
+
 from sherpa.utils import public
 from sherpa.utils.logging import config_logger
 import sherpa
-import re
 
 from . import plot_backend as backend
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -209,16 +209,20 @@ def test_image_12578_set_coord_bad_coord(make_data_path, clean_astro_ui):
     assert okmsg in str(exc.value)
 
 
-@unittest.skip("TODO: failing test used to have a different name and " +
-               "was never executed")
-@pytest.mark.parametrize("model", ['beta1d', 'lorentz1d', 'normbeta1d'])
-def test_psf_model1d(model, clean_astro_ui):
+# DJB notes (2020/02/29) that these tests used to not be run,
+# because the lorentz1d model retrned 1 rather than 4. This
+# has now been included in the test so that we can check
+# the behavior if the PSF centering code is ever changed.
+#
+@pytest.mark.parametrize("model,center", [('beta1d', 4.0),
+                                          ('lorentz1d', 1.0),
+                                          ('normbeta1d', 4.0)])
+def test_psf_model1d(model, center, clean_astro_ui):
     ui.dataspace1d(1, 10)
     ui.load_psf('psf1d', model + '.mdl')
     ui.set_psf('psf1d')
     mdl = ui.get_model_component('mdl')
-    assert (numpy.array(mdl.get_center()) ==
-            numpy.array([4])).all()
+    assert mdl.get_center() == (center, )
 
 
 @pytest.mark.parametrize("model", ['beta2d', 'devaucouleurs2d', 'hubblereynolds', 'lorentz2d'])

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -18,541 +18,472 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from collections import namedtuple
 import os
 import re
 import unittest
 import tempfile
+import logging
 
 import pytest
 
 import numpy
 from numpy.testing import assert_allclose
 
-from sherpa.utils.testing import SherpaTestCase, requires_data, \
-    requires_fits, requires_group, requires_xspec
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group
+from sherpa.utils.err import DataErr, IdentifierErr, StatErr
 from sherpa.astro import ui
+from sherpa.astro.instrument import RMFModelPHA
 from sherpa.data import Data1D
 from sherpa.astro.data import DataPHA
 
-import logging
 logger = logging.getLogger("sherpa")
 
 
+@pytest.fixture(autouse=True)
+def hide_logging():
+    "hide INFO-level logging in all these tests"
+
+    olevel = logger.getEffectiveLevel()
+    logger.setLevel(logging.ERROR)
+    yield
+    logger.setLevel(olevel)
+
+
+def identity(x):
+    return x
+
+
+@pytest.fixture
+def setup_files(make_data_path):
+
+    out = namedtuple('store1', ['ascii', 'fits', 'img'
+                                'singledat', 'singletbl',
+                                'doubledat', 'doubletbl',
+                                'filter_single_int_ascii',
+                                'filter_single_int_table',
+                                'filter_single_log_table'])
+
+    out.ascii = make_data_path('sim.poisson.1.dat')
+    out.fits = make_data_path('1838_rprofile_rmid.fits')
+    out.singledat = make_data_path('single.dat')
+    out.singletbl = make_data_path('single.fits')
+    out.doubledat = make_data_path('double.dat')
+    out.doubletbl = make_data_path('double.fits')
+    out.img = make_data_path('img.fits')
+    out.filter_single_int_ascii = make_data_path(
+        'filter_single_integer.dat')
+    out.filter_single_int_table = make_data_path(
+        'filter_single_integer.fits')
+    out.filter_single_log_table = make_data_path(
+        'filter_single_logical.fits')
+
+    ui.dataspace1d(1, 1000, dstype=ui.Data1D)
+
+    return out
+
+
 @requires_fits
 @requires_data
-class test_ui(SherpaTestCase):
-
-    def setUp(self):
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-
-        self.ascii = self.make_path('sim.poisson.1.dat')
-        self.fits = self.make_path('1838_rprofile_rmid.fits')
-        self.singledat = self.make_path('single.dat')
-        self.singletbl = self.make_path('single.fits')
-        self.doubledat = self.make_path('double.dat')
-        self.doubletbl = self.make_path('double.fits')
-        self.img = self.make_path('img.fits')
-        self.filter_single_int_ascii = self.make_path(
-            'filter_single_integer.dat')
-        self.filter_single_int_table = self.make_path(
-            'filter_single_integer.fits')
-        self.filter_single_log_table = self.make_path(
-            'filter_single_logical.fits')
-
-        self.func = lambda x: x
-        ui.dataspace1d(1, 1000, dstype=ui.Data1D)
-
-    def tearDown(self):
-        if hasattr(self, '_old_logger_level'):
-            logger.setLevel(self._old_logger_level)
-
-    def test_ascii(self):
-        ui.load_ascii(1, self.ascii)
-        ui.load_ascii(1, self.ascii, 2)
-        ui.load_ascii(1, self.ascii, 2, ("col2", "col1"))
-
-    def test_table(self):
-        ui.load_table(1, self.fits)
-        ui.load_table(1, self.fits, 3)
-        ui.load_table(1, self.fits, 3, ["RMID", "SUR_BRI", "SUR_BRI_ERR"])
-        ui.load_table(1, self.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
-                      ui.Data1DInt)
-
-    # Test table model
-    def test_table_model_ascii_table(self):
-        ui.load_table_model('tbl', self.singledat)
-        ui.load_table_model('tbl', self.doubledat)
-
-    def test_table_model_fits_table(self):
-        ui.load_table_model('tbl', self.singletbl)
-        ui.load_table_model('tbl', self.doubletbl)
-
-    def test_table_model_fits_image(self):
-        ui.load_table_model('tbl', self.img)
-
-    # Test user model
-    def test_user_model_ascii_table(self):
-        ui.load_user_model(self.func, 'mdl', self.singledat)
-        ui.load_user_model(self.func, 'mdl', self.doubledat)
-
-    def test_user_model_fits_table(self):
-        ui.load_user_model(self.func, 'mdl', self.singletbl)
-        ui.load_user_model(self.func, 'mdl', self.doubletbl)
-
-    def test_filter_ascii(self):
-        ui.load_filter(self.filter_single_int_ascii)
-        ui.load_filter(self.filter_single_int_ascii, ignore=True)
-
-    # Test load_filter
-    def test_filter_table(self):
-        ui.load_filter(self.filter_single_int_table)
-        ui.load_filter(self.filter_single_int_table, ignore=True)
-
-        ui.load_filter(self.filter_single_log_table)
-        ui.load_filter(self.filter_single_log_table, ignore=True)
+def test_ui_ascii(setup_files):
+    ui.load_ascii(1, setup_files.ascii)
+    ui.load_ascii(1, setup_files.ascii, 2)
+    ui.load_ascii(1, setup_files.ascii, 2, ("col2", "col1"))
 
 
+@requires_fits
+@requires_data
+def test_ui_table(setup_files):
+    ui.load_table(1, setup_files.fits)
+    ui.load_table(1, setup_files.fits, 3)
+    ui.load_table(1, setup_files.fits, 3, ["RMID", "SUR_BRI", "SUR_BRI_ERR"])
+    ui.load_table(1, setup_files.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
+                  ui.Data1DInt)
+
+# Test table model
+@requires_fits
+@requires_data
+def test_ui_table_model_ascii_table(setup_files):
+    ui.load_table_model('tbl', setup_files.singledat)
+    ui.load_table_model('tbl', setup_files.doubledat)
+
+
+@requires_fits
+@requires_data
+def test_ui_table_model_fits_table(setup_files):
+    ui.load_table_model('tbl', setup_files.singletbl)
+    ui.load_table_model('tbl', setup_files.doubletbl)
+
+
+@requires_fits
+@requires_data
+def test_ui_table_model_fits_image(setup_files):
+    ui.load_table_model('tbl', setup_files.img)
+
+
+# Test user model
+@requires_fits
+@requires_data
+def test_ui_user_model_ascii_table(setup_files):
+    ui.load_user_model(identity, 'mdl', setup_files.singledat)
+    ui.load_user_model(identity, 'mdl', setup_files.doubledat)
+
+
+@requires_fits
+@requires_data
+def test_ui_user_model_fits_table(setup_files):
+    ui.load_user_model(identity, 'mdl', setup_files.singletbl)
+    ui.load_user_model(identity, 'mdl', setup_files.doubletbl)
+
+
+@requires_fits
+@requires_data
+def test_ui_filter_ascii(setup_files):
+    ui.load_filter(setup_files.filter_single_int_ascii)
+    ui.load_filter(setup_files.filter_single_int_ascii, ignore=True)
+
+
+# Test load_filter
+@requires_fits
+@requires_data
+def test_ui_filter_table(setup_files):
+    ui.load_filter(setup_files.filter_single_int_table)
+    ui.load_filter(setup_files.filter_single_int_table, ignore=True)
+
+    ui.load_filter(setup_files.filter_single_log_table)
+    ui.load_filter(setup_files.filter_single_log_table, ignore=True)
+
+
+# bug #12732
+@requires_fits
+@requires_data
+def test_more_ui_string_model_with_rmf(make_data_path):
+
+    ui.load_pha("foo", make_data_path('pi2286.fits'))
+    ui.load_rmf("foo", make_data_path('rmf2286.fits'))
+
+    # Check that get_rmf(id)('modelexpression') works. If it
+    # raises an error the test will fail.
+    #
+    m = ui.get_rmf("foo")("powlaw1d.pl1")
+    assert isinstance(m, RMFModelPHA)
+
+
+#bug #38
+@requires_fits
+@requires_data
+@requires_group
+def test_more_ui_bug38(make_data_path):
+    ui.load_pha('3c273', make_data_path('3c273.pi'))
+    ui.notice_id('3c273', 0.3, 2)
+    ui.group_counts('3c273', 30)
+    ui.group_counts('3c273', 15)
+
+
+# bug #12578
 @requires_data
 @requires_fits
-class test_more_ui(SherpaTestCase):
+def test_image_12578_set_coord_bad_coord(make_data_path, clean_astro_ui):
 
-    def setUp(self):
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-        self.img = self.make_path('img.fits')
-        self.pha = self.make_path('pi2286.fits')
-        self.rmf = self.make_path('rmf2286.fits')
-        self.pha3c273 = self.make_path('3c273.pi')
+    img = make_data_path('img.fits')
 
-    def tearDown(self):
-        if hasattr(self, "_old_logger_level"):
-            logger.setLevel(self._old_logger_level)
+    # Test Case #1: if the list of ids is empty, raise
+    # IdentifierErr['nodatasets']
+    #
+    with pytest.raises(IdentifierErr):
+        ui.set_coord('image')
 
-    # bug #12732
-    def test_string_model_with_rmf(self):
-        ui.load_pha("foo", self.pha)
-        ui.load_rmf("foo", self.rmf)
-        # Check that get_rmf(id)('modelexpression') works
-        caught = False
-        try:
-            m = ui.get_rmf("foo")("powlaw1d.pl1")
-        except:
-            caught = True
-        if caught:
-            self.fail("Exception caught when it shouldn't")
-        from sherpa.astro.instrument import RMFModelPHA
-        self.assertTrue(isinstance(m, RMFModelPHA))
+    # Test Case #2: check the user expected behavior. The call
+    # set_coord("sky") will result in the error message
+    # DataErr: unknown coordinates: 'sky'\n \
+    # Valid coordinates: logical, image, physical, world, wcs
+    #
+    ui.load_image(img)
 
-    #bug #38
-    @requires_group
-    def test_bug38(self):
-        ui.load_pha('3c273', self.pha3c273)
-        ui.notice_id('3c273', 0.3, 2)
-        ui.group_counts('3c273', 30)
-        ui.group_counts('3c273', 15)
+    with pytest.raises(DataErr) as exc:
+        ui.set_coord("sky")
+
+    okmsg = "unknown coordinates: 'sky'\nValid options: " + \
+            "logical, image, physical, world, wcs"
+    assert okmsg in str(exc.value)
 
 
-@requires_data
-@requires_fits
-class test_image_12578(SherpaTestCase):
-    def setUp(self):
-        self.img = self.make_path('img.fits')
-        self.loggingLevel = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-        ui.clean()
-
-    def tearDown(self):
-        if hasattr(self, 'loggingLevel'):
-            logger.setLevel(self.loggingLevel)
-
-    # bug #12578
-    def test_set_coord_bad_coord(self):
-        from sherpa.utils.err import IdentifierErr, DataErr
-
-        # Test Case #1: if the list of ids is empty, raise
-        # IdentifierErr['nodatasets']
-        caught = False
-        try:
-            ui.set_coord('image')
-        except IdentifierErr:
-            caught = True
-        if not caught:
-            self.fail("Test Case #1: IdentifierErr Exception not caught")
-
-        # Test Case #2: check the user expected behavior. The call
-        # set_coord("sky") will result in the error message
-        # DataErr: unknown coordinates: 'sky'\n \
-        # Valid coordinates: logical, image, physical, world, wcs
-        ui.load_image(self.img)
-
-        caught = False
-        try:
-            ui.set_coord("sky")
-        except DataErr as e:
-            okmsg = "unknown coordinates: 'sky'\nValid options: " + \
-                    "logical, image, physical, world, wcs"
-            self.assertEqual(okmsg, str(e))
-            caught = True
-        if not caught:
-            self.fail("Test Case #2: DataErr Exception not caught")
+@unittest.skip("TODO: failing test used to have a different name and " +
+               "was never executed")
+@pytest.mark.parametrize("model", ['beta1d', 'lorentz1d', 'normbeta1d'])
+def test_psf_model1d(model, clean_astro_ui):
+    ui.dataspace1d(1, 10)
+    ui.load_psf('psf1d', model + '.mdl')
+    ui.set_psf('psf1d')
+    mdl = ui.get_model_component('mdl')
+    assert (numpy.array(mdl.get_center()) ==
+            numpy.array([4])).all()
 
 
-class test_psf_ui(SherpaTestCase):
+@pytest.mark.parametrize("model", ['beta2d', 'devaucouleurs2d', 'hubblereynolds', 'lorentz2d'])
+def test_psf_model2d(model, clean_astro_ui):
+    ui.dataspace2d([216, 261])
+    ui.load_psf('psf2d', model + '.mdl')
+    ui.set_psf('psf2d')
+    mdl = ui.get_model_component('mdl')
+    assert (numpy.array(mdl.get_center()) ==
+            numpy.array([108, 130])).all()
 
-    models1d = ['beta1d', 'lorentz1d', 'normbeta1d']
-    models2d = ['beta2d', 'devaucouleurs2d', 'hubblereynolds', 'lorentz2d']
 
-    def setUp(self):
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-
-    def tearDown(self):
-        if hasattr(self, "_old_logger_level"):
-            logger.setLevel(self._old_logger_level)
-
-    @unittest.skip("TODO: failing test used to have a different name and " +
-                   "was never executed")
-    def test_psf_model1d(self):
-        ui.dataspace1d(1, 10)
-        for model in self.models1d:
-            try:
-                ui.load_psf('psf1d', model + '.mdl')
-                ui.set_psf('psf1d')
-                mdl = ui.get_model_component('mdl')
-                self.assertTrue((numpy.array(mdl.get_center()) ==
-                                 numpy.array([4])).all())
-            except:
-                print(model)
-                raise
-
-    def test_psf_model2d(self):
-        ui.dataspace2d([216, 261])
-        for model in self.models2d:
-            try:
-                ui.load_psf('psf2d', model + '.mdl')
-                ui.set_psf('psf2d')
-                mdl = ui.get_model_component('mdl')
-                self.assertTrue((numpy.array(mdl.get_center()) ==
-                                 numpy.array([108, 130])).all())
-            except:
-                print(model)
-                raise
-
-    # bug #12503
-    def test_psf_pars_are_frozen(self):
-        ui.create_model_component("beta2d", "p1")
-        p1 = ui.get_model_component("p1")
-        ui.load_psf('psf', p1)
-        self.assertEqual([], p1.thawedpars)
+def test_psf_pars_are_frozen(clean_astro_ui):
+    "bug #12503"
+    ui.create_model_component("beta2d", "p1")
+    p1 = ui.get_model_component("p1")
+    ui.load_psf('psf', p1)
+    assert p1.thawedpars == []
 
 
 @requires_data
 @requires_fits
-class test_stats_ui(SherpaTestCase):
-    def setUp(self):
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-        self.data = self.make_path('3c273.pi')
-        ui.clean()
+def test_chi2(make_data_path, clean_astro_ui):
+    "bugs #11400, #13297, #12365"
 
-    def tearDown(self):
-        if hasattr(self, "_old_logger_level"):
-            logger.setLevel(self._old_logger_level)
+    data = make_data_path('3c273.pi')
 
-    # bugs #11400, #13297, #12365
-    def test_chi2(self):
+    # Case 1: first ds has no error, second has, chi2-derived (chi2gehrels)
+    # statistic. I expect stat.name to be chi2gehrels for ds1, chi2 for
+    # ds2, chi2gehrels for ds1,2
+    ui.load_data(1, data)
+    ui.load_data(2, data, use_errors=True)
 
-        # Case 1: first ds has no error, second has, chi2-derived (chi2gehrels)
-        # statistic. I expect stat.name to be chi2gehrels for ds1, chi2 for
-        # ds2, chi2gehrels for ds1,2
-        ui.load_data(1, self.data)
-        ui.load_data(2, self.data, use_errors=True)
+    ui.set_source(1, "gauss1d.g1")
+    ui.set_source(2, "gauss1d.g1")
 
-        ui.set_source(1, "gauss1d.g1")
-        ui.set_source(2, "gauss1d.g1")
+    ui.set_stat("chi2gehrels")
 
-        ui.set_stat("chi2gehrels")
+    si = ui.get_stat_info()
 
-        si = ui.get_stat_info()
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
+    assert stat1 == 'chi2gehrels'
+    assert stat2 == 'chi2'
+    assert stat12 == 'chi2gehrels'
 
-        self.assertEqual('chi2gehrels', stat1)
-        self.assertEqual('chi2', stat2)
-        self.assertEqual('chi2gehrels', stat12)
+    # Case 2: first ds has errors, second has not, chi2-derived
+    # (chi2gehrels) statistic. I expect stat.name to be chi2 for ds1,
+    # chi2gehrels for ds2, chi2gehrels for ds1,2
+    ui.load_data(2, data)
+    ui.load_data(1, data, use_errors=True)
 
-        # Case 2: first ds has errors, second has not, chi2-derived
-        # (chi2gehrels) statistic. I expect stat.name to be chi2 for ds1,
-        # chi2gehrels for ds2, chi2gehrels for ds1,2
-        ui.load_data(2, self.data)
-        ui.load_data(1, self.data, use_errors=True)
+    si = ui.get_stat_info()
 
-        si = ui.get_stat_info()
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
+    assert stat1 == 'chi2'
+    assert stat2 == 'chi2gehrels'
+    assert stat12 == 'chi2gehrels'
 
-        self.assertEqual('chi2gehrels', stat2)
-        self.assertEqual('chi2', stat1)
-        self.assertEqual('chi2gehrels', stat12)
+    # Case 3: both datasets have errors, chi2-derived (chi2gehrels)
+    # statistic. I expect stat.name to be chi2 for all of them.
+    ui.load_data(2, data, use_errors=True)
+    ui.load_data(1, data, use_errors=True)
 
-        # Case 3: both datasets have errors, chi2-derived (chi2gehrels)
-        # statistic. I expect stat.name to be chi2 for all of them.
-        ui.load_data(2, self.data, use_errors=True)
-        ui.load_data(1, self.data, use_errors=True)
+    si = ui.get_stat_info()
 
-        si = ui.get_stat_info()
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
+    assert stat1 == 'chi2'
+    assert stat2 == 'chi2'
+    assert stat12 == 'chi2'
 
-        self.assertEqual('chi2', stat2)
-        self.assertEqual('chi2', stat1)
-        self.assertEqual('chi2', stat12)
+    # Case 4: first ds has errors, second has not, LeastSq statistic
+    # I expect stat.name to be leastsq for all of them.
+    ui.load_data(2, data)
+    ui.load_data(1, data, use_errors=True)
 
-        # Case 4: first ds has errors, second has not, LeastSq statistic
-        # I expect stat.name to be leastsq for all of them.
-        ui.load_data(2, self.data)
-        ui.load_data(1, self.data, use_errors=True)
+    ui.set_stat("leastsq")
 
-        ui.set_stat("leastsq")
+    si = ui.get_stat_info()
 
-        si = ui.get_stat_info()
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
+    assert stat1 == 'leastsq'
+    assert stat2 == 'leastsq'
+    assert stat12 == 'leastsq'
 
-        self.assertEqual('leastsq', stat2)
-        self.assertEqual('leastsq', stat1)
-        self.assertEqual('leastsq', stat12)
+    # Case 5: both ds have errors, LeastSq statistic
+    # I expect stat.name to be leastsq for all of them.
+    ui.load_data(2, data, use_errors=True)
+    ui.load_data(1, data, use_errors=True)
 
-        # Case 5: both ds have errors, LeastSq statistic
-        # I expect stat.name to be leastsq for all of them.
-        ui.load_data(2, self.data, use_errors=True)
-        ui.load_data(1, self.data, use_errors=True)
+    ui.set_stat("leastsq")
 
-        ui.set_stat("leastsq")
+    si = ui.get_stat_info()
 
-        si = ui.get_stat_info()
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
+    assert stat1 == 'leastsq'
+    assert stat2 == 'leastsq'
+    assert stat12 == 'leastsq'
 
-        self.assertEqual('leastsq', stat2)
-        self.assertEqual('leastsq', stat1)
-        self.assertEqual('leastsq', stat12)
+    # Case 6: first ds has errors, second has not, CStat statistic
+    # I expect stat.name to be cstat for all of them.
+    ui.load_data(2, data)
+    ui.load_data(1, data, use_errors=True)
 
-        # Case 6: first ds has errors, second has not, CStat statistic
-        # I expect stat.name to be cstat for all of them.
-        ui.load_data(2, self.data)
-        ui.load_data(1, self.data, use_errors=True)
+    ui.set_stat("cstat")
 
-        ui.set_stat("cstat")
+    si = ui.get_stat_info()
 
-        si = ui.get_stat_info()
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
+    assert stat1 == 'cstat'
+    assert stat2 == 'cstat'
+    assert stat12 == 'cstat'
 
-        self.assertEqual('cstat', stat2)
-        self.assertEqual('cstat', stat1)
-        self.assertEqual('cstat', stat12)
+    # Case7: select chi2 as statistic. One of the ds does not provide
+    # errors. I expect sherpa to raise a StatErr exception.
+    ui.set_stat('chi2')
 
-        # Case7: select chi2 as statistic. One of the ds does not provide
-        # errors. I expect sherpa to raise a StatErr exception.
-        ui.set_stat('chi2')
+    with pytest.raises(StatErr):
+        ui.get_stat_info()
 
-        caught = False
+    # Case8: select chi2 as statistic. Both datasets provide errors
+    # I expect stat to be 'chi2'
+    ui.load_data(2, data, use_errors=True)
+    si = ui.get_stat_info()
 
-        from sherpa.utils.err import StatErr
-        try:
-            ui.get_stat_info()
-        except StatErr:
-            caught = True
+    stat1 = si[0].statname
+    stat2 = si[1].statname
+    stat12 = si[2].statname
 
-        self.assertTrue(caught, msg='StatErr was not caught')
-
-        # Case8: select chi2 as statistic. Both datasets provide errors
-        # I expect stat to be 'chi2'
-        ui.load_data(2, self.data, use_errors=True)
-        si = ui.get_stat_info()
-
-        stat1 = si[0].statname
-        stat2 = si[1].statname
-        stat12 = si[2].statname
-
-        self.assertEqual('chi2', stat2)
-        self.assertEqual('chi2', stat1)
-        self.assertEqual('chi2', stat12)
+    assert stat1 == 'chi2'
+    assert stat2 == 'chi2'
+    assert stat12 == 'chi2'
 
 
-@requires_fits
-class test_save_arrays_base(SherpaTestCase):
+def save_arrays(colnames, fits, read_func):
+    """Write out a small set of data using ui.save_arrays
+    and then read it back in, to check it was written out
+    correctly (or, at least, in a way that can be read back
+    in).
 
-    # _colnames:  specify column names (True) or not
-    # _fits:      use FITS format for output?
+    Parameter
+    ---------
+    colnames, fits : bool
+    read_func : function
 
-    _colnames = False
-    _fits = None
+    """
 
-    def _read_func(self, filename):
-        raise NotImplementedError
+    # It looks like the input arrays to `write_arrays` should be numpy
+    # arrays, so enforce that invariant.
+    a = numpy.asarray([1, 3, 9])
+    b = numpy.sqrt(numpy.asarray(a))
+    c = b * 0.1
 
-    def save_arrays(self):
-        """Write out a small set of data using ui.save_arrays
-        and then read it back in, to check it was written out
-        correctly (or, at least, in a way that can be read back
-        in).
-        """
+    if colnames:
+        fields = ["x", "yy", "z"]
+    else:
+        fields = None
 
-        # It looks like the input arrays to `write_arrays` should be numpy
-        # arrays, so enforce that invariant.
-        a = numpy.asarray([1, 3, 9])
-        b = numpy.sqrt(numpy.asarray(a))
-        c = b * 0.1
+    ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+    ui.save_arrays(ofh.name, [a, b, c], fields=fields,
+                   ascii=not fits, clobber=True)
 
-        if self._colnames:
-            fields = ["x", "yy", "z"]
-        else:
-            fields = None
+    out = read_func(ofh.name)
+    assert isinstance(out, Data1D)
 
-        ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
-        ui.save_arrays(ofh.name, [a, b, c], fields=fields,
-                       ascii=not self._fits, clobber=True)
+    rtol = 0
+    atol = 1e-5
 
-        out = self._read_func(ofh.name)
+    # remove potential dm syntax introduced by backend before checking for equality
+    out_name = re.sub(r"\[.*\]", "", out.name)
 
-        rtol = 0
-        atol = 1e-5
-        self.assertIsInstance(out, Data1D)
-
-        # remove potential dm syntax introduced by backend before checking for equality
-        out_name = re.sub(r"\[.*\]", "", out.name)
-
-        self.assertEqual(out_name, ofh.name, msg="file name")
-        assert_allclose(out.x, a, rtol=rtol, atol=atol, err_msg="x column")
-        assert_allclose(out.y, b, rtol=rtol, atol=atol, err_msg="y column")
-        assert_allclose(out.staterror, c, rtol=rtol, atol=atol,
-                        err_msg="staterror")
-        self.assertIsNone(out.syserror, msg="syserror")
+    assert ofh.name == out_name, 'file name'
+    assert_allclose(out.x, a, rtol=rtol, atol=atol, err_msg="x column")
+    assert_allclose(out.y, b, rtol=rtol, atol=atol, err_msg="y column")
+    assert_allclose(out.staterror, c, rtol=rtol, atol=atol,
+                    err_msg="staterror")
+    assert out.syserror is None, 'syserror'
 
 
 @requires_fits
-class test_save_arrays_nocols_FITS(test_save_arrays_base):
+@pytest.mark.parametrize("colnames", [False, True])
+def test_save_arrays_FITS(colnames):
 
-    _fits = True
-
-    def _read_func(self, filename):
+    def read_func(filename):
         return ui.unpack_table(filename, ncols=3)
 
-    def test_save_arrays(self):
-        self.save_arrays()
+    save_arrays(colnames=colnames, fits=True, read_func=read_func)
 
 
 @requires_fits
-class test_save_arrays_cols_FITS(test_save_arrays_nocols_FITS):
+@pytest.mark.parametrize("colnames", [False, True])
+def test_save_arrays_ASCII(colnames):
 
-    _colnames = True
-
-    def test_save_arrays(self):
-        self.save_arrays()
-
-
-@requires_fits
-class test_save_arrays_nocols_ASCII(test_save_arrays_base):
-
-    _fits = False
-
-    def _read_func(self, filename):
+    def read_func(filename):
         return ui.unpack_ascii(filename, ncols=3)
 
-    def test_save_arrays(self):
-        self.save_arrays()
-
-
-@requires_fits
-class test_save_arrays_cols_ASCII(test_save_arrays_nocols_ASCII):
-
-    _colnames = True
-
-    def test_save_arrays(self):
-        self.save_arrays()
+    save_arrays(colnames=colnames, fits=False, read_func=read_func)
 
 
 @requires_fits
 @requires_data
-class test_save_pha(SherpaTestCase):
-    """Write out a PHA data set as a FITS file."""
+def testWrite(make_data_path):
 
-    longMessage = True
+    fname = make_data_path('3c273.pi')
+    ui.load_pha(1, fname)
+    pha_orig = ui.get_data(1)
 
-    def setUp(self):
-        # hide warning messages from file I/O
-        self._old_logger_level = logger.level
-        logger.setLevel(logging.ERROR)
+    ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+    ui.save_pha(1, ofh.name, ascii=False, clobber=True)
 
-        self._id = 1
-        fname = self.make_path('3c273.pi')
-        ui.load_pha(self._id, fname)
-        self._pha = ui.get_data(self._id)
+    # limited checks
+    pha = ui.unpack_pha(ofh.name)
+    assert isinstance(pha, DataPHA)
 
-    def tearDown(self):
-        logger.setLevel(self._old_logger_level)
+    for key in ["channel", "counts"]:
+        newval = getattr(pha, key)
+        oldval = getattr(pha_orig, key)
+        assert_allclose(oldval, newval, err_msg=key)
 
-    def testWrite(self):
-        ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
-        ui.save_pha(self._id, ofh.name, ascii=False, clobber=True)
+    # at present grouping and quality are not written out
 
-        # limited checks
-        pha = ui.unpack_pha(ofh.name)
-        self.assertIsInstance(pha, DataPHA)
+    for key in ["exposure", "backscal", "areascal"]:
+        newval = getattr(pha, key)
+        oldval = getattr(pha_orig, key)
+        assert newval == pytest.approx(oldval), key
 
-        for key in ["channel", "counts"]:
-            newval = getattr(pha, key)
-            oldval = getattr(self._pha, key)
-            assert_allclose(oldval, newval, err_msg=key)
+    """
+    Since the original file has RMF and ARF, the units
+    are energy, but on write out these files are not
+    created/saved, so when read back in the PHA has no
+    ARF/RMF, and will have units=channel.
 
-        # at present grouping and quality are not written out
-
-        for key in ["exposure", "backscal", "areascal"]:
-            newval = getattr(pha, key)
-            oldval = getattr(self._pha, key)
-            self.assertAlmostEqual(oldval, newval, msg=key)
-
-        """
-        Since the original file has RMF and ARF, the units
-        are energy, but on write out these files are not
-        created/saved, so when read back in the PHA has no
-        ARF/RMF, and will have units=channel.
-
-        for key in ["units"]:
-            newval = getattr(pha, key)
-            oldval = getattr(self._pha, key)
-            self.assertEqual(oldval, newval, msg=key)
-        """
+    for key in ["units"]:
+        newval = getattr(pha, key)
+        oldval = getattr(self._pha, key)
+        assert newval == oldval, key
+    """
 
 
 @requires_fits
-class test_basic_io(SherpaTestCase):
-    def setUp(self):
-        ui.clean()
-
-    def test_load_table_fits(self):
-        # QUS: why is this not in the sherpa-test-data repository?
-        this_dir = os.path.dirname(os.path.abspath(__file__))
-        ui.load_table(1, os.path.join(this_dir, 'data',
-                                      'two_column_x_y.fits.gz'))
-        data = ui.get_data(1)
-        self.assertEqualWithinTol(data.x, [1, 2, 3])
-        self.assertEqualWithinTol(data.y, [4, 5, 6])
+def test_load_table_fits(clean_astro_ui):
+    # QUS: why is this not in the sherpa-test-data repository?
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    ui.load_table(1, os.path.join(this_dir, 'data',
+                                  'two_column_x_y.fits.gz'))
+    data = ui.get_data(1)
+    assert data.x == pytest.approx([1, 2, 3])
+    assert data.y == pytest.approx([4, 5, 6])
 
 
 @requires_data
@@ -568,8 +499,7 @@ def test_bug_276(make_data_path):
 
 @requires_data
 @requires_fits
-@pytest.mark.usefixtures("clean_astro_ui")
-def test_bug_316(make_data_path):
+def test_bug_316(make_data_path, clean_astro_ui):
     """get_source_plot does not apply lo/hi directly
 
     This does not need a plot backend, as no plot is created,
@@ -613,7 +543,7 @@ def test_bug_316(make_data_path):
 
 @requires_data
 @requires_fits
-def test_load_multi_arfsrmfs(make_data_path):
+def test_load_multi_arfsrmfs(make_data_path, clean_astro_ui):
     """Added in #728 to ensure cache parameter is sent along by
     MultiResponseSumModel.
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -667,3 +667,32 @@ def test_pileup_model(make_data_path, clean_astro_ui):
 
     stat2 = ui.calc_stat('pileup')
     assert stat2 == stat0
+
+
+def test_list_pileup_ids_empty(clean_astro_ui):
+    assert ui.list_pileup_model_ids() == []
+
+
+@pytest.mark.parametrize("id", [None, 2, "2"])
+def test_list_pileup_ids_single(id, clean_astro_ui):
+
+    # Note: do not need to set a source model
+    ui.load_arrays(id, [1, 2, 3], [1, 1, 1], ui.DataPHA)
+    ui.set_pileup_model(id, ui.jdpileup.jdp)
+
+    if id is None:
+        id = 1
+
+    assert ui.list_pileup_model_ids() == [id]
+
+
+def test_list_pileup_ids_multi(clean_astro_ui):
+
+    jdp = ui.create_model_component('jdpileup', "jdp")
+
+    for id in [1, "2"]:
+        ui.load_arrays(id, [1, 2, 3], [1, 1, 1], ui.DataPHA)
+        ui.set_pileup_model(id, jdp)
+
+    ans = ui.list_pileup_model_ids()
+    assert ans == [1, "2"]

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8934,6 +8934,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
+        delete_pileup_model : Delete the pile up model for a data set.
         fit : Fit one or more data sets.
         get_model : Return the model expression for a data set.
         get_source : Return the source model expression for a data set.
@@ -8949,6 +8950,33 @@ class Session(sherpa.ui.utils.Session):
         """
         return self._get_item(id, self._pileup_models, 'pileup model',
                               'has not been set')
+
+    def delete_pileup_model(self, id=None):
+        """Delete the pile up model for a data set.
+
+        Remove the pile up model applied to a source model.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The data set. If not given then the
+           default identifier is used, as returned by `get_default_id`.
+
+        See Also
+        --------
+        set_pileup_model : Add a pile up model to a data set.
+        get_pileup_model : Return the pile up model for a data set.
+
+        Examples
+        --------
+
+        >>> delete_pileup_model()
+
+        >>> delete_pileup_model('core')
+
+        """
+        id = self._fix_id(id)
+        self._pileup_models.pop(id, None)
 
     # DOC-NOTE: should this be made a general function, since it
     # presumably does not care about pileup, just adds the
@@ -8972,6 +9000,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
+        delete_pileup_model : Delete the pile up model for a data set.
         fit : Fit one or more data sets.
         get_pileup_model : Return the pile up model for a data set.
         sherpa.models.model.JDPileup : The ACIS pile up model.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8939,6 +8939,7 @@ class Session(sherpa.ui.utils.Session):
         get_model : Return the model expression for a data set.
         get_source : Return the source model expression for a data set.
         sherpa.astro.models.JDPileup : The ACIS pile up model.
+        list_pileup_model_ids : List of all the data sets with a pile up model.
         set_pileup_model : Include a model of the Chandra ACIS pile up when fitting PHA data.
 
         Examples
@@ -8964,8 +8965,9 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        set_pileup_model : Add a pile up model to a data set.
         get_pileup_model : Return the pile up model for a data set.
+        list_pileup_model_ids : List of all the data sets with a pile up model.
+        set_pileup_model : Add a pile up model to a data set.
 
         Examples
         --------
@@ -8977,6 +8979,25 @@ class Session(sherpa.ui.utils.Session):
         """
         id = self._fix_id(id)
         self._pileup_models.pop(id, None)
+
+    def list_pileup_model_ids(self):
+        """List of all the data sets with a pile up model.
+
+        Returns
+        -------
+        ids : list of int or str
+           The identifiers for all the data sets which have a pile up
+           model set by `set_pileup_model`.
+
+        See Also
+        --------
+        list_data_ids : List the identifiers for the loaded data sets.
+        list_model_ids : List of all the data sets with a source expression.
+        set_pileup_model : Add a pile up model to a data set.
+
+        """
+        keys = list(self._pileup_models.keys())
+        return sorted(keys, key=str)
 
     # DOC-NOTE: should this be made a general function, since it
     # presumably does not care about pileup, just adds the
@@ -9004,6 +9025,7 @@ class Session(sherpa.ui.utils.Session):
         fit : Fit one or more data sets.
         get_pileup_model : Return the pile up model for a data set.
         sherpa.models.model.JDPileup : The ACIS pile up model.
+        list_pileup_model_ids : List of all the data sets with a pile up model.
         set_full_model : Define the convolved model expression for a data set.
         set_model : Set the source model expression for a data set.
 

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -160,6 +160,29 @@ def test_models_all():
     assert nall == len(mcomb)
 
 
+def test_get_functions():
+    """Limited check of get_functions"""
+
+    s = Session()
+    fns = s.get_functions()
+    assert type(fns) == list
+    assert len(fns) > 1
+    assert all([type(f) == str for f in fns])
+    assert 'load_data' in fns
+
+
+def test_list_functions():
+    """Limited check of list_functions"""
+
+    s = Session()
+    store = StringIO()
+    s.list_functions(outfile=store)
+    txt = store.getvalue()
+    fns = txt.split('\n')
+    assert len(fns) > 1
+    assert 'calc_stat' in fns
+
+
 def test_paramprompt_function():
     """Does paramprompt toggle the state setting?"""
 

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -21,14 +21,11 @@
 There is a copy of this test in sherpa/ui/astro/tests/ that needs
 to be kept up to date.
 """
-import numpy
 
-from sherpa.astro.data import DataPHA
 from sherpa.utils.testing import requires_plotting, requires_xspec
 from sherpa.ui.utils import Session
-from sherpa.astro.ui.utils import Session as AstroSession
 from numpy.testing import assert_array_equal
-from sherpa.models import parameter, Const1D
+from sherpa.models import parameter
 import sherpa.models.basic
 
 import pytest
@@ -335,22 +332,3 @@ def test_list_model_ids():
 
     s.set_model('const1d.mdla')
     assert set(s.list_model_ids()) == set([1, 'ma', 'mb'])
-
-
-# Fix 476 - this should be in sherpa/ui/tests/test_session.py
-def test_zero_division_calc_stat():
-    ui = AstroSession()
-    x = numpy.arange(100)
-    y = numpy.zeros(100)
-    ui.load_arrays(1, x, y, DataPHA)
-    ui.group_counts(1, 100)
-    ui.set_full_model(1, Const1D("const"))
-
-    # in principle I wouldn't need to call calc_stat_info(), I could just
-    # use _get_stat_info to reproduce the issue, However, _get_stat_info is not a public
-    # method, so I want to double check that calc_stat_info does not throw an exception.
-    # So, first we try to run calc_stat_info and make sure there are no exceptions.
-    # Then, since calc_stat_info only logs something and doesn't return anything, we use
-    # a white box approach to get the result from _get_stat_info.
-    ui.calc_stat_info()
-    assert ui._get_stat_info()[0].rstat is numpy.nan

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -548,3 +548,31 @@ def test_cache():
     data = Data1D('tmp', x, y)
     fit = Fit(data, model, LeastSq())
     fit.fit(cache=False)
+
+
+def test_list_psf_ids_empty(clean_ui):
+    assert ui.list_psf_ids() == []
+
+
+@pytest.mark.parametrize("id", [None, 2, "2"])
+def test_list_psf_ids_single(id, clean_ui):
+    ui.dataspace1d(1, 10, id=id)
+    ui.load_psf('psf1d', 'gauss1d.mdl')
+    ui.set_psf(id, 'psf1d')
+
+    if id is None:
+        id = 1
+
+    assert ui.list_psf_ids() == [id]
+
+
+def test_list_psf_ids_multi(clean_ui):
+
+    ui.dataspace1d(1, 10)
+    ui.dataspace1d(1, 10, id="2")
+    ui.load_psf('psf1d', 'gauss1d.mdl')
+    ui.set_psf('psf1d')
+    ui.set_psf("2", 'psf1d')
+
+    ans = ui.list_psf_ids()
+    assert ans == [1, "2"]

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -5542,6 +5542,7 @@ class Session(NoNewAttributesAfterInit):
         --------
         list_data_ids : List the identifiers for the loaded data sets.
         list_model_components : List the names of all the model components.
+        list_psf_ids : List of all the data sets with a PSF.
         set_model : Set the source model expression for a data set.
 
         """
@@ -7142,6 +7143,7 @@ class Session(NoNewAttributesAfterInit):
         --------
         delete_psf : Delete the PSF model for a data set.
         image_psf : Display the 2D PSF model for a data set in the image viewer.
+        list_psf_ids : List of all the data sets with a PSF.
         load_psf : Create a PSF model.
         plot_psf : Plot the 1D PSF model applied to a data set.
         set_psf : Add a PSF model to a data set.
@@ -7171,6 +7173,7 @@ class Session(NoNewAttributesAfterInit):
 
         See Also
         --------
+        list_psf_ids : List of all the data sets with a PSF.
         load_psf : Create a PSF model.
         set_psf : Add a PSF model to a data set.
         get_psf : Return the PSF model defined for a data set.
@@ -7185,6 +7188,25 @@ class Session(NoNewAttributesAfterInit):
         """
         id = self._fix_id(id)
         self._psf.pop(id, None)
+
+    def list_psf_ids(self):
+        """List of all the data sets with a PSF.
+
+        Returns
+        -------
+        ids : list of int or str
+           The identifiers for all the data sets which have a PSF
+           model set by `set_psf`.
+
+        See Also
+        --------
+        list_data_ids : List the identifiers for the loaded data sets.
+        list_model_ids : List of all the data sets with a source expression.
+        set_psf : Add a PSF model to a data set.
+
+        """
+        keys = list(self._psf.keys())
+        return sorted(keys, key=str)
 
     def _add_psf(self, id, data, model):
         id = self._fix_id(id)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -5163,14 +5163,18 @@ class Session(NoNewAttributesAfterInit):
             if item in keys:
                 keys.remove(item)
 
+        select = None
         if show.startswith("xspec"):
-            return filter(lambda x: x.startswith('xs'), keys)
+            select = lambda x: x.startswith('xs')
         elif show.startswith("1d"):
-            return filter(lambda x: (not x.startswith('xs')) and (not x.endswith("2d")), keys)
+            select = lambda x: (not x.startswith('xs')) and (not x.endswith("2d"))
         elif show.startswith("2d"):
-            return filter(lambda x: x.endswith('2d'), keys)
+            select = lambda x: x.endswith('2d')
 
-        return keys
+        if select is None:
+            return keys
+
+        return list(filter(select, keys))
 
     def list_model_components(self):
         """List the names of all the model components.

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2772,7 +2772,7 @@ def parallel_map_funcs(funcs, datasets, numcores=None):
     to the different cores, the functions should be very time consuming
     to compute (of order 0.1-1s).  This is similar to the ``parallel_map``
     function.
-    
+
     An ordered iterable (i.e. tuple or list) should be used to pass multiple
     values to the multiple functions. The lengths of the iterable funcs and
     datasets must be equal. The corresponding funcs and datasets are passed
@@ -3986,6 +3986,9 @@ def public(f):
     http://groups.google.com/group/comp.lang.python/msg/11cbb03e09611b8a
     * Improved via a suggestion by Dave Angel:
     http://groups.google.com/group/comp.lang.python/msg/3d400fb22d8a42e1
+
+    See also https://bugs.python.org/issue26632
+
     """
     _all = sys.modules[f.__module__].__dict__.setdefault('__all__', [])
     if f.__name__ not in _all:  # Prevent duplicates if run from an IDE.


### PR DESCRIPTION
# Summary

Add the delete_pileup_model() function to allow a pileup model to be removed from a fit (issue #441), and list_psf_ids() and list_pileup_model_ids() routines to list those datasets with an associated PSF or pileup model. The list_models() routine no-longer returns an iterator but a list when given an option (issue #749).

# Details

This matches the existing set_psf/delete_psf routines (for delete_pileup_model) and list_data_ids/list_model_ids for the list_psf_ids and list_pileup_model_ids routines. 

One possibility for the pileup routines was to drop the "_model", but I wanted to keep consistency with set_pileup_model and I don't expect these routines to be used heavily, so having a long name is not a big concern.

The test_astro_ui.py test suite was updated to use pytest as part of this. In doing so I was able to identify a test previously marked as "skip" - test_psf_model1d  - because it was originally never ran (due to a name clash) and turned out to fail. I reworked the test to loop through the models at the test level (rather than within the test), which showed that only one of the three models was failing. I changed the test so that it passed for this test, and they are now all running. It's not clear whether the result makes sense but it now at least will be caught if we ever work on the psf-centering code.

The test_ui.py tests were also converted to pytest and cleaned up (so finally able to move a comment @olaurino added about how this would be better with pytest parameters).

I have also added some random tests from the session class that I noticed were't being covered (there's plenty more that are needed for sherpa.ui.utils but that can wait).