### PR TITLE
channel settings with grouped PHA data and model plotting

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1472,8 +1472,7 @@ class DataPHA(Data1D):
                             tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if (hasattr(bkg, "group_bins")):
-                bkg.group_bins(num, tabStops=tabStops)
+            bkg.group_bins(num, tabStops=tabStops)
 
     def group_width(self, val, tabStops=None):
         """Group into a fixed bin width.
@@ -1517,8 +1516,7 @@ class DataPHA(Data1D):
                             tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if (hasattr(bkg, "group_width")):
-                bkg.group_width(val, tabStops=tabStops)
+            bkg.group_width(val, tabStops=tabStops)
 
     def group_counts(self, num, maxLength=None, tabStops=None):
         """Group into a minimum number of counts per bin.
@@ -1566,8 +1564,7 @@ class DataPHA(Data1D):
                             maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if (hasattr(bkg, "group_counts")):
-                bkg.group_counts(num, maxLength=maxLength, tabStops=tabStops)
+            bkg.group_counts(num, maxLength=maxLength, tabStops=tabStops)
 
     # DOC-TODO: see discussion in astro.ui.utils regarding errorCol
     def group_snr(self, snr, maxLength=None, tabStops=None, errorCol=None):
@@ -1623,9 +1620,8 @@ class DataPHA(Data1D):
                             errorCol=errorCol)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if (hasattr(bkg, "group_snr")):
-                bkg.group_snr(snr, maxLength=maxLength, tabStops=tabStops,
-                              errorCol=errorCol)
+            bkg.group_snr(snr, maxLength=maxLength, tabStops=tabStops,
+                          errorCol=errorCol)
 
     def group_adapt(self, minimum, maxLength=None, tabStops=None):
         """Adaptively group to a minimum number of counts.
@@ -1676,9 +1672,8 @@ class DataPHA(Data1D):
                             maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if (hasattr(bkg, "group_adapt")):
-                bkg.group_adapt(minimum, maxLength=maxLength,
-                                tabStops=tabStops)
+            bkg.group_adapt(minimum, maxLength=maxLength,
+                            tabStops=tabStops)
 
     # DOC-TODO: see discussion in astro.ui.utils regarding errorCol
     def group_adapt_snr(self, minimum, maxLength=None, tabStops=None,
@@ -1738,9 +1733,8 @@ class DataPHA(Data1D):
                             errorCol=errorCol)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if (hasattr(bkg, "group_adapt_snr")):
-                bkg.group_adapt_snr(minimum, maxLength=maxLength,
-                                    tabStops=tabStops, errorCol=errorCol)
+            bkg.group_adapt_snr(minimum, maxLength=maxLength,
+                                tabStops=tabStops, errorCol=errorCol)
 
     def eval_model(self, modelfunc):
         return modelfunc(*self.get_indep(filter=False))

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2279,6 +2279,15 @@ class DataPHA(Data1D):
         return numpy.sqrt(numpy.sum(array * array))
 
     def get_noticed_channels(self):
+        """Return the noticed channels.
+
+        Returns
+        -------
+        channels : ndarray
+            The noticed channels (this is independent of the
+            analysis setting).
+
+        """
         chans = self.channel
         mask = self.get_mask()
         if mask is not None:
@@ -2298,6 +2307,14 @@ class DataPHA(Data1D):
         return chans
 
     def get_mask(self):
+        """Returns the (ungrouped) mask.
+
+        Returns
+        -------
+        mask : ndarray or None
+            The mask, in channels, or None.
+
+        """
         groups = self.grouping
         if self.mask is False:
             return None

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1082,19 +1082,19 @@ def test_get_filter_channel_grouped(make_data_path):
     assert pha.grouped
     pha.set_analysis('channel')
 
-    # This returns "group" number
-    assert pha.get_filter() == '1:46'
+    # This returns channels (now)
+    assert pha.get_filter() == '9:850'
 
     # Reset the grouping to use an easier-to-check scheme: groups
     # have a fixed number of channels, in this case 50.
     #
     pha.group_width(50)
-    assert pha.get_filter() == '1:21'
+    assert pha.get_filter() == '25:1012'
 
     # What units does ignore use? It appears to be channels.
     pha.ignore(151, 300)
 
-    assert pha.get_filter() == '1:3,7:21'
+    assert pha.get_filter() == '25:125,325:1012'
 
 
 @requires_data
@@ -1117,12 +1117,12 @@ def test_get_filter_channel_grouped_prefiltered(make_data_path):
     pha.notice(1.0, 7.0)
 
     pha.set_analysis('channel')
-    assert pha.get_filter() == '2:10'
+    assert pha.get_filter() == '75:475'  # DOES NOT MATCH 69-480
 
     # What units does ignore use? It appears to be channels.
     pha.ignore(150, 300)
 
-    assert pha.get_filter() == '2,7:10'
+    assert pha.get_filter() == '75,325:475'  #  ODD
 
 
 @requires_data
@@ -1392,8 +1392,8 @@ def test_notice_channel_grouping(make_data_path):
 
     assert pha.get_mask() == pytest.approx(mask)
 
-    # Returns the group numbers
-    assert pha.get_filter(format='%.4f') == '14:43'
+    # Returns the channel numbers
+    assert pha.get_filter(format='%.4f') == '70:386'
 
     # Returns the channel numbers (groups 14 to 43
     # is 69 - 404).
@@ -1407,9 +1407,9 @@ def xfail(*args):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, '1:46'),
-                          (30, 2000, '3:46'),
-                          (-5, 350, '1:42'),
+                         [(-5, 2000, '9:850'),
+                          (30, 2000, '27:850'),
+                          (-5, 350, '9:356'),
                           (-20, -5, ''),
                           (2000, 3000, ''),
                          ])
@@ -1480,10 +1480,10 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
                          [(-5, 2000, ''),
-                          (30, 2000, '1:2'),
-                          (-5, 350, '43:46'),
-                          (-20, -5, '1:46'),
-                          (2000, 3000, '1:46'),
+                          (30, 2000, '9:19'),
+                          (-5, 350, '386:850'),
+                          (-20, -5, '9:850'),
+                          (2000, 3000, '9:850'),
                          ])
 def test_ignore_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1564,7 +1564,7 @@ def test_channel_changing_limits(make_data_path):
     #
     pha.notice(60, 350)
 
-    expected1 = '11:42'
+    expected1 = '60:356'
     expected2 = '60:368'
     assert pha.get_filter() == expected1
     assert pha.get_filter(group=False) == expected2

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1410,7 +1410,7 @@ def xfail(*args):
                          [(-5, 2000, '9:850'),
                           (30, 2000, '27:850'),
                           (-5, 350, '9:356'),
-                          (-20, -5, ''),
+                          xfail(-20, -5, ''),
                           (2000, 3000, ''),
                          ])
 def test_notice_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
@@ -1482,7 +1482,7 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 2000, ''),
                           (30, 2000, '9:19'),
                           (-5, 350, '386:850'),
-                          (-20, -5, '9:850'),
+                          xfail(-20, -5, '9:850'),
                           (2000, 3000, '9:850'),
                          ])
 def test_ignore_channel_grouping_outofbounds(lo, hi, expected, make_data_path):

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1,0 +1,125 @@
+#
+#  Copyright (C) 2020
+#        Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Continued testing of sherpa.astro.data."""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.data import DataPHA
+from sherpa.utils.err import DataErr
+
+
+def test_can_not_group_ungrouped():
+    """Does setting the grouping setting fail with no data?"""
+
+    pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
+    assert not pha.grouped
+    with pytest.raises(DataErr) as exc:
+        pha.grouped = True
+
+    assert str(exc.value) == "data set 'name' does not specify grouping flags"
+
+
+def test_get_mask_is_none():
+
+    pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
+    assert pha.mask is True
+    assert pha.get_mask() is None
+
+
+def test_get_filter_expr_channel():
+    """Check get_filter_expr is called"""
+
+    pha = DataPHA('name', np.asarray([1, 2, 3]), [1, 1, 1])
+    assert pha.get_filter_expr() == '1-3 Channel'
+
+    pha.ignore(None, 1)
+    assert pha.get_filter_expr() == '2-3 Channel'
+
+
+def test_get_filter_is_empty():
+
+    # Need to send in numpy arrays otherwise the code fails as it
+    # assumes a numpy array. This should be addressed upstream.
+    #
+    # pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
+    pha = DataPHA('name', np.asarray([1, 2, 3]), [1, 1, 1])
+    assert pha.get_filter() == '1:3'
+    pha.ignore()
+    assert pha.get_filter() == 'No noticed bins'
+
+
+@pytest.mark.xfail
+def test_need_numpy_channels():
+    """We need to convert the  input to NumPy arrrays.
+
+    This should be done in the constructor to DataPHA, but
+    for now error out if not set.
+    """
+
+    pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
+    assert pha.get_filter() == '1:3'
+    # This errors out with a TypeError on 'elo = self.channel - 0.5'
+    pha.ignore()
+    assert pha.get_filter() == 'No noticed bins'
+
+
+@pytest.mark.parametrize("chan", [0, -1, 4])
+def test_error_on_invalid_channel_ungrouped(chan):
+    """Does channel access fail when outside the bounds?
+
+    For ungrouped data it currently does not, but just
+    acts as an identity function.
+    """
+
+    pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
+    assert pha._to_channel(chan) == chan
+    assert pha._from_channel(chan) == chan
+
+
+@pytest.mark.parametrize("chan,exp1,exp2",
+                         [(0, 0, 0),
+                          (-1, -1, -1)])
+def test_error_on_invalid_channel_grouped(chan, exp1, exp2):
+    """Does channel access fail when outside the bounds?
+
+    It is not clear what _from_channel is doing here, so
+    just check the responses.
+    """
+
+    pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
+                  grouping=[1, -1, 1])
+    assert pha.grouped
+    assert pha._to_channel(chan) == exp1
+    assert pha._from_channel(chan) == exp2
+
+
+@pytest.mark.parametrize("chan", [-2, 4])
+def test_error_on_invalid_channel_grouped2(chan):
+    """Does channel access fail when outside the bounds?
+    """
+
+    pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
+                  grouping=[1, -1, 1])
+    assert pha.grouped
+
+    assert pha._from_channel(chan) == chan

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -99,8 +99,8 @@ def test_error_on_invalid_channel_ungrouped(chan):
 
 
 @pytest.mark.parametrize("chan,exp1,exp2",
-                         [(0, 0, 0),
-                          (-1, -1, -1)])
+                         [(0, 1, 3),
+                          (-1, 1, 1)])
 def test_error_on_invalid_channel_grouped(chan, exp1, exp2):
     """Does channel access fail when outside the bounds?
 
@@ -118,13 +118,19 @@ def test_error_on_invalid_channel_grouped(chan, exp1, exp2):
 @pytest.mark.parametrize("chan", [-2, 4])
 def test_error_on_invalid_channel_grouped2(chan):
     """Does channel access fail when outside the bounds?
+
+    This one does error out in _from_channel.
     """
 
     pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
                   grouping=[1, -1, 1])
     assert pha.grouped
+    with pytest.raises(DataErr) as exc:
+        pha._from_channel(chan)
 
-    assert pha._from_channel(chan) == chan
+    # The error message is wrong
+    # assert str(exc.value) == 'invalid group number: {}'.format(chan)
+    assert str(exc.value) == 'invalid group number: {}'.format(chan - 1)
 
 
 def test_288_a():

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -147,7 +147,7 @@ def test_288_a():
 
 
 def test_288_b():
-    """The issue from #288 which fails"""
+    """The issue from #288 which was failing"""
 
     channels = np.arange(1, 6)
     counts = np.asarray([5, 5, 10, 10, 2])
@@ -157,7 +157,7 @@ def test_288_b():
     assert pha.mask
     pha.ignore(3.1, 4)
 
-    assert pha.mask == pytest.approx([True, True, True])
+    assert pha.mask == pytest.approx([True, False, True])
 
 
 @pytest.mark.xfail
@@ -199,11 +199,11 @@ def test_416_a():
     pha.group_counts(3)
 
     # We have a simplified mask
-    mask = [False, False]
+    mask = [True, True]
     assert pha.mask == pytest.approx(mask)
 
     # the "full" mask can be retrieved with get_mask
-    mask = [False] * 10
+    mask = [True] * 10
     assert pha.get_mask() == pytest.approx(mask)
 
     grouping = [1, -1, -1, -1, -1,  1, -1, -1, -1, -1.]
@@ -213,7 +213,7 @@ def test_416_a():
     assert pha.quality == pytest.approx(quality)
 
     dep = pha.get_dep(filter=True)
-    assert dep == pytest.approx([])
+    assert dep == pytest.approx([3, 1])
 
 
 def test_416_b(caplog):

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1306,8 +1306,8 @@ def test_pha1_get_model_plot_filtered(clean_astro_ui, basic_pha1):
 @requires_fits
 @requires_data
 @pytest.mark.parametrize("units,xlabel,ylabel,xlo,xhi",
-                         [pytest.param("channel", 'Channel', 'Counts/sec/channel',
-                                       33, 677, marks=pytest.mark.xfail),
+                         [("channel", 'Channel', 'Counts/sec/channel',
+                           33, 677),
                           ("wavelength", 'Wavelength (Angstrom)', 'Counts/sec/Angstrom',
                            26.537710718511885,  1.2562229845315145),
                          ])


### PR DESCRIPTION
# Summary

Fixes a bug when filtering a grouped PHA dataset using analysis=channel. The selected bin ranges did not  always match the versions you would have got when doing the same operation with energy or wavelength analysis (the first or last bin may have been different).

Fixes issue #920 where the plot_model command could change the noticed data ranges for PHA data if the analysis was set to channel space, plot_model was called, and then to energy or wavelength.

Issues #288 and #416 have also been fixed as part of this work.

# Details

This is a bit messy, so trying to make sure we have useful tests before changing anything.

The filtering of grouped data when analysis=channel was changed to use a much simpler scheme (find the group in which the selected channel falls) rather than the previous scheme, which contained complicated logic. There are not a lot of explicit tests of this functionality (which is why a number were added to the start of this PR). An example of this change:

    expected = np.array([213, 136,  79,  47,  47,  29,  27, 18])
    for analysis in ['energy', 'wavelength', 'channel']:
        pha = sherpa.astro.io.read_pha('3c273.pi')
        pha.ignore(None, 1)
        pha.ignore(7, None)
        pha.set_analysis(analysis)
        pha.group_width(50)
        dep = pha.get_dep(filter=True)
        assert pha == pytest.approx(expected)

Without this fix the channel call would fail, since get_dep returns expected[1:] instead of expected, because of the invalid filtering that occurs when the grouping is applied.

The fix for #920 involves correctly converting between group and channel units with the notice, ignore, and get_filter methods. The initial fix was to insert it into the code path just where it was needed. This was then updated to move this conversion logic down into the DataPHA._to_channel and _from channel routines, as it makes more sense there. Issue #920 can be checked with

    ui.notice()
    ui.notice(0.5, 7)
    ui.plot_model()
    ui.set_analysis('channel')
    ui.plot_model()
    ui.set_analysis('energy')
    ui.plot_model()

There are some tests that were added that remain marked as xfail, because of issue #926 (it is a separate issue from this one and I have made no head-way on fixing it today so I'm leaving them as is).

# Example of #920

```
import logging
from matplotlib import pyplot as plt
from sherpa.astro import ui

logging.getLogger('sherpa').setLevel(logging.ERROR)
ui.load_pha('/home/dburke/sherpa/sherpa-master/sherpa-test-data/sherpatest/3c273.pi')
logging.getLogger('sherpa').setLevel(logging.INFO)

ui.notice(0.5, 7)
ui.set_source(ui.powlaw1d.pl)
pl.gamma = 1.93
pl.ampl = 1.74e-4

ui.plot_model()
ui.set_analysis('channel')
ui.plot_model()
ui.set_analysis('energy')
ui.plot_model()
plt.savefig('example.png')
``` 

So the model should show the 0.5-7 keV range, approximately, but with master we get

![OLD](https://user-images.githubusercontent.com/224638/92046413-7d164700-ed50-11ea-824b-edfafbc0386a.png)

The correct behavior in this PR is

![NEW](https://user-images.githubusercontent.com/224638/92046462-94edcb00-ed50-11ea-94cb-d770427256a7.png)

You can also see this by calling `ui.get_filter()` at this point, which returns

- ```'0.277400001884:0.605900019407'```  (master)
- ```'0.518300011754:8.219800233841'``` (this PR)
