### PR TITLE
Use C99 def for INFINITY, NAN, isfinite and isnan to build on aarch64 (fix issue #970)

### DIFF
--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -147,6 +147,8 @@ utils = Extension('sherpa.utils._utils',
               depends=(get_deps(['extension', 'utils'])+
                        ['sherpa/utils/src/gsl/fcmp.h',
                         'sherpa/utils/src/cephes/cephes.h',
+                        'sherpa/utils/src/cephes/mconf.h',
+                        'sherpa/utils/src/cephes/protos.h',
                         'sherpa/utils/src/sjohnson/Faddeeva.hh']))
 
 modelfcts = Extension('sherpa.models._modelfcts',

--- a/sherpa/utils/src/cephes/const.c
+++ b/sherpa/utils/src/cephes/const.c
@@ -134,7 +134,7 @@ unsigned short LOGE2[4]  = {0x39ef,0xfefa,0x2e42,0x3fe6};
 unsigned short LOGSQ2[4] = {0x39ef,0xfefa,0x2e42,0x3fd6};
 unsigned short THPIO4[4] = {0x21d2,0x7f33,0xd97c,0x4002};
 unsigned short TWOOPI[4] = {0xc883,0x6dc9,0x5f30,0x3fe4};
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 #ifdef INFINITIES
 unsigned short INFINITY[4] = {0x0000,0x0000,0x0000,0x7ff0};
 #else
@@ -248,7 +248,7 @@ extern unsigned short LOGE2[];
 extern unsigned short LOGSQ2[];
 extern unsigned short THPIO4[];
 extern unsigned short TWOOPI[];
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 extern unsigned short INFINITY[];
 extern unsigned short NAN[];
 #endif

--- a/sherpa/utils/src/cephes/const.c
+++ b/sherpa/utils/src/cephes/const.c
@@ -134,7 +134,7 @@ unsigned short LOGE2[4]  = {0x39ef,0xfefa,0x2e42,0x3fe6};
 unsigned short LOGSQ2[4] = {0x39ef,0xfefa,0x2e42,0x3fd6};
 unsigned short THPIO4[4] = {0x21d2,0x7f33,0xd97c,0x4002};
 unsigned short TWOOPI[4] = {0xc883,0x6dc9,0x5f30,0x3fe4};
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 #ifdef INFINITIES
 unsigned short INFINITY[4] = {0x0000,0x0000,0x0000,0x7ff0};
 #else
@@ -248,7 +248,7 @@ extern unsigned short LOGE2[];
 extern unsigned short LOGSQ2[];
 extern unsigned short THPIO4[];
 extern unsigned short TWOOPI[];
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 extern unsigned short INFINITY[];
 extern unsigned short NAN[];
 #endif

--- a/sherpa/utils/src/cephes/const.c
+++ b/sherpa/utils/src/cephes/const.c
@@ -134,6 +134,7 @@ unsigned short LOGE2[4]  = {0x39ef,0xfefa,0x2e42,0x3fe6};
 unsigned short LOGSQ2[4] = {0x39ef,0xfefa,0x2e42,0x3fd6};
 unsigned short THPIO4[4] = {0x21d2,0x7f33,0xd97c,0x4002};
 unsigned short TWOOPI[4] = {0xc883,0x6dc9,0x5f30,0x3fe4};
+#ifdef MAKECEPHESC99COMPLIANT
 #ifdef INFINITIES
 unsigned short INFINITY[4] = {0x0000,0x0000,0x0000,0x7ff0};
 #else
@@ -143,6 +144,7 @@ unsigned short INFINITY[4] = {0xffff,0xffff,0xffff,0x7fef};
 unsigned short NAN[4] = {0x0000,0x0000,0x0000,0x7ffc};
 #else
 unsigned short NAN[4] = {0x0000,0x0000,0x0000,0x0000};
+#endif
 #endif
 #ifdef MINUSZERO
 unsigned short NEGZERO[4] = {0x0000,0x0000,0x0000,0x8000};
@@ -246,7 +248,9 @@ extern unsigned short LOGE2[];
 extern unsigned short LOGSQ2[];
 extern unsigned short THPIO4[];
 extern unsigned short TWOOPI[];
+#ifdef MAKECEPHESC99COMPLIANT
 extern unsigned short INFINITY[];
 extern unsigned short NAN[];
+#endif
 extern unsigned short NEGZERO[];
 #endif

--- a/sherpa/utils/src/cephes/gamma.c
+++ b/sherpa/utils/src/cephes/gamma.c
@@ -274,7 +274,7 @@ extern double MAXLOG, MAXNUM, PI;
 double pow(), log(), exp(), sin(), polevl(), p1evl(), floor(), fabs();
 int isnan(), isfinite();
 #else
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 extern int isfinite ( double x );
 #endif
 static double stirf(double);

--- a/sherpa/utils/src/cephes/gamma.c
+++ b/sherpa/utils/src/cephes/gamma.c
@@ -274,7 +274,7 @@ extern double MAXLOG, MAXNUM, PI;
 double pow(), log(), exp(), sin(), polevl(), p1evl(), floor(), fabs();
 int isnan(), isfinite();
 #else
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 extern int isfinite ( double x );
 #endif
 static double stirf(double);

--- a/sherpa/utils/src/cephes/gamma.c
+++ b/sherpa/utils/src/cephes/gamma.c
@@ -274,7 +274,9 @@ extern double MAXLOG, MAXNUM, PI;
 double pow(), log(), exp(), sin(), polevl(), p1evl(), floor(), fabs();
 int isnan(), isfinite();
 #else
+#ifdef MAKECEPHESC99COMPLIANT
 extern int isfinite ( double x );
+#endif
 static double stirf(double);
 #endif
 #ifdef INFINITIES

--- a/sherpa/utils/src/cephes/igami.c
+++ b/sherpa/utils/src/cephes/igami.c
@@ -51,7 +51,7 @@ Copyright 1984, 1987, 1995 by Stephen L. Moshier
 #include "mconf.h"
 #include <stdio.h>
 
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 extern double MACHEP, MAXNUM, MAXLOG, MINLOG, NAN;
 #else
 extern double MACHEP, MAXNUM, MAXLOG, MINLOG/*, NAN*/;

--- a/sherpa/utils/src/cephes/igami.c
+++ b/sherpa/utils/src/cephes/igami.c
@@ -51,10 +51,10 @@ Copyright 1984, 1987, 1995 by Stephen L. Moshier
 #include "mconf.h"
 #include <stdio.h>
 
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 extern double MACHEP, MAXNUM, MAXLOG, MINLOG, NAN;
 #else
-extern double MACHEP, MAXNUM, MAXLOG, MINLOG/*, NAN*/;
+extern double MACHEP, MAXNUM, MAXLOG, MINLOG;
 #endif
 
 #ifndef ANSIPROT

--- a/sherpa/utils/src/cephes/igami.c
+++ b/sherpa/utils/src/cephes/igami.c
@@ -51,7 +51,8 @@ Copyright 1984, 1987, 1995 by Stephen L. Moshier
 #include "mconf.h"
 #include <stdio.h>
 
-extern double MACHEP, MAXNUM, MAXLOG, MINLOG, NAN;
+extern double MACHEP, MAXNUM, MAXLOG, MINLOG/*, NAN*/;
+
 #ifndef ANSIPROT
 double igamc(), ndtri(), exp(), fabs(), log(), sqrt(), lgam();
 #endif

--- a/sherpa/utils/src/cephes/igami.c
+++ b/sherpa/utils/src/cephes/igami.c
@@ -51,7 +51,11 @@ Copyright 1984, 1987, 1995 by Stephen L. Moshier
 #include "mconf.h"
 #include <stdio.h>
 
+#ifdef MAKECEPHESC99COMPLIANT
+extern double MACHEP, MAXNUM, MAXLOG, MINLOG, NAN;
+#else
 extern double MACHEP, MAXNUM, MAXLOG, MINLOG/*, NAN*/;
+#endif
 
 #ifndef ANSIPROT
 double igamc(), ndtri(), exp(), fabs(), log(), sqrt(), lgam();

--- a/sherpa/utils/src/cephes/incbet.c
+++ b/sherpa/utils/src/cephes/incbet.c
@@ -80,7 +80,9 @@ static double incbcf(), incbd(), pseries();
 static double big = 4.503599627370496e15;
 static double biginv =  2.22044604925031308085e-16;
 
+#ifdef MAKECEPHESC99COMPLIANT
 extern double NAN;
+#endif
 
 double incbet( aa, bb, xx )
 double aa, bb, xx;

--- a/sherpa/utils/src/cephes/incbet.c
+++ b/sherpa/utils/src/cephes/incbet.c
@@ -80,7 +80,7 @@ static double incbcf(), incbd(), pseries();
 static double big = 4.503599627370496e15;
 static double biginv =  2.22044604925031308085e-16;
 
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 extern double NAN;
 #endif
 

--- a/sherpa/utils/src/cephes/incbet.c
+++ b/sherpa/utils/src/cephes/incbet.c
@@ -80,7 +80,7 @@ static double incbcf(), incbd(), pseries();
 static double big = 4.503599627370496e15;
 static double biginv =  2.22044604925031308085e-16;
 
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 extern double NAN;
 #endif
 

--- a/sherpa/utils/src/cephes/isnan.c
+++ b/sherpa/utils/src/cephes/isnan.c
@@ -71,6 +71,7 @@ Copyright 1984, 1995 by Stephen L. Moshier
 #endif
 #endif
 
+#ifdef MAKECEPHESC99COMPLIANT
 #ifdef ANSIPROT
 extern int signbit ( double x );
 extern int cephes_isnan ( double x );
@@ -116,7 +117,7 @@ else
 #endif
 	}
 }
-
+#endif
 
 /* Return 1 if x is a number that is Not a Number, else return 0.  */
 
@@ -187,7 +188,7 @@ return(0);
 
 
 /* Return 1 if x is not infinite and is not a NaN.  */
-
+#ifdef MAKECEPHESC99COMPLIANT
 int isfinite(x)
 double x;
 {
@@ -238,3 +239,4 @@ else
 return(1);
 #endif
 }
+#endif

--- a/sherpa/utils/src/cephes/isnan.c
+++ b/sherpa/utils/src/cephes/isnan.c
@@ -71,7 +71,7 @@ Copyright 1984, 1995 by Stephen L. Moshier
 #endif
 #endif
 
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 #ifdef ANSIPROT
 extern int signbit ( double x );
 extern int cephes_isnan ( double x );
@@ -188,7 +188,7 @@ return(0);
 
 
 /* Return 1 if x is not infinite and is not a NaN.  */
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 int isfinite(x)
 double x;
 {

--- a/sherpa/utils/src/cephes/isnan.c
+++ b/sherpa/utils/src/cephes/isnan.c
@@ -71,7 +71,7 @@ Copyright 1984, 1995 by Stephen L. Moshier
 #endif
 #endif
 
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 #ifdef ANSIPROT
 extern int signbit ( double x );
 extern int cephes_isnan ( double x );
@@ -188,7 +188,7 @@ return(0);
 
 
 /* Return 1 if x is not infinite and is not a NaN.  */
-#ifdef MAKECEPHESC99COMPLIANT
+#ifdef NOC99COMPILER
 int isfinite(x)
 double x;
 {

--- a/sherpa/utils/src/cephes/mconf.h
+++ b/sherpa/utils/src/cephes/mconf.h
@@ -62,7 +62,8 @@ Cephes Math Library Release 2.3:  June, 1995
 Copyright 1984, 1987, 1989, 1995 by Stephen L. Moshier
 */
 
-//#include "cephes_names.h"
+#include <math.h>
+/*#include "cephes_names.h"*/
 
 /* Constant definitions for math error conditions
  */
@@ -173,6 +174,7 @@ typedef struct
 /* Define to support tiny denormal numbers, else undefine. */
 #define DENORMAL 1
 
+#ifdef MAKECEPHESC99COMPLIANT          
 /* Define to ask for infinity support, else undefine. */
 #define INFINITIES 1
 #ifdef NOINFINITIES
@@ -184,6 +186,7 @@ typedef struct
 #define NANS 1
 #ifdef NONANS
 #undef NANS
+#endif
 #endif
 
 /* Define to distinguish between -0.0 and +0.0.  */

--- a/sherpa/utils/src/cephes/mconf.h
+++ b/sherpa/utils/src/cephes/mconf.h
@@ -65,23 +65,11 @@ Copyright 1984, 1987, 1989, 1995 by Stephen L. Moshier
 /*
  * The Cephes Math Library was written before the C99 standards
  * were available as a result: a few math constants and functtions
- * were defined by the library.  If the NOC99COMPILER is defined,
- * i.e. by uncomment the following line:
-#define NOC99COMPILER 1
- * then the code will be restored to its original state otherwise
- * the aforementioned math constants and functions from the C99
- * compiler shall be used.
+ * were defined by the library.
  */
+#if (__STDC_VERSION__ >= 199901L)
 /*
-#define NOC99COMPILER 1
-*/
-#ifdef NOC99COMPILER
-/*
- * Restore Lib to its original state
- */
-#else
-/*
- * Use relevant math constants and funcs from C99 compiler
+ * Use relevant math constants and funcs from C99 compliant compiler
  */
 #include <math.h>
 #endif
@@ -197,7 +185,7 @@ typedef struct
 /* Define to support tiny denormal numbers, else undefine. */
 #define DENORMAL 1
 
-#ifdef NOC99COMPILER
+#ifndef __STDC_VERSION__
 /* Define to ask for infinity support, else undefine. */
 #define INFINITIES 1
 #ifdef NOINFINITIES

--- a/sherpa/utils/src/cephes/mconf.h
+++ b/sherpa/utils/src/cephes/mconf.h
@@ -62,7 +62,30 @@ Cephes Math Library Release 2.3:  June, 1995
 Copyright 1984, 1987, 1989, 1995 by Stephen L. Moshier
 */
 
+/*
+ * The Cephes Math Library was written before the C99 standards
+ * were available as a result: a few math constants and functtions
+ * were defined by the library.  If the NOC99COMPILER is defined,
+ * i.e. by uncomment the following line:
+#define NOC99COMPILER 1
+ * then the code will be restored to its original state otherwise
+ * the aforementioned math constants and functions from the C99
+ * compiler shall be used.
+ */
+/*
+#define NOC99COMPILER 1
+*/
+#ifdef NOC99COMPILER
+/*
+ * Restore Lib to its original state
+ */
+#else
+/*
+ * Use relevant math constants and funcs from C99 compiler
+ */
 #include <math.h>
+#endif
+
 /*#include "cephes_names.h"*/
 
 /* Constant definitions for math error conditions
@@ -174,7 +197,7 @@ typedef struct
 /* Define to support tiny denormal numbers, else undefine. */
 #define DENORMAL 1
 
-#ifdef MAKECEPHESC99COMPLIANT          
+#ifdef NOC99COMPILER
 /* Define to ask for infinity support, else undefine. */
 #define INFINITIES 1
 #ifdef NOINFINITIES


### PR DESCRIPTION
# Note

Use the math constants (```IFINITIY```, ```NAN```) and funcs (```isfinite```, ```isnan```, ```signbit```) from a C99 compliant compiler if the compiler option ```-std=c99``` or greater is used, otherwise use the quantities as defined by the library.

[See how test was done for details](https://github.com/sherpa/sherpa/pull/978#issuecomment-726316153)