### PR TITLE
Move logic from ui layer to DataPHA class: background responses (fix #879, #880)

### DIFF
--- a/sherpa/astro/background.py
+++ b/sherpa/astro/background.py
@@ -62,4 +62,12 @@ class BackgroundSumModel(CompositeModel, ArithmeticModel):
             # of p)
             return bmodel(*args, **kwargs)
 
+        # Evaluate the background model for each dataset using the same
+        # grid and apply the background-to-source correction factors.
+        #
+        # This will only work if the scaling factors are scalars,
+        # since if there are any array elements then the models
+        # have been evaluated on the energy/wavelength grid,
+        # but the correction factors are defined in channel space.
+        #
         return self.srcdata.sum_background_data(eval_bkg_model)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1142,7 +1142,7 @@ class DataPHA(Data1D):
         return scale
 
     def get_backscal(self, group=True, filter=False):
-        """Return the area scaling of the PHA data set.
+        """Return the background scaling of the PHA data set.
 
         Return the BACKSCAL setting [BSCAL]_ for the PHA data set.
 
@@ -1169,7 +1169,7 @@ class DataPHA(Data1D):
         to the total number of image pixels. The fact that there is no
         ironclad definition for this quantity does not matter so long
         as the value for a source dataset and its associated
-        background dataset are defined in the similar manner, because
+        background dataset are defined in the same manner, because
         only the ratio of source and background BACKSCAL values is
         used. It can be a scalar or an array.
 
@@ -1690,9 +1690,56 @@ class DataPHA(Data1D):
 
     def sum_background_data(self,
                             get_bdata_func=(lambda key, bkg: bkg.counts)):
+        """Sum up data, applying the background correction value.
+
+        Parameter
+        ---------
+        get_bdata_func : function, optional
+            What data should be used for each background dataset. The
+            function takes the background identifier and background
+            DataPHA object and returns the data to use. The default is
+            to use the counts array of the background dataset.
+
+        Returns
+        -------
+        value : scalar or NumPy array
+            The sum of the data, including any area, background, and
+            exposure-time corrections.
+
+        Notes
+        -----
+        For each associated background, the data is retrieved (via
+        the get_bdata_func parameter), and then
+
+          - divided by its BACKSCAL value (if set)
+          - divided by its AREASCAL value (if set)
+          - divided by its exposure time (if set)
+
+        The individual background components are then summed together,
+        and then multiplied by the source BACKSCAL (if set),
+        multiplied by the source AREASCAL (if set), and multiplied
+        by the source exposure time (if set). The final step is
+        to divide by the number of background files used.
+
+        Example
+        -------
+
+        Calculate the background counts, per channel, scaled to match
+        the source:
+
+        >>> bcounts = src.sum_background_data()
+
+        Calculate the scaling factor that you need to multiply the
+        background data to match the source data. In this case the
+        background data has been replaced by the value 1 (rather than
+        the per-channel values used with the default argument):
+
+        >>> bscale = src.sum_background_data(lambda k, d: 1)
+
+        """
+
         bdata_list = []
 
-        # for key, bkg in self._backgrounds.items():
         for key in self.background_ids:
             bkg = self.get_background(key)
             bdata = get_bdata_func(key, bkg)
@@ -1712,7 +1759,10 @@ class DataPHA(Data1D):
             bdata_list.append(bdata)
 
         nbkg = len(bdata_list)
-        assert (nbkg > 0)
+        if nbkg == 0:
+            # do not have a good id to use for the error message
+            raise DataErr('nobkg', self.name)
+
         if nbkg == 1:
             bkgsum = bdata_list[0]
         else:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -804,7 +804,7 @@ class DataPHA(Data1D):
         if (rmf is None and arf is None) and \
            (self.bin_lo is None and self.bin_hi is None) and \
            quantity != 'channel':
-            raise DataErr('noinstr', self.name)
+            raise DataErr('norsp', self.name)
 
         if rmf is None and arf is not None and quantity != 'channel' and \
            len(arf.energ_lo) != len(self.channel):

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1104,6 +1104,22 @@ class DataPHA(Data1D):
         self.background_ids = ids
 
     def get_background_scale(self):
+        """Return the correction factor for the background datasets.
+
+        Returns
+        -------
+        scale : None, number, or NumPy array
+            The scaling factor to correct the background data onto the
+            source data set. If there are no associated backgrounds
+            then None is returned.
+
+        Notes
+        -----
+        The corrections include BACKSCAL, AREASCAL, and exposure
+        corrections.
+
+        """
+
         if len(self.background_ids) == 0:
             return None
         return self.sum_background_data(lambda key, bkg: 1.)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -18,6 +18,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import logging
 import warnings
 
 import numpy as np
@@ -29,7 +30,6 @@ from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.utils.err import DataErr
 from sherpa.utils.testing import SherpaTestCase, requires_data, requires_fits
 
-import logging
 logger = logging.getLogger('sherpa')
 
 
@@ -1033,3 +1033,13 @@ def test_pha_mask_filtered(infile, size, nset, make_data_path):
     assert pha.mask.dtype == np.bool
     assert pha.mask.size == size
     assert pha.mask.sum() == nset
+
+
+def test_sum_background_data_missing():
+    """Check we error out if there's no background data"""
+
+    d = DataPHA('tmp', np.arange(3), np.arange(3))
+    with pytest.raises(DataErr) as exc:
+        d.sum_background_data()
+
+    assert str(exc.value) == "data set 'tmp' does not have any associated backgrounds"

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -267,8 +267,6 @@ def test_setup_pha1_file_models_two_single(id, make_data_path, clean_astro_ui, h
     ui.set_bkg_source(id, ui.powlaw1d.bpl)
     ui.set_bkg_source(id, ui.powlaw1d.bpl, bkg_id=2)
 
-    iid = 1 if id is None else id
-
     bmdl = ui.get_bkg_model(id, bkg_id=1)
     assert bmdl.name == 'apply_rmf(apply_arf((1000 * powlaw1d.bpl)))'
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1082,7 +1082,7 @@ def test_response_source_data(make_data_path, clean_astro_ui, hide_logging):
     assert eterm.val == pytest.approx(bexpval)
 
 
-def validate_response_source_data_manual(direct=True):
+def validate_response_source_data_manual():
     """Tests for test_response_source_data_manual[_datapha]
 
     It checks out issue #880.
@@ -1102,10 +1102,7 @@ def validate_response_source_data_manual(direct=True):
     # adapt to the current behavior.
     #
     pname = mdl.pha.name.split('/')[-1]
-    if direct:
-        assert pname == 'fake'
-    else:
-        assert pname == '12845.pi'
+    assert pname == 'fake'
 
     aname = mdl.arf.name.split('/')[-1]
     assert aname == '12845.warf'
@@ -1115,10 +1112,7 @@ def validate_response_source_data_manual(direct=True):
 
     eterm = mdl.parts[0].parts[0]
     assert isinstance(eterm, ArithmeticConstantModel)
-    if direct:
-        assert eterm.val == pytest.approx(bexpval)
-    else:
-        assert eterm.val == pytest.approx(expval)
+    assert eterm.val == pytest.approx(bexpval)
 
     # Source response
     #
@@ -1202,7 +1196,7 @@ def test_response_source_data_manual_datapha(make_data_path, clean_astro_ui, hid
     ui.set_source(ui.powlaw1d.smdl)
     ui.set_bkg_source(ui.const1d.bmdl)
 
-    validate_response_source_data_manual(direct=False)
+    validate_response_source_data_manual()
 
 
 @requires_data
@@ -1387,16 +1381,6 @@ def test_bkg_analysis_setting_changed(idval, direct, analysis, clean_astro_ui):
 
     src = ui.get_data(idval)
     bkg = ui.get_bkg(idval)
-
-    # Want to be able to mark some tests as XFAIL, but as it
-    # involves a parameter setting, how best to do this and
-    # get to see a XPASS when the code is fixed?
-    #
-    if direct and analysis != 'channel':
-        if bkg.units == analysis:
-            assert False, "Test was expected to fail, but can not mark XPASS"
-
-        pytest.xfail("Using set_background does not set units")
 
     assert src.units == analysis
     assert bkg.units == analysis

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -396,9 +396,20 @@ def test_pha1_instruments(clean_astro_ui):
     # We don't check the scaling here
     scales = (1, 1, 1)
     ui.set_data(1, setup_pha1(scales, scales, scales))
-    ui.set_source(1, ui.stephi1d.smdl)
-    ui.set_bkg_source(1, ui.steplo1d.bmdl)
-    ui.set_bkg_source(1, bmdl, bkg_id=2)
+
+    s = ui.stephi1d.s
+    b = ui.steplo1d.b
+    ui.set_source(1, s)
+    ui.set_bkg_source(1, b)
+    ui.set_bkg_source(1, b, bkg_id=2)
+
+    ssrc = ui.get_source()
+    bsrc1 = ui.get_bkg_source(bkg_id=1)
+    bsrc2 = ui.get_bkg_source(bkg_id=2)
+
+    assert ssrc == s
+    assert bsrc1 == b
+    assert bsrc2 == b
 
     smdl = ui.get_model()
     bmdl1 = ui.get_bkg_model(bkg_id=1)
@@ -429,9 +440,10 @@ def test_pha1_instruments_missing(bid, clean_astro_ui):
     bkg = ui.get_bkg(1, bkg_id=bid)
     bkg.delete_response()
 
-    # Where is this response coming from?
-    ans = ui.get_bkg_model(bkg_id=bid)
-    assert isinstance(ans, ARFModelPHA)
+    with pytest.raises(DataErr) as exc:
+        ui.get_bkg_model(bkg_id=bid)
+
+    assert str(exc.value) == 'No instrument response found for dataset 1 background {}'.format(bid)
 
     oid = 1 if bid == 2 else 2
     bmdl = ui.get_bkg_model(bkg_id=oid)

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1352,7 +1352,7 @@ def test_bkg_analysis_setting_no_response(idval, direct, clean_astro_ui):
         with pytest.raises(DataErr) as exc:
             ui.set_analysis(idval, 'energy')
 
-    assert str(exc.value) == 'No instrument model found for dataset ex'
+    assert str(exc.value) == 'No instrument response found for dataset ex'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one"])

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -355,17 +355,16 @@ def test_get_bkg_plot_energy(idval, clean_astro_ui):
         ui.set_analysis(idval, 'energy')
         bp = ui.get_bkg_plot(idval)
 
-    assert bp.x == pytest.approx(_data_chan)
+    assert bp.x == pytest.approx(_energies_mid)
 
-    # normalise by exposure time and bin width,
-    # and since this is incorrectly in channels there's no normalisation
+    # normalise by exposure time and bin width
     #
-    yexp = _data_bkg / (1201.0 * _bexpscale)
+    yexp = _data_bkg / (1201.0 * _bexpscale) / _energies_width
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'example-bkg'
-    assert bp.xlabel == 'Channel'
-    assert bp.ylabel == 'Counts/sec/channel'
+    assert bp.xlabel == 'Energy (keV)'
+    assert bp.ylabel == 'Counts/sec/keV'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -501,7 +500,7 @@ def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
     """Basic testing of get_bkg_model_plot
 
     We test ui.set_bkg as well as datapha.set_background to check
-    issue #879 and #880.
+    issue #879 and #880 has been resolved.
 
     The same ARF is used as the source (by construction), which is
     likely to be a common use case.
@@ -517,9 +516,6 @@ def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
     assert bp.xhi == pytest.approx(_data_chan + 1)
 
     yexp = _arf * BGND_NORM * _energies_width
-    if direct:
-        yexp /= _bexpscale
-
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Model'
@@ -537,11 +533,6 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
     logic that set_bkg can do (issues #879 and #880)
     """
 
-    # The way I have set up the data means that set_analysis
-    # doesn't seem to change the setting for the background,
-    # which should be tracked down (Sep 2019) but not just now
-    # (issue #879)
-    #
     setup_example_bkg_model(idval, direct=direct)
     if idval is None:
         ui.set_analysis('energy')
@@ -550,33 +541,15 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
         ui.set_analysis(idval, 'energy')
         bp = ui.get_bkg_model_plot(idval)
 
-    # TODO: is this a bug in the plotting code, or does it just
-    # indicate that the test hasn't set up the correct invariants
-    # (which may be true as the code above has to change the units
-    # setting of the background object)?
-    #
-    # I was expecting bp.x to return energy and not channel values
-    #
-    if direct:
-        assert bp.xlo == pytest.approx(_data_chan)
-        assert bp.xhi == pytest.approx(_data_chan + 1)
-    else:
-        assert bp.xlo == pytest.approx(_energies_lo)
-        assert bp.xhi == pytest.approx(_energies_hi)
+    assert bp.xlo == pytest.approx(_energies_lo)
+    assert bp.xhi == pytest.approx(_energies_hi)
 
     yexp = _arf * BGND_NORM
-    if direct:
-        yexp *= (_energies_width / _bexpscale)
-
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Model'
-    if direct:
-        assert bp.xlabel == 'Channel'
-        assert bp.ylabel == 'Counts/sec/channel'
-    else:
-        assert bp.xlabel == 'Energy (keV)'
-        assert bp.ylabel == 'Counts/sec/keV'
+    assert bp.xlabel == 'Energy (keV)'
+    assert bp.ylabel == 'Counts/sec/keV'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -594,7 +567,7 @@ def test_get_bkg_resid_plot(idval, clean_astro_ui):
 
     # correct the counts by the bin width and exposure time
     #
-    yexp = _data_bkg / (1201.0 * _bexpscale) - _arf * BGND_NORM * _energies_width / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale) - _arf * BGND_NORM * _energies_width
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
@@ -615,16 +588,16 @@ def test_get_bkg_resid_plot_energy(idval, clean_astro_ui):
         ui.set_analysis(idval, 'energy')
         bp = ui.get_bkg_resid_plot(idval)
 
-    assert bp.x == pytest.approx(_data_chan)
+    assert bp.x == pytest.approx(_energies_mid)
 
-    # correct the counts by the bin width (which is 1) and exposure time
+    # correct the counts by the bin width and exposure time
     #
-    yexp = _data_bkg / (1201.0 * _bexpscale) - _arf * BGND_NORM * _energies_width / _bexpscale
+    yexp = _data_bkg / (1201.0 * _bexpscale * _energies_width) - _arf * BGND_NORM
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Residuals of example-bkg - Bkg Model'
-    assert bp.xlabel == 'Channel'
-    assert bp.ylabel == 'Counts/sec/channel'
+    assert bp.xlabel == 'Energy (keV)'
+    assert bp.ylabel == 'Counts/sec/keV'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -652,7 +625,7 @@ def test_get_bkg_fit_plot(idval, clean_astro_ui):
     yexp = _data_bkg / (1201.0 * _bexpscale)
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf * BGND_NORM * _energies_width / _bexpscale
+    yexp = _arf * BGND_NORM * _energies_width
     assert mp.y == pytest.approx(yexp)
 
 
@@ -676,14 +649,14 @@ def test_get_bkg_fit_plot_energy(idval, clean_astro_ui):
     assert mp.title == 'Background Model Contribution'
 
     for plot in [dp, mp]:
-        assert plot.xlabel == 'Channel'
-        assert plot.ylabel == 'Counts/sec/channel'
-        assert plot.x == pytest.approx(_data_chan)
+        assert plot.xlabel == 'Energy (keV)'
+        assert plot.ylabel == 'Counts/sec/keV'
+        assert plot.x == pytest.approx(_energies_mid)
 
     yexp = _data_bkg / (1201.0 * _bexpscale)
     assert dp.y == pytest.approx(dp.y)
 
-    yexp = _arf * BGND_NORM * _energies_width / _bexpscale
+    yexp = _arf * BGND_NORM
     assert mp.y == pytest.approx(yexp)
 
 
@@ -717,7 +690,7 @@ def check_bkg_fit(plotfunc):
     yexp = _data_bkg / (1201.0 * _bexpscale)
     assert dplot.y == pytest.approx(yexp)
 
-    yexp = _arf * BGND_NORM * _energies_width / _bexpscale
+    yexp = _arf * BGND_NORM * _energies_width
     assert mplot.y == pytest.approx(yexp)
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -501,7 +501,7 @@ def test_get_bkg_model_plot(idval, direct, clean_astro_ui):
     """Basic testing of get_bkg_model_plot
 
     We test ui.set_bkg as well as datapha.set_background to check
-    issue #879.
+    issue #879 and #880.
 
     The same ARF is used as the source (by construction), which is
     likely to be a common use case.
@@ -537,6 +537,11 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
     logic that set_bkg can do (issues #879 and #880)
     """
 
+    # The way I have set up the data means that set_analysis
+    # doesn't seem to change the setting for the background,
+    # which should be tracked down (Sep 2019) but not just now
+    # (issue #879)
+    #
     setup_example_bkg_model(idval, direct=direct)
     if idval is None:
         ui.set_analysis('energy')
@@ -545,6 +550,13 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
         ui.set_analysis(idval, 'energy')
         bp = ui.get_bkg_model_plot(idval)
 
+    # TODO: is this a bug in the plotting code, or does it just
+    # indicate that the test hasn't set up the correct invariants
+    # (which may be true as the code above has to change the units
+    # setting of the background object)?
+    #
+    # I was expecting bp.x to return energy and not channel values
+    #
     if direct:
         assert bp.xlo == pytest.approx(_data_chan)
         assert bp.xhi == pytest.approx(_data_chan + 1)
@@ -555,6 +567,7 @@ def test_get_bkg_model_plot_energy(idval, direct, clean_astro_ui):
     yexp = _arf * BGND_NORM
     if direct:
         yexp *= (_energies_width / _bexpscale)
+
     assert bp.y == pytest.approx(yexp)
 
     assert bp.title == 'Model'

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -147,6 +147,27 @@ def test_set_filter_mismatch(f, bid):
     assert str(exc.value) == 'size mismatch between 3 and 2'
 
 
+@pytest.mark.parametrize("f", [[False, True], np.asarray([False, True])])
+@pytest.mark.parametrize("bid", [None, 1])
+def test_set_filter_mismatch_with_filter(f, bid):
+    """Does set_filter error when there's a mis-match after a filter?
+
+    test_set_filter_mismatch checks when .mask is a scalar,
+    so now check when it's a NumPy array.
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    ui.set_bkg(bkg)
+
+    ui.ignore(3, None)  # set the .mask attribute to an array
+
+    with pytest.raises(DataErr) as exc:
+        ui.set_filter(f, bkg_id=bid)
+
+    assert str(exc.value) == 'size mismatch between 3 and 2'
+
+
 @pytest.mark.parametrize("bid", [None, 1])
 def test_get_syserror_missing(bid):
     """Does get_syserror error out?"""

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1503,8 +1503,6 @@ class Session(sherpa.ui.utils.Session):
         else:
             self.set_data(id, data)
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def unpack_image(self, arg, coord='logical',
                      dstype=sherpa.astro.data.DataIMG):
         """Create an image data structure.
@@ -1617,8 +1615,6 @@ class Session(sherpa.ui.utils.Session):
             id, arg = arg, id
         self.set_data(id, self.unpack_image(arg, coord, dstype))
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     # DOC-TODO: what does this return when given a PHA2 file?
     def unpack_pha(self, arg, use_errors=False):
         """Create a PHA data structure.
@@ -1671,8 +1667,6 @@ class Session(sherpa.ui.utils.Session):
         use_errors = sherpa.utils.bool_cast(use_errors)
         return sherpa.astro.io.read_pha(arg, use_errors)
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     # DOC-TODO: what does this return when given a PHA2 file?
     def unpack_bkg(self, arg, use_errors=False):
         """Create a PHA data structure for a background data set.
@@ -1901,12 +1895,14 @@ class Session(sherpa.ui.utils.Session):
             info("One data set has been input: {}".format(ids[0]))
 
     def _get_pha_data(self, id):
+        """Ensure the dataset is a PHA"""
         data = self.get_data(id)
         if not isinstance(data, sherpa.astro.data.DataPHA):
             raise ArgumentErr('nopha', self._fix_id(id))
         return data
 
     def _get_img_data(self, id):
+        """Ensure the dataset is an image"""
         data = self.get_data(id)
         if not isinstance(data, sherpa.astro.data.DataIMG):
             raise ArgumentErr('noimg', self._fix_id(id))
@@ -1932,8 +1928,6 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_filter(self, id, filename=None, bkg_id=None, ignore=False,
                     ncols=2, *args, **kwargs):
         """Load the filter array from a file and add to a data set.
@@ -2012,8 +2006,6 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id, ignore=ignore)
 
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     # DOC-TODO: prob. needs a review as the existing ahelp documentation
     # talks about 2 cols, but experimentation suggests 1 col.
     def load_grouping(self, id, filename=None, bkg_id=None, *args, **kwargs):
@@ -2102,8 +2094,6 @@ class Session(sherpa.ui.utils.Session):
         self.set_grouping(id,
                           self._read_user_model(filename, *args, **kwargs)[1], bkg_id=bkg_id)
 
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_quality(self, id, filename=None, bkg_id=None, *args, **kwargs):
         """Load the quality array from a file and add to a PHA data set.
 
@@ -4605,8 +4595,6 @@ class Session(sherpa.ui.utils.Session):
 
         sherpa.astro.io.write_pha(filename, d, ascii, clobber)
 
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def save_grouping(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
         """Save the grouping scheme to a file.
 
@@ -4690,8 +4678,6 @@ class Session(sherpa.ui.utils.Session):
         sherpa.astro.io.write_arrays(filename, [d.channel, d.grouping],
                                      ['CHANNEL', 'GROUPS'], ascii, clobber)
 
-    # DOC-TODO: labelling as AstroPy; i.e. assuming conversion
-    # from PyFITS lands soon.
     def save_quality(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
         """Save the quality array to a file.
 
@@ -5007,8 +4993,6 @@ class Session(sherpa.ui.utils.Session):
                     except:
                         raise
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def pack_pha(self, id=None):
         """Convert a PHA data set into a file structure.
 
@@ -5037,8 +5021,6 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.pack_pha(self._get_pha_data(id))
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def pack_image(self, id=None):
         """Convert a data set into an image structure.
 
@@ -5062,8 +5044,6 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.pack_image(self.get_data(id))
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def pack_table(self, id=None):
         """Convert a data set into a table structure.
 
@@ -5366,8 +5346,6 @@ class Session(sherpa.ui.utils.Session):
         if data.units == 'channel':
             data._set_initial_quantity()
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def unpack_arf(self, arg):
         """Create an ARF data structure.
 
@@ -5422,8 +5400,6 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_arf(self, id, arg=None, resp_id=None, bkg_id=None):
         """Load an ARF from a file and add it to a PHA data set.
 
@@ -5553,8 +5529,6 @@ class Session(sherpa.ui.utils.Session):
         return self.get_arf(id, resp_id, bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_bkg_arf(self, id, arg=None):
         """Load an ARF from a file and add it to the background of a
         PHA data set.
@@ -5843,8 +5817,6 @@ class Session(sherpa.ui.utils.Session):
         if data.units == 'channel':
             data._set_initial_quantity()
 
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def unpack_rmf(self, arg):
         """Create a RMF data structure.
 
@@ -5899,8 +5871,6 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_rmf(self, id, arg=None, resp_id=None, bkg_id=None):
         """Load a RMF from a file and add it to a PHA data set.
 
@@ -6025,8 +5995,6 @@ class Session(sherpa.ui.utils.Session):
         return self.get_rmf(id, resp_id, bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    # DOC-TODO: labelling as AstroPy HDUList; i.e. assuming conversion
-    # from PyFITS lands soon.
     def load_bkg_rmf(self, id, arg=None):
         """Load a RMF from a file and add it to the background of a
         PHA data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -2231,8 +2231,7 @@ class Session(sherpa.ui.utils.Session):
                 else:
                     d.mask &= ~filter
             else:
-                raise sherpa.utils.err.DataErr('mismatch',
-                                               len(d.mask), len(filter))
+                raise DataErr('mismatch', len(d.mask), len(filter))
         else:
             if len(d.get_y(False)) == len(filter):
                 if not ignore:
@@ -2240,8 +2239,7 @@ class Session(sherpa.ui.utils.Session):
                 else:
                     d.mask = ~filter
             else:
-                raise sherpa.utils.err.DataErr('mismatch',
-                                               len(d.get_y(False)), len(filter))
+                raise DataErr('mismatch', len(d.get_y(False)), len(filter))
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
@@ -2958,7 +2956,7 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         err = d.get_syserror(filter)
         if err is None or not numpy.iterable(err):
-            raise sherpa.utils.err.DataErr('nosyserr', id)
+            raise DataErr('nosyserr', id)
         return err
 
     # DOC-NOTE: also in sherpa.utils, where it does not have
@@ -4233,9 +4231,9 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
         if d.mask is False:
-            raise sherpa.utils.err.DataErr('notmask')
+            raise DataErr('notmask')
         if not numpy.iterable(d.mask):
-            raise sherpa.utils.err.DataErr('nomask', id)
+            raise DataErr('nomask', id)
 
         x = d.get_indep(filter=False)[0]
         mask = numpy.asarray(d.mask, numpy.int)
@@ -4673,7 +4671,7 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
 
         if d.grouping is None or not numpy.iterable(d.grouping):
-            raise sherpa.utils.err.DataErr('nogrouping', id)
+            raise DataErr('nogrouping', id)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.grouping],
                                      ['CHANNEL', 'GROUPS'], ascii, clobber)
@@ -4756,7 +4754,7 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
 
         if d.quality is None or not numpy.iterable(d.quality):
-            raise sherpa.utils.err.DataErr('noquality', id)
+            raise DataErr('noquality', id)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.quality],
                                      ['CHANNEL', 'QUALITY'], ascii, clobber)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6217,6 +6217,11 @@ class Session(sherpa.ui.utils.Session):
         respectively. The remaining parameters are expected to be
         given as named arguments.
 
+        If the background has no grouping of quality arrays then they
+        are copied from the source region. If the background has no
+        response information (ARF or RMF) then the response is copied
+        from the source region.
+
         Examples
         --------
 
@@ -6237,20 +6242,6 @@ class Session(sherpa.ui.utils.Session):
         data = self._get_pha_data(id)
         _check_type(bkg, sherpa.astro.data.DataPHA, 'bkg', 'a PHA data set')
         data.set_background(bkg, bkg_id)
-        if bkg.grouping is None:
-            bkg.grouping = data.grouping
-            bkg.grouped = (bkg.grouping is not None)
-        if bkg.quality is None:
-            bkg.quality = data.quality
-
-        if bkg.get_response() == (None, None):
-            bkg.set_response(*data.get_response())
-
-        if bkg.get_response() != (None, None):
-            bkg.units = data.units
-
-        bkg.rate = data.rate
-        bkg.plot_fac = data.plot_fac
 
     def list_bkg_ids(self, id=None):
         """List all the background identifiers for a data set.

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -24,7 +24,10 @@ Note that this test is almost duplicated in
 sherpa/astro/ui/tests/test_astro_ui_unit.py
 """
 
+import pytest
+
 from sherpa import ui
+from sherpa.utils.err import ArgumentTypeErr
 
 
 # This is part of #397
@@ -63,3 +66,13 @@ def test_all_has_no_repeated_elements():
     n1 = len(ui.__all__)
     n2 = len(set(ui.__all__))
     assert n1 == n2
+
+
+@pytest.mark.parametrize("func", [ui.notice_id, ui.ignore_id])
+def test_check_ids_not_none(func):
+    """Check they error out when id is None"""
+
+    with pytest.raises(ArgumentTypeErr) as exc:
+        func(None)
+
+    assert str(exc.value) == "'ids' must be an identifier or list of identifiers"

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4598,6 +4598,10 @@ class Session(NoNewAttributesAfterInit):
         for vals in sherpa.utils.parse_expr(expr):
             self.notice_id(ids, *vals, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def notice(self, lo=None, hi=None, **kwargs):
         """Include data in the fit.
 
@@ -4616,6 +4620,12 @@ class Session(NoNewAttributesAfterInit):
            higher than, or equal to, ``a``.
         hi : number, optional
            The upper bound of the filter when ``lo`` is not a string.
+        bkg_id : int or str, optional
+           The filter will be applied to the associated background
+           component of the data set if ``bkg_id`` is set. Only PHA
+           data sets support this option; if not given, then the
+           filter is applied to all background components as well
+           as the source data.
 
         See Also
         --------
@@ -4685,6 +4695,10 @@ class Session(NoNewAttributesAfterInit):
         for d in self._data.values():
             d.notice(lo, hi, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def ignore(self, lo=None, hi=None, **kwargs):
         """Exclude data from the fit.
 
@@ -4703,6 +4717,12 @@ class Session(NoNewAttributesAfterInit):
            higher than, or equal to, ``a``.
         hi : number, optional
            The upper bound of the filter when ``lo`` is not a string.
+        bkg_id : int or str, optional
+           The filter will be applied to the associated background
+           component of the data set if ``bkg_id`` is set. Only PHA
+           data sets support this option; if not given, then the
+           filter is applied to all background components as well
+           as the source data.
 
         See Also
         --------
@@ -4759,6 +4779,10 @@ class Session(NoNewAttributesAfterInit):
             return self._notice_expr(lo, **kwargs)
         self.notice(lo, hi, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def notice_id(self, ids, lo=None, hi=None, **kwargs):
         """Include data from the fit for a data set.
 
@@ -4821,7 +4845,10 @@ class Session(NoNewAttributesAfterInit):
         >>> notice_id(["core","jet"], "0.5:2, 2.2:7")
 
         """
-        if self._valid_id(ids):
+        if ids is None:
+            _argument_type_error('ids',
+                                 'an identifier or list of identifiers')
+        elif self._valid_id(ids):
             ids = (ids,)
         else:
             try:
@@ -4835,6 +4862,10 @@ class Session(NoNewAttributesAfterInit):
         for i in ids:
             self.get_data(i).notice(lo, hi, **kwargs)
 
+    # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
+    # should only be in the sherpa.astro.ui version, but it is not
+    # worth creating a copy of the routine just for this.
+    #
     def ignore_id(self, ids, lo=None, hi=None, **kwargs):
         """Exclude data from the fit for a data set.
 

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2017, 2019
+#  Copyright (C) 2010, 2016, 2017, 2019, 2020
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -232,6 +232,7 @@ class DataErr(SherpaErr):
             'normffake': 'An RMF has not been found or supplied for data set %s',
             'noenerg': 'no energy grid found in PHA response',
             'norsp': 'No instrument response found for dataset %s',
+            'nobrsp': 'No instrument response found for dataset %s background %s',
             'ogip-error': "The %s '%s' %s"
             }
 

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -228,7 +228,6 @@ class DataErr(SherpaErr):
             'nocoord': "data set '%s' does not contain a %s coordinate system",
             'bkgmodel': 'background %r has no associated model',
             'plottype': "unknown plot type '%s', choose %s",
-            'noinstr': "No instrument model found for dataset %s",
             'normffake': 'An RMF has not been found or supplied for data set %s',
             'noenerg': 'no energy grid found in PHA response',
             'norsp': 'No instrument response found for dataset %s',
@@ -319,7 +318,6 @@ class ModelErr(SherpaErr):
             'filterarray': "filter '%s' is not an array",
             'filtermismatch': "Mismatch between %s and %s",
             'nobkg': 'background model %s for data set %s has not been set',
-            'norsp': 'No background response found for background %s in data set %s',
             'nogrid': 'There is no grid on which to evaluate the model',
             'needspoint': 'A non-integrated grid is required for model evaluation',
             }


### PR DESCRIPTION
# Summary

Move the logic for adding a background response, if one doesn't exist, from the UI layer to the DataPHA class. This clears up several corner cases. Fixes #879 and #880.

There is the potential for differences in the results of fitting a model to the background dataset due to these changes, but it requires use of methods from the object API to trigger, rather than uses of just the sherpa.astro.ui routines, and the new behavior is more consistent.

# Details

There are several minor changes not directly related to #879 and #880.

## Current behavior

If you have a PHA file with BACKFILE, ANCRFILE, and RESPFILE set (but not for the background file), then you have the following (I use `unpack_pha` as if it holds here then it holds for `load_pha`):

```
>>> pha = sherpa.astro.ui.unpack_pha('3c273.pi')
read ARF file ...
read RMF file ...
read background file ...
>>> arf, rmf = pha.get_background().get_response()
>>> assert isinstance(arf, ui.DataARF)
>>> assert isinstance(rmf, ui.DataRMF)
```

Now I a going to remove the background component and then re-add it (to simulate adding a background to a PHA dataset which doesn't have a BACKFILE keyword)

If I add the background using the DataPHA method (`set_background`) then the response is not set:

```
>>> pha.delete_background()
>>> bkg = ui.unpack_pha('/home/dburke/sherpa/sherpa-master/sherpa-test-data/sherpatest/3c273_bg.pi')
>>> bkg.get_response()
(None, None)
>>> pha.set_background(bkg)
>>> bkg.get_response()
(None, None)
>>> pha.get_background().get_response()
(None, None)
```

If I Instead use the UI layer then note that the background response is set (copied from the source region):

```
>>> ui.set_data(pha)
>>> pha.delete_background()
>>> ui.set_bkg(bkg)
>>> bkg.get_response()
(<DataARF data set instance '...f'>,
 <DataRMF data set instance '...'>)
```

## This PR

This moves the logic for setting the background response (if it isn't set) from `ui.set_bkg` to `DataPHA.set_background` so in both cases above the background response (once associated with a source dataset) is set and not `(None, None)`. It then means that we can assume a background response exists in the UI layer, which simplifies things (and, if the response does not exist, it means the user has removed it on purpose, so we can error out when a response is needed, rather than trying to fix one up when needed).