### PR TITLE
docstring fixes

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -897,7 +897,7 @@ class NormBeta1D(RegriddableModel1D):
 
 
 class Schechter(RegriddableModel1D):
-    """One-dimensional Schecter model function.
+    """One-dimensional Schechter model function.
 
     This model is for integrated data grids only.
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1847,7 +1847,7 @@ class Session(sherpa.ui.utils.Session):
         >>> list_data_ids()
         [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
 
-        If the id is a string then the identtifier is formed by adding
+        If the id is a string then the identifier is formed by adding
         the number of the dataset (starting at 1) to the end of
         id. Note that the `list_data_ids` routine does not guarantee
         an ordering to the output (as shown below):
@@ -2991,7 +2991,7 @@ class Session(sherpa.ui.utils.Session):
 
         The function returns the total errors (a quadrature addition
         of the statistical and systematic errors) on the values
-        (dependent acis) of a data set or its background. The individual
+        (dependent axis) of a data set or its background. The individual
         components can be retrieved with the `get_staterror` and
         `get_syserror` functions.
 
@@ -5373,7 +5373,7 @@ class Session(sherpa.ui.utils.Session):
 
         If a PHA data set has an associated ARF - either from when the
         data was loaded or explicitly with the `set_arf` function -
-        then the model fit to the data will include the efect of the
+        then the model fit to the data will include the effect of the
         ARF when the model is created with `set_model` or
         `set_source`. In this case the `get_source` function returns
         the user model, and `get_model` the model that is fit to the
@@ -5513,7 +5513,7 @@ class Session(sherpa.ui.utils.Session):
 
         If a PHA data set has an associated ARF - either from when the
         data was loaded or explicitly with the `set_arf` function -
-        then the model fit to the data will include the efect of the
+        then the model fit to the data will include the effect of the
         ARF when the model is created with `set_model` or
         `set_source`. In this case the `get_source` function returns
         the user model, and `get_model` the model that is fit to the
@@ -5844,7 +5844,7 @@ class Session(sherpa.ui.utils.Session):
 
         If a PHA data set has an associated RMF - either from when the
         data was loaded or explicitly with the `set_rmf` function -
-        then the model fit to the data will include the efect of the
+        then the model fit to the data will include the effect of the
         RMF when the model is created with `set_model` or
         `set_source`. In this case the `get_source` function returns
         the user model, and `get_model` the model that is fit to the
@@ -5984,7 +5984,7 @@ class Session(sherpa.ui.utils.Session):
 
         If a PHA data set has an associated RMF - either from when the
         data was loaded or explicitly with the `set_rmf` function -
-        then the model fit to the data will include the efect of the
+        then the model fit to the data will include the effect of the
         RMF when the model is created with `set_model` or
         `set_source`. In this case the `get_source` function returns
         the user model, and `get_model` the model that is fit to the
@@ -7447,7 +7447,7 @@ class Session(sherpa.ui.utils.Session):
            indicates that the bin is part of the group. This array is
            not filtered - that is, there is one element for each channel
            in the PHA data set.  Changes to the elements of this array will
-           change the values in the dataset (is is a reference to the values
+           change the values in the dataset (it is a reference to the values
            used to define the quality, not a copy).
 
         Raises
@@ -10243,7 +10243,7 @@ class Session(sherpa.ui.utils.Session):
         >>> s2 = get_source_plot(2)
         >>> s2.plot()
 
-        Retrive the source plots for the 0.5 to 7 range of the
+        Retrieve the source plots for the 0.5 to 7 range of the
         'jet' and 'core' data sets and display them on the same plot:
 
         >>> splot1 = get_source_plot(id='jet', lo=0.5, hi=7)
@@ -10635,7 +10635,7 @@ class Session(sherpa.ui.utils.Session):
         >>> b1.plot()
         >>> b2.overplot()
 
-        Retrive the background source plots for the 0.5 to 7 range of the
+        Retrieve the background source plots for the 0.5 to 7 range of the
         'jet' and 'core' data sets and display them on the same plot:
 
         >>> splot1 = get_bkg_source_plot(id='jet', lo=0.5, hi=7)
@@ -11252,7 +11252,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_data`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11371,7 +11371,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_source`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11446,7 +11446,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_model`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11498,7 +11498,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11566,7 +11566,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_model`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11624,7 +11624,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_resid`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11690,7 +11690,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_ratio`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11755,7 +11755,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_ratio`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11817,7 +11817,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_chisqr`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11870,7 +11870,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_fit`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -11935,7 +11935,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_model`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12047,7 +12047,7 @@ class Session(sherpa.ui.utils.Session):
            than use the values from the last time the function was
            run.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12205,7 +12205,7 @@ class Session(sherpa.ui.utils.Session):
            than use the values from the last time the function was
            run.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12305,7 +12305,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the previous values. The default is
            ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12363,7 +12363,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_fit_ratio`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12437,7 +12437,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_fit_resid`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12510,7 +12510,7 @@ class Session(sherpa.ui.utils.Session):
            Set to ``True`` to use the values calculated by the last
            call to `plot_bkg_fit_delchi`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1721,7 +1721,7 @@ class XSbexrav(XSAdditiveModel):
     cosIncl
         The cosine of the inclination angle.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -1792,7 +1792,7 @@ class XSbexriv(XSAdditiveModel):
     redshift
         The redshift of the source.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -2328,7 +2328,7 @@ class XSc6pmekl(XSAdditiveModel):
     """The XSPEC c6pmekl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
 
     The model is described at [1]_. It differs from ``XSc6mekl`` by
-    by using the exponential of the 6th order Chebyshev polynomial.
+    using the exponential of the 6th order Chebyshev polynomial.
 
     Attributes
     ----------
@@ -2383,7 +2383,7 @@ class XSc6pvmkl(XSAdditiveModel):
     """The XSPEC c6pvmkl model: differential emission measure using Chebyshev representations with multi-temperature mekal.
 
     The model is described at [1]_. It differs from ``XSc6vmekl`` by
-    by using the exponential of the 6th order Chebyshev polynomial.
+    using the exponential of the 6th order Chebyshev polynomial.
 
     Attributes
     ----------
@@ -2526,7 +2526,7 @@ class XScemekl(XSAdditiveModel):
     alpha
         The power-law index of the emissivity function.
     Tmax
-        The maxmimum temperature, in keV.
+        The maximum temperature, in keV.
     nH
         H density, in cm^-3.
     abundanc
@@ -2577,7 +2577,7 @@ class XScevmkl(XSAdditiveModel):
     alpha
         The power-law index of the emissivity function.
     Tmax
-        The maxmimum temperature, in keV.
+        The maximum temperature, in keV.
     nH
         H density, in cm^-3.
     He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
@@ -2645,7 +2645,7 @@ class XScflow(XSAdditiveModel):
     lowT
         The minimum temperature, in keV.
     highT
-        The maxmimum temperature, in keV.
+        The maximum temperature, in keV.
     Abundanc
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
@@ -4347,7 +4347,7 @@ class XSmkcflow(XSAdditiveModel):
     lowT
         The minimum temperature, in keV.
     highT
-        The maxmimum temperature, in keV.
+        The maximum temperature, in keV.
     Abundanc
         The abundance relative to Solar, as set by ``set_xsabund``.
     redshift
@@ -4787,7 +4787,7 @@ class XSnsatmos(XSAdditiveModel):
 class XSnsmax(XSAdditiveModel):
     """The XSPEC nsmax model: Neutron Star Magnetic Atmosphere.
 
-    The model is described at [1]_. It has been superceeded by
+    The model is described at [1]_. It has been superseded by
     ``XSnsmaxg``.
 
     Attributes
@@ -5092,7 +5092,7 @@ class XSpexrav(XSAdditiveModel):
     redshift
         The redshift of the source.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -5153,7 +5153,7 @@ class XSpexriv(XSAdditiveModel):
     redshift
         The redshift of the source.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -5521,7 +5521,7 @@ class XSrefsch(XSAdditiveModel):
     redshift
         The redshift of the source.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -5737,7 +5737,7 @@ class XSsresc(XSAdditiveModel):
         flux has dropped by a factor of 6 from a straight power law.
         See [1]_ for more details.
     norm
-        The 1 Ghz flux in Jy.
+        The 1 GHz flux in Jy.
 
     See Also
     --------
@@ -6261,7 +6261,7 @@ class XSvmcflow(XSAdditiveModel):
     lowT
         The minimum temperature, in keV.
     highT
-        The maxmimum temperature, in keV.
+        The maximum temperature, in keV.
     He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
         The abundance relative to Solar.
     redshift
@@ -7884,7 +7884,7 @@ class XSredden(XSMultiplicativeModel):
     Attributes
     ----------
     E_BmV
-        The value of E(B-v) for the line of sight to the source.
+        The value of E(B-V) for the line of sight to the source.
 
     See Also
     --------
@@ -8260,7 +8260,7 @@ class XSuvred(XSMultiplicativeModel):
     Attributes
     ----------
     E_BmV
-        The value of E(B-v) for the line of sight to the source.
+        The value of E(B-V) for the line of sight to the source.
 
     References
     ----------
@@ -8464,7 +8464,7 @@ class XSxion(XSMultiplicativeModel):
     inner
         The inner radius of the disk (in Schwarzschild radii).
     outer
-        The er radius of the disk (in Schwarzschild radii).
+        The outer radius of the disk (in Schwarzschild radii).
     index
         The photon index of the source.
     redshift
@@ -8745,7 +8745,7 @@ class XSzredden(XSMultiplicativeModel):
     Attributes
     ----------
     E_BmV
-        The value of E(B-v) for the line of sight to the source.
+        The value of E(B-V) for the line of sight to the source.
     redshift
         The redshift of the absorber.
 
@@ -8783,7 +8783,7 @@ class XSzsmdust(XSMultiplicativeModel):
     Attributes
     ----------
     E_BmV
-        The value of E(B-v) for the line of sight to the source.
+        The value of E(B-V) for the line of sight to the source.
     ExtIndex
         The spectral index of the extinction curve.
     Rv
@@ -10114,7 +10114,7 @@ class XSpexmon(XSAdditiveModel):
     redshift
         The redshift of the source.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -11354,7 +11354,7 @@ class XSslimbh(XSAdditiveModel):
         zero then the disk emission is limb-darkened, otherwise it is assumed
         to be isotropic.
     vflag
-        A flag to contorl the surface profile. If greater than zero,
+        A flag to control the surface profile. If greater than zero,
         raytracing is done from the actual photosphere, otherwise the
         spectrum is raytraced from the equatorial plane ignoring the
         height profile of the disk.
@@ -11414,11 +11414,11 @@ class XSsnapec(XSAdditiveModel):
     N_SNe
         The number of SNe (in units of 10^9).
     R
-        The percentage of SN1a.
+        The percentage of SNIa.
     SNIModelIndex
         SNIa yield model: see [1]_ for more details.
     SNIIModelIndex
-        SNIIa yield model: see [1]_ for more details.
+        SNII yield model: see [1]_ for more details.
     redshift
         The redshift of the plasma.
     norm
@@ -11799,7 +11799,7 @@ class XSxscat(XSMultiplicativeModel):
         self.Xpos = Parameter(name, 'Xpos', 0.5, 0, 0.99, 0, 0.999)
         self.Rext = Parameter(name, 'Rext', 10.0, 0, 235.0, 0, 240.0, 'arcsec',
                               frozen=True)
-        # The maxmimum number of models depends on the data file, so pick
+        # The maximum number of models depends on the data file, so pick
         # a value that is unlikely to be exceeded (the max at the time
         # of writing was 3).
         self.DustModel = Parameter(name, 'DustModel', 1, 1, 100, 1, 100,
@@ -11832,7 +11832,7 @@ class XScflux(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
@@ -11906,7 +11906,7 @@ class XSclumin(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
@@ -11982,7 +11982,7 @@ class XScpflux(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
@@ -12034,7 +12034,7 @@ class XSgsmooth(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12068,7 +12068,7 @@ class XSireflect(XSConvolutionKernel):
     Redshift
         The redshift of the source.
     abund
-        The abundance of elements heaver than He relative to their solar
+        The abundance of elements heavier than He relative to their solar
         abundances.
     Fe_abund
         The iron abundance relative to the above.
@@ -12086,7 +12086,7 @@ class XSireflect(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     The precision of the numerical integration can be changed by using
     the ``set_xsxset`` function to set the value of the IREFLECT_PRECISION
@@ -12154,7 +12154,7 @@ class XSkdblur(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12212,7 +12212,7 @@ class XSkdblur2(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12280,7 +12280,7 @@ class XSkerrconv(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12330,7 +12330,7 @@ class XSkyconv(XSConvolutionKernel):
     a
         a/M, the black-hole angular momentum in (GM/c).
     theta_o
-        The observer inclinitation in degrees (0 is pole on).
+        The observer inclination in degrees (0 is pole on).
     rin
         The inner radius, in GM/c^2.
     ms
@@ -12361,7 +12361,7 @@ class XSkyconv(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     This model is only available when used with XSPEC 12.10.1 or later.
 
@@ -12432,7 +12432,7 @@ class XSlsmooth(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12467,7 +12467,7 @@ class XSpartcov(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12508,7 +12508,7 @@ class XSrdblur(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12552,7 +12552,7 @@ class XSreflect(XSConvolutionKernel):
     Redshift
         The redshift of the source.
     abund
-        The abundance of the elements heaver than He relative to their
+        The abundance of the elements heavier than He relative to their
         solar abundance, as set by the ``set_xsabund`` function.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
@@ -12567,7 +12567,7 @@ class XSreflect(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     The precision of the numerical integration can be changed by using
     the ``set_xsxset`` function to set the value of the REFLECT_PRECISION
@@ -12618,7 +12618,7 @@ class XSrfxconv(XSConvolutionKernel):
         The redshift of the source.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
-        the ``set_xsabund`` function. ALl other elements are assumed to
+        the ``set_xsabund`` function. All other elements are assumed to
         have Solar abundances.
     cosIncl
         The cosine of the inclination angle in degrees.
@@ -12632,7 +12632,7 @@ class XSrfxconv(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     The precision of the numerical integration can be changed by using
     the ``set_xsxset`` function to set the value of the RFXCONV_PRECISION
@@ -12684,7 +12684,7 @@ class XSrgsxsrc(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     The ``set_xsxset`` function must be used to set the RGS_XSOURCE_FILE
     value to point to a file as described in [1]_.
@@ -12724,7 +12724,7 @@ class XSsimpl(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -12785,7 +12785,7 @@ class XSthcomp(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     This model is only available when used with XSPEC 12.11.0 or later.
 
@@ -12840,7 +12840,7 @@ class XSvashift(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     This model is only available when used with XSPEC 12.9.1 or later.
 
@@ -12881,7 +12881,7 @@ class XSvmshift(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     This model is only available when used with XSPEC 12.9.1 or later.
 
@@ -12919,7 +12919,7 @@ class XSxilconv(XSConvolutionKernel):
         The redshift of the source.
     Fe_abund
         The iron abundance relative to the solar abundance, as set by
-        the ``set_xsabund`` function. ALl other elements are assumed to
+        the ``set_xsabund`` function. All other elements are assumed to
         have Solar abundances.
     cosIncl
         The cosine of the inclination angle in degrees.
@@ -12935,7 +12935,7 @@ class XSxilconv(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     The precision of the numerical integration can be changed by using
     the ``set_xsxset`` function to set the value of the XILCONV_PRECISION
@@ -12995,7 +12995,7 @@ class XSzashift(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------
@@ -13031,7 +13031,7 @@ class XSzmshift(XSConvolutionKernel):
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
-    models, rather then using the multiplication symbol.
+    models, rather than using the multiplication symbol.
 
     References
     ----------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -853,8 +853,8 @@ class Session(NoNewAttributesAfterInit):
     def show_model(self, id=None, outfile=None, clobber=False):
         """Display the model expression used to fit a data set.
 
-        This displays the model used to fit the data set, that is
-        that is, the expression set by `set_model` or `set_source`
+        This displays the model used to fit the data set, that is, 
+        the expression set by `set_model` or `set_source`
         combined with any instrumental responses, together with the
         parameter values of the model. The `show_source` function
         displays just the source expression, without the instrumental
@@ -1803,7 +1803,7 @@ class Session(NoNewAttributesAfterInit):
         from model amplitudes derived in the previous iteration of the
         fit. This 'Iterative Weighting' ([1]_) attempts to remove
         biased estimates of model parameters which is inherent in
-        chi-square2 statistics ([2]_).
+        chi-square statistics ([2]_).
 
         The variance in bin i is estimated to be::
 
@@ -1848,7 +1848,7 @@ class Session(NoNewAttributesAfterInit):
         --------
 
         Switch to the 'sigmarej' scheme for iterative fitting and
-        change the low and hige rejection limits to 4 and 3
+        change the low and high rejection limits to 4 and 3
         respectively:
 
         >>> set_iter_method('sigmarej')
@@ -2910,7 +2910,7 @@ class Session(NoNewAttributesAfterInit):
 
         The function returns the total errors (a quadrature addition
         of the statistical and systematic errors) on the values
-        (dependent acis) of a data set. The individual components
+        (dependent axis) of a data set. The individual components
         can be retrieved with the `get_staterror` and `get_syserror`
         functions.
 
@@ -4662,7 +4662,7 @@ class Session(NoNewAttributesAfterInit):
         --------
 
         Since the `notice` call is applied to an un-filtered
-        data set, the filter choses only those points that lie
+        data set, the filter chooses only those points that lie
         within the range 12 <= X <= 18.
 
         >>> load_arrays(1, [10, 15, 20, 30], [5, 10, 7, 13])
@@ -5921,7 +5921,7 @@ class Session(NoNewAttributesAfterInit):
         non-zero value for this attribute means that the results of
         evaluating the model will be cached if all the parameters are
         frozen, which may lead to a reduction in the time taken to
-        evaluate a fit. A zero value turns off the cacheing.  The
+        evaluate a fit. A zero value turns off the caching.  The
         default setting for X-Spec and 1D analytic models is that
         ``cache`` is ``5``, but ``0`` for the 2D analytic models.
 
@@ -11193,7 +11193,7 @@ class Session(NoNewAttributesAfterInit):
         -------
         resid_data : a `sherpa.plot.DataContour` instance
            The ``y`` attribute contains the residual values and the ``x0``
-           and ``x1`` arrays the corresponsing coordinate values, as
+           and ``x1`` arrays contain the corresponding coordinate values, as
            one-dimensional arrays.
 
         Raises
@@ -11284,7 +11284,7 @@ class Session(NoNewAttributesAfterInit):
         -------
         resid_data : a `sherpa.plot.ModelContour` instance
            The ``y`` attribute contains the model values and the ``x0``
-           and ``x1`` arrays the corresponsing coordinate values, as
+           and ``x1`` arrays contain the corresponding coordinate values, as
            one-dimensional arrays.
 
         Raises
@@ -11325,7 +11325,7 @@ class Session(NoNewAttributesAfterInit):
         -------
         resid_data : a `sherpa.plot.SourceContour` instance
            The ``y`` attribute contains the model values and the ``x0``
-           and ``x1`` arrays the corresponsing coordinate values, as
+           and ``x1`` arrays contain the corresponding coordinate values, as
            one-dimensional arrays.
 
         Raises
@@ -11461,7 +11461,7 @@ class Session(NoNewAttributesAfterInit):
         -------
         resid_data : a `sherpa.plot.ResidContour` instance
            The ``y`` attribute contains the residual values and the ``x0``
-           and ``x1`` arrays the corresponsing coordinate values, as
+           and ``x1`` arrays contain the corresponding coordinate values, as
            one-dimensional arrays.
 
         Raises
@@ -11503,7 +11503,7 @@ class Session(NoNewAttributesAfterInit):
         -------
         ratio_data : a `sherpa.plot.RatioContour` instance
            The ``y`` attribute contains the ratio values and the ``x0``
-           and ``x1`` arrays the corresponsing coordinate values, as
+           and ``x1`` arrays contain the corresponding coordinate values, as
            one-dimensional arrays.
 
         Raises
@@ -12111,7 +12111,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_data`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12215,7 +12215,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_model`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12297,7 +12297,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_source_component`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12372,7 +12372,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_model_component`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12451,7 +12451,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_source`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12521,7 +12521,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_fit`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12609,7 +12609,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_resid`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12686,7 +12686,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_chisqr`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12748,7 +12748,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_delchi`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12823,7 +12823,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_ratio`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12895,7 +12895,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_psf`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -12952,7 +12952,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_kernel`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13010,7 +13010,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_fit_resid`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13087,7 +13087,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the previous values. The default is
            ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13171,7 +13171,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_fit_ratio`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13257,7 +13257,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_fit_delchi`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13349,7 +13349,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_pdf`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13422,7 +13422,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_cdf`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13498,7 +13498,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_trace`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13578,7 +13578,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `plot_scatter`. The default is ``False``.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
         clearwindow : bool, optional
            Should the existing plot area be cleared before creating this
@@ -13769,7 +13769,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_data`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -13812,7 +13812,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_model`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -13857,7 +13857,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_source`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -13902,7 +13902,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_fit`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -13945,7 +13945,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_resid`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -13987,7 +13987,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_ratio`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -14027,7 +14027,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_psf`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -14057,7 +14057,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_kernel`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -14089,7 +14089,7 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `contour_fit_resid`. The default is ``False``.
         overcontour : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new contour plot. The default is ``False``.
 
         See Also
@@ -14160,11 +14160,11 @@ class Session(NoNewAttributesAfterInit):
            ignoring *all other* parameter values. Otherwise, the
            statistic curve is re-calculated, but not plotted.
         min : number, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : int, optional
@@ -14266,11 +14266,11 @@ class Session(NoNewAttributesAfterInit):
            ignoring *all other* parameter values. Otherwise, the
            statistic curve is re-calculated, but not plotted.
         min : number, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : int, optional
@@ -14375,11 +14375,11 @@ class Session(NoNewAttributesAfterInit):
            the current setting (only for the error analysis) to use
            a faster optimization method. The default is ``False``.
         min : pair of numbers, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : pair of number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : pair of int, optional
@@ -14497,11 +14497,11 @@ class Session(NoNewAttributesAfterInit):
            the current setting (only for the error analysis) to use
            a faster optimization method. The default is ``False``.
         min : pair of numbers, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : pair of number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : pair of int, optional
@@ -14645,11 +14645,11 @@ class Session(NoNewAttributesAfterInit):
            the current setting (only for the error analysis) to use
            a faster optimization method. The default is ``False``.
         min : number, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : int, optional
@@ -14670,7 +14670,7 @@ class Session(NoNewAttributesAfterInit):
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
 
         See Also
@@ -14758,11 +14758,11 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `int_proj`. The default is ``False``.
         min : number, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : int, optional
@@ -14783,7 +14783,7 @@ class Session(NoNewAttributesAfterInit):
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
 
         See Also
@@ -14902,11 +14902,11 @@ class Session(NoNewAttributesAfterInit):
            the current setting (only for the error analysis) to use
            a faster optimization method. The default is ``False``.
         min : pair of numbers, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : pair of number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : pair of int, optional
@@ -14935,7 +14935,7 @@ class Session(NoNewAttributesAfterInit):
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
 
         See Also
@@ -15026,11 +15026,11 @@ class Session(NoNewAttributesAfterInit):
            Set to ``True`` to use the values calculated by the last
            call to `int_proj`. The default is ``False``.
         min : pair of numbers, optional
-           The minimum parameter value for the calcutation. The
+           The minimum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         max : pair of number, optional
-           The maximum parameter value for the calcutation. The
+           The maximum parameter value for the calculation. The
            default value of ``None`` means that the limit is calculated
            from the covariance, using the `fac` value.
         nloop : pair of int, optional
@@ -15059,7 +15059,7 @@ class Session(NoNewAttributesAfterInit):
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
         overplot : bool, optional
-           If ``True`` then add the data to an exsiting plot, otherwise
+           If ``True`` then add the data to an existing plot, otherwise
            create a new plot. The default is ``False``.
 
         See Also


### PR DESCRIPTION
### Summary:
Numerous typos fixed in docstrings.

### Description:
Most of the typos listed in #948 have been fixed, with the exception of:
- get_energy_flux_hist/get_photon_flux_hist/plot_energy_flux/plot_photon_flux/sample_energy_flux/sample_photon_flux/sample_flux: parameter table entry 'hi' typo "guven" --> "given"

- get_xsxset: "retrive" -- > "retrieve"

which I can no longer find within the repository and may have been already been fixed in the most recent updates.