### PR TITLE
Travis: update ds9 to 8.1 and XPA to 2.1.20 (fix #913)

### DIFF
--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -42,8 +42,8 @@ download () {
 
 ### DS9 and XPA
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.0.1.tar.gz
-xpa_tar=xpa.${ds9_os}.2.1.18.tar.gz
+ds9_tar=ds9.${ds9_os}.8.1.tar.gz
+xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
 
 # Fetch them
 download $ds9_base_url/$ds9_os/$ds9_tar


### PR DESCRIPTION
Updates the Travis builds that run DS9 tests to use DS9 version 8.1 as 8.0.1 is no-longer available. The XPA version has been bumped from 2.1.18 to 2.1.20 because it is available. 