### PR TITLE
Add tests of background handling

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -474,3 +474,128 @@ def test_pha1_eval_vector_stat(dofilter, expected, clean_astro_ui):
 
     s = ui.calc_stat()
     assert s == pytest.approx(expected)
+
+
+# Fails from ui.get_model raising
+# TypeError: only size-1 arrays can be converted to Python scalars
+#
+@pytest.mark.xfail
+def test_pha1_eval_vector_show(clean_astro_ui):
+    """Check we can show the source/bgnd models with vector scaling
+    test_pha1_eval does most of the work; this test is
+    to check when there's a vector, not scalar, for
+    scaling the background to match the source.
+    """
+
+    scale = np.ones(19)
+    scale[9:15] = 0.8
+
+    exps = (100.0, 1000.0)
+    bscales = (0.01, 0.05 * scale)
+    ascales = (0.8, 0.4)
+    ui.set_data(setup_pha1(exps, bscales, ascales))
+
+    ui.set_source(ui.box1d.smdl)
+    ui.set_bkg_source(ui.box1d.bmdl1)
+
+    def r(sval, bval):
+        return sval / bval
+
+    bmdl = ui.get_bkg_model()
+    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+
+    smdl = ui.get_model()
+
+    array = r(*exps) * r(*bscales) * r(*ascales)
+    src = '(apply_arf((100.0 * box1d.smdl))'
+    src += ' + (apply_arf((100.0 * box1d.bmdl1))'
+    src += ' * {}))'.format(array)
+
+    assert smdl.name == src
+
+
+# Fails from ui.get_model_plot raising
+# TypeError: only size-1 arrays can be converted to Python scalars
+#
+@pytest.mark.xfail
+def test_pha1_eval_vector(clean_astro_ui):
+    """Check we can evaluate the source/bgnd values and vector scaling
+    test_pha1_eval does most of the work; this test is
+    to check when there's a vector, not scalar, for
+    scaling the background to match the source.
+    """
+
+    scale = np.ones(19)
+    scale[9:15] = 0.8
+
+    exps = (100.0, 1000.0)
+    bscales = (0.01, 0.05 * scale)
+    ascales = (0.8, 0.4)
+    ui.set_data(setup_pha1(exps, bscales, ascales))
+
+    ui.set_source(ui.box1d.smdl)
+    ui.set_bkg_source(ui.box1d.bmdl1)
+
+    smdl.ampl.max = 10
+    smdl.ampl = 10
+    smdl.xlow = 0.95
+    smdl.xhi = 1.59
+
+    bmdl1.ampl.max = 2
+    bmdl1.ampl = 2
+    bmdl1.xlow = 0.74
+    bmdl1.xhi = 1.71
+
+    # Check the evaluation of the source (no instrument)
+    #
+    splot = ui.get_source_plot()
+    bplot1 = ui.get_bkg_source_plot()
+
+    assert splot.title == 'Source Model of tst0'
+    assert bplot1.title == 'Source Model of tst1'
+
+    # check the model evaluates correctly
+    #
+    # source: bins 3-9
+    # bgnd 1:      1-11
+    #
+    sy = np.zeros(19)
+    sy[3] = 5
+    sy[4:9] = 10
+    sy[9] = 9
+
+    by1 = np.zeros(19)
+    by1[1] = 1.2
+    by1[2:11] = 2
+    by1[11] = 0.2
+
+    assert splot.y == pytest.approx(sy)
+    assert bplot1.y == pytest.approx(by1)
+
+    # Check the evaluation of the source (no instrument)
+    #
+    splot = ui.get_model_plot()
+    bplot1 = ui.get_bkg_model_plot()
+
+    assert splot.title == 'Model'
+    assert bplot1.title == 'Model'
+
+    # check the model evaluates correctly
+    # - backgrond is just multiplied by the arf
+    # - source needs to include the scaled background
+    #
+    sy *= 100
+    by1 *= 90
+
+    # need to correct by exposure time, backscal,
+    # area scaling, and to correct for the ARF used to
+    # calculate by, and then divide by the number of
+    # backgrounds.
+    #
+    def r(sval, bval):
+        return sval / bval
+
+    sy += r(*exps) * r(*bscales) * r(*ascales) * (100 / 90) * by1
+
+    assert splot.y == pytest.approx(sy)
+    assert bplot1.y == pytest.approx(by1)

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -32,6 +32,7 @@ import pytest
 
 from sherpa.astro import ui
 from sherpa.astro.data import DataARF, DataPHA
+from sherpa.astro.instrument import ARFModelPHA
 from sherpa.utils.err import DataErr, ModelErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
@@ -401,6 +402,28 @@ def test_pha1_show_data(id, exps, bscales, ascales, results, clean_astro_ui):
 
     assert msg[notice] == 'Noticed Channels: 1-19'
     assert msg[notice + 1] == 'name           = tst0'
+
+
+def test_pha1_instruments(clean_astro_ui):
+    """Check we get the correct responses for various options.
+    """
+
+    # We don't check the scaling here
+    scales = (1, 1, 1)
+    ui.set_data(1, setup_pha1(scales, scales, scales))
+    ui.set_source(1, ui.stephi1d.smdl)
+    ui.set_bkg_source(1, ui.steplo1d.bmdl)
+    ui.set_bkg_source(1, bmdl, bkg_id=2)
+
+    smdl = ui.get_model()
+    bmdl1 = ui.get_bkg_model(bkg_id=1)
+    bmdl2 = ui.get_bkg_model(bkg_id=2)
+
+    # check the response contains the correct names
+    for i, mdl in enumerate([smdl, bmdl1, bmdl2]):
+        assert isinstance(mdl, ARFModelPHA)
+        assert mdl.pha.name == 'tst{}'.format(i)
+        assert mdl.arf.name == 'arf{}'.format(i)
 
 
 SCALING = np.ones(19)

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -281,6 +281,43 @@ def test_evaluation_requires_models(func, etype, emsg, clean_astro_ui):
 
 @pytest.mark.parametrize("exps,bscales,ascales,results",
                          [((100, 200), (2, 4), (0.5, 0.1),
+                           [(100 * 2 * 1) / (200 * 4 * 1)]),
+                          ((100, 200, 400), (2, 4, 0.5), (0.5, 0.1, 0.8),
+                           [0.5 * (100 * 2 * 1) / (200 * 4 * 1),
+                            0.5 * (100 * 2 * 1) / (400 * 0.5 * 1)]),
+                          ((100, 200, 400),
+                           (2, 4 * np.ones(19) * 0.8, 0.5 * np.ones(19) * 1.1),
+                           (0.5, 0.1, 0.8),
+                           [0.5 * (100 * 2 * 1) / (200 * 4 * np.ones(19) * 0.8 * 1),
+                            0.5 * (100 * 2 * 1) / (400 * 0.5 * np.ones(19) * 1.1 * 1)]),
+                          ])
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_pha1_subtract(id, exps, bscales, ascales, results, clean_astro_ui, hide_logging):
+    """Check we can subtract the background.
+
+    NOTE: the correction factor does NOT include the
+          areascal correction - is this a bug?
+
+    """
+
+    ui.set_data(id, setup_pha1(exps, bscales, ascales))
+
+    sdata = ui.get_dep(id)
+    expected = np.zeros(19)
+    for i, r in enumerate(results, 1):
+        expected += r * ui.get_dep(id, bkg_id=i)
+
+    expected = sdata - expected
+
+    ui.subtract(id)
+    data = ui.get_dep(id)
+
+    assert (data < sdata).all()  # this just checks the subtraction does subtract
+    assert data == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("exps,bscales,ascales,results",
+                         [((100, 200), (2, 4), (0.5, 0.1),
                            [(100 * 2 * 0.5) / (200 * 4 * 0.1)]),
                           ((100, 200, 400), (2, 4, 0.5), (0.5, 0.1, 0.8),
                            [0.5 * (100 * 2 * 0.5) / (200 * 4 * 0.1),

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1,0 +1,220 @@
+#
+#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test handling of fitting a background to PHA data.
+
+There are a few tests scattered around that do this, but this
+attempts to provide a solid test base. There is likely to be
+overlap in the WSTAT tests, for one.
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro import ui
+from sherpa.astro.data import DataPHA
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_filter(id, make_data_path, clean_astro_ui, hide_logging):
+    """Can I change filtering of the background?"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    sdata = ui.get_data(id)
+    bdata = ui.get_bkg(id)
+
+    # Need an argument for notice/ignore_id
+    iid = 1 if id is None else id
+
+    # The idea here is to check that we can have
+    # different filters for the source and background
+    # regions.
+    #
+    assert sdata.get_dep(filter=True).size == 46
+    assert bdata.get_dep(filter=True).size == 46
+
+    ui.ignore_id(iid, None, 0.5)
+    ui.ignore_id(iid, 7, None)
+
+    assert sdata.get_dep(filter=True).size == 40
+    assert bdata.get_dep(filter=True).size == 40
+
+    # need to reset the background filter
+    ui.notice_id(iid, None, None, bkg_id=1)
+
+    assert sdata.get_dep(filter=True).size == 40
+    assert bdata.get_dep(filter=True).size == 46
+
+    ui.ignore_id(iid, None, 0.3, bkg_id=1)
+    ui.ignore_id(iid, 8, None, bkg_id=1)
+
+    assert sdata.get_dep(filter=True).size == 40
+    assert bdata.get_dep(filter=True).size == 42
+
+
+@requires_data
+@requires_fits
+@requires_group
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_group(id, make_data_path, clean_astro_ui, hide_logging):
+    """Can I change grouping of the background?"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    sdata = ui.get_data(id)
+    bdata = ui.get_bkg(id)
+
+    dtype = np.dtype('>i2')  # why not np.dtype(np.int16)?
+    assert sdata.grouping.dtype == dtype
+    assert bdata.grouping.dtype == dtype
+
+    assert sdata.quality.dtype == dtype
+    assert bdata.quality.dtype == dtype
+
+    assert sdata.grouped
+    assert bdata.grouped
+
+    # Check default grouping (taken from source)
+    sgrouping = sdata.grouping.copy()
+    assert sgrouping.sum() == -932
+    assert (bdata.grouping == sgrouping).all()
+
+    # Change the grouping of the background daga
+    #
+    ui.group_counts(id, 5, bkg_id=1)
+    assert (sdata.grouping == sgrouping).all()
+    assert bdata.grouping.sum() == -952
+
+    # check we can ungroup just the background
+    ui.ungroup(id, bkg_id=1)
+    assert sdata.grouped
+    assert not bdata.grouped
+
+    assert bdata.grouping.sum() == -952
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_models(id, make_data_path, clean_astro_ui, hide_logging):
+    """Is the model set correctly for the background"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    # Check the source models
+    #
+    ui.set_source(id, ui.powlaw1d.pl)
+    ui.set_bkg_source(id, ui.powlaw1d.bpl)
+
+    smdl = ui.get_source(id)
+    assert smdl.name == 'powlaw1d.pl'
+
+    bmdl = ui.get_bkg_source(id)
+    assert bmdl.name == 'powlaw1d.bpl'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((38564.608926889 * (powlaw1d.pl + 0.134921 * (powlaw1d.bpl)))))'
+
+    bmdl = ui.get_bkg_model(id)
+    assert bmdl.name == 'apply_rmf(apply_arf((38564.608926889 * powlaw1d.bpl)))'
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("id", [None, 1, "bgnd"])
+def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_logging):
+    """Is the model set correctly for two background components"""
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(id, infile)
+
+    # Tweak scaling values to make output easier to check.
+    # The ARF is changed as well, to a different value, to
+    # check what value is used in the model expression.
+    #
+    sdata = ui.get_data(id)
+    sdata.exposure = 100
+    sdata.get_arf().exposure = 150
+    sdata.backscal = 0.1
+    sdata.areascal = 0.8
+
+    # scale factor to correct to source is
+    #   = (100 / 1000) * (0.1 / 0.4) * (0.8 / 0.4)
+    #     exp = 0.1   back = 0.25  area = 2
+    #   = 0.025 if exclude the area scaling
+    #   = 0.05  if include the area scaling
+    #
+    bdata1 = ui.get_bkg(id, bkg_id=1)
+    bdata1.exposure = 1000
+    # bdata1.get_arf().exposure = 1500  no ARF
+    bdata1.backscal = 0.4
+    bdata1.areascal = 0.4
+
+    # add a second dataset (copy of the background)
+    #
+    # scale factor
+    #   = (100 / 2000) * (0.1 / 0.8) * (0.8 / 0.5)
+    #     exp = 0.05   back = 0.125  area = 1.6
+    #   = 0.00625 if exclude the area scaling
+    #   = 0.01    if include the area scaling
+    #
+    bdata2 = ui.unpack_pha(make_data_path('3c273_bg.pi'))
+    bdata2.exposure = 2000
+    # bdata2.get_arf().exposure = 2500  no ARF
+    bdata2.backscal = 0.8
+    bdata2.areascal = 0.5
+    ui.set_bkg(id, bdata2, bkg_id=2)
+
+    # Check the source models:
+    #  - first with one
+    #  - then with two
+    #
+    ui.set_source(id, ui.powlaw1d.pl)
+    ui.set_bkg_source(id, ui.powlaw1d.bpl)
+
+    smdl = ui.get_source(id)
+    assert smdl.name == 'powlaw1d.pl'
+
+    bmdl = ui.get_bkg_source(id)
+    assert bmdl.name == 'powlaw1d.bpl'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((100 * (powlaw1d.pl + 0.03 * (powlaw1d.bpl)))))'
+
+    bmdl = ui.get_bkg_model(id)
+    assert bmdl.name == 'apply_rmf(apply_arf((1000 * powlaw1d.bpl)))'
+
+    ui.set_bkg_source(id, ui.polynom1d.bpl2, bkg_id=2)
+
+    bmdl = ui.get_bkg_model(id, bkg_id=1)
+    assert bmdl.name == 'apply_rmf(apply_arf((1000 * powlaw1d.bpl)))'
+
+    bmdl = ui.get_bkg_model(id, bkg_id=2)
+    assert bmdl.name == 'apply_rmf(apply_arf((2000 * polynom1d.bpl2)))'
+
+    smdl = ui.get_model(id)
+    assert smdl.name == 'apply_rmf(apply_arf((100 * (powlaw1d.pl + 0.03 * (powlaw1d.bpl + polynom1d.bpl2)))))'

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1057,6 +1057,63 @@ def test_response_source_data(make_data_path, clean_astro_ui, hide_logging):
     assert eterm.val == pytest.approx(bexpval)
 
 
+def validate_response_source_data_manual(direct=True):
+    """Tests for test_response_source_data_manual[_datapha]
+
+    It checks out issue #880.
+    """
+
+    expval = ui.get_exposure()
+    bexpval = ui.get_exposure(bkg_id=1)
+    assert expval == pytest.approx(37845.662207644)
+    assert bexpval == pytest.approx(37845.662207644 * 5)
+
+    # What is used as the response?
+    #
+    mdl = ui.get_bkg_model()
+
+    # The value here should be 'fake' but thanks to #880 it
+    # depends. Rather than make this an XFAIL for one case,
+    # adapt to the current behavior.
+    #
+    pname = mdl.pha.name.split('/')[-1]
+    if direct:
+        assert pname == 'fake'
+    else:
+        assert pname == '12845.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    if direct:
+        assert eterm.val == pytest.approx(bexpval)
+    else:
+        assert eterm.val == pytest.approx(expval)
+
+    # Source response
+    #
+    mdl = ui.get_model()
+
+    pname = mdl.pha.name.split('/')[-1]
+    assert pname == '12845.pi'
+
+    aname = mdl.arf.name.split('/')[-1]
+    assert aname == '12845.warf'
+
+    rname = mdl.rmf.name.split('/')[-1]
+    assert rname == '12845.wrmf'
+
+    # The exposure time is the same as not the same as the background
+    eterm = mdl.parts[0].parts[0]
+    assert isinstance(eterm, ArithmeticConstantModel)
+    assert eterm.val == pytest.approx(expval)
+
+
 @requires_data
 @requires_fits
 def test_response_source_data_manual(make_data_path, clean_astro_ui, hide_logging):
@@ -1084,40 +1141,7 @@ def test_response_source_data_manual(make_data_path, clean_astro_ui, hide_loggin
     ui.set_source(ui.powlaw1d.smdl)
     ui.set_bkg_source(ui.const1d.bmdl)
 
-    # What is used as the response?
-    #
-    mdl = ui.get_bkg_model()
-
-    pname = mdl.pha.name.split('/')[-1]
-    assert pname == 'fake'
-
-    aname = mdl.arf.name.split('/')[-1]
-    assert aname == '12845.warf'
-
-    rname = mdl.rmf.name.split('/')[-1]
-    assert rname == '12845.wrmf'
-
-    eterm = mdl.parts[0].parts[0]
-    assert isinstance(eterm, ArithmeticConstantModel)
-    assert eterm.val == pytest.approx(bexpval)
-
-    # Source response
-    #
-    mdl = ui.get_model()
-
-    pname = mdl.pha.name.split('/')[-1]
-    assert pname == '12845.pi'
-
-    aname = mdl.arf.name.split('/')[-1]
-    assert aname == '12845.warf'
-
-    rname = mdl.rmf.name.split('/')[-1]
-    assert rname == '12845.wrmf'
-
-    # The exposure time is the same as not the same as the background
-    eterm = mdl.parts[0].parts[0]
-    assert isinstance(eterm, ArithmeticConstantModel)
-    assert eterm.val == pytest.approx(expval)
+    validate_response_source_data_manual()
 
 
 @requires_data
@@ -1128,7 +1152,7 @@ def test_response_source_data_manual_datapha(make_data_path, clean_astro_ui, hid
     This is test_response_source_data_manual but using the
     DataPHA method to add the background to the source, since it
     leads to different behavior with the background instrument
-    response.
+    response. This is a combination of issue #879 and #880
     """
 
     infile = make_data_path('12845.pi')
@@ -1153,45 +1177,7 @@ def test_response_source_data_manual_datapha(make_data_path, clean_astro_ui, hid
     ui.set_source(ui.powlaw1d.smdl)
     ui.set_bkg_source(ui.const1d.bmdl)
 
-    # What is used as the response?
-    #
-    # Note: unlike test_response_source_data_manual we use the
-    #       source dataset for the background model.
-    #
-    mdl = ui.get_bkg_model()
-
-    pname = mdl.pha.name.split('/')[-1]
-    # assert pname == 'fake'
-    assert pname == '12845.pi'
-
-    aname = mdl.arf.name.split('/')[-1]
-    assert aname == '12845.warf'
-
-    rname = mdl.rmf.name.split('/')[-1]
-    assert rname == '12845.wrmf'
-
-    eterm = mdl.parts[0].parts[0]
-    assert isinstance(eterm, ArithmeticConstantModel)
-    # assert eterm.val == pytest.approx(bexpval)
-    assert eterm.val == pytest.approx(expval)
-
-    # Source response
-    #
-    mdl = ui.get_model()
-
-    pname = mdl.pha.name.split('/')[-1]
-    assert pname == '12845.pi'
-
-    aname = mdl.arf.name.split('/')[-1]
-    assert aname == '12845.warf'
-
-    rname = mdl.rmf.name.split('/')[-1]
-    assert rname == '12845.wrmf'
-
-    # The exposure time is the same as not the same as the background
-    eterm = mdl.parts[0].parts[0]
-    assert isinstance(eterm, ArithmeticConstantModel)
-    assert eterm.val == pytest.approx(expval)
+    validate_response_source_data_manual(direct=False)
 
 
 @requires_data
@@ -1288,3 +1274,104 @@ def test_source_overwrites_background(make_data_path, clean_astro_ui, hide_loggi
 
     assert ui.get_dep(filter=True).size == 42
     assert ui.get_dep(filter=True, bkg_id=1).size == 42
+
+
+def fake_pha(idval, direct, response=True):
+    """Create a fake PHA file with a response and background"""
+
+    chans = np.arange(3, dtype=np.int16)
+    d = ui.DataPHA('ex', chans, chans * 0, exposure=20, backscal=0.1)
+    b = ui.DataPHA('bg', chans, chans * 0, exposure=200, backscal=0.2)
+
+    # add in a RMF
+    if response:
+        ebins = np.asarray([0.1, 0.2, 0.4, 0.5])
+        elo = ebins[:-1]
+        ehi = ebins[1:]
+        r = ui.create_rmf(elo, ehi, e_min=elo, e_max=ehi)
+        d.set_rmf(r)
+
+    if direct:
+        d.set_background(b)
+
+    if idval is None:
+        ui.set_data(d)
+    else:
+        ui.set_data(idval, d)
+
+    if not direct:
+        if idval is None:
+            ui.set_bkg(b)
+        else:
+            ui.set_bkg(idval, b)
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one"])
+@pytest.mark.parametrize("direct", [True, False])
+def test_bkg_analysis_setting_no_response(idval, direct, clean_astro_ui):
+    """There's no response, so setting the analysis will error out.
+    """
+
+    fake_pha(idval, direct, response=False)
+
+    if idval is None:
+        with pytest.raises(DataErr) as exc:
+            ui.set_analysis('energy')
+    else:
+        with pytest.raises(DataErr) as exc:
+            ui.set_analysis(idval, 'energy')
+
+    assert str(exc.value) == 'No instrument model found for dataset ex'
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one"])
+@pytest.mark.parametrize("direct", [True, False])
+def test_bkg_analysis_setting_default(idval, direct, clean_astro_ui):
+    """Check the analysis setting of the background.
+
+    The default setting is channel
+
+    """
+
+    fake_pha(idval, direct)
+
+    src = ui.get_data(idval)
+    bkg = ui.get_bkg(idval)
+
+    assert src.units == 'channel'
+    assert bkg.units == 'channel'
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one"])
+@pytest.mark.parametrize("direct", [True, False])
+@pytest.mark.parametrize("analysis", ['channel', 'energy', 'wavelength'])
+def test_bkg_analysis_setting_changed(idval, direct, analysis, clean_astro_ui):
+    """Change the analysis setting of the background.
+
+    This compares datapha.set_background to ui.set_bkg to
+    check issue #879
+
+    """
+
+    fake_pha(idval, direct)
+
+    if idval is None:
+        ui.set_analysis(analysis)
+    else:
+        ui.set_analysis(idval, analysis)
+
+    src = ui.get_data(idval)
+    bkg = ui.get_bkg(idval)
+
+    # Want to be able to mark some tests as XFAIL, but as it
+    # involves a parameter setting, how best to do this and
+    # get to see a XPASS when the code is fixed?
+    #
+    if direct and analysis != 'channel':
+        if bkg.units == analysis:
+            assert False, "Test was expected to fail, but can not mark XPASS"
+
+        pytest.xfail("Using set_background does not set units")
+
+    assert src.units == analysis
+    assert bkg.units == analysis

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -73,7 +73,7 @@ def example_pha_data():
     d = ui.DataPHA('example', _data_chan.copy(),
                    _data_counts.copy(),
                    exposure=etime,
-                   backscal=0.1)
+                   backscal=0.2)
 
     a = ui.create_arf(_energies[:-1].copy(),
                       _energies[1:].copy(),
@@ -136,7 +136,7 @@ def example_bkg_model():
     ui.create_model_component('powlaw1d', 'bcpt')
     bcpt = ui.get_model_component('bcpt')
     bcpt.gamma = 0.0  # use a flat model to make it easy to evaluate
-    bcpt.ampl = 1e-1
+    bcpt.ampl = 0.4
     return bcpt
 
 
@@ -519,7 +519,7 @@ def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
 
     # TODO: this is the same output as test_get_bkg_model_plot_energy,
     #       which doesn't make sense.
-    yexp = _arf / 100
+    yexp = _arf / 25
     if direct:
         yexp /= _bexpscale
 
@@ -571,7 +571,7 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
 
     # TODO: The factor of 100 comes from the bin width (0.1 keV), but
     # why is there a scaling by _bexpscale?
-    yexp = _arf / 100
+    yexp = _arf / 25
     if direct:
         yexp /= _bexpscale
     else:
@@ -600,7 +600,7 @@ def test_get_bkg_resid_plot(idval):
 
     # correct the counts by the bin width and exposure time
     #
-    yexp = (_data_bkg * 100.0 / 1201.0 - _arf) / (_bexpscale * 100)
+    yexp = (_data_bkg * 25.0 / 1201.0 - _arf) / (_bexpscale * 25)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
@@ -628,7 +628,7 @@ def test_get_bkg_resid_plot_energy(idval):
 
     # correct the counts by the bin width and exposure time
     #
-    yexp = (_data_bkg * 100.0 / 1201.0 - _arf) / (_bexpscale * 100)
+    yexp = (_data_bkg * 25.0 / 1201.0 - _arf) / (_bexpscale * 25)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
@@ -662,7 +662,7 @@ def test_get_bkg_fit_plot(idval):
     yexp = _data_bkg / 1201.0 / _bexpscale
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf / 100.0 / _bexpscale
+    yexp = _arf / 25.0 / _bexpscale
     assert mp.y == pytest.approx(yexp)
 
 
@@ -696,7 +696,7 @@ def test_get_bkg_fit_plot_energy(idval):
     yexp = _data_bkg / 1201.0 / _bexpscale
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf / 100.0 / _bexpscale
+    yexp = _arf / 25.0 / _bexpscale
     assert mp.y == pytest.approx(yexp)
 
 
@@ -730,7 +730,7 @@ def check_bkg_fit(plotfunc):
     yexp = _data_bkg / 1201.0 / _bexpscale
     assert dplot.y == pytest.approx(yexp)
 
-    yexp = _arf / (_bexpscale * 100)
+    yexp = _arf / (_bexpscale * 25.0)
     assert mplot.y == pytest.approx(yexp)
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -53,10 +53,18 @@ _data_bkg = np.asarray([1, 0, 0, 1, 0, 0, 2, 0, 0, 1],
 
 _arf = np.asarray([0.8, 0.8, 0.9, 1.0, 1.1, 1.1, 0.7, 0.6, 0.6, 0.6])
 
-# using a "perfect" RMF, in that there's a one-to-one mapping
-# from channel to energy
+# Using a "perfect" RMF, in that there's a one-to-one mapping
+# from channel to energy. I use a non-uniform grid to make
+# it obvious when the bin width is being used: when using a
+# constant bin width like 0.1 keV the factor of 10 is too easy
+# to confuse for other terms.
 #
 _energies = np.linspace(0.5, 1.5, 11)
+_energies = np.asarray([0.5, 0.65, 0.75, 0.8, 0.9, 1. , 1.1, 1.12, 1.3, 1.4, 1.5])
+_energies_lo = _energies[:-1]
+_energies_hi = _energies[1:]
+_energies_mid = (_energies_lo + _energies_hi) / 2
+_energies_width = _energies_hi - _energies_lo
 
 # How much longer is the background exposure compared to the source
 # exposure; chose a non-integer value to make it more obvious when
@@ -64,6 +72,17 @@ _energies = np.linspace(0.5, 1.5, 11)
 # to the backscal values).
 #
 _bexpscale = 2.5
+
+# Make sure the arrays can't be changed
+for _array in [_data_chan, _data_counts, _data_bkg, _arf, _energies]:
+    _array.flags.writeable = False
+
+del _array
+
+# Normalisation of the models.
+#
+MODEL_NORM = 1.02e2
+BGND_NORM = 0.4
 
 
 def example_pha_data():
@@ -75,15 +94,15 @@ def example_pha_data():
                    exposure=etime,
                    backscal=0.2)
 
-    a = ui.create_arf(_energies[:-1].copy(),
-                      _energies[1:].copy(),
+    a = ui.create_arf(_energies_lo.copy(),
+                      _energies_hi.copy(),
                       specresp=_arf.copy(),
                       exposure=etime)
 
-    r = ui.create_rmf(_energies[:-1].copy(),
-                      _energies[1:].copy(),
-                      e_min=_energies[:-1].copy(),
-                      e_max=_energies[1:].copy(),
+    r = ui.create_rmf(_energies_lo.copy(),
+                      _energies_hi.copy(),
+                      e_min=_energies_lo.copy(),
+                      e_max=_energies_hi.copy(),
                       startchan=1,
                       fname=None)
 
@@ -126,7 +145,7 @@ def example_model():
 
     ui.create_model_component('const1d', 'cpt')
     cpt = ui.get_model_component('cpt')
-    cpt.c0 = 1.02e2
+    cpt.c0 = MODEL_NORM
     return cpt
 
 
@@ -136,7 +155,7 @@ def example_bkg_model():
     ui.create_model_component('powlaw1d', 'bcpt')
     bcpt = ui.get_model_component('bcpt')
     bcpt.gamma = 0.0  # use a flat model to make it easy to evaluate
-    bcpt.ampl = 0.4
+    bcpt.ampl = BGND_NORM
     return bcpt
 
 
@@ -272,9 +291,8 @@ get_source_plot              X
 """
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_arf_plot(idval):
+def test_get_arf_plot(idval, clean_astro_ui):
     """Basic testing of get_arf_plot
     """
 
@@ -286,8 +304,8 @@ def test_get_arf_plot(idval):
 
     assert isinstance(ap, ARFPlot)
 
-    assert ap.xlo == pytest.approx(_energies[:-1])
-    assert ap.xhi == pytest.approx(_energies[1:])
+    assert ap.xlo == pytest.approx(_energies_lo)
+    assert ap.xhi == pytest.approx(_energies_hi)
 
     assert ap.y == pytest.approx(_arf)
 
@@ -298,9 +316,8 @@ def test_get_arf_plot(idval):
     # assert ap.ylabel == 'cm$^2$'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_plot(idval):
+def test_get_bkg_plot(idval, clean_astro_ui):
     """Basic testing of get_bkg_plot
     """
 
@@ -317,7 +334,7 @@ def test_get_bkg_plot(idval):
     # normalise by exposure time and bin width, but bin width here
     # is 1 (because it is being measured in channels).
     #
-    yexp = _data_bkg / 1201.0 / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'example-bkg'
@@ -325,52 +342,37 @@ def test_get_bkg_plot(idval):
     assert bp.ylabel == 'Counts/sec/channel'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_plot_energy(idval):
+def test_get_bkg_plot_energy(idval, clean_astro_ui):
     """Basic testing of get_bkg_plot: energy
     """
 
-    # The way I have set up the data means that set_analysis
-    # doesn't seem to change the setting for the background,
-    # which should be tracked down (Sep 2019) but not just now.
-    #
     setup_example_bkg(idval)
     if idval is None:
         ui.set_analysis('energy')
-        ui.get_bkg().units = 'energy'
         bp = ui.get_bkg_plot()
     else:
         ui.set_analysis(idval, 'energy')
-        ui.get_bkg(idval).units = 'energy'
         bp = ui.get_bkg_plot(idval)
 
-    # TODO: is this a bug in the plotting code, or does it just
-    # indicate that the test hasn't set up the correct invariants
-    # (which may be true as the code above has to change the units
-    # setting of the background object)?
-    #
-    # I was expecting bp.x to return energy and not channel values
-    #
     assert bp.x == pytest.approx(_data_chan)
 
-    # normalise by exposure time and bin width, but bin width here
-    # is 1 (because it is being measured in channels).
+    # normalise by exposure time and bin width,
+    # and since this is incorrectly in channels there's no normalisation
     #
-    yexp = _data_bkg / 1201.0 / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'example-bkg'
-    assert bp.xlabel == 'Energy (keV)'
-    assert bp.ylabel == 'Counts/sec/keV'
+    assert bp.xlabel == 'Channel'
+    assert bp.ylabel == 'Counts/sec/channel'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("gfunc", [ui.get_bkg_plot,
                                    ui.get_bkg_model_plot,
                                    ui.get_bkg_fit_plot])
-def test_get_bkg_plot_no_bkg(idval, gfunc):
+def test_get_bkg_plot_no_bkg(idval, gfunc, clean_astro_ui):
     """Basic testing of get_bkg_XXX_plot when there's no background
     """
 
@@ -382,9 +384,8 @@ def test_get_bkg_plot_no_bkg(idval, gfunc):
             gfunc(idval)
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_model_plot(idval):
+def test_get_model_plot(idval, clean_astro_ui):
     """Basic testing of get_model_plot
     """
 
@@ -404,7 +405,7 @@ def test_get_model_plot(idval):
     # right. It should also be divided by the channel width, but in
     # this case each bin has a channel width of 1.
     #
-    yexp = _arf * 1.02e2 * (_energies[1:] - _energies[:-1])
+    yexp = _arf * MODEL_NORM * _energies_width
     assert mp.y == pytest.approx(yexp)
 
     assert mp.title == 'Model'
@@ -412,9 +413,8 @@ def test_get_model_plot(idval):
     assert mp.ylabel == 'Counts/sec/channel'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_model_plot_energy(idval):
+def test_get_model_plot_energy(idval, clean_astro_ui):
     """Basic testing of get_model_plot: energy
     """
 
@@ -426,14 +426,14 @@ def test_get_model_plot_energy(idval):
         ui.set_analysis(idval, 'energy')
         mp = ui.get_model_plot(idval)
 
-    assert mp.xlo == pytest.approx(_energies[:-1])
-    assert mp.xhi == pytest.approx(_energies[1:])
+    assert mp.xlo == pytest.approx(_energies_lo)
+    assert mp.xhi == pytest.approx(_energies_hi)
 
     # This should be normalized by the bin width, but it is cancelled
     # out by the fact that the model normalization has to be multiplied
     # by the bin width (both in energy).
     #
-    yexp = _arf * 1.02e2
+    yexp = _arf * MODEL_NORM
     assert mp.y == pytest.approx(yexp)
 
     assert mp.title == 'Model'
@@ -441,9 +441,8 @@ def test_get_model_plot_energy(idval):
     assert mp.ylabel == 'Counts/sec/keV'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_source_plot_warning(caplog, idval):
+def test_get_source_plot_warning(idval, caplog, clean_astro_ui):
     """Does get_source_plot create a warning about channel space?
 
     This is a logged warning, not a UserWarning.
@@ -468,9 +467,8 @@ def test_get_source_plot_warning(caplog, idval):
     assert msg == emsg
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_source_plot_energy(idval):
+def test_get_source_plot_energy(idval, clean_astro_ui):
     """Basic testing of get_source_plot: energy
     """
 
@@ -484,10 +482,10 @@ def test_get_source_plot_energy(idval):
 
     assert isinstance(sp, SourcePlot)
 
-    assert sp.xlo == pytest.approx(_energies[:-1])
-    assert sp.xhi == pytest.approx(_energies[1:])
+    assert sp.xlo == pytest.approx(_energies_lo)
+    assert sp.xhi == pytest.approx(_energies_hi)
 
-    yexp = 1.02e2 * np.ones(10)
+    yexp = MODEL_NORM * np.ones(10)
     assert sp.y == pytest.approx(yexp)
 
     assert sp.title == 'Source Model of example'
@@ -502,9 +500,11 @@ def test_get_source_plot_energy(idval):
 def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
     """Basic testing of get_bkg_model_plot
 
-    We test ui.set_bkg as well as datapha.set_background,
-    since I have seen subtle differences due to the extra
-    logic that set_bkg can do (issues #879 and #880)
+    We test ui.set_bkg as well as datapha.set_background to check
+    issue #879.
+
+    The same ARF is used as the source (by construction), which is
+    likely to be a common use case.
     """
 
     setup_example_bkg_model(idval, direct=direct)
@@ -513,13 +513,10 @@ def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
     else:
         bp = ui.get_bkg_model_plot(idval)
 
-    print(bp)
     assert bp.xlo == pytest.approx(_data_chan)
     assert bp.xhi == pytest.approx(_data_chan + 1)
 
-    # TODO: this is the same output as test_get_bkg_model_plot_energy,
-    #       which doesn't make sense.
-    yexp = _arf / 25
+    yexp = _arf * BGND_NORM * _energies_width
     if direct:
         yexp /= _bexpscale
 
@@ -540,53 +537,37 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
     logic that set_bkg can do (issues #879 and #880)
     """
 
-    # The way I have set up the data means that set_analysis
-    # doesn't seem to change the setting for the background,
-    # which should be tracked down (Sep 2019) but not just now
-    # (issue #879)
-    #
     setup_example_bkg_model(idval, direct=direct)
     if idval is None:
         ui.set_analysis('energy')
-        ui.get_bkg().units = 'energy'
         bp = ui.get_bkg_model_plot()
     else:
         ui.set_analysis(idval, 'energy')
-        ui.get_bkg(idval).units = 'energy'
         bp = ui.get_bkg_model_plot(idval)
 
-    # TODO: is this a bug in the plotting code, or does it just
-    # indicate that the test hasn't set up the correct invariants
-    # (which may be true as the code above has to change the units
-    # setting of the background object)?
-    #
-    # I was expecting bp.x to return energy and not channel values
-    #
     if direct:
-        assert bp.xlo == pytest.approx(_data_chan - 0.5)
-        assert bp.xhi == pytest.approx(_data_chan + 0.5)
+        assert bp.xlo == pytest.approx(_data_chan)
+        assert bp.xhi == pytest.approx(_data_chan + 1)
     else:
-        assert bp.xlo == pytest.approx(_energies[:-1])
-        assert bp.xhi == pytest.approx(_energies[1:])
+        assert bp.xlo == pytest.approx(_energies_lo)
+        assert bp.xhi == pytest.approx(_energies_hi)
 
-    # TODO: The factor of 100 comes from the bin width (0.1 keV), but
-    # why is there a scaling by _bexpscale?
-    yexp = _arf / 25
+    yexp = _arf * BGND_NORM
     if direct:
-        yexp /= _bexpscale
-    else:
-        yexp *= 10  # what is this from?
-
+        yexp *= (_energies_width / _bexpscale)
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Model'
-    assert bp.xlabel == 'Energy (keV)'
-    assert bp.ylabel == 'Counts/sec/keV'
+    if direct:
+        assert bp.xlabel == 'Channel'
+        assert bp.ylabel == 'Counts/sec/channel'
+    else:
+        assert bp.xlabel == 'Energy (keV)'
+        assert bp.ylabel == 'Counts/sec/keV'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_resid_plot(idval):
+def test_get_bkg_resid_plot(idval, clean_astro_ui):
     """Basic testing of get_bkg_resid_plot
     """
 
@@ -600,7 +581,7 @@ def test_get_bkg_resid_plot(idval):
 
     # correct the counts by the bin width and exposure time
     #
-    yexp = (_data_bkg * 25.0 / 1201.0 - _arf) / (_bexpscale * 25)
+    yexp = _data_bkg / (1201.0 * _bexpscale) - _arf * BGND_NORM * _energies_width / _bexpscale
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
@@ -608,37 +589,33 @@ def test_get_bkg_resid_plot(idval):
     assert bp.ylabel == 'Counts/sec/channel'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_resid_plot_energy(idval):
+def test_get_bkg_resid_plot_energy(idval, clean_astro_ui):
     """Basic testing of get_bkg_resid_plot: energy
     """
 
     setup_example_bkg_model(idval)
     if idval is None:
         ui.set_analysis('energy')
-        ui.get_bkg().units = 'energy'
         bp = ui.get_bkg_resid_plot()
     else:
         ui.set_analysis(idval, 'energy')
-        ui.get_bkg(idval).units = 'energy'
         bp = ui.get_bkg_resid_plot(idval)
 
     assert bp.x == pytest.approx(_data_chan)
 
-    # correct the counts by the bin width and exposure time
+    # correct the counts by the bin width (which is 1) and exposure time
     #
-    yexp = (_data_bkg * 25.0 / 1201.0 - _arf) / (_bexpscale * 25)
+    yexp = _data_bkg / (1201.0 * _bexpscale) - _arf * BGND_NORM * _energies_width / _bexpscale
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
-    assert bp.xlabel == 'Energy (keV)'
-    assert bp.ylabel == 'Counts/sec/keV'
+    assert bp.xlabel == 'Channel'
+    assert bp.ylabel == 'Counts/sec/channel'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_fit_plot(idval):
+def test_get_bkg_fit_plot(idval, clean_astro_ui):
     """Basic testing of get_bkg_fit_plot
     """
 
@@ -659,27 +636,24 @@ def test_get_bkg_fit_plot(idval):
         assert plot.ylabel == 'Counts/sec/channel'
         assert plot.x == pytest.approx(_data_chan)
 
-    yexp = _data_bkg / 1201.0 / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale)
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf / 25.0 / _bexpscale
+    yexp = _arf * BGND_NORM * _energies_width / _bexpscale
     assert mp.y == pytest.approx(yexp)
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_fit_plot_energy(idval):
+def test_get_bkg_fit_plot_energy(idval, clean_astro_ui):
     """Basic testing of get_bkg_fit_plot: energy
     """
 
     setup_example_bkg_model(idval)
     if idval is None:
         ui.set_analysis('energy')
-        ui.get_bkg().units = 'energy'
         fp = ui.get_bkg_fit_plot()
     else:
         ui.set_analysis(idval, 'energy')
-        ui.get_bkg(idval).units = 'energy'
         fp = ui.get_bkg_fit_plot(idval)
 
     dp = fp.dataplot
@@ -689,14 +663,14 @@ def test_get_bkg_fit_plot_energy(idval):
     assert mp.title == 'Background Model Contribution'
 
     for plot in [dp, mp]:
-        assert plot.xlabel == 'Energy (keV)'
-        assert plot.ylabel == 'Counts/sec/keV'
+        assert plot.xlabel == 'Channel'
+        assert plot.ylabel == 'Counts/sec/channel'
         assert plot.x == pytest.approx(_data_chan)
 
-    yexp = _data_bkg / 1201.0 / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale)
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf / 25.0 / _bexpscale
+    yexp = _arf * BGND_NORM * _energies_width / _bexpscale
     assert mp.y == pytest.approx(yexp)
 
 
@@ -727,10 +701,10 @@ def check_bkg_fit(plotfunc):
     assert dplot.title == 'example-bkg'
     assert mplot.title == 'Background Model Contribution'
 
-    yexp = _data_bkg / 1201.0 / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale)
     assert dplot.y == pytest.approx(yexp)
 
-    yexp = _arf / (_bexpscale * 25.0)
+    yexp = _arf * BGND_NORM * _energies_width / _bexpscale
     assert mplot.y == pytest.approx(yexp)
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -92,10 +92,19 @@ def example_pha_data():
     return d
 
 
-def example_pha_with_bkg_data():
+def example_pha_with_bkg_data(direct=True):
     """Create an example data set with background
 
     There is no response for the background.
+
+    Parameters
+    ----------
+    direct : bool, optional
+        If True then the background is added to the source
+        and only the source is returned. If False then the
+        return is (source, bgnd) and the background is not
+        associated with the source.
+
     """
 
     d = example_pha_data()
@@ -105,8 +114,11 @@ def example_pha_with_bkg_data():
                    exposure=1201.0 * _bexpscale,
                    backscal=0.4)
 
-    d.set_background(b)
-    return d
+    if direct:
+        d.set_background(b)
+        return d
+
+    return d, b
 
 
 def example_model():
@@ -180,7 +192,7 @@ def setup_example_bkg(idval):
         ui.set_source(idval, m)
 
 
-def setup_example_bkg_model(idval):
+def setup_example_bkg_model(idval, direct=True):
     """Set up a simple dataset + background for use in the tests.
 
     This includes a model for the background, unlike
@@ -196,16 +208,25 @@ def setup_example_bkg_model(idval):
     setup_example_bkg
     """
 
-    d = example_pha_with_bkg_data()
+    d = example_pha_with_bkg_data(direct=direct)
     m = example_model()
     bm = example_bkg_model()
     if idval is None:
-        ui.set_data(d)
+        if direct:
+            ui.set_data(d)
+        else:
+            ui.set_data(d[0])
+            ui.set_bkg(d[1])
+
         ui.set_source(m)
         ui.set_bkg_model(bm)
 
     else:
-        ui.set_data(idval, d)
+        if direct:
+            ui.set_data(idval, d)
+        else:
+            ui.set_data(idval, d[0])
+            ui.set_bkg(idval, d[1])
         ui.set_source(idval, m)
         ui.set_bkg_model(idval, bm)
 
@@ -476,13 +497,17 @@ def test_get_source_plot_energy(idval):
     # assert sp.ylabel == 'f(E)  Photons/sec/cm$^2$/keV'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_model_plot(idval):
+@pytest.mark.parametrize("direct", [True, False])
+def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
     """Basic testing of get_bkg_model_plot
+
+    We test ui.set_bkg as well as datapha.set_background,
+    since I have seen subtle differences due to the extra
+    logic that set_bkg can do (issues #879 and #880)
     """
 
-    setup_example_bkg_model(idval)
+    setup_example_bkg_model(idval, direct=direct)
     if idval is None:
         bp = ui.get_bkg_model_plot()
     else:
@@ -494,7 +519,10 @@ def test_get_bkg_model_plot(idval):
 
     # TODO: this is the same output as test_get_bkg_model_plot_energy,
     #       which doesn't make sense.
-    yexp = _arf / (_bexpscale * 100)
+    yexp = _arf / 100
+    if direct:
+        yexp /= _bexpscale
+
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Model'
@@ -502,17 +530,22 @@ def test_get_bkg_model_plot(idval):
     assert bp.ylabel == 'Counts/sec/channel'
 
 
-@pytest.mark.usefixtures("clean_astro_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_bkg_model_plot_energy(idval):
+@pytest.mark.parametrize("direct", [True, False])
+def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
     """Basic testing of get_bkg_model_plot: energy
+
+    We test ui.set_bkg as well as datapha.set_background,
+    since I have seen subtle differences due to the extra
+    logic that set_bkg can do (issues #879 and #880)
     """
 
     # The way I have set up the data means that set_analysis
     # doesn't seem to change the setting for the background,
-    # which should be tracked down (Sep 2019) but not just now.
+    # which should be tracked down (Sep 2019) but not just now
+    # (issue #879)
     #
-    setup_example_bkg_model(idval)
+    setup_example_bkg_model(idval, direct=direct)
     if idval is None:
         ui.set_analysis('energy')
         ui.get_bkg().units = 'energy'
@@ -529,12 +562,21 @@ def test_get_bkg_model_plot_energy(idval):
     #
     # I was expecting bp.x to return energy and not channel values
     #
-    assert bp.xlo == pytest.approx(_data_chan - 0.5)
-    assert bp.xhi == pytest.approx(_data_chan + 0.5)
+    if direct:
+        assert bp.xlo == pytest.approx(_data_chan - 0.5)
+        assert bp.xhi == pytest.approx(_data_chan + 0.5)
+    else:
+        assert bp.xlo == pytest.approx(_energies[:-1])
+        assert bp.xhi == pytest.approx(_energies[1:])
 
     # TODO: The factor of 100 comes from the bin width (0.1 keV), but
     # why is there a scaling by _bexpscale?
-    yexp = _arf / (_bexpscale * 100)
+    yexp = _arf / 100
+    if direct:
+        yexp /= _bexpscale
+    else:
+        yexp *= 10  # what is this from?
+
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Model'

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016, 2018, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,19 +37,21 @@ corresponding functions in sherpa.astro.ui.utils.
 #    table model
 #
 
-import re
 from io import StringIO
+import logging
+import re
 import tempfile
 
 import numpy
 from numpy.testing import assert_array_equal
+
+import pytest
 
 from sherpa.utils.testing import SherpaTestCase, requires_data, \
     requires_xspec, has_package_from_list, requires_fits, requires_group
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
 
-import logging
 logger = logging.getLogger('sherpa')
 
 has_xspec = has_package_from_list("sherpa.astro.xspec")
@@ -823,446 +825,467 @@ _canonical_pha_grouped += _canonical_extra
 _canonical_usermodel += _canonical_extra
 
 
-class test_ui(SherpaTestCase):
-
-    def setUp(self):
-        try:
-            numpy.set_printoptions(legacy='1.13')
-        except TypeError:  # numpy < 1.14
-            pass
-
-        ui.clean()  # I thought the test harness did this anyway
-        self._old_logging_level = logger.level
-        logger.setLevel(logging.ERROR)
-        if has_xspec:
-            from sherpa.astro import xspec
-            self._xspec_state = xspec.get_xsstate()
-            ui.set_xschatter(0)
-            ui.set_xsabund('angr')
-            ui.set_xsxsect('bcmc')
-
-    def tearDown(self):
-        try:
-            numpy.set_printoptions(legacy=False)
-        except TypeError:  # numpy < 1.14
-            pass
-        logger.setLevel(self._old_logging_level)
-        if has_xspec:
-            from sherpa.astro import xspec
-            xspec.set_xsstate(self._xspec_state)
-
-        ui.clean()
-
-    def _add_datadir_path(self, output):
-        """Replace any @@ characters by the value of self.datadir,
-        making sure that the replacement text does not end in a /."""
-
-        dname = self.datadir
-        if dname.endswith('/'):
-            dname = dname[:-1]
-
-        return re.sub('@@', dname, output, count=0)
-
-    def _compile(self, output):
-        # Let it just throw an exception in case of failure.
-        compile(output, "test.py", "exec")
-
-    def _compare_lines(self, expected, got):
-        """Check that each line in got matches that in
-        expected. This is to provide a more-readable
-        set of error messages (may prefer a diff-style
-        analysis).
-        """
-
-        elines = expected.split('\n')
-        glines = got.split('\n')
-
-        # _dump_lines(elines)
-        # _dump_lines(glines)
-
-        for e, g in zip(elines, glines):
-            self.assertEqual(e, g)
-
-        # Do the line length after checking for the file
-        # contents as it is easier to see what the difference
-        # is this way around, since a difference in the
-        # number of lines is often not very informative.
-        self.assertEqual(len(elines), len(glines))
-
-    def _compare(self, expected):
-        """Run save_all and check the output (saved to a
-        StringIO object) to the string value expected.
-        """
-        output = StringIO()
-        ui.save_all(output)
-        output = output.getvalue()
-
-        # check the output is a valid Python program.
-        # this check does not guard against potential issues,
-        # but ensures that the program can compile.
-        self._compile(output)
-
-        self._compare_lines(expected, output)
-
-    def _restore(self):
-        """Run save_all then call clean and try to restore
-        the Sherpa state from the saved file. Will raise
-        a test failure if there was an error when
-        executing the save file.
-        """
-
-        output = StringIO()
-        ui.save_all(output)
-        output = output.getvalue()
-        ui.clean()
-        try:
-            exec(output)
-            success = True
-            e = "no exception"
-        except Exception as e:
-            success = False
-
-        self.assertTrue(success, msg="exception={}".format(e))
-
-    def _setup_pha_basic(self):
-        """Load up a PHA file and make "simple" changes to the
-        Sherpa state. Returns the name of the file that is
-        loaded and the canonical output.
-        """
+# This extends the clean_astro_ui logic but it isn't obvious
+# to me how to chain them together, so it re-implements
+# clean_astro_ui.
+#
+@pytest.fixture(autouse=True)
+def setup(clean_astro_ui):
+
+    # Setup for the test
+    try:
+        numpy.set_printoptions(legacy='1.13')
+    except TypeError:  # numpy < 1.14
+        pass
+
+    old_logging_level = logger.level
+    logger.setLevel(logging.ERROR)
+
+    if has_xspec:
+        from sherpa.astro import xspec
+        old_xspec = xspec.get_xsstate()
+
+        # ensure we have the same settings as the test cases
+        # used (changes to XSPEC may have changed the defaults)
+        xspec.set_xschatter(0)
+        xspec.set_xsabund('angr')
+        xspec.set_xsxsect('bcmc')
+    else:
+        old_xspec = None
+
+    ui.clean()
+
+    # run the test
+    yield
+
+    # Restore the Sherpa/related settings
+    ui.clean()
+
+    if old_xspec is not None:
+        xspec.set_xsstate(old_xspec)
+
+    try:
+        numpy.set_printoptions(legacy=False)
+    except TypeError:  # numpy < 1.14
+        pass
+
+    logger.setLevel(old_logging_level)
+
+
+def add_datadir_path(output):
+    """Replace any @@ characters by the value of self.datadir,
+    making sure that the replacement text does not end in a /."""
+
+    # it would be nice not to use SherpaTestCase
+    dname = SherpaTestCase.datadir
+    if dname.endswith('/'):
+        dname = dname[:-1]
+
+    return re.sub('@@', dname, output, count=0)
+
+def compileit(output):
+    # Let it just throw an exception in case of failure.
+    compile(output, "test.py", "exec")
+
+
+def compare_lines(expected, got):
+    """Check that each line in got matches that in
+    expected. This is to provide a more-readable
+    set of error messages (may prefer a diff-style
+    analysis).
+    """
+
+    elines = expected.split('\n')
+    glines = got.split('\n')
+
+    # _dump_lines(elines)
+    # _dump_lines(glines)
+
+    for e, g in zip(elines, glines):
+        assert e == g
+
+    # Do the line length after checking for the file
+    # contents as it is easier to see what the difference
+    # is this way around, since a difference in the
+    # number of lines is often not very informative.
+    #
+    assert len(elines) == len(glines)
 
-        ui.clean()
-        fname = self.make_path('3c273.pi')
-        ui.load_pha(1, fname)
-        ui.subtract()
-        ui.set_stat('chi2datavar')
-        ui.notice(0.5, 7)
-        ui.set_source(ui.xsphabs.gal * (ui.powlaw1d.pl +
-                                        ui.xsapec.src))
-        return fname, self._add_datadir_path(_canonical_pha_basic)
 
-    def _setup_pha_grouped(self):
-        """Add in grouping and a few different choices.
+def compare(expected):
+    """Run save_all and check the output (saved to a
+    StringIO object) to the string value expected.
+    """
+    output = StringIO()
+    ui.save_all(output)
+    output = output.getvalue()
 
-        Returns the name of the file that is
-        loaded, the new grouping and quality arrays,
-        and the canonical output.
-        """
+    # check the output is a valid Python program.
+    # this check does not guard against potential issues,
+    # but ensures that the program can compile.
+    #
+    compileit(output)
+    compare_lines(expected, output)
 
-        ui.clean()
-        fname = self.make_path('3c273.pi')
-        ui.load_pha('grp', fname)
-        channels = ui.get_data('grp').channel
 
-        exclude = (channels < 20) | (channels > 800)
-        qual = exclude * 1
+def restore():
+    """Run save_all then call clean and try to restore
+    the Sherpa state from the saved file. Will raise
+    a test failure if there was an error when
+    executing the save file.
+    """
 
-        ui.subtract('grp')
-        ui.group_counts('grp', 10, tabStops=exclude)
-        ui.set_quality('grp', exclude)
+    output = StringIO()
+    ui.save_all(output)
+    output = output.getvalue()
+    ui.clean()
+    try:
+        exec(output)
+        success = True
+        e = "no exception"
+    except Exception as e:
+        success = False
 
-        grp = ui.get_data('grp').grouping
+    assert success, "exception={}".format(e)
 
-        ui.set_stat('chi2gehrels')
-        ui.notice_id('grp', 0.5, 6)
-        ui.set_source('grp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
-        ui.powlaw1d.gpl.gamma.max = 5
-        ui.set_par('ggal.nh', val=2.0, frozen=True)
 
-        return fname, (grp, qual), \
-            self._add_datadir_path(_canonical_pha_grouped)
+def setup_pha_basic(make_data_path):
+    """Load up a PHA file and make "simple" changes to the
+    Sherpa state. Returns the name of the file that is
+    loaded and the canonical output.
+    """
 
-    def _setup_pha_back(self):
-        """Fit the background, rather than subtract it.
-        """
+    fname = make_data_path('3c273.pi')
+    ui.load_pha(1, fname)
+    ui.subtract()
+    ui.set_stat('chi2datavar')
+    ui.notice(0.5, 7)
+    ui.set_source(ui.xsphabs.gal * (ui.powlaw1d.pl +
+                                    ui.xsapec.src))
+    return fname, add_datadir_path(_canonical_pha_basic)
 
-        ui.clean()
-        fname = self.make_path('3c273.pi')
-        ui.load_pha('bgrp', fname)
 
-        # Note: do not group the source dataset
+def setup_pha_grouped(make_data_path):
+    """Add in grouping and a few different choices.
 
-        bchannels = ui.get_bkg('bgrp').channel
+    Returns the name of the file that is
+    loaded, the new grouping and quality arrays,
+    and the canonical output.
+    """
 
-        bexclude = (bchannels < 10) | (bchannels > 850)
-        bqual = bexclude * 1
+    fname = make_data_path('3c273.pi')
+    ui.load_pha('grp', fname)
+    channels = ui.get_data('grp').channel
 
-        ui.group_counts('bgrp', 10, tabStops=bexclude, bkg_id=1)
-        ui.set_quality('bgrp', bexclude, bkg_id=1)
+    exclude = (channels < 20) | (channels > 800)
+    qual = exclude * 1
 
-        bgrp = ui.get_bkg('bgrp').grouping
+    ui.subtract('grp')
+    ui.group_counts('grp', 10, tabStops=exclude)
+    ui.set_quality('grp', exclude)
 
-        ui.set_stat('chi2xspecvar')
+    grp = ui.get_data('grp').grouping
 
-        # This call sets the noticed range for both source and
-        # background data sets.
-        ui.notice_id('bgrp', 0.5, 6)
+    ui.set_stat('chi2gehrels')
+    ui.notice_id('grp', 0.5, 6)
+    ui.set_source('grp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
+    ui.powlaw1d.gpl.gamma.max = 5
+    ui.set_par('ggal.nh', val=2.0, frozen=True)
 
-        # Remove the "source" filter
-        ui.notice_id('bgrp', None, None, bkg_id=1)
-        ui.notice_id('bgrp', 2, 7, bkg_id=1)
+    return fname, (grp, qual), \
+        add_datadir_path(_canonical_pha_grouped)
 
-        ui.set_source('bgrp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
-        ui.set_bkg_source('bgrp', ui.steplo1d.bstep + ui.polynom1d.bpoly)
 
-        ui.set_xsabund('lodd')
-        ui.set_xsxsect('vern')
-        ui.set_xscosmo(72, 0.02, 0.71)
+def setup_pha_back(make_data_path):
+    """Fit the background, rather than subtract it.
+    """
 
-        ui.powlaw1d.gpl.gamma.min = -5
-        ui.freeze(ui.polynom1d.bpoly.c0)
+    fname = make_data_path('3c273.pi')
+    ui.load_pha('bgrp', fname)
 
-        ui.set_par('ggal.nh', val=2.0, frozen=True)
+    # Note: do not group the source dataset
 
-        return fname, (bgrp, bqual), \
-            self._add_datadir_path(_canonical_pha_back)
+    bchannels = ui.get_bkg('bgrp').channel
 
-    def _setup_usermodel(self):
-        """Try a user model.
-        """
+    bexclude = (bchannels < 10) | (bchannels > 850)
+    bqual = bexclude * 1
 
-        ui.clean()
-        # Note: array is not sorted on purpose, and float/int
-        # values.
-        ui.load_arrays(3, [1, 12.2, 2, 14], [4, 8, 12, 4])
+    ui.group_counts('bgrp', 10, tabStops=bexclude, bkg_id=1)
+    ui.set_quality('bgrp', bexclude, bkg_id=1)
 
-        def mymodel_func(pars, x, xhi=None):
-            return pars[0] + pars[1] * x
+    bgrp = ui.get_bkg('bgrp').grouping
 
-        ui.load_user_model(mymodel_func, "mymodel")
-        ui.add_user_pars("mymodel",
-                         parnames=["c", "m"],
-                         parvals=[2, 0.5],
-                         parmins=[-10, 0],
-                         parmaxs=[10, 5.5],
-                         parunits=["m", ""],
-                         parfrozen=[False, True])
+    ui.set_stat('chi2xspecvar')
 
-        mymodel = ui.get_model_component("mymodel")
-        ui.set_source(3, ui.sin.sin_model + mymodel)
+    # This call sets the noticed range for both source and
+    # background data sets.
+    ui.notice_id('bgrp', 0.5, 6)
 
-        ui.set_stat('cash')
-        ui.set_method('simplex')
+    # Remove the "source" filter
+    ui.notice_id('bgrp', None, None, bkg_id=1)
+    ui.notice_id('bgrp', 2, 7, bkg_id=1)
 
-    def test_compile_failure(self):
-        try:
-            self._compile("foo bar")
-        except:
-            return
-        self.fail("Compilation should have failed")
+    ui.set_source('bgrp', ui.xsphabs.ggal * ui.powlaw1d.gpl)
+    ui.set_bkg_source('bgrp', ui.steplo1d.bstep + ui.polynom1d.bpoly)
 
-    def test_restore_empty(self):
-        "Can the empty state be evaluated?"
+    ui.set_xsabund('lodd')
+    ui.set_xsxsect('vern')
+    ui.set_xscosmo(72, 0.02, 0.71)
 
-        ui.clean()
+    ui.powlaw1d.gpl.gamma.min = -5
+    ui.freeze(ui.polynom1d.bpoly.c0)
 
-        # At present the only check is that the file can be
-        # loaded.
-        self._restore()
+    ui.set_par('ggal.nh', val=2.0, frozen=True)
 
-    def test_canonical_empty(self):
-        self._compare(_canonical_empty)
+    return fname, (bgrp, bqual), \
+        add_datadir_path(_canonical_pha_back)
 
-    def test_canonical_empty_outfile(self):
-        tfile = tempfile.NamedTemporaryFile(suffix='.sherpa')
-        ui.save_all(tfile.name, clobber=True)
-        with open(tfile.name, 'r') as fh:
-            output = fh.read()
-        self._compare_lines(_canonical_empty, output)
 
-    def test_canonical_empty_stats(self):
+def setup_usermodel():
+    """Try a user model.
+    """
 
-        ui.set_stat('leastsq')
+    # Note: array is not sorted on purpose, and float/int
+    # values.
+    ui.load_arrays(3, [1, 12.2, 2, 14], [4, 8, 12, 4])
 
-        ui.set_method('simplex')
-        ui.set_method_opt('maxfev', 5000)
-        ui.set_method_opt('verbose', 1)
+    def mymodel_func(pars, x, xhi=None):
+        return pars[0] + pars[1] * x
 
-        self._compare(_canonical_empty_stats)
+    ui.load_user_model(mymodel_func, "mymodel")
+    ui.add_user_pars("mymodel",
+                     parnames=["c", "m"],
+                     parvals=[2, 0.5],
+                     parmins=[-10, 0],
+                     parmaxs=[10, 5.5],
+                     parunits=["m", ""],
+                     parfrozen=[False, True])
 
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    def test_canonical_pha_basic(self):
+    mymodel = ui.get_model_component("mymodel")
+    ui.set_source(3, ui.sin.sin_model + mymodel)
 
-        _, canonical = self._setup_pha_basic()
-        self._compare(canonical)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    def test_restore_pha_basic(self):
-        "Can the state be evaluated?"
-
-        fname, _ = self._setup_pha_basic()
-        statval = ui.calc_stat()
-
-        self._restore()
-
-        self.assertEqual([1], ui.list_data_ids())
-        self.assertEqual(fname, ui.get_data(1).name)
-        self.assertTrue(ui.get_data().subtracted,
-                        msg='Data should be subtracted')
-
-        src_expr = ui.get_source()
-        self.assertEqual(src_expr.name,
-                         '(xsphabs.gal * (powlaw1d.pl + xsapec.src))')
-        self.assertEqual(ui.xsphabs.gal.name, 'xsphabs.gal')
-        self.assertEqual(ui.powlaw1d.pl.name, 'powlaw1d.pl')
-        self.assertEqual(ui.xsapec.src.name, 'xsapec.src')
-
-        self.assertAlmostEqual(ui.calc_stat(), statval)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_canonical_pha_grouped(self):
-
-        _, _, canonical = self._setup_pha_grouped()
-        self._compare(canonical)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_restore_pha_grouped(self):
-        "Can the state be evaluated?"
-
-        fname, (grp, qual), _ = self._setup_pha_grouped()
-        statval = ui.calc_stat('grp')
-
-        self._restore()
-
-        self.assertEqual(['grp'], ui.list_data_ids())
-        self.assertEqual(fname, ui.get_data('grp').name)
-        self.assertTrue(ui.get_data('grp').subtracted,
-                        msg='Data should be subtracted')
-
-        g = ui.get_grouping('grp')
-        q = ui.get_quality('grp')
-        self.assertEqual(g.dtype, numpy.int16)
-        self.assertEqual(q.dtype, numpy.int16)
-
-        assert_array_equal(grp, g, err_msg='grouping column')
-        assert_array_equal(qual, q, err_msg='grouping column')
-
-        src_expr = ui.get_source('grp')
-        self.assertEqual(src_expr.name,
-                         '(xsphabs.ggal * powlaw1d.gpl)')
-        self.assertTrue(ui.xsphabs.ggal.nh.frozen, msg="is ggal.nh frozen?")
-        self.assertEqual(ui.xsphabs.ggal.nh.val, 2.0)
-        self.assertEqual(ui.powlaw1d.gpl.gamma.max, 5.0)
-
-        self.assertAlmostEqual(ui.calc_stat('grp'), statval)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_canonical_pha_back(self):
-
-        _, _, canonical = self._setup_pha_back()
-        self._compare(canonical)
-
-    @requires_data
-    @requires_xspec
-    @requires_fits
-    @requires_group
-    def test_restore_pha_back(self):
-        "Can the state be evaluated?"
-
-        fname, (bgrp, bqual), _ = self._setup_pha_back()
-        statval = ui.calc_stat('bgrp')
-
-        # At present the model is not saved correctly for the
-        # background component - it includes apply_arf/rmf
-        # statements - which means that running the saved script
-        # results in an error.
-        self._restore()
-
-        self.assertEqual(['bgrp'], ui.list_data_ids())
-        self.assertEqual(fname, ui.get_data('bgrp').name)
-        self.assertFalse(ui.get_data('bgrp').subtracted,
-                         msg='Data should not be subtracted')
-        self.assertFalse(ui.get_bkg('bgrp').subtracted,
-                         msg='Background should not be subtracted')
-
-        # TODO: at present the source is grouped; is this "correct"?
-        # self.assertFalse(ui.get_data('bgrp').grouped,
-        #                  msg='Data should not be grouped')
-        self.assertTrue(ui.get_data('bgrp').grouped,
-                        msg='Data should be grouped')  # FIXME?
-        self.assertTrue(ui.get_bkg('bgrp').grouped,
-                        msg='Background should be grouped')
-
-        # g = ui.get_grouping('bgrp')
-        # q = ui.get_quality('bgrp')
-        # The data types are '>i2' / int16
-        # self.assertEqual(g.dtype, numpy.int16)
-        # self.assertEqual(q.dtype, numpy.int16)
-
-        # TODO set up correct grouping bins...
-        # nchan = ui.get_data('bgrp').channel.size
-        # assert_array_equal(g, numpy.ones(nchan), err_msg='src grouping')
-        # assert_array_equal(q, numpy.zeros(nchan), err_msg='src quality')
-
-        bg = ui.get_grouping('bgrp', bkg_id=1)
-        bq = ui.get_quality('bgrp', bkg_id=1)
-        self.assertEqual(bg.dtype, numpy.int16)
-        self.assertEqual(bq.dtype, numpy.int16)
-
-        assert_array_equal(bg, bgrp, err_msg='bgnd grouping')
-        assert_array_equal(bq, bqual, err_msg='bgnd quality')
-
-        # TODO: check noticed range
-
-        src_expr = ui.get_source('bgrp')
-        self.assertEqual(src_expr.name,
-                         '(xsphabs.ggal * powlaw1d.gpl)')
-
-        bg_expr = ui.get_bkg_source('bgrp')
-        self.assertEqual(bg_expr.name,
-                         '(steplo1d.bstep + polynom1d.bpoly)')
-
-        self.assertTrue(ui.xsphabs.ggal.nh.frozen, msg="is ggal.nh frozen?")
-        self.assertTrue(ui.polynom1d.bpoly.c0.frozen, msg="is bpoly.c0 frozen?")
-        self.assertEqual(ui.xsphabs.ggal.nh.val, 2.0)
-        self.assertEqual(ui.powlaw1d.gpl.gamma.min, -5.0)
-
-        self.assertEqual(ui.get_xsabund(), 'lodd')
-        self.assertEqual(ui.get_xsxsect(), 'vern')
-        cosmo = ui.get_xscosmo()
-        self.assertAlmostEqual(cosmo[0], 72.0)
-        self.assertAlmostEqual(cosmo[1], 0.02)
-        self.assertAlmostEqual(cosmo[2], 0.71)
-
-        self.assertAlmostEqual(ui.calc_stat('bgrp'), statval)
-
-    def test_canonical_usermodel(self):
-
-        self._setup_usermodel()
-        self._compare(_canonical_usermodel)
-
-    def test_restore_usermodel(self):
-        "Can the state be evaluated?"
-
-        self._setup_usermodel()
-        statval = ui.calc_stat(3)
-        self._restore()
-
-        # TODO: For the moment the source expression is created, in
-        # the serialized form, using set_full_model. This should
-        # be changed so that get_source can be used below.
-        #
-        # src_expr = ui.get_source(3)
-        src_expr = ui.get_model(3)
-        self.assertEqual(src_expr.name,
-                         '(sin.sin_model + usermodel.mymodel)')
-        mymodel = ui.get_model_component("mymodel")
-        self.assertTrue(mymodel.m.frozen, msg="is mymodel.m frozen?")
-        self.assertEqual(mymodel.c.val, 2.0)
-        self.assertEqual(mymodel.c.units, "m")
-        self.assertEqual(mymodel.m.max, 5.5)
-        self.assertEqual(mymodel.m.units, "")
-
-        self.assertEqual(ui.calc_stat(3), statval)
+    ui.set_stat('cash')
+    ui.set_method('simplex')
+
+
+def test_compile_failure():
+    with pytest.raises(Exception):
+        compileit("foo bar")
+
+
+def test_restore_empty():
+    "Can the empty state be evaluated?"
+
+    # At present the only check is that the file can be
+    # loaded.
+    restore()
+
+
+def test_canonical_empty():
+    "Contents of empty state are as expected"
+    compare(_canonical_empty)
+
+
+def test_canonical_empty_outfile():
+    "Can read in a save file"
+    tfile = tempfile.NamedTemporaryFile(suffix='.sherpa')
+    ui.save_all(tfile.name, clobber=True)
+    with open(tfile.name, 'r') as fh:
+        output = fh.read()
+
+    compare_lines(_canonical_empty, output)
+
+
+def test_canonical_empty_stats():
+    "Change several settings but load no data"
+
+    ui.set_stat('leastsq')
+
+    ui.set_method('simplex')
+    ui.set_method_opt('maxfev', 5000)
+    ui.set_method_opt('verbose', 1)
+
+    compare(_canonical_empty_stats)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+def test_canonical_pha_basic(make_data_path):
+
+    _, canonical = setup_pha_basic(make_data_path)
+    compare(canonical)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+def test_restore_pha_basic(make_data_path):
+    "Can the state be evaluated?"
+
+    fname, _ = setup_pha_basic(make_data_path)
+    statval = ui.calc_stat()
+
+    restore()
+
+    assert ui.list_data_ids() == [1]
+    assert ui.get_data(1).name == fname
+    assert ui.get_data().subtracted, 'Data should be subtracted'
+
+    src_expr = ui.get_source()
+    assert src_expr.name == '(xsphabs.gal * (powlaw1d.pl + xsapec.src))'
+    assert ui.xsphabs.gal.name == 'xsphabs.gal'
+    assert ui.powlaw1d.pl.name == 'powlaw1d.pl'
+    assert ui.xsapec.src.name == 'xsapec.src'
+
+    assert ui.calc_stat() == pytest.approx(statval)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_canonical_pha_grouped(make_data_path):
+
+    _, _, canonical = setup_pha_grouped(make_data_path)
+    compare(canonical)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_restore_pha_grouped(make_data_path):
+    "Can the state be evaluated?"
+
+    fname, (grp, qual), _ = setup_pha_grouped(make_data_path)
+    statval = ui.calc_stat('grp')
+
+    restore()
+
+    assert ui.list_data_ids() == ['grp']
+    assert ui.get_data('grp').name == fname
+    assert ui.get_data('grp').subtracted, 'Data should be subtracted'
+
+    g = ui.get_grouping('grp')
+    q = ui.get_quality('grp')
+    assert g.dtype == numpy.int16
+    assert q.dtype == numpy.int16
+
+    assert_array_equal(grp, g, err_msg='grouping column')
+    assert_array_equal(qual, q, err_msg='grouping column')
+
+    src_expr = ui.get_source('grp')
+    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+    assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
+    assert ui.xsphabs.ggal.nh.val == 2.0
+    assert ui.powlaw1d.gpl.gamma.max == 5.0
+
+    assert ui.calc_stat('grp') == pytest.approx(statval)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_canonical_pha_back(make_data_path):
+
+    _, _, canonical = setup_pha_back(make_data_path)
+    compare(canonical)
+
+
+@requires_data
+@requires_xspec
+@requires_fits
+@requires_group
+def test_restore_pha_back(make_data_path):
+    "Can the state be evaluated?"
+
+    fname, (bgrp, bqual), _ = setup_pha_back(make_data_path)
+    statval = ui.calc_stat('bgrp')
+
+    # At present the model is not saved correctly for the
+    # background component - it includes apply_arf/rmf
+    # statements - which means that running the saved script
+    # results in an error.
+    restore()
+
+    assert ui.list_data_ids() == ['bgrp']
+    assert ui.get_data('bgrp').name == fname
+    assert not ui.get_data('bgrp').subtracted, 'Data should not be subtracted'
+    assert not ui.get_bkg('bgrp').subtracted, 'Background should not be subtracted'
+
+    # TODO: at present the source is grouped; is this "correct"?
+    assert ui.get_data('bgrp').grouped, 'Data should be grouped'  # FIXME?
+    assert ui.get_bkg('bgrp').grouped, 'Background should be grouped'
+
+    # g = ui.get_grouping('bgrp')
+    # q = ui.get_quality('bgrp')
+    # The data types are '>i2' / int16
+    # assert g.dtype == numpy.int16
+    # assert q.dtype == numpy.int16
+
+    # TODO set up correct grouping bins...
+    # nchan = ui.get_data('bgrp').channel.size
+    # assert_array_equal(g, numpy.ones(nchan), err_msg='src grouping')
+    # assert_array_equal(q, numpy.zeros(nchan), err_msg='src quality')
+
+    bg = ui.get_grouping('bgrp', bkg_id=1)
+    bq = ui.get_quality('bgrp', bkg_id=1)
+    assert bg.dtype == numpy.int16
+    assert bq.dtype == numpy.int16
+
+    assert_array_equal(bg, bgrp, err_msg='bgnd grouping')
+    assert_array_equal(bq, bqual, err_msg='bgnd quality')
+
+    # TODO: check noticed range
+
+    src_expr = ui.get_source('bgrp')
+    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+
+    bg_expr = ui.get_bkg_source('bgrp')
+    assert bg_expr.name == '(steplo1d.bstep + polynom1d.bpoly)'
+
+    assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
+    assert ui.polynom1d.bpoly.c0.frozen, "is bpoly.c0 frozen?"
+    assert ui.xsphabs.ggal.nh.val == 2.0
+    assert ui.powlaw1d.gpl.gamma.min == -5.0
+
+    assert ui.get_xsabund() == 'lodd'
+    assert ui.get_xsxsect() == 'vern'
+    cosmo = ui.get_xscosmo()
+    assert cosmo[0] == pytest.approx(72.0)
+    assert cosmo[1] == pytest.approx(0.02)
+    assert cosmo[2] == pytest.approx(0.71)
+
+    assert ui.calc_stat('bgrp') == pytest.approx(statval)
+
+
+def test_canonical_usermodel():
+    "Can we save a usermodel?"
+    setup_usermodel()
+    compare(_canonical_usermodel)
+
+
+def test_restore_usermodel():
+    "Can the reload a usermodel"
+
+    setup_usermodel()
+    statval = ui.calc_stat(3)
+    restore()
+
+    # TODO: For the moment the source expression is created, in
+    # the serialized form, using set_full_model. This should
+    # be changed so that get_source can be used below.
+    #
+    # src_expr = ui.get_source(3)
+    src_expr = ui.get_model(3)
+    assert src_expr.name == '(sin.sin_model + usermodel.mymodel)'
+    mymodel = ui.get_model_component("mymodel")
+    assert mymodel.m.frozen,"is mymodel.m frozen?"
+    assert mymodel.c.val == 2.0
+    assert mymodel.c.units == "m"
+    assert mymodel.m.max == 5.5
+    assert mymodel.m.units == ""
+
+    assert ui.calc_stat(3) == pytest.approx(statval)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1204,10 +1204,6 @@ def test_restore_pha_back(make_data_path):
     fname, (bgrp, bqual), _ = setup_pha_back(make_data_path)
     statval = ui.calc_stat('bgrp')
 
-    # At present the model is not saved correctly for the
-    # background component - it includes apply_arf/rmf
-    # statements - which means that running the saved script
-    # results in an error.
     restore()
 
     assert ui.list_data_ids() == ['bgrp']

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -18,10 +18,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import pytest
 import os
 import sys
 import re
+import logging
+
+import pytest
 
 import numpy as np
 from numpy import VisibleDeprecationWarning
@@ -465,3 +467,16 @@ def reset_seed(request):
 
     yield
     np.random.seed()
+
+
+@pytest.fixture
+def hide_logging():
+    """Set Sherpa's logging to ERROR for the test.
+
+    """
+
+    logger = logging.getLogger('sherpa')
+    olvl = logger.getEffectiveLevel()
+    logger.setLevel(logging.ERROR)
+    yield
+    logger.setLevel(olvl)

--- a/sherpa/stats/tests/test_wstat.py
+++ b/sherpa/stats/tests/test_wstat.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -78,437 +78,379 @@
 #     search for "Note: this is related to issue 227".
 #
 
+import logging
+
 import numpy as np
 
-from sherpa.utils.testing import SherpaTestCase, requires_data, \
-    requires_fits, requires_group
-from sherpa.astro import ui
+import pytest
 
-import logging
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group
+from sherpa.astro import ui
 
 logger = logging.getLogger('sherpa')
 
 
+# Single PHA file with a scalar backscal value"""
+
+@pytest.fixture
+def single_scalar_setup(make_data_path):
+
+    ui.set_stat('wstat')
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(1, infile)
+
+    ui.set_source(1, ui.powlaw1d.pl)
+
+    # The powerlaw slope and normalization are
+    # intended to be "a reasonable approximation"
+    # to the data, just to make sure that any statistic
+    # calculation doesn't blow-up too much.
+    #
+    ui.set_par("pl.gamma", 1.782)
+    ui.set_par("pl.ampl", 1.622e-4)
+
+
+def filter_data():
+    """Filter the data.
+
+    Use a slightly-complex filter - e.g. not just the
+    end points - to exercise the system.
+    """
+
+    ui.ignore(None, 0.5)
+    ui.ignore(3, 4)
+    ui.ignore(7, None)
+
+
+def check_stat(nbins, expected, idval=None):
+
+    # check the filter sizes (mainly so that these tests
+    # get flagged as in need of a look if anything changes
+    # in other parts of the code, such as filtering and binning
+    #
+    assert ui.get_data(idval).get_dep(True).size == nbins
+
+    stat = ui.calc_stat(idval)
+
+    # this used to check to a given number of decimal places
+    # rather than relative
+    assert stat == pytest.approx(expected)
+
+
+def check_stat2(expected):
+    """Is calc_stat() == expected?"""
+
+    stat = ui.calc_stat()
+
+    # this used to check to a given number of decimal places
+    # rather than relative
+    assert stat == pytest.approx(expected)
+
+
 @requires_data
 @requires_fits
-class test_wstat_single_scalar(SherpaTestCase):
-    """Single PHA file with a scalar backscal value"""
+def test_wstat_single_scalar_grouped_all(clean_astro_ui, hide_logging, single_scalar_setup):
 
-    def setUp(self):
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(46, 62.12275005769554)
 
-        # defensive programming (one of the tests has been seen to fail
-        # when the whole test suite is run without this)
-        ui.clean()
 
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+@requires_data
+@requires_fits
+def test_wstat_single_scalar_grouped_filtered(clean_astro_ui, hide_logging, single_scalar_setup):
+    filter_data()
 
-        ui.set_stat('wstat')
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(35, 39.84715083397662)
 
-        infile = self.make_path('3c273.pi')
-        ui.load_pha(1, infile)
 
-        ui.set_source(1, ui.powlaw1d.pl)
+@requires_data
+@requires_fits
+def test_wstat_single_scalar_ungrouped_all(clean_astro_ui, hide_logging, single_scalar_setup):
+    ui.ungroup()
 
-        # The powerlaw slope and normalization are
-        # intended to be "a reasonable approximation"
-        # to the data, just to make sure that any statistic
-        # calculation doesn't blow-up too much.
-        #
-        ui.set_par("pl.gamma", 1.782)
-        ui.set_par("pl.ampl", 1.622e-4)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(1024, 652.9968167212116)
 
-    def tearDown(self):
-        ui.clean()
 
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
+@requires_data
+@requires_fits
+def test_wstat_single_scalar_ungrouped_filtered(clean_astro_ui, hide_logging, single_scalar_setup):
+    ui.ungroup()
+    filter_data()
 
-    def _filter_data(self):
-        """Filter the data.
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(375, 416.0601496345599)
 
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
 
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
+# Two PHA files with a scalar backscal value
 
-    def _check_stat(self, nbins, expected):
+@pytest.fixture
+def two_scalar_setup(make_data_path):
 
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data().get_dep(True).size)
+    ui.set_stat('wstat')
 
-        stat = ui.calc_stat()
-        self.assertAlmostEqual(expected, stat, places=7)
+    infile1 = make_data_path('3c273.pi')
+    infile2 = make_data_path('9774.pi')
+    ui.load_pha(1, infile1)
+    ui.load_pha(2, infile2)
 
-    def test_wstat_grouped_all(self):
+    # Since 9774.pi isn't grouped, group it. Note that this
+    # call groups the background to 20 counts per bin. In this
+    # case we do not want that; instead we want to use the same
+    # grouping scheme as the source file.
+    #
+    # Note: this is related to issue 227
+    #
+    ui.group_counts(2, 20)
+    ui.set_grouping(2, bkg_id=1, val=ui.get_grouping(2))
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(46, 62.12275005769554)
+    # There's no need to have the same model in both datasets,
+    # but assume the same source model can be used, with a
+    # normalization difference.
+    #
+    ui.set_source(1, ui.powlaw1d.pl1)
+    ui.set_source(2, ui.const1d.c2 * ui.get_source(1))
 
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(35, 39.84715083397662)
-
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(1024, 652.9968167212116)
-
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup()
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(375, 416.0601496345599)
+    # The powerlaw slope and normalization are
+    # intended to be "a reasonable approximation"
+    # to the data, just to make sure that any statistic
+    # calculation doesn't blow-up too much.
+    #
+    # Note: the model values for 3c273 are slighly different
+    #       to the single-PHA-file case, so stat results are
+    #       slightly different
+    #
+    ui.set_par("pl1.gamma", 1.7)
+    ui.set_par("pl1.ampl", 1.6e-4)
+    ui.set_par("c2.c0", 45)
 
 
 @requires_group
 @requires_data
 @requires_fits
-class test_wstat_two_scalar(SherpaTestCase):
-    """Two PHA files with a scalar backscal value"""
+def test_wstat_two_scalar_grouped_all(clean_astro_ui, hide_logging, two_scalar_setup):
 
-    def setUp(self):
-
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
-
-        ui.set_stat('wstat')
-
-        infile1 = self.make_path('3c273.pi')
-        infile2 = self.make_path('9774.pi')
-        ui.load_pha(1, infile1)
-        ui.load_pha(2, infile2)
-
-        # Since 9774.pi isn't grouped, group it. Note that this
-        # call groups the background to 20 counts per bin. In this
-        # case we do not want that; instead we want to use the same
-        # grouping scheme as the source file.
-        #
-        # Note: this is related to issue 227
-        #
-        ui.group_counts(2, 20)
-        ui.set_grouping(2, bkg_id=1, val=ui.get_grouping(2))
-
-        # There's no need to have the same model in both datasets,
-        # but assume the same source model can be used, with a
-        # normalization difference.
-        #
-        ui.set_source(1, ui.powlaw1d.pl1)
-        ui.set_source(2, ui.const1d.c2 * ui.get_source(1))
-
-        # The powerlaw slope and normalization are
-        # intended to be "a reasonable approximation"
-        # to the data, just to make sure that any statistic
-        # calculation doesn't blow-up too much.
-        #
-        # Note: the model values for 3c273 are slighly different
-        #       to the single-PHA-file case, so stat results are
-        #       slightly different
-        #
-        ui.set_par("pl1.gamma", 1.7)
-        ui.set_par("pl1.ampl", 1.6e-4)
-        ui.set_par("c2.c0", 45)
-
-    def tearDown(self):
-        ui.clean()
-
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
-
-    def _filter_data(self):
-        """Filter the data.
-
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
-
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
-
-    def _check_stat(self, idval, nbins, expected):
-
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data(idval).get_dep(True).size)
-
-        stat = ui.calc_stat(idval)
-        self.assertAlmostEqual(expected, stat, places=7)
-
-    def _check_stat2(self, expected):
-        """Is calc_stat() == expected?"""
-
-        stat = ui.calc_stat()
-        self.assertAlmostEqual(expected, stat, places=7)
-
-    def test_wstat_grouped_all(self):
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 66.20114213871206
-        exp2 = 401.75572944361613
-        self._check_stat(1, 46, exp1)
-        self._check_stat(2, 148, exp2)
-        self._check_stat2(exp1 + exp2)
-
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 45.93447168433694
-        exp2 = 127.35556915677182
-        self._check_stat(1, 35, exp1)
-        self._check_stat(2, 120, exp2)
-        self._check_stat2(exp1 + exp2)
-
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup(1)
-        ui.ungroup(2)
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 657.2275371837611
-        exp2 = 880.8442022201893
-        self._check_stat(1, 1024, exp1)
-        self._check_stat(2, 1024, exp2)
-        self._check_stat2(exp1 + exp2)
-
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup(1)
-        ui.ungroup(2)
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        exp1 = 420.50951039235736
-        exp2 = 397.4089421041855
-        self._check_stat(1, 375, exp1)
-        self._check_stat(2, 375, exp2)
-        self._check_stat2(exp1 + exp2)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 66.20114213871206
+    exp2 = 401.75572944361613
+    check_stat(46, exp1, 1)
+    check_stat(148, exp2, 2)
+    check_stat2(exp1 + exp2)
 
 
 @requires_group
 @requires_data
 @requires_fits
-class test_wstat_group_counts(SherpaTestCase):
-    """PHA file that has been grouped.
+def test_wstat_two_scalar_grouped_filtered(clean_astro_ui, hide_logging, two_scalar_setup):
+    filter_data()
 
-    This is the error reported in issue #227, whereby the
-    grouping in the source and background files is different,
-    which causes an error. It is not clear yet whether this
-    should be supported or not, but a regression test is added
-    to check this behavior.
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 45.93447168433694
+    exp2 = 127.35556915677182
+    check_stat(35, exp1, 1)
+    check_stat(120, exp2, 2)
+    check_stat2(exp1 + exp2)
 
-    The settings are the same as the test_wstat_two_scalar
-    case, for the 9774.pi file. It would be easier to move this
-    into test_wstat_two_scalar (since it avoids having multiple
-    copies of the settings, and lets the wstat be tested on
-    > 2 data sets), but for now keep as a separate set of tests
-    to make sure it is obvious what is and isn't failing.
-    """
 
-    def setUp(self):
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_two_scalar_ungrouped_all(clean_astro_ui, hide_logging, two_scalar_setup):
+    ui.ungroup(1)
+    ui.ungroup(2)
 
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 657.2275371837611
+    exp2 = 880.8442022201893
+    check_stat(1024, exp1, 1)
+    check_stat(1024, exp2, 2)
+    check_stat2(exp1 + exp2)
 
-        ui.set_stat('wstat')
 
-        infile = self.make_path('9774.pi')
-        ui.load_pha(1, infile)
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_two_scalar_ungrouped_filtered(clean_astro_ui, hide_logging, two_scalar_setup):
+    ui.ungroup(1)
+    ui.ungroup(2)
+    filter_data()
 
-        ui.group_counts(1, 20)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    exp1 = 420.50951039235736
+    exp2 = 397.4089421041855
+    check_stat(375, exp1, 1)
+    check_stat(375, exp2, 2)
+    check_stat2(exp1 + exp2)
 
-        # Unlike the test_wstat_two_scalar case, the grouping
-        # is not copied over.
-        # ui.set_grouping(1, bkg_id=1, val=ui.get_grouping(1))
 
-        ui.set_source(1, ui.const1d.c1 * ui.powlaw1d.pl1)
+# PHA file that has been grouped.
+#
+# This is the error reported in issue #227, whereby the
+# grouping in the source and background files is different,
+# which causes an error. It is not clear yet whether this
+# should be supported or not, but a regression test is added
+# to check this behavior.
+#
+# The settings are the same as the test_wstat_two_scalar
+# case, for the 9774.pi file. It would be easier to move this
+# into test_wstat_two_scalar (since it avoids having multiple
+# copies of the settings, and lets the wstat be tested on
+# > 2 data sets), but for now keep as a separate set of tests
+# to make sure it is obvious what is and isn't failing.
 
-        # These should be the same as test_wstat_two_scalar
-        #
-        ui.set_par("pl1.gamma", 1.7)
-        ui.set_par("pl1.ampl", 1.6e-4)
-        ui.set_par("c1.c0", 45)
 
-    def tearDown(self):
-        ui.clean()
+@pytest.fixture
+def group_setup(make_data_path):
 
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
+    ui.set_stat('wstat')
 
-    def _filter_data(self):
-        """Filter the data.
+    infile = make_data_path('9774.pi')
+    ui.load_pha(1, infile)
 
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
+    ui.group_counts(1, 20)
 
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
+    # Unlike the test_wstat_two_scalar case, the grouping
+    # is not copied over.
+    # ui.set_grouping(1, bkg_id=1, val=ui.get_grouping(1))
 
-    def _check_stat(self, idval, nbins, expected):
+    ui.set_source(1, ui.const1d.c1 * ui.powlaw1d.pl1)
 
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data(idval).get_dep(True).size)
+    # These should be the same as test_wstat_two_scalar
+    #
+    ui.set_par("pl1.gamma", 1.7)
+    ui.set_par("pl1.ampl", 1.6e-4)
+    ui.set_par("c1.c0", 45)
 
-        stat = ui.calc_stat(idval)
-        self.assertAlmostEqual(expected, stat, places=7)
 
-    def test_wstat_grouped_all(self):
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_grouped_all(clean_astro_ui, hide_logging, group_setup):
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 401.75572944361613
-        self._check_stat(1, 148, expval)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 401.75572944361613
+    check_stat(148, expval, 1)
 
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 127.35556915677182
-        self._check_stat(1, 120, expval)
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_grouped_filtered(clean_astro_ui, hide_logging, group_setup):
+    filter_data()
 
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup(1)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 127.35556915677182
+    check_stat(120, expval, 1)
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 880.8442022201893
-        self._check_stat(1, 1024, expval)
 
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup(1)
-        self._filter_data()
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_ungrouped_all(clean_astro_ui, hide_logging, group_setup):
+    ui.ungroup(1)
 
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        expval = 397.4089421041855
-        self._check_stat(1, 375, expval)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 880.8442022201893
+    check_stat(1024, expval, 1)
+
+
+@requires_group
+@requires_data
+@requires_fits
+def test_wstat_group_ungrouped_filtered(clean_astro_ui, hide_logging, group_setup):
+    ui.ungroup(1)
+    filter_data()
+
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    expval = 397.4089421041855
+    check_stat(375, expval, 1)
+
+
+# Single PHA file with an array of backscal values.
+#
+# This really should use a grating PHA dataset, but it's not
+# obvious we have one (along with the necessary responses) in
+# the sherpa-test-data/ repository. So for now "hack" in
+# one. The statistic values were calculated by changing the
+# backscal by 0.9 but leaving it as a scalar. As the tests
+# currently fail, they have not been validated.
+
+@pytest.fixture
+def single_array_setup(make_data_path):
+
+    ui.set_stat('wstat')
+
+    infile = make_data_path('3c273.pi')
+    ui.load_pha(1, infile)
+
+    # Change the backscale value slightly so that the
+    # results are different to other runs with this file.
+    #
+    nbins = ui.get_data(1).get_dep(False).size
+    bscal = 0.9 * np.ones(nbins) * ui.get_backscal(1)
+    ui.set_backscal(1, backscale=bscal)
+
+    ui.set_source(1, ui.powlaw1d.pl)
+
+    # The powerlaw slope and normalization are
+    # intended to be "a reasonable approximation"
+    # to the data, just to make sure that any statistic
+    # calculation doesn't blow-up too much.
+    #
+    ui.set_par("pl.gamma", 1.7)
+    ui.set_par("pl.ampl", 1.7e-4)
 
 
 @requires_data
 @requires_fits
-class test_wstat_single_array(SherpaTestCase):
-    """Single PHA file with an array of backscal values.
+def test_wstat_single_array_grouped_all(clean_astro_ui, hide_logging, single_array_setup):
 
-    This really should use a grating PHA dataset, but it's not
-    obvious we have one (along with the necessary responses) in
-    the sherpa-test-data/ repository. So for now "hack" in
-    one. The statistic values were calculated by changing the
-    backscal by 0.9 but leaving it as a scalar. As the tests
-    currently fail, they have not been validated.
-    """
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(46, 71.21845954979574)
 
-    def setUp(self):
 
-        self._old_logger_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+@requires_data
+@requires_fits
+def test_wstat_single_array_grouped_filtered(clean_astro_ui, hide_logging, single_array_setup):
+    filter_data()
 
-        ui.set_stat('wstat')
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(35, 45.6311990089982)
 
-        infile = self.make_path('3c273.pi')
-        ui.load_pha(1, infile)
 
-        # Change the backscale value slightly so that the
-        # results are different to other runs with this file.
-        #
-        nbins = ui.get_data(1).get_dep(False).size
-        bscal = 0.9 * np.ones(nbins) * ui.get_backscal(1)
-        ui.set_backscal(1, backscale=bscal)
+@requires_data
+@requires_fits
+def test_wstat_single_array_ungrouped_all(clean_astro_ui, hide_logging, single_array_setup):
+    ui.ungroup()
 
-        ui.set_source(1, ui.powlaw1d.pl)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(1024, 663.0160968458746)
 
-        # The powerlaw slope and normalization are
-        # intended to be "a reasonable approximation"
-        # to the data, just to make sure that any statistic
-        # calculation doesn't blow-up too much.
-        #
-        ui.set_par("pl.gamma", 1.7)
-        ui.set_par("pl.ampl", 1.7e-4)
 
-    def tearDown(self):
-        ui.clean()
+@requires_data
+@requires_fits
+def test_wstat_single_array_ungrouped_filtered(clean_astro_ui, hide_logging, single_array_setup):
+    ui.ungroup()
+    filter_data()
 
-        try:
-            logger.setLevel(self._old_logger_level)
-        except AttributeError:
-            pass
-
-    def _filter_data(self):
-        """Filter the data.
-
-        Use a slightly-complex filter - e.g. not just the
-        end points - to exercise the system.
-        """
-
-        ui.ignore(None, 0.5)
-        ui.ignore(3, 4)
-        ui.ignore(7, None)
-
-    def _check_stat(self, nbins, expected):
-
-        # check the filter sizes (mainly so that these tests
-        # get flagged as in need of a look if anything changes
-        # in other parts of the code, such as filtering and binning
-        #
-        self.assertEqual(nbins, ui.get_data().get_dep(True).size)
-
-        stat = ui.calc_stat()
-        self.assertAlmostEqual(expected, stat, places=7)
-
-    def test_wstat_grouped_all(self):
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(46, 71.21845954979574)
-
-    def test_wstat_grouped_filtered(self):
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(35, 45.6311990089982)
-
-    def test_wstat_ungrouped_all(self):
-        ui.ungroup()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(1024, 663.0160968458746)
-
-    def test_wstat_ungrouped_filtered(self):
-        ui.ungroup()
-        self._filter_data()
-
-        # Used git commit 770359b5004374b969ebb63c173f293419397b4c
-        # to create the oracle value, on a linux 64-bit machine.
-        self._check_stat(375, 420.8390856766203)
+    # Used git commit 770359b5004374b969ebb63c173f293419397b4c
+    # to create the oracle value, on a linux 64-bit machine.
+    check_stat(375, 420.8390856766203)


### PR DESCRIPTION
# Summary

Update tests to use the current best practices, and add tests of background handling (primarily when fitting a background model).

# Details

The new tests are not expected to significantly improve the test coverage, but they do provide a number of explicit checks for the planned background rework. It has been separated out of #869 since this is an easy set of tests, and it's useful to have the tests in place before the code gets changed.

The number of commits and files changed in this PR are:

     11 sherpa/astro/ui/tests/test_astro_ui_background.py
      3 sherpa/astro/ui/tests/test_astro_ui_plot.py
      2 sherpa/astro/ui/tests/test_serialize.py
      1 sherpa/conftest.py
      1 sherpa/stats/tests/test_wstat.py
 
Changes are:

## sherpa/conftest.py

Adds the hide_logging fixture, which runs a test with the sherpa logging level set to the ERROR level, and then returns it to it's previous level.

## sherpa/stats/tests/test_wstat.py

This changes the tests from unittest to pytest.

## sherpa/astro/ui/tests/test_serialize.py

This changes the tests from unittest to pytest and removes an old comment. Oh, I've just notices one of the tests can be written to use 'with pytest.raises' but that can wait,

## sherpa/astro/ui/tests/test_astro_ui_plot.py

Some of the test values are adjusted to make it a bit more obvious what is changing: we look at some combination of the ratio of energy-grid width, exposure, backscal, and areascal values in various tests, and I had chosen values that were not necessarily unique for the various values. The big improvement is moving from a uniform energy grid to a vector, but there are also other changes too.

There are also several tests where I remove some calls (explicitly setting the units of the background dataset) which I had added to work around #879 (but I had dropped the ball and never reported it as an issue at that time, September 2019). This is to make the fixes and change in behavior in #884 more obvious.

## sherpa/astro/ui/tests/test_astro_ui_background.py

This is a new set of tests which I created to provide some basic tests of the functionality I plan to test. Some of these are 'upfront' new tests, checking things that appear to be relevant, and some were added during development (i.e. that either encode a useful invariant or ones that show a change in behavior in either #884 or #888. The focus is handling of the background dataset, or datasets, of a PHA file. To make the checks easier, most of the tests use artificial datasets, created on the fly. Of particular interest is the various model expressions created for the source and background datasets (when fitting, it subtracting, the background): checking the string output of the model and evaluating the model.