### PR TITLE
Fix model evaluation when changing the integrate setting (fix #958)

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -59,8 +59,30 @@ def modelCacher1d(func):
         digest = ''
         if use_caching:
 
+            # Up until Sherpa 4.12.2 we used the kwargs to define the
+            # integrate setting, with
+            # boolean_to_byte(kwargs.get('integrate', False)) but
+            # unfortunately this is used in code like
+            #
+            #    @modelCacher1d
+            #    def calc(..):
+            #        kwargs['integrate'] = self.integrate
+            #        return somefunc(... **kwargs)
+            #
+            # and the decorator is applied to calc, which is not
+            # called with a integrate kwarg, rather than the call to
+            # somefunc, which was sent an integrate setting.
+            #
+            try:
+                integrate = cls.integrate
+            except AttributeError:
+                # Rely on the integrate kwarg as there's no
+                # model setting.
+                #
+                integrate = kwargs.get('integrate', False)
+
             data = [numpy.array(pars).tobytes(),
-                    boolean_to_byte(kwargs.get('integrate', False)),
+                    boolean_to_byte(integrate),
                     numpy.asarray(xlo).tobytes()]
             if args:
                 data.append(numpy.asarray(args[0]).tobytes())

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -30,7 +30,7 @@ import pytest
 from sherpa.utils.err import ModelErr
 from sherpa.models.model import ArithmeticModel, ArithmeticConstantModel, \
     ArithmeticFunctionModel, BinaryOpModel, FilterModel, NestedModel, \
-    UnaryOpModel
+    UnaryOpModel, RegridWrappedModel
 from sherpa.models.parameter import Parameter, hugeval, tinyval
 from sherpa.models.basic import Sin, Const1D, Box1D, Polynom1D
 
@@ -793,3 +793,44 @@ def test_evaluate_cache_swap():
     y2 = mdl(xlo, xhi)
     assert y2 == pytest.approx(expected)
     check_cache(mdl, expected, xlo, xhi)
+
+
+def test_evaluate_cache_arithmeticconstant():
+    """Check we run with cacheing: ArihmeticConstant"""
+
+    mdl = ArithmeticConstantModel(2.3)
+    assert not hasattr(mdl, '_use_caching')
+
+
+def test_evaluate_cache_unaryop():
+    """UnaryOp has no cache"""
+
+    mdl = Polynom1D()
+    assert hasattr(mdl, '_use_caching')
+
+    fmdl = -mdl
+    assert isinstance(fmdl, UnaryOpModel)
+    assert not hasattr(fmdl, '_use_caching')
+
+
+def test_evaluate_cache_binaryop():
+    """BinaryOp has no cache"""
+
+    mdl = Polynom1D()
+    assert hasattr(mdl, '_use_caching')
+
+    fmdl = mdl + 2
+    assert isinstance(fmdl, BinaryOpModel)
+    assert not hasattr(fmdl, '_use_caching')
+
+
+def test_evaluate_cache_regrid1d():
+    """How about a regridded model?"""
+
+    mdl = Polynom1D()
+
+    x = numpy.arange(2, 20, 0.5)
+    rmdl = mdl.regrid(x)
+
+    assert isinstance(rmdl, RegridWrappedModel)
+    assert not hasattr(rmdl, '_use_caching')

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -723,7 +723,6 @@ def test_evaluate_no_cache1dint():
     assert len(mdl._cache) == 0
 
 
-@pytest.mark.xfail
 def test_evaluate_cache1dint():
     """Check we run with cacheing on: 1dint"""
 
@@ -754,7 +753,6 @@ def test_evaluate_cache1dint():
     check_cache(mdl, expected, xlo, xhi)
 
 
-@pytest.mark.xfail
 def test_evaluate_cache_swap():
     """Check issue #959 when swapping integrate flag caused problems.
 


### PR DESCRIPTION
# Summary

Fix an issue with cache evaluation on 1D models using integrated bins and the user has changed the integrate setting of the model.

# Details

I add several tests of the cache code, using low-level tests that the digest is calculated correctly (although as we just repeat the code from the `sherpa.models.model.py::modelCacher1d` routine there is no external validation). There are two tests that show #958 - the original problem and one that I used to identify the problem. It is worth keeping both as they do test slightly-different scenarios and are not expensive tests to run. A number of other tests are also added to check out various features of the code.

The actual fix is very simple - the integrate setting is taken from the input object (called `cls` in the `modelCacher1d` routine) rather than looking for the setting in `kwargs['integrate']`. It is unclear whether we can have a mis-match between `cls.integrate` and `kwargs['integrate']`; I would claim that this indicates a problem somewhere, but it's not clear why we explicitly add the `integrate` setting to the model calls in the first place.