### PR TITLE
Add MacOS LDFLAGS warning to devdocs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -104,6 +104,18 @@ can be activated and Sherpa can be build from source.
     conda activate sherpaciao
     python setup.py develop
 
+
+.. warning::
+
+   Just like in the case of a normal source install, when building Sherpa
+   on recent versions of macOS within a conda environment, the following
+   environment variable must be set::
+
+     export PYTHON_LDFLAGS=' '
+
+   That is, the variable is set to a space, not the empty string.
+
+
 How do I ...
 ============
 


### PR DESCRIPTION
# Summary
This just copies the warning about setting PYTHON_LDFLAGS from the install page to the developer docs. Initially, I thought that was not needed when compiling this way, but it turns out that's because I was on an old version of MacOSX. The current version of MacOSX needs that flag to be set, so might as well copy the warning over to the development page.