### PR TITLE
Attempt to support building on C++98 compliant compilers (XSPEC code)

### DIFF
--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -62,6 +62,21 @@ namespace sherpa { namespace astro { namespace xspec {
 typedef sherpa::Array< float, NPY_FLOAT > FloatArray;
 typedef float FloatArrayType;
 
+// Try and support the use of std::transform while still building
+// against C++-98 compilers.
+//
+#if __cplusplus > 199711L
+#define CONVERTARRAY(orig, out, npts)					\
+        std::transform(std::begin(orig), std::end(orig), std::begin(out), \
+                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
+#else
+#define CONVERTARRAY(orig, out, npts)					\
+	for (int i = 0; i < npts; i++) { \
+          out[i] = (FloatArrayType) orig[i]; \
+        }
+#endif
+
+
 // XSpec models can be called from Sherpa using either
 //   - a single array for the grid
 //   - two arrays for the grid
@@ -488,8 +503,7 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
-                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
+	CONVERTARRAY(ear, fear, ngrid);
 
 	// Number of bins to send to XSPEC
 	int nout = ngrid;
@@ -792,8 +806,7 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
-                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
+	CONVERTARRAY(ear, fear, ngrid);
 
 	// Number of bins to send to XSPEC
 	int nout = ngrid;
@@ -894,8 +907,7 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
-                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
+	CONVERTARRAY(ear, fear, ngrid);
 
 	// Number of bins to send to XSPEC
 	int nout = ngrid;
@@ -997,8 +1009,7 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 
         // convert to 32-byte float
         std::vector<FloatArrayType> fear(ngrid);
-        std::transform(std::begin(ear), std::end(ear), std::begin(fear),
-                       [](const double val) -> FloatArrayType { return static_cast<FloatArrayType>(val); });
+	CONVERTARRAY(ear, fear, ngrid);
 
 	// Number of bins to send to XSPEC
 	int nout = ngrid;

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -72,7 +72,7 @@ typedef float FloatArrayType;
 #else
 #define CONVERTARRAY(orig, out, npts)					\
 	for (int i = 0; i < npts; i++) { \
-          out[i] = (FloatArrayType) orig[i]; \
+          out[i] = static_cast<FloatArrayType>(orig[i]); \
         }
 #endif
 


### PR DESCRIPTION
# Summary

Support building the XSPEC interface using compilers which default to the C++98 standard.

# Details

The std::begin/end templates, and the use of lambda expressions
requite C++11. Rather than try to come up with a C++98 version of
std::transform, I just went back and used the old C-style loop.

The contents of the macro is based on a check against __cplusplus,
which is not universally defined but is hopefully standard on the
platforms we are targeting. Rather than picking a potential version,
which could be confusing, I trigger on whether the value is larger
than the C++98 standard or not (a simplification of the code given
in https://github.com/sherpa/sherpa/pull/859#issuecomment-673294542 )

This should not be needed, as we should be requiring/sending -std=c++11 but there appears to be issues somewhere.

Unfortunately this code is not exercised on the Travis infrastructure (the compilers seem to be new enough that they are defaulting to the C++11 standard).