### PR TITLE
Tests: run FullBayes as well as PragBayes (and hopefully all codecov tests)

### DIFF
--- a/sherpa/astro/sim/pragbayes.py
+++ b/sherpa/astro/sim/pragbayes.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2017, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2017, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/sim/pragbayes.py
+++ b/sherpa/astro/sim/pragbayes.py
@@ -231,8 +231,8 @@ class WalkWithSubIters(Walk):
                     try:
                         proposed_params = self._sampler.draw(current_params)
                     except CovarError:
-                        info("Draw rejected: covariance matrix failed. " +
-                             str(proposed_params))
+                        info("Draw rejected: covariance matrix failed: " +
+                             "{}".format(current_params))
                         # automatically reject if the covar is malformed
                         self._sampler.reject()
                         continue


### PR DESCRIPTION
# Summary

Increase coverage of the pragbayes and fullbayes samplers and fix an error condition.

# Details

Since FullBayes builds off PragBayes we can run the same tests, particularly as there's actually no check of the validity of the response. There is one change however, since FullBayes can not be run with a 'simarf' (just 'pcaarf'), so we need to check for this error.

There is also an attempt to check for the LimitError check (that the bounds are exceeded during a draw). Since the fits are randomised and we haven't moved to the NumPy 1.17 random interface, which might make it easier to pick a particular seed/random generator for a test this is somewhat ad-hoc. The test itself is written to try and force quickly hitting the limits, with some "interesting" choice of models and parameter limits.

This PR is aimed at fixing some of the recent coverage failures we've seen because the pragbayes coverage has decreased, in code completely unrelated to the pragbayes code. It would be nice to actually be able to test the return values of the draws, but it's not obvious how best to test this (and is something missing in the current code base).

There's one code fix, which is hard to test: if a covariance error is raised when calculating the proposed draw it's meant to reject this iteration and carry on, but if this happens the first time the system is run then the warning message will error out. I've changed the warning message to contain a more-meaningful set of data.