### PR TITLE
Improve plots of PHA data sets and models when the response grid is not ideal

### DIFF
--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -270,7 +270,6 @@ def test_sourceplot_prepare_wavelength(make_data_path):
     assert plot.y.size == 1090
 
 
-@pytest.mark.xfail(reason='issue #977')
 def test_pha_data_with_gaps_977():
     """If the lo/hi edges don't quite match what happens?
 
@@ -311,7 +310,6 @@ def test_pha_data_with_gaps_977():
     assert (xlo[1:] == xhi[:-1]).all()
 
 
-@pytest.mark.xfail(reason='issue #977')
 def test_pha_model_with_gaps_977():
     """If the lo/hi edges don't quite match what happens?
 


### PR DESCRIPTION
# Summary

Improve the display (plots) of PHA data and models when the response grid contains minor numerical differences. This fixes #977.

# Details

    The code now checks for "close" edges and replaces them so that
    they are identical. In this case the sherpa.utils.sao_fcmp method,
    with a tolerance of numpy.finfo(numpy.float32).eps, is used to
    identify close values. This works for the problematic case found
    in #977 but is not a guarantee for all cases. if the difference is
    much larger than I argue that the PHA or response file is "not
    ideal" and really it's an issue for the data producer.

    I could not see any obvious code in sherpa.astro.data or
    sherpa.astro.instrument that worries about such differences. This
    should really be addressed but is a much-larger issue than this
    fix.

    One possibility for fixing #977 was to place the logic into the
    sherpa.plot histogram code, so that all histogram plots would
    benefit. I did not do this because for the PHA data we have
    domain knowledge that the bins are not going to relevant at
    very-small values (e.g. float32 eps sizes), whereas in the
    general case we do not. It therefore seems safer to only
    apply a fix for these cases.
