### PR TITLE
Tests: support Crates as well as the AstroPy backend

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -92,12 +92,11 @@ def test_setup_pha1_file_group(id, make_data_path, clean_astro_ui, hide_logging)
     sdata = ui.get_data(id)
     bdata = ui.get_bkg(id)
 
-    dtype = np.dtype('>i2')  # why not np.dtype(np.int16)?
-    assert sdata.grouping.dtype == dtype
-    assert bdata.grouping.dtype == dtype
+    assert sdata.grouping.dtype.type == np.int16
+    assert bdata.grouping.dtype.type == np.int16
 
-    assert sdata.quality.dtype == dtype
-    assert bdata.quality.dtype == dtype
+    assert sdata.quality.dtype.type == np.int16
+    assert bdata.quality.dtype.type == np.int16
 
     assert sdata.grouped
     assert bdata.grouped


### PR DESCRIPTION
# Summary

Update a test to pass when run using the Crates I/O backend.

# Details

The Crates and AstroPy I/O backends are not guaranteed to return
exactly the same datatypes, so change a datatype check to be more
generic (checking the type attribute of the dtype to support synonyms).