### PR TITLE
Update travis testing

### DIFF
--- a/travis/test.sh
+++ b/travis/test.sh
@@ -24,7 +24,7 @@ smokevars="${XSPECTEST} ${FITSTEST} -v 3"
 if [ ${TEST} == submodule ]; then
     # pip install pytest-cov codecov;
     conda install -yq pytest-cov codecov;
-    python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
+    pytest -q --cov=sherpa --cov-report=term || exit 1;
     codecov;
 fi
 


### PR DESCRIPTION
# Summary

Update the Travis testing setup to reflect changes to the Python ecosystem.

Argh - it looks like we may have to implement #784 to get this "simple" change to work - there are issues with things like `sherpa.utils._utils` not being importable which I think is related to issues like #50 #198 #595

# Details

There are two changes:

 - use `pip install` rather than `python setup.py install` (and similar for `develop`), as this is the "suggested" approach
   **ACTUALLY** this has been removed from this PR since it lead to a surprising number of problems and failures
 - use `pytest` directly rather than via `python setup.py test`, as the latter is marked for removal

I believe we are likely to move to using `tox` to build and test Sherpa, but this is a long way off (see #784), and this is a simple update we can make now.

The changes were

## `.travis.yml`

```
 install:
-    - python setup.py $INSTALL_TYPE
+    - if [ "${INSTALL_TYPE}" == "install" ];
+       then pip install .;
+      elif [ "${INSTALL_TYPE}" == "develop" ];
+       then pip install -e .;
+      else
+       python setup.py $INSTALL_TYPE;
+      fi
```

## `travis/test.sh`

```
 if [ ${TEST} == submodule ]; then
     # pip install pytest-cov codecov;
     conda install -yq pytest-cov codecov;
-    python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
+    pytest -q --cov=sherpa --cov-report=term || exit 1;
     codecov;
 fi
```

## `.travis.yml`

(this one was never tested, but I noted that the INSTALL_TYPE setting for XSPEC wasn't consistent)

```
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.1n" TRAVIS_PYTHON_VERSION="3.7"
+    - env: INSTALL_TYPE=install FITS="astropy" TEST=submodule MATPLOTLIBVER=3 XSPECVER="12.10.1n" TRAVIS_PYTHON_VERSION="3.7"
       os: osx
```

and

```
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
-    - env: XSPECVER="12.10.1n" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0 pytest-doctestplus<=0.5.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
+    - env: XSPECVER="12.10.1n" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0 pytest-doctestplus<=0.5.0" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER=2 TRAVIS_PYTHON_VERSION="3.5"
     # As above, Python 3.6, setup.py install, xspec 12.10
```