### PR TITLE
Rework stats tests

### DIFF
--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -957,6 +957,10 @@ class WStat(Likelihood):
         exp_bkg = []
         backscales = []
 
+        # Why are we looping over model.parts as it isn't used?
+        # Is it just a way to restrict to only use those
+        # datasets for which we have a model?
+        #
         for dset, mexpr in zip(data.datasets, model.parts):
 
             y = dset.to_fit(staterrfunc=None)[0]
@@ -966,7 +970,7 @@ class WStat(Likelihood):
             try:
                 bids = dset.background_ids
             except AttributeError:
-                raise StatErr('usecstat')
+                raise StatErr('usecstat') from None
 
             nbkg = len(bids)
             if nbkg == 0:


### PR DESCRIPTION
# Summary

Update the stats tests to use pytest.

# Details

This is needed by #947 (and hence #831) because in that PR we stop supporting calling XSPEC models with a single grid, which the code here used before this PR (thanks to not using a response function in the model expression).

The tests are changed from unittest style to pytest, taking some advantage of pytest features. We could actually move most of the tests to a single driver routine, passing in the expected values along with the statistic and tolerance, but I have not decided to go that far.

The main change is that the tests used to 

a) not include the response function, so the models were being evaluated with channel numbers, and so weren't "meaningful"
b) many of the tests used "absorption + powerlaw" rather than "absorption * powerlaw"

Technically this is okay, as all we're doing is checking we find the same minimum as previously, but there is a lot of benefit in having the tests be "meaningful", since we can check that the final statistic is sensible (ie ~ dof for those stats that provide a Chi-square-like meaning) and we can see that the best-fit parameter values are "sensible" (ie they are similar between the different statistics). So the tests now include a response and use absorption * powerlaw for the model.

The fits have changed to using the 0.3-7 keV range. Previously the "source" data was 0.5-7 and the background dataset had no energy filter. Using just the 0.5-7 keV range meant that the fits generally were not able to constrain the nH value of the absorption model, so it often fell to very-low levels. Including the 0.3-0.5 keV range means that the nH values are now better constrained, but I have still elected to fit the log of the nH value (at least for the source datasets) since it's easier to check a value like -2.1 rather than 0.008. Ideally we'd use data with a larger nH value to make this a bit better.

The chi-square tests have been changed to use grouped data (group by 20 for source, by 10 for the background as there's less counts) just to better support the chi-square approximation. The Cash/CSTAT tests use the ungrouped data.

The absorption model was changed from XSphabs to XSwabs since we don't really care about the accuracy of this model (and it's not that relevant for the test data we are using here) and the advantage of XSwabs, other than probably being quicker, is that it is unlikely to be changed in future XSPEC releases, as it is marked as "don't use this for science".