### PR TITLE
Refactor: remove _get_model/source methods

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8831,7 +8831,7 @@ class Session(sherpa.ui.utils.Session):
 
         data = self.get_data(id)
         if isinstance(data, sherpa.astro.data.DataPHA):
-            model = self._get_model(id)
+            model = self.get_model(id)
 
             if data._responses:
 


### PR DESCRIPTION
# Summary

Remove the _get_source and _get_model methods as they are the same as get_source and get_model (sherpa.ui/sherpa.astro.ui).

# Details

It took me some time to track down code changes between the sherpa.ui
and sherpa.astro.ui modules which were down to the fact that some
called _get_source and some get_source, but they are the same
function (in reality). I've therefore dropped the _get_source and
_get_model versions as we have enough difficulty tracking things
down without adding more potential confusion.

Since the removed functions begin with _ it's a Pythom idiom that
they are considered internal methods, so it's safe(ish) for us to
remove them (people should not be relying on them, and note that
the _get_source/model methods had no documentation).