### PR TITLE
Update Data1DInt / DataPHA data plots to use the histogram plot style

### DIFF
--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -179,7 +179,7 @@ def test_dataphahistogram_prepare_wavelength(make_data_path):
     pha.set_analysis('wave', type='counts')
     pha.notice(3, 5)
 
-    plot = aplot.DataPlot()
+    plot = aplot.DataPHAPlot()
     plot.prepare(pha)
 
     assert plot.xlabel == 'Wavelength (Angstrom)'
@@ -187,7 +187,11 @@ def test_dataphahistogram_prepare_wavelength(make_data_path):
     assert plot.title == 'my-name.pi'
 
     # data is inverted
-    assert plot.x[0] > plot.x[-1]
+    assert plot.xlo[0] > plot.xlo[-1]
+
+    # can we access the "pseudo" x attribute?
+    # assert plot.x[0] > plot.x[-1] Not yet
+
     assert np.all(plot.y > 0)
 
     # regression test

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -165,6 +165,41 @@ def test_plot_fail_with_non_pha(ptype):
 @requires_pylab
 @requires_data
 @requires_fits
+def test_dataphahistogram_prepare_wavelength(make_data_path):
+    """Check we can use wavelength setting"""
+
+    from sherpa.astro.io import read_pha
+
+    # could fake a dataset but it's easier to use one
+    infile = make_data_path('3c273.pi')
+    pha = read_pha(infile)
+    pha.name = 'my-name.pi'
+
+    # Also check out the type='counts' option
+    pha.set_analysis('wave', type='counts')
+    pha.notice(3, 5)
+
+    plot = aplot.DataPlot()
+    plot.prepare(pha)
+
+    assert plot.xlabel == 'Wavelength (Angstrom)'
+    assert plot.ylabel == 'Counts/Angstrom'
+    assert plot.title == 'my-name.pi'
+
+    # data is inverted
+    assert plot.x[0] > plot.x[-1]
+    assert np.all(plot.y > 0)
+
+    # regression test
+    yexp = np.asarray([39.44132393, 68.92072985, 64.39425057,
+                       48.69954162, 41.17454851, 88.87982014,
+                       74.70504415, 79.22094498, 94.57773635])
+    assert plot.y == pytest.approx(yexp)
+
+
+@requires_pylab
+@requires_data
+@requires_fits
 def test_modelphahistogram_prepare_wavelength(make_data_path):
     """Check we can use wavelength setting"""
 

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -190,7 +190,7 @@ def test_dataphahistogram_prepare_wavelength(make_data_path):
     assert plot.xlo[0] > plot.xlo[-1]
 
     # can we access the "pseudo" x attribute?
-    # assert plot.x[0] > plot.x[-1] Not yet
+    assert plot.x[0] > plot.x[-1]
 
     assert np.all(plot.y > 0)
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -775,7 +775,7 @@ def test_list_pileup_ids_multi(clean_astro_ui):
     assert ans == [1, "2"]
 
 
-def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
+def check_bad_grouping(exp_xlo,exp_xhi, exp_counts, lo1, hi1, lo2, hi2):
     """Common tests from test_grouped_pha_all_badXXX
 
     Sending in two ranges is a bit excessive but easiest
@@ -786,7 +786,8 @@ def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
     assert cts == pytest.approx([exp_counts])
 
     dplot = ui.get_data_plot()
-    assert dplot.x == pytest.approx([exp_xmid])
+    assert dplot.xlo == pytest.approx([exp_xlo])
+    assert dplot.xhi == pytest.approx([exp_xhi])
     assert dplot.y == pytest.approx([exp_counts])
 
     # ignore all the data
@@ -800,7 +801,8 @@ def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
     assert len(cts) == 0
 
     dplot = ui.get_data_plot()
-    assert len(dplot.x) == 0
+    assert len(dplot.xlo) == 0
+    assert len(dplot.xhi) == 0
     assert len(dplot.y) == 0
 
     # ignore does not fail
@@ -814,7 +816,8 @@ def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
     assert cts == pytest.approx([exp_counts])
 
     dplot = ui.get_data_plot()
-    assert dplot.x == pytest.approx([exp_xmid])
+    assert dplot.xlo == pytest.approx([exp_xlo])
+    assert dplot.xhi == pytest.approx([exp_xhi])
     assert dplot.y == pytest.approx([exp_counts])
 
     # now ignore the bad channels (ie everything)
@@ -825,7 +828,8 @@ def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
     assert len(cts) == 0
 
     dplot = ui.get_data_plot()
-    assert len(dplot.x) == 0
+    assert len(dplot.xlo) == 0
+    assert len(dplot.xhi) == 0
     assert len(dplot.y) == 0
 
     # there's nothing to notice (this line is an example of #790)
@@ -835,7 +839,8 @@ def check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2):
     assert len(cts) == 0
 
     dplot = ui.get_data_plot()
-    assert len(dplot.x) == 0
+    assert len(dplot.xlo) == 0
+    assert len(dplot.xhi) == 0
     assert len(dplot.y) == 0
 
 
@@ -860,16 +865,16 @@ def test_grouped_pha_all_bad_channel(clean_astro_ui):
     ui.set_data(dset)
 
     # Run tests
-    check_bad_grouping(3, 0.8, 0, 6, 2, 10)
+    check_bad_grouping(1, 6, 0.8, 0, 6, 2, 10)
 
 
 @pytest.mark.parametrize("arf,rmf", [(True, False), (False, True), (True, True)])
-@pytest.mark.parametrize("chantype,exp_counts,exp_xmid,lo1,hi1,lo2,hi2",
-                         [("channel", 0.8, 3, 0, 7, 2, 6),
-                          ("energy", 8.0, 0.35, 0.05, 1.0, 0.2, 0.8),
-                          ("wave", 0.03871461, 52.59935223, 20, 90, 30, 85)
+@pytest.mark.parametrize("chantype,exp_counts,exp_xlo,exp_xhi,lo1,hi1,lo2,hi2",
+                         [("channel", 0.8, 1.0, 6, 0, 7, 2, 6),
+                          ("energy", 8.0, 0.1, 0.6, 0.05, 1.0, 0.2, 0.8),
+                          ("wave", 0.03871461, 123.9841874, 20.66403123, 20, 90, 30, 85)
                          ])
-def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xmid, lo1, hi1, lo2, hi2, clean_astro_ui):
+def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xlo, exp_xhi, lo1, hi1, lo2, hi2, clean_astro_ui):
     """Helpdesk ticket: low-count data had no valid bins after grouping #790
 
     A simple PHA dataset is created, which has no "good" grouped data
@@ -913,7 +918,7 @@ def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xmid, 
     ui.set_analysis(chantype)
 
     # Run tests
-    check_bad_grouping(exp_xmid, exp_counts, lo1, hi1, lo2, hi2)
+    check_bad_grouping(exp_xlo, exp_xhi, exp_counts, lo1, hi1, lo2, hi2)
 
 
 @requires_fits

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -2367,6 +2367,55 @@ def test_data1d_plot_model(cls, plottype, extraargs, title):
 @requires_pylab
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+@pytest.mark.parametrize("plottype,extraargs,title,plotcls",
+                         [("model", [], "Model",
+                           sherpa.plot.ModelPlot),
+                          ("model_component", ['mdl'],
+                           "Model component: polynom1d.mdl",
+                           sherpa.plot.ComponentModelPlot),
+                          ("source", [], "Source",
+                           sherpa.plot.SourcePlot),
+                          ("source_component", ['mdl'],
+                           "Source model component: polynom1d.mdl",
+                           sherpa.plot.ComponentSourcePlot)])
+def test_data1dint_get_model_plot(cls, plottype, extraargs, title, plotcls):
+    """Check we can plot a Data1DInt model.
+
+    For the Data1DInt case source and model return the
+    same plots apart for the title.
+
+    Note that we test both Session classes here.
+    """
+
+    from matplotlib import pyplot as plt
+
+    xlo = np.asarray([10, 12, 16, 20, 22])
+    xhi = np.asarray([12, 16, 19, 22, 26])
+    y = np.asarray([50, 54, 58, 60, 64])
+    yexp = np.asarray([22, 56, 52.5, 42, 96])
+
+    s = cls()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(1, xlo, xhi, y, Data1DInt)
+
+    mdl = s.create_model_component('polynom1d', 'mdl')
+    mdl.c0 = 0
+    mdl.c1 = 1
+
+    s.set_source(mdl)
+
+    plot = getattr(s, "get_{}_plot".format(plottype))(*extraargs)
+
+    assert isinstance(plot, plotcls)
+    assert plot.title == title
+    assert plot.x == pytest.approx((xlo + xhi) / 2)
+    assert plot.y == pytest.approx(yexp)
+
+
+@requires_pylab
+@pytest.mark.parametrize("cls",
+                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
                          [("model", [], "Model"),
                           ("model_component", ['tmdl'],

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -448,7 +448,7 @@ def test_get_bkg_plot_energy(idval, clean_astro_ui):
         bp = ui.get_bkg_plot(idval)
 
     assert bp.xlo == pytest.approx(_energies_lo)
-    # assert bp.x == pytest.approx(_energies_mid)  will be added back in a later PR
+    assert bp.x == pytest.approx(_energies_mid)
 
     # normalise by exposure time and bin width
     #

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -64,12 +64,14 @@ class Session(sherpa.ui.utils.Session):
         self._background_models = {}
         self._background_sources = {}
 
+        self._dataphaplot = sherpa.astro.plot.DataPHAPlot()
         self._astrosourceplot = sherpa.astro.plot.SourcePlot()
         self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
         self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
         self._modelhisto = sherpa.astro.plot.ModelHistogram()
         self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
 
+        # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
         self._bkgdataplot = sherpa.astro.plot.BkgDataPlot()
         self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
         self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
@@ -171,6 +173,7 @@ class Session(sherpa.ui.utils.Session):
         self._modelhisto = sherpa.astro.plot.ModelHistogram()
         self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
 
+        # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
         self._bkgdataplot = sherpa.astro.plot.BkgDataPlot()
         self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
         self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
@@ -10222,6 +10225,20 @@ class Session(sherpa.ui.utils.Session):
     # Plotting
     ###########################################################################
 
+    def get_data_plot_prefs(self, id=None):
+
+        try:
+            d = self.get_data(id)
+            if isinstance(d, sherpa.astro.data.DataPHA):
+                return self._dataphaplot.histo_prefs
+
+        except IdentifierErr:
+            pass
+
+        return super().get_data_plot_prefs(id)
+
+    get_data_plot_prefs.__doc__ = sherpa.ui.utils.Session.get_data_plot_prefs.__doc__
+
     def get_model_plot_prefs(self, id=None):
 
         try:
@@ -10236,10 +10253,28 @@ class Session(sherpa.ui.utils.Session):
 
     get_model_plot_prefs.__doc__ = sherpa.ui.utils.Session.get_model_plot_prefs.__doc__
 
-    # also in sherpa.utils; it does not seem worthwhile creating a new
-    # docstring here
+    def get_data_plot(self, id=None, recalc=True):
+        try:
+            d = self.get_data(id)
+        except IdentifierErr:
+            return super().get_data_plot(id, recalc=recalc)
+
+        if isinstance(d, sherpa.astro.data.DataPHA):
+            plotobj = self._dataphaplot
+            if recalc:
+                plotobj.prepare(d, self.get_stat())
+            return plotobj
+
+        return super().get_data_plot(id, recalc=recalc)
+
+    get_data_plot.__doc__ = sherpa.ui.utils.Session.get_data_plot.__doc__
+
     def get_model_plot(self, id=None, recalc=True):
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr:
+            return super().get_model_plot(id, recalc=recalc)
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._modelhisto
             if recalc:
@@ -12395,8 +12430,8 @@ class Session(sherpa.ui.utils.Session):
                                     clearwindow=clearwindow, **kwargs)
 
             oldval = plot2.plot_prefs['xlog']
-            if (('xlog' in self._bkgdataplot.plot_prefs and
-                 self._bkgdataplot.plot_prefs['xlog']) or
+            if (('xlog' in self._bkgdataplot.histo_prefs and
+                 self._bkgdataplot.histo_prefs['xlog']) or
                 ('xlog' in self._bkgmodelplot.histo_prefs and
                  self._bkgmodelplot.histo_prefs['xlog'])):
                 plot2.plot_prefs['xlog'] = True

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -524,6 +524,23 @@ class HistogramPlot(Histogram):
         """Return a HTML (string) representation of the histogram plot."""
         return backend.as_html_histogram(self)
 
+    @property
+    def x(self):
+        """Return (xlo + xhi) / 2
+
+        This is intended to make it easier to swap between
+        plot- and histogram-style plots by providing access
+        to an X value.
+        """
+
+        if self.xlo is None or self.xhi is None:
+            return  None
+
+        # As we do not (yet) require NumPy arrays, enforce it.
+        xlo = numpy.asarray(self.xlo)
+        xhi = numpy.asarray(self.xhi)
+        return (xlo + xhi) / 2
+
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -217,6 +217,7 @@ def point(x, y, overplot=True, clearwindow=False,
 
 def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
           overplot=False, clearwindow=True,
+          xerrorbars=False,
           yerrorbars=False,
           ecolor=_errorbar_defaults['ecolor'],
           capsize=_errorbar_defaults['capsize'],
@@ -290,7 +291,7 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
     objs = plot(x, y2, yerr=None, xerr=None,
                 title=title, xlabel=xlabel, ylabel=ylabel,
                 overplot=overplot, clearwindow=clearwindow,
-                xerrorbars=False, yerrorbars=yerrorbars,
+                xerrorbars=False, yerrorbars=False,
                 ecolor=ecolor, capsize=capsize, barsabove=barsabove,
                 xlog=xlog, ylog=ylog,
                 linestyle=linestyle,
@@ -303,19 +304,22 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
     # also be used for marker[face]color and ecolor?
     #
     xmid = 0.5 * (xlo + xhi)
+    xerr = (xhi - xlo) / 2 if xerrorbars else None
+    yerr = yerr if yerrorbars else None
+
     try:
         color = objs[0].get_color()
     except AttributeError:
         pass
-
-    # How do we want to handle X errors?
-    xerr = None
 
     axes = plt.gca()
     zorder = find_zorder(axes)
 
     # Do not draw a line connecting the points
     #
+    # Unlike plot, using errorbar for both cases.
+    #
+
     axes.errorbar(xmid, y, yerr, xerr,
                   color=color,
                   alpha=alpha,
@@ -436,6 +440,9 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
 
     # Rely on color-cycling to work for both the "no errorbar" and
     # "errorbar" case.
+    #
+    # TODO: do we really need this, or can we just use errorbar
+    #       for both cases?
     #
     if xerrorbars or yerrorbars:
         if markerfacecolor is None:

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -31,6 +31,7 @@ from sherpa import plot as sherpaplot
 from sherpa.data import Data1D, Data1DInt
 from sherpa.utils.testing import requires_data, requires_plotting
 
+
 _datax = numpy.array(
     [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
        11.,  12.,  13.,  14.,  15.,  16.,  17.,  18.,  19.,  20.,  21.,
@@ -603,3 +604,51 @@ def test_errors_with_no_stat():
     dp = sherpaplot.DataPlot()
     dp.prepare(d, stat=None)
     assert dp.yerr is None
+
+
+def test_histogram_returns_x():
+    """We support x accessor for histogram plots."""
+
+    xlo = [10, 20, 40, 80]
+    xhi = [20, 40, 60, 90]
+    y = [1, 2, 3, 4]
+    d = Data1DInt('xx', xlo, xhi, y)
+
+    dp = sherpaplot.DataHistogramPlot()
+    dp.prepare(d)
+
+    xlo = numpy.asarray(xlo)
+    xhi = numpy.asarray(xhi)
+
+    assert dp.xlo == pytest.approx(xlo)
+    assert dp.xhi == pytest.approx(xhi)
+    assert dp.x == pytest.approx(0.5 * (xlo + xhi))
+
+    # check x is not in the str output
+    #
+    for line in str(dp).split('\n'):
+        toks = line.split()
+        assert len(toks) > 2
+        assert toks[0] != 'x'
+
+
+def test_histogram_can_not_set_x():
+    """We cannot change the x accessor"""
+
+    xlo = [10, 20, 40, 80]
+    xhi = [20, 40, 60, 90]
+    y = [1, 2, 3, 4]
+    d = Data1DInt('xx', xlo, xhi, y)
+
+    dp = sherpaplot.DataHistogramPlot()
+    dp.prepare(d)
+
+    with pytest.raises(AttributeError):
+        dp.x = xlo
+
+
+def test_histogram_empty_x():
+    """x accessor is None if there's no data"""
+
+    dp = sherpaplot.DataHistogramPlot()
+    assert dp.x is None

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -27,7 +27,8 @@ import sherpa.all as sherpa
 from sherpa.ui.utils import Session as BaseSession
 from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.models import basic
-from sherpa.data import Data1DInt
+from sherpa import plot as sherpaplot
+from sherpa.data import Data1D, Data1DInt
 from sherpa.utils.testing import requires_data, requires_plotting
 
 _datax = numpy.array(
@@ -593,3 +594,12 @@ def test_numpy_histogram_density_vs_normed():
     assert plot.y == pytest.approx(expected_y)
     assert plot.xlo == pytest.approx(expected_xlo)
     assert plot.xhi == pytest.approx(expected_xhi)
+
+
+def test_errors_with_no_stat():
+    """Check we get no errors when stat is None"""
+
+    d = Data1D('x', numpy.asarray([2, 4, 10]), numpy.asarray([2, 4, 0]))
+    dp = sherpaplot.DataPlot()
+    dp.prepare(d, stat=None)
+    assert dp.yerr is None

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -41,7 +41,8 @@ from sherpa.plot import CDFPlot, DataPlot, FitPlot, ModelPlot, \
     PDFPlot, PSFPlot, PSFKernelPlot, ScatterPlot, TracePlot,\
     DataContour, ModelContour, SourceContour, ResidContour, \
     RatioContour, FitContour, PSFContour, LRHistogram, \
-    ModelHistogramPlot, ResidPlot, RatioPlot, DelchiPlot, ChisqrPlot
+    ModelHistogramPlot, ResidPlot, RatioPlot, DelchiPlot, ChisqrPlot, \
+    DataHistogramPlot
 
 from sherpa.stats import Chi2Gehrels
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr
@@ -196,13 +197,15 @@ def test_plot_prefs_xxx_data1dint(session, ptype):
 
     # It's not easy to check the difference between
     # point and histogram preferences. Some differences
-    # are xerrorbars, xaxis, and ratioline.
+    # are xaxis and ratioline.
+    #
+    # I also check xerrorbars as we want this for histograms.
     #
     prefs = get_prefs()
-    assert 'xerrorbars' not in prefs or ptype == 'data'
-    assert 'xaxis' not in prefs or ptype == 'data'
-    assert 'ratioline' not in prefs or ptype == 'data'
-    assert not prefs['xlog'] or ptype == 'data'
+    assert 'xerrorbars' in prefs
+    assert 'xaxis' not in prefs
+    assert 'ratioline' not in prefs
+    assert not prefs['xlog']
 
     prefs = get_prefs(2)
     assert 'xerrorbars' in prefs
@@ -1946,13 +1949,14 @@ def test_data_plot_recalc(session):
     s.load_arrays(1, [20, 30, 40], [25, 40, 60], [10, 12, 14], Data1DInt)
 
     p = s.get_data_plot(recalc=False)
-    assert isinstance(p, DataPlot)
-    assert p.x == pytest.approx([1, 2])
-    assert p.y == pytest.approx([1, 0])
+    assert isinstance(p, DataHistogramPlot)
+    assert p.xlo is None
+    assert p.y is None
 
     p = s.get_data_plot(recalc=True)
-    assert isinstance(p, DataPlot)
-    assert p.x == pytest.approx([22.5, 35, 50])
+    assert isinstance(p, DataHistogramPlot)
+    assert p.xlo == pytest.approx([20, 30, 40])
+    assert p.xhi == pytest.approx([25, 40, 60])
     assert p.y == pytest.approx([10, 12, 14])
 
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -170,13 +170,14 @@ def test_plot_prefs_xxx(session, ptype, arg):
 
 @requires_plotting
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_prefs_model_data1dint(session):
-    """Data1DInt model class is different to Data1D
+@pytest.mark.parametrize("ptype", ["data", "model"])
+def test_plot_prefs_xxx_data1dint(session, ptype):
+    """Data1DInt is different to Data1D.
     """
 
     s = session()
 
-    get_prefs = getattr(s, 'get_model_plot_prefs')
+    get_prefs = getattr(s, 'get_{}_plot_prefs'.format(ptype))
 
     s.load_arrays(1, [1, 2, 4], [2, 3, 5], [4, 5, 10],
                   Data1DInt)
@@ -190,20 +191,25 @@ def test_plot_prefs_model_data1dint(session):
     assert 'xerrorbars' in prefs
     assert 'xaxis' in prefs
     assert 'ratioline' in prefs
+    assert not prefs['xlog']
+    prefs['xlog'] = True
 
     # It's not easy to check the difference between
     # point and histogram preferences. Some differences
     # are xerrorbars, xaxis, and ratioline.
     #
     prefs = get_prefs()
-    assert 'xerrorbars' not in prefs
-    assert 'xaxis' not in prefs
-    assert 'ratioline' not in prefs
+    assert 'xerrorbars' not in prefs or ptype == 'data'
+    assert 'xaxis' not in prefs or ptype == 'data'
+    assert 'ratioline' not in prefs or ptype == 'data'
+    assert not prefs['xlog'] or ptype == 'data'
 
     prefs = get_prefs(2)
     assert 'xerrorbars' in prefs
     assert 'xaxis' in prefs
     assert 'ratioline' in prefs
+    assert prefs['xlog']
+
 
 def change_example(idval):
     """Change the example y values (created by setup_example)"""

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -343,6 +343,7 @@ class Session(NoNewAttributesAfterInit):
         self._splitplot = sherpa.plot.SplitPlot()
         self._jointplot = sherpa.plot.JointPlot()
         self._dataplot = sherpa.plot.DataPlot()
+        self._datahistplot = sherpa.plot.DataHistogramPlot()
         self._modelplot = sherpa.plot.ModelPlot()
         self._modelhistplot = sherpa.plot.ModelHistogramPlot()
 
@@ -10569,7 +10570,21 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._dataplot
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_data_plot was last called.
+        #
+        try:
+            is_int = isinstance(self.get_data(id), sherpa.data.Data1DInt)
+        except IdentifierErr:
+            is_int = False
+
+        if is_int:
+            plotobj = self._datahistplot
+        else:
+            plotobj = self._dataplot
+
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_stat())
         return plotobj
@@ -10688,7 +10703,14 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # At the moment id is ignored
+        try:
+            d = self.get_data(id)
+            if isinstance(d, sherpa.data.Data1DInt):
+                return self._datahistplot.histo_prefs
+
+        except IdentifierErr:
+            pass
+
         return self._dataplot.plot_prefs
 
     # also in sherpa.astro.utils (copies this docstring)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -11021,7 +11021,6 @@ class Session(NoNewAttributesAfterInit):
 
         return self._modelplot.plot_prefs
 
-
     def get_fit_plot(self, id=None, recalc=True):
         """Return the data used to create the fit plot.
 


### PR DESCRIPTION
# Summary

Switch the plot_data/plot_bkg plots to draw the data as histograms for Data1DInt and DataPHA plots. By default this doesn't change anything significant (just the x-axis range of the plot), but you can tweak things, such as set `linestyle='-'` to see the bin edges.

This will change the behavior of code that accesses the plot data - e.g. get_data_plot() or the dataplot element of get_fit_plot() - since for DataPHA and Data1DInt datasets the data will no-longer have an x attribute but xlo and xhi. To reduce the need for code changes for existing scripts - as many people use get_model_plot and get_data_plot to get the data - the histogram plots will return (xlo+xhi)/2 when asked for the x attribute.

# Details

It builds off of the changes in #906 to draw models of Data1DInt/DataPHA as histograms, and fixes up a corner case left from that work (the handling of the `xerrorbars` setting).

The choice for what to do when you call get_data_plot(id, recalc=False) is interesting, as we don't know what the data type was before hand - e.g. it could have been Data1D although now it's Data1DInt. This is too hard to fix, so I think it's best to just return the plot object of the current "dataset=id" value.

I've added in a fix for the handling of the background id when sherpa.astro.ui.set_default_id is used - it previously changed both the default dataset id and the default id for the background dataset, but unfortunately we don't actually allow the DataPHA object to change that setting, leading to odd behavior. The easiest solution is to just not change the default background id when set_default_id is called.

# Example - 1D Int

```
In [2]: ui.load_arrays(1, [2, 4, 8], [4, 6, 10], [10, 12, 7], ui.Data1DInt)
In [3]: ui.plot_data()
```

![FIG](https://user-images.githubusercontent.com/224638/92282866-8a584080-eecc-11ea-9eea-a2c10b41b085.png)

This should be unchanged compared to the master branch (well, actually this covers the full range of the X axis, so 2-10, whereas the master branch just shows the centers of the bins (so 3-9).

If I tweak things I get:

```
In [4]: ui.plot_data(linestyle='-', marker='')
```

![FIG](https://user-images.githubusercontent.com/224638/92282939-b70c5800-eecc-11ea-8e90-94001ac0a925.png)

Here's what this plot looks like with the current code (you can see the restricted range of the axis):

![FIG](https://user-images.githubusercontent.com/224638/92283044-03f02e80-eecd-11ea-93ff-e7f1c06b4ed3.png)

You can try to make it "more histogramey", but I still don't like it (note this is with the current master branch, not this PR):

```
In [4]: ui.plot_data(linestyle='-', marker='', drawstyle='steps-mid')
```
![FIG](https://user-images.githubusercontent.com/224638/92283132-3e59cb80-eecd-11ea-8594-47fefb4480e3.png)

# Example - PHA

```
>>> ui.load_pha('sherpa-test-data/sherpatest/3c273.pi')
>>> ui.notice(0.5, 7)
>>> ui.ignore(2.5, 3)
>>> ui.set_source(ui.xsphabs.gal * ui.xspowerlaw.pl)
>>> gal.nh = 0.05; pl.phoindex = 1.98; pl.norm = 1.93e-4
>>> ui.plot_data()
```

This doesn't look much different (although the x-axis range is slightly larger as it covers xlo/first bin to xhi/last bin, rather than (xlo+xhi)/2.

![FIG](https://user-images.githubusercontent.com/224638/92330904-936a1e80-f040-11ea-81ad-0e1771bb5b27.png)

```
>>> ui.plot_data(linestyle='-', marker='', xlog=True)
```

This shows odd the "proper" histogram display now:

![FIG](https://user-images.githubusercontent.com/224638/92330949-dd530480-f040-11ea-83ae-8ab85f8a476c.png)

```
>>> ui.plot_data(xerrorbars=True, xlog=True)
```

We still get error bars (although they look very similar to the linestyle='-' version now):

![FIG](https://user-images.githubusercontent.com/224638/92330991-1f7c4600-f041-11ea-9380-bfa0d5c24de9.png)

```
>>> ui.plot_data(xerrorbars=True, xlog=True)
```

Default plot as normal

![FIG](https://user-images.githubusercontent.com/224638/92331011-4aff3080-f041-11ea-91b8-41241588bdca.png)

A different version

```
>> ui.plot_fit(xlog=True, ylog=True, linestyle='-', marker='')
```

![FIG](https://user-images.githubusercontent.com/224638/92331022-69652c00-f041-11ea-85c1-4c60b3a05508.png)
