### PR TITLE
Test FIXUP issue with merge of #906

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -975,7 +975,7 @@ def test_pha1_eval_vector(clean_astro_ui):
     bplot1 = ui.get_bkg_model_plot()
 
     assert splot.title == 'Model'
-    assert bplot1.title == 'Model'
+    assert bplot1.title == 'Background Model Contribution'
 
     # check the model evaluates correctly
     # - backgrond is just multiplied by the arf
@@ -1083,7 +1083,7 @@ def test_pha1_eval_vector_two(dofilter, expected, clean_astro_ui):
     bplot1 = ui.get_bkg_model_plot()
 
     assert splot.title == 'Model'
-    assert bplot1.title == 'Model'
+    assert bplot1.title == 'Background Model Contribution'
 
     # check the model evaluates correctly
     # - backgrond is just multiplied by the arf
@@ -1116,7 +1116,7 @@ def test_pha1_eval_vector_two(dofilter, expected, clean_astro_ui):
 
     bplot2 = ui.get_bkg_model_plot(bkg_id=2)
 
-    assert bplot2.title == 'Model'
+    assert bplot2.title == 'Background Model Contribution'
 
     assert bplot2.y == pytest.approx(by1 * 80)
 


### PR DESCRIPTION
# Summary

Fix three tests that were affected by the merge of #906.

# Details

There are no code changes here.

For some reason merging #906 caused these tests to fail. Fortunately the test was just a "check the value is this value". I assume this came in from the interminable number of rebases I had to do to this code as it waited to get merged.