### PR TITLE
Docs: note plot_fit_xxx overplot change and add info on notebook support

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -119,6 +119,25 @@ can be activated and Sherpa can be build from source.
 How do I ...
 ============
 
+Add a new notebook
+------------------
+
+The easiest way to add a new notebook to the documentation is to
+add it to the desired location in the ``docs/`` tree and add it to
+the table of contents. If you want to place the notebook into the
+top-level ``notebooks/`` directory and also have it included in
+the documentation then add an entry to the ``notebooks/nbmapping.dat``
+file, which is a tab-separated text file listing the name
+of the notebook and the location in the ``docs/`` directory structure
+that it should be copied to. The ``docs/conf.py`` file will ensure
+it is copied (if necessary) when building the documentation. The
+location of the documentation version **must** be added to the
+``.gitignore`` file (see the section near the end) to make sure it
+does not accidentally get added.
+
+At present we require that the notebook be fully evaluated as we
+do not run the notebooks while building the documentation.
+
 Update the XSPEC bindings?
 --------------------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -470,7 +470,9 @@ additional packages:
 * `Sphinx <https://sphinx.pocoo.org/>`_, version 1.8 or later
 * The ``sphinx_rtd_theme``
 * NumPy and `sphinx-astropy <https://github.com/astropy/sphinx-astropy/>`_
-  (the latter can be installed with ``pip``).
+  (the latter can be installed with ``pip``)
+* `nbsphinx <https://pypi.org/project/nbsphinx/>`_, ``ipykernel``, and ``pandoc``
+  for including Jupyter notebooks
 * `Graphviz <https://www.graphviz.org/>`_ (for the inheritance diagrams)
 
 With these installed, the documentation can be built with the

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12480,6 +12480,9 @@ class Session(sherpa.ui.utils.Session):
         This creates two plots - the first from `plot_bkg_fit` and the
         second from `plot_bkg_ratio` - for a data set.
 
+        .. versionchanged:: 4.12.2
+           The ``overplot`` option now works.
+
         .. versionadded:: 4.12.0
 
         Parameters
@@ -12552,6 +12555,9 @@ class Session(sherpa.ui.utils.Session):
 
         This creates two plots - the first from `plot_bkg_fit` and the
         second from `plot_bkg_resid` - for a data set.
+
+        .. versionchanged:: 4.12.2
+           The ``overplot`` option now works.
 
         .. versionchanged:: 4.12.0
            The Y axis of the residual plot is now always drawn using a
@@ -12626,6 +12632,9 @@ class Session(sherpa.ui.utils.Session):
 
         This creates two plots - the first from `plot_bkg_fit` and the
         second from `plot_bkg_delchi` - for a data set.
+
+        .. versionchanged:: 4.12.2
+           The ``overplot`` option now works.
 
         .. versionchanged:: 4.12.0
            The Y axis of the residual plot is now always drawn using a

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13329,6 +13329,9 @@ class Session(NoNewAttributesAfterInit):
         This creates two plots - the first from `plot_fit` and the
         second from `plot_resid` - for a data set.
 
+        .. versionchanged:: 4.12.2
+           The ``overplot`` option now works.
+
         .. versionchanged:: 4.12.0
            The Y axis of the residual plot is now always drawn using a
            linear scale.
@@ -13417,6 +13420,9 @@ class Session(NoNewAttributesAfterInit):
         This creates two plots - the first from `plot_fit` and the
         second from `plot_ratio` - for a data set.
 
+        .. versionchanged:: 4.12.2
+           The ``overplot`` option now works.
+
         .. versionadded:: 4.12.0
 
         Parameters
@@ -13502,6 +13508,9 @@ class Session(NoNewAttributesAfterInit):
 
         This creates two plots - the first from `plot_fit` and the
         second from `plot_delchi` - for a data set.
+
+        .. versionchanged:: 4.12.2
+           The ``overplot`` option now works.
 
         .. versionchanged:: 4.12.0
            The Y axis of the delchi plot is now always drawn using a


### PR DESCRIPTION
# Summary

Minor documentation improvements.

# Details:

Random documentation fixes

- note the overplot support in plot_fit_xxx and plot_bkg_fit_xxx functions
- added to the RTD documentation
  - extra requirements for building the sphinx documentation
  - added a 'How do I add a notebook' section to the developers section
