### PR TITLE
fix an issue with PHA filtering that affects plot_model

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -973,7 +973,7 @@ def test_pha_get_filter_filter(infile, expected, make_data_path):
 @requires_fits
 @pytest.mark.parametrize("infile,expected",
                          [("9774.pi", '0.5037:0.6059'),
-                          ("3c273.pi", '0.5183,0.6059')])
+                          ("3c273.pi", '0.5183:0.6059')])
 def test_pha_get_filter_edgecase(infile, expected, make_data_path):
     """Check get_filter with an edge case
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -181,6 +181,63 @@ def test_more_ui_bug38(make_data_path):
     ui.group_counts('3c273', 15)
 
 
+@requires_fits
+@requires_data
+def test_bug38_filtering(make_data_path):
+    """Low-level tests related to bugs #38, #917: filter"""
+
+    from sherpa.astro.io import read_pha
+    pha = read_pha(make_data_path('3c273.pi'))
+
+    assert pha.mask is True
+    pha.notice(0.3, 2)
+    assert pha.mask.size == 46
+    assert pha.mask.sum() == 25
+    assert pha.mask[1:26].all()
+
+
+@requires_fits
+@requires_data
+def test_bug38_filtering_grouping(make_data_path):
+    """Low-level tests related to bugs #38, #917: filter+group"""
+
+    from sherpa.astro.io import read_pha
+    pha = read_pha(make_data_path('3c273.pi'))
+
+    pha.notice(1, 6)
+    pha.ignore(3, 4)
+
+    assert pha.get_filter(group=True, format='%.4f') == '1.0147:2.7886,4.1391:6.2342'
+    # Not correct, but it's what the code generates
+    assert pha.get_filter(group=False, format='%.4f') == '1.0001:1.2775,1.2921:6.5627'
+
+    pha.group_width(40)
+
+    # Not correct, but it's what the code generates
+    assert pha.get_filter(group=True, format='%.4f') == '0.8760:6.7160'
+    assert pha.get_filter(group=False, format='%.4f') == '0.5913:7.0007'
+
+    assert pha.mask.size == 26
+    assert pha.mask.sum() == 11
+    assert pha.mask[1:5].all()
+    assert pha.mask[5]
+    assert pha.mask[6:12].all()
+
+    # get the ungrouped mask
+    mask = pha.get_mask()
+    assert mask.sum() == 11 * 40
+    assert mask[40:200].all()
+    assert mask[200:240].all()
+    assert mask[240:480].all()
+
+    # check filtered bins
+    elo_all, ehi_all = pha._get_ebins(group=False)
+    elo, ehi = pha._get_ebins(group=True)
+
+    assert elo[1] == elo_all[40]
+    assert ehi[11] == ehi_all[479]
+
+
 # bug #12578
 @requires_data
 @requires_fits

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -208,26 +208,22 @@ def test_bug38_filtering_grouping(make_data_path):
     pha.ignore(3, 4)
 
     assert pha.get_filter(group=True, format='%.4f') == '1.0147:2.7886,4.1391:6.2342'
-    # Not correct, but it's what the code generates
-    assert pha.get_filter(group=False, format='%.4f') == '1.0001:1.2775,1.2921:6.5627'
+    assert pha.get_filter(group=False, format='%.4f') == '1.0001:2.8543,4.0369:6.5627'
 
     pha.group_width(40)
 
-    # Not correct, but it's what the code generates
-    assert pha.get_filter(group=True, format='%.4f') == '0.8760:6.7160'
-    assert pha.get_filter(group=False, format='%.4f') == '0.5913:7.0007'
+    assert pha.get_filter(group=True, format='%.4f') == '0.8760:2.6280,3.7960:6.7160'
+    assert pha.get_filter(group=False, format='%.4f') == '0.5913:2.9127,3.5113:7.0007'
 
     assert pha.mask.size == 26
-    assert pha.mask.sum() == 11
+    assert pha.mask.sum() == 10
     assert pha.mask[1:5].all()
-    assert pha.mask[5]
     assert pha.mask[6:12].all()
 
     # get the ungrouped mask
     mask = pha.get_mask()
-    assert mask.sum() == 11 * 40
+    assert mask.sum() == 10 * 40
     assert mask[40:200].all()
-    assert mask[200:240].all()
     assert mask[240:480].all()
 
     # check filtered bins

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1285,13 +1285,7 @@ def test_pha1_get_model_plot_filtered(clean_astro_ui, basic_pha1):
     assert mplot.xlo.size == mplot.xhi.size
     assert mplot.xlo.size == mplot.y.size
 
-    # This is the number of unfiltered bins between 0.5-7 keV
-    # and has not been reduced by the 2-3 keV range. After
-    # removing the 2-3 keV range the expected number of bins
-    # is 566.
-    #
-    # assert mplot.y.size == 566
-    assert mplot.y.size == 644
+    assert mplot.y.size == 566
 
     assert mplot.xlo[0] == pytest.approx(0.46720001101493835)
     assert mplot.xhi[0] == pytest.approx(0.48179998993873596)
@@ -1302,8 +1296,5 @@ def test_pha1_get_model_plot_filtered(clean_astro_ui, basic_pha1):
     assert mplot.xlo[100] == pytest.approx(1.9271999597549438)
     assert mplot.xhi[100] == pytest.approx(1.9417999982833862)
 
-    # This should be 101
-    # nextbin = 101
-    nextbin = 179
-    assert mplot.xlo[nextbin] == pytest.approx(3.0806000232696533)
-    assert mplot.xhi[nextbin] == pytest.approx(3.0952000617980957)
+    assert mplot.xlo[101] == pytest.approx(3.0806000232696533)
+    assert mplot.xhi[101] == pytest.approx(3.0952000617980957)

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1265,3 +1265,45 @@ def test_plot_defaults(funcname, expected):
     prefs = getattr(ui, funcname)()
     assert isinstance(prefs, dict)
     assert prefs == expected
+
+
+@requires_fits
+@requires_data
+def test_pha1_get_model_plot_filtered(clean_astro_ui, basic_pha1):
+    """Does get_model_plot register filters correctly?
+
+    If there is an ignored range within a model, is it ignored?
+    This also holds for plot_model and the model_component
+    variants, but this is untested
+    """
+
+    # Ignore the 2-3 keV range
+    ui.ignore(2, 3)
+
+    mplot = ui.get_model_plot()
+
+    assert mplot.xlo.size == mplot.xhi.size
+    assert mplot.xlo.size == mplot.y.size
+
+    # This is the number of unfiltered bins between 0.5-7 keV
+    # and has not been reduced by the 2-3 keV range. After
+    # removing the 2-3 keV range the expected number of bins
+    # is 566.
+    #
+    # assert mplot.y.size == 566
+    assert mplot.y.size == 644
+
+    assert mplot.xlo[0] == pytest.approx(0.46720001101493835)
+    assert mplot.xhi[0] == pytest.approx(0.48179998993873596)
+
+    assert mplot.xlo[-1] == pytest.approx(9.854999542236328)
+    assert mplot.xhi[-1] == pytest.approx(9.869600296020508)
+
+    assert mplot.xlo[100] == pytest.approx(1.9271999597549438)
+    assert mplot.xhi[100] == pytest.approx(1.9417999982833862)
+
+    # This should be 101
+    # nextbin = 101
+    nextbin = 179
+    assert mplot.xlo[nextbin] == pytest.approx(3.0806000232696533)
+    assert mplot.xhi[nextbin] == pytest.approx(3.0952000617980957)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1452,20 +1452,23 @@ def parse_expr(expr):
     [(None, None)]
 
     """
-    res = []
+
     if expr is None or str(expr).strip() == '':
-        res.append((None, None))
-        return res
+        return [(None, None)]
+
+    res = []
     vals = str(expr).strip().split(',')
     for val in vals:
         lo, hi = None, None
+
         interval = val.strip().split(':')
-        if len(interval) == 1:
+        ninterval = len(interval)
+        if ninterval == 1:
             lo = interval[0]
             if lo == '':
                 lo = None
             hi = lo
-        elif len(interval) > 1:
+        elif ninterval == 2:
             lo = interval[0]
             hi = interval[1]
             if lo == '':
@@ -1473,7 +1476,14 @@ def parse_expr(expr):
             if hi == '':
                 hi = None
         else:
+            # This check exited but was never hit due to the way the
+            # code was written. It now errors out if a used gives
+            # a:b:c, whereas the old version would have just ignored
+            # the ':c' part. Perhaps we should just keep dropping
+            # it, in case there's existing code that assumes this.
+            #
             raise TypeError("interval syntax requires a tuple, 'lo:hi'")
+
         if lo is not None:
             try:
                 lo = float(lo)
@@ -1484,7 +1494,9 @@ def parse_expr(expr):
                 hi = float(hi)
             except ValueError:
                 raise TypeError("Invalid upper bound '%s'" % str(hi))
+
         res.append((lo, hi))
+
     return res
 
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1523,10 +1523,10 @@ def parse_expr(expr):
                 hi = None
         else:
             # This check exited but was never hit due to the way the
-            # code was written. It now errors out if a used gives
+            # code was written. It now errors out if a user gives
             # a:b:c, whereas the old version would have just ignored
             # the ':c' part. Perhaps we should just keep dropping
-            # it, in case there's existing code that assumes this.
+            # it, in case there's existing code that assumes this?
             #
             raise TypeError("interval syntax requires a tuple, 'lo:hi'")
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1400,17 +1400,12 @@ def create_expr(vals, mask=None, format='%s', delim='-'):
         # values, so it doesn't matter if index starts at 0 or 1.
         #
         index = numpy.arange(len(mask))
-
         seq = index[mask]
 
     # diffs has 1 less element than vals
     #
     diffs = numpy.apply_along_axis(numpy.diff, 0, seq)
     diffs = diffs == 1
-
-    # Work around no size check
-    if len(diffs) == 0:
-        return ''
 
     def filt(start, end):
         "What is the filter expression for this range?"

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -485,63 +485,32 @@ def test_parse_expr_empty(arg):
     assert utils.parse_expr(arg) == [(None, None)]
 
 
-def test_parse_expr_lolim():
-    assert utils.parse_expr("2:") == [(2.0, None)]
-
-
-def test_parse_expr_lolim2():
-    assert utils.parse_expr("1:4, 5:") == [(1.0, 4.0), (5.0, None)]
-
-
-def test_parse_expr_lolim3():
-    assert utils.parse_expr("1:4, 5:6, 9:") == [(1.0, 4.0), (5.0, 6.0), (9.0, None)]
-
-
-def test_parse_expr_hilim():
-    assert utils.parse_expr(":2") == [(None, 2.0)]
-
-
-def test_parse_expr_hilim_2():
-    assert utils.parse_expr(":2, 3:4") == [(None, 2.0), (3.0, 4.0)]
-
-
-def test_parse_expr_hilim_3():
-    assert utils.parse_expr(":2, 3:4, 5:6") == [(None, 2.0), (3.0, 4.0), (5.0, 6.0)]
-
-
-def test_parse_expr_allset2():
-    """All limits are given.
+@pytest.mark.parametrize("arg,expected",
+                         [("2:", [(2.0, None)]),
+                          ("1:4, 5:", [(1.0, 4.0), (5.0, None)]),
+                          ("1:4, 5:6, 9:", [(1.0, 4.0), (5.0, 6.0), (9.0, None)]),
+                          (":2", [(None, 2.0)]),
+                          (":2, 3:4", [(None, 2.0), (3.0, 4.0)]),
+                          (":2, 3:4, 5:6", [(None, 2.0), (3.0, 4.0), (5.0, 6.0)]),
+                          (" 1:2,4:5  ", [(1.0, 2.0), (4.0, 5.0)]),
+                          (":2, 3, 5:6", [(None, 2.0), (3.0, 3.0), (5.0, 6.0)]),
+                          (" :2 ,4:  ", [(None, 2.0), (4.0, None)]),
+                          ("1:2 , 4:5, 6:8", [(1.0, 2.0), (4.0, 5.0), (6.0, 8.0)]),
+                          (" :2 , 4:5, 6: ", [(None, 2.0), (4.0, 5.0), (6.0, None)]),
+                          (":", [(None, None)]),
+                          ("2:3,:,4", [(2.0, 3.0), (None, None), (4.0, 4.0)]),
+                          (",2", [(None, None), (2.0, 2.0)]),
+                          ("2,", [(2.0, 2.0), (None, None)]),
+                          ("2,,3:4", [(2.0, 2.0), (None, None), (3.0, 4.0)]),
+                          (" , :", [(None, None), (None, None)]),
+                         ])
+def test_parse_expr(arg, expected):
+    """Check parse_expr with various conditions
 
     Would be nice to use something like hypothesis to use
     property-based testing.
     """
-    assert utils.parse_expr(" 1:2,4:5  ") == [(1.0, 2.0), (4.0, 5.0)]
-
-
-def test_parse_expr_single():
-    assert utils.parse_expr(":2, 3, 5:6") == [(None, 2.0), (3.0, 3.0), (5.0, 6.0)]
-
-
-
-def test_parse_expr_set2():
-    """Lower and upper limits not given.
-    """
-    assert utils.parse_expr(" :2 ,4:  ") == [(None, 2.0), (4.0, None)]
-
-
-def test_parse_expr_allset3():
-    """All limits are given.
-
-    Would be nice to use something like hypothesis to use
-    property-based testing.
-    """
-    assert utils.parse_expr("1:2 , 4:5, 6:8") == [(1.0, 2.0), (4.0, 5.0), (6.0, 8.0)]
-
-
-def test_parse_expr_set3():
-    """Lower and upper limits not given.
-    """
-    assert utils.parse_expr(" :2 , 4:5, 6: ") == [(None, 2.0), (4.0, 5.0), (6.0, None)]
+    assert utils.parse_expr(arg) == expected
 
 
 @pytest.mark.parametrize("instr,bound",
@@ -564,11 +533,9 @@ def test_parse_expr_not_num(instr, bound):
     assert  str(exc.value) == emsg
 
 
-# keep the expected output in case we want to revert this change
-@pytest.mark.parametrize("instr,expected",
-                         [("1:2:4", [(1.0, 2.0)]),
-                          ("1:3 , 4:5:0.2", [(1.0, 3.0), (4.0, 5.0)])])
-def test_parse_expr_unexpected_parses(instr, expected):
+@pytest.mark.parametrize("instr",
+                         ["1:2:4", "1:3 , 4 : 5:0.2"])
+def test_parse_expr_unexpected_parses(instr):
     """You used to be able to say a:b:c:d:e and still have it parsed"""
 
     with pytest.raises(TypeError) as exc:

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -564,13 +564,17 @@ def test_parse_expr_not_num(instr, bound):
     assert  str(exc.value) == emsg
 
 
+# keep the expected output in case we want to revert this change
 @pytest.mark.parametrize("instr,expected",
                          [("1:2:4", [(1.0, 2.0)]),
                           ("1:3 , 4:5:0.2", [(1.0, 3.0), (4.0, 5.0)])])
 def test_parse_expr_unexpected_parses(instr, expected):
-    """You can say a:b:c:d:e and still have it parsed"""
+    """You used to be able to say a:b:c:d:e and still have it parsed"""
 
-    assert utils.parse_expr(instr) == expected
+    with pytest.raises(TypeError) as exc:
+        utils.parse_expr(instr)
+
+    assert str(exc.value) == "interval syntax requires a tuple, 'lo:hi'"
 
 
 @pytest.mark.parametrize("instr,expected",

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -17,13 +17,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import pytest
 import numpy
-from numpy.testing import assert_allclose, assert_equal
+
+import pytest
 
 from sherpa import utils
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit
-from sherpa.utils.testing import SherpaTestCase
 from sherpa.data import Data1D
 from sherpa.models.basic import Gauss1D
 from sherpa.optmethods import LevMar
@@ -31,240 +30,278 @@ from sherpa.stats import LeastSq
 from sherpa.fit import Fit, DataSimulFit, SimulFitModel
 
 
-class test_utils(SherpaTestCase):
+def f1(a, b, c):
+    pass
 
-    def setUp(self):
-        def f1(a, b, c):
-            pass
-        self.f1 = f1
+def f2(a, b=1, c=2, d=3, e=4):
+    pass
 
-        def f2(a, b=1, c=2, d=3, e=4):
-            pass
-        self.f2 = f2
+def f3(a=None, b=1, c=2, d=3, e=4):
+    pass
 
-        def f3(a=None, b=1, c=2, d=3, e=4):
-            pass
-        self.f3 = f3
 
-    def test_NoNewAttributesAfterInit(self):
-        class C(NoNewAttributesAfterInit):
-            def __init__(self):
-                self.x = 1
-                self.y = 2
-                self.z = 3
-                del self.z
-                NoNewAttributesAfterInit.__init__(self)
+def test_NoNewAttributesAfterInit():
+    class C(NoNewAttributesAfterInit):
+        def __init__(self):
+            self.x = 1
+            self.y = 2
+            self.z = 3
+            del self.z
+            NoNewAttributesAfterInit.__init__(self)
 
-        c = C()
-        self.assertEqual(c.x, 1)
-        self.assertEqual(c.y, 2)
-        self.assertFalse(hasattr(c, 'z'))
-        self.assertRaises(AttributeError, delattr, c, 'x')
-        self.assertRaises(AttributeError, delattr, c, 'z')
-        self.assertRaises(AttributeError, setattr, c, 'z', 5)
-        c.x = 4
-        self.assertEqual(c.x, 4)
+    c = C()
 
-    def test_export_method(self):
-        class C():
-            def m(self, x, y=2):
-                'Instance method m()'
-                return x * y
+    assert c.x == 1
+    c.x = 4
+    assert c.x == 4
 
-            def margs(self, x, y=2, *args):
-                'Instance method margs() with *args'
-                return x * y + len(args)
+    assert c.y == 2
+    assert not hasattr(c, 'z')
 
-            def kwargs(self, x, y=2, **kwargs):
-                'Instance method kwargs() with **kwargs'
-                return x * y + 2 * len(kwargs)
+    # attribute that exists
+    with pytest.raises(AttributeError):
+        del c.x
 
-            def bargs(self, x, y=2, *args, **kwargs):
-                'Instance method bargs() with *args and **kwargs'
-                return x * y + len(args) + 2 * len(kwargs)
+    # attribute that not exist
+    with pytest.raises(AttributeError):
+        del c.z
 
-            @classmethod
-            def cm(klass, x, y=2):
-                'Class method cm()'
-                return x * y
+    with pytest.raises(AttributeError):
+        c.z = 5
 
-            @staticmethod
-            def sm(x, y=2):
-                'Static method sm()'
-                return x * y
 
-        c = C()
+def test_export_method():
+    class C():
 
-        # Basic usage
-        for meth in (c.m, c.margs, c.kwargs, c.bargs, c.cm, c.sm):
-            m = utils.export_method(meth)
-            self.assertEqual(m.__name__, meth.__name__)
-            self.assertTrue(m.__doc__ is not None)
-            self.assertEqual(m.__doc__, meth.__doc__)
-            self.assertEqual(m(3), 6)
-            self.assertEqual(m(3, 7), 21)
-            e = None
-            try:
-                m()
-            except TypeError as e:
-                emsg2 = "{}() ".format(meth.__name__) + \
-                        "takes at least 1 argument (0 given)"
-                emsg3 = "{}() ".format(meth.__name__) + \
-                        "missing 1 required positional argument: 'x'"
-                self.assertIn(str(e), [emsg2, emsg3])
+        def m(self, x, y=2):
+            'Instance method m()'
+            return x * y
 
-        # Check that *args/**kwargs are handled correctly for methods;
-        # should perhaps be included above to avoid repeated calls
-        # to export_method?
-        #
-        meth = utils.export_method(c.margs)
-        self.assertTrue(meth(3, 7, "a", "b"), 23)
-        try:
-            meth(12, dummy=None)
-        except TypeError as e:
-            emsg = "margs() got an unexpected keyword argument 'dummy'"
-            self.assertEqual(str(e), emsg)
+        def margs(self, x, y=2, *args):
+            'Instance method margs() with *args'
+            return x * y + len(args)
 
-        meth = utils.export_method(c.kwargs)
-        self.assertTrue(meth(3, 7, foo="a", bar="b"), 25)
-        try:
-            meth(12, 14, 15)
-        except TypeError as e:
-            emsg2 = "kwargs() takes at most 2 arguments (3 given)"
-            emsg3 = "kwargs() takes from 1 to 2 positional arguments " + \
-                    "but 3 were given"
-            self.assertIn(str(e), [emsg2, emsg3])
+        def kwargs(self, x, y=2, **kwargs):
+            'Instance method kwargs() with **kwargs'
+            return x * y + 2 * len(kwargs)
 
-        meth = utils.export_method(c.bargs)
-        self.assertTrue(meth(3, 7, 14, 15, foo=None), 25)
+        def bargs(self, x, y=2, *args, **kwargs):
+            'Instance method bargs() with *args and **kwargs'
+            return x * y + len(args) + 2 * len(kwargs)
 
-        # Non-method argument
-        def f(x):
-            return 2 * x
-        self.assertTrue(utils.export_method(f) is f)
+        @classmethod
+        def cm(klass, x, y=2):
+            'Class method cm()'
+            return x * y
 
-        # Name and module name
-        m = utils.export_method(c.m, 'foo', 'bar')
-        self.assertEqual(m.__name__, 'foo')
-        self.assertEqual(m.__module__, 'bar')
-        self.assertEqual(m(3), 6)
-        self.assertEqual(m(3, 7), 21)
+        @staticmethod
+        def sm(x, y=2):
+            'Static method sm()'
+            return x * y
 
-    def test_get_num_args(self):
-        self.assertEqual(utils.get_num_args(self.f1), (3, 3, 0))
-        self.assertEqual(utils.get_num_args(self.f2), (5, 1, 4))
-        self.assertEqual(utils.get_num_args(self.f3), (5, 0, 5))
+    c = C()
 
-    def test_get_keyword_names(self):
-        self.assertEqual(utils.get_keyword_names(self.f1), [])
-        l = ['b', 'c', 'd', 'e']
-        self.assertEqual(utils.get_keyword_names(self.f2), l)
-        self.assertEqual(utils.get_keyword_names(self.f2, 2), l[2:])
-        self.assertEqual(utils.get_keyword_names(self.f2, 7), [])
-        l = ['a', 'b', 'c', 'd', 'e']
-        self.assertEqual(utils.get_keyword_names(self.f3), l)
-        self.assertEqual(utils.get_keyword_names(self.f3, 1), l[1:])
-        self.assertEqual(utils.get_keyword_names(self.f3, 7), [])
+    # Basic usage
+    for meth in (c.m, c.margs, c.kwargs, c.bargs, c.cm, c.sm):
+        m = utils.export_method(meth)
 
-    def test_get_keyword_defaults(self):
-        self.assertEqual(utils.get_keyword_defaults(self.f1), {})
-        d = {'b': 1, 'c': 2, 'd': 3, 'e': 4}
-        self.assertEqual(utils.get_keyword_defaults(self.f2), d)
-        del d['b']
-        del d['c']
-        self.assertEqual(utils.get_keyword_defaults(self.f2, 2), d)
-        self.assertEqual(utils.get_keyword_defaults(self.f2, 7), {})
-        d = {'a': None, 'b': 1, 'c': 2, 'd': 3, 'e': 4}
-        self.assertEqual(utils.get_keyword_defaults(self.f3), d)
-        del d['a']
-        self.assertEqual(utils.get_keyword_defaults(self.f3, 1), d)
-        self.assertEqual(utils.get_keyword_defaults(self.f3, 7), {})
+        assert m.__name__ == meth.__name__
+        assert m.__doc__ is not None
+        assert m.__doc__ == meth.__doc__
 
-    def test_print_fields(self):
-        names = ['a', 'bb', 'ccc']
-        vals = {'a': 3, 'bb': 'Ham', 'ccc': numpy.array([1.0, 2.0, 3.0])}
-        self.assertEqual(utils.print_fields(names, vals),
-                         'a   = 3\nbb  = Ham\nccc = Float64[3]')
+        assert m(3) == 6
+        assert m(3, 7) == 21
 
-    def test_calc_total_error(self):
-        stat = numpy.array([1, 2])
-        sys = numpy.array([3, 4])
+        with pytest.raises(TypeError) as exc:
+            m()
 
-        self.assertEqual(utils.calc_total_error(None, None), None)
-        assert_equal(utils.calc_total_error(stat, None), stat)
-        assert_equal(utils.calc_total_error(None, sys), sys)
+        emsg = "{}() ".format(meth.__name__) + \
+                "missing 1 required positional argument: 'x'"
+        assert str(exc.value) == emsg
 
-        # Unlike the above tests, only look for equivalence within
-        # a tolerance, since the numbers are manipulated rather than
-        # copied in this case (although the equation should be the same
-        # so the old approach of using equality should actually be okay
-        # here).
-        ans = numpy.sqrt(stat * stat + sys * sys)
-        assert_allclose(utils.calc_total_error(stat, sys), ans)
+    # Check that *args/**kwargs are handled correctly for methods;
+    # should perhaps be included above to avoid repeated calls
+    # to export_method?
+    #
+    meth = utils.export_method(c.margs)
+    assert meth(3, 7, "a", "b") == 23
 
-    def test_poisson_noise(self):
-        out = utils.poisson_noise(1000)
-        self.assertEqual(type(out), SherpaFloat)
-        self.assertGreater(out, 0.0)
+    with pytest.raises(TypeError) as exc:
+        meth(12, dummy=None)
 
-        for x in (-1000, 0):
-            out = utils.poisson_noise(x)
-            self.assertEqual(type(out), SherpaFloat)
-            self.assertEqual(out, 0.0)
+    emsg = "margs() got an unexpected keyword argument 'dummy'"
+    assert str(exc.value) == emsg
 
-        out = utils.poisson_noise([1001, 1002, 0.0, 1003, -1004])
-        self.assertEqual(type(out), numpy.ndarray)
-        self.assertEqual(out.dtype.type, SherpaFloat)
-        ans = numpy.flatnonzero(out > 0.0)
-        assert_equal(ans, numpy.array([0, 1, 3]))
+    meth = utils.export_method(c.kwargs)
+    assert meth(3, 7, foo="a", bar="b" == 25)
 
-        self.assertRaises(ValueError, utils.poisson_noise, 'ham')
-        self.assertRaises(TypeError, utils.poisson_noise, [1, 2, 'ham'])
+    with pytest.raises(TypeError) as exc:
+        meth(12, 14, 15)
 
-    def test_neville(self):
-        func = numpy.exp
-        tol = 1.0e-6
-        num = 10
-        # TODO: can we not just use vectorized code here?
-        x = []
-        y = []
-        for ii in range(num):
-            x.append(ii / float(num))
-            y.append(func(x[ii]))
-        xx = numpy.array(x)
-        yy = numpy.array(y)
-        for ii in range(num):
-            tmp = 1.01 * (ii / float(num))
-            answer = func(tmp)
-            val = utils.neville(tmp, xx, yy)
-            self.assertTrue(utils.Knuth_close(answer, val, tol))
+    emsg = "kwargs() takes from 1 to 2 positional arguments " + \
+            "but 3 were given"
+    assert str(exc.value) in emsg
 
-    def test_neville2d(self):
-        funcx = numpy.sin
-        funcy = numpy.exp
-        nrow = 10
-        ncol = 10
-        tol = 1.0e-4
-        # TODO: As with test_neville; can this not be simplified with
-        # vectorized code
-        x = numpy.zeros((nrow, ))
-        y = numpy.zeros((ncol, ))
-        fval = numpy.empty((nrow, ncol))
-        row_tmp = numpy.pi / nrow
-        # col_tmp = 1.0 / float(ncol)
-        for row in range(nrow):
-            x[row] = (row + 1.0) * row_tmp
-            for col in range(ncol):
-                y[col] = (col + 1.0) / float(ncol)
-                fval[row][col] = funcx(x[row]) * funcy(y[col])
+    meth = utils.export_method(c.bargs)
+    assert meth(3, 7, 14, 15, foo=None) == 25
 
-        for row in range(ncol):
-            xx = (-0.1 + (row + 1.0) / float(nrow)) * numpy.pi
-            for col in range(4):
-                yy = -0.1 + (col + 1.0) / float(ncol)
-                answer = funcx(xx) * funcy(yy)
-                val = utils.neville2d(xx, yy, x, y, fval)
-                self.assertTrue(utils.Knuth_close(answer, val, tol))
+    # Non-method argument
+    def f(x):
+        return 2 * x
+
+    assert utils.export_method(f) is f
+
+    # Name and module name
+    m = utils.export_method(c.m, 'foo', 'bar')
+    assert m.__name__ == 'foo'
+    assert m.__module__ == 'bar'
+    assert m(3) == 6
+    assert m(3, 7) == 21
+
+
+@pytest.mark.parametrize("func,expected",
+                         [(f1, (3, 3, 0)),
+                          (f2, (5, 1, 4)),
+                          (f3, (5, 0, 5))])
+def test_get_num_args(func, expected):
+    assert utils.get_num_args(func) == expected
+
+
+def test_get_keyword_names_f1():
+    assert utils.get_keyword_names(f1) == []
+
+
+def test_get_keyword_names_f2():
+    l = ['b', 'c', 'd', 'e']
+    assert utils.get_keyword_names(f2) == l
+    assert utils.get_keyword_names(f2, 2) == l[2:]
+    assert utils.get_keyword_names(f2, 7) == []
+
+
+def test_get_keyword_names_f3():
+    l = ['a', 'b', 'c', 'd', 'e']
+    assert utils.get_keyword_names(f3) == l
+    assert utils.get_keyword_names(f3, 1) == l[1:]
+    assert utils.get_keyword_names(f3, 7) == []
+
+
+def test_get_keyword_defaults_f1():
+    assert utils.get_keyword_defaults(f1) == {}
+
+
+def test_get_keyword_defaults_f2():
+    d = {'b': 1, 'c': 2, 'd': 3, 'e': 4}
+    assert utils.get_keyword_defaults(f2) == d
+
+    del d['b']
+    del d['c']
+    assert utils.get_keyword_defaults(f2, 2) == d
+    assert utils.get_keyword_defaults(f2, 7) == {}
+
+
+def test_get_keyword_defaults_f3():
+    d = {'a': None, 'b': 1, 'c': 2, 'd': 3, 'e': 4}
+    assert utils.get_keyword_defaults(f3) == d
+
+    del d['a']
+    assert utils.get_keyword_defaults(f3, 1) == d
+    assert utils.get_keyword_defaults(f3, 7) == {}
+
+
+def test_print_fields():
+    names = ['a', 'bb', 'ccc']
+    vals = {'a': 3, 'bb': 'Ham', 'ccc': numpy.array([1.0, 2.0, 3.0])}
+
+    out = 'a   = 3\nbb  = Ham\nccc = Float64[3]'
+    assert utils.print_fields(names, vals) == out
+
+
+def test_calc_total_error():
+    stat = numpy.array([1, 2])
+    sys = numpy.array([3, 4])
+
+    assert utils.calc_total_error(None, None) is None
+    assert (utils.calc_total_error(stat, None) == stat).all()
+    assert (utils.calc_total_error(None, sys) == sys).all()
+
+    # Unlike the above tests, only look for equivalence within
+    # a tolerance, since the numbers are manipulated rather than
+    # copied in this case (although the equation should be the same
+    # so the old approach of using equality should actually be okay
+    # here).
+    ans = numpy.sqrt(stat * stat + sys * sys)
+    assert utils.calc_total_error(stat, sys) == pytest.approx(ans)
+
+
+def test_poisson_noise():
+    out = utils.poisson_noise(1000)
+    assert type(out) == SherpaFloat
+    assert out > 0.0
+
+    for x in (-1000, 0):
+        out = utils.poisson_noise(x)
+        assert type(out) == SherpaFloat
+        assert out == 0.0
+
+    out = utils.poisson_noise([1001, 1002, 0.0, 1003, -1004])
+    assert type(out) == numpy.ndarray
+    assert out.dtype.type == SherpaFloat
+
+    ans = numpy.flatnonzero(out > 0.0)
+    assert (ans == numpy.array([0, 1, 3])).all()
+
+    with pytest.raises(ValueError):
+        utils.poisson_noise('ham')
+
+    with pytest.raises(TypeError):
+        utils.poisson_noise(1, 2, 'ham')
+
+
+def test_neville():
+    func = numpy.exp
+    tol = 1.0e-6
+    num = 10
+    # TODO: can we not just use vectorized code here?
+    x = []
+    y = []
+    for ii in range(num):
+        x.append(ii / float(num))
+        y.append(func(x[ii]))
+    xx = numpy.array(x)
+    yy = numpy.array(y)
+    for ii in range(num):
+        tmp = 1.01 * (ii / float(num))
+        answer = func(tmp)
+        val = utils.neville(tmp, xx, yy)
+        assert utils.Knuth_close(answer, val, tol)
+
+
+def test_neville2d():
+    funcx = numpy.sin
+    funcy = numpy.exp
+    nrow = 10
+    ncol = 10
+    tol = 1.0e-4
+    # TODO: As with test_neville; can this not be simplified with
+    # vectorized code
+    x = numpy.zeros((nrow, ))
+    y = numpy.zeros((ncol, ))
+    fval = numpy.empty((nrow, ncol))
+    row_tmp = numpy.pi / nrow
+    # col_tmp = 1.0 / float(ncol)
+    for row in range(nrow):
+        x[row] = (row + 1.0) * row_tmp
+        for col in range(ncol):
+            y[col] = (col + 1.0) / float(ncol)
+            fval[row][col] = funcx(x[row]) * funcy(y[col])
+
+    for row in range(ncol):
+        xx = (-0.1 + (row + 1.0) / float(nrow)) * numpy.pi
+        for col in range(4):
+            yy = -0.1 + (col + 1.0) / float(ncol)
+            answer = funcx(xx) * funcy(yy)
+            val = utils.neville2d(xx, yy, x, y, fval)
+            assert utils.Knuth_close(answer, val, tol)
 
 
 @pytest.mark.parametrize("num_tasks, num_segments",
@@ -285,7 +322,7 @@ def test_parallel_map(num_tasks, num_segments):
 
         pararesult = utils.parallel_map(f, iterable, num_tasks)
 
-        assert_equal(result, numpy.asarray(pararesult))
+        assert numpy.asarray(pararesult) == pytest.approx(result)
 
 
 @pytest.mark.parametrize("los, his, axis", [([], [], [0,1,2,3,4]),
@@ -394,6 +431,7 @@ def test_filter_bins_unordered():
     for got, exp in zip(flags, expected):
         assert got == exp
 
+
 def test_parallel_map_funcs1():
     for arg in range(1, 5):
         func = [numpy.sum]
@@ -402,7 +440,9 @@ def test_parallel_map_funcs1():
         result = []
         for func, data in zip(funcs, datas):
             result.extend(numpy.asarray(list(map(func, data))))
-        assert_equal(result, utils.parallel_map_funcs(funcs, datas, arg))
+
+        assert utils.parallel_map_funcs(funcs, datas, arg) == pytest.approx(result)
+
 
 def test_parallel_map_funcs2():
     def tst(ncores, sg, stat, opt):
@@ -410,12 +450,15 @@ def test_parallel_map_funcs2():
         f = Fit(sd, sg, stat, opt)
         result = f.fit()
         return result
+
     def cmp_results(result, tol=1.0e-3):
         assert(result.succeeded == True)
         parvals = (1.7555670572301785, 1.5092728216164186, 4.893136872267538)
         assert result.numpoints == 200
-        assert_allclose(result.parvals, parvals, rtol=tol, atol=tol)
-        
+
+        # use tol in approx?
+        assert result.parvals == pytest.approx(parvals)
+
     numpy.random.seed(0)
     x = numpy.linspace(-5., 5., 100)
     ampl = 5
@@ -432,5 +475,6 @@ def test_parallel_map_funcs2():
 
     result = tst(1, sg, stat, opt)
     cmp_results(result)
+
     result = tst(2, sg, stat, opt)
     cmp_results(result)

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -611,17 +611,19 @@ def test_create_expr_empty_mask():
     assert out == ""
 
 
-@pytest.mark.parametrize("mask,expected",
-                         [(numpy.zeros(5, dtype=numpy.bool), ""),
-                          (numpy.ones(2, dtype=numpy.bool), "1,4")])
-def test_create_expr_mask_size_error(mask, expected):
+@pytest.mark.parametrize("mask",
+                         [numpy.zeros(5, dtype=numpy.bool),
+                          numpy.ones(2, dtype=numpy.bool)])
+def test_create_expr_mask_size_error(mask):
     """What happens when the mask][True] and vals arrays have different sizes?
 
     This should be an error but currently isn't.
     """
 
-    out = utils.create_expr([1, 2, 3, 4], mask)
-    assert out == expected
+    with pytest.raises(ValueError) as exc:
+        utils.create_expr([1, 2, 3, 4], mask)
+
+    assert str(exc.value) == 'mask array mis-match with vals'
 
 
 @pytest.mark.parametrize("val,expected",
@@ -736,9 +738,7 @@ def test_create_expr_missing_start2_nomask():
     chans = chans[chans != 3]
     out = utils.create_expr(chans)
 
-    # Technically this is correct, but we would prefer the range
-    # assert out == "1-2,4-19"
-    assert out == "1,2,4-19"
+    assert out == "1-2,4-19"
 
 
 def test_create_expr_missing_start2_mask():
@@ -750,9 +750,7 @@ def test_create_expr_missing_start2_mask():
     vals = numpy.arange(19) * 0.01 + 0.4
     out = utils.create_expr(vals[filt], filt, format='%4.2f')
 
-    # Technically this is correct, but we would prefer the range
-    # assert out == "0.40-0.41,0.43-0.58"
-    assert out == "0.40,0.41,0.43-0.58"
+    assert out == "0.40-0.41,0.43-0.58"
 
 
 def test_create_expr_missing_end_nomask():
@@ -773,9 +771,7 @@ def test_create_expr_missing_multiple1_nomask():
     chans = numpy.asarray([1, 2, 4, 6, 7, 10, 18], dtype=numpy.int16)
     out = utils.create_expr(chans)
 
-    # Technically this is correct, but we would prefer the range
-    # assert out == "1-2,4,6-7,10,18"
-    assert out == "1,2,4,6-7,10,18"
+    assert out == "1-2,4,6-7,10,18"
 
 
 def test_create_expr_missing_multiple2_nomask():


### PR DESCRIPTION
# Summary

Fix an issue when applying filters to generate the plot_model and plot_model_component plots for PHA datasets.

Fixes #917

# Details

First of all I add a bunch of tests that I came up with trying to diagnose the problem.

The sherpa.utils.parse_expr and sherpa.utils.expr.create_expr now have docstrings and have seen some clean up. The create_expr changes are more extensive, but I claim is simpler than before, and also fixes a logical issue (that doesn't really have any downstream consequences). Both routines now error out for invalid cases (the parse_expr case had code claiming it raised an error but thanks to the logic of the code the error could never be raised), and the create_expr error condition is actually hit in a number of tests.

Investigating sherpa.astro.data.DataPHA.get_filter() showed (eventually) that the case was when called with group=False. The data to be passed to create_expr is supposed to be ungrouped, and the values (the energy/wavelength/channel grid) was, but the mask was taken from self.mask. The trouble is that self.mask is grouped! The solution is to use self.get_mask() in this case. I have left in a safety check to warn users if mask.sum() does not equal the number of data values, but I do not make this an error because we know there are grouping/filtering issues.

The fix for plot_model/plot_model_component comes "for free" - i.e. it doesn't require a change to the plotting code. I mention this as the driver for the fix since it seems to be the only way to trigger this issue (and is a user-visible change of this PR), even if the actual code changes are all very-low level.

Note that the fix commit - Fix subtle create_expr/DataPHA.get_filter issue - only has to change a small number of tests.

# Example

Using the code

```
from sherpa.astro import ui
ui.load_pha('/home/dburke/sherpa/sherpa-master/sherpa-test-data/sherpatest/3c273.pi')
ui.set_source(ui.powlaw1d.pl)

ui.notice(0.5, 7)
ui.ignore(2, 3)

d = ui.get_data()

print("# filter(group=True)")
print(d.get_filter(group=True, format='%.4f'))

print("# filter(group=False)")
print(d.get_filter(group=False, format='%.4f'))

ui.plot_model()
```

## Current master branch

The screen output is

```
# filter(group=True)
0.5183:1.9199,3.2339:8.2198
# filter(group=False)
0.4745:0.7811,0.7957:9.8623
```

Note that the output of get_filter(group=False) doesn't make any sense: it is not roughly 0.5:2,3:7.

The plot is

![filtered_model](https://user-images.githubusercontent.com/224638/91759674-0c302d00-eba0-11ea-8f1f-6e27db9705c9.png)

or, if we switch from line to symbols to make it more-obvious where the points are [unfortunately I created this with ifferent model parameters, so the shape is different, but the point is that we see points i the 2-3 keV range]:

```
ui.plot_model(linestyle='', marker='s')
```

![old](https://user-images.githubusercontent.com/224638/91868168-726d8c00-ec42-11ea-9472-7c21cb38e185.png)


## This PR

The screen output now provides sensible information for the filter(group=False) call:

```
# filter(group=True)
0.5183:1.9199,3.2339:8.2198
# filter(group=False)
0.4745:1.9345,3.0879:9.8623
Created: filtered_model.png
```

and the model plot now excludes the ignored range (2-3 keV):

![filtered_model](https://user-images.githubusercontent.com/224638/91759802-46013380-eba0-11ea-925d-28aa26a20c73.png)

or, if we switch from line to symbols to make it more-obvious where the points are [the model parameters are different, which is why the plot looks different, but it's the same as the above points-only plot]:

```
ui.plot_model(linestyle='', marker='s')
```

![new](https://user-images.githubusercontent.com/224638/91868270-8fa25a80-ec42-11ea-9ad5-bd549846a27c.png)


I've created the following plot by rebasing this PR onto #906 as it changes how the model plot is shown, in particular it better handles ignored bin ranges, and you get (with `ui.plot_model`):

![filtered_model](https://user-images.githubusercontent.com/224638/91762447-5ebf1880-eba3-11ea-94fc-1e9129ee7a68.png)
