### PR TITLE
Improve handling of the default id with PHA background datasets (fix issue #943)

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1098,7 +1098,8 @@ def fail(x):
                                       fail(ui.plot_bkg_fit_ratio),
                                       fail(ui.plot_bkg_fit_delchi)])
 def test_pha1_bkg_plot(plotfunc, clean_astro_ui, basic_pha1, hide_logging):
-    """These fail because of issue #943"""
+    """Test issue #943 and general check of plot_bkg_xxx"""
+
     ui.unsubtract()
     ui.set_bkg_source(ui.const1d.bmdl + ui.gauss1d.bgmdl)
     plotfunc()

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1084,19 +1084,15 @@ def test_pha1_plot(clean_astro_ui, basic_pha1, plotfunc):
     plotfunc()
 
 
-def fail(x):
-    return pytest.param(x, marks=pytest.mark.xfail)
-
-
 @requires_plotting
 @requires_fits
 @requires_data
-@pytest.mark.parametrize("plotfunc", [fail(ui.plot_bkg_model),
+@pytest.mark.parametrize("plotfunc", [ui.plot_bkg_model,
                                       ui.plot_bkg_source,
-                                      fail(ui.plot_bkg_fit),
-                                      fail(ui.plot_bkg_fit_resid),
-                                      fail(ui.plot_bkg_fit_ratio),
-                                      fail(ui.plot_bkg_fit_delchi)])
+                                      ui.plot_bkg_fit,
+                                      ui.plot_bkg_fit_resid,
+                                      ui.plot_bkg_fit_ratio,
+                                      ui.plot_bkg_fit_delchi])
 def test_pha1_bkg_plot(plotfunc, clean_astro_ui, basic_pha1, hide_logging):
     """Test issue #943 and general check of plot_bkg_xxx"""
 
@@ -2745,7 +2741,7 @@ def test_pha1_bkg_fit_plot_no_model(clean_astro_ui, basic_pha1):
     with pytest.raises(ModelErr) as exc:
         ui.get_bkg_fit_plot('tst')
 
-    emsg = 'background model tst for data set tst has not been set'
+    emsg = 'background model 1 for data set tst has not been set'
     assert str(exc.value) == emsg
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -248,7 +248,6 @@ def test_delete_bkg_model(clean_astro_ui):
     assert set(mdls) == set(['bmdl', 'gmdl'])
 
 
-@pytest.mark.xfail
 def test_default_background_issue(clean_astro_ui):
     """Test issue #943"""
 
@@ -272,7 +271,6 @@ def test_default_background_issue(clean_astro_ui):
     assert mdl2.c0.val == pytest.approx(2 / 3 / 0.1)
 
 
-@pytest.mark.xfail
 def test_show_bkg_model_issue943(clean_astro_ui):
     """Test issue #943
 
@@ -294,7 +292,6 @@ def test_show_bkg_model_issue943(clean_astro_ui):
     ui.show_bkg_model()
 
 
-@pytest.mark.xfail
 def test_default_background_issue_fit(clean_astro_ui):
     """Test issue #943 with fit
 
@@ -342,7 +339,7 @@ def test_bkg_id_get_bkg_source(clean_astro_ui):
     with pytest.raises(ModelErr) as exc:
         ui.get_bkg_source()
 
-    assert str(exc.value) == 'background model x for data set x has not been set'
+    assert str(exc.value) == 'background model 1 for data set x has not been set'
 
 
 def test_fix_background_id_error_checks1():

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -32,7 +32,7 @@ import pytest
 
 from sherpa.astro import ui
 from sherpa.utils import poisson_noise
-from sherpa.utils.err import ArgumentTypeErr, DataErr, ModelErr
+from sherpa.utils.err import ArgumentTypeErr, DataErr, IdentifierErr, ModelErr
 
 
 # This is part of #397
@@ -246,3 +246,148 @@ def test_delete_bkg_model(clean_astro_ui):
     # components still exist
     mdls = ui.list_model_components()
     assert set(mdls) == set(['bmdl', 'gmdl'])
+
+
+@pytest.mark.xfail
+def test_default_background_issue(clean_astro_ui):
+    """Test issue #943"""
+
+    ui.set_default_id('x')
+
+    # use least-square as we don't really care about the fit
+    ui.set_stat('leastsq')
+
+    ui.load_arrays('x', [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    arf = ui.create_arf(np.asarray([0.1, 0.2, 0.3]), np.asarray([0.2, 0.3, 0.4]))
+    bkg.set_arf(arf)
+    ui.set_bkg(bkg)
+
+    ui.set_bkg_source(ui.const1d.mdl2)
+
+    # Ensure we can fit the background model. Prior to #943 being
+    # fixed the fit_bkg call would error out.
+    #
+    ui.fit_bkg()
+    assert mdl2.c0.val == pytest.approx(2 / 3 / 0.1)
+
+
+@pytest.mark.xfail
+def test_show_bkg_model_issue943(clean_astro_ui):
+    """Test issue #943
+
+    We do not check that show_bkg_model is creating anything
+    useful, just that it can be called.
+
+    See https://github.com/sherpa/sherpa/issues/943#issuecomment-696119982
+    """
+
+    ui.set_default_id('x')
+
+    ui.load_arrays('x', [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    arf = ui.create_arf(np.asarray([0.1, 0.2, 0.3]), np.asarray([0.2, 0.3, 0.4]))
+    bkg.set_arf(arf)
+    ui.set_bkg(bkg)
+
+    ui.set_bkg_source(ui.const1d.mdl2)
+    ui.show_bkg_model()
+
+
+@pytest.mark.xfail
+def test_default_background_issue_fit(clean_astro_ui):
+    """Test issue #943 with fit
+
+    See https://github.com/sherpa/sherpa/issues/943#issuecomment-696119982
+    """
+
+    ui.set_default_id('x')
+
+    # use least-square as we don't really care about the fit
+    ui.set_stat('leastsq')
+
+    ui.load_arrays('x', [1, 2, 3, 4], [5, 4, 3, 4], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3, 4]), [1, 1, 0, 1])
+    arf = ui.create_arf(np.asarray([0.1, 0.2, 0.3, 0.4]),
+                        np.asarray([0.2, 0.3, 0.4, 0.5]))
+    ui.set_arf(arf)
+    bkg.set_arf(arf)
+    ui.set_bkg(bkg)
+
+    # The model being fitted is a constant to 1,1,0,1 for
+    # the background, so that should be 0.75 / 0.1 (as the
+    # bin width is constant), and for the source it is
+    # 5,4,3,4 - <0.75> [here ignoring the bin-width],
+    # so [4.25,3.25,2.25,3.25] -> 13 / 4 -> 3.25
+    #
+    ui.set_source(ui.const1d.mdl1)
+    ui.set_bkg_source(ui.const1d.mdl2)
+
+    # Prior to #943 this would give a confusing error.
+    #
+    ui.fit()
+    assert mdl1.c0.val == pytest.approx(3.25 / 0.1)
+    assert mdl2.c0.val == pytest.approx(0.75 / 0.1)
+
+
+def test_bkg_id_get_bkg_source(clean_astro_ui):
+    """Check the error message when the background model has not been set (issue #943)"""
+
+    ui.set_default_id('x')
+
+    ui.load_arrays('x', [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    ui.set_bkg(bkg)
+
+    with pytest.raises(ModelErr) as exc:
+        ui.get_bkg_source()
+
+    assert str(exc.value) == 'background model x for data set x has not been set'
+
+
+def test_fix_background_id_error_checks1():
+    """Check error handling of background id"""
+
+    ui.load_arrays(2, [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    ui.set_bkg(2, bkg)
+
+    with pytest.raises(ArgumentTypeErr) as exc:
+        ui.get_bkg_source(id=2, bkg_id=bkg)
+
+    assert str(exc.value) == 'identifiers must be integers or strings'
+
+
+def test_fix_background_id_error_checks2():
+    """Check error handling of background id"""
+
+    ui.load_arrays(2, [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    ui.set_bkg(2, bkg)
+
+    with pytest.raises(IdentifierErr) as exc:
+        ui.get_bkg_source(id=2, bkg_id='bkg')
+
+    assert str(exc.value) == "identifier 'bkg' is a reserved word"
+
+
+@pytest.mark.parametrize("id", [1, 'x'])
+def test_delete_bkg_model_with_bkgid(id, clean_astro_ui):
+    """Check we call delete_bkg_model with non-default bkg_id"""
+
+    ui.load_arrays(id, [1, 2, 3], [5, 4, 3], ui.DataPHA)
+    bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
+    ui.set_bkg(id, bkg, bkg_id=2)
+
+    ui.set_bkg_source(id, ui.const1d.bmdl, bkg_id=2)
+    assert ui.list_model_components() == ['bmdl']
+    assert ui.get_bkg_source(id, 2).name == 'const1d.bmdl'
+
+    ui.delete_bkg_model(id, bkg_id=2)
+    assert ui.list_model_components() == ['bmdl']
+
+    with pytest.raises(ModelErr) as exc:
+        ui.get_bkg_source(id, 2)
+
+    emsg = 'background model 2 for data set {} has not been set'.format(id)
+    assert str(exc.value) == emsg

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -137,6 +137,32 @@ class Session(sherpa.ui.utils.Session):
     # High-level utilities
     ###########################################################################
 
+    def _fix_background_id(self, id, bkg_id):
+        """Check the background id
+
+        Notes
+        -----
+        Since there is currently no way to set the default
+        background id of the DataPHA class (e.g. in unpack_pha)
+        we do not use the _default_id setting here.
+        """
+
+        if bkg_id is None:
+            # The assumption here is that if we are asking about a
+            # background identifier then there must already be a
+            # loaded PHA dataset.
+            data = self._get_pha_data(id)
+            return data.default_background_id
+
+            # return self._default_id
+
+        if not self._valid_id(bkg_id):
+            raise ArgumentTypeErr('intstr')
+        if bkg_id in self._plot_types.keys() or bkg_id in self._contour_types.keys():
+            raise IdentifierErr('badid', bkg_id)
+
+        return bkg_id
+
     def __setstate__(self, state):
         if '_background_sources' not in state:
             self.__dict__['_background_sources'] = state.pop(
@@ -9243,7 +9269,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
         id = self._fix_id(id)
-        bkg_id = self._fix_id(bkg_id)
+        bkg_id = self._fix_background_id(id, bkg_id)
 
         model = self._background_sources.get(id, {}).get(bkg_id)
         if model is None:
@@ -9294,7 +9320,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
         id = self._fix_id(id)
-        bkg_id = self._fix_id(bkg_id)
+        bkg_id = self._fix_background_id(id, bkg_id)
 
         mdl = self._background_models.get(id, {}).get(bkg_id)
 
@@ -9390,7 +9416,7 @@ class Session(sherpa.ui.utils.Session):
             id, model = model, id
 
         id = self._fix_id(id)
-        bkg_id = self._fix_id(bkg_id)
+        bkg_id = self._fix_background_id(id, bkg_id)
 
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
@@ -9512,7 +9538,7 @@ class Session(sherpa.ui.utils.Session):
             id, model = model, id
 
         id = self._fix_id(id)
-        bkg_id = self._fix_id(bkg_id)
+        bkg_id = self._fix_background_id(id, bkg_id)
 
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
@@ -9572,10 +9598,11 @@ class Session(sherpa.ui.utils.Session):
 
         """
         id = self._fix_id(id)
-        bkg_id = self._fix_id(bkg_id)
+        bkg_id = self._fix_background_id(id, bkg_id)
+
         # remove dependency of having a loaded PHA dataset at the time
         # of bkg model init.
-#        bkg_id = self._get_pha_data(id)._fix_background_id(bkg_id)
+        #  bkg_id = self._get_pha_data(id)._fix_background_id(bkg_id)
         self._background_models.get(id, {}).pop(bkg_id, None)
         self._background_sources.get(id, {}).pop(bkg_id, None)
 


### PR DESCRIPTION
# Summary

The `sherpa.astro.ui.set_default_id` call no-longer sets the default identifier for background ids, which are now kept as the value 1. This avoids several issues when using `set_default_id` with the background components of PHA datasets.

# Details

Until now the default background id was set to match the default dataset id, but this is problematic since there is no way to
pass this identifier to the DataPHA class when creating the data objects, and so there is a mis-match between what the sherpa.astro.ui level and the DataPHA object thinks is the default background identifier.

We now have a separate _fix_background_id method in the sherpa.astro.ui Session, to make it explicit what is being checked, and this routine will return the DataPHA.default_background_id setting now.

We could pass an identifier for the default background dataset to the DataPHA clas, but that is left for another time.

You can see some examples from @anetasie in the discussion on this PR, as well as the tests I added.

# Notes

I originally added this as part of #931 but it is a separate issue so I've made it a separate PR.