### PR TITLE
Issues with fitting background and source datasets

### DIFF
--- a/docs/evaluation/astro_background.rst
+++ b/docs/evaluation/astro_background.rst
@@ -11,9 +11,17 @@ The sherpa.astro.background module
    .. autosummary::
       :toctree: api
 
-      BackgroundSumModel
+      ScaleArray
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      add_response
+
 
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: BackgroundSumModel
+.. inheritance-diagram:: ScaleArray

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -22,58 +22,11 @@
 """
 
 from sherpa.models.parameter import Parameter
-from sherpa.models.model import ArithmeticModel, CompositeModel, \
-    modelCacher1d
+from sherpa.models.model import ArithmeticModel, modelCacher1d
 
-from sherpa.utils.err import DataErr, ModelErr
+from sherpa.utils.err import ModelErr
 
-__all__ = ('BackgroundSumModel', 'ScaleArray')
-
-
-class BackgroundSumModel(CompositeModel, ArithmeticModel):
-    """Combine multiple background datasets.
-
-    Define the model expression to be applied to the source
-    region accounting for the background models.
-
-    Parameters
-    ----------
-    srcdata : sherpa.astro.data.DataPHA instance
-        The source dataset.
-    bkgmodels : dict
-        The background components, where the key is the identifier
-        in this dataset and the value is the model. This dictionary
-        cannot be empty.
-
-    """
-
-    def __init__(self, srcdata, bkgmodels):
-        self.srcdata = srcdata
-        self.bkgmodels = bkgmodels
-        scale_factor = self.srcdata.sum_background_data(lambda key, bkg:1)
-        bkgnames = [model.name for model in bkgmodels.values()]
-        name = '%g * (' % scale_factor + ' + '.join(bkgnames) + ')'
-        CompositeModel.__init__(self, name, self.bkgmodels.values())
-
-    def calc(self, p, *args, **kwargs):
-        def eval_bkg_model(key, bkg):
-            bmodel = self.bkgmodels.get(key)
-            if bmodel is None:
-                raise DataErr('bkgmodel', key)
-            # FIXME: we're not using p here (and therefore assuming that the
-            # parameter values have already been updated to match the contents
-            # of p)
-            return bmodel(*args, **kwargs)
-
-        # Evaluate the background model for each dataset using the same
-        # grid and apply the background-to-source correction factors.
-        #
-        # This will only work if the scaling factors are scalars,
-        # since if there are any array elements then the models
-        # have been evaluated on the energy/wavelength grid,
-        # but the correction factors are defined in channel space.
-        #
-        return self.srcdata.sum_background_data(eval_bkg_model)
+__all__ = ('ScaleArray', )
 
 
 class ScaleArray(ArithmeticModel):

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -53,8 +53,6 @@ class ScaleArray(ArithmeticModel):
     ----------
     ampl
         The amplitude of the model.
-    y
-        The array of values.
 
     Examples
     --------
@@ -77,7 +75,7 @@ class ScaleArray(ArithmeticModel):
 
     @property
     def y(self):
-        """The data to return"""
+        """The array of values."""
         return self._y
 
     @y.setter

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -21,12 +21,23 @@
 
 """
 
+from collections import defaultdict
+from functools import reduce
+import logging
+import operator
+
+import numpy
+
+from sherpa.astro.instrument import PileupResponse1D
 from sherpa.models.parameter import Parameter
 from sherpa.models.model import ArithmeticModel, modelCacher1d
-
 from sherpa.utils.err import ModelErr
 
-__all__ = ('ScaleArray', )
+
+__all__ = ('ScaleArray', 'add_response')
+
+
+warning = logging.getLogger(__name__).warning
 
 
 class ScaleArray(ArithmeticModel):
@@ -85,3 +96,94 @@ class ScaleArray(ArithmeticModel):
             raise ModelErr("Model data (y) is not set.")
 
         return p[0] * self._y
+
+
+def add_response(session, id, data, model):
+    """Create the response model describing the source and model.
+
+    """
+
+    resp = session._get_response(id, data)
+    if data.subtracted:
+        return resp(model)
+
+    bkg_srcs = session._background_sources.get(id, {})
+    if len(bkg_srcs) == 0:
+        return resp(model)
+
+    # What are the scaling factors for each background component?
+    # This gives the value you multply the background model to
+    # correct it to the source aperture, exposure time, and
+    # area scaling.
+    #
+    scales = {}
+    for bkg_id in data.background_ids:
+        if bkg_id not in bkg_srcs:
+            raise ModelErr('nobkg', bkg_id, id)
+
+        scales[bkg_id] = data.get_background_scale(bkg_id, group=False)
+
+    # Group by the scale factor: numpy arrays do not hash,
+    # so we need a way to handle them. For now I am
+    # going to assume that each vector is unique (i.e.
+    # it is not worth combining components).
+    #
+    # TODO: combine with the above loop.
+    #
+    flattened = defaultdict(list)
+    vectors = []
+    for key, scale in scales.items():
+        if numpy.isscalar(scale):
+            flattened[scale].append(key)
+        else:
+            vectors.append((key, scale))
+
+    for scale in sorted(flattened.keys(), reverse=True):
+        ms = [bkg_srcs[k] for k in flattened[scale]]
+        combined = reduce(operator.add, ms)
+        model += scale * combined
+
+    model = resp(model)
+    if len(vectors) == 0:
+        return model
+
+    # Warn if a pileup model is being used. The error message here
+    # is terrible.
+    #
+    # Should this be a Python Warning rather than a logged message?
+    #
+    if isinstance(resp, PileupResponse1D):
+        bkg_ids = ",".join([str(k) for k, _ in vectors])
+        wmsg = "model results for dataset {} ".format(id) + \
+                "likely wrong: use of pileup model and scaling " + \
+                "of bkg_id={}".format(bkg_ids)
+
+        # warnings.warn(wmsg)
+        warning(wmsg)
+
+    for key, scale in vectors:
+
+        # Use a tablemodel to contain the array values:
+        # this makes the string output nicer, but we
+        # need to deal with the namespace for these
+        # models, and cleaning up after ourselves. We actually
+        # use a specialized model class, rather than a tablemodel,
+        # since it has to just return the full data (in
+        # the same way the RSP models do).
+        #
+        tbl = ScaleArray('scale{}_{}'.format(id, key))
+        tbl.y = scale
+
+        # Add the model to the global symbol list, so
+        # users can interrogate it. The issues are:
+        #  - name clash: it's okay to overwrite models created
+        #    here, but what happens if a user has created a
+        #    model with this name?
+        #  - how do we clean up after the data goes out of
+        #    scope (or the background scaling changes)
+        #
+        session._add_model_component(tbl)
+
+        model += tbl * resp(bkg_srcs[key])
+
+    return model

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -171,7 +171,7 @@ def add_response(session, id, data, model):
         except KeyError:
             raise ModelErr('nobkg', bkg_id, id)
 
-        scale = data.get_background_scale(bkg_id, group=False)
+        scale = data.get_background_scale(bkg_id, units='rate', group=False)
 
         if np.isscalar(scale):
             store = scales_scalar

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -62,4 +62,12 @@ class BackgroundSumModel(CompositeModel, ArithmeticModel):
             # of p)
             return bmodel(*args, **kwargs)
 
+        # Evaluate the background model for each dataset using the same
+        # grid and apply the background-to-source correction factors.
+        #
+        # This will only work if the scaling factors are scalars,
+        # since if there are any array elements then the models
+        # have been evaluated on the energy/wavelength grid,
+        # but the correction factors are defined in channel space.
+        #
         return self.srcdata.sum_background_data(eval_bkg_model)

--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -21,10 +21,13 @@
 
 """
 
-from sherpa.models.model import CompositeModel, ArithmeticModel
-from sherpa.utils.err import DataErr
+from sherpa.models.parameter import Parameter
+from sherpa.models.model import ArithmeticModel, CompositeModel, \
+    modelCacher1d
 
-__all__ = ('BackgroundSumModel',)
+from sherpa.utils.err import DataErr, ModelErr
+
+__all__ = ('BackgroundSumModel', 'ScaleArray')
 
 
 class BackgroundSumModel(CompositeModel, ArithmeticModel):
@@ -71,3 +74,61 @@ class BackgroundSumModel(CompositeModel, ArithmeticModel):
         # but the correction factors are defined in channel space.
         #
         return self.srcdata.sum_background_data(eval_bkg_model)
+
+
+class ScaleArray(ArithmeticModel):
+    """Represent a scale array as a Sherpa model.
+
+    The model always return the saved data (multiplied by the
+    amplitude), whatever grid it is asked to evaluate. This is
+    designed for handling the scaling factor to convert a background
+    model to match the source aperture when the value is an array, not
+    a scalar.
+
+    Attributes
+    ----------
+    ampl
+        The amplitude of the model.
+    y
+        The array of values.
+
+    Examples
+    --------
+
+    Create a component and set the y attribute to contain the ``vals``
+    array. The model always evaluates to the y array (multiplied by
+    the ``ampl`` parameter, which defaults to 1):
+
+    >>> sc = ScaleArray('sc')
+    >>> sc.y = vals
+    >>> all(sc([1, 2, 4, 5]) == vals)
+    >>> all(sc([0.2, 0.3, 0.4], [0.3, 0.4, 0.5]) == vals)
+
+    """
+
+    def __init__(self, name='scalearray'):
+        self._y = None
+        self.ampl = Parameter(name, 'ampl', 1, frozen=True)
+        ArithmeticModel.__init__(self, name, (self.ampl,))
+
+    @property
+    def y(self):
+        """The data to return"""
+        return self._y
+
+    @y.setter
+    def y(self, value):
+        self._y = value
+
+    @modelCacher1d
+    def calc(self, p, x0, x1=None, *args, **kwargs):
+        """The model data is always returned.
+
+        The input grids are ignored, and the scaled
+        model data is returned.
+        """
+
+        if self._y is None:
+            raise ModelErr("Model data (y) is not set.")
+
+        return p[0] * self._y

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -834,7 +834,7 @@ class DataPHA(Data1D):
         if (rmf is None and arf is None) and \
            (self.bin_lo is None and self.bin_hi is None) and \
            quantity != 'channel':
-            raise DataErr('noinstr', self.name)
+            raise DataErr('norsp', self.name)
 
         if rmf is None and arf is not None and quantity != 'channel' and \
            len(arf.energ_lo) != len(self.channel):

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1743,8 +1743,8 @@ class DataPHA(Data1D):
                             get_bdata_func=(lambda key, bkg: bkg.counts)):
         """Sum up data, applying the background correction value.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         get_bdata_func : function, optional
             What data should be used for each background dataset. The
             function takes the background identifier and background

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -786,8 +786,39 @@ class DataPHA(Data1D):
         self.__dict__.update(state)
 
     primary_response_id = 1
+    """The identifier for the response component when not set."""
 
     def set_analysis(self, quantity, type='rate', factor=0):
+        """Return the units used when fitting spectral data.
+
+        Parameters
+        ----------
+        quantity : {'channel', 'energy', 'wavelength'}
+            The analysis setting.
+        type : {'rate', 'counts'}, optional
+            Do plots display a rate or show counts?
+        factor : int, optional
+           The Y axis of plots is multiplied by Energy^factor or
+           Wavelength^factor before display. The default is 0.
+
+        Raises
+        ------
+        sherpa.utils.err.DatatErr
+           If the type argument is invalid, the RMF or ARF has the
+           wrong size, or there in no response.
+
+        See Also
+        --------
+        get_analysis
+
+        Examples
+        --------
+
+        >>> pha.set_analysis('energy')
+
+        >>> pha.set_analysis('wave', type='counts' factor=1)
+
+        """
         self.plot_fac = factor
 
         type = str(type).strip().lower()
@@ -844,10 +875,49 @@ class DataPHA(Data1D):
         return id
 
     def get_response(self, id=None):
+        """Return the response component.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        Returns
+        -------
+        arf, rmf: sherpa.astro.data.DataARF,sherpa.astro.data.DataRMF instances or None
+           The response, as an ARF and RMF. Either, or both,
+           components can be None.
+
+        See Also
+        --------
+        delete_response, get_arf, get_rmf, set_response
+
+        """
         id = self._fix_response_id(id)
         return self._responses.get(id, (None, None))
 
     def set_response(self, arf=None, rmf=None, id=None):
+        """Add or replace a response component.
+
+        To remove a response use delete_response(), as setting arf and
+        rmf to None here does nothing.
+
+        Parameters
+        ----------
+        arf : sherpa.astro.data.DataARF instance or None, optional
+           The ARF to add if any.
+        rmf : sherpa.astro.data.DataRMF instance or None, optional
+           The RMF to add, if any.
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        See Also
+        --------
+        delete_response, get_response, set_arf, set_rmf
+
+        """
         if (arf is None) and (rmf is None):
             return
 
@@ -859,6 +929,22 @@ class DataPHA(Data1D):
         self.response_ids = ids
 
     def delete_response(self, id=None):
+        """Remove the response component.
+
+        If the response component does not exist then the method
+        does nothing.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        See Also
+        --------
+        set_response
+
+        """
         id = self._fix_response_id(id)
         self._responses.pop(id, None)
         ids = self.response_ids[:]
@@ -866,15 +952,89 @@ class DataPHA(Data1D):
         self.response_ids = ids
 
     def get_arf(self, id=None):
+        """Return the ARF from the response.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        Returns
+        -------
+        arf: sherpa.astro.data.DataARF instance or None
+           The ARF, if set.
+
+        See Also
+        --------
+        get_response, get_rmf
+
+        """
         return self.get_response(id)[0]
 
     def get_rmf(self, id=None):
+        """Return the RMF from the response.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        Returns
+        -------
+        rmf: sherpa.astro.data.DataRMF instance or None
+           The RMF, if set.
+
+        See Also
+        --------
+        get_arf, get_response
+
+        """
         return self.get_response(id)[1]
 
     def set_arf(self, arf, id=None):
+        """Add or replace the ARF in a response component.
+
+        This replaces the existing ARF of the response, keeping the
+        previous RMF (if set). Use the delete_response method to
+        remove the response, rather than setting arf to None.
+
+        Parameters
+        ----------
+        arf : sherpa.astro.data.DataARF instance
+           The ARF to add.
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        See Also
+        --------
+        delete_response, set_response, set_rmf
+
+        """
         self.set_response(arf, self.get_rmf(id), id)
 
     def set_rmf(self, rmf, id=None):
+        """Add or replace the RMF in a response component.
+
+        This replaces the existing RMF of the response, keeping the
+        previous ARF (if set). Use the delete_response method to
+        remove the response, rather than setting rmf to None.
+
+        Parameters
+        ----------
+        rmf : sherpa.astro.data.DataRMF instance
+           The RMF to add.
+        id : int or str, optional
+           The identifier of the response component. If it is None
+           then the default response identifier is used.
+
+        See Also
+        --------
+        delete_response, set_response, set_arf
+
+        """
         self.set_response(self.get_arf(id), rmf, id)
 
     def get_specresp(self, filter=False):
@@ -1068,6 +1228,7 @@ class DataPHA(Data1D):
         return self._energy_to_channel(vals)
 
     default_background_id = 1
+    """The identifier for the background component when not set."""
 
     def _fix_background_id(self, id):
         if id is None:
@@ -1075,10 +1236,44 @@ class DataPHA(Data1D):
         return id
 
     def get_background(self, id=None):
+        """Return the background component.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier of the background component. If it is None
+           then the default background identifier is used.
+
+        Returns
+        -------
+        bkg : sherpa.astro.data.DataPHA instance or None
+           The background dataset. If there is no component then None
+           is returned.
+
+        See Also
+        --------
+        delete_background, set_background
+
+        """
         id = self._fix_background_id(id)
         return self._backgrounds.get(id)
 
     def set_background(self, bkg, id=None):
+        """Add or replace a background component.
+
+        Parameters
+        ----------
+        bkg : sherpa.astro.data.DataPHA instance
+           The background dataset to add.
+        id : int or str, optional
+           The identifier of the background component. If it is None
+           then the default background identifier is used.
+
+        See Also
+        --------
+        delete_background, get_background
+
+        """
         id = self._fix_background_id(id)
         self._backgrounds[id] = bkg
         ids = self.background_ids[:]
@@ -1087,6 +1282,28 @@ class DataPHA(Data1D):
         self.background_ids = ids
 
     def delete_background(self, id=None):
+        """Remove the background component.
+
+        If the background component does not exist then the method
+        does nothing.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier of the background component. If it is None
+           then the default background identifier is used.
+
+        See Also
+        --------
+        set_background
+
+        Notes
+        -----
+        If this call removes the last of the background components
+        then the subtracted flag is cleared (if set).
+
+        """
+
         id = self._fix_background_id(id)
         self._backgrounds.pop(id, None)
         if len(self._backgrounds) == 0:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1096,18 +1096,25 @@ class DataPHA(Data1D):
             ids.remove(id)
         self.background_ids = ids
 
-    def get_background_scale(self, bkg_id=1, group=True, filter=False):
+    def get_background_scale(self, bkg_id=1, units='counts',
+                             group=True, filter=False):
         """Return the correction factor for the background dataset.
 
         .. versionchanged:: 4.12.2
-           The bkg_id parameter has been added and the routine
-           no-longer calculates the average scaling for all the
-           background components but just for the given component.
+           The bkg_id, units, group, and filter parameters have been
+           added and the routine no-longer calculates the average
+           scaling for all the background components but just for the
+           given component.
 
         Parameters
         ----------
         bkg_id : int or str, optional
            The background component to use (the default is 1).
+        units : {'counts', 'rate'}, optional
+           The correction is applied to a model defined as counts, the
+           default, or a rate. The latter should be used when
+           calculating the correction factor for adding the background
+           data to the source aperture.
         group : bool, optional
             Should the values be grouped to match the data?
         filter : bool, optional
@@ -1122,7 +1129,7 @@ class DataPHA(Data1D):
 
         Notes
         -----
-        The correction factor is::
+        The correction factor when units is 'counts' is::
 
             scale_exposure * scale_backscal * scale_areascal / nbkg
 
@@ -1130,7 +1137,17 @@ class DataPHA(Data1D):
         scale_x is the source value divided by the background
         value for the field x.
 
+        When units is 'rate' the correction is:
+
+            scale_backscal / nbkg
+
+        and it is currently uncertain whether it should include the
+        AREASCAL scaling.
+
         """
+
+        if units not in ['counts', 'rate']:
+            raise ValueError("Invalid units argument: {}".format(units))
 
         if bkg_id not in self.background_ids:
             return None
@@ -1146,10 +1163,10 @@ class DataPHA(Data1D):
             if obj.backscal is not None:
                 ans *= self._check_scale(obj.backscal, group=False)
 
-            if obj.areascal is not None:
+            if obj.areascal is not None and units == 'counts':
                 ans *= self._check_scale(obj.areascal, group=False)
 
-            if obj.exposure is not None:
+            if obj.exposure is not None and units == 'counts':
                 ans *= self._check_scale(obj.exposure, group=False)
 
             return ans

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1096,8 +1096,15 @@ class DataPHA(Data1D):
             ids.remove(id)
         self.background_ids = ids
 
-    def get_background_scale(self):
+    def get_background_scale(self, group=True, filter=False):
         """Return the correction factor for the background datasets.
+
+        Parameters
+        ----------
+        group : bool, optional
+            Should the values be grouped to match the data?
+        filter : bool, optional
+            Should the values be filtered to match the data?
 
         Returns
         -------
@@ -1115,7 +1122,9 @@ class DataPHA(Data1D):
 
         if len(self.background_ids) == 0:
             return None
-        return self.sum_background_data(lambda key, bkg: 1.)
+
+        bscale = self.sum_background_data(lambda key, bkg: 1.)
+        return self._check_scale(bscale, group=group, filter=filter)
 
     def _check_scale(self, scale, group=True, filter=False):
         """Ensure the scale value is positive and filtered/grouped.

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1126,6 +1126,57 @@ class DataPHA(Data1D):
         bscale = self.sum_background_data(lambda key, bkg: 1.)
         return self._check_scale(bscale, group=group, filter=filter)
 
+    def _get_background_scales(self):
+        """Return the correction factors for the background datasets.
+
+        Returns
+        -------
+        scales : None or dict
+            The per-background scaling factors, indexed by the
+            background identifier, where each element can be a scalar
+            or array. If there are no associated backgrounds then None
+            is returned.
+
+        Notes
+        -----
+        The corrections include BACKSCAL, AREASCAL, and exposure
+        corrections.
+
+        """
+
+        nbkg = len(self.background_ids)
+        if nbkg == 0:
+            return None
+
+        def correct(obj):
+            """Correction factor for the object"""
+            ans = 1.0
+
+            if obj.backscal is not None:
+                ans *= self._check_scale(obj.backscal, group=False)
+
+            if obj.areascal is not None:
+                ans *= self._check_scale(obj.areascal, group=False)
+
+            if obj.exposure is not None:
+                ans *= self._check_scale(obj.exposure, group=False)
+
+            return ans
+
+        # what are the source correction factors
+        #
+        src = correct(self)
+
+        # calculate the factors for each background component
+        #
+        out = {}
+        for key in self.background_ids:
+
+            bkg = correct(self.get_background(key))
+            out[key] = src / bkg / nbkg
+
+        return out
+
     def _check_scale(self, scale, group=True, filter=False):
         """Ensure the scale value is positive and filtered/grouped.
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1097,6 +1097,22 @@ class DataPHA(Data1D):
         self.background_ids = ids
 
     def get_background_scale(self):
+        """Return the correction factor for the background datasets.
+
+        Returns
+        -------
+        scale : None, number, or NumPy array
+            The scaling factor to correct the background data onto the
+            source data set. If there are no associated backgrounds
+            then None is returned.
+
+        Notes
+        -----
+        The corrections include BACKSCAL, AREASCAL, and exposure
+        corrections.
+
+        """
+
         if len(self.background_ids) == 0:
             return None
         return self.sum_background_data(lambda key, bkg: 1.)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1261,10 +1261,16 @@ class DataPHA(Data1D):
     def set_background(self, bkg, id=None):
         """Add or replace a background component.
 
+        If the background has no grouping of quality arrays then they
+        are copied from the source region. If the background has no
+        response information (ARF or RMF) then the response is copied
+        from the source region.
+
         Parameters
         ----------
         bkg : sherpa.astro.data.DataPHA instance
-           The background dataset to add.
+           The background dataset to add. This object may be changed
+           by this method.
         id : int or str, optional
            The identifier of the background component. If it is None
            then the default background identifier is used.
@@ -1280,6 +1286,29 @@ class DataPHA(Data1D):
         if id not in ids:
             ids.append(id)
         self.background_ids = ids
+
+        # Copy over data from the source to the background
+        # if its not present in the background:
+        #  - background and grouping
+        #  - response information (ONLY THE FIRST TERM)
+        #
+        # The units (only when a response is present), rate, and
+        # plot_fac values are always copied.
+        #
+        if bkg.grouping is None:
+            bkg.grouping = self.grouping
+            bkg.grouped = bkg.grouping is not None
+        if bkg.quality is None:
+            bkg.quality = self.quality
+
+        if bkg.get_response() == (None, None):
+            bkg.set_response(*self.get_response())
+
+        if bkg.get_response() != (None, None):
+            bkg.units = self.units
+
+        bkg.rate = self.rate
+        bkg.plot_fac = self.plot_fac
 
     def delete_background(self, id=None):
         """Remove the background component.

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -729,6 +729,51 @@ class RMF1D(NoNewAttributesAfterInit):
 
 
 class Response1D(NoNewAttributesAfterInit):
+    """A factory class for generating the instrument response.
+
+    This should not be used when a pileup model is required.
+
+    Parameters
+    ----------
+    pha : sherpa.astro.data.DataPHA instance
+        The data object which defines the channel grid and instrument
+        response. There must be either an ARF or RMF associated
+        with the dataset.
+
+    Raises
+    ------
+    sherpa.utils.err.DataErr
+        The argument does not contain any response information (it is
+        missing an ARF and a RMF).
+
+    See Also
+    --------
+    MultipleResponse1D, PileupResponse1D
+
+    Notes
+    -----
+    When the object is called it can be sent a ``session`` parameter,
+    which defines the session to use when converting a string model to
+    a ArithmeticModel instance. It is not used for any other function.
+    The default value for this parameter is `None`, in which case the
+    code uses the sherpa.astro.ui._session object.
+
+    The response will include the exposure time if is is defined in
+    either the PHA or ARF datasets (PHA taking precedence). The final
+    response will be one of RSPModelPHA, ARFModelPHA, or RMFModelPHA.
+
+    Examples
+    --------
+
+    Add the response to a model (``src_model``) and then evaluate it.
+    The response will ignore the input argument, and evaluate it for
+    all channels (hence the use of a dummy argument [1]):
+
+    >>> rsp = Response1D(pha)
+    >>> full_model = rsp(src_model)
+    >>> ycnts = full_model([1])
+
+    """
 
     def __init__(self, pha):
         self.pha = pha
@@ -944,6 +989,27 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
 
 
 class MultipleResponse1D(Response1D):
+    """A factory class for generating the instrument response.
+
+    This should not be used when a pileup model is required.
+
+    Parameters
+    ----------
+    pha : sherpa.astro.data.DataPHA instance
+        Support PHA files with multiple responses (e.g. orders) to
+        describe the data.
+
+    Raises
+    ------
+    sherpa.utils.err.DataErr
+        The argument does not contain any response information (it is
+        missing an ARF and a RMF).
+
+    See Also
+    --------
+    Response1D
+
+    """
 
     def __call__(self, model, session=None):
         pha = self.pha
@@ -1051,6 +1117,29 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
 
 
 class PileupResponse1D(NoNewAttributesAfterInit):
+    """A factory class for generating a response including pileup.
+
+    Parameters
+    ----------
+    pha : sherpa.astro.data.DataPHA instance
+        The data object which defines the channel grid and instrument
+        response. There must be both an ARF or RMF associated
+        with the dataset when it is called.
+    pileup_model : sherpa.astro.models.JDPileup instance
+        The pileup model.
+
+    Raises
+    ------
+    sherpa.utils.err.DataErr
+        The argument does not contain any response information (it is
+        missing an ARF or RMF).
+
+    See Also
+    --------
+    Response1D
+
+    """
+
 
     def __init__(self, pha, pileup_model):
         self.pha = pha

--- a/sherpa/astro/ui/__init__.py
+++ b/sherpa/astro/ui/__init__.py
@@ -44,6 +44,9 @@ _session._add_model_types(sherpa.instrument,baselist=(sherpa.models.Model,))
 # Get RMFModel, ARFModel in list of models
 _session._add_model_types(sherpa.astro.instrument)
 
+# Do we want to add ScaleArray or not?
+_session._add_model_types(sherpa.astro.background)
+
 if hasattr(sherpa.astro, 'xspec'):
     _session._add_model_types(sherpa.astro.xspec,
                               (sherpa.astro.xspec.XSAdditiveModel,

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -24,6 +24,7 @@ attempts to provide a solid test base. There is likely to be
 overlap in the WSTAT tests, for one.
 """
 
+from io import StringIO
 import logging
 
 import numpy as np
@@ -274,6 +275,62 @@ def setup_pha1(exps, bscals, ascals):
     return dset
 
 
+@pytest.mark.parametrize("exps,bscales,ascales,results",
+                         [((100, 200), (2, 4), (0.5, 0.1),
+                           [(100 * 2 * 0.5) / (200 * 4 * 0.1)]),
+                          ((100, 200, 400), (2, 4, 0.5), (0.5, 0.1, 0.8),
+                           [0.5 * (100 * 2 * 0.5) / (200 * 4 * 0.1),
+                            0.5 * (100 * 2 * 0.5) / (400 * 0.5 * 0.8)]),
+                          ((100, 200, 1.0), (2, 4, 1 * np.ones(19)), (0.5, 0.1, 1.0),
+                           [0.5 * (100 * 2 * 0.5) / (200 * 4 * 0.1),
+                            None]),
+                         ])
+@pytest.mark.parametrize("id", [None, 1, "x"])
+def test_pha1_show_data(id, exps, bscales, ascales, results, clean_astro_ui):
+    """Check we can show the data and get the scaling.
+
+    This *only* checks the background scaling, not the
+    full output. Since the scaling value isn't shown
+    when it's a vector we don't need to care about the values
+    """
+
+    iid = 1 if id is None else id
+
+    ui.set_data(id, setup_pha1(exps, bscales, ascales))
+
+    out = StringIO()
+    ui.show_data(outfile=out)
+    msg = out.getvalue().split('\n')
+
+    assert msg[0] == 'Data Set: {}'.format(iid)
+    assert msg[1] == 'Filter: 0.6500-2.4500 Energy (keV)'
+
+    def check(line, result, bkg_id=None):
+        out = 'Bkg Scale'
+        if bkg_id is not None:
+            out += ' {}'.format(bkg_id)
+
+        out += ': '
+        if result is None:
+            out += 'float64[19]'
+        else:
+            out += '{}'.format(result)
+
+        assert line == out
+
+    nbkg = len(results)
+    notice = 2 + nbkg
+    if len(results) == 1:
+        check(msg[2], results[0])
+    else:
+        for i, r in enumerate(results, 1):
+            check(msg[1 + i], r, bkg_id=i)
+
+    # just check we have the correct following lines
+    assert msg[notice] == 'Noticed Channels: 1-19'
+    assert msg[notice + 1] == 'name           = tst0'
+
+
 # Try and pick routines with different pathways through the code
 # to catch all cases.
 #
@@ -299,25 +356,24 @@ SCALING = np.ones(19)
 SCALING[2:5] = 0.8
 SCALING[15] = 0.7
 
-@pytest.mark.parametrize("exps,bscales,ascales,result",
+@pytest.mark.parametrize("exps,bscales,ascales,bkg_id,result",
                          [((100, 1000), (0.01, 0.05), (0.4, 0.5),
-                           (100 * 0.01 * 0.4) / (1000 * 0.05 * 0.5)),
+                           1, (100 * 0.01 * 0.4) / (1000 * 0.05 * 0.5)),
                           ((100, 1000, 1500), (0.01, 0.05, 0.04), (0.2, 0.5, 0.4),
-                           0.5 * (100 * 0.01 * 0.2) *
-                           (1 / (1000 * 0.05 * 0.5) + 1 / (1500 * 0.04 * 0.4))),
-                          ((100, 1000), (0.01, 0.05 * SCALING), (0.4, 0.5),
-                           (100 * 0.01 * 0.4) / (1000 * 0.05 * SCALING * 0.5)),
+                           1, 0.5 * (100 * 0.01 * 0.2) / (1000 * 0.05 * 0.5)),
+                          ((100, 1000, 1500), (0.01, 0.05, 0.04), (0.2, 0.5, 0.4),
+                           2, 0.5 * (100 * 0.01 * 0.2) / (1500 * 0.04 * 0.4)),
                           ((100, 1000, 1500), (0.01, 0.05 * SCALING, 0.04), (0.4, 0.5, 0.6 * SCALING),
-                           0.5 * (100 * 0.01 * 0.4) *
-                           (1 / (1000 * 0.05 * SCALING * 0.5) +
-                            1 / (1500 * 0.04 * 0.6 * SCALING))),
+                           1, 0.5 * (100 * 0.01 * 0.4) / (1000 * 0.05 * SCALING * 0.5)),
+                          ((100, 1000, 1500), (0.01, 0.05 * SCALING, 0.04), (0.4, 0.5, 0.6 * SCALING),
+                           2, 0.5 * (100 * 0.01 * 0.4) / (1500 * 0.04 * 0.6 * SCALING)),
                          ])
 @pytest.mark.parametrize("id", [None, "x"])
-def test_pha1_get_bkg_scale(id, exps, bscales, ascales, result, clean_astro_ui):
+def test_pha1_get_bkg_scale(id, exps, bscales, ascales, bkg_id, result, clean_astro_ui):
     """Check we can calculate the scaling factor"""
 
     ui.set_data(id, setup_pha1(exps, bscales, ascales))
-    bscal = ui.get_bkg_scale(id)
+    bscal = ui.get_bkg_scale(id, bkg_id)
     assert bscal == pytest.approx(result)
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -791,6 +791,6 @@ def test_jdpileup_warning(caplog, clean_astro_ui):
 
     assert len(caplog.records) == 1
     name, level, msg = caplog.record_tuples[0]
-    assert name == 'sherpa.astro.ui.utils'
+    assert name == 'sherpa.astro.background'
     assert level == logging.WARNING
     assert msg == 'model results for dataset x likely wrong: use of pileup model and scaling of bkg_id=2'

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -238,7 +238,27 @@ def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_log
     assert bmdl.name == 'apply_rmf(apply_arf((2000 * polynom1d.bpl2)))'
 
     smdl = ui.get_model(id)
-    assert smdl.name == 'apply_rmf(apply_arf((100 * ((powlaw1d.pl + (0.025 * powlaw1d.bpl)) + (0.005000000000000001 * polynom1d.bpl2)))))'
+
+    # The string representation can depend on Python version, so break
+    # it up so we can check terms separately.
+    #
+    toks = smdl.name.split('(')
+    assert toks[0] == 'apply_rmf'
+    assert toks[1] == 'apply_arf'
+    assert toks[2] == ''
+    assert toks[3] == '100 * '
+    assert toks[4] == ''
+    assert toks[5] == 'powlaw1d.pl + '
+
+    x1 = '0.025 * powlaw1d.bpl)) + '
+    x2 = '0.005000000000000001 * polynom1d.bpl2)))))'
+
+    y1 = '0.005000000000000001 * polynom1d.bpl2)) + '
+    y2 = '0.025 * powlaw1d.bpl)))))'
+
+    assert toks[6] in [x1, y1]
+    assert toks[7] in [x2, y2]
+    assert len(toks) == 8
 
     assert ui.list_model_components() == ['bpl', 'bpl2', 'pl']
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1201,7 +1201,7 @@ def test_response_source_data(make_data_path, clean_astro_ui, hide_logging):
     assert eterm.val == pytest.approx(bexpval)
 
 
-def validate_response_source_data_manual(direct=True):
+def validate_response_source_data_manual():
     """Tests for test_response_source_data_manual[_datapha]
 
     It checks out issue #880.
@@ -1221,10 +1221,7 @@ def validate_response_source_data_manual(direct=True):
     # adapt to the current behavior.
     #
     pname = mdl.pha.name.split('/')[-1]
-    if direct:
-        assert pname == 'fake'
-    else:
-        assert pname == '12845.pi'
+    assert pname == 'fake'
 
     aname = mdl.arf.name.split('/')[-1]
     assert aname == '12845.warf'
@@ -1234,10 +1231,7 @@ def validate_response_source_data_manual(direct=True):
 
     eterm = mdl.parts[0].parts[0]
     assert isinstance(eterm, ArithmeticConstantModel)
-    if direct:
-        assert eterm.val == pytest.approx(bexpval)
-    else:
-        assert eterm.val == pytest.approx(expval)
+    assert eterm.val == pytest.approx(bexpval)
 
     # Source response
     #
@@ -1321,7 +1315,7 @@ def test_response_source_data_manual_datapha(make_data_path, clean_astro_ui, hid
     ui.set_source(ui.powlaw1d.smdl)
     ui.set_bkg_source(ui.const1d.bmdl)
 
-    validate_response_source_data_manual(direct=False)
+    validate_response_source_data_manual()
 
 
 @requires_data
@@ -1506,16 +1500,6 @@ def test_bkg_analysis_setting_changed(idval, direct, analysis, clean_astro_ui):
 
     src = ui.get_data(idval)
     bkg = ui.get_bkg(idval)
-
-    # Want to be able to mark some tests as XFAIL, but as it
-    # involves a parameter setting, how best to do this and
-    # get to see a XPASS when the code is fixed?
-    #
-    if direct and analysis != 'channel':
-        if bkg.units == analysis:
-            assert False, "Test was expected to fail, but can not mark XPASS"
-
-        pytest.xfail("Using set_background does not set units")
 
     assert src.units == analysis
     assert bkg.units == analysis

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -242,6 +242,53 @@ def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_log
     assert ui.list_model_components() == ['bpl', 'bpl2', 'pl']
 
 
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_models_two_single(id, make_data_path, clean_astro_ui, hide_logging):
+    """The common use case is for the same background model
+
+    See test_setup_pha1_file_models_two
+    """
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    sdata = ui.get_data(id)
+    sdata.exposure = 100
+    sdata.get_arf().exposure = 150
+    sdata.backscal = 0.1
+    sdata.areascal = 0.8
+
+    bdata1 = ui.get_bkg(id, bkg_id=1)
+    bdata1.exposure = 1000
+    bdata1.backscal = 0.4
+    bdata1.areascal = 0.4
+
+    bdata2 = ui.unpack_pha(make_data_path('3c273_bg.pi'))
+    bdata2.exposure = 2000
+    bdata2.backscal = 0.8
+    bdata2.areascal = 0.5
+    ui.set_bkg(id, bdata2, bkg_id=2)
+
+    ui.set_source(id, ui.powlaw1d.pl)
+    ui.set_bkg_source(id, ui.powlaw1d.bpl)
+    ui.set_bkg_source(id, ui.powlaw1d.bpl, bkg_id=2)
+
+    iid = 1 if id is None else id
+
+    bmdl = ui.get_bkg_model(id, bkg_id=1)
+    assert bmdl.name == 'apply_rmf(apply_arf((1000 * powlaw1d.bpl)))'
+
+    bmdl = ui.get_bkg_model(id, bkg_id=2)
+    assert bmdl.name == 'apply_rmf(apply_arf((2000 * powlaw1d.bpl)))'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((100 * ((powlaw1d.pl + (0.025 * powlaw1d.bpl)) + (0.005000000000000001 * powlaw1d.bpl)))))'
+
+    assert ui.list_model_components() == ['bpl', 'pl']
+
+
 def setup_pha1(exps, bscals, ascals):
     """Create multiple PHA files (source + backgrounds).
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -34,6 +34,7 @@ import pytest
 from sherpa.astro import ui
 from sherpa.astro.data import DataARF, DataPHA
 from sherpa.astro.instrument import ARFModelPHA
+from sherpa.models.model import ArithmeticConstantModel
 from sherpa.utils.err import ModelErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
@@ -107,11 +108,20 @@ def test_setup_pha1_file_group(id, make_data_path, clean_astro_ui, hide_logging)
     assert sgrouping.sum() == -932
     assert (bdata.grouping == sgrouping).all()
 
+    # check the UI get_grouping method agrees
+    #
+    assert (ui.get_grouping(id) == ui.get_grouping(id, bkg_id=1)).all()
+
+    # The quality array is all 0's, so not an illuminating test
+    assert (ui.get_quality(id) == ui.get_quality(id, bkg_id=1)).all()
+
     # Change the grouping of the background daga
     #
     ui.group_counts(id, 5, bkg_id=1)
     assert (sdata.grouping == sgrouping).all()
     assert bdata.grouping.sum() == -952
+
+    assert (ui.get_grouping(id) != ui.get_grouping(id, bkg_id=1)).any()
 
     # check we can ungroup just the background
     ui.ungroup(id, bkg_id=1)
@@ -892,3 +902,533 @@ def test_get_bkg_scale(clean_astro_ui):
     bscale2 = ui.get_bkg_scale('x', bkg_id=2, units='rate')
     assert bscale2.size == 19
     assert bscale2 == pytest.approx(0.5 * r(bscales, 2))
+
+
+@requires_data
+@requires_fits
+def test_use_source_data(make_data_path, clean_astro_ui, hide_logging):
+    """Check a fit uses the sousrce data to define its fit
+
+    The source region binning and filtering is used here
+    as nothing has been set for the background.
+
+    It does not check the statistic value
+
+    See also test_use_background_data
+    """
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+
+    # Use the source to define grouping and filtering
+    ui.notice(0.5, 7)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+
+    stats = ui.get_stat_info()
+    assert len(stats) == 3
+
+    src = stats[0]
+    bgnd = stats[1]
+    comb = stats[2]
+
+    assert src.name == 'Dataset 1'
+    assert bgnd.name == 'Background 1 for Dataset 1'
+    assert comb.name == 'Dataset [1]'
+
+    assert src.ids == (1,)
+    assert bgnd.ids == (1,)
+    assert comb.ids == [1]
+
+    assert src.bkg_ids is None
+    assert bgnd.bkg_ids == (1,)
+    assert comb.bkg_ids is None
+
+    assert src.numpoints == 42
+    assert bgnd.numpoints == 42
+    assert comb.numpoints == 84
+
+    # Note: comb.dof > src.dof + bgnd.dof here
+    #
+    # source dataset is fit with powlaw1d + const1d, so has
+    # three free parameters.
+    # background dataset is fit with const1d, so has 1 free
+    # parameter.
+    # the combined dataset is fit with powlae1d+const1d, const1d
+    # so has three free parameters
+    #
+    assert src.dof == 39
+    assert bgnd.dof == 41
+    assert comb.dof == 81
+
+
+@requires_data
+@requires_fits
+def test_use_source_data_manual(make_data_path, clean_astro_ui, hide_logging):
+    """Check a fit uses the source data to define its fit (load in bkg)
+
+    The source region binning and filtering is used here
+    as nothing has been set for the background. Unlike test_use_source_data
+    we load in the background separately (ie not via BACKFILE keyword)
+    to see if this makes any difference.
+
+    It does not check the statistic value
+
+    See also test_use_background_data
+    """
+
+    infile = make_data_path('12845.pi')
+    ui.load_pha(infile)
+
+    assert ui.list_bkg_ids() == []
+
+    # Add in a background
+    bpha = ui.unpack_pha(infile)
+    bpha.delete_response()
+
+    ui.set_bkg(bpha)
+
+    assert ui.list_bkg_ids() == [1]
+
+    # Use the source to define grouping and filtering
+    ui.notice(0.5, 7)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+
+    stats = ui.get_stat_info()
+    assert len(stats) == 3
+
+    src = stats[0]
+    bgnd = stats[1]
+    comb = stats[2]
+
+    assert src.name == 'Dataset 1'
+    assert bgnd.name == 'Background 1 for Dataset 1'
+    assert comb.name == 'Dataset [1]'
+
+    assert src.ids == (1,)
+    assert bgnd.ids == (1,)
+    assert comb.ids == [1]
+
+    assert src.bkg_ids is None
+    assert bgnd.bkg_ids == (1,)
+    assert comb.bkg_ids is None
+
+    assert src.numpoints == 446
+    assert bgnd.numpoints == 446
+    assert comb.numpoints == 892
+
+    assert src.dof == 443
+    assert bgnd.dof == 445
+    assert comb.dof == 889
+
+
+@requires_group
+@requires_data
+@requires_fits
+def test_use_background_data(make_data_path, clean_astro_ui, hide_logging):
+    """Check a fit uses the background data to define its fit
+
+    See also test_use_source_data and test_use_backgroud_data_two
+    """
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+
+    bexpval = ui.get_exposure(bkg_id=1)
+
+    # Use different grouping and filtering for source and
+    # background apertures.
+    #
+    ui.group_width(5, bkg_id=1)
+
+    ui.notice(0.5, 7)
+
+    ui.notice(None, None, bkg_id=1)
+    ui.notice(0.3, 8, bkg_id=1)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+
+    stats = ui.get_stat_info()
+    assert len(stats) == 3
+
+    src = stats[0]
+    bgnd = stats[1]
+    comb = stats[2]
+
+    assert src.name == 'Dataset 1'
+    assert bgnd.name == 'Background 1 for Dataset 1'
+    assert comb.name == 'Dataset [1]'
+
+    assert src.ids == (1,)
+    assert bgnd.ids == (1,)
+    assert comb.ids == [1]
+
+    assert src.bkg_ids is None
+    assert bgnd.bkg_ids == (1,)
+    assert comb.bkg_ids is None
+
+    assert src.numpoints == 42
+    assert bgnd.numpoints == 106
+    assert comb.numpoints == 148
+
+    assert src.dof == 39
+    assert bgnd.dof == 105
+    assert comb.dof == 145
+
+
+@requires_group
+@requires_data
+@requires_fits
+def test_use_background_data_two(make_data_path, clean_astro_ui, hide_logging):
+    """Check a fit uses the background data to define its fit (2 backgrounds)
+
+    See also test_use_source_data and  and test_use_backgroud_data
+    """
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+
+    # Fake a second background, and use one with a response
+    # (this one doesn't have a background)
+    bgfile = make_data_path('12845.pi')
+    ui.load_bkg(bgfile, bkg_id=2)
+
+    # Use different grouping and filtering for source and
+    # background apertures.
+    #
+    ui.group_width(5, bkg_id=1)
+    ui.group_width(10, bkg_id=2)
+
+    ui.notice(0.5, 7)
+
+    ui.notice(None, None, bkg_id=1)
+    ui.notice(0.3, 8, bkg_id=1)
+
+    ui.notice(None, None, bkg_id=2)
+    ui.notice(1, 6, bkg_id=2)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+    ui.set_bkg_source(bmdl, bkg_id=2)
+
+    stats = ui.get_stat_info()
+    assert len(stats) == 4
+
+    src = stats[0]
+    bgnd1 = stats[1]
+    bgnd2 = stats[2]
+    comb = stats[3]
+
+    assert src.name == 'Dataset 1'
+    assert bgnd1.name == 'Background 1 for Dataset 1'
+    assert bgnd2.name == 'Background 2 for Dataset 1'
+    assert comb.name == 'Dataset [1]'
+
+    assert src.ids == (1,)
+    assert bgnd1.ids == (1,)
+    assert bgnd2.ids == (1,)
+    assert comb.ids == [1]
+
+    assert src.bkg_ids is None
+    assert bgnd1.bkg_ids == (1,)
+    assert bgnd2.bkg_ids == (2,)
+    assert comb.bkg_ids is None
+
+    assert src.numpoints == 42
+    assert bgnd1.numpoints == 106
+    assert bgnd2.numpoints == 36
+    assert comb.numpoints == 184
+
+    assert src.dof == 39
+    assert bgnd1.dof == 105
+    assert bgnd2.dof == 35
+    assert comb.dof == 181
+
+
+@requires_data
+@requires_fits
+def test_response_source_data(make_data_path, clean_astro_ui, hide_logging):
+    """Check the full model expressions"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+
+    bexpval = ui.get_exposure(bkg_id=1)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+
+    # What is used as the background response?
+    #
+    mdl = ui.get_bkg_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == '3c273_bg.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '3c273.arf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '3c273.rmf'
+
+    # Check the exposure time (this is sensitive to the
+    # structure of the model expression).
+    #
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(bexpval)
+
+    # Source response
+    #
+    mdl = ui.get_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == '3c273.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '3c273.arf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '3c273.rmf'
+
+    # The exposure time is the same as the background
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(bexpval)
+
+
+@requires_data
+@requires_fits
+def test_response_source_data_manual(make_data_path, clean_astro_ui, hide_logging):
+    """Check the full model expressions: explicitly load background"""
+
+    infile = make_data_path('12845.pi')
+    ui.load_pha(infile)
+
+    assert ui.list_bkg_ids() == []
+
+    expval = ui.get_exposure()
+
+    # Change scaling and remove response from the fake background
+    bpha = ui.unpack_pha(infile)
+    bpha.name = 'fake'
+    bpha.exposure *= 5
+    bpha.backscal *= 2
+    bpha.delete_response()
+
+    ui.set_bkg(bpha)
+
+    bexpval = ui.get_exposure(bkg_id=1)
+    assert bexpval == pytest.approx(expval * 5)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+
+    # What is used as the response?
+    #
+    mdl = ui.get_bkg_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == 'fake'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(bexpval)
+
+    # Source response
+    #
+    mdl = ui.get_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == '12845.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    # The exposure time is the same as not the same as the background
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(expval)
+
+
+@requires_data
+@requires_fits
+def test_response_source_data_manual_datapha(make_data_path, clean_astro_ui, hide_logging):
+    """Check the full model expressions: explicitly load background: DataPHA
+
+    This is test_response_source_data_manual but using the
+    DataPHA method to add the background to the source, since it
+    leads to different behavior with the background instrument
+    response.
+    """
+
+    infile = make_data_path('12845.pi')
+    ui.load_pha(infile)
+
+    assert ui.list_bkg_ids() == []
+
+    expval = ui.get_exposure()
+
+    # Change scaling and remove response from the fake background
+    bpha = ui.unpack_pha(infile)
+    bpha.name = 'fake'
+    bpha.exposure *= 5
+    bpha.backscal *= 2
+    bpha.delete_response()
+
+    ui.get_data().set_background(bpha)
+
+    bexpval = ui.get_exposure(bkg_id=1)
+    assert bexpval == pytest.approx(expval * 5)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+
+    # What is used as the response?
+    #
+    # Note: unlike test_response_source_data_manual we use the
+    #       source dataset for the background model.
+    #
+    mdl = ui.get_bkg_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    # assert pname == 'fake'
+    assert pname == '12845.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    # assert eterm.val == pytest.approx(bexpval)
+    assert eterm.val == pytest.approx(expval)
+
+    # Source response
+    #
+    mdl = ui.get_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == '12845.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    # The exposure time is the same as not the same as the background
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(expval)
+
+
+@requires_data
+@requires_fits
+def test_response_two_backgrounds(make_data_path, clean_astro_ui, hide_logging):
+    """Check the full model expressions: two backgrounds"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+
+    # Fake a second background, and use one with a response
+    # (this one doesn't have a background)
+    bgfile = make_data_path('12845.pi')
+    ui.load_bkg(bgfile, bkg_id=2)
+
+    bexpval1 = ui.get_exposure(bkg_id=1)
+    bexpval2 = ui.get_exposure(bkg_id=2)
+
+    assert bexpval1 == pytest.approx(38564.608926889)
+    assert bexpval2 == pytest.approx(37845.662207644)
+
+    ui.set_source(ui.powlaw1d.smdl)
+    ui.set_bkg_source(ui.const1d.bmdl)
+    ui.set_bkg_source(bmdl, bkg_id=2)
+
+    # What is used as the response?
+    #
+    mdl1 = ui.get_bkg_model()
+
+    pname = mdl1.pha.name.split('/')[-1]
+    assert pname == '3c273_bg.pi'
+
+    aname = mdl1.arf.name.split('/')[-1]
+    assert aname == '3c273.arf'
+
+    rname = mdl1.rmf.name.split('/')[-1]
+    assert rname == '3c273.rmf'
+
+    eterm = mdl1.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(bexpval1)
+
+    mdl2 = ui.get_bkg_model(bkg_id=2)
+
+    pname = mdl2.pha.name.split('/')[-1]
+    assert pname == '12845.pi'
+
+    aname = mdl2.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl2.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    eterm = mdl2.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(bexpval2)
+
+    # Source response
+    #
+    mdl = ui.get_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == '3c273.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '3c273.arf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '3c273.rmf'
+
+    # The exposure time is the same as the first background
+    # component
+    #
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(bexpval1)
+
+
+@requires_data
+@requires_fits
+def test_source_overwrites_background(make_data_path, clean_astro_ui, hide_logging):
+    """Changing the source clears out the background filters"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(infile)
+
+    ui.notice(2, 4, bkg_id=1)
+
+    assert ui.get_dep(filter=True).size == 46
+    assert ui.get_dep(filter=True, bkg_id=1).size == 13
+
+    # This over-writes the background filter
+    ui.notice(0.5, 7)
+
+    assert ui.get_dep(filter=True).size == 42
+    assert ui.get_dep(filter=True, bkg_id=1).size == 42

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -274,7 +274,11 @@ def setup_pha1(exps, bscals, ascals):
     return dset
 
 
-def test_evaluation_requires_models(clean_astro_ui):
+# Try and pick routines with different pathways through the code
+# to catch all cases.
+#
+@pytest.mark.parametrize("func", [ui.calc_stat, ui.get_model_plot])
+def test_evaluation_requires_models(func, clean_astro_ui):
     """We need a background model for each dataset"""
 
     exps = (100.0, 1000.0, 1500.0)
@@ -286,9 +290,35 @@ def test_evaluation_requires_models(clean_astro_ui):
     ui.set_bkg_source(ui.box1d.bmdl)
 
     with pytest.raises(ModelErr) as exc:
-        ui.calc_stat()
+        func()
 
     assert "background model 2 for data set 1 has not been set" == str(exc.value)
+
+
+SCALING = np.ones(19)
+SCALING[2:5] = 0.8
+SCALING[15] = 0.7
+
+@pytest.mark.parametrize("exps,bscales,ascales,result",
+                         [((100, 1000), (0.01, 0.05), (0.4, 0.5),
+                           (100 * 0.01 * 0.4) / (1000 * 0.05 * 0.5)),
+                          ((100, 1000, 1500), (0.01, 0.05, 0.04), (0.2, 0.5, 0.4),
+                           0.5 * (100 * 0.01 * 0.2) *
+                           (1 / (1000 * 0.05 * 0.5) + 1 / (1500 * 0.04 * 0.4))),
+                          ((100, 1000), (0.01, 0.05 * SCALING), (0.4, 0.5),
+                           (100 * 0.01 * 0.4) / (1000 * 0.05 * SCALING * 0.5)),
+                          ((100, 1000, 1500), (0.01, 0.05 * SCALING, 0.04), (0.4, 0.5, 0.6 * SCALING),
+                           0.5 * (100 * 0.01 * 0.4) *
+                           (1 / (1000 * 0.05 * SCALING * 0.5) +
+                            1 / (1500 * 0.04 * 0.6 * SCALING))),
+                         ])
+@pytest.mark.parametrize("id", [None, "x"])
+def test_pha1_get_bkg_scale(id, exps, bscales, ascales, result, clean_astro_ui):
+    """Check we can calculate the scaling factor"""
+
+    ui.set_data(id, setup_pha1(exps, bscales, ascales))
+    bscal = ui.get_bkg_scale(id)
+    assert bscal == pytest.approx(result)
 
 
 def test_pha1_eval(clean_astro_ui):
@@ -522,6 +552,66 @@ def test_pha1_eval_vector(clean_astro_ui):
 
     assert splot.y == pytest.approx(sy)
     assert bplot1.y == pytest.approx(by1)
+
+
+@pytest.mark.parametrize('dofilter,expected',
+                         [(False, 15.059210673609382),
+                          pytest.param(True, 2.6057323845799996,
+                                       marks=pytest.mark.xfail)])
+def test_pha1_eval_vector_stat(dofilter, expected, clean_astro_ui):
+    """Compare statistic, with and without filtering.
+
+    The statistic values are calculated from the code, and
+    so only act as a regression test.
+    """
+
+    scale = np.ones(19)
+    scale[9:15] = 0.8
+
+    exps = (100.0, 1000.0)
+    bscales = (0.01, 0.05 * scale)
+    ascales = (0.8, 0.4)
+    ui.set_data(setup_pha1(exps, bscales, ascales))
+
+    # change counts to reduce the statistic difference
+    #
+    y = np.zeros(19, dtype=np.int16)
+    y[1] = 4
+    y[2] = 10
+    y[3] = 507
+    y[4:9] = 1007
+    y[9] = 910
+    y[10] = 11
+    y[11] = 2
+    ui.set_dep(y * 8)
+
+    y = np.zeros(19, dtype=np.int16)
+    y[1] = 110
+    y[2:11] = 181
+    y[11] = 17
+    ui.set_dep(y * 40, bkg_id=1)
+
+    ui.set_source(ui.box1d.smdl)
+    ui.set_bkg_source(ui.box1d.bmdl1)
+
+    smdl.ampl.max = 10
+    smdl.ampl = 10
+    smdl.xlow = 0.95
+    smdl.xhi = 1.59
+
+    bmdl1.ampl.max = 2
+    bmdl1.ampl = 2
+    bmdl1.xlow = 0.74
+    bmdl1.xhi = 1.71
+
+    ui.set_stat('chi2datavar')
+
+    if dofilter:
+        ui.ignore(None, 0.79)
+        ui.ignore(1.38, None)
+
+    s = ui.calc_stat()
+    assert s == pytest.approx(expected)
 
 
 def test_jdpileup_no_warning(caplog, clean_astro_ui):

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -284,7 +284,7 @@ def test_setup_pha1_file_models_two_single(id, make_data_path, clean_astro_ui, h
     assert bmdl.name == 'apply_rmf(apply_arf((2000 * powlaw1d.bpl)))'
 
     smdl = ui.get_model(id)
-    assert smdl.name == 'apply_rmf(apply_arf((100 * ((powlaw1d.pl + (0.025 * powlaw1d.bpl)) + (0.005000000000000001 * powlaw1d.bpl)))))'
+    assert smdl.name == 'apply_rmf(apply_arf((100 * (powlaw1d.pl + (0.030000000000000002 * powlaw1d.bpl)))))'
 
     assert ui.list_model_components() == ['bpl', 'pl']
 
@@ -602,11 +602,11 @@ def test_pha1_eval_vector_show(clean_astro_ui):
 
     # array = r(*exps) * r(*bscales) * r(*ascales)
     src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (scalearray.scale1_1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src += ' + (scalearray.scale1 * apply_arf((100.0 * box1d.bmdl1))))'
 
     assert smdl.name == src
 
-    assert ui.list_model_components() == ['bmdl1', 'scale1_1', 'smdl']
+    assert ui.list_model_components() == ['bmdl1', 'scale1', 'smdl']
 
 
 def test_pha1_eval_vector(clean_astro_ui):
@@ -773,7 +773,7 @@ def test_jdpileup_no_warning(caplog, clean_astro_ui):
 
 
 def test_jdpileup_warning(caplog, clean_astro_ui):
-    """jdpileup model has warnng when vector scaling"""
+    """jdpileup model has warning when vector scaling"""
 
     exps = (100.0, 1000.0, 200)
     bscales = (0.01, 0.02, 0.05)
@@ -793,4 +793,4 @@ def test_jdpileup_warning(caplog, clean_astro_ui):
     name, level, msg = caplog.record_tuples[0]
     assert name == 'sherpa.astro.background'
     assert level == logging.WARNING
-    assert msg == 'model results for dataset x likely wrong: use of pileup model and scaling of bkg_id=2'
+    assert msg == 'model results for dataset x likely wrong: use of pileup model and array scaling for the background'

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1498,7 +1498,7 @@ def test_bkg_analysis_setting_no_response(idval, direct, clean_astro_ui):
         with pytest.raises(DataErr) as exc:
             ui.set_analysis(idval, 'energy')
 
-    assert str(exc.value) == 'No instrument model found for dataset ex'
+    assert str(exc.value) == 'No instrument response found for dataset ex'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one"])

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -415,10 +415,9 @@ def test_pha1_eval_vector_show(clean_astro_ui):
 
     smdl = ui.get_model()
 
-    array = r(*exps) * r(*bscales) * r(*ascales)
+    # array = r(*exps) * r(*bscales) * r(*ascales)
     src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (apply_arf((100.0 * box1d.bmdl1))'
-    src += ' * {}))'.format(array)
+    src += ' + (scale1_1 * apply_arf((100.0 * box1d.bmdl1))))'
 
     assert smdl.name == src
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -33,6 +33,7 @@ import pytest
 
 from sherpa.astro import ui
 from sherpa.astro.data import DataARF, DataPHA
+from sherpa.astro.instrument import ARFModelPHA
 from sherpa.utils.err import ModelErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
@@ -413,6 +414,28 @@ def test_pha1_show_data(id, exps, bscales, ascales, results, clean_astro_ui):
     # just check we have the correct following lines
     assert msg[notice] == 'Noticed Channels: 1-19'
     assert msg[notice + 1] == 'name           = tst0'
+
+
+def test_pha1_instruments(clean_astro_ui):
+    """Check we get the correct responses for various options.
+    """
+
+    # We don't check the scaling here
+    scales = (1, 1, 1)
+    ui.set_data(1, setup_pha1(scales, scales, scales))
+    ui.set_source(1, ui.stephi1d.smdl)
+    ui.set_bkg_source(1, ui.steplo1d.bmdl)
+    ui.set_bkg_source(1, bmdl, bkg_id=2)
+
+    smdl = ui.get_model()
+    bmdl1 = ui.get_bkg_model(bkg_id=1)
+    bmdl2 = ui.get_bkg_model(bkg_id=2)
+
+    # check the response contains the correct names
+    for i, mdl in enumerate([smdl, bmdl1, bmdl2]):
+        assert isinstance(mdl, ARFModelPHA)
+        assert mdl.pha.name == 'tst{}'.format(i)
+        assert mdl.arf.name == 'arf{}'.format(i)
 
 
 # Try and pick routines with different pathways through the code

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -128,22 +128,31 @@ def test_setup_pha1_file_models(id, make_data_path, clean_astro_ui, hide_logging
     infile = make_data_path('3c273.pi')
     ui.load_pha(id, infile)
 
+    assert ui.list_model_components() == []
+
     # Check the source models
     #
     ui.set_source(id, ui.powlaw1d.pl)
+    assert ui.list_model_components() == ['pl']
+
     ui.set_bkg_source(id, ui.powlaw1d.bpl)
+    assert ui.list_model_components() == ['bpl', 'pl']
 
     smdl = ui.get_source(id)
     assert smdl.name == 'powlaw1d.pl'
+    assert ui.list_model_components() == ['bpl', 'pl']
 
     bmdl = ui.get_bkg_source(id)
     assert bmdl.name == 'powlaw1d.bpl'
+    assert ui.list_model_components() == ['bpl', 'pl']
 
     smdl = ui.get_model(id)
     assert smdl.name == 'apply_rmf(apply_arf((38564.608926889 * (powlaw1d.pl + (0.134920643888096 * powlaw1d.bpl)))))'
+    assert ui.list_model_components() == ['bpl', 'pl']
 
     bmdl = ui.get_bkg_model(id)
     assert bmdl.name == 'apply_rmf(apply_arf((38564.608926889 * powlaw1d.bpl)))'
+    assert ui.list_model_components() == ['bpl', 'pl']
 
 
 @requires_data
@@ -228,6 +237,8 @@ def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_log
 
     smdl = ui.get_model(id)
     assert smdl.name == 'apply_rmf(apply_arf((100 * ((powlaw1d.pl + (0.025 * powlaw1d.bpl)) + (0.005000000000000001 * polynom1d.bpl2)))))'
+
+    assert ui.list_model_components() == ['bpl', 'bpl2', 'pl']
 
 
 def setup_pha1(exps, bscals, ascals):
@@ -407,19 +418,25 @@ def test_pha1_eval_vector_show(clean_astro_ui):
     ui.set_source(ui.box1d.smdl)
     ui.set_bkg_source(ui.box1d.bmdl1)
 
+    assert ui.list_model_components() == ['bmdl1', 'smdl']
+
     def r(sval, bval):
         return sval / bval
 
     bmdl = ui.get_bkg_model()
     assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
 
+    assert ui.list_model_components() == ['bmdl1', 'smdl']
+
     smdl = ui.get_model()
 
     # array = r(*exps) * r(*bscales) * r(*ascales)
     src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (scale1_1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src += ' + (tablemodel.scale1_1 * apply_arf((100.0 * box1d.bmdl1))))'
 
     assert smdl.name == src
+
+    assert ui.list_model_components() == ['bmdl1', 'scale1_1', 'smdl']
 
 
 def test_pha1_eval_vector(clean_astro_ui):

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -462,7 +462,7 @@ def test_pha1_eval_vector_show(clean_astro_ui):
 
     # array = r(*exps) * r(*bscales) * r(*ascales)
     src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (tablemodel.scale1_1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src += ' + (scalearray.scale1_1 * apply_arf((100.0 * box1d.bmdl1))))'
 
     assert smdl.name == src
 
@@ -556,8 +556,7 @@ def test_pha1_eval_vector(clean_astro_ui):
 
 @pytest.mark.parametrize('dofilter,expected',
                          [(False, 15.059210673609382),
-                          pytest.param(True, 2.6057323845799996,
-                                       marks=pytest.mark.xfail)])
+                          (True, 4.34458466)])
 def test_pha1_eval_vector_stat(dofilter, expected, clean_astro_ui):
     """Compare statistic, with and without filtering.
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1,0 +1,220 @@
+#
+#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test handling of fitting a background to PHA data.
+
+There are a few tests scattered around that do this, but this
+attempts to provide a solid test base. There is likely to be
+overlap in the WSTAT tests, for one.
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro import ui
+from sherpa.astro.data import DataPHA
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_filter(id, make_data_path, clean_astro_ui, hide_logging):
+    """Can I change filtering of the background?"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    sdata = ui.get_data(id)
+    bdata = ui.get_bkg(id)
+
+    # Need an argument for notice/ignore_id
+    iid = 1 if id is None else id
+
+    # The idea here is to check that we can have
+    # different filters for the source and background
+    # regions.
+    #
+    assert sdata.get_dep(filter=True).size == 46
+    assert bdata.get_dep(filter=True).size == 46
+
+    ui.ignore_id(iid, None, 0.5)
+    ui.ignore_id(iid, 7, None)
+
+    assert sdata.get_dep(filter=True).size == 40
+    assert bdata.get_dep(filter=True).size == 40
+
+    # need to reset the background filter
+    ui.notice_id(iid, None, None, bkg_id=1)
+
+    assert sdata.get_dep(filter=True).size == 40
+    assert bdata.get_dep(filter=True).size == 46
+
+    ui.ignore_id(iid, None, 0.3, bkg_id=1)
+    ui.ignore_id(iid, 8, None, bkg_id=1)
+
+    assert sdata.get_dep(filter=True).size == 40
+    assert bdata.get_dep(filter=True).size == 42
+
+
+@requires_data
+@requires_fits
+@requires_group
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_group(id, make_data_path, clean_astro_ui, hide_logging):
+    """Can I change grouping of the background?"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    sdata = ui.get_data(id)
+    bdata = ui.get_bkg(id)
+
+    dtype = np.dtype('>i2')  # why not np.dtype(np.int16)?
+    assert sdata.grouping.dtype == dtype
+    assert bdata.grouping.dtype == dtype
+
+    assert sdata.quality.dtype == dtype
+    assert bdata.quality.dtype == dtype
+
+    assert sdata.grouped
+    assert bdata.grouped
+
+    # Check default grouping (taken from source)
+    sgrouping = sdata.grouping.copy()
+    assert sgrouping.sum() == -932
+    assert (bdata.grouping == sgrouping).all()
+
+    # Change the grouping of the background daga
+    #
+    ui.group_counts(id, 5, bkg_id=1)
+    assert (sdata.grouping == sgrouping).all()
+    assert bdata.grouping.sum() == -952
+
+    # check we can ungroup just the background
+    ui.ungroup(id, bkg_id=1)
+    assert sdata.grouped
+    assert not bdata.grouped
+
+    assert bdata.grouping.sum() == -952
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_models(id, make_data_path, clean_astro_ui, hide_logging):
+    """Is the model set correctly for the background"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    # Check the source models
+    #
+    ui.set_source(id, ui.powlaw1d.pl)
+    ui.set_bkg_source(id, ui.powlaw1d.bpl)
+
+    smdl = ui.get_source(id)
+    assert smdl.name == 'powlaw1d.pl'
+
+    bmdl = ui.get_bkg_source(id)
+    assert bmdl.name == 'powlaw1d.bpl'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((38564.608926889 * (powlaw1d.pl + 0.134921 * (powlaw1d.bpl)))))'
+
+    bmdl = ui.get_bkg_model(id)
+    assert bmdl.name == 'apply_rmf(apply_arf((38564.608926889 * powlaw1d.bpl)))'
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_logging):
+    """Is the model set correctly for two background components"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    # Tweak scaling values to make output easier to check.
+    # The ARF is changed as well, to a different value, to
+    # check what value is used in the model expression.
+    #
+    sdata = ui.get_data(id)
+    sdata.exposure = 100
+    sdata.get_arf().exposure = 150
+    sdata.backscal = 0.1
+    sdata.areascal = 0.8
+
+    # scale factor to correct to source is
+    #   = (100 / 1000) * (0.1 / 0.4) * (0.8 / 0.4)
+    #     exp = 0.1   back = 0.25  area = 2
+    #   = 0.025 if exclude the area scaling
+    #   = 0.05  if include the area scaling
+    #
+    bdata1 = ui.get_bkg(id, bkg_id=1)
+    bdata1.exposure = 1000
+    # bdata1.get_arf().exposure = 1500  no ARF
+    bdata1.backscal = 0.4
+    bdata1.areascal = 0.4
+
+    # add a second dataset (copy of the background)
+    #
+    # scale factor
+    #   = (100 / 2000) * (0.1 / 0.8) * (0.8 / 0.5)
+    #     exp = 0.05   back = 0.125  area = 1.6
+    #   = 0.00625 if exclude the area scaling
+    #   = 0.01    if include the area scaling
+    #
+    bdata2 = ui.unpack_pha(make_data_path('3c273_bg.pi'))
+    bdata2.exposure = 2000
+    # bdata2.get_arf().exposure = 2500  no ARF
+    bdata2.backscal = 0.8
+    bdata2.areascal = 0.5
+    ui.set_bkg(id, bdata2, bkg_id=2)
+
+    # Check the source models:
+    #  - first with one
+    #  - then with two
+    #
+    ui.set_source(id, ui.powlaw1d.pl)
+    ui.set_bkg_source(id, ui.powlaw1d.bpl)
+
+    smdl = ui.get_source(id)
+    assert smdl.name == 'powlaw1d.pl'
+
+    bmdl = ui.get_bkg_source(id)
+    assert bmdl.name == 'powlaw1d.bpl'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((100 * (powlaw1d.pl + 0.03 * (powlaw1d.bpl)))))'
+
+    bmdl = ui.get_bkg_model(id)
+    assert bmdl.name == 'apply_rmf(apply_arf((1000 * powlaw1d.bpl)))'
+
+    ui.set_bkg_source(id, ui.polynom1d.bpl2, bkg_id=2)
+
+    bmdl = ui.get_bkg_model(id, bkg_id=1)
+    assert bmdl.name == 'apply_rmf(apply_arf((1000 * powlaw1d.bpl)))'
+
+    bmdl = ui.get_bkg_model(id, bkg_id=2)
+    assert bmdl.name == 'apply_rmf(apply_arf((2000 * polynom1d.bpl2)))'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((100 * (powlaw1d.pl + 0.03 * (powlaw1d.bpl + polynom1d.bpl2)))))'

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -73,7 +73,7 @@ def example_pha_data():
     d = ui.DataPHA('example', _data_chan.copy(),
                    _data_counts.copy(),
                    exposure=etime,
-                   backscal=0.1)
+                   backscal=0.2)
 
     a = ui.create_arf(_energies[:-1].copy(),
                       _energies[1:].copy(),
@@ -136,7 +136,7 @@ def example_bkg_model():
     ui.create_model_component('powlaw1d', 'bcpt')
     bcpt = ui.get_model_component('bcpt')
     bcpt.gamma = 0.0  # use a flat model to make it easy to evaluate
-    bcpt.ampl = 1e-1
+    bcpt.ampl = 0.4
     return bcpt
 
 
@@ -519,7 +519,7 @@ def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
 
     # TODO: this is the same output as test_get_bkg_model_plot_energy,
     #       which doesn't make sense.
-    yexp = _arf / 100
+    yexp = _arf / 25
     if direct:
         yexp /= _bexpscale
 
@@ -571,7 +571,7 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
 
     # TODO: The factor of 100 comes from the bin width (0.1 keV), but
     # why is there a scaling by _bexpscale?
-    yexp = _arf / 100
+    yexp = _arf / 25
     if direct:
         yexp /= _bexpscale
     else:
@@ -600,7 +600,7 @@ def test_get_bkg_resid_plot(idval):
 
     # correct the counts by the bin width and exposure time
     #
-    yexp = (_data_bkg * 100.0 / 1201.0 - _arf) / (_bexpscale * 100)
+    yexp = (_data_bkg * 25.0 / 1201.0 - _arf) / (_bexpscale * 25)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
@@ -628,7 +628,7 @@ def test_get_bkg_resid_plot_energy(idval):
 
     # correct the counts by the bin width and exposure time
     #
-    yexp = (_data_bkg * 100.0 / 1201.0 - _arf) / (_bexpscale * 100)
+    yexp = (_data_bkg * 25.0 / 1201.0 - _arf) / (_bexpscale * 25)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
@@ -662,7 +662,7 @@ def test_get_bkg_fit_plot(idval):
     yexp = _data_bkg / 1201.0 / _bexpscale
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf / 100.0 / _bexpscale
+    yexp = _arf / 25.0 / _bexpscale
     assert mp.y == pytest.approx(yexp)
 
 
@@ -696,7 +696,7 @@ def test_get_bkg_fit_plot_energy(idval):
     yexp = _data_bkg / 1201.0 / _bexpscale
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf / 100.0 / _bexpscale
+    yexp = _arf / 25.0 / _bexpscale
     assert mp.y == pytest.approx(yexp)
 
 
@@ -730,7 +730,7 @@ def check_bkg_fit(plotfunc):
     yexp = _data_bkg / 1201.0 / _bexpscale
     assert dplot.y == pytest.approx(yexp)
 
-    yexp = _arf / (_bexpscale * 100)
+    yexp = _arf / (_bexpscale * 25.0)
     assert mplot.y == pytest.approx(yexp)
 
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016, 2018, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,19 +37,21 @@ corresponding functions in sherpa.astro.ui.utils.
 #    table model
 #
 
-import re
 from io import StringIO
+import logging
+import re
 import tempfile
 
 import numpy
 from numpy.testing import assert_array_equal
+
+import pytest
 
 from sherpa.utils.testing import SherpaTestCase, requires_data, \
     requires_xspec, has_package_from_list, requires_fits, requires_group
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
 
-import logging
 logger = logging.getLogger('sherpa')
 
 has_xspec = has_package_from_list("sherpa.astro.xspec")
@@ -823,446 +825,467 @@ _canonical_pha_grouped += _canonical_extra
 _canonical_usermodel += _canonical_extra
 
 
-class test_ui(SherpaTestCase):
-
-    def setUp(self):
-        try:
-            numpy.set_printoptions(legacy='1.13')
-        except TypeError:  # numpy < 1.14
-            pass
-
-        ui.clean()  # I thought the test harness did this anyway
-        self._old_logging_level = logger.level
-        logger.setLevel(logging.ERROR)
-        if has_xspec:
-            from sherpa.astro import xspec
-            self._xspec_state = xspec.get_xsstate()
-            ui.set_xschatter(0)
-            ui.set_xsabund('angr')
-            ui.set_xsxsect('bcmc')
-
-    def tearDown(self):
-        try:
-            numpy.set_printoptions(legacy=False)
-        except TypeError:  # numpy < 1.14
-            pass
-        logger.setLevel(self._old_logging_level)
-        if has_xspec:
-            from sherpa.astro import xspec
-            xspec.set_xsstate(self._xspec_state)
-
-        ui.clean()
-
-    def _add_datadir_path(self, output):
-        """Replace any @@ characters by the value of self.datadir,
-        making sure that the replacement text does not end in a /."""
-
-        dname = self.datadir
-        if dname.endswith('/'):
-            dname = dname[:-1]
-
-        return re.sub('@@', dname, output, count=0)
-
-    def _compile(self, output):
-        # Let it just throw an exception in case of failure.
-        compile(output, "test.py", "exec")
-
-    def _compare_lines(self, expected, got):
-        """Check that each line in got matches that in
-        expected. This is to provide a more-readable
-        set of error messages (may prefer a diff-style
-        analysis).
-        """
-
-        elines = expected.split('\n')
-        glines = got.split('\n')
-
-        # _dump_lines(elines)
-        # _dump_lines(glines)
-
-        for e, g in zip(elines, glines):
-            self.assertEqual(e, g)
-
-        # Do the line length after checking for the file
-        # contents as it is easier to see what the difference
-        # is this way around, since a difference in the
-        # number of lines is often not very informative.
-        self.assertEqual(len(elines), len(glines))
-
-    def _compare(self, expected):
-        """Run save_all and check the output (saved to a
-        StringIO object) to the string value expected.
-        """
-        output = StringIO()
-        ui.save_all(output)
-        output = output.getvalue()
-
-        # check the output is a valid Python program.
-        # this check does not guard against potential issues,
-        # but ensures that the program can compile.
-        self._compile(output)
-
-        self._compare_lines(expected, output)
-
-    def _restore(self):
-        """Run save_all then call clean and try to restore
-        the Sherpa state from the saved file. Will raise
-        a test failure if there was an error when
-        executing the save file.
-        """
-
-        output = StringIO()
-        ui.save_all(output)
-        output = output.getvalue()
-        ui.clean()
-        try:
-            exec(output)
-            success = True
-            e = "no exception"
-        except Exception as e:
-            success = False
-
-        self.assertTrue(success, msg="exception={}".format(e))
-
-    def _setup_pha_basic(self):
-        """Load up a PHA file and make "simple" changes to the
-        Sherpa state. Returns the name of the file that is
-        loaded and the canonical output.
-        """
+# This extends the clean_astro_ui logic but it isn't obvious
+# to me how to chain them together, so it re-implements
+# clean_astro_ui.
+#
+@pytest.fixture(autouse=True)
+def setup(clean_astro_ui):
+
+    # Setup for the test
+    try:
+        numpy.set_printoptions(legacy='1.13')
+    except TypeError:  # numpy < 1.14
+        pass
+
+    old_logging_level = logger.level
+    logger.setLevel(logging.ERROR)
+
+    if has_xspec:
+        from sherpa.astro import xspec
+        old_xspec = xspec.get_xsstate()
+
+        # ensure we have the same settings as the test cases
+        # used (changes to XSPEC may have changed the defaults)
+        xspec.set_xschatter(0)
+        xspec.set_xsabund('angr')
+        xspec.set_xsxsect('bcmc')
+    else:
+        old_xspec = None
+
+    ui.clean()
+
+    # run the test
+    yield
+
+    # Restore the Sherpa/related settings
+    ui.clean()
+
+    if old_xspec is not None:
+        xspec.set_xsstate(old_xspec)
+
+    try:
+        numpy.set_printoptions(legacy=False)
+    except TypeError:  # numpy < 1.14
+        pass
+
+    logger.setLevel(old_logging_level)
+
+
+def add_datadir_path(output):
+    """Replace any @@ characters by the value of self.datadir,
+    making sure that the replacement text does not end in a /."""
+
+    # it would be nice not to use SherpaTestCase
+    dname = SherpaTestCase.datadir
+    if dname.endswith('/'):
+        dname = dname[:-1]
+
+    return re.sub('@@', dname, output, count=0)
+
+def compileit(output):
+    # Let it just throw an exception in case of failure.
+    compile(output, "test.py", "exec")
+
+
+def compare_lines(expected, got):
+    """Check that each line in got matches that in
+    expected. This is to provide a more-readable
+    set of error messages (may prefer a diff-style
+    analysis).
+    """
+
+    elines = expected.split('\n')
+    glines = got.split('\n')
+
+    # _dump_lines(elines)
+    # _dump_lines(glines)
+
+    for e, g in zip(elines, glines):
+        assert e == g
+
+    # Do the line length after checking for the file
+    # contents as it is easier to see what the difference
+    # is this way around, since a difference in the
+    # number of lines is often not very informative.
+    #
+    assert len(elines) == len(glines)
 
-        ui.clean()
-        fname = self.make_path('3c273.pi')
-        ui.load_pha(1, fname)
-        ui.subtract()
-        ui.set_stat('chi2datavar')
-        ui.notice(0.5, 7)
-        ui.set_source(ui.xsphabs.gal * (ui.powlaw1d.pl +
-                                        ui.xsapec.src))
-        return fname, self._add_datadir_path(_canonical_pha_basic)
 
-    def _setup_pha_grouped(self):
-        """Add in grouping and a few different choices.
+def compare(expected):
+    """Run save_all and check the output (saved to a
+    StringIO object) to the string value expected.
+    """
+    output = StringIO()
+    ui.save_all(output)
+    output = output.getvalue()
 
-        Returns the name of the file that is
-        loaded, the new grouping and quality arrays,
-        and the canonical output.
-        """
+    # check the output is a valid Python program.
+    # this check does not guard against potential issues,
+    # but ensures that the program can compile.
+    #
+    compileit(output)
+    compare_lines(expected, output)
 
-        ui.clean()
-        fname = self.make_path('3c273.pi')
-        ui.load_pha('grp', fname)
-        channels = ui.get_data('grp').channel
 
-        exclude = (channels < 20) | (channels > 800)
-        qual = exclude * 1
+def restore():
+    """Run save_all then call clean and try to restore
+    the Sherpa state from the saved file. Will raise
+    a test failure if there was an error when
+    executing the save file.
+    """
 
-        ui.subtract('grp')
-        ui.group_counts('grp', 10, tabStops=exclude)
-        ui.set_quality('grp', exclude)
+    output = StringIO()
+    ui.save_all(output)
+    output = output.getvalue()
+    ui.clean()
+    try:
+        exec(output)
+        success = True
+        e = "no exception"
+    except Exception as e:
+        success = False
 
-        grp = ui.get_data('grp').grouping
+    assert success, "exception={}".format(e)
 
-        ui.set_stat('chi2gehrels')
-        ui.notice_id('grp', 0.5, 6)
-        ui.set_source('grp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
-        ui.powlaw1d.gpl.gamma.max = 5
-        ui.set_par('ggal.nh', val=2.0, frozen=True)
 
-        return fname, (grp, qual), \
-            self._add_datadir_path(_canonical_pha_grouped)
+def setup_pha_basic(make_data_path):
+    """Load up a PHA file and make "simple" changes to the
+    Sherpa state. Returns the name of the file that is
+    loaded and the canonical output.
+    """
 
-    def _setup_pha_back(self):
-        """Fit the background, rather than subtract it.
-        """
+    fname = make_data_path('3c273.pi')
+    ui.load_pha(1, fname)
+    ui.subtract()
+    ui.set_stat('chi2datavar')
+    ui.notice(0.5, 7)
+    ui.set_source(ui.xsphabs.gal * (ui.powlaw1d.pl +
+                                    ui.xsapec.src))
+    return fname, add_datadir_path(_canonical_pha_basic)
 
-        ui.clean()
-        fname = self.make_path('3c273.pi')
-        ui.load_pha('bgrp', fname)
 
-        # Note: do not group the source dataset
+def setup_pha_grouped(make_data_path):
+    """Add in grouping and a few different choices.
 
-        bchannels = ui.get_bkg('bgrp').channel
+    Returns the name of the file that is
+    loaded, the new grouping and quality arrays,
+    and the canonical output.
+    """
 
-        bexclude = (bchannels < 10) | (bchannels > 850)
-        bqual = bexclude * 1
+    fname = make_data_path('3c273.pi')
+    ui.load_pha('grp', fname)
+    channels = ui.get_data('grp').channel
 
-        ui.group_counts('bgrp', 10, tabStops=bexclude, bkg_id=1)
-        ui.set_quality('bgrp', bexclude, bkg_id=1)
+    exclude = (channels < 20) | (channels > 800)
+    qual = exclude * 1
 
-        bgrp = ui.get_bkg('bgrp').grouping
+    ui.subtract('grp')
+    ui.group_counts('grp', 10, tabStops=exclude)
+    ui.set_quality('grp', exclude)
 
-        ui.set_stat('chi2xspecvar')
+    grp = ui.get_data('grp').grouping
 
-        # This call sets the noticed range for both source and
-        # background data sets.
-        ui.notice_id('bgrp', 0.5, 6)
+    ui.set_stat('chi2gehrels')
+    ui.notice_id('grp', 0.5, 6)
+    ui.set_source('grp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
+    ui.powlaw1d.gpl.gamma.max = 5
+    ui.set_par('ggal.nh', val=2.0, frozen=True)
 
-        # Remove the "source" filter
-        ui.notice_id('bgrp', None, None, bkg_id=1)
-        ui.notice_id('bgrp', 2, 7, bkg_id=1)
+    return fname, (grp, qual), \
+        add_datadir_path(_canonical_pha_grouped)
 
-        ui.set_source('bgrp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
-        ui.set_bkg_source('bgrp', ui.steplo1d.bstep + ui.polynom1d.bpoly)
 
-        ui.set_xsabund('lodd')
-        ui.set_xsxsect('vern')
-        ui.set_xscosmo(72, 0.02, 0.71)
+def setup_pha_back(make_data_path):
+    """Fit the background, rather than subtract it.
+    """
 
-        ui.powlaw1d.gpl.gamma.min = -5
-        ui.freeze(ui.polynom1d.bpoly.c0)
+    fname = make_data_path('3c273.pi')
+    ui.load_pha('bgrp', fname)
 
-        ui.set_par('ggal.nh', val=2.0, frozen=True)
+    # Note: do not group the source dataset
 
-        return fname, (bgrp, bqual), \
-            self._add_datadir_path(_canonical_pha_back)
+    bchannels = ui.get_bkg('bgrp').channel
 
-    def _setup_usermodel(self):
-        """Try a user model.
-        """
+    bexclude = (bchannels < 10) | (bchannels > 850)
+    bqual = bexclude * 1
 
-        ui.clean()
-        # Note: array is not sorted on purpose, and float/int
-        # values.
-        ui.load_arrays(3, [1, 12.2, 2, 14], [4, 8, 12, 4])
+    ui.group_counts('bgrp', 10, tabStops=bexclude, bkg_id=1)
+    ui.set_quality('bgrp', bexclude, bkg_id=1)
 
-        def mymodel_func(pars, x, xhi=None):
-            return pars[0] + pars[1] * x
+    bgrp = ui.get_bkg('bgrp').grouping
 
-        ui.load_user_model(mymodel_func, "mymodel")
-        ui.add_user_pars("mymodel",
-                         parnames=["c", "m"],
-                         parvals=[2, 0.5],
-                         parmins=[-10, 0],
-                         parmaxs=[10, 5.5],
-                         parunits=["m", ""],
-                         parfrozen=[False, True])
+    ui.set_stat('chi2xspecvar')
 
-        mymodel = ui.get_model_component("mymodel")
-        ui.set_source(3, ui.sin.sin_model + mymodel)
+    # This call sets the noticed range for both source and
+    # background data sets.
+    ui.notice_id('bgrp', 0.5, 6)
 
-        ui.set_stat('cash')
-        ui.set_method('simplex')
+    # Remove the "source" filter
+    ui.notice_id('bgrp', None, None, bkg_id=1)
+    ui.notice_id('bgrp', 2, 7, bkg_id=1)
 
-    def test_compile_failure(self):
-        try:
-            self._compile("foo bar")
-        except:
-            return
-        self.fail("Compilation should have failed")
+    ui.set_source('bgrp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
+    ui.set_bkg_source('bgrp', ui.steplo1d.bstep + ui.polynom1d.bpoly)
 
-    def test_restore_empty(self):
-        "Can the empty state be evaluated?"
+    ui.set_xsabund('lodd')
+    ui.set_xsxsect('vern')
+    ui.set_xscosmo(72, 0.02, 0.71)
 
-        ui.clean()
+    ui.powlaw1d.gpl.gamma.min = -5
+    ui.freeze(ui.polynom1d.bpoly.c0)
 
-        # At present the only check is that the file can be
-        # loaded.
-        self._restore()
+    ui.set_par('ggal.nh', val=2.0, frozen=True)
 
-    def test_canonical_empty(self):
-        self._compare(_canonical_empty)
+    return fname, (bgrp, bqual), \
+        add_datadir_path(_canonical_pha_back)
 
-    def test_canonical_empty_outfile(self):
-        tfile = tempfile.NamedTemporaryFile(suffix='.sherpa')
-        ui.save_all(tfile.name, clobber=True)
-        with open(tfile.name, 'r') as fh:
-            output = fh.read()
-        self._compare_lines(_canonical_empty, output)
 
-    def test_canonical_empty_stats(self):
+def setup_usermodel():
+    """Try a user model.
+    """
 
-        ui.set_stat('leastsq')
+    # Note: array is not sorted on purpose, and float/int
+    # values.
+    ui.load_arrays(3, [1, 12.2, 2, 14], [4, 8, 12, 4])
 
-        ui.set_method('simplex')
-        ui.set_method_opt('maxfev', 5000)
-        ui.set_method_opt('verbose', 1)
+    def mymodel_func(pars, x, xhi=None):
+        return pars[0] + pars[1] * x
 
-        self._compare(_canonical_empty_stats)
+    ui.load_user_model(mymodel_func, "mymodel")
+    ui.add_user_pars("mymodel",
+                     parnames=["c", "m"],
+                     parvals=[2, 0.5],
+                     parmins=[-10, 0],
+                     parmaxs=[10, 5.5],
+                     parunits=["m", ""],
+                     parfrozen=[False, True])
 
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    def test_canonical_pha_basic(self):
+    mymodel = ui.get_model_component("mymodel")
+    ui.set_source(3, ui.sin.sin_model + mymodel)
 
-        _, canonical = self._setup_pha_basic()
-        self._compare(canonical)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    def test_restore_pha_basic(self):
-        "Can the state be evaluated?"
-
-        fname, _ = self._setup_pha_basic()
-        statval = ui.calc_stat()
-
-        self._restore()
-
-        self.assertEqual([1], ui.list_data_ids())
-        self.assertEqual(fname, ui.get_data(1).name)
-        self.assertTrue(ui.get_data().subtracted,
-                        msg='Data should be subtracted')
-
-        src_expr = ui.get_source()
-        self.assertEqual(src_expr.name,
-                         '(xsphabs.gal * (powlaw1d.pl + xsapec.src))')
-        self.assertEqual(ui.xsphabs.gal.name, 'xsphabs.gal')
-        self.assertEqual(ui.powlaw1d.pl.name, 'powlaw1d.pl')
-        self.assertEqual(ui.xsapec.src.name, 'xsapec.src')
-
-        self.assertAlmostEqual(ui.calc_stat(), statval)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_canonical_pha_grouped(self):
-
-        _, _, canonical = self._setup_pha_grouped()
-        self._compare(canonical)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_restore_pha_grouped(self):
-        "Can the state be evaluated?"
-
-        fname, (grp, qual), _ = self._setup_pha_grouped()
-        statval = ui.calc_stat('grp')
-
-        self._restore()
-
-        self.assertEqual(['grp'], ui.list_data_ids())
-        self.assertEqual(fname, ui.get_data('grp').name)
-        self.assertTrue(ui.get_data('grp').subtracted,
-                        msg='Data should be subtracted')
-
-        g = ui.get_grouping('grp')
-        q = ui.get_quality('grp')
-        self.assertEqual(g.dtype, numpy.int16)
-        self.assertEqual(q.dtype, numpy.int16)
-
-        assert_array_equal(grp, g, err_msg='grouping column')
-        assert_array_equal(qual, q, err_msg='grouping column')
-
-        src_expr = ui.get_source('grp')
-        self.assertEqual(src_expr.name,
-                         '(xsphabs.ggal * powlaw1d.gpl)')
-        self.assertTrue(ui.xsphabs.ggal.nh.frozen, msg="is ggal.nh frozen?")
-        self.assertEqual(ui.xsphabs.ggal.nh.val, 2.0)
-        self.assertEqual(ui.powlaw1d.gpl.gamma.max, 5.0)
-
-        self.assertAlmostEqual(ui.calc_stat('grp'), statval)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_canonical_pha_back(self):
-
-        _, _, canonical = self._setup_pha_back()
-        self._compare(canonical)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_restore_pha_back(self):
-        "Can the state be evaluated?"
-
-        fname, (bgrp, bqual), _ = self._setup_pha_back()
-        statval = ui.calc_stat('bgrp')
-
-        # At present the model is not saved correctly for the
-        # background component - it includes apply_arf/rmf
-        # statements - which means that running the saved script
-        # results in an error.
-        self._restore()
-
-        self.assertEqual(['bgrp'], ui.list_data_ids())
-        self.assertEqual(fname, ui.get_data('bgrp').name)
-        self.assertFalse(ui.get_data('bgrp').subtracted,
-                         msg='Data should not be subtracted')
-        self.assertFalse(ui.get_bkg('bgrp').subtracted,
-                         msg='Background should not be subtracted')
-
-        # TODO: at present the source is grouped; is this "correct"?
-        # self.assertFalse(ui.get_data('bgrp').grouped,
-        #                  msg='Data should not be grouped')
-        self.assertTrue(ui.get_data('bgrp').grouped,
-                        msg='Data should be grouped')  # FIXME?
-        self.assertTrue(ui.get_bkg('bgrp').grouped,
-                        msg='Background should be grouped')
-
-        # g = ui.get_grouping('bgrp')
-        # q = ui.get_quality('bgrp')
-        # The data types are '>i2' / int16
-        # self.assertEqual(g.dtype, numpy.int16)
-        # self.assertEqual(q.dtype, numpy.int16)
-
-        # TODO set up correct grouping bins...
-        # nchan = ui.get_data('bgrp').channel.size
-        # assert_array_equal(g, numpy.ones(nchan), err_msg='src grouping')
-        # assert_array_equal(q, numpy.zeros(nchan), err_msg='src quality')
-
-        bg = ui.get_grouping('bgrp', bkg_id=1)
-        bq = ui.get_quality('bgrp', bkg_id=1)
-        self.assertEqual(bg.dtype, numpy.int16)
-        self.assertEqual(bq.dtype, numpy.int16)
-
-        assert_array_equal(bg, bgrp, err_msg='bgnd grouping')
-        assert_array_equal(bq, bqual, err_msg='bgnd quality')
-
-        # TODO: check noticed range
-
-        src_expr = ui.get_source('bgrp')
-        self.assertEqual(src_expr.name,
-                         '(xsphabs.ggal * powlaw1d.gpl)')
-
-        bg_expr = ui.get_bkg_source('bgrp')
-        self.assertEqual(bg_expr.name,
-                         '(steplo1d.bstep + polynom1d.bpoly)')
-
-        self.assertTrue(ui.xsphabs.ggal.nh.frozen, msg="is ggal.nh frozen?")
-        self.assertTrue(ui.polynom1d.bpoly.c0.frozen, msg="is bpoly.c0 frozen?")
-        self.assertEqual(ui.xsphabs.ggal.nh.val, 2.0)
-        self.assertEqual(ui.powlaw1d.gpl.gamma.min, -5.0)
-
-        self.assertEqual(ui.get_xsabund(), 'lodd')
-        self.assertEqual(ui.get_xsxsect(), 'vern')
-        cosmo = ui.get_xscosmo()
-        self.assertAlmostEqual(cosmo[0], 72.0)
-        self.assertAlmostEqual(cosmo[1], 0.02)
-        self.assertAlmostEqual(cosmo[2], 0.71)
-
-        self.assertAlmostEqual(ui.calc_stat('bgrp'), statval)
-
-    def test_canonical_usermodel(self):
-
-        self._setup_usermodel()
-        self._compare(_canonical_usermodel)
-
-    def test_restore_usermodel(self):
-        "Can the state be evaluated?"
-
-        self._setup_usermodel()
-        statval = ui.calc_stat(3)
-        self._restore()
-
-        # TODO: For the moment the source expression is created, in
-        # the serialized form, using set_full_model. This should
-        # be changed so that get_source can be used below.
-        #
-        # src_expr = ui.get_source(3)
-        src_expr = ui.get_model(3)
-        self.assertEqual(src_expr.name,
-                         '(sin.sin_model + usermodel.mymodel)')
-        mymodel = ui.get_model_component("mymodel")
-        self.assertTrue(mymodel.m.frozen, msg="is mymodel.m frozen?")
-        self.assertEqual(mymodel.c.val, 2.0)
-        self.assertEqual(mymodel.c.units, "m")
-        self.assertEqual(mymodel.m.max, 5.5)
-        self.assertEqual(mymodel.m.units, "")
-
-        self.assertEqual(ui.calc_stat(3), statval)
+    ui.set_stat('cash')
+    ui.set_method('simplex')
+
+
+def test_compile_failure():
+    with pytest.raises(Exception):
+        compileit("foo bar")
+
+
+def test_restore_empty():
+    "Can the empty state be evaluated?"
+
+    # At present the only check is that the file can be
+    # loaded.
+    restore()
+
+
+def test_canonical_empty():
+    "Contents of empty state are as expected"
+    compare(_canonical_empty)
+
+
+def test_canonical_empty_outfile():
+    "Can read in a save file"
+    tfile = tempfile.NamedTemporaryFile(suffix='.sherpa')
+    ui.save_all(tfile.name, clobber=True)
+    with open(tfile.name, 'r') as fh:
+        output = fh.read()
+
+    compare_lines(_canonical_empty, output)
+
+
+def test_canonical_empty_stats():
+    "Change several settings but load no data"
+
+    ui.set_stat('leastsq')
+
+    ui.set_method('simplex')
+    ui.set_method_opt('maxfev', 5000)
+    ui.set_method_opt('verbose', 1)
+
+    compare(_canonical_empty_stats)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+def test_canonical_pha_basic(make_data_path):
+
+    _, canonical = setup_pha_basic(make_data_path)
+    compare(canonical)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+def test_restore_pha_basic(make_data_path):
+    "Can the state be evaluated?"
+
+    fname, _ = setup_pha_basic(make_data_path)
+    statval = ui.calc_stat()
+
+    restore()
+
+    assert ui.list_data_ids() == [1]
+    assert ui.get_data(1).name == fname
+    assert ui.get_data().subtracted, 'Data should be subtracted'
+
+    src_expr = ui.get_source()
+    assert src_expr.name == '(xsphabs.gal * (powlaw1d.pl + xsapec.src))'
+    assert ui.xsphabs.gal.name == 'xsphabs.gal'
+    assert ui.powlaw1d.pl.name == 'powlaw1d.pl'
+    assert ui.xsapec.src.name == 'xsapec.src'
+
+    assert ui.calc_stat() == pytest.approx(statval)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_canonical_pha_grouped(make_data_path):
+
+    _, _, canonical = setup_pha_grouped(make_data_path)
+    compare(canonical)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_restore_pha_grouped(make_data_path):
+    "Can the state be evaluated?"
+
+    fname, (grp, qual), _ = setup_pha_grouped(make_data_path)
+    statval = ui.calc_stat('grp')
+
+    restore()
+
+    assert ui.list_data_ids() == ['grp']
+    assert ui.get_data('grp').name == fname
+    assert ui.get_data('grp').subtracted, 'Data should be subtracted'
+
+    g = ui.get_grouping('grp')
+    q = ui.get_quality('grp')
+    assert g.dtype == numpy.int16
+    assert q.dtype == numpy.int16
+
+    assert_array_equal(grp, g, err_msg='grouping column')
+    assert_array_equal(qual, q, err_msg='grouping column')
+
+    src_expr = ui.get_source('grp')
+    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+    assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
+    assert ui.xsphabs.ggal.nh.val == 2.0
+    assert ui.powlaw1d.gpl.gamma.max == 5.0
+
+    assert ui.calc_stat('grp') == pytest.approx(statval)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_canonical_pha_back(make_data_path):
+
+    _, _, canonical = setup_pha_back(make_data_path)
+    compare(canonical)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_restore_pha_back(make_data_path):
+    "Can the state be evaluated?"
+
+    fname, (bgrp, bqual), _ = setup_pha_back(make_data_path)
+    statval = ui.calc_stat('bgrp')
+
+    # At present the model is not saved correctly for the
+    # background component - it includes apply_arf/rmf
+    # statements - which means that running the saved script
+    # results in an error.
+    restore()
+
+    assert ui.list_data_ids() == ['bgrp']
+    assert ui.get_data('bgrp').name == fname
+    assert not ui.get_data('bgrp').subtracted, 'Data should not be subtracted'
+    assert not ui.get_bkg('bgrp').subtracted, 'Background should not be subtracted'
+
+    # TODO: at present the source is grouped; is this "correct"?
+    assert ui.get_data('bgrp').grouped, 'Data should be grouped'  # FIXME?
+    assert ui.get_bkg('bgrp').grouped, 'Background should be grouped'
+
+    # g = ui.get_grouping('bgrp')
+    # q = ui.get_quality('bgrp')
+    # The data types are '>i2' / int16
+    # assert g.dtype == numpy.int16
+    # assert q.dtype == numpy.int16
+
+    # TODO set up correct grouping bins...
+    # nchan = ui.get_data('bgrp').channel.size
+    # assert_array_equal(g, numpy.ones(nchan), err_msg='src grouping')
+    # assert_array_equal(q, numpy.zeros(nchan), err_msg='src quality')
+
+    bg = ui.get_grouping('bgrp', bkg_id=1)
+    bq = ui.get_quality('bgrp', bkg_id=1)
+    assert bg.dtype == numpy.int16
+    assert bq.dtype == numpy.int16
+
+    assert_array_equal(bg, bgrp, err_msg='bgnd grouping')
+    assert_array_equal(bq, bqual, err_msg='bgnd quality')
+
+    # TODO: check noticed range
+
+    src_expr = ui.get_source('bgrp')
+    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+
+    bg_expr = ui.get_bkg_source('bgrp')
+    assert bg_expr.name == '(steplo1d.bstep + polynom1d.bpoly)'
+
+    assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
+    assert ui.polynom1d.bpoly.c0.frozen, "is bpoly.c0 frozen?"
+    assert ui.xsphabs.ggal.nh.val == 2.0
+    assert ui.powlaw1d.gpl.gamma.min == -5.0
+
+    assert ui.get_xsabund() == 'lodd'
+    assert ui.get_xsxsect() == 'vern'
+    cosmo = ui.get_xscosmo()
+    assert cosmo[0] == pytest.approx(72.0)
+    assert cosmo[1] == pytest.approx(0.02)
+    assert cosmo[2] == pytest.approx(0.71)
+
+    assert ui.calc_stat('bgrp') == pytest.approx(statval)
+
+
+def test_canonical_usermodel():
+    "Can we save a usermodel?"
+    setup_usermodel()
+    compare(_canonical_usermodel)
+
+
+def test_restore_usermodel():
+    "Can the reload a usermodel"
+
+    setup_usermodel()
+    statval = ui.calc_stat(3)
+    restore()
+
+    # TODO: For the moment the source expression is created, in
+    # the serialized form, using set_full_model. This should
+    # be changed so that get_source can be used below.
+    #
+    # src_expr = ui.get_source(3)
+    src_expr = ui.get_model(3)
+    assert src_expr.name == '(sin.sin_model + usermodel.mymodel)'
+    mymodel = ui.get_model_component("mymodel")
+    assert mymodel.m.frozen,"is mymodel.m frozen?"
+    assert mymodel.c.val == 2.0
+    assert mymodel.c.units == "m"
+    assert mymodel.m.max == 5.5
+    assert mymodel.m.units == ""
+
+    assert ui.calc_stat(3) == pytest.approx(statval)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1204,10 +1204,6 @@ def test_restore_pha_back(make_data_path):
     fname, (bgrp, bqual), _ = setup_pha_back(make_data_path)
     statval = ui.calc_stat('bgrp')
 
-    # At present the model is not saved correctly for the
-    # background component - it includes apply_arf/rmf
-    # statements - which means that running the saved script
-    # results in an error.
     restore()
 
     assert ui.list_data_ids() == ['bgrp']

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8860,6 +8860,20 @@ class Session(sherpa.ui.utils.Session):
         if len(vectors) == 0:
             return model
 
+        # Warn if a pileup model is being used. The error message here
+        # is terrible.
+        #
+        # Should this be a Python Warning rather than a logged message?
+        #
+        if isinstance(resp, sherpa.astro.instrument.PileupResponse1D):
+            bkg_ids = ",".join([str(k) for k, _ in vectors])
+            wmsg = "model results for dataset {} ".format(id) + \
+                    "likely wrong: use of pileup model and scaling " + \
+                    "of bkg_id={}".format(bkg_ids)
+
+            # warnings.warn(wmsg)
+            warning(wmsg)
+
         for key, scale in vectors:
             # NOTE: with a NumPy array we need to
             # say mdl * array and not the other way

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -3510,7 +3510,7 @@ class Session(sherpa.ui.utils.Session):
         return self._get_pha_data(id).exposure
 
     def get_backscal(self, id=None, bkg_id=None):
-        """Return the background scaling of a PHA data set.
+        """Return the BACKSCAL scaling of a PHA data set.
 
         Return the BACKSCAL setting [1]_ for the source or background
         component of a PHA data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -3567,18 +3567,20 @@ class Session(sherpa.ui.utils.Session):
             return self.get_bkg(id, bkg_id).backscal
         return self._get_pha_data(id).backscal
 
-    def get_bkg_scale(self, id=None, bkg_id=1, group=True, filter=False):
+    def get_bkg_scale(self, id=None, bkg_id=1, units='counts',
+                      group=True, filter=False):
         """Return the background scaling factor for a background data set.
 
         Return the factor applied to the background component to scale
-        it to match it to the source (either when subtracting the
-        background, or fitting it simultaneously).
+        it to match it to the source, either when subtracting the
+        background (units='counts'), or fitting it simultaneously
+        (units='rate').
 
         .. versionchanged:: 4.12.2
-           The bkg_id, group, and filter parameters have been added
-           and the routine no-longer calculates the average scaling
-           for all the background components but just for the given
-           component.
+           The bkg_id, counts, group, and filter parameters have been
+           added and the routine no-longer calculates the average
+           scaling for all the background components but just for the
+           given component.
 
         Parameters
         ----------
@@ -3589,6 +3591,11 @@ class Session(sherpa.ui.utils.Session):
         bkg_id : int or str, optional
            Set to identify which background component to use.  The
            default value is 1.
+        units : {'counts', 'rate'}, optional
+           The correction is applied to a model defined as counts, the
+           default, or a rate. The latter should be used when
+           calculating the correction factor for adding the background
+           data to the source aperture.
         group : bool, optional
             Should the values be grouped to match the data?
         filter : bool, optional
@@ -3610,7 +3617,7 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        The scale factor is::
+        The scale factor when units='counts' is::
 
           exp_src * bscale_src * areascal_src /
           (exp_bgnd * bscale_bgnd * areascal_ngnd) /
@@ -3620,7 +3627,8 @@ class Session(sherpa.ui.utils.Session):
         exposure, BACKSCAL, and AREASCAL values for the source
         (``x=src``) and background (``x=bgnd``) regions, respectively,
         and ``nbkg`` is the number of background datasets associated
-        with the source aperture.
+        with the source aperture. When units='rate', the exposure and
+        areascal corrections are not included.
 
         Examples
         --------
@@ -3637,14 +3645,17 @@ class Session(sherpa.ui.utils.Session):
         0.034514770047217924
 
         Calculate the factors for the first two background components
-        of the default dataset:
+        of the default dataset, valid for combining the source
+        and background models to fit the source aperture:
 
-        >>> scale1 = get_bkg_scale()
-        >>> scale2 = get_bkg_scale(bkg_id=2)
+        >>> scale1 = get_bkg_scale(units='rate')
+        >>> scale2 = get_bkg_scale(units='rate', bkg_id=2)
 
         """
 
-        scale = self._get_pha_data(id).get_background_scale(bkg_id, group=group, filter=filter)
+        dset = self._get_pha_data(id)
+        scale = dset.get_background_scale(bkg_id, units=units,
+                                          group=group, filter=filter)
         if scale is None:
             # TODO: need to add bkg_id?
             raise DataErr('nobkg', self._fix_id(id))

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1503,8 +1503,6 @@ class Session(sherpa.ui.utils.Session):
         else:
             self.set_data(id, data)
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def unpack_image(self, arg, coord='logical',
                      dstype=sherpa.astro.data.DataIMG):
         """Create an image data structure.
@@ -1617,8 +1615,6 @@ class Session(sherpa.ui.utils.Session):
             id, arg = arg, id
         self.set_data(id, self.unpack_image(arg, coord, dstype))
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     # DOC-TODO: what does this return when given a PHA2 file?
     def unpack_pha(self, arg, use_errors=False):
         """Create a PHA data structure.
@@ -1671,8 +1667,6 @@ class Session(sherpa.ui.utils.Session):
         use_errors = sherpa.utils.bool_cast(use_errors)
         return sherpa.astro.io.read_pha(arg, use_errors)
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     # DOC-TODO: what does this return when given a PHA2 file?
     def unpack_bkg(self, arg, use_errors=False):
         """Create a PHA data structure for a background data set.
@@ -1851,12 +1845,14 @@ class Session(sherpa.ui.utils.Session):
             self.set_data(id, phasets)
 
     def _get_pha_data(self, id):
+        """Ensure the dataset is a PHA"""
         data = self.get_data(id)
         if not isinstance(data, sherpa.astro.data.DataPHA):
             raise ArgumentErr('nopha', self._fix_id(id))
         return data
 
     def _get_img_data(self, id):
+        """Ensure the dataset is an image"""
         data = self.get_data(id)
         if not isinstance(data, sherpa.astro.data.DataIMG):
             raise ArgumentErr('noimg', self._fix_id(id))
@@ -1882,8 +1878,6 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_filter(self, id, filename=None, bkg_id=None, ignore=False,
                     ncols=2, *args, **kwargs):
         """Load the filter array from a file and add to a data set.
@@ -1962,8 +1956,6 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id, ignore=ignore)
 
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     # DOC-TODO: prob. needs a review as the existing ahelp documentation
     # talks about 2 cols, but experimentation suggests 1 col.
     def load_grouping(self, id, filename=None, bkg_id=None, *args, **kwargs):
@@ -2052,8 +2044,6 @@ class Session(sherpa.ui.utils.Session):
         self.set_grouping(id,
                           self._read_user_model(filename, *args, **kwargs)[1], bkg_id=bkg_id)
 
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_quality(self, id, filename=None, bkg_id=None, *args, **kwargs):
         """Load the quality array from a file and add to a PHA data set.
 
@@ -4555,8 +4545,6 @@ class Session(sherpa.ui.utils.Session):
 
         sherpa.astro.io.write_pha(filename, d, ascii, clobber)
 
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def save_grouping(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
         """Save the grouping scheme to a file.
 
@@ -4640,8 +4628,6 @@ class Session(sherpa.ui.utils.Session):
         sherpa.astro.io.write_arrays(filename, [d.channel, d.grouping],
                                      ['CHANNEL', 'GROUPS'], ascii, clobber)
 
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def save_quality(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
         """Save the quality array to a file.
 
@@ -4957,8 +4943,6 @@ class Session(sherpa.ui.utils.Session):
                     except:
                         raise
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def pack_pha(self, id=None):
         """Convert a PHA data set into a file structure.
 
@@ -4987,8 +4971,6 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.pack_pha(self._get_pha_data(id))
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def pack_image(self, id=None):
         """Convert a data set into an image structure.
 
@@ -5012,8 +4994,6 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.pack_image(self.get_data(id))
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def pack_table(self, id=None):
         """Convert a data set into a table structure.
 
@@ -5316,8 +5296,6 @@ class Session(sherpa.ui.utils.Session):
         if data.units == 'channel':
             data._set_initial_quantity()
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def unpack_arf(self, arg):
         """Create an ARF data structure.
 
@@ -5372,8 +5350,6 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_arf(self, id, arg=None, resp_id=None, bkg_id=None):
         """Load an ARF from a file and add it to a PHA data set.
 
@@ -5503,8 +5479,6 @@ class Session(sherpa.ui.utils.Session):
         return self.get_arf(id, resp_id, bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_bkg_arf(self, id, arg=None):
         """Load an ARF from a file and add it to the background of a
         PHA data set.
@@ -5793,8 +5767,6 @@ class Session(sherpa.ui.utils.Session):
         if data.units == 'channel':
             data._set_initial_quantity()
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def unpack_rmf(self, arg):
         """Create a RMF data structure.
 
@@ -5849,8 +5821,6 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_rmf(self, id, arg=None, resp_id=None, bkg_id=None):
         """Load a RMF from a file and add it to a PHA data set.
 
@@ -5975,8 +5945,6 @@ class Session(sherpa.ui.utils.Session):
         return self.get_rmf(id, resp_id, bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_bkg_rmf(self, id, arg=None):
         """Load a RMF from a file and add it to the background of a
         PHA data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9059,22 +9059,6 @@ class Session(sherpa.ui.utils.Session):
         self._set_item(id, model, self._pileup_models, sherpa.models.Model,
                        'model', 'a model object or model expression string')
 
-    def _get_bkg_model_status(self, id=None, bkg_id=None):
-        src = self._background_sources.get(id, {}).get(bkg_id)
-        mdl = self._background_models.get(id, {}).get(bkg_id)
-
-        if src is None and mdl is None:
-            IdentifierErr('getitem', 'model', id, 'has not been set')
-
-        model = mdl
-        is_source = False
-
-        if mdl is None and src is not None:
-            is_source = True
-            model = src
-
-        return (model, is_source)
-
     def get_bkg_source(self, id=None, bkg_id=None):
         """Return the model expression for the background of a PHA data set.
 
@@ -9170,23 +9154,33 @@ class Session(sherpa.ui.utils.Session):
         """
         id = self._fix_id(id)
         bkg_id = self._fix_id(bkg_id)
-        src, is_source = self._get_bkg_model_status(id, bkg_id)
+
+        mdl = self._background_models.get(id, {}).get(bkg_id)
+
+        if mdl is None:
+            is_source = True
+            src = self._background_sources.get(id, {}).get(bkg_id)
+        else:
+            is_source = False
+            src = mdl
 
         if src is None:
             raise ModelErr('nobkg', bkg_id, id)
 
-        # Evaluate these even if is_source is False
-        data = self._get_pha_data(id)
-        bkg = self.get_bkg(id, bkg_id)
-
         if not is_source:
             return src
 
-        if len(bkg.response_ids) != 0:
-            resp = sherpa.astro.instrument.Response1D(bkg)
-        else:
-            resp = sherpa.astro.instrument.Response1D(data)
+        # The background response is set bu the DataPHA.set_background
+        # method (copying one over, if it does not exist), which means
+        # that the only way to get to this point is if the user has
+        # explicitly deleted the background response. In this case
+        # we error out.
+        #
+        bkg = self.get_bkg(id, bkg_id)
+        if len(bkg.response_ids) == 0:
+            raise DataErr('nobrsp', str(id), str(bkg_id))
 
+        resp = sherpa.astro.instrument.Response1D(bkg)
         return resp(src)
 
     def set_bkg_full_model(self, id, model=None, bkg_id=None):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6232,6 +6232,11 @@ class Session(sherpa.ui.utils.Session):
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
+        If the background has no grouping of quality arrays then they
+        are copied from the source region. If the background has no
+        response information (ARF or RMF) then the response is copied
+        from the source region.
+
         Examples
         --------
 
@@ -6254,7 +6259,7 @@ class Session(sherpa.ui.utils.Session):
         data.set_background(bkg, bkg_id)
         if bkg.grouping is None:
             bkg.grouping = data.grouping
-            bkg.grouped = (bkg.grouping is not None)
+            bkg.grouped = bkg.grouping is not None
         if bkg.quality is None:
             bkg.quality = data.quality
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9173,18 +9173,19 @@ class Session(sherpa.ui.utils.Session):
         if src is None:
             raise ModelErr('nobkg', bkg_id, id)
 
+        # Evaluate these even if is_source is False
         data = self._get_pha_data(id)
         bkg = self.get_bkg(id, bkg_id)
 
-        model = src
-        if is_source:
-            if len(bkg.response_ids) != 0:
-                resp = sherpa.astro.instrument.Response1D(bkg)
-                model = resp(src)
-            else:
-                resp = sherpa.astro.instrument.Response1D(data)
-                model = resp(src)
-        return model
+        if not is_source:
+            return src
+
+        if len(bkg.response_ids) != 0:
+            resp = sherpa.astro.instrument.Response1D(bkg)
+        else:
+            resp = sherpa.astro.instrument.Response1D(data)
+
+        return resp(src)
 
     def set_bkg_full_model(self, id, model=None, bkg_id=None):
         """Define the convolved background model expression for a PHA data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8882,19 +8882,26 @@ class Session(sherpa.ui.utils.Session):
             # need to deal with the namespace for these
             # models, and cleaning up after ourselves.
             #
-            # The current approach is to not use the global
-            # name table for models, which means we do not
-            # need to bother about name clashes or cleaning-up
-            # once the model has been disposed, but it is
-            # not user friendly.
+            # The tablemodel is set with x and y (rather than
+            # setting x to None in the load call) so that it
+            # can be filtered (although this doesn't seem to
+            # actually work).
             #
             npts = scale.size
             tbl = TableModel('scale{}_{}'.format(id, key))
             tbl.load(numpy.arange(1, npts + 1), scale)
             tbl.ampl.freeze()
 
-            # self._tbl_models.append(tbl)
-            # self._add_model_component(tbl)
+            # Add the model to the global symbol list, so
+            # users can interrogate it. The issues are:
+            #  - name clash: it's okay to overwrite models created
+            #    here, but what happens if a user has created a
+            #    model with this name?
+            #  - how do we clean up after the data goes out of
+            #    scope (or the background scaling changes)
+            #
+            self._tbl_models.append(tbl)
+            self._add_model_component(tbl)
 
             model += tbl * resp(bkg_srcs[key])
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -37,6 +37,7 @@ from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.data import Data1D, Data1DAsymmetricErrs
 import sherpa.astro.all
+from sherpa.astro.background import ScaleArray
 import sherpa.astro.plot
 from sherpa.astro.ui import serialize
 from sherpa.sim import NormalParameterSampleFromScaleMatrix
@@ -8880,17 +8881,13 @@ class Session(sherpa.ui.utils.Session):
             # Use a tablemodel to contain the array values:
             # this makes the string output nicer, but we
             # need to deal with the namespace for these
-            # models, and cleaning up after ourselves.
+            # models, and cleaning up after ourselves. We actually
+            # use a specialized model class, rather than a tablemodel,
+            # since it has to just return the full data (in
+            # the same way the RSP models do).
             #
-            # The tablemodel is set with x and y (rather than
-            # setting x to None in the load call) so that it
-            # can be filtered (although this doesn't seem to
-            # actually work).
-            #
-            npts = scale.size
-            tbl = TableModel('scale{}_{}'.format(id, key))
-            tbl.load(numpy.arange(1, npts + 1), scale)
-            tbl.ampl.freeze()
+            tbl = ScaleArray('scale{}_{}'.format(id, key))
+            tbl.y = scale
 
             # Add the model to the global symbol list, so
             # users can interrogate it. The issues are:
@@ -8900,7 +8897,6 @@ class Session(sherpa.ui.utils.Session):
             #  - how do we clean up after the data goes out of
             #    scope (or the background scaling changes)
             #
-            self._tbl_models.append(tbl)
             self._add_model_component(tbl)
 
             model += tbl * resp(bkg_srcs[key])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6257,20 +6257,6 @@ class Session(sherpa.ui.utils.Session):
         data = self._get_pha_data(id)
         _check_type(bkg, sherpa.astro.data.DataPHA, 'bkg', 'a PHA data set')
         data.set_background(bkg, bkg_id)
-        if bkg.grouping is None:
-            bkg.grouping = data.grouping
-            bkg.grouped = bkg.grouping is not None
-        if bkg.quality is None:
-            bkg.quality = data.quality
-
-        if bkg.get_response() == (None, None):
-            bkg.set_response(*data.get_response())
-
-        if bkg.get_response() != (None, None):
-            bkg.units = data.units
-
-        bkg.rate = data.rate
-        bkg.plot_fac = data.plot_fac
 
     def list_bkg_ids(self, id=None):
         """List all the background identifiers for a data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8812,34 +8812,55 @@ class Session(sherpa.ui.utils.Session):
     set_full_model.__doc__ = sherpa.ui.utils.Session.set_full_model.__doc__
 
     def _add_convolution_models(self, id, data, model, is_source):
+
+        id = self._fix_id(id)
+
+        # Add any convolution components from the sherpa.ui layer
         model = \
             sherpa.ui.utils.Session._add_convolution_models(self, id, data,
                                                             model, is_source)
-        id = self._fix_id(id)
-        if (isinstance(data, sherpa.astro.data.DataPHA) and is_source):
-            if not data.subtracted:
-                bkg_srcs = self._background_sources.get(self._fix_id(id), {})
-                if len(bkg_srcs.keys()) != 0:
-                    model = (model +
-                             sherpa.astro.background.BackgroundSumModel
-                             (data, bkg_srcs))
 
-            pileup_model = self._pileup_models.get(self._fix_id(id))
-            if pileup_model is not None:
-                resp = \
-                    sherpa.astro.instrument.PileupResponse1D(
-                        data, pileup_model)
-                model = resp(model)
+        # If we don't need to deal with DataPHA issues we can return
+        if not isinstance(data, sherpa.astro.data.DataPHA) or not is_source:
+            return model
 
-            elif len(data._responses) > 1:
-                resp = sherpa.astro.instrument.MultipleResponse1D(data)
-                model = resp(model)
+        if not data.subtracted:
+            bkg_srcs = self._background_sources.get(id, {})
+            if len(bkg_srcs.keys()) != 0:
+                model = (model +
+                         sherpa.astro.background.BackgroundSumModel
+                         (data, bkg_srcs))
 
-            else:
-                resp = sherpa.astro.instrument.Response1D(data)
-                model = resp(model)
+        resp = self._get_response(id, data)
+        return resp(model)
 
-        return model
+    def _get_response(self, id, pha):
+        """Calculate the response for the dataset.
+
+        Parameter
+        ---------
+        id : int or str
+            The identifier (this is required to be valid).
+        pha : sherpa.astro.data.DataPHA
+            The dataset
+
+        Returns
+        -------
+        response
+           The return value depends on whether an ARF, RMF, or pile up
+           model has been associated with the data set.
+
+        """
+
+        pileup_model = self._pileup_models.get(id)
+        if pileup_model is not None:
+            resp = sherpa.astro.instrument.PileupResponse1D(pha, pileup_model)
+        elif len(pha._responses) > 1:
+            resp = sherpa.astro.instrument.MultipleResponse1D(pha)
+        else:
+            resp = sherpa.astro.instrument.Response1D(pha)
+
+        return resp
 
     def get_response(self, id=None, bkg_id=None):
         """Return the response information applied to a PHA data set.
@@ -8896,20 +8917,13 @@ class Session(sherpa.ui.utils.Session):
         >>> set_full_model(rsp(powlaw1d.pl) + const1d.bgnd)
 
         """
-        pha = self._get_pha_data(id)
+        id = self._fix_id(id)
         if bkg_id is not None:
             pha = self.get_bkg(id, bkg_id)
-        resp = None
-
-        pileup_model = self._pileup_models.get(self._fix_id(id))
-        if pileup_model is not None:
-            resp = sherpa.astro.instrument.PileupResponse1D(pha, pileup_model)
-        elif len(pha._responses) > 1:
-            resp = sherpa.astro.instrument.MultipleResponse1D(pha)
         else:
-            resp = sherpa.astro.instrument.Response1D(pha)
+            pha = self._get_pha_data(id)
 
-        return resp
+        return self._get_response(id, pha)
 
     def get_pileup_model(self, id=None):
         """Return the pile up model for a data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -2202,8 +2202,7 @@ class Session(sherpa.ui.utils.Session):
                 else:
                     d.mask &= ~filter
             else:
-                raise sherpa.utils.err.DataErr('mismatch',
-                                               len(d.mask), len(filter))
+                raise DataErr('mismatch', len(d.mask), len(filter))
         else:
             if len(d.get_y(False)) == len(filter):
                 if not ignore:
@@ -2211,8 +2210,7 @@ class Session(sherpa.ui.utils.Session):
                 else:
                     d.mask = ~filter
             else:
-                raise sherpa.utils.err.DataErr('mismatch',
-                                               len(d.get_y(False)), len(filter))
+                raise DataErr('mismatch', len(d.get_y(False)), len(filter))
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
@@ -2929,7 +2927,7 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         err = d.get_syserror(filter)
         if err is None or not numpy.iterable(err):
-            raise sherpa.utils.err.DataErr('nosyserr', id)
+            raise DataErr('nosyserr', id)
         return err
 
     # DOC-NOTE: also in sherpa.utils, where it does not have
@@ -4248,9 +4246,9 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
         if d.mask is False:
-            raise sherpa.utils.err.DataErr('notmask')
+            raise DataErr('notmask')
         if not numpy.iterable(d.mask):
-            raise sherpa.utils.err.DataErr('nomask', id)
+            raise DataErr('nomask', id)
 
         x = d.get_indep(filter=False)[0]
         mask = numpy.asarray(d.mask, numpy.int)
@@ -4688,7 +4686,7 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
 
         if d.grouping is None or not numpy.iterable(d.grouping):
-            raise sherpa.utils.err.DataErr('nogrouping', id)
+            raise DataErr('nogrouping', id)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.grouping],
                                      ['CHANNEL', 'GROUPS'], ascii, clobber)
@@ -4771,7 +4769,7 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
 
         if d.quality is None or not numpy.iterable(d.quality):
-            raise sherpa.utils.err.DataErr('noquality', id)
+            raise DataErr('noquality', id)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.quality],
                                      ['CHANNEL', 'QUALITY'], ascii, clobber)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -18,10 +18,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import pytest
 import os
 import sys
 import re
+import logging
+
+import pytest
 
 from numpy import VisibleDeprecationWarning
 
@@ -443,3 +445,16 @@ def restore_xspec_settings():
 
     # clean up after test
     xspec.set_xsstate(state)
+
+
+@pytest.fixture
+def hide_logging():
+    """Set Sherpa's logging to ERROR for the test.
+
+    """
+
+    logger = logging.getLogger('sherpa')
+    olvl = logger.getEffectiveLevel()
+    logger.setLevel(logging.ERROR)
+    yield
+    logger.setLevel(olvl)

--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -78,437 +78,379 @@
 #     search for "Note: this is related to issue 227".
 #
 
+import logging
+
 import numpy as np
 
-from sherpa.utils.testing import SherpaTestCase, requires_data, \
-    requires_fits, requires_group
-from sherpa.astro import ui
+import pytest
 
-import logging
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group
+from sherpa.astro import ui
 
 logger = logging.getLogger('sherpa')
 
 
+# Single PHA file with a scalar backscal value"""
+
+@pytest.fixture
+def single_scalar_setup(make_data_path):
+
+    ui.set_stat('wstat')
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(1, infile)
+
+    ui.set_source(1, ui.powlaw1d.pl)
+
+    # The powerlaw slope and normalization are
+    # intended to be "a reasonable approximation"
+    # to the data, just to make sure that any statistic
+    # calculation doesn't blow-up too much.
+    #
+    ui.set_par("pl.gamma", 1.782)
+    ui.set_par("pl.ampl", 1.622e-4)
+
+
+def filter_data():
+    """Filter the data.
+
+    Use a slightly-complex filter - e.g. not just the
+    end points - to exercise the system.
+    """
+
+    ui.ignore(None, 0.5)
+    ui.ignore(3, 4)
+    ui.ignore(7, None)
+
+
+def check_stat(nbins, expected, idval=None):
+
+    # check the filter sizes (mainly so that these tests
+    # get flagged as in need of a look if anything changes
+    # in other parts of the code, such as filtering and binning
+    #
+    assert ui.get_data(idval).get_dep(True).size == nbins
+
+    stat = ui.calc_stat(idval)
+
+    # this used to check to a given number of decimal places
+    # rather than relative
+    assert stat == pytest.approx(expected)
+
+
+def check_stat2(expected):
+    """Is calc_stat() == expected?"""
+
+    stat = ui.calc_stat()
+
+    # this used to check to a given number of decimal places
+    # rather than relative
+    assert stat == pytest.approx(expected)
+
+
 @requires_data
 @requires_fits
-class test_wstat_single_scalar(SherpaTestCase):
-    """Single PHA file with a scalar backscal value"""
+def test_wstat_single_scalar_grouped_all(clean_astro_ui, hide_logging, single_scalar_setup):
 
-    def setUp(self):
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(46, 62.12275005769554)
 
-        # defensive programming (one of the tests has been seen to fail
-        # when the whole test suite is run without this)
-        ui.clean()
 
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+@requires_data
+@requires_fits
+def test_wstat_single_scalar_grouped_filtered(clean_astro_ui, hide_logging, single_scalar_setup):
+    filter_data()
 
-        ui.set_stat('wstat')
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(35, 39.84715083397662)
 
-        infile = self.make_path('3c273.pi')
-        ui.load_pha(1, infile)
 
-        ui.set_source(1, ui.powlaw1d.pl)
+@requires_data
+@requires_fits
+def test_wstat_single_scalar_ungrouped_all(clean_astro_ui, hide_logging, single_scalar_setup):
+    ui.ungroup()
 
-        # The powerlaw slope and normalization are
-        # intended to be "a reasonable approximation"
-        # to the data, just to make sure that any statistic
-        # calculation doesn't blow-up too much.
-        #
-        ui.set_par("pl.gamma", 1.782)
-        ui.set_par("pl.ampl", 1.622e-4)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(1024, 652.9968167212116)
 
-    def tearDown(self):
-        ui.clean()
 
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
+@requires_data
+@requires_fits
+def test_wstat_single_scalar_ungrouped_filtered(clean_astro_ui, hide_logging, single_scalar_setup):
+    ui.ungroup()
+    filter_data()
 
-    def _filter_data(self):
-        """Filter the data.
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(375, 416.0601496345599)
 
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
 
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
+# Two PHA files with a scalar backscal value
 
-    def _check_stat(self, nbins, expected):
+@pytest.fixture
+def two_scalar_setup(make_data_path):
 
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data().get_dep(True).size)
+    ui.set_stat('wstat')
 
-        stat = ui.calc_stat()
-        self.assertAlmostEqual(expected, stat, places=7)
+    infile1 = make_data_path('3c273.pi')
+    infile2 = make_data_path('9774.pi')
+    ui.load_pha(1, infile1)
+    ui.load_pha(2, infile2)
 
-    def test_wstat_grouped_all(self):
+    # Since 9774.pi isn't grouped, group it. Note that this
+    # call groups the background to 20 counts per bin. In this
+    # case we do not want that; instead we want to use the same
+    # grouping scheme as the source file.
+    #
+    # Note: this is related to issue 227
+    #
+    ui.group_counts(2, 20)
+    ui.set_grouping(2, bkg_id=1, val=ui.get_grouping(2))
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(46, 62.12275005769554)
+    # There's no need to have the same model in both datasets,
+    # but assume the same source model can be used, with a
+    # normalization difference.
+    #
+    ui.set_source(1, ui.powlaw1d.pl1)
+    ui.set_source(2, ui.const1d.c2 * ui.get_source(1))
 
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(35, 39.84715083397662)
-
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(1024, 652.9968167212116)
-
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup()
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(375, 416.0601496345599)
+    # The powerlaw slope and normalization are
+    # intended to be "a reasonable approximation"
+    # to the data, just to make sure that any statistic
+    # calculation doesn't blow-up too much.
+    #
+    # Note: the model values for 3c273 are slighly different
+    #       to the single-PHA-file case, so stat results are
+    #       slightly different
+    #
+    ui.set_par("pl1.gamma", 1.7)
+    ui.set_par("pl1.ampl", 1.6e-4)
+    ui.set_par("c2.c0", 45)
 
 
 @requires_group
 @requires_data
 @requires_fits
-class test_wstat_two_scalar(SherpaTestCase):
-    """Two PHA files with a scalar backscal value"""
+def test_wstat_two_scalar_grouped_all(clean_astro_ui, hide_logging, two_scalar_setup):
 
-    def setUp(self):
-
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-
-        ui.set_stat('wstat')
-
-        infile1 = self.make_path('3c273.pi')
-        infile2 = self.make_path('9774.pi')
-        ui.load_pha(1, infile1)
-        ui.load_pha(2, infile2)
-
-        # Since 9774.pi isn't grouped, group it. Note that this
-        # call groups the background to 20 counts per bin. In this
-        # case we do not want that; instead we want to use the same
-        # grouping scheme as the source file.
-        #
-        # Note: this is related to issue 227
-        #
-        ui.group_counts(2, 20)
-        ui.set_grouping(2, bkg_id=1, val=ui.get_grouping(2))
-
-        # There's no need to have the same model in both datasets,
-        # but assume the same source model can be used, with a
-        # normalization difference.
-        #
-        ui.set_source(1, ui.powlaw1d.pl1)
-        ui.set_source(2, ui.const1d.c2 * ui.get_source(1))
-
-        # The powerlaw slope and normalization are
-        # intended to be "a reasonable approximation"
-        # to the data, just to make sure that any statistic
-        # calculation doesn't blow-up too much.
-        #
-        # Note: the model values for 3c273 are slighly different
-        #       to the single-PHA-file case, so stat results are
-        #       slightly different
-        #
-        ui.set_par("pl1.gamma", 1.7)
-        ui.set_par("pl1.ampl", 1.6e-4)
-        ui.set_par("c2.c0", 45)
-
-    def tearDown(self):
-        ui.clean()
-
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
-
-    def _filter_data(self):
-        """Filter the data.
-
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
-
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
-
-    def _check_stat(self, idval, nbins, expected):
-
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data(idval).get_dep(True).size)
-
-        stat = ui.calc_stat(idval)
-        self.assertAlmostEqual(expected, stat, places=7)
-
-    def _check_stat2(self, expected):
-        """Is calc_stat() == expected?"""
-
-        stat = ui.calc_stat()
-        self.assertAlmostEqual(expected, stat, places=7)
-
-    def test_wstat_grouped_all(self):
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 66.20114213871206
-        exp2 = 401.75572944361613
-        self._check_stat(1, 46, exp1)
-        self._check_stat(2, 148, exp2)
-        self._check_stat2(exp1 + exp2)
-
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 45.93447168433694
-        exp2 = 127.35556915677182
-        self._check_stat(1, 35, exp1)
-        self._check_stat(2, 120, exp2)
-        self._check_stat2(exp1 + exp2)
-
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup(1)
-        ui.ungroup(2)
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 657.2275371837611
-        exp2 = 880.8442022201893
-        self._check_stat(1, 1024, exp1)
-        self._check_stat(2, 1024, exp2)
-        self._check_stat2(exp1 + exp2)
-
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup(1)
-        ui.ungroup(2)
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 420.50951039235736
-        exp2 = 397.4089421041855
-        self._check_stat(1, 375, exp1)
-        self._check_stat(2, 375, exp2)
-        self._check_stat2(exp1 + exp2)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 66.20114213871206
+    exp2 = 401.75572944361613
+    check_stat(46, exp1, 1)
+    check_stat(148, exp2, 2)
+    check_stat2(exp1 + exp2)
 
 
 @requires_group
 @requires_data
 @requires_fits
-class test_wstat_group_counts(SherpaTestCase):
-    """PHA file that has been grouped.
+def test_wstat_two_scalar_grouped_filtered(clean_astro_ui, hide_logging, two_scalar_setup):
+    filter_data()
 
-    This is the error reported in issue #227, whereby the
-    grouping in the source and background files is different,
-    which causes an error. It is not clear yet whether this
-    should be supported or not, but a regression test is added
-    to check this behavior.
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 45.93447168433694
+    exp2 = 127.35556915677182
+    check_stat(35, exp1, 1)
+    check_stat(120, exp2, 2)
+    check_stat2(exp1 + exp2)
 
-    The settings are the same as the test_wstat_two_scalar
-    case, for the 9774.pi file. It would be easier to move this
-    into test_wstat_two_scalar (since it avoids having multiple
-    copies of the settings, and lets the wstat be tested on
-    > 2 data sets), but for now keep as a separate set of tests
-    to make sure it is obvious what is and isn't failing.
-    """
 
-    def setUp(self):
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_two_scalar_ungrouped_all(clean_astro_ui, hide_logging, two_scalar_setup):
+    ui.ungroup(1)
+    ui.ungroup(2)
 
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 657.2275371837611
+    exp2 = 880.8442022201893
+    check_stat(1024, exp1, 1)
+    check_stat(1024, exp2, 2)
+    check_stat2(exp1 + exp2)
 
-        ui.set_stat('wstat')
 
-        infile = self.make_path('9774.pi')
-        ui.load_pha(1, infile)
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_two_scalar_ungrouped_filtered(clean_astro_ui, hide_logging, two_scalar_setup):
+    ui.ungroup(1)
+    ui.ungroup(2)
+    filter_data()
 
-        ui.group_counts(1, 20)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 420.50951039235736
+    exp2 = 397.4089421041855
+    check_stat(375, exp1, 1)
+    check_stat(375, exp2, 2)
+    check_stat2(exp1 + exp2)
 
-        # Unlike the test_wstat_two_scalar case, the grouping
-        # is not copied over.
-        # ui.set_grouping(1, bkg_id=1, val=ui.get_grouping(1))
 
-        ui.set_source(1, ui.const1d.c1 * ui.powlaw1d.pl1)
+# PHA file that has been grouped.
+#
+# This is the error reported in issue #227, whereby the
+# grouping in the source and background files is different,
+# which causes an error. It is not clear yet whether this
+# should be supported or not, but a regression test is added
+# to check this behavior.
+#
+# The settings are the same as the test_wstat_two_scalar
+# case, for the 9774.pi file. It would be easier to move this
+# into test_wstat_two_scalar (since it avoids having multiple
+# copies of the settings, and lets the wstat be tested on
+# > 2 data sets), but for now keep as a separate set of tests
+# to make sure it is obvious what is and isn't failing.
 
-        # These should be the same as test_wstat_two_scalar
-        #
-        ui.set_par("pl1.gamma", 1.7)
-        ui.set_par("pl1.ampl", 1.6e-4)
-        ui.set_par("c1.c0", 45)
 
-    def tearDown(self):
-        ui.clean()
+@pytest.fixture
+def group_setup(make_data_path):
 
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
+    ui.set_stat('wstat')
 
-    def _filter_data(self):
-        """Filter the data.
+    infile = make_data_path('9774.pi')
+    ui.load_pha(1, infile)
 
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
+    ui.group_counts(1, 20)
 
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
+    # Unlike the test_wstat_two_scalar case, the grouping
+    # is not copied over.
+    # ui.set_grouping(1, bkg_id=1, val=ui.get_grouping(1))
 
-    def _check_stat(self, idval, nbins, expected):
+    ui.set_source(1, ui.const1d.c1 * ui.powlaw1d.pl1)
 
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data(idval).get_dep(True).size)
+    # These should be the same as test_wstat_two_scalar
+    #
+    ui.set_par("pl1.gamma", 1.7)
+    ui.set_par("pl1.ampl", 1.6e-4)
+    ui.set_par("c1.c0", 45)
 
-        stat = ui.calc_stat(idval)
-        self.assertAlmostEqual(expected, stat, places=7)
 
-    def test_wstat_grouped_all(self):
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_grouped_all(clean_astro_ui, hide_logging, group_setup):
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 401.75572944361613
-        self._check_stat(1, 148, expval)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 401.75572944361613
+    check_stat(148, expval, 1)
 
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 127.35556915677182
-        self._check_stat(1, 120, expval)
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_grouped_filtered(clean_astro_ui, hide_logging, group_setup):
+    filter_data()
 
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup(1)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 127.35556915677182
+    check_stat(120, expval, 1)
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 880.8442022201893
-        self._check_stat(1, 1024, expval)
 
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup(1)
-        self._filter_data()
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_ungrouped_all(clean_astro_ui, hide_logging, group_setup):
+    ui.ungroup(1)
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 397.4089421041855
-        self._check_stat(1, 375, expval)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 880.8442022201893
+    check_stat(1024, expval, 1)
+
+
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_ungrouped_filtered(clean_astro_ui, hide_logging, group_setup):
+    ui.ungroup(1)
+    filter_data()
+
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 397.4089421041855
+    check_stat(375, expval, 1)
+
+
+# Single PHA file with an array of backscal values.
+#
+# This really should use a grating PHA dataset, but it's not
+# obvious we have one (along with the necessary responses) in
+# the sherpa-test-data/ repository. So for now "hack" in
+# one. The statistic values were calculated by changing the
+# backscal by 0.9 but leaving it as a scalar. As the tests
+# currently fail, they have not been validated.
+
+@pytest.fixture
+def single_array_setup(make_data_path):
+
+    ui.set_stat('wstat')
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(1, infile)
+
+    # Change the backscale value slightly so that the
+    # results are different to other runs with this file.
+    #
+    nbins = ui.get_data(1).get_dep(False).size
+    bscal = 0.9 * np.ones(nbins) * ui.get_backscal(1)
+    ui.set_backscal(1, backscale=bscal)
+
+    ui.set_source(1, ui.powlaw1d.pl)
+
+    # The powerlaw slope and normalization are
+    # intended to be "a reasonable approximation"
+    # to the data, just to make sure that any statistic
+    # calculation doesn't blow-up too much.
+    #
+    ui.set_par("pl.gamma", 1.7)
+    ui.set_par("pl.ampl", 1.7e-4)
 
 
 @requires_data
 @requires_fits
-class test_wstat_single_array(SherpaTestCase):
-    """Single PHA file with an array of backscal values.
+def test_wstat_single_array_grouped_all(clean_astro_ui, hide_logging, single_array_setup):
 
-    This really should use a grating PHA dataset, but it's not
-    obvious we have one (along with the necessary responses) in
-    the sherpa-test-data/ repository. So for now "hack" in
-    one. The statistic values were calculated by changing the
-    backscal by 0.9 but leaving it as a scalar. As the tests
-    currently fail, they have not been validated.
-    """
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(46, 71.21845954979574)
 
-    def setUp(self):
 
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+@requires_data
+@requires_fits
+def test_wstat_single_array_grouped_filtered(clean_astro_ui, hide_logging, single_array_setup):
+    filter_data()
 
-        ui.set_stat('wstat')
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(35, 45.6311990089982)
 
-        infile = self.make_path('3c273.pi')
-        ui.load_pha(1, infile)
 
-        # Change the backscale value slightly so that the
-        # results are different to other runs with this file.
-        #
-        nbins = ui.get_data(1).get_dep(False).size
-        bscal = 0.9 * np.ones(nbins) * ui.get_backscal(1)
-        ui.set_backscal(1, backscale=bscal)
+@requires_data
+@requires_fits
+def test_wstat_single_array_ungrouped_all(clean_astro_ui, hide_logging, single_array_setup):
+    ui.ungroup()
 
-        ui.set_source(1, ui.powlaw1d.pl)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(1024, 663.0160968458746)
 
-        # The powerlaw slope and normalization are
-        # intended to be "a reasonable approximation"
-        # to the data, just to make sure that any statistic
-        # calculation doesn't blow-up too much.
-        #
-        ui.set_par("pl.gamma", 1.7)
-        ui.set_par("pl.ampl", 1.7e-4)
 
-    def tearDown(self):
-        ui.clean()
+@requires_data
+@requires_fits
+def test_wstat_single_array_ungrouped_filtered(clean_astro_ui, hide_logging, single_array_setup):
+    ui.ungroup()
+    filter_data()
 
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
-
-    def _filter_data(self):
-        """Filter the data.
-
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
-
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
-
-    def _check_stat(self, nbins, expected):
-
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data().get_dep(True).size)
-
-        stat = ui.calc_stat()
-        self.assertAlmostEqual(expected, stat, places=7)
-
-    def test_wstat_grouped_all(self):
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(46, 71.21845954979574)
-
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(35, 45.6311990089982)
-
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(1024, 663.0160968458746)
-
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup()
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(375, 420.8390856766203)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(375, 420.8390856766203)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4605,6 +4605,10 @@ class Session(NoNewAttributesAfterInit):
         for vals in sherpa.utils.parse_expr(expr):
             self.notice_id(ids, *vals, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def notice(self, lo=None, hi=None, **kwargs):
         """Include data in the fit.
 
@@ -4623,6 +4627,12 @@ class Session(NoNewAttributesAfterInit):
            higher than, or equal to, ``a``.
         hi : number, optional
            The upper bound of the filter when ``lo`` is not a string.
+        bkg_id : int or str, optional
+           The filter will be applied to the associated background
+           component of the data set if ``bkg_id`` is set. Only PHA
+           data sets support this option; if not given, then the
+           filter is applied to all background components as well
+           as the source data.
 
         See Also
         --------
@@ -4692,6 +4702,10 @@ class Session(NoNewAttributesAfterInit):
         for d in self._data.values():
             d.notice(lo, hi, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def ignore(self, lo=None, hi=None, **kwargs):
         """Exclude data from the fit.
 
@@ -4710,6 +4724,12 @@ class Session(NoNewAttributesAfterInit):
            higher than, or equal to, ``a``.
         hi : number, optional
            The upper bound of the filter when ``lo`` is not a string.
+        bkg_id : int or str, optional
+           The filter will be applied to the associated background
+           component of the data set if ``bkg_id`` is set. Only PHA
+           data sets support this option; if not given, then the
+           filter is applied to all background components as well
+           as the source data.
 
         See Also
         --------
@@ -4766,6 +4786,10 @@ class Session(NoNewAttributesAfterInit):
             return self._notice_expr(lo, **kwargs)
         self.notice(lo, hi, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def notice_id(self, ids, lo=None, hi=None, **kwargs):
         """Include data from the fit for a data set.
 
@@ -4828,7 +4852,10 @@ class Session(NoNewAttributesAfterInit):
         >>> notice_id(["core","jet"], "0.5:2, 2.2:7")
 
         """
-        if self._valid_id(ids):
+        if ids is None:
+            _argument_type_error('ids',
+                                 'an identifier or list of identifiers')
+        elif self._valid_id(ids):
             ids = (ids,)
         else:
             try:
@@ -4842,6 +4869,10 @@ class Session(NoNewAttributesAfterInit):
         for i in ids:
             self.get_data(i).notice(lo, hi, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def ignore_id(self, ids, lo=None, hi=None, **kwargs):
         """Exclude data from the fit for a data set.
 

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2017, 2019
+#  Copyright (C) 2010, 2016, 2017, 2019, 2020
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -232,6 +232,7 @@ class DataErr(SherpaErr):
             'normffake': 'An RMF has not been found or supplied for data set %s',
             'noenerg': 'no energy grid found in PHA response',
             'norsp': 'No instrument response found for dataset %s',
+            'nobrsp': 'No instrument response found for dataset %s background %s',
             'ogip-error': "The %s '%s' %s"
             }
 

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -228,7 +228,6 @@ class DataErr(SherpaErr):
             'nocoord': "data set '%s' does not contain a %s coordinate system",
             'bkgmodel': 'background %r has no associated model',
             'plottype': "unknown plot type '%s', choose %s",
-            'noinstr': "No instrument model found for dataset %s",
             'normffake': 'An RMF has not been found or supplied for data set %s',
             'noenerg': 'no energy grid found in PHA response',
             'norsp': 'No instrument response found for dataset %s',
@@ -319,7 +318,6 @@ class ModelErr(SherpaErr):
             'filterarray': "filter '%s' is not an array",
             'filtermismatch': "Mismatch between %s and %s",
             'nobkg': 'background model %s for data set %s has not been set',
-            'norsp': 'No background response found for background %s in data set %s',
             'nogrid': 'There is no grid on which to evaluate the model',
             'needspoint': 'A non-integrated grid is required for model evaluation',
             }


### PR DESCRIPTION
This PR has been replaced by the following PRs:

1. First is #882 which just provides a number of tests that I added in this PR (as well as reworking tests to use pytest rather than SherpaTestCase). 
2. Then is #884, which fixes #879 and #880
3. Then #888, which supports vector backscales and addresses other issues with fitting background data.

It would be nice if GitHub had [merge train](https://docs.gitlab.com/ee/ci/merge_request_pipelines/pipelines_for_merged_results/merge_trains/) support,

# Summary

When fitting source and background datasets simultaneously, there were times that the scaling factor for including background models into the source aperture was incorrectly including the ratio of exposure (source) to exposure (background), and so the background contribution to the source aperture was being systematically biased when the source and background exposure times are different.

This PR adds support for vector scale values for the conversion of background models from the background aperture to the source aperture (when fitting models to the source and background apertures). Prior to this change Sherpa would error out when generating the combined model terms. **TODO** after all the changes I need to ho back and review this statement.

The logic for setting background settings from the source dataset has been moved from sherpa.astro.ui.set_bkg to sherpa.astro.data.DataPha.set_background to remove potential confusion (issue #879). This has simplified the code path for generating the response used to fit a background model, removing some odd corner cases (issue #880).

The sherpa.astro.ui.get_bkg_scale routine now returns values for one background component, rather than the average value
for all the background components associated with the dataset.  It also now can calculate the scaling factor for background subtraction (units='counts') or when fitting simultaneously (units='rate').

The display of the source "model" expression - the output of `get_model().name` - was incorrect when multiple background datasets with models was present (the per-component model expression was not normalized by the number of background components). This is now fixed. Note that this **only** affected the screen display, the actual model calculation correctly normalized the background signal (for the common case when the same background model was used for all background datasets).

---

# Outstanding issues

 - [ ] should the new ScaleArray class just be replaced by ArithmeticConstantModel?
 - [x] have to warn when dealing with a pileup model
 - [ ] how best to handle the naming of the models used to store the vector scale values, the current approach picks a name 'scale<dataset id>_<bkg_id>' which is going to break if the dataset name has "interesting" characters in it, and has the potential to clobber ser models
 - [ ] can we delete the scale-array model when the dataset is cleared out
 - [x] get_backscal should handle multi bkg better: either give an id or return all, don't just combine them

# Details

As I've dug into the code there are a number of related issues, which makes it hard to separate into simple changes. If needed I can do so, bit I don't think any one particular problem is a lot of code, it's just all over the place.

## 1) How should the background be scaled when fitting?

This is #629 

When subtracting the background data you say

      source - r_exposure * r_backscale * r_areascal * bgnd

where r_x is the ratio of source x to background x (this assumes a
single background dataset but it extends to multiple
datasets).

When modelling the background we have to create the model (excluding
the response term)

      tsrc * (source_model + scale_factor * background_model)

where tsrc is the source exposure time and scale_factor corrects the
background model to the source aperture.

The existing code uses the same scaling factor as above - namely

      scale_factor = r_exposure * r_backscale * r_areascal

but this is wrong. The source and background models return rates
and not counts. This is why the source model starts with 'tsrc * '
since you need to convert to counts. This means that the ratio
between the source and background exposure times DOES NOT FACTOR
into scale_factor. It is unclear to me whether AREASCAL should be
included or not: XSPEC treats it as an exposure correction, so
I am also dropping it here, but this **could be** wrong.

The correct scale factor should therefore be

      scale_factor = r_backscale

that is, we just correct for the aperture size when adding the
background model to the source aperture.

Fortunately this is not likely to be a big problem with existing
users as I **IMAGINE** that the source and background exposures
are often the same, and so it doesn't matter.

It will matter for users fitting a background model to "blank-sky
datasets", where the exposure time is different in the source and
background spectra.


## 2) Using a vector to scale background to source apertures (when fitting)

This is code designed to look into #797 and #435. The first part is a number of code clean ups, adding documentation, and tests. The you get to "EXPERIMENT support vectors for background scale factors (when fitting)" which is a proposed solution to the problem. I have added and/or expanded test cases as needed, and improved some documentation.

Note that there is some overlap in the test cases added in #719 and in this test. They do test similar functionality, but they don't overlap completely so I think it's worth having both,

The sherpa.astro.background.BackgroundSumModel was only used in one place, and is no-longer used, so I've removed it.

One consequence of this PR is that you can not reliably use a pileup model when fitting the source + background of a dataset where there is a vector array defining the scaling of the background-to-source ratio. The code will run but it warns the user, and the output will not be correct (the amount depends on how much pileup there is).

## What is the problem

When fitting source + background, the source model (that is the expression that contains the instrument model) becomes (in principle, but not actually)

    response(exposure * (source_model + bscale * bgnd_model))

where the response is actually 'apply_rmf(apply_arf',  just to make this simple. The `bscale` value has to be a scalar (otherwise it errors out, as discussed below). If you call

    print(get_model())

then you sill see the above. An example is the following, where xsvapec.Av1 is the source model, xsvapec.Bv1 is the background, and the scale factor is 0.1458

```
>>> print(get_model().name)
apply_rmf(apply_arf((48631.388921332 * (xsvapec.Av1 + 0.1458 * (xsvapec.Bv1_)))))
```

This is actually an approximation of the truth, since if we look at the actual model, we have (breaking down the binary operations):

```
>>> mdl = ui.get_model()
>>> print(type(mdl))
<class 'sherpa.astro.instrument.RSPModelPHA'>
>>> mdl.parts[0]
<BinaryOpModel model instance '(48631.388921332 * (xsvapec.Av1 + 0.1458 * (xsvapec.Bv1)))'>
>>> mdl.parts[0].parts[0]
<ArithmeticConstantModel model instance '48631.388921332'>
>>> mdl.parts[0].parts[1]
<BinaryOpModel model instance '(xsvapec.Av1 + 0.1458 * (xsvapec.Bv1))'>
>>> mdl.parts[0].parts[1].parts
(<XSvapec model instance 'xsvapec.Av1'>,
 <BackgroundSumModel model instance '0.1458 * (xsvapec.Bv1)'>)
```

The trick here is that we actually have a sherpa.astro.background.BackgroundSumModel which provides a screen output of "scale * models" but internally it actually evaluates this a bit differently. This is okay, but I wanted to explain this to explain where the BackgroundSumModel class is used.

There's two issues with the BackgroundSumModel instance:

 - the initialisation tries to generate a string like `'%g * models" % bscale` (used in the string output above), **and this fails** when an array is used
 - the scale factors are applied to the model before it has been passed through the instrument response, and so need to have binning matching the instrument grid, and not the channel space. We never hit this problem because of the previous point.

In my original investigation in #435 I only tried to fix the first of these two problems. This let us create the model with a vector background scale, but trying to use it failed with size-mismatch errors (see the comments in that PR).

I note in #629 that the display of the source model was wrong when there are multiple background components (this is only the display, the actual model calculation is correct), The example from #629 was

    apply_arf(10 * (source_model + 0.55 * (bgnd_model + bgnd_model)))

when it should have said (some form of):

    apply_arf(10 * (source_model + 0.55 * (bgnd_mode / 2l + bgnd_model / 2)))

## How does this PR fix it

Instead of using BackgroundSumModel to do the magic of combining the background components I now explicitly create the model expression. The code is in `sherpa.astro.ui.utils._add_convolution_models`.

The process is roughly (for the case of a dataset with a background when we are trying to fit the background):

  - calculate the scale factor for each background component for the dataset
  - for each scale factor which is a scalar (in which case we don't need to do anything fancy)

         bmdls = scale_key1 * background_model_key1 + scale_key2 * background_model_key2 + ...

     where the _key suffix is just to point out this is done for each background component
  - if source_model is the source model expression, and resp is the instrument model,  then create

        out_model = resp(source_model + bmdls)

  - now we need to deal with the remaining vector scale values: if these are scale_j1/background_model_j1
    to _jn then we need to generate

        out_model += scale_j1 * resp(background_model_j1) + ... + scale_j2 * resp(background_model_jn)

    The trick is that we apply the response model to the background model, which converts to channel space,
    and then we can multiply by the array of values in channel space.

Unfortunately if will not work if resp() is non-linear - so resp(a) + resp(b) != resp(a + b) - which is the case of pileup models. I can not see any way around this while keeping the scale factor in channel units (and that's what the input is in).

One trick in the `scale_j1 * resp(..)` step is that `scale_j1` is actually a model (a tablemodel-like instance, added as sherpa.astro.background.ScaleArray, which acts to multiply by a numpy array of values. This is done because it makes the string output of the model a lot easier to handle (i,e, no attempt to include each value of the array). For reasons depending on the RSPModel*PHA classes, this always returns the full channel dataset (whatever the input arguments), in the same way that resp() does when it's a RSPModel... instance (filtering to match the cignore/notice channel range is done at a later stage).

As an example, the case above now becomes (variable names may change depending on exactly what  version of the code is used):

'(apply_rmf(apply_arf((48631.388921332 * xsvapec.Av1))) + (scalearray.scale2_1 * apply_rmf(apply_arf((48631.388921332 * xsvapec.Bv1)))))'

## Optimising for the expected use case

It is expected that the same background model is used for all components. Note that in this case the previous behavior of `sherpa.astro.ui.utils.get_bkg_scale` to return the average scaling factor is correct, it's only if you have different background models that that approach fails.

When we have the same background model used for multiple background components then we can reduce some computation, since we can convert (here assuming it's a scalar correction factor) 

    bmdls = scale_key1 * background_model_key1 + scale_key2 * background_model_key2 + ...

to

    bmdls = (scale_key1 + scale_key2 + ...) * background_model

# Examples

I've read in a grating spectrum and am fitting overly-simple models: the source is an xsvapec and the background is a powerlaw.It's not physically meaningful, but that's not to relevant here.

Here's the names of the various "models" - e.g. the "source" and "model" versions which refer to the models the user sets and the one that Sherpa actually uses [the use of "model" in this case conflicts with the general use of "model" and I wished we'come up with a better term...].

```
In [62]: print(get_source().name)
xsvapec.vsrc

In [63]: print(get_bkg_source().name)
xspowerlaw.bpl

In [64]: print(get_bkg_model().name)
apply_rmf(apply_arf((158805.39418195 * xspowerlaw.bpl)))
```

So far as expected. 

**NOTE** the next command fails in master branch with the error message

```
~/sherpa/sherpa-xspec-12101/sherpa/astro/background.py in __init__(self, srcdata, bkgmodels)
     50         scale_factor = self.srcdata.sum_background_data(lambda key, bkg:1)
     51         bkgnames = [model.name for model in bkgmodels.values()]
---> 52         name = '%g * (' % scale_factor + ' + '.join(bkgnames) + ')'
     53         CompositeModel.__init__(self, name, self.bkgmodels.values())
     54

TypeError: only size-1 arrays can be converted to Python scalars
```

The model name looks okay, but if you look carefully you'll see it is actually different:

```
In [65]: print(get_model().name)
(apply_rmf(apply_arf((158805.16994966 * xsvapec.vsrc))) + (scalearray.scale1_1 * apply_rmf(apply_arf((158805.16994966 * xspowerlaw.bpl)))))
```

The differences are

a) instead of `apply_rmf(apply_arf(src + scale * bgnd))` we now have  `apply_rmf(apply_rmf(src)) + scale * apply_rmf(apply_arf(bgnd))`

b) the scale factor is not a number but a model component: `scalearray.scale1_1`

You can view this component (it has been created for you so the following works), and its y attribute contains the actual scaling array:

```
In [66]: print(scale1_1)
scalearray.scale1_1
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   scale1_1.ampl frozen            1 -3.40282e+38  3.40282e+38

In [68]: scale1_1.y.shape
Out[68]: (8192,)

In [69]: scale1_1.y[0:4]
Out[69]: array([0.99999859, 0.99999859, 0.99999859, 0.99999859])
```

If you print out the get_model() you see it as part of the model parameters

```
In [67]: print(get_model())
(apply_rmf(apply_arf((158805.16994966 * xsvapec.vsrc))) + (scalearray.scale1_1 * apply_rmf(apply_arf((158805.16994966 * xspowerlaw.bpl)))))
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   vsrc.kT      thawed     0.586205       0.0808       68.447        keV
   vsrc.He      thawed   0.00242171            0         1000
   vsrc.C       thawed   0.00139063            0         1000
   vsrc.N       thawed    0.0320576            0         1000
   vsrc.O       thawed     0.587276            0         1000
   vsrc.Ne      thawed     0.273331            0         1000
   vsrc.Mg      thawed     0.279274            0         1000
   vsrc.Al      thawed     0.979798            0         1000
   vsrc.Si      thawed     0.326917            0         1000
   vsrc.S       thawed      1.07481            0         1000
   vsrc.Ar      thawed      26.8577            0         1000
   vsrc.Ca      thawed      8.06943            0         1000
   vsrc.Fe      thawed     0.199196            0         1000
   vsrc.Ni      thawed  0.000675637            0         1000
   vsrc.redshift frozen            0       -0.999           10
   vsrc.norm    thawed   0.00111689            0        1e+24
   scale1_1.ampl frozen            1 -3.40282e+38  3.40282e+38
   bpl.PhoIndex thawed      4.64582           -2            9
   bpl.norm     thawed  0.000494137            0        1e+24
```

---

# NOTES

From the existing datasets I've investigated, I think there's a general issue in the BACKSCAL values when it's a vector and they come from combined datasets. The values are often <some value when there are 0 counts> and then the actual scale values. This works for when we subtract the background, because the <some value when there are 0 counts> calue gets multiplied by 0 ,so it doesn't matter what the value is. When we are trying to fit the background then we care about each channel (not just those with counts in the background), and then **how** do we deal with the <some value when there are 0 counts>, as it is generally not correct from what I've seen.

This is not directly an issue with this PR ,but it may indicate whether we have any sensible data for fitting.