### PR TITLE
WIP XSPEC changes: integrate setting and require lo,hi grids

### DIFF
--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -210,7 +210,9 @@ def test_pragbayes_pcaarf_limits(sampler, setup, caplog, reset_seed):
     pmins = np.asarray(covar_results.parmins)
     pmaxs = np.asarray(covar_results.parmaxes)
 
-    fit.model = myabs * mypl
+    # Make sure we add the response
+    rsp = Response1D(fit.data)
+    fit.model = rsp(myabs * mypl)
 
     fit.model.thawedpars = pvals
     fit.model.thawedparmins = pvals + 2 * pmins  # pmins are < 0

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -284,7 +284,7 @@ pl.ampl.units   = ""
 pl.ampl.frozen  = False
 
 create_model_component("xsphabs", "gal")
-gal.integrate = True
+gal.integrate = False
 
 gal.nH.default_val = 1.0
 gal.nH.default_min = 0.0
@@ -415,7 +415,7 @@ gpl.ampl.units   = ""
 gpl.ampl.frozen  = False
 
 create_model_component("xsphabs", "ggal")
-ggal.integrate = True
+ggal.integrate = False
 
 ggal.nH.default_val = 2.0
 ggal.nH.default_min = 0.0
@@ -537,7 +537,7 @@ gpl.ampl.units   = ""
 gpl.ampl.frozen  = False
 
 create_model_component("xsphabs", "ggal")
-ggal.integrate = True
+ggal.integrate = False
 
 ggal.nH.default_val = 2.0
 ggal.nH.default_min = 0.0

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,15 +17,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
-from tempfile import NamedTemporaryFile
-
-from sherpa.astro import ui
-from sherpa.utils.testing import has_package_from_list
-from numpy.testing import assert_almost_equal
 import logging
 import sys
 import os
+import unittest
+from tempfile import NamedTemporaryFile
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+from sherpa.astro import ui
+from sherpa.utils.testing import has_package_from_list
 
 logger = logging.getLogger("sherpa")
 
@@ -126,8 +128,9 @@ class SmokeTest(unittest.TestCase):
         folder = os.path.dirname(datastack.__file__)
         self.fits = os.path.join(folder, "tests", "data", "acisf07867_000N001_r0002_pha3.fits")
 
-        self.x = [1, 2, 3]
-        self.y = [1, 2, 3]
+        self.x = np.asarray([1, 2, 3])
+        self.x2 = self.x + 1
+        self.y = np.asarray([1, 2, 3])
 
     def tearDown(self):
         if hasattr(self, "old_level"):
@@ -171,13 +174,13 @@ class SmokeTest(unittest.TestCase):
         This test proves that the xspec extension properly works, and that there are no obvious building, linking, or
         environment issues that would prevent the xspec model from running.
         """
-        ui.load_arrays(1, self.x, self.y)
+        ui.load_arrays(1, self.x, self.x2, self.y, ui.Data1DInt)
         ui.set_source("xspowerlaw.p")
         ui.set_method("moncar")
         ui.set_stat("chi2xspecvar")
         ui.fit()
         model = ui.get_model_component("p")
-        expected = [-1.3686404, 0.5687635]
+        expected = [-1.2940997851602858, 0.5969328003146177]
         observed = [model.PhoIndex.val, model.norm.val]
         assert_almost_equal(observed, expected)
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1198,13 +1198,16 @@ class XSConvolutionKernel(XSModel):
         *args
             The model grid. There should be two arrays (the low and
             high edges of the bin) to make sure the wrapped model is
-            evaluated correctly. One array can be used but this should
-            only be used when the wrapped model only contains XSPEC
-            models.
+            evaluated correctly.
         **kwargs
             At present all additional keyword arguments are dropped.
 
         """
+
+        nargs = 2 + len(args)
+        if nargs != 4:
+            emsg = "calc() requires pars,rhs,lo,hi arguments, sent {} arguments".format(nargs)
+            raise TypeError(emsg)
 
         npars = len(self.pars)
         lpars = pars[:npars]
@@ -1328,13 +1331,16 @@ class XSConvolutionModel(CompositeModel, XSModel):
         *args
             The model grid. There should be two arrays (the low and
             high edges of the bin) to make sure the wrapped model is
-            evaluated correctly. One array can be used but this should
-            only be used when the wrapped model only contains XSPEC
-            models.
+            evaluated correctly.
         **kwargs
             Additional keyword arguments.
 
         """
+
+        nargs = 1 + len(args)
+        if nargs != 3:
+            emsg = "calc() requires pars,lo,hi arguments, sent {} arguments".format(nargs)
+            raise TypeError(emsg)
 
         return self.wrapper.calc(p, self.model.calc,
                                  *args, **kwargs)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1020,6 +1020,14 @@ class XSTableModel(XSModel):
 
     @modelCacher1d
     def calc(self, p, *args, **kwargs):
+
+        # Note the kwargs is ignored
+
+        nargs = 1 + len(args)
+        if nargs != 3:
+            emsg = "calc() requires pars,lo,hi arguments, sent {} arguments".format(nargs)
+            raise TypeError(emsg)
+
         # The function used depends on XSPEC version and, prior
         # to XSPEC 12.10.1, the type of table.
         #
@@ -1036,16 +1044,15 @@ class XSTableModel(XSModel):
 
         if hasattr(_xspec, 'tabint'):
             tabtype = 'add' if self.addmodel else 'mul'
-            return _xspec.tabint(p,
-                                 filename=self.filename, tabtype=tabtype,
-                                 *args, **kwargs)
+            return _xspec.tabint(p, *args,
+                                 filename=self.filename, tabtype=tabtype)
 
         if self.addmodel:
             func = _xspec.xsatbl
         else:
             func = _xspec.xsmtbl
 
-        return func(p, filename=self.filename, *args, **kwargs)
+        return func(p, *args, filename=self.filename)
 
 
 class XSAdditiveModel(XSModel):

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -873,6 +873,25 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
+        """Calculate the model given the parameters and grid.
+
+        Notes
+        -----
+        XSPEC models must always be evaluated with low and high
+        bin edges. Although supported by the XSPEC model interface
+        the ability to evaluate using an XSPEC-style grid (n+1
+        values for n bins which we pad with a 0), we do not
+        allow this here since it complicates the handling of
+        the regrid method.
+
+        Keyword arguments are ignored.
+        """
+
+        nargs = len(args)
+        if nargs != 3:
+            emsg = "calc() requires pars,lo,hi arguments, sent {} arguments".format(nargs)
+            raise TypeError(emsg)
+
         # Ensure output is finite (Keith Arnaud mentioned that XSPEC
         # does this as a check). This is done at this level (Python)
         # rather than in the C++ interface since:

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -115,9 +115,8 @@ def get_xspec_models():
 def make_grid():
     """Return the 'standard' contiguous grid used in these tests.
 
-    Returns egrid, elo, ehi, wgrid, wlo, whi where the e-xxx values
-    are in keV and the w-xxx values in Angstrom, *grid are a
-    single grid of values (i.e. one array) and the *lo/*hi values
+    Returns elo, ehi, wlo, whi where the e-xxx values
+    are in keV and the w-xxx values in Angstrom. The *lo/*hi values
     are this grid separated out into bin edges.
 
     The following condition holds: *hi[i] > *lo[i], and the
@@ -143,7 +142,7 @@ def make_grid():
     whi = wgrid[:-1]
     wlo = wgrid[1:]
 
-    return egrid, elo, ehi, wgrid, wlo, whi
+    return elo, ehi, wlo, whi
 
 
 def make_grid_noncontig2():
@@ -153,7 +152,7 @@ def make_grid_noncontig2():
     The grid from make_grid is modified to make one gap.
     """
 
-    egrid, elo, ehi, wgrid, wlo, whi = make_grid()
+    elo, ehi, wlo, whi = make_grid()
 
     # remove two sections
     idx1 = (elo <= 1.1) | (elo >= 1.4)
@@ -233,7 +232,7 @@ def test_create_model_instances(clean_astro_ui):
 
 
 @requires_xspec
-def test_norm_works(clean_astro_ui):
+def test_norm_works():
     # Check that the norm parameter for additive models
     # works, as it is handled separately from the other
     # parameters.
@@ -242,14 +241,15 @@ def test_norm_works(clean_astro_ui):
     # need an additive model
     mdl = xs.XSpowerlaw()
     mdl.PhoIndex = 2
-    egrid = [0.1, 0.2, 0.3, 0.4]
+    egrid1 = [0.1, 0.2, 0.3, 0.4]
+    egrid2 = [0.2, 0.3, 0.4, 0.5]
 
     mdl.norm = 1.2
-    y1 = mdl(egrid)
+    y1 = mdl(egrid1, egrid2)
 
     mfactor = 2.1
     mdl.norm = mdl.norm.val * mfactor
-    y2 = mdl(egrid)
+    y2 = mdl(egrid1, egrid2)
 
     # check that the sum is not 0 and that it
     # scales as expected.
@@ -264,14 +264,49 @@ def test_norm_works(clean_astro_ui):
 def test_evaluate_model(clean_astro_ui):
     import sherpa.astro.xspec as xs
     mdl = xs.XSbbody()
-    out = mdl([1, 2, 3, 4])
+    out = mdl([1, 2, 3, 4], [2, 3, 4, 5])
     if mdl.calc.__name__.startswith('C_'):
         otype = numpy.float64
     else:
         otype = numpy.float32
 
     assert out.dtype.type == otype
-    assert int(numpy.flatnonzero(out == 0.0)) == 3
+    # check all values are > 0
+    assert (out > 0).all()
+
+
+@requires_xspec
+@pytest.mark.parametrize('model', ['powerlaw', 'gaussian',
+                                   'vapec',  # pick this as scientifically "useful"
+                                   'constant', 'wabs'])
+def test_lowlevel(model):
+    """The XSPEC class interface requires lo,hi but the low-level allows just x
+
+    Pick a few additive and multiplicative models.
+    """
+
+    import sherpa.astro.xspec as xs
+
+    cls = getattr(xs, 'XS{}'.format(model))
+    mdl = cls()
+
+    pars = [p.val for p in mdl.pars]
+
+    # grid chosen to match XSgaussian's default parameter setting
+    # (to make sure evaluates to > 0).
+    #
+    egrid = numpy.arange(6, 7, 0.1)
+    e1 = egrid[:-1]
+    e2 = egrid[1:]
+
+    y1 = mdl._calc(pars, egrid)
+    y2 = mdl._calc(pars, e1, e2)
+
+    # should be able to use equality rather than approx, but
+    # this is easier to use
+    assert y1[:-1] == pytest.approx(y2)
+    assert y1[-1] == 0.0
+    assert (y2 > 0).all()
 
 
 @requires_xspec
@@ -281,10 +316,9 @@ def test_checks_input_length(clean_astro_ui):
 
     # Check when input array is too small (< 2 elements)
     with pytest.raises(TypeError):
-        mdl([0.1])
+        mdl([0.1], [0.2])
 
-    # Check when input arrays are not the same size (when the
-    # low and high bin edges are given)
+    # Check when input arrays are not the same size.
     with pytest.raises(TypeError):
         mdl([0.1, 0.2, 0.3], [0.2, 0.3])
 
@@ -303,10 +337,9 @@ def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_pa
 
     # Check when input array is too small (< 2 elements)
     with pytest.raises(TypeError):
-        mdl([0.1])
+        mdl([0.1], [0.2])
 
-    # Check when input arrays are not the same size (when the
-    # low and high bin edges are given)
+    # Check when input arrays are not the same size.
     with pytest.raises(TypeError):
         mdl([0.1, 0.2, 0.3], [0.2, 0.3])
 
@@ -334,25 +367,15 @@ def test_xspec_xstablemodel(loadfunc, clean_astro_ui, make_data_path):
 
     assert tmod.name == 'xstablemodel.tmod'
 
-    egrid, elo, ehi, wgrid, wlo, whi = make_grid()
+    elo, ehi, wlo, whi = make_grid()
 
-    evals1 = tmod(egrid)
-    evals2 = tmod(elo, ehi)
+    evals = tmod(elo, ehi)
+    wvals = tmod(wlo, whi)
 
-    wvals1 = tmod(wgrid)
-    wvals2 = tmod(wlo, whi)
+    assert_is_finite(evals, tmod, "energy")
+    assert_is_finite(wvals, tmod, "wavelength")
 
-    assert_is_finite(evals1, tmod, "energy")
-    assert_is_finite(wvals1, tmod, "wavelength")
-
-    emsg = "table model evaluation failed: "
-    assert_array_equal(evals1[:-1], evals2,
-                       err_msg=emsg + "energy comparison")
-
-    assert_allclose(evals1, wvals1,
-                    err_msg=emsg + "single arg")
-    assert_allclose(evals2, wvals2,
-                    err_msg=emsg + "two args")
+    assert wvals == pytest.approx(evals)
 
 
 @requires_xspec
@@ -365,33 +388,31 @@ def test_xspec_xstablemodel_noncontiguous2(loadfunc, clean_astro_ui, make_data_p
 
     elo, ehi, wlo, whi = make_grid_noncontig2()
 
-    evals2 = tmod(elo, ehi)
-    wvals2 = tmod(wlo, whi)
+    evals = tmod(elo, ehi)
+    wvals = tmod(wlo, whi)
 
-    assert_is_finite(evals2, tmod, "energy")
-    assert_is_finite(wvals2, tmod, "wavelength")
+    assert_is_finite(evals, tmod, "energy")
+    assert_is_finite(wvals, tmod, "wavelength")
 
-    emsg = "table model non-contiguous evaluation failed: "
-    rtol = 1e-3
-    assert_allclose(evals2, wvals2, rtol=rtol,
-                    err_msg=emsg + "energy to wavelength")
+    assert wvals == pytest.approx(evals)
+    assert (wvals > 0).any()
 
 
 @requires_xspec
 @requires_data
 @requires_fits
-def test_xpec_tablemodel_outofbound(clean_astro_ui, make_data_path):
+def test_xspec_tablemodel_outofbound(clean_astro_ui, make_data_path):
     ui.load_xstable_model('tmod', make_data_path('xspec-tablemodel-RCS.mod'))
     # when used in the test suite it appears that the tmod
     # global symbol is not created, so need to access the component
     tmod = ui.get_model_component('tmod')
     with pytest.raises(ParameterErr) as e:
-        tmod.calc([0., .2, 1., 1.], numpy.arange(1, 5))
+        tmod.calc([0., .2, 1., 1.], numpy.arange(1, 5), numpy.arange(2, 6))
     assert 'minimum' in str(e)
 
 
 @requires_xspec
-def test_convolution_model_cflux(clean_astro_ui):
+def test_convolution_model_cflux():
     # Use the cflux convolution model, since this gives
     # an easily-checked result. At present the only
     # interface to these models is via direct access
@@ -410,6 +431,8 @@ def test_convolution_model_cflux(clean_astro_ui):
     elo = 0.55
     ehi = 1.45
     egrid = numpy.linspace(0.5, 1.5, 101)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
 
     mdl1 = xs.XSpowerlaw()
     mdl1.PhoIndex = 2
@@ -417,7 +440,8 @@ def test_convolution_model_cflux(clean_astro_ui):
     # flux of mdl1 over the energy range of interest; converting
     # from a flux in photon/cm^2/s to erg/cm^2/s, when the
     # energy grid is in keV.
-    y1 = mdl1(egrid)
+    y1 = mdl1(eg1, eg2)
+
     idx, = numpy.where((egrid >= elo) & (egrid < ehi))
 
     # To match XSpec, need to multiply by (Ehi^2-Elo^2)/(Ehi-Elo)
@@ -434,9 +458,10 @@ def test_convolution_model_cflux(clean_astro_ui):
     # flux in erg/cm^2/s). The parameters chosen for the
     # powerlaw, and energy range, should have f1 ~ 1.5e-9
     # (log 10 of this is -8.8).
+    #
     lflux = -5.0
     pars = [elo, ehi, lflux]
-    y2 = xs._xspec.C_cflux(pars, y1, egrid)
+    y2 = xs._xspec.C_cflux(pars, y1, eg1, eg2)
 
     assert_is_finite(y2, "cflux", "energy")
 
@@ -447,16 +472,7 @@ def test_convolution_model_cflux(clean_astro_ui):
     wlo = wgrid[1:]
 
     expected = y1 * 10**lflux / f1
-    numpy.testing.assert_allclose(expected, y2,
-                                  err_msg='energy, single grid')
-
-    y1 = mdl1(wgrid)
-    y2 = xs._xspec.C_cflux(pars, y1, wgrid)
-    assert_is_finite(y2, "cflux", "wavelength")
-    numpy.testing.assert_allclose(expected, y2,
-                                  err_msg='wavelength, single grid')
-
-    expected = expected[:-1]
+    assert y2 == pytest.approx(expected)
 
     y1 = mdl1(elo, ehi)
     y2 = xs._xspec.C_cflux(pars, y1, elo, ehi)
@@ -470,7 +486,7 @@ def test_convolution_model_cflux(clean_astro_ui):
 
 
 @requires_xspec
-def test_convolution_model_cpflux_noncontiguous(clean_astro_ui):
+def test_convolution_model_cpflux_noncontiguous():
     # The models should raise an error if given a non-contiguous
     # grid.
     import sherpa.astro.xspec as xs
@@ -543,7 +559,7 @@ def test_nonexistent_model():
     m = XSbtapec()
 
     with pytest.raises(AttributeError) as exc:
-        m([])
+        m([], [])
 
     assert include_if.DISABLED_MODEL_MESSAGE.format("XSbtapec") == str(exc.value)
 
@@ -569,7 +585,7 @@ def test_not_compiled_model():
     m = XSfoo()
 
     with pytest.raises(AttributeError) as exc:
-        m([])
+        m([], [])
 
     assert ModelMeta.NOT_COMPILED_FUNCTION_MESSAGE == str(exc.value)
 
@@ -594,11 +610,11 @@ def test_old_style_xspec_class():
 
     m = XSfoo()
 
-    actual = m([1, 2, 3])
+    actual = m([1, 2, 3], [2, 3, 4])
 
-    expected = XSzbabs()([1, 2, 3])
+    expected = XSzbabs()([1, 2, 3], [2, 3, 4])
 
-    assert_array_equal(expected, actual)
+    assert actual == pytest.approx(actual)
 
 
 @requires_xspec
@@ -626,7 +642,7 @@ def test_evaluate_xspec_model(modelcls):
     if isinstance(mdl, xspec.XSConvolutionKernel):
         return
 
-    egrid, elo, ehi, wgrid, wlo, whi = make_grid()
+    elo, ehi, wlo, whi = make_grid()
 
     # The model checks that the values are all finite,
     # so there is no need to check that the output of
@@ -634,34 +650,13 @@ def test_evaluate_xspec_model(modelcls):
     # NOTE: this is no-longer the case, so include an
     #       explicit check for the single-argument forms
     #
-    evals1 = mdl(egrid)
-    evals2 = mdl(elo, ehi)
+    evals = mdl(elo, ehi)
+    wvals = mdl(wlo, whi)
 
-    wvals1 = mdl(wgrid)
-    wvals2 = mdl(wlo, whi)
+    assert_is_finite(evals, modelcls, "energy")
+    assert_is_finite(wvals, modelcls, "wavelength")
 
-    assert_is_finite(evals1, modelcls, "energy")
-    assert_is_finite(wvals1, modelcls, "wavelength")
-
-    emsg = "{} model evaluation failed: ".format(modelcls)
-
-    # It might be expected that the test should be
-    #   assert_allclose(evals1[:-1], evals2)
-    # to ensure there's no floating-point issues,
-    # but in this case the grid and parameter
-    # values *should* be exactly the same, so the
-    # results *should* be exactly equal, hence
-    # the use of assert_array_equal
-    assert_array_equal(evals1[:-1], evals2,
-                       err_msg=emsg + "energy comparison")
-    assert_array_equal(wvals1[:-1], wvals2,
-                       err_msg=emsg + "wavelength comparison")
-
-    # When comparing wavelength to energy values, have
-    # to use allclose since the bins are not identically
-    # equal.
-    assert_allclose(evals1, wvals1,
-                    err_msg=emsg + "energy to wavelength")
+    assert wvals == pytest.approx(evals)
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -378,8 +378,9 @@ def test_cflux_nbins():
 
     The test_cflux_calc_xxx routines do include a test of the number
     of bins, but that is just for a Data1DInt dataset, so the model
-    only ever gets called with explicit lo and hi edges. This test
-    calls the model directly to check both 1 and 2 argument variants.
+    only ever gets called with explicit lo and hi edges. Now that
+    we no-longer support evaluating the model with a single grid
+    this test may not add much power, but leave in for now.
 
     Notes
     -----
@@ -401,11 +402,8 @@ def test_cflux_nbins():
     nbins = elo.size
 
     def check_bins(lbl, mdl):
-        y1 = mdl(egrid)
-        y2 = mdl(elo, ehi)
-
-        assert y1.size == nbins + 1, '{}: egrid'.format(lbl)
-        assert y2.size == nbins, '{}: elo/ehi'.format(lbl)
+        y = mdl(elo, ehi)
+        assert y.size == nbins, '{}: elo/ehi'.format(lbl)
 
     # verify assumptions
     #

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1025,3 +1025,42 @@ def test_integrate_is_fixed_convolution(clsname):
     emsg = 'Unable to change integrate setting of ' + \
            'xscflux({})'.format(clsname)
     assert str(exc.value) == emsg
+
+
+@requires_xspec
+def test_xspec_convolution_model_requires_bins():
+    """Ensure you can not call with a single grid for the energies."""
+
+    from sherpa.astro import xspec
+
+    conv = xspec.XScflux()
+    mdl = xspec.XSpowerlaw()
+    cmdl = conv(mdl)
+
+    with pytest.raises(TypeError) as exc:
+        cmdl([0.1, 0.2, 0.3, 0.4])
+
+    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+    assert str(exc.value) == emsg
+
+
+@requires_xspec
+def test_xspec_convolution_kernel_requires_bins():
+    """Ensure you can not call with a single grid for the energies.
+
+    This is a low-level interface check for completeness.
+    """
+
+    from sherpa.astro import xspec
+
+    conv = xspec.XScflux()
+    mdl = xspec.XSpowerlaw()
+
+    cmdl = conv(mdl)
+    cpars = [p.val for p in cmdl.pars]
+
+    with pytest.raises(TypeError) as exc:
+        conv.calc(cpars, cmdl.calc, [0.1, 0.2, 0.3, 0.4])
+
+    emsg = 'calc() requires pars,rhs,lo,hi arguments, sent 3 arguments'
+    assert str(exc.value) == emsg

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -709,6 +709,22 @@ def test_read_xstable_model(make_data_path):
         assert not(p.frozen)
 
 
+@requires_xspec
+@pytest.mark.parametrize("clsname", ["powerlaw", "wabs"])
+def test_xspec_model_requires_bins(clsname):
+    """Ensure you can not call with a single grid for the energies."""
+
+    from sherpa.astro import xspec
+
+    mdl = getattr(xspec, 'XS{}'.format(clsname))()
+
+    with pytest.raises(TypeError) as exc:
+        mdl([0.1, 0.2, 0.3, 0.4])
+
+    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+    assert str(exc.value) == emsg
+
+
 @requires_data
 @requires_fits
 @requires_xspec
@@ -947,6 +963,10 @@ def test_integrate_is_fixed(clsname, truth):
 
     assert mdl.integrate is truth
 
+    # Check we can set it to itself
+    mdl.integrate = truth
+
+    # Check we can not change it
     with pytest.raises(ModelErr) as exc:
         mdl.integrate = not truth
 


### PR DESCRIPTION
This has been replaced by #1111 (merged), #1112 (merged), and #1179 (WIP). I'm leaving this up as a reminder until #1179 is in better shape.

# Summary

XSPEC model classes must now be evaluated with bin edges - that is with low,high bins. The support for sending in a single grid and treating it a consecutive set of bins has been removed from the model class interface. This feature is still supported for anyone evaluating the models directly from the sherpa.astro.xspec._xspec module.

The XSPEC multiplicative models are now set to have integrate=False, and the integrate setting of XSPEC models can not be changed.

# Details

Neither of these changes has much impact on their own:

 - XSPEC models, when evaluated by an instrument model, already use the two-argument form (ie send in low,high bin edges)
 - the integrate setting of the XSPEC models isn't really used

However, they will be used in #830

Sherpa models with integrate=False and called with low,high bins actually just ignore the high bins (no matter what the documentation says), so after `mdl.integrate = False`, `mdl(elo, ehi)` and `mdl(elo)` will return the same answer. This isn't true of XSPEC additive models since

  a) you can not call it with `mdl(elo)` thanks to this PR
  b) it is up to the model whether to use elo, ehi, or some function of elo,ehi such as the mid-point

I am therefore, with this PR, subtly changing the interpretation of the integrate flag. There is no documentation within the Sherpa code base to indicate what the semantics of this setting are intended to be, so we can only be guided by the actual implementation (the documentation of the integrate flag in our "user-level" docstrings is written to match the existing behavior rather than being a blueprint for the implementation).

# Notes

This builds on #946 (it requires the clean up of the stats tests) and comes out of work on #830. I have pulled it out to try and make things a bit easier to review.

This actually makes a noticeable (but not spectacular) reduction in the time to run the Sherpa test suite (when you have XSPEC support enabled) since we no-longer have to run each XSPEC model with both one and two grids.