### PR TITLE
If _ncpus==1, lmdif should not try to call parallel_map

### DIFF
--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -41,7 +41,7 @@ def tst_opt(opt, fct, npar, reltol=1.0e-3, abstol=1.0e-3):
     x0, xmin, xmax, fmin = init(fct.__name__, npar)
     status, x, fval, msg, xtra = opt(fct, x0, xmin, xmax)
     assert fmin == pytest.approx(fval, rel=reltol, abs=abstol)
-    if opt == lmdif:
+    if opt == lmdif and _ncpus > 1:
         status, x, fval, msg, xtra = opt(fct, x0, xmin, xmax, numcores=_ncpus)
         assert fmin  == pytest.approx(fval, rel=reltol, abs=abstol)
         assert xtra.get('num_parallel_map') != 0


### PR DESCRIPTION
# Note 

This PR fixes the test failures on the virtual machine running macOS. ```_ncpus``` on the virtual machine running macOS has ```_ncpus == 1``` so there is no need to call ```parallel_map```.  The current test failures:

```
miniconda3/envs/check-sherpa/lib/python3.7/site-packages/sherpa/optmethods/tests/test_optmethods.py F [  0%]
...xxxxx...F...F...F...F...F...F...xx..ssssF...F...x...F...ssssF... [ 29%]
F...Fx..F...Fx.xssssF...x...F...F...xxxxF...F...F...F...F...F...F.. [ 57%]
.F...x.x........................x..x.xx.xx.xx................xx.x.. [ 86%]
....x..x.x...x.xx.xx.x...x.....                                     [100%]

================================ FAILURES =================================
_________________________ test_rosenbrock[lmdif] __________________________
...
FAILED miniconda3/envs/check-sherpa/lib/python3.7/site-packages/sherpa/optmethods/tests/test_optmethods.py::test_linear_chebyquad[lmdif]
========= 26 failed, 156 passed, 12 skipped, 39 xfailed in 10.21s =========
```

Once this PR is merged the CIAOD/X test should pass:

```
(check-sherpa) vagrants-MacBook-Pro:Downloads vagrant$ pytest $CONDA_PREFIX/lib/python3.7/site-packages/sherpa/optmethods/tests/test_optmethods.py
=========================== test session starts ===========================
platform darwin -- Python 3.7.9, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /Users/vagrant/Downloads
collected 233 items                                                       

miniconda3/envs/check-sherpa/lib/python3.7/site-packages/sherpa/optmethods/tests/test_optmethods.py . [  0%]
...xxxxx...........................xx..ssss........x.......ssss.... [ 29%]
.....x.......x.xssss....x...........xxxx........................... [ 57%]
.....x.x........................x..x.xx.xx.xx................xx.x.. [ 86%]
....x..x.x...x.xx.xx.x...x.....                                     [100%]

=============== 182 passed, 12 skipped, 39 xfailed in 9.80s ===============
(check-sherpa) vagrants-MacBook-Pro:Downloads vagrant$ 
```