### PR TITLE
Add support for XSPEC 12.11.1

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -123,7 +123,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.11.0 down to 12.9.0. It may build against
+:term:`XSPEC` versions 12.11.1 down to 12.9.0. It may build against
 newer versions, but if it does it will not provide access
 to any new models in the release. The following steps are needed
 to update to a newer version, and assume that you have the new version
@@ -141,18 +141,23 @@ them).
 
    Current version: `helpers/xspec_config.py <https://github.com/sherpa/sherpa/blob/master/helpers/xspec_config.py>`_.
 
-   When adding support for XSPEC 12.11.0, the code in the ``run``
-   method was changed to include::
+   When adding support for XSPEC 12.11.1, the code in the ``run``
+   method was changed to include the triple ``(12, 11, 1)``::
 
-       if xspec_version >= LooseVersion("12.11.0"):
-           macros += [('XSPEC_12_11_0', None)]
+       for major, minor, patch in [(12, 9, 0), (12, 9, 1),
+                                   (12, 10, 0), (12, 10, 1),
+                                   (12, 11, 0), (12, 11, 1)]:
+           version = '{}.{}.{}'.format(major, minor, patch)
+           macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
+           if xspec_version >= LooseVersion(version):
+               macros += [(macro, None)]
 
    and the version check to::
 
        # Since there are patches (e.g. 12.10.0c), look for the
        # "next highest version.
-       if xspec_version >= LooseVersion("12.11.1"):
-           self.warn("XSPEC Version is greater than 12.11.0, which is the latest supported version for Sherpa")
+       if xspec_version >= LooseVersion("12.11.2"):
+           self.warn("XSPEC Version is greater than 12.11.1, which is the latest supported version for Sherpa")
 
    The define should be named ``XSPEC_<a>_<b>_<c>`` for XSPEC release
    ``<a>.<b>.<c>`` (the XSPEC patch level is not included). This define
@@ -203,7 +208,8 @@ them).
 
      diff heasoft-6.26.1/spectral/manager/model.dat heasoft-6.27/spectral/manager/model.dat
 
-   will tell you the differences. If you do not have the previous
+   will tell you the differences (this example was for XSPEC 12.11.0,
+   please adjust as appropriate). If you do not have the previous
    version then the release notes will tell you which models to
    look for in the ``model.dat`` file.
 

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.11.0, 12.10.1 (patch level `a`
+       Sherpa can be built to use XSPEC versions 12.11.1, 12.11.0, 12.10.1 (patch level `a`
        or later), 12.10.0, 12.9.1, or 12.9.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -51,7 +51,7 @@ if installed:
 The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
 functions from the :term:`XSPEC`.
-The supported versions of XSPEC are 12.11.0, 12.10.1 (patch level `a` or later),
+The supported versions of XSPEC are 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later),
 12.10.0, 12.9.1, and 12.9.0.
 
 Interactive display and manipulation of two-dimensional images
@@ -215,7 +215,7 @@ XSPEC
    to support changes made in XSPEC 12.10.0.
 
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC` versions 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
+:term:`XSPEC` versions 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
 12.9.1, and 12.9.0. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
@@ -246,7 +246,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.5`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.11.0 system has been built then use::
+1. If the full XSPEC 12.11.1 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.11.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.28
+       ccfits_libraries = CCfits_2.5
+       wcslib_libraries = wcs-5.19.1
+
+   where the version numbers were taken from version 6.28 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.11.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.0
@@ -259,7 +272,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.27 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.10.1 system has been built then use::
+3. If the full XSPEC 12.10.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.1
@@ -272,7 +285,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.26.1 of HEASOFT and
    may need updating with a newer release.
 
-3. If the full XSPEC 12.10.0 system has been built then use::
+4. If the full XSPEC 12.10.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.0
@@ -282,7 +295,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
 
-4. If the full XSPEC 12.9.x system has been built then use::
+5. If the full XSPEC 12.9.x system has been built then use::
 
        with-xspec = True
        xspec_version = 12.9.1
@@ -294,7 +307,7 @@ match the contents of the XSPEC installation.
 
    changing ``12.9.1`` to ``12.9.0`` as appropriate.
 
-5. If the model-only build of XSPEC has been installed, then
+6. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may
    not need version numbers and locations, depending on how the
    ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
@@ -322,7 +335,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.11.0
+    12.11.1
 
 .. warning::
 

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -112,27 +112,24 @@ class xspec_config(Command):
                 self.announce("Found XSPEC version: {}".format(xspec_raw_version), 2)
                 xspec_version = LooseVersion(xspec_raw_version)
 
-                if xspec_version >= LooseVersion("12.9.0"):
-                    macros += [('XSPEC_12_9_0', None)]
-                else:
+                if xspec_version < LooseVersion("12.9.0"):
                     self.warn("XSPEC Version is less than 12.9.0, which is the minimal supported version for Sherpa")
 
-                if xspec_version >= LooseVersion("12.9.1"):
-                    macros += [('XSPEC_12_9_1', None)]
-
-                if xspec_version >= LooseVersion("12.10.0"):
-                    macros += [('XSPEC_12_10_0', None)]
-
-                if xspec_version >= LooseVersion("12.10.1"):
-                    macros += [('XSPEC_12_10_1', None)]
-
-                if xspec_version >= LooseVersion("12.11.0"):
-                    macros += [('XSPEC_12_11_0', None)]
+                # I am not sure what the naming of the XSPEC components are,
+                # but let's stick with major, minor, and patch.
+                #
+                for major, minor, patch in [(12, 9, 0), (12, 9, 1),
+                                            (12, 10, 0), (12, 10, 1),
+                                            (12, 11, 0), (12, 11, 1)]:
+                    version = '{}.{}.{}'.format(major, minor, patch)
+                    macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
+                    if xspec_version >= LooseVersion(version):
+                        macros += [(macro, None)]
 
                 # Since there are patches (e.g. 12.10.0c), look for the
                 # "next highest version.
-                if xspec_version >= LooseVersion("12.11.1"):
-                    self.warn("XSPEC Version is greater than 12.11.0, which is the latest supported version for Sherpa")
+                if xspec_version >= LooseVersion("12.11.2"):
+                    self.warn("XSPEC Version is greater than 12.11.1, which is the latest supported version for Sherpa")
 
             extension = build_ext('xspec', ld, inc, l, define_macros=macros)
 

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -91,19 +91,6 @@ class xspec_config(Command):
             inc = clean(inc1 + inc2 + inc3 + inc4 + inc5)
             l = clean(l1 + l2 + l3 + l4 + l5)
 
-            # I do not know if l2/l3 are guaranteed to be indexable
-            # entries with at least one element in them.
-            #
-            try:
-                cfitsio = l2[0]
-            except IndexError:
-                cfitsio = None
-
-            try:
-                ccfits = l3[0]
-            except IndexError:
-                ccfits = None
-
             xspec_raw_version = self.xspec_version
 
             macros = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,8 +81,8 @@ source-dir = docs
 #
 # If you are using a full XSPEC build, then add the correct version
 # numbers to the cfitsio, CCfits, and wcs libraries used in the build,
-# if necessary. For XSPEC 12.11.0 (HEAsoft 6.27) this means using
-# CCfits_2.5, wcs-5.19.1, and hdsp_6.27.
+# if necessary. For XSPEC 12.11.1 (HEAsoft 6.28) this means using
+# CCfits_2.5, wcs-5.19.1, and hdsp_6.28.
 #
 # For XSPEC 12.10.0 and later, the xspec_libraries line should
 # be changed to

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
+Sherpa supports versions 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
 of XSPEC [1]_, and can be built against the model library or the full
 application.  There is no guarantee of support for older or newer
 versions of XSPEC.
@@ -12679,14 +12679,22 @@ class XSthcomp(XSConvolutionKernel):
 
     The model is described at [1]_.
 
+    .. note:: Parameter renames in XSPEC 12.11.1
+
+       In XSPEC 12.11.1 the parameters are now called ``Gamma_tau`` and
+       ``cov_frac`` rather than ``gamma_tau`` and ``FracSctr``. The case of
+       ``Gamma_tau`` does not matter for Sherpa, but the scattering-fraction
+       parameter has been renamed (with an alias in place for users used to
+       the XSPEC 12.11.0 names).
+
     Attributes
     ----------
-    gamma_tau
+    Gamma_tau
         The low-energy power-law photon index when positive and the Thomson
         optical depth (multiplied by -1) when negative.
     kT_e
         The electron temperature (high energy rollover)
-    FracSctr
+    cov_frac
         The scattering fraction (between 0 and 1). If 1 then all of the
         seed photons will be Comptonized, and if 0 then only the original
         seed photons will be seen.
@@ -12715,19 +12723,22 @@ class XSthcomp(XSConvolutionKernel):
 
     def __init__(self, name='xsthcomp'):
         # TODO: allow negative
-        self.gamma_tau = Parameter(name, 'gamma_tau', 1.7, min=1.001, max=5.0,
+        self.Gamma_tau = Parameter(name, 'Gamma_tau', 1.7, min=1.001, max=5.0,
                                    hard_min=1.001, hard_max=10.0, frozen=False)
         self.kT_e = Parameter(name, 'kT_e', 50.0, min=0.5, max=150.0,
                               hard_min=0.5, hard_max=150.0, units='keV',
                               frozen=False)
-        self.FracStr = Parameter(name, 'FracSctr', 1.0, min=0.0, max=1.0,
-                                  hard_min=0.0, hard_max=1.0, frozen=False)
+        # In XSPEC 12.11.0 the parameter was named FracSctr, and thanks to a typo
+        # it was stored as the parameter FracStr.
+        self.cov_frac = Parameter(name, 'cov_frac', 1.0, min=0.0, max=1.0,
+                                  hard_min=0.0, hard_max=1.0, frozen=False,
+                                  aliases=["FracSctr", "FracStr"])
         self.z = Parameter(name, 'z', 0.0, min=0.0, max=5.0,
                            hard_min=0.0, hard_max=5.0, frozen=True)
 
-        XSConvolutionKernel.__init__(self, name, (self.gamma_tau,
+        XSConvolutionKernel.__init__(self, name, (self.Gamma_tau,
                                                   self.kT_e,
-                                                  self.FracStr,
+                                                  self.cov_frac,
                                                   self.z
                                                   ))
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2231,6 +2231,10 @@ class XSbwcycl(XSAdditiveModel):
     norm
         The normalization of the model (fix it to one).
 
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.11.0 or later.
+
     References
     ----------
 
@@ -7175,6 +7179,10 @@ class XSzkerrbb(XSAdditiveModel):
     --------
     XSkerrbb
 
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.11.0 or later.
+
     References
     ----------
 
@@ -7377,6 +7385,10 @@ class XSconstant(XSMultiplicativeModel):
     ----------
     factor
         The value of the model.
+
+    See Also
+    --------
+    XSlogconst, XSlog10con
 
     References
     ----------
@@ -11181,6 +11193,10 @@ class XSismdust(XSMultiplicativeModel):
     --------
     XSolivineabs
 
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.11.0 or later.
+
     References
     ----------
 
@@ -11211,6 +11227,14 @@ class XSlogconst(XSMultiplicativeModel):
     logfact
         The constant factor in natural log.
 
+    See Also
+    --------
+    XSconstant, XSlog10con
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.11.0 or later.
+
     References
     ----------
 
@@ -11235,6 +11259,14 @@ class XSlog10con(XSMultiplicativeModel):
     ----------
     log10fac
         The constant factor in base 10 log.
+
+    See Also
+    --------
+    XSconstant, XSlogconst
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -11266,6 +11298,10 @@ class XSolivineabs(XSMultiplicativeModel):
     See Also
     --------
     XSismdust
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -12710,7 +12746,7 @@ class XSthcomp(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather then using the multiplication symbol.
 
-    This model is only available when used with XSPEC 12.10.0 or later.
+    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------


### PR DESCRIPTION
# Summary

Allows Sherpa to be built against XSPEC 12.11.1. There are no new or changed models in this release compared to XSPEC 12.11.0.

# Details

This is as about an easy XSPEC update as we could hope for. I took the opportunity to refactor the `xspec_config.py` code very slightly and remove some unused code.

There is one technical change to the models in XSPEC 12.11.1, as the XSthcomp convolution model (new in 12.11.0) had two parameters renamed: `gamma_tau` -> `Gamma_tau`, which is technically a no-op for us since the parameter access is case insensitive, but I have chosen to update the codem and `FracSctr` to `cov_frac`, for which I've renamed the parameter and made use of the alias functionality for the I-am-willing-to-bet-0-users-who-have-started-using-this-model to support the old paramter name. Of course, I realised that the 12.11.0-added code had a logical error (the name of the parameter is `FracSctr` but it was given the `FracStr` attribute name), so the alias supports both versions.

There are some unrelated doc changes which I noticed related to XSPEC 12.11.0 (a number of models were not labelled as requiring XSPEC 12.11.0), and a few 'See Also' links were added between models added in this release.

## Example

Here's an example showing the alias names working for XSthcomp (note how the `cov_frac` parameter changes when fracsctr/fracstr are used):

```
In [15]: from sherpa.astro import ui

In [16]: ui.xsthcomp.mdl
Out[16]: <XSthcomp kernel instance 'xsthcomp.mdl'>

In [17]: print(mdl)
xsthcomp.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.Gamma_tau thawed          1.7        1.001            5
   mdl.kT_e     thawed           50          0.5          150        keV
   mdl.cov_frac thawed            1            0            1
   mdl.z        frozen            0            0            5

In [18]: mdl.FracSctr = 0.1

In [19]: print(mdl)
xsthcomp.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.Gamma_tau thawed          1.7        1.001            5
   mdl.kT_e     thawed           50          0.5          150        keV
   mdl.cov_frac thawed          0.1            0            1
   mdl.z        frozen            0            0            5

In [20]: mdl.fracstr = 0.2

In [21]: print(mdl)
xsthcomp.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.Gamma_tau thawed          1.7        1.001            5
   mdl.kT_e     thawed           50          0.5          150        keV
   mdl.cov_frac thawed          0.2            0            1
   mdl.z        frozen            0            0            5

In [22]: from sherpa.astro import xspec

In [23]: xspec.get_xsversion()
Out[23]: '12.11.1'
```