### PR TITLE
Tests: change test_astro_sim.py::test_pragbayes_pcaarf_limits

### DIFF
--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -159,11 +159,21 @@ def test_pragbayes_pcaarf(sampler, setup):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("sampler", ["pragBayes", "fullbayes"])
-def test_pragbayes_pcaarf_limits(sampler, setup, caplog):
-    """Try and trigger limit issues"""
+def test_pragbayes_pcaarf_limits(sampler, setup, caplog, reset_seed):
+    """Try and trigger limit issues.
+
+    """
 
     from sherpa.astro.xspec import XSAdditiveModel, XSMultiplicativeModel, \
         XSwabs, XSpowerlaw
+
+    # Set the seed for the RNG. The seed was adjusted to try and make
+    # sure the coverage was "good" (i.e. hits parts of
+    # sherpa/astro/sim/*bayes.py) whilst still passing the test and
+    # reducing the runtime.  This is not a guarantee that this is the
+    # "fastest" seed, just that it's one of the better ones I've seen.
+    #
+    np.random.seed(0x723c)
 
     class HackAbs(XSwabs):
         """Restrict hard limits"""

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -23,6 +23,7 @@ import os
 import sys
 import re
 
+import numpy as np
 from numpy import VisibleDeprecationWarning
 
 from sherpa.utils.testing import SherpaTestCase
@@ -157,7 +158,7 @@ if have_astropy:
     known_warnings.update(astropy_warnings)
 
 
-"""    
+"""
 # Currently no matplotlib warnings to ignore, but leave code so it is
 # easy to add one back in
 
@@ -448,3 +449,19 @@ def restore_xspec_settings():
 
     # clean up after test
     xspec.set_xsstate(state)
+
+
+@pytest.fixture
+def reset_seed(request):
+    """Force a random seed after the test.
+
+    The random seed is set to np.random.seed() after the
+    test is done. It is expected that the test sets the
+    seed to an explicit value. Ideally we would use the
+    new NumPy RNG but we still need to support older NumPy
+    versions.
+
+    """
+
+    yield
+    np.random.seed()


### PR DESCRIPTION
# Summary

Use a known seed when testing a MCMC run, introduced in #893, to avoid occasional failures.

# Details

The test_pragbayes_pcaarf_limits test from #893 uses a random seed to
run a MCMC chain which has been engineered to trigger a number
of "problem" cases (e.g. values exceeding the parameter limits).

Unfortunately this test occasionally fails, so I've selected a
random seed to run this test with which works on my machine.

A new fixture has been added - reset_seed - which can be used for
tests for which we want to force a random seed. Note that it
resets the seed to a "random" value after the test as I want to
make sure we only force it when required.