### PR TITLE
Fix 2d image filtering (fix #965)

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3806,27 +3806,40 @@ class DataIMG(Data2D):
     get_filter = get_filter_expr
 
     def notice2d(self, val=None, ignore=False):
-        mask = None
+        """Apply a 2D filter.
+
+        Parameters
+        ----------
+        val : str or None, optional
+            The filter to apply. It can be a region string or a
+            filename.
+        ignore : bool, optional
+            If set then the filter should be ignored, not noticed.
+
+        """
+
         ignore = bool_cast(ignore)
-        if val is not None:
 
-            if not regstatus:
-                raise ImportErr('importfailed', 'region', 'notice2d')
-
-            val = str(val).strip()
-            (self._region,
-             mask) = region_mask(self._region, val,
-                                 self.get_x0(), self.get_x1(),
-                                 os.path.isfile(val), ignore)
-            mask = numpy.asarray(mask, dtype=numpy.bool_)
-        else:
-            self._region = None
-
-        if mask is None:
+        # This was originally a bit-more complex, but it has been
+        # simplified.
+        #
+        if val is None:
             self.mask = not ignore
             self._region = None
+            return
 
-        elif not ignore:
+        if not regstatus:
+            raise ImportErr('importfailed', 'region', 'notice2d')
+
+        val = str(val).strip()
+        ans = region_mask(self._region, val,
+                          self.get_x0(), self.get_x1(),
+                          os.path.isfile(val), ignore)
+
+        self._region, mask = ans
+        mask = mask.astype(numpy.bool)
+
+        if not ignore:
             if self.mask is True:
                 self.mask = mask
             else:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3860,6 +3860,9 @@ class DataIMG(Data2D):
         # Create the new region shape.
         #
         if self._region is None:
+            if ignore:
+                reg.invert()
+
             self._region = reg
         else:
             self._region = self._region.combine(reg, ignore)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -45,7 +45,7 @@ warning = logging.getLogger(__name__).warning
 
 regstatus = False
 try:
-    from sherpa.astro.utils._region import Region, region_combine, region_mask
+    from sherpa.astro.utils._region import Region
     regstatus = True
 except ImportError:
     warning('failed to import sherpa.astro.utils._region; Region routines ' +
@@ -3839,8 +3839,7 @@ class DataIMG(Data2D):
         # Calculate the mask for this region as an "included"
         # region.
         #
-        mask = region_mask(reg,
-                           self.get_x0(), self.get_x1())
+        mask = reg.mask(self.get_x0(), self.get_x1())
         mask = mask.astype(numpy.bool)
 
         # Apply the new mask to the existing mask.
@@ -3863,7 +3862,7 @@ class DataIMG(Data2D):
         if self._region is None:
             self._region = reg
         else:
-            self._region = region_combine(self._region, reg, ignore)
+            self._region = self._region.combine(reg, ignore)
 
     def get_bounding_mask(self):
         mask = self.mask

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -611,3 +611,57 @@ def test_img_get_bounding_mask_filtered(make_test_image):
     assert len(ans) == 2
     assert ans[0] == pytest.approx(mask)
     assert ans[1] == (5, 7)
+
+
+def test_img_get_filter(make_test_image):
+    """Simple get_filter check on an image."""
+    d = make_test_image
+    assert d.get_filter() == ''
+
+    shape = 'ellipse(4260,3840,3,2,0)'
+    d.notice2d(shape)
+    assert d.get_filter() == shape.capitalize()
+
+
+def test_img_get_filter_none(make_test_image):
+    """Simple get_filter check on an image: no data"""
+    d = make_test_image
+
+    shape = 'ellipse(4260,3840,3,2,0)'
+    d.notice2d(shape)
+    d.notice2d(ignore=True)
+
+    # It's not clear what the filter should be here
+    assert d.get_filter() == ''
+
+
+@pytest.mark.skip(reason='can cause a segfault')
+def test_img_get_filter_combined(make_test_image):
+    """Simple get_filter check on an image."""
+    d = make_test_image
+    assert d.get_filter() == ''
+
+    shape1 = 'ellipse(4260,3840,3,2,0)'
+    d.notice2d(shape1)
+
+    shape2 = 'rect(4258,3830,4264,3841)'
+    d.notice2d(shape1)
+
+    shape = shape1.capitalize() + '+' + shape2.capitalize()
+    assert d.get_filter() == shape
+
+
+@pytest.mark.skip(reason='can cause a segfault')
+def test_img_get_filter_excluded(make_test_image):
+    """Simple get_filter check on an image."""
+    d = make_test_image
+    assert d.get_filter() == ''
+
+    shape1 = 'ellipse(4260,3840,3,2,0)'
+    d.notice2d(shape1)
+
+    shape2 = 'rect(4258,3830,4264,3841)'
+    d.notice2d(shape1, ignore=True)
+
+    shape = shape1.capitalize() + '&!' + shape2.capitalize()
+    assert d.get_filter() == shape

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -635,7 +635,6 @@ def test_img_get_filter_none(make_test_image):
     assert d.get_filter() == ''
 
 
-@pytest.mark.skip(reason='can cause a segfault')
 def test_img_get_filter_combined(make_test_image):
     """Simple get_filter check on an image."""
     d = make_test_image
@@ -645,13 +644,13 @@ def test_img_get_filter_combined(make_test_image):
     d.notice2d(shape1)
 
     shape2 = 'rect(4258,3830,4264,3841)'
-    d.notice2d(shape1)
+    d.notice2d(shape2)
 
-    shape = shape1.capitalize() + '+' + shape2.capitalize()
+    shape2 = shape2.replace('rect', 'rectangle')
+    shape = shape1.capitalize() + '&' + shape2.capitalize()
     assert d.get_filter() == shape
 
 
-@pytest.mark.skip(reason='can cause a segfault')
 def test_img_get_filter_excluded(make_test_image):
     """Simple get_filter check on an image."""
     d = make_test_image
@@ -661,7 +660,8 @@ def test_img_get_filter_excluded(make_test_image):
     d.notice2d(shape1)
 
     shape2 = 'rect(4258,3830,4264,3841)'
-    d.notice2d(shape1, ignore=True)
+    d.notice2d(shape2, ignore=True)
 
+    shape2 = shape2.replace('rect', 'rectangle')
     shape = shape1.capitalize() + '&!' + shape2.capitalize()
     assert d.get_filter() == shape

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -26,8 +26,9 @@ import numpy as np
 
 import pytest
 
-from sherpa.astro.data import DataPHA
+from sherpa.astro.data import DataIMG, DataPHA
 from sherpa.utils.err import DataErr
+from sherpa.utils.testing import requires_data, requires_fits
 
 
 def test_can_not_group_ungrouped():
@@ -302,3 +303,311 @@ def test_416_c():
     exp = np.zeros(8)
     exp[3] = 3
     assert dep == pytest.approx(exp)
+
+
+@pytest.fixture
+def make_test_image():
+    """A simple image
+
+    Note that normally you'd have logical axes of 1:31,
+    1:21 here and then a WCS, but I've decided to number
+    the axes differently (in physical units) as there is
+    no requirement that the logical units are 1:nx/ny.
+    """
+
+    x1, x0 = np.mgrid[3830:3850, 4245:4275]
+
+    # What is the ordering of shape? At the moment going for
+    # NumPy style (ny, nx), but there is no credible documentation
+    # (any documentation was added to describe the behavior we
+    # have now).
+    #
+    shape = x0.shape
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = np.ones(x0.size)
+    return DataIMG('d', x0, x1, y, shape=shape)
+
+
+def test_img_set_coord_invalid(make_test_image):
+    """An invalid coord setting"""
+    d = make_test_image
+    assert d.coord == 'logical'
+
+    with pytest.raises(DataErr) as exc:
+        d.set_coord('bob')
+
+    emsg = "unknown coordinates: 'bob'\n"
+    emsg += "Valid options: logical, image, physical, world, wcs"
+    assert str(exc.value) == emsg
+
+    assert d.coord == 'logical'
+
+
+@pytest.mark.parametrize('coord,expected',
+                         [('physical', 'physical'),
+                          ('world', 'world'),
+                          ('wcs', 'world')])
+def test_img_set_coord_notset(coord, expected, make_test_image):
+    """A valid coord setting but we don't have the data"""
+
+    d = make_test_image
+    with pytest.raises(DataErr) as exc:
+        d.set_coord(coord)
+
+    emsg = "data set 'd' does not contain a {} coordinate system".format(expected)
+    assert str(exc.value) == emsg
+
+    assert d.coord == 'logical'
+
+
+@pytest.mark.parametrize('coord,expected',
+                         [('physical', 'physical'),
+                          ('world', 'world'),
+                          ('wcs', 'world')])
+def test_img_get_coord_notset(coord, expected, make_test_image):
+    """Check get_physical/world fail when there's no WCS"""
+    d = make_test_image
+
+    meth = getattr(d, 'get_{}'.format(coord))
+    with pytest.raises(DataErr) as exc:
+        meth()
+
+    emsg = "data set 'd' does not contain a {} coordinate system".format(expected)
+    assert str(exc.value) == emsg
+
+
+def test_img_set_coord_image(make_test_image):
+    """Can set to image though"""
+    d = make_test_image
+    assert d.coord == 'logical'
+
+    d.set_coord('image')
+    assert d.coord == 'logical'
+
+
+def test_img_get_coord_image(make_test_image):
+    """Can call get_image though"""
+    d = make_test_image
+
+    cs = d.get_image()
+
+    x1, x0 = np.mgrid[3830:3850, 4245:4275]
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+
+    assert cs[0] == pytest.approx(x0)
+    assert cs[1] == pytest.approx(x1)
+    assert len(cs) == 2
+
+
+@pytest.fixture
+def read_test_image(make_data_path):
+    from sherpa.astro.io import read_image
+    filename = 'acisf07999_000N001_r0035_regevt3_srcimg.fits'
+    d = read_image(make_data_path(filename))
+    d.name = 'test.img'
+    return d
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord,expected',
+                         [('logical', 'logical'),
+                          ('image', 'logical'),
+                          ('physical', 'physical'),
+                          ('world', 'world'),
+                          ('wcs', 'world')])
+def test_img_file_set_coord(coord, expected, read_test_image):
+    """call set_coord with an image with WCS"""
+    d = read_test_image
+    assert d.coord == 'logical'
+    d.set_coord(coord)
+    assert d.coord == expected
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord', ['logical', 'image', 'physical', 'world', 'wcs'])
+def test_img_file_get_logical(coord, read_test_image):
+    """get_logical when coord is set"""
+    d = read_test_image
+    d.set_coord(coord)
+
+    yexp, xexp = np.mgrid[1:378, 1:170]
+    xexp = xexp.flatten()
+    yexp = yexp.flatten()
+
+    x, y = d.get_logical()
+    assert x == pytest.approx(xexp)
+    assert y == pytest.approx(yexp)
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord', ['logical', 'image', 'physical', 'world', 'wcs'])
+def test_img_file_get_physical(coord, read_test_image):
+    """get_physical when coord is set"""
+    d = read_test_image
+    d.set_coord(coord)
+
+    yexp, xexp = np.mgrid[4333.1298828125:4710:1, 3062.3100585938:3231:1]
+    xexp = xexp.flatten()
+    yexp = yexp.flatten()
+
+    x, y = d.get_physical()
+    assert x == pytest.approx(xexp)
+    assert y == pytest.approx(yexp)
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord', ['logical', 'image', 'physical', 'world', 'wcs'])
+def test_img_file_get_world(coord, read_test_image):
+    """get_world when coord is set"""
+    d = read_test_image
+    d.set_coord(coord)
+
+    # Since the pixel size isn't guaranteed to be constant
+    # just check the corners. Note that this is not a
+    # check from first principles: it just checks that we
+    # get the same answer as previous calls to this routine.
+    #
+    x, y = d.get_world()
+
+    # BL
+    assert x[0] == pytest.approx(150.02683651815326)
+    assert y[0] == pytest.approx(2.6402818651328728)
+
+    # TR
+    assert x[-1] == pytest.approx(150.00385708212673)
+    assert y[-1] == pytest.approx(2.6916707654223244)
+
+    # BR
+    assert x[168] == pytest.approx(150.00385224075313)
+    assert y[168] == pytest.approx(2.640284264823834)
+
+    # TL
+    assert x[169 * 377 - 169] == pytest.approx(150.0268422985145)
+    assert y[169 * 377 - 169] == pytest.approx(2.691668318963721)
+
+
+def test_img_get_axes_logical(make_test_image):
+    """Does get_axes work?"""
+    d = make_test_image
+    x, y = d.get_axes()
+
+    assert x == pytest.approx(np.arange(1, 31, 1))
+    assert y == pytest.approx(np.arange(1, 21, 1))
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord', ['logical', 'image'])
+def test_img_file_get_axes_logical(coord, read_test_image):
+    """get_axes when coord is set: logical"""
+    d = read_test_image
+    d.set_coord(coord)
+    x, y = d.get_axes()
+
+    assert x == pytest.approx(np.arange(1, 170, 1))
+    assert y == pytest.approx(np.arange(1, 378, 1))
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord', ['physical'])
+def test_img_file_get_axes_physical(coord, read_test_image):
+    """get_axes when coord is set: physical"""
+    d = read_test_image
+    d.set_coord(coord)
+    x, y = d.get_axes()
+
+    assert x == pytest.approx(np.arange(3062.3100585938, 3231, 1))
+    assert y == pytest.approx(np.arange(4333.1298828125, 4710, 1))
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord', ['world', 'wcs'])
+def test_img_file_get_axes_world(coord, read_test_image):
+    """get_axes when coord is set: world"""
+    d = read_test_image
+    d.set_coord(coord)
+    x, y = d.get_axes()
+
+    assert x.size == 169
+    assert y.size == 377
+
+    # This is an interesting combination of the corners from
+    # test_img_file_get_world
+    assert x[0] == pytest.approx(150.02683651815326)
+    assert y[0] == pytest.approx(2.6402818651328728)
+    assert x[-1] == pytest.approx(150.00385224075313)
+    assert y[-1] == pytest.approx(2.691668318963721)
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord,expected',
+                         [('logical', 'x0'),
+                          ('image', 'x0'),
+                          ('physical', 'x0 (pixels)'),
+                          ('world', 'RA (deg)'),
+                          ('wcs', 'RA (deg)')])
+def test_img_file_get_xlabel(coord, expected, read_test_image):
+    """get_x0label"""
+    d = read_test_image
+    d.set_coord(coord)
+    assert d.get_x0label() == expected
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize('coord,expected',
+                         [('logical', 'x1'),
+                          ('image', 'x1'),
+                          ('physical', 'x1 (pixels)'),
+                          ('world', 'DEC (deg)'),
+                          ('wcs', 'DEC (deg)')])
+def test_img_file_get_ylabel(coord, expected, read_test_image):
+    """get_x1label"""
+    d = read_test_image
+    d.set_coord(coord)
+    assert d.get_x1label() == expected
+
+
+def test_img_get_bounding_mask_nofilter(make_test_image):
+    """get_bounding_mask with no filter"""
+    d = make_test_image
+    ans = d.get_bounding_mask()
+    assert len(ans) == 2
+    assert ans[0]
+    assert ans[1] is None
+
+
+def test_img_get_bounding_mask_nodata(make_test_image):
+    """get_bounding_mask with all data masked"""
+    d = make_test_image
+    d.notice2d(ignore=True)
+    ans = d.get_bounding_mask()
+    assert len(ans) == 2
+    assert not ans[0]
+    assert ans[1] is None
+
+
+def test_img_get_bounding_mask_filtered(make_test_image):
+    """get_bounding_mask with data partially filtered"""
+    d = make_test_image
+    d.notice2d('ellipse(4260,3840,3,2,0)')
+    ans = d.get_bounding_mask()
+    print(np.where(ans[0]))
+
+    mask = np.zeros(5 * 7, dtype=np.bool)
+    for i in [ 3,  8,  9, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 31]:
+        mask[i] = True
+
+    assert len(ans) == 2
+    assert ans[0] == pytest.approx(mask)
+    assert ans[1] == (5, 7)

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -18,13 +18,15 @@
 #
 
 import logging
+
 import numpy
-from ._utils import arf_fold, do_group, expand_grouped_mask, \
-    filter_resp, is_in, resp_init, rmf_fold, shrink_effarea
-from ._pileup import apply_pileup
 
 from sherpa.utils import get_position, filter_bins
 from sherpa.utils.err import IOErr, DataErr
+
+from ._utils import arf_fold, do_group, expand_grouped_mask, \
+    filter_resp, is_in, resp_init, rmf_fold, shrink_effarea
+from ._pileup import apply_pileup
 
 
 __all__ = ['arf_fold', 'rmf_fold', 'do_group', 'apply_pileup',
@@ -39,16 +41,6 @@ __all__ = ['arf_fold', 'rmf_fold', 'do_group', 'apply_pileup',
 
 warning = logging.getLogger(__name__).warning
 
-
-try:
-    from ._region import Region, region_mask
-
-    __all__.append('region_mask')
-    __all__.append('Region')
-
-except ImportError:
-    warning('failed to import sherpa.astro.utils._region; Region routines ' +
-            'will not be available')
 
 # Useful constants
 #

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -42,11 +42,10 @@ static PyObject* region_combine( PyRegion* self, PyObject* args, PyObject *kwarg
 static regRegion* parse_string( char* str, int fileflag ) {
 
   regRegion *reg = NULL;
-  std::string input(str); // what benefit do we get casting to std:string?
   if( fileflag ) {
-    reg = regReadAsciiRegion( (char*)input.c_str() , 0 ); // Verbosity set to 0
+    reg = regReadAsciiRegion( str, 0 ); // Verbosity set to 0
   } else {
-    reg = regParse( (char*)input.c_str() );
+    reg = regParse( str );
   }
 
   return reg;

--- a/sherpa/astro/utils/tests/test_region_unit.py
+++ b/sherpa/astro/utils/tests/test_region_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,7 +17,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import pytest
-from sherpa.astro.utils._region import region_mask, Region
+
+from sherpa.astro.utils._region import Region, region_combine, region_mask
 
 
 region_string = 'Circle(256 ,256 , 25)'
@@ -28,46 +29,203 @@ xm = [254, 255, 256]
 ym = [254, 255, 256]
 
 
+def test_region_empty():
+    """The empty region"""
+    r = Region()
+    assert '' == str(r)
+
+
 def test_region_string():
+    """We can create with a string.
+
+    Note the regon gets normalized.
+    """
     r = Region(region_string)
     assert normalized_string == str(r)
 
 
-def test_region_mask_string():
-    r, m = region_mask(None, region_string, x, y, False, False)
+def test_region_string_invalid():
+    """Check we error out with invalid input"""
+    wrong = 'circle 100 200 30'
+    with pytest.raises(ValueError) as exc:
+        Region(wrong)
+
+    emsg = 'unable to parse region string: ' + wrong
+    assert str(exc.value) == emsg
+
+
+def test_region_file(tmpdir):
+    """Can we create a region from a file?"""
+    f = tmpdir.join('reg')
+    f.write(normalized_string)
+
+    r = Region(str(f), True)
     assert normalized_string == str(r)
+
+
+def test_region_file_invalid(tmpdir):
+    """What happens if the file is invalid.
+
+    Note that the file parser apparently fails if
+    there are spaces, so I use region_string here
+    in case the parser ever gets improved.
+    """
+    f = tmpdir.join('reg')
+    f.write(region_string)
+
+    with pytest.raises(ValueError) as exc:
+        Region(str(f), True)
+
+    emsg = 'unable to read region from: {}'.format(f)
+    assert str(exc.value) == emsg
+
+
+@pytest.mark.parametrize("arg", [None, 3])
+def test_region_invalid(arg):
+    """What happens with some invalid arguments?"""
+    with pytest.raises(TypeError):
+        Region(arg)
+
+
+def test_region_mask_nomatch():
+    """All points are excluded"""
+    r = Region(region_string)
+    m = region_mask(r, x, y)
     assert all(val == 0 for val in m)
 
 
-def test_region_mask_string_match():
-    r, m = region_mask(None, region_string, xm, ym, False, False)
-    assert normalized_string == str(r)
-    assert all(val != 0 for val in m)
+def test_region_mask_match():
+    """All points are included"""
+    r = Region(region_string)
+    m = region_mask(r, xm, ym)
+    assert all(val == 1 for val in m)
 
 
-def test_region_mask_file(tmpdir):
+def test_region_mask_nomatch_file(tmpdir):
+    """It shoudn't matter where the region comes from"""
     f = tmpdir.join("reg")
     f.write(normalized_string)
-    r, m = region_mask(None, str(f), x, y, True, False)
-    assert normalized_string == str(r)
+
+    r = Region(str(f), True)
+    m = region_mask(r, x, y)
     assert all(val == 0 for val in m)
 
 
-def test_region_non_string():
-    with pytest.raises(TypeError):
-        Region(3)
+def test_region_mask_match_file(tmpdir):
+    """It shoudn't matter where the region comes from"""
+    f = tmpdir.join("reg")
+    f.write(normalized_string)
 
-
-def test_region_null():
-    with pytest.raises(TypeError):
-        Region(None)
-
-
-def test_region_mask_non_string():
-    with pytest.raises(TypeError):
-        region_mask(None, 3, x, y, False, False)
+    r = Region(str(f), True)
+    m = region_mask(r, xm, ym)
+    assert all(val == 1 for val in m)
 
 
 def test_region_mask_null():
+    """What happens if the region is empty?"""
+    empty = Region()
+    m = region_mask(empty, x, y)
+    assert all(val == 0 for val in m)
+
+
+@pytest.mark.parametrize("arg", [None, "circle(100,100,3)"])
+def test_region_mask_non_region(arg):
+    """The first argument must be a Region"""
     with pytest.raises(TypeError):
-        region_mask(None, None, x, y, False, False)
+        region_mask(arg, x, y)
+
+
+def test_region_combine_nothing1():
+    """Adding a region to nothing == region"""
+
+    r = region_combine(Region(), Region(region_string))
+    assert normalized_string == str(r)
+
+
+def test_region_ignore_nothing1():
+    """Ignoring a region frm nothing == !region"""
+
+    r = region_combine(Region(), Region(region_string), True)
+    assert '!' + normalized_string == str(r)
+
+
+@pytest.mark.parametrize('ignore', [False, True])
+def test_region_combine_nothing2(ignore):
+    """Adding or ignoring nothing to a region == region"""
+
+    r = region_combine(Region(region_string), Region(), ignore)
+    assert normalized_string == str(r)
+
+
+def test_region_combine():
+    """Adding two regions together"""
+
+    r1 = 'circle(10,10,10)'
+    r2 = 'rect(100,100,200,200)'
+    r = region_combine(Region(r1), Region(r2))
+
+    r2 = r2.replace('rect', 'rectangle')
+    expected = r1.capitalize() + '&' + r2.capitalize()
+    assert expected == str(r)
+
+
+def test_region_ignore_no_overlap():
+    """Ignoring a region which doesn't overlap.
+
+    It looks like the region lib doesn't try to simplify
+    the combination of shapes.
+    """
+
+    r1 = 'circle(10,10,10)'
+    r2 = 'rect(100,100,200,200)'
+    r = region_combine(Region(r1), Region(r2), True)
+
+    r2 = r2.replace('rect', 'rectangle')
+    expected = r1.capitalize() + '&!' + r2.capitalize()
+    assert expected == str(r)
+
+
+def test_region_ignore_overlap():
+    """Ignoring a region which does overlap."""
+
+    r1 = 'circle(10,10,10)'
+    r2 = 'rect(5,5,7,10)'
+    r = region_combine(Region(r1), Region(r2), True)
+
+    r2 = r2.replace('rect', 'rectangle')
+    expected = r1.capitalize() + '&!' + r2.capitalize()
+    assert expected == str(r)
+
+
+def test_region_combine_combined():
+    """Check multiple calls to region_combine"""
+
+    r1 = 'circle(10,10,10)'
+    r2 = 'rect(100,100,200,200)'
+    r3 = 'ellipse(70,70,10,12,45)'
+
+    rcomb = region_combine(Region(r1), Region(r2))
+    rcomb = region_combine(rcomb, Region(r3))
+
+    r2 = r2.replace('rect', 'rectangle')
+    expected = '&'.join([x.capitalize() for x in [r1, r2, r3]])
+    assert expected == str(rcomb)
+
+
+def test_region_ignore_combined():
+    """Check multiple calls to region_combine
+
+    I am not sure I agree with the result but I just want
+    to check the results.
+    """
+
+    r1 = 'circle(10,10,10)'
+    r2 = 'rect(100,100,200,200)'
+    r3 = 'ellipse(70,70,10,12,45)'
+
+    rcomb = region_combine(Region(r1), Region(r2), True)
+    rcomb = region_combine(rcomb, Region(r3))
+
+    r2 = '!' + r2.replace('rect', 'rectangle').capitalize()
+    expected = '&'.join([r1.capitalize(), r2, r3.capitalize()])
+    assert expected == str(rcomb)

--- a/sherpa/astro/utils/tests/test_region_unit.py
+++ b/sherpa/astro/utils/tests/test_region_unit.py
@@ -18,6 +18,8 @@
 #
 import pytest
 
+import numpy as np
+
 from sherpa.astro.utils._region import Region
 
 
@@ -285,3 +287,35 @@ def test_region_combine_invalid(arg):
 
     with pytest.raises(TypeError):
         Region().combine(arg)
+
+
+def test_region_invert():
+    """Can we invert a region?"""
+
+    x = np.asarray([50, 95, 105])
+    y = np.asarray([50, 105, 115])
+
+    r = Region("box(100,100,10,20)")
+
+    assert r.mask(x, y) == pytest.approx([0, 1, 0])
+
+    r.invert()
+    assert str(r) == "!Box(100,100,10,20)"
+
+    assert r.mask(x, y) == pytest.approx([1, 0, 1])
+
+
+def test_region_invert_empty():
+    """Can we invert an empty region?"""
+
+    x = np.asarray([50, 95, 105])
+    y = np.asarray([50, 105, 115])
+
+    r = Region()
+
+    assert r.mask(x, y) == pytest.approx([0, 0, 0])
+
+    r.invert()
+    assert str(r) == ''
+
+    assert r.mask(x, y) == pytest.approx([0, 0, 0])

--- a/sherpa/astro/utils/tests/test_region_unit.py
+++ b/sherpa/astro/utils/tests/test_region_unit.py
@@ -42,7 +42,7 @@ def test_region_empty():
 def test_region_string():
     """We can create with a string.
 
-    Note the regon gets normalized.
+    Note the region gets normalized.
     """
     r = Region(region_string)
     assert normalized_string == str(r)


### PR DESCRIPTION
# Summary

Fix problems with ignore2d and notice2d when multiple regions are used that could cause a segmentation fault.

# Details

I have no idea when or why #965 started - is it that the external region lib code got updated and our _region module didn't follow some changes, or some other reason?

There are two commits to add some basic image tests which we were not covering. The ones in the first commit are not related to the problem but are nice to have. The second commit adds some tests which we have to skip because they cause Python to crash.

The third commit reworks the sherpa.astro.data.DataIMG.notice2d method slightly, to make it a bit clearer what it is doing. It still errors out though.

The fourth commit is where the fix happens:

    I don't actually know why the old code failed, but I decided to
    simplify the region_mask routine in sherpa.astro.utils._region
    which ended up in reworking that module completely. Since this
    is a low-level module, and it is *only* used by sherpa.astro.data
    I felt we were unlikely to be breaking any external code (these
    routines are poorly documented).

    Changes:

    - the import of sherpa.astro.utils._region is now done by
      sherpa.astro.data rather than importing it via
      sherpa.astro.utils
    - the Region lib has changed from accepting a string, which
      must contain a region, to
      - being able to create with no argument, to create an
        empty region
      - if called with a single string it is a region
      - if called with a string and an integer, then if the
        integer is 0 it is taken to be a region, otherwise
        it is taken to be the name of an ASCII file
        containing the region
    - region_mask has been simplified into three routines:
      a) use Region() to parse the region specification
      b) use region_mask to *ONLY* calculate the mask for
         the region (treated as an include)
      c) use region_combine to combine regions

    Somewhere in the rework of region_mask I appear to have fixed
    issue #965

    The tests in test_astro_data2.py - test_img_get_filter_combined
    and test_img_get_filter_excluded - have had the skip pytest
    mark removed, since they now no-longer crash Python. Unfortunately
    there were several gremlins in the original test (since I
    couldn't run it to test the expected outout) which had to be
    fixed at the same time.

    The tests in test_region_unit have had to be changed since
    region_mask has changed significantly. I've added a number of
    simple tests to improve the coverage of the C++ code.

    I have spent time reviewing the Region, region_mask, and
    region_combine routines to check they do not leak memory,
    running a loop like

    while True:
       ...:     r1 = Region('circle(200,200,20)')
       ...:     r2 = Region('circle(205,205,20)')
       ...:     r = region_combine(r1, r2)
       ...:     region_mask(r, [200, 300, 210], [200, 300, 210])

    while checking top, and (after some fun) the memory use
    looks good.

The fifth commit moves the methods region_mask and region_combine to methods of the Region
class, as it makes more sense to have them as methods (they both require a region, so may as well
make them methods!). This makes the memory leak check

    from sherpa.astro.utils._region import Region
    while True:
       ...:     r1 = Region('circle(200,200,20)')
       ...:     r2 = Region('circle(205,205,20)')
       ...:     r = r1.combine(r2)
       ...:     r.mask([200, 300, 210], [200, 300, 210])

The sixth commit just adds some tests that the coverage checks showed were missing.

Commit 7 removes an unnecessary cast.

Commit 8 fixes a bug introduced in the rewrite: if the first region added is an excluded region then this wasn't being handled correctly.

# Notes

I have my suspicions that the bug is in the old `region_mask` section

```
  if( reverse ) {
    regRegion *tmp = reg;
    reg = regInvert( tmp );
    if( tmp ) regFree( tmp );
  }

  // If possible, append the new region string to the stack
  if( reg_obj != Py_None ) {
    region = (PyRegion*)(reg_obj);
    regRegion *tmp = reg;

    reg = regCombineRegion( region->region, tmp );

    if ( NULL == reg) {
      PyErr_SetString( PyExc_TypeError,
                       (char*)"unable to combine regions successfully" );
      return NULL;
    }

    pyRegion_dealloc( region );
    if( tmp ) regFree( tmp );
  }
  region = (PyRegion*) pyRegion_build( &pyRegion_Type, reg );

  Py_XINCREF(region);

  return Py_BuildValue((char*)"ON", region, mask.return_new_ref());
```

and has several suspicious areas - the freeing of regions associated with the Python region structure, a random pyRegion_dealloc call to an object that is in use, and the Py_XINCREF - but I haven't spent time trying to track
down what the problem was (or, probably were).