### PR TITLE
Add requires_fits decorators to test_xspec_con.py

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -23,7 +23,7 @@ from numpy.testing import assert_allclose
 
 import pytest
 
-from sherpa.utils.testing import requires_xspec, requires_data
+from sherpa.utils.testing import requires_xspec, requires_data, requires_fits
 from sherpa.data import Data1DInt
 from sherpa.models.basic import Box1D, Const1D, PowLaw1D
 from sherpa.models.parameter import Parameter
@@ -553,6 +553,7 @@ def test_xspec_con_ui_registered():
 
 @requires_xspec
 @requires_data
+@requires_fits
 def test_xspec_con_ui_cflux(make_data_path, clean_astro_ui, restore_xspec_settings):
     """Check cflux from the UI layer with a response."""
 
@@ -623,6 +624,7 @@ def test_xspec_con_ui_cflux(make_data_path, clean_astro_ui, restore_xspec_settin
 
 @requires_xspec
 @requires_data
+@requires_fits
 def test_xspec_con_ui_shift(make_data_path, clean_astro_ui, restore_xspec_settings):
     """Check shifted models from the UI layer with a response.
 
@@ -707,6 +709,7 @@ def test_xspec_con_ui_shift(make_data_path, clean_astro_ui, restore_xspec_settin
 
 @requires_xspec
 @requires_data
+@requires_fits
 def test_xspec_con_ui_shift_regrid(make_data_path, clean_astro_ui, restore_xspec_settings):
     """Check shifted models from the UI layer with a response and regrid.
 


### PR DESCRIPTION
# Summary

Add decorators to two test routines that were missing (it requires XSPEC to be built but no I/O module available, which is an uncommon choice).

# Details

I had forgotten these three decorators. Our test builds don't have
a build with XSPEC but no IO library, which is why this is not seen.