### PR TITLE
enable regrid for the BinaryOpModel class (rebased #798)

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -587,6 +587,9 @@ class ArithmeticModel(Model):
             if key not in valid_keys:
                 raise TypeError("unknown keyword argument: '%s'" % key)
 
+    def regrid(self, *args, **kwargs):
+        raise NotImplementedError
+
     def startup(self, cache=False):
         self._queue = ['']
         self._cache = {}

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -597,16 +597,6 @@ class ArithmeticModel(Model):
     def apply(self, outer, *otherargs, **otherkwargs):
         return NestedModel(outer, self, *otherargs, **otherkwargs)
 
-    def regrid_1d(self, *arrays, **kwargs):
-        valid_keys = ('interp', )
-        for key in kwargs.keys():
-            if key not in valid_keys:
-                raise TypeError("unknown keyword argument: '%s'" % key)
-        eval_space = EvaluationSpace1D(*arrays)
-        regridder = ModelDomainRegridder1D(eval_space, **kwargs)
-        regridder._make_and_validate_grid(arrays)
-        return regridder.apply_to(self)
-
 
 class RegriddableModel1D(ArithmeticModel):
     """Allow 1D models to be regridded."""
@@ -628,7 +618,15 @@ class RegriddableModel1D(ArithmeticModel):
         >>> request_space = np.arange(1, 10, 0.1)
         >>> regrid_model = mybox.regrid(request_space, interp=linear_interp)
         """
-        return self.regrid_1d(*arrays, **kwargs)
+        valid_keys = ('interp', )
+        for key in kwargs.keys():
+            if key not in valid_keys:
+                raise TypeError("unknown keyword argument: '%s'" % key)
+        eval_space = EvaluationSpace1D(*arrays)
+        regridder = ModelDomainRegridder1D(eval_space, **kwargs)
+        regridder._make_and_validate_grid(arrays)
+        return regridder.apply_to(self)
+
 
 class RegriddableModel2D(ArithmeticModel):
     """Allow 2D models to be regridded."""
@@ -654,7 +652,7 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
         return self.op(self.arg.calc(p, *args, **kwargs))
 
 
-class BinaryOpModel(CompositeModel, ArithmeticModel):
+class BinaryOpModel(CompositeModel, RegriddableModel1D):
 
     @staticmethod
     def wrapobj(obj):
@@ -693,12 +691,6 @@ class BinaryOpModel(CompositeModel, ArithmeticModel):
                              (type(self.lhs).__name__, len(lhs),
                               type(self.rhs).__name__, len(rhs)))
         return val
-
-    def regrid(self, *arrays, **kwargs):
-        result = self.regrid_1d(*arrays, **kwargs)
-        for part in self:
-            part.regrid(*arrays, **kwargs)
-        return result
 
 
 class FilterModel(CompositeModel, ArithmeticModel):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -581,15 +581,6 @@ class ArithmeticModel(Model):
     def __getitem__(self, filter):
         return FilterModel(self, filter)
 
-    def check_regrid_kwargs(self, **kwargs):
-        valid_keys = ('interp', '_self',)
-        for key in kwargs.keys():
-            if key not in valid_keys:
-                raise TypeError("unknown keyword argument: '%s'" % key)
-
-    def regrid(self, *args, **kwargs):
-        raise NotImplementedError
-
     def startup(self, cache=False):
         self._queue = ['']
         self._cache = {}
@@ -607,7 +598,19 @@ class ArithmeticModel(Model):
         return NestedModel(outer, self, *otherargs, **otherkwargs)
 
 
-class RegriddableModel1D(ArithmeticModel):
+class RegriddableModel(ArithmeticModel):
+    def check_regrid_kwargs(self, **kwargs):
+        valid_keys = ('interp', '_self',)
+        for key in kwargs.keys():
+            if key not in valid_keys:
+                raise TypeError("unknown keyword argument: '%s'" % key)
+        return kwargs.get('_self', self)
+
+    def regrid(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class RegriddableModel1D(RegriddableModel):
     """Allow 1D models to be regridded."""
 
     ndim = 1
@@ -627,30 +630,24 @@ class RegriddableModel1D(ArithmeticModel):
         >>> request_space = np.arange(1, 10, 0.1)
         >>> regrid_model = mybox.regrid(request_space, interp=linear_interp)
         """
-        try:
-            self.check_regrid_kwargs(**kwargs)
-        except TypeError as te:
-            raise te
+        myself = self.check_regrid_kwargs(**kwargs)
         eval_space = EvaluationSpace1D(*args)
         regridder = ModelDomainRegridder1D(eval_space, **kwargs)
         regridder._make_and_validate_grid(args)
-        return regridder.apply_to(kwargs.get('_self', self))
+        return regridder.apply_to(myself)
 
 
-class RegriddableModel2D(ArithmeticModel):
+class RegriddableModel2D(RegriddableModel):
     """Allow 2D models to be regridded."""
 
     ndim = 2
     "A two-dimensional model."
 
     def regrid(self, *args, **kwargs):
-        try:
-            self.check_regrid_kwargs(**kwargs)
-        except TypeError as te:
-            raise te
+        myself = self.check_regrid_kwargs(**kwargs)
         eval_space = EvaluationSpace2D(*args)
         regridder = ModelDomainRegridder2D(eval_space)
-        return regridder.apply_to(kwargs.get('_self', self))
+        return regridder.apply_to(myself)
 
 
 class UnaryOpModel(CompositeModel, ArithmeticModel):
@@ -685,6 +682,8 @@ class BinaryOpModel(CompositeModel, ArithmeticModel):
 
     def regrid(self, *args, **kwargs):
         for part in self.parts:
+            # The entire model expression must be passed so
+            #  RegridWrappedModel can return the correct model expression
             return part.regrid(*args, _self=self, **kwargs)
 
     def startup(self, cache=False):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -692,6 +692,10 @@ class BinaryOpModel(CompositeModel, ArithmeticModel):
                               type(self.rhs).__name__, len(rhs)))
         return val
 
+    def regrid(self, *arrays):
+        for part in self:
+            part.regrid(*arrays)
+
 
 class FilterModel(CompositeModel, ArithmeticModel):
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -643,7 +643,6 @@ class RegriddableModel2D(RegriddableModel):
     "A two-dimensional model."
 
     def regrid(self, *args, **kwargs):
-        self.check_regrid_kwargs(**kwargs)
         eval_space = EvaluationSpace2D(*args)
         regridder = ModelDomainRegridder2D(eval_space)
         return regridder.apply_to(self)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -608,19 +608,6 @@ class RegriddableModel(ArithmeticModel):
     def regrid(self, *args, **kwargs):
         raise NotImplementedError
 
-    def regrid1D(self, *args, **kwargs):
-        self.check_regrid_kwargs(**kwargs)
-        eval_space = EvaluationSpace1D(*args)
-        regridder = ModelDomainRegridder1D(eval_space, **kwargs)
-        regridder._make_and_validate_grid(args)
-        return regridder.apply_to(self)
-
-    def regrid2D(self, *args, **kwargs):
-        self.check_regrid_kwargs(**kwargs)
-        eval_space = EvaluationSpace2D(*args)
-        regridder = ModelDomainRegridder2D(eval_space)
-        return regridder.apply_to(self)
-
 
 class RegriddableModel1D(RegriddableModel):
     """Allow 1D models to be regridded."""
@@ -642,7 +629,11 @@ class RegriddableModel1D(RegriddableModel):
         >>> request_space = np.arange(1, 10, 0.1)
         >>> regrid_model = mybox.regrid(request_space, interp=linear_interp)
         """
-        return self.regrid1D(*args, **kwargs)
+        self.check_regrid_kwargs(**kwargs)
+        eval_space = EvaluationSpace1D(*args)
+        regridder = ModelDomainRegridder1D(eval_space, **kwargs)
+        regridder._make_and_validate_grid(args)
+        return regridder.apply_to(self)
 
 
 class RegriddableModel2D(RegriddableModel):
@@ -652,7 +643,11 @@ class RegriddableModel2D(RegriddableModel):
     "A two-dimensional model."
 
     def regrid(self, *args, **kwargs):
-        return self.regrid2D(*args, **kwargs)
+        self.check_regrid_kwargs(**kwargs)
+        eval_space = EvaluationSpace2D(*args)
+        regridder = ModelDomainRegridder2D(eval_space)
+        return regridder.apply_to(self)
+
 
 class UnaryOpModel(CompositeModel, ArithmeticModel):
 
@@ -686,13 +681,13 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
 
     def regrid(self, *args, **kwargs):
         for part in self.parts:
-            if isinstance(part, RegriddableModel1D):
-                return self.regrid1D(*args, **kwargs)
-            elif isinstance(part, RegriddableModel2D):
-                return self.regrid2D(*args, **kwargs)
-            else:
-                raise NotImplementedError('unknown class type')
-
+            # ArithmeticConstantModel does not support regrid by design
+            if not hasattr(part, 'regrid'):
+                continue
+            # The full model expression must be used
+            return part.__class__.regrid(self, *args, **kwargs)
+        raise ModelErr('Neither component supports regrid method')
+    
     def startup(self, cache=False):
         self.lhs.startup(cache)
         self.rhs.startup(cache)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -599,12 +599,6 @@ class ArithmeticModel(Model):
 
 
 class RegriddableModel(ArithmeticModel):
-    def check_regrid_kwargs(self, **kwargs):
-        valid_keys = ('interp',)
-        for key in kwargs.keys():
-            if key not in valid_keys:
-                raise TypeError("unknown keyword argument: '%s'" % key)
-
     def regrid(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -629,7 +623,10 @@ class RegriddableModel1D(RegriddableModel):
         >>> request_space = np.arange(1, 10, 0.1)
         >>> regrid_model = mybox.regrid(request_space, interp=linear_interp)
         """
-        self.check_regrid_kwargs(**kwargs)
+        valid_keys = ('interp',)
+        for key in kwargs.keys():
+            if key not in valid_keys:
+                raise TypeError("unknown keyword argument: '%s'" % key)
         eval_space = EvaluationSpace1D(*args)
         regridder = ModelDomainRegridder1D(eval_space, **kwargs)
         regridder._make_and_validate_grid(args)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -598,7 +598,7 @@ class ArithmeticModel(Model):
         return NestedModel(outer, self, *otherargs, **otherkwargs)
 
     def regrid_1d(self, *arrays, **kwargs):
-        valid_keys = ('interp')
+        valid_keys = ('interp', )
         for key in kwargs.keys():
             if key not in valid_keys:
                 raise TypeError("unknown keyword argument: '%s'" % key)
@@ -697,7 +697,7 @@ class BinaryOpModel(CompositeModel, ArithmeticModel):
     def regrid(self, *arrays, **kwargs):
         result = self.regrid_1d(*arrays, **kwargs)
         for part in self:
-            part.regrid(*arrays)
+            part.regrid(*arrays, **kwargs)
         return result
 
 

--- a/sherpa/models/tests/test_regrid.py
+++ b/sherpa/models/tests/test_regrid.py
@@ -295,12 +295,55 @@ def test_runtime_interp():
 def test_regrid_binaryop():
     """issue #762, Cannot regrid a composite model (BinaryOpModel)"""
     import sherpa.astro.ui as ui
-    ui.dataspace1d(-5, 15, 1, dstype=Data1D)
-    b = Box1D()
-    c = Const1D
-    ui.set_source(ui.const1d.c1 + ui.box1d.b1)
-    mdl = ui.get_source()
-    mdl.regrid(np.linspace(-5, 15))
+
+    class MyConst1D(RegriddableModel1D):
+
+        def __init__(self, name='myconst1d'):
+            self.c0 = Parameter(name, 'c0', 3.1)
+            self.counter = 0
+            ArithmeticModel.__init__(self, name, (self.c0,))
+
+        def calc(self, par, *args, **kwargs):
+            x = args[0]
+            self.counter += x.size
+            return par[0]
+
+
+    class MyGauss(RegriddableModel1D):
+
+        def __init__(self, name='mygauss'):
+            self.sigma = Parameter(name, 'sigma', 10, min=0, max=10)
+            self.pos = Parameter(name, 'pos', 0, min=-10, max=10)
+            self.ampl = Parameter(name, 'ampl', 5)
+            self.counter = 0
+            ArithmeticModel.__init__(self, name, (self.sigma, self.pos, self.ampl))
+
+        def calc(self, par, *args, **kwargs):
+            sigma, pos, ampl = par[0], par[1], par[2]
+            x = args[0]
+            self.counter += x.size
+            return ampl * np.exp(-0.5 * (args[0] - pos)**2 / sigma**2)
+
+
+    np.random.seed(0)
+    mygauss = MyGauss()
+    myconst = MyConst1D()
+    mymodel = mygauss + myconst
+    x = np.linspace(-5., 5., 5)
+    err = 0.25
+    y = mymodel(x) + np.random.normal(mygauss.pos.val, err, x.shape)
+    ui.load_arrays(1, x, y)
+
+    x_regrid = np.linspace(-5., 5., 25)
+    mymodel_regrid = mymodel.regrid(x_regrid)
+    ui.set_source(mymodel_regrid)
+    ui.set_stat('leastsq')
+    ui.fit()
+    result = ui.get_fit_results()
+    assert result.numpoints == x.size
+    assert result.statval < 1.0
+    assert mygauss.counter == myconst.counter
+    assert (result.nfev + 4) * len(x_regrid) + len(x) == mygauss.counter
 
 
 class MyModel(RegriddableModel1D):

--- a/sherpa/models/tests/test_regrid.py
+++ b/sherpa/models/tests/test_regrid.py
@@ -292,6 +292,17 @@ def test_runtime_interp():
     assert ygot == approx(yexpected)
 
 
+def test_regrid_binaryop():
+    """issue #762, Cannot regrid a composite model (BinaryOpModel)"""
+    import sherpa.astro.ui as ui
+    ui.dataspace1d(-5, 15, 1, dstype=Data1D)
+    b = Box1D()
+    c = Const1D
+    ui.set_source(ui.const1d.c1 + ui.box1d.b1)
+    mdl = ui.get_source()
+    mdl.regrid(np.linspace(-5, 15))
+
+
 class MyModel(RegriddableModel1D):
     """
     A model that returns [100, ] * len(x) if 2.5 is in the input array x

--- a/sherpa/models/tests/test_regrid.py
+++ b/sherpa/models/tests/test_regrid.py
@@ -27,7 +27,7 @@ from sherpa.astro.data import DataIMG, DataIMGInt
 from sherpa.astro.ui.utils import Session
 from sherpa.data import Data1DInt, Data1D
 from sherpa.models.basic import Box1D
-from sherpa.models import Const1D, RegriddableModel1D, Parameter, Const2D, RegriddableModel2D, ArithmeticModel
+from sherpa.models import Const1D, RegriddableModel1D, Parameter, Const2D, RegriddableModel2D, ArithmeticModel, Gauss2D
 from sherpa.utils.err import ModelErr
 from sherpa.utils import neville, linear_interp
 from sherpa.utils import akima
@@ -292,7 +292,7 @@ def test_runtime_interp():
     assert ygot == approx(yexpected)
 
 
-def test_regrid_binaryop():
+def test_regrid_binaryop_1d():
     """issue #762, Cannot regrid a composite model (BinaryOpModel)"""
     from sherpa.stats import LeastSq
     from sherpa.fit import Fit
@@ -357,6 +357,40 @@ def test_regrid_binaryop():
     assert result.statval < 1.0
     assert mygauss.counter == myconst.counter
     assert (result.nfev + 4) * x_regrid.size  == mygauss.counter
+
+def test_regrid_binaryop_2d():
+    y0, x0 = np.mgrid[20:29, 10:20]
+    y0 = y0.flatten()
+    x0 = x0.flatten()
+
+    gmdl = Gauss2D()
+    gmdl.fwhm = 14
+    gmdl.xpos = 15
+    gmdl.ypos = 24
+    gmdl.ampl = 10
+
+    cmdl = Const2D()
+    cmdl.c0 = 4
+
+    xr1 = np.arange(10, 20, 1)
+    yr1 = np.arange(20, 29, 1)
+
+    rmdlg = gmdl.regrid(xr1, yr1)
+    rmdlc = cmdl.regrid(xr1, yr1)
+
+    shape = y0.shape
+    truthg = gmdl(x0, y0).reshape(shape)
+    truthc = cmdl(x0, y0).reshape(shape)
+    truth = truthg + truthc
+
+    ans1 = rmdlg(x0, y0).reshape(shape)
+    ans2 = rmdlc(x0, y0).reshape(shape)
+    assert (ans1 != truthg).any() == False
+    assert (ans2 != truthc).any() == False
+
+    rmdl = (gmdl + cmdl).regrid(xr1, yr1)
+    ans3 = rmdl(x0, y0).reshape(shape)
+    assert (ans3 != truth).any() == False
 
 
 class MyModel(RegriddableModel1D):

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -25,7 +25,7 @@ import pytest
 
 from sherpa.models.model import Model, ArithmeticModel, CompositeModel, \
     ArithmeticFunctionModel, RegridWrappedModel
-from sherpa.models.basic import Box1D, Const1D, Gauss1D, Const2D, Gauss2D, \
+from sherpa.models.basic import Box1D, Const1D, Gauss1D, Const2D, \
     PowLaw1D, StepLo1D
 from sherpa.models.parameter import Parameter
 from sherpa.instrument import PSFModel
@@ -774,7 +774,6 @@ def test_regrid1d_interpolation(eincr, rincr, margs, setup_1d):
     _test_regrid1d_interpolation(rtol=tol, method=method,
                                  eval_incr=eincr, req_incr=rincr, setup_1d=setup_1d)
 
-
 def test_regrid1d_int(setup_1d):
     _test_regrid1d_int(rtol=0.015, setup_1d=setup_1d)
 
@@ -1079,3 +1078,12 @@ def setup_overlapping_spaces(integrated, x_overlaps, y_overlaps):
     else:
         y2 = [-1, -2, -3], None
     return x1, y1, x2, y2, (x_overlaps and y_overlaps)
+
+def test_wrong_kwargs():
+    xgrid = np.arange(2, 6, 0.1)
+    d = Data1D('tst', xgrid, np.ones_like(xgrid))
+    mdl = Box1D()
+    requested = np.arange(1, 7, 0.1)
+    with pytest.raises(TypeError) as excinfo:
+        ygot = d.eval_model(mdl.regrid(requested, fubar='wrong_kwargs'))
+    assert "unknown keyword argument: 'fubar'" in str(excinfo.value)


### PR DESCRIPTION
# Summary

Enable composite models (created by a binary operation between two models) to be regridded. The composite model is evaluated at the new grid, and it is only the combined model expression that is rebinned to the data grid.

# Details

This is a rebased version of #798. PR #900 meant that merging required a little bit of work. 