### PR TITLE
FEATURE: support alpha transparency for matplotlib plots

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1198,3 +1198,61 @@ def test_pha1_reg_proj(clean_astro_ui, basic_pha1):
     #
     ncontours = len(ax.collections)
     assert ncontours in [2, 3]
+
+
+DATA_PREFS = {'alpha': None,
+              'barsabove': False,
+              'capsize': None,
+              'color': None,
+              'drawstyle': 'default',
+              'ecolor': None,
+              'linecolor': None,
+              'linestyle': 'None',
+              'marker': '.',
+              'markerfacecolor': None,
+              'markersize': None,
+              'ratioline': False,
+              'xaxis': False,
+              'xerrorbars': False,
+              'xlog': False,
+              'yerrorbars': True,
+              'ylog': False}
+
+MODEL_PREFS = {'alpha': None,
+               'barsabove': False,
+               'capsize': None,
+               'color': None,
+               'drawstyle': 'default',
+               'ecolor': None,
+               'linecolor': None,
+               'linestyle': '-',
+               'marker': 'None',
+               'markerfacecolor': None,
+               'markersize': None,
+               'ratioline': False,
+               'xaxis': False,
+               'xerrorbars': False,
+               'xlog': False,
+               'yerrorbars': False,
+               'ylog': False}
+
+
+CONTOUR_PREFS = {'alpha': None,
+                 'colors': None,
+                 'linewidths': None,
+                 'xlog': False,
+                 'ylog': False}
+
+
+@requires_pylab
+@pytest.mark.parametrize("funcname,expected",
+                         [("get_data_plot_prefs", DATA_PREFS),
+                          ("get_model_plot_prefs", MODEL_PREFS),
+                          ("get_data_contour_prefs", CONTOUR_PREFS),
+                          ("get_model_contour_prefs", CONTOUR_PREFS)])
+def test_plot_defaults(funcname, expected):
+    """What are the plot defaults?"""
+
+    prefs = getattr(ui, funcname)()
+    assert isinstance(prefs, dict)
+    assert prefs == expected

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1056,6 +1056,7 @@ def test_pha1_plot_fit_options(clean_astro_ui, basic_pha1):
     """Test that the options have changed things, where easy to do so"""
 
     from matplotlib import pyplot as plt
+    import matplotlib
 
     dprefs = ui.get_data_plot_prefs()
     dprefs['xerrorbars'] = True
@@ -1124,7 +1125,15 @@ def test_pha1_plot_fit_options(clean_astro_ui, basic_pha1):
 
     assert len(coll.get_segments()) == 42
 
-    assert coll.get_linestyles() == [(None, None)]
+    # The return value depends on matplotlib version (>= 3.3
+    # returns something). What has changed? Maybe this should
+    # not be tested?
+    #
+    expected = [(None, None)]
+    if matplotlib.__version__ >= '3.3.0':
+        expected = [(0.0, None)]
+
+    assert coll.get_linestyles() == expected
 
     # looks like the color has been converted to individual channels
     # - e.g. floating-point values for R, G, B, and alpha.

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2017, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2015, 2017, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -122,7 +122,7 @@ def setup_plot(axes, title, xlabel, ylabel, xlog=False, ylog=False):
 
 
 def point(x, y, overplot=True, clearwindow=False,
-          symbol=None,
+          symbol=None, alpha=None,
           color=None):
 
     axes = setup_axes(overplot, clearwindow)
@@ -132,7 +132,7 @@ def point(x, y, overplot=True, clearwindow=False,
     else:
         style = '{}{}'.format(color, symbol)
 
-    axes.plot(numpy.array([x]), numpy.array([y]), style)
+    axes.plot(numpy.array([x]), numpy.array([y]), style, alpha=alpha)
 
 
 def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
@@ -147,6 +147,7 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
           linecolor=None,
           drawstyle='steps-mid',
           color=None,
+          alpha=None,
           marker='None',
           markerfacecolor=None,
           markersize=None):
@@ -160,7 +161,7 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
          xlog=xlog, ylog=ylog,
          linestyle=linestyle, linecolor=linecolor,
          drawstyle=drawstyle,
-         color=color, marker=marker,
+         color=color, marker=marker, alpha=alpha,
          markerfacecolor=markerfacecolor, markersize=markersize,
          xaxis=False, ratioline=False)
 
@@ -200,6 +201,8 @@ def _set_line(line, linecolor=None, linestyle=None, linewidth=None):
         set('linewidth', linewidth)
 
 
+# There is no support for alpha in the Plot.vline class
+#
 def vline(x, ymin=0, ymax=1,
           linecolor=None,
           linestyle=None,
@@ -213,6 +216,8 @@ def vline(x, ymin=0, ymax=1,
               linewidth=linewidth)
 
 
+# There is no support for alpha in the Plot.hline class
+#
 def hline(y, xmin=0, xmax=1,
           linecolor=None,
           linestyle=None,
@@ -242,6 +247,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
          marker='None',
          markerfacecolor=None,
          markersize=None,
+         alpha=None,
          xaxis=False,
          ratioline=False):
 
@@ -317,6 +323,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
                       marker=marker,
                       markersize=markersize,
                       markerfacecolor=markerfacecolor,
+                      alpha=alpha,
                       ecolor=ecolor,
                       capsize=capsize,
                       barsabove=barsabove,
@@ -325,6 +332,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
     else:
         axes.plot(x, y,
                   color=color,
+                  alpha=alpha,
                   linestyle=linestyle,
                   drawstyle=drawstyle,
                   marker=marker,
@@ -364,6 +372,7 @@ def contour(x0, x1, y, levels=None, title=None, xlabel=None, ylabel=None,
             overcontour=False, clearwindow=True,
             xlog=False,
             ylog=False,
+            alpha=None,
             linewidths=None,
             colors=None):
 
@@ -383,10 +392,11 @@ def contour(x0, x1, y, levels=None, title=None, xlabel=None, ylabel=None,
         setup_plot(axes, title, xlabel, ylabel, xlog=xlog, ylog=ylog)
 
     if levels is None:
-        axes.contour(x0, x1, y, colors=colors, linewidths=linewidths)
+        axes.contour(x0, x1, y, alpha=alpha,
+                     colors=colors, linewidths=linewidths)
     else:
-        axes.contour(x0, x1, y, levels, colors=colors,
-                     linewidths=linewidths)
+        axes.contour(x0, x1, y, levels, alpha=alpha,
+                     colors=colors, linewidths=linewidths)
 
 
 def set_subplot(row, col, nrows, ncols, clearaxes=True,

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12128,12 +12128,13 @@ class Session(NoNewAttributesAfterInit):
         >>> plot_data(linestyle='dotted')
 
         and plotting multiple data sets on the same plot, using
-        a log scale for the Y axis, and explicitly setting the
+        a log scale for the Y axis, setting the alpha transparency
+        for each plot, and explicitly setting the
         colors of the last two datasets:
 
-        >>> plot_data(ylog=True)
-        >>> plot_data(2, overplot=True, color='brown')
-        >>> plot_data(3, overplot=True, color='purple')
+        >>> plot_data(ylog=True, alpha=0.7)
+        >>> plot_data(2, overplot=True, alpha=0.7, color='brown')
+        >>> plot_data(3, overplot=True, alpha=0.7, color='purple')
 
         """
         self._plot(id, self._dataplot, replot=replot, overplot=overplot,
@@ -12203,10 +12204,10 @@ class Session(NoNewAttributesAfterInit):
         of the dictionary returned by `get_model_plot_prefs`. The
         following plots the model using a log scale for both axes,
         and then overplots the model from data set 2 using a dashed
-        line:
+        line and slightly transparent:
 
         >>> plot_model(xlog=True, ylog=True)
-        >>> plot_model(2, overplot=True, linestyle='dashed')
+        >>> plot_model(2, overplot=True, alpha=0.7, linestyle='dashed')
 
         """
         self._plot(id, self._modelplot, replot=replot, overplot=overplot,
@@ -12515,6 +12516,12 @@ class Session(NoNewAttributesAfterInit):
         used):
 
         >>> plot_fit(color='orange')
+
+        Draw the fits for two datasets, setting the second one partially
+        transparent (this assumes Matplotlib is used):
+
+        >>> plot_fit(1)
+        >>> plot_fit(2, alpha=0.7, overplot=True)
 
         """
         self._plot(id, self._fitplot, replot=replot, overplot=overplot,

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10530,6 +10530,10 @@ class Session(NoNewAttributesAfterInit):
         The following preferences are recognized by the matplotlib
         backend:
 
+        ``alpha``
+           The transparency value to drawn the line (0 is fully transparent
+           and 1 is fully opaque).
+
         ``barsabove``
            The barsabove argument for the matplotlib errorbar function.
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10531,8 +10531,8 @@ class Session(NoNewAttributesAfterInit):
         backend:
 
         ``alpha``
-           The transparency value to drawn the line (0 is fully transparent
-           and 1 is fully opaque).
+           The transparency value used to draw the line or symbol,
+           where 0 is fully transparent and 1 is fully opaque.
 
         ``barsabove``
            The barsabove argument for the matplotlib errorbar function.


### PR DESCRIPTION
# Summary

Support the 'alpha' preference setting for most plots and contours generated by Matplotlib. For example, `plot_data(alpha=0.7)`. 

# Details

The transparency can be set at the plot site - e.g.

    plot_fit(alpha=0.7)

or via the 'alpha' setting in the plot preferences.

Thanks to the current design of the vline and hline methods of
sherpa.plot.Plot we can not set the alpha setting for these,
so

    plot_cdf(alpha=0.4)

will only change the transparency of the data, not the lower,
upper, and median lines.

## Example

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
/home/dburke/anaconda/envs/sherpa-master/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: Unable to load the ciao_version module to determine version number- defaulting 'group' version to 0.0.0
  return f(*args, **kwds)

In [2]: import logging

In [3]: logging.getLogger('sherpa').setLevel(logging.ERROR)

In [4]: load_pha('sherpa-test-data/sherpatest/3c273.pi')

In [5]: notice(0.5, 7)

In [6]: set_source(xsphabs.gal * powlaw1d.pl)

In [7]: fit()

In [8]: plot_data(alpha=0.2)

In [9]: plot_model(overplot=True)
/home/dburke/sherpa/sherpa-master/sherpa/plot/pylab_backend.py:338: MatplotlibDeprecationWarning: Passing the drawstyle with the linestyle as a single string is deprecated since Matplotlib 3.1 and support will be removed in 3.3; please pass the drawstyle separately using the drawstyle keyword argument to Line2D or set_drawstyle() method (or ds/set_ds()).
  zorder=zorder)

```

You can see the data has been drawn with a low alpha setting:

![FIG](https://user-images.githubusercontent.com/224638/90958652-ca96d800-e463-11ea-83d5-a653dd99983a.png)

