### PR TITLE
Add 'est_method_args' to fulfill CAT5 specfit.py requirements.

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -62,7 +62,7 @@ def calc_flux(fit, data, src, samples, method=calc_energy_flux,
 
 
 def sample_flux(fit, data, src, method=calc_energy_flux, correlated=False,
-                num=1, lo=None, hi=None, numcores=None, samples=None):
+                num=1, lo=None, hi=None, numcores=None, samples=None, est_method_args=None):
 
     #
     # The following function should be modified to take advantage of numpy
@@ -87,7 +87,7 @@ def sample_flux(fit, data, src, method=calc_energy_flux, correlated=False,
         if numpy.ndarray == type(samples):
             samples = samples.diagonal(0)
 
-    samples = sampler.get_sample(fit, samples, num=num)
+    samples = sampler.get_sample(fit, samples, num=num, est_method_args=est_method_args)
 
     hardmins = fit.model._get_thawed_par_hardmins()
     hardmaxs = fit.model._get_thawed_par_hardmaxes()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12391,7 +12391,7 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: should this accept the confidence parameter?
     def sample_energy_flux(self, lo=None, hi=None, id=None, num=1, scales=None,
-                           correlated=False, numcores=None, bkg_id=None):
+                           correlated=False, numcores=None, bkg_id=None, est_method_args=None):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12489,12 +12489,13 @@ class Session(sherpa.ui.utils.Session):
         return sherpa.astro.flux.sample_flux(fit, data, src,
                                              sherpa.astro.utils.calc_energy_flux,
                                              correlated, num, lo, hi, numcores,
-                                             scales)
+                                             scales, est_method_args)
 
     # DOC-NOTE: are scales the variance or standard deviation?
     def sample_flux(self, modelcomponent=None, lo=None, hi=None, id=None,
                     num=1, scales=None, correlated=False,
-                    numcores=None, bkg_id=None, Xrays=True, confidence=68):
+                    numcores=None, bkg_id=None, Xrays=True, confidence=68,
+                    est_method_args=None):
         """Return the flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -12627,7 +12628,7 @@ class Session(sherpa.ui.utils.Session):
                                               scales=scales,
                                               correlated=correlated,
                                               numcores=numcores,
-                                              bkg_id=bkg_id)
+                                              bkg_id=bkg_id, est_method_args=est_method_args)
 
         return sherpa.astro.flux.calc_sample_flux(id, lo, hi, self, fit, data,
                                                   samples, modelcomponent,


### PR DESCRIPTION
For the Chandra Source Catalog 2.0 development (CAT4.5 build), we asked to add a new parameter 'est_method_args' to sherpa.astro.sample_flux(). These changes were added to branch cat45_ciao49.  For the Chandra Source Catalog 2.1 build (CAT5.1), we updated sherpa to release 4.12.0, and still require the 'est_method_args' parameter in sample_flux().

These PR changes are basically the same changes that are on the cat45_ciao49 branch, but put on top of the sherpa 4.12.0 release. The CAT pipelines team would like to have the changes on a new branch so we can pull from there when we build CAT like we did for CAT4.5, without affecting sherpa's main development branch.

Related JIRA issues:
 PTCAT-2733: Update all tools to be python3/ciao4.12 compatible.
 PTCAT-2754: Replace PyChips with matplotlib in specfit.py