### PR TITLE
Support overplot option in plot_fit_xxx (issue #700)

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -120,6 +120,12 @@ known_warnings = {
             # Matplotlib version 2 warnings (from HTML notebook represention)
             #
             r'Attempting to set identical bottom==top results\nin singular transformations; automatically expanding.\nbottom=1.0, top=1.0',
+
+            # See issue #571 and tests
+            # test_ui_plot.py
+            #    test_plot_fit_xxx_pylab
+            #    test_plot_fiot_xxx_overplot_pylab
+            r"Attempted to set non-positive left xlim on a log-scaled axis.*"
         ],
     RuntimeWarning:
         [r"invalid value encountered in sqrt",

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -124,8 +124,9 @@ known_warnings = {
             # See issue #571 and tests
             # test_ui_plot.py
             #    test_plot_fit_xxx_pylab
-            #    test_plot_fiot_xxx_overplot_pylab
-            r"Attempted to set non-positive left xlim on a log-scaled axis.*"
+            #    test_plot_fit_xxx_overplot_pylab
+            r"Attempted to set non-positive xlimits for log-scale axis; invalid limits will be ignored.",
+            r"Attempted to set non-positive left xlim on a log-scaled axis.*",
         ],
     RuntimeWarning:
         [r"invalid value encountered in sqrt",

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1062,24 +1062,28 @@ class SplitPlot(Plot, Contour):
         self.contour(row, col, plot, *args, **kwargs)
 
 
+# TODO: move logic from sherpa.ui.utils.Session._plot_jointplot
+#       regarding the X axis here
+#
 class JointPlot(SplitPlot):
-    "Multiple plots that share a common axis"
+    """Multiple plots that share a common axis
+
+    This supports two plots, where the top plot is twice as
+    tall as the bottom plot.
+    """
 
     def __init__(self):
         SplitPlot.__init__(self)
 
-    def _clear_window(self, row, col, erase=True):
-        if not self._cleared_window:
-            if erase:
-                backend.clear_window()
-            backend.set_jointplot(row, col, self.rows, self.cols, False)
-            self._cleared_window = True
-        else:
-            backend.set_jointplot(row, col, self.rows, self.cols)
+    def plottop(self, plot, *args, overplot=False, clearwindow=True,
+                **kwargs):
 
-    def plottop(self, plot, *args, **kwargs):
-        clearaxes = kwargs.get('clearwindow', True)
-        self._clear_window(0, 0, clearaxes)
+        create = clearwindow and not overplot
+        if create:
+            self._clear_window()
+
+        backend.set_jointplot(0, 0, self.rows, self.cols,
+                              create=create)
 
         # The code used to check if the plot was an instance of
         # FitPlot, which has been updated to check for the presence
@@ -1096,15 +1100,17 @@ class JointPlot(SplitPlot):
                 mplot.xlabel = ''
 
         kwargs['clearwindow'] = False
-        plot.plot(*args, **kwargs)
+        plot.plot(*args, overplot=overplot, **kwargs)
 
-    def plotbot(self, plot, *args, **kwargs):
-        self._clear_window(1, 0)
+    def plotbot(self, plot, *args, overplot=False, **kwargs):
+
+        backend.set_jointplot(1, 0, self.rows, self.cols,
+                              create=False)
 
         # FIXME: terrible hack to remove title from bottom
         plot.title = ''
         kwargs['clearwindow'] = False
-        plot.plot(*args, **kwargs)
+        plot.plot(*args, overplot=overplot, **kwargs)
 
 
 class DataPlot(Plot):

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -2648,3 +2648,74 @@ def test_fit_contour_recalc(session):
     assert pd.y== pytest.approx(ny)
     # just check the model is flat
     assert pm.y.min() == pm.y.max()
+
+
+@requires_pylab
+@pytest.mark.parametrize("ptype",
+                         ["resid", "ratio", "delchi"])
+def test_plot_fit_xxx_pylab(ptype):
+    """Just ensure we can create a plot_fit_xxx call."""
+
+    from matplotlib import pyplot as plt
+
+    setup_example(1)
+    pfunc = getattr(ui, 'plot_fit_{}'.format(ptype))
+    pfunc(xlog=True, ylog=True)
+
+    fig = plt.gcf()
+    axes = fig.axes
+    assert len(axes) == 2
+    assert axes[0].xaxis.get_label().get_text() == ''
+
+    assert axes[0].xaxis.get_scale() == 'log'
+    assert axes[0].yaxis.get_scale() == 'log'
+
+    assert axes[1].xaxis.get_scale() == 'log'
+    assert axes[1].yaxis.get_scale() == 'linear'
+
+    # Check we have the correct data (at least in the
+    # number of data objects). The residual plot has
+    # the data but also the axis line.
+    #
+    assert len(axes[0].lines) == 2
+    assert len(axes[1].lines) == 2
+
+
+@requires_pylab
+@pytest.mark.parametrize("ptype",
+                         ["resid", "ratio", "delchi"])
+def test_plot_fit_xxx_overplot_pylab(ptype, caplog):
+    """Just ensure we can create a plot_fit_xxx(overplot=True) call."""
+
+    from matplotlib import pyplot as plt
+
+    setup_example(1)
+    setup_example(2)
+
+    pfunc = getattr(ui, 'plot_fit_{}'.format(ptype))
+    pfunc(xlog=True, ylog=True)
+    pfunc(2, overplot=True)
+
+    fig = plt.gcf()
+    axes = fig.axes
+    assert len(axes) == 2
+    assert axes[0].xaxis.get_label().get_text() == ''
+
+    assert axes[0].xaxis.get_scale() == 'log'
+    assert axes[0].yaxis.get_scale() == 'log'
+
+    assert axes[1].xaxis.get_scale() == 'log'
+    assert axes[1].yaxis.get_scale() == 'linear'
+
+    # Check we have the correct data (at least in the
+    # number of data objects). The residual plot has
+    # the data but also the axis line.
+    #
+    assert len(axes[0].lines) == 4
+    assert len(axes[1].lines) == 4
+
+    # data is repeated so can check
+    for idx in [0, 1]:
+        l0 = axes[idx].lines
+        assert l0[0].get_xydata() == pytest.approx(l0[2].get_xydata())
+        assert l0[1].get_xydata() == pytest.approx(l0[3].get_xydata())

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -888,7 +888,7 @@ class Session(NoNewAttributesAfterInit):
     def show_model(self, id=None, outfile=None, clobber=False):
         """Display the model expression used to fit a data set.
 
-        This displays the model used to fit the data set, that is, 
+        This displays the model used to fit the data set, that is,
         the expression set by `set_model` or `set_source`
         combined with any instrumental responses, together with the
         parameter values of the model. The `show_source` function


### PR DESCRIPTION
# Summary

The overplot argument can now be used with the plot_fit_xxx and plot_bkg_fit_xxx routines (e.g. plot_fit_ratio).

Fix #700 

# Details

This allows you to say

    plot_fit_resid(ylog=True)
    plot_fit_resid(2, overplot=True)

The underlying plot objects are poorly documented, so it's not obvious what they were meant to be doing. I have taken the liberty to change things around a little bit to support the overplot setting. Tests have been added to show this is working, and fortunately it's the only use case for JointPlot in the ui code.

The tests trigger #571 so I've added a suppressor to the test code. I  would prefer this to be local to the test, rather than for the whole test suite, but that is a larger change.