### PR TITLE
Address set_xlog/ylog problems with DataPHA/Data1DInt classes (#981)

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3132,7 +3132,7 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
     """Does set_ylog/ylinear work?
 
     Unlike test_set_plot_opt_x, the Y axis setting of the plot
-    does not necessarily folloe the set_ylog setting (e.g.
+    does not necessarily follow the set_ylog setting (e.g.
     the residual plots).
     """
 
@@ -3166,6 +3166,10 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
             assert p1.dataplot.plot_prefs['ylog'] == answer
             assert p1.modelplot.plot_prefs['ylog'] == answer
     elif plotfunc in ['resid', 'ratio', 'delchi']:
+        # We use plot_prefs even if is_int is True for
+        # the residual-style plots. That is, the ordering
+        # of the checks here is important.
+        #
         assert p1.plot_prefs['ylog'] == answer
     elif is_int:
         assert p1.histo_prefs['ylog'] == answer
@@ -3247,7 +3251,7 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
         # Note that for DataPHA datasets the modelplot object is
         # created on-the-fly using sherpa.astro.plot.ModelPHAHistogram,
         # rather than a session._plotobj value that is also set in
-        # session._plot_types, so it doesn't get changed bu set_xlog etc.
+        # session._plot_types, so it doesn't get changed by set_xlog etc.
         #
         # Ideally this would match the dataplot setting but it isn't
         # actually required for the plot to work.

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3452,7 +3452,6 @@ def test_set_opt_invalid(cls):
 
 
 @requires_pylab
-@pytest.mark.xfail
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 def test_set_plot_opt_explicit(cls):

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3039,7 +3039,7 @@ def test_datapha_plot_after_clean():
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("datafunc", [example_data1d,
-                                      pytest.param(example_data1dint, marks=pytest.mark.xfail)])
+                                      example_data1dint])
 @pytest.mark.parametrize("plotfunc",
                          ['data',
                           'model',
@@ -3118,7 +3118,7 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc):
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("datafunc", [example_data1d,
-                                      pytest.param(example_data1dint, marks=pytest.mark.xfail)])
+                                      example_data1dint])
 @pytest.mark.parametrize("plotfunc,answer",
                          [('data', True),
                           ('model', True),
@@ -3243,7 +3243,12 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
     p1 = pdata()
     if plotfunc in ['fit', 'bkg_fit']:
         assert p1.dataplot.histo_prefs['xlog']
-        # Check the current behavior of the model plot in case it changes
+        # Check the current behavior of the model plot in case it changes.
+        # Note that for DataPHA datasets the modelplot object is
+        # created on-the-fly using sherpa.astro.plot.ModelPHAHistogram,
+        # rather than a session._plotobj value that is also set in
+        # session._plot_types, so it doesn't get changed bu set_xlog etc.
+        #
         # Ideally this would match the dataplot setting but it isn't
         # actually required for the plot to work.
         #
@@ -3340,7 +3345,6 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
 
 
 @requires_pylab
-@pytest.mark.xfail(reason='known failure with Data1DInt')
 def test_set_plot_opt_with_plot_x():
     """Does set_xlog/xlinear work with plot()  Astro data objects only.
 
@@ -3390,7 +3394,6 @@ def test_set_plot_opt_with_plot_x():
 
 
 @requires_pylab
-@pytest.mark.xfail(reason='known failure with Data1DInt')
 def test_set_plot_opt_with_plot_y():
     """Does set_ylog/ylinear work with plot()  Astro data objects only.
     """

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11447,12 +11447,13 @@ class Session(sherpa.ui.utils.Session):
                 plots = [plots]
 
             for plot in plots:
-                if sherpa.ui.utils._is_subclass(plot.__class__,
-                                                sherpa.plot.Histogram):
-                    plot.histo_prefs[item] = value
-                elif sherpa.ui.utils._is_subclass(plot.__class__,
-                                                  sherpa.plot.Plot):
+                try:
                     plot.plot_prefs[item] = value
+                except AttributeError:
+                    try:
+                        plot.histo_prefs[item] = value
+                    except AttributeError:
+                        pass
 
     def plot_arf(self, id=None, resp_id=None, replot=False, overplot=False,
                  clearwindow=True, **kwargs):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -104,6 +104,7 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['astrocompsource'] = self._astrocompsrcplot
         self._plot_types['astrocompmodel'] = self._astrocompmdlplot
 
+        self._plot_types['astrodata'] = self._dataphaplot
         self._plot_types['astrosource'] = self._astrosourceplot
         self._plot_types['astromodel'] = self._modelhisto
         self._plot_types['arf'] = self._arfplot
@@ -122,6 +123,7 @@ class Session(sherpa.ui.utils.Session):
         self._plot_type_names['astrocompsource'] = 'source_component'
         self._plot_type_names['astrocompmodel'] = 'model_componentl'
 
+        self._plot_type_names['astrodata'] = 'data'
         self._plot_type_names['astrosource'] = 'source'  # is this meaningful anymore
         self._plot_type_names['astromodel'] = 'model'  # is this meaningful anymore
         self._plot_type_names['arf'] = 'arf'
@@ -194,6 +196,7 @@ class Session(sherpa.ui.utils.Session):
         self._background_models = {}
         self._background_sources = {}
 
+        self._dataphaplot = sherpa.astro.plot.DataPHAPlot()
         self._astrosourceplot = sherpa.astro.plot.SourcePlot()
         self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
         self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
@@ -226,6 +229,7 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['astrocompsource'] = self._astrocompsrcplot
         self._plot_types['astrocompmodel'] = self._astrocompmdlplot
 
+        self._plot_types['astrodata'] = self._dataphaplot
         self._plot_types['astrosource'] = self._astrosourceplot
         self._plot_types['astromodel'] = self._modelhisto
         self._plot_types['arf'] = self._arfplot
@@ -244,6 +248,7 @@ class Session(sherpa.ui.utils.Session):
         self._plot_type_names['astrocompsource'] = 'source_component'
         self._plot_type_names['astrocompmodel'] = 'model_componentl'
 
+        self._plot_type_names['astrodata'] = 'data'
         self._plot_type_names['astrosource'] = 'source'  # is this meaningful anymore
         self._plot_type_names['astromodel'] = 'model'  # is this meaningful anymore
         self._plot_type_names['arf'] = 'arf'
@@ -11432,7 +11437,7 @@ class Session(sherpa.ui.utils.Session):
             keys = [plottype]
 
         for key in keys:
-            plots = self._plot_types[key]
+            plots = [self._plot_types[key]]
 
             # the astro package complicates plotting by using a regular and
             # astro version of model plots, source plots, and
@@ -11441,10 +11446,15 @@ class Session(sherpa.ui.utils.Session):
             # To avoid confusion for the user, when 'model' is passed.  Change
             # both the regular and astro model plot type.  Astro versions are
             # prefixed with 'astro' in the _plot_types key.
-            if key in ["model", "source", "compsource", "compmodel"]:
-                plots = [plots, self._plot_types["astro" + key]]
-            else:
-                plots = [plots]
+            #
+            # Try and make this automatic rather than special-casing this
+            # behavior.
+            #
+            akey = 'astro{}'.format(key)
+            try:
+                plots.append(self._plot_types[akey])
+            except KeyError:
+                pass
 
             for plot in plots:
                 try:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -61,80 +61,9 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
 
     def __init__(self):
-        self._pileup_models = {}
-        self._background_models = {}
-        self._background_sources = {}
 
-        self._dataphaplot = sherpa.astro.plot.DataPHAPlot()
-        self._astrosourceplot = sherpa.astro.plot.SourcePlot()
-        self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
-        self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
-        self._modelhisto = sherpa.astro.plot.ModelHistogram()
-        self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
-
-        # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
-        self._bkgdataplot = sherpa.astro.plot.BkgDataPlot()
-        self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
-        self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
-        self._bkgchisqrplot = sherpa.astro.plot.BkgChisqrPlot()
-        self._bkgdelchiplot = sherpa.astro.plot.BkgDelchiPlot()
-        self._bkgresidplot = sherpa.astro.plot.BkgResidPlot()
-        self._bkgratioplot = sherpa.astro.plot.BkgRatioPlot()
-        self._bkgsourceplot = sherpa.astro.plot.BkgSourcePlot()
-        self._arfplot = sherpa.astro.plot.ARFPlot()
-        self._orderplot = sherpa.astro.plot.OrderPlot()
-        self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
-        self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
-
-        # This is a new dictionary of XSPEC module settings.  It
-        # is meant only to be populated by the save function, so
-        # that the user's XSPEC settings can be saved in the pickle
-        # file.  Then, restore can peel out settings from the
-        # restored _xspec_state variable, and set abundance,
-        # cross-section, etc. in the XSPEC module.
-        self._xspec_state = None
-
+        self.clean()
         sherpa.ui.utils.Session.__init__(self)
-
-        self._pyblocxs = sherpa.astro.sim.MCMC()
-
-        self._plot_types['order'] = self._orderplot
-        self._plot_types['energy'] = self._energyfluxplot
-        self._plot_types['photon'] = self._photonfluxplot
-        self._plot_types['astrocompsource'] = self._astrocompsrcplot
-        self._plot_types['astrocompmodel'] = self._astrocompmdlplot
-
-        self._plot_types['astrodata'] = self._dataphaplot
-        self._plot_types['astrosource'] = self._astrosourceplot
-        self._plot_types['astromodel'] = self._modelhisto
-        self._plot_types['arf'] = self._arfplot
-        self._plot_types['bkg'] = self._bkgdataplot
-        self._plot_types['bkgmodel'] = self._bkgmodelhisto
-        self._plot_types['bkgfit'] = self._bkgfitplot
-        self._plot_types['bkgsource'] = self._bkgsourceplot
-        self._plot_types['bkgratio'] = self._bkgratioplot
-        self._plot_types['bkgresid'] = self._bkgresidplot
-        self._plot_types['bkgdelchi'] = self._bkgdelchiplot
-        self._plot_types['bkgchisqr'] = self._bkgchisqrplot
-
-        self._plot_type_names['order'] = 'order'
-        # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
-        # self._plot_type_names['photon'] = 'photon'
-        self._plot_type_names['astrocompsource'] = 'source_component'
-        self._plot_type_names['astrocompmodel'] = 'model_componentl'
-
-        self._plot_type_names['astrodata'] = 'data'
-        self._plot_type_names['astrosource'] = 'source'  # is this meaningful anymore
-        self._plot_type_names['astromodel'] = 'model'  # is this meaningful anymore
-        self._plot_type_names['arf'] = 'arf'
-        self._plot_type_names['bkg'] = 'bkg'
-        self._plot_type_names['bkgmodel'] = 'bkg_model'
-        self._plot_type_names['bkgfit'] = 'bkg_fit'
-        self._plot_type_names['bkgsource'] = 'bkg_source'
-        self._plot_type_names['bkgratio'] = 'bkg_ratio'
-        self._plot_type_names['bkgresid'] = 'bkg_resid'
-        self._plot_type_names['bkgdelchi'] = 'bkg_delchi'
-        self._plot_type_names['bkgchisqr'] = 'bkg_chisqr'
 
     ###########################################################################
     # High-level utilities
@@ -217,30 +146,42 @@ class Session(sherpa.ui.utils.Session):
         self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
         self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
 
+        # This is a new dictionary of XSPEC module settings.  It
+        # is meant only to be populated by the save function, so
+        # that the user's XSPEC settings can be saved in the pickle
+        # file.  Then, restore can peel out settings from the
+        # restored _xspec_state variable, and set abundance,
+        # cross-section, etc. in the XSPEC module.
+        #
+        # TODO: it should probably not be reset by clean since there's
+        #       no way to clear the XSPEC state (we could try and
+        #       unset all the changes but it's not guaranteed we can
+        #       do so).
+        #
         self._xspec_state = None
 
         sherpa.ui.utils.Session.clean(self)
 
         self._pyblocxs = sherpa.astro.sim.MCMC()
 
-        self._plot_types['order'] = self._orderplot
-        self._plot_types['energy'] = self._energyfluxplot
-        self._plot_types['photon'] = self._photonfluxplot
-        self._plot_types['astrocompsource'] = self._astrocompsrcplot
-        self._plot_types['astrocompmodel'] = self._astrocompmdlplot
+        self._plot_types['order'] = [self._orderplot]
+        self._plot_types['energy'] = [self._energyfluxplot]
+        self._plot_types['photon'] = [self._photonfluxplot]
+        self._plot_types['compsource'].append(self._astrocompsrcplot)
+        self._plot_types['compmodel'].append(self._astrocompmdlplot)
 
-        self._plot_types['astrodata'] = self._dataphaplot
-        self._plot_types['astrosource'] = self._astrosourceplot
-        self._plot_types['astromodel'] = self._modelhisto
-        self._plot_types['arf'] = self._arfplot
-        self._plot_types['bkg'] = self._bkgdataplot
-        self._plot_types['bkgmodel'] = self._bkgmodelhisto
-        self._plot_types['bkgfit'] = self._bkgfitplot
-        self._plot_types['bkgsource'] = self._bkgsourceplot
-        self._plot_types['bkgratio'] = self._bkgratioplot
-        self._plot_types['bkgresid'] = self._bkgresidplot
-        self._plot_types['bkgdelchi'] = self._bkgdelchiplot
-        self._plot_types['bkgchisqr'] = self._bkgchisqrplot
+        self._plot_types['data'].append(self._dataphaplot)
+        self._plot_types['source'].append(self._astrosourceplot)
+        self._plot_types['model'].append(self._modelhisto)
+        self._plot_types['arf'] = [self._arfplot]
+        self._plot_types['bkg'] = [self._bkgdataplot]
+        self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
+        self._plot_types['bkgfit'] = [self._bkgfitplot]
+        self._plot_types['bkgsource'] = [self._bkgsourceplot]
+        self._plot_types['bkgratio'] = [self._bkgratioplot]
+        self._plot_types['bkgresid'] = [self._bkgresidplot]
+        self._plot_types['bkgdelchi'] = [self._bkgdelchiplot]
+        self._plot_types['bkgchisqr'] = [self._bkgchisqrplot]
 
         self._plot_type_names['order'] = 'order'
         # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
@@ -11426,44 +11367,6 @@ class Session(sherpa.ui.utils.Session):
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
         return self._photonfluxplot
-
-    def _set_plot_item(self, plottype, item, value):
-        keys = list(self._plot_types.keys())
-
-        if plottype.strip().lower() != "all":
-            if plottype not in keys:
-                raise sherpa.utils.err.PlotErr(
-                    'wrongtype', plottype, str(keys))
-            keys = [plottype]
-
-        for key in keys:
-            plots = [self._plot_types[key]]
-
-            # the astro package complicates plotting by using a regular and
-            # astro version of model plots, source plots, and
-            # component plots.  One is for PHA, the other is everything else.
-
-            # To avoid confusion for the user, when 'model' is passed.  Change
-            # both the regular and astro model plot type.  Astro versions are
-            # prefixed with 'astro' in the _plot_types key.
-            #
-            # Try and make this automatic rather than special-casing this
-            # behavior.
-            #
-            akey = 'astro{}'.format(key)
-            try:
-                plots.append(self._plot_types[akey])
-            except KeyError:
-                pass
-
-            for plot in plots:
-                try:
-                    plot.plot_prefs[item] = value
-                except AttributeError:
-                    try:
-                        plot.histo_prefs[item] = value
-                    except AttributeError:
-                        pass
 
     def plot_arf(self, id=None, resp_id=None, replot=False, overplot=False,
                  clearwindow=True, **kwargs):

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -348,8 +348,11 @@ class Session(NoNewAttributesAfterInit):
 
         self._plot_types = {
             'data': self._dataplot,
+            'data1dint': self._datahistplot,
             'model': self._modelplot,
+            'model1dint': self._modelhistplot,
             'source': self._sourceplot,
+            'source1dint': self._sourcehistplot,
             'fit': self._fitplot,
             'resid': self._residplot,
             'ratio': self._ratioplot,

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -11998,10 +11998,13 @@ class Session(NoNewAttributesAfterInit):
 
         for key in keys:
             plot = self._plot_types[key]
-            if _is_subclass(plot.__class__, sherpa.plot.Plot):
+            try:
                 plot.plot_prefs[item] = value
-            elif _is_subclass(plot.__class__, sherpa.plot.Histogram):
-                plot.histo_prefs[item] = value
+            except AttributeError:
+                try:
+                    plot.histo_prefs[item] = value
+                except AttributeError:
+                    pass
 
     def set_xlog(self, plottype="all"):
         """New plots will display a logarithmically-scaled X axis.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -347,21 +347,18 @@ class Session(NoNewAttributesAfterInit):
         self._regunc = sherpa.plot.RegionUncertainty()
 
         self._plot_types = {
-            'data': self._dataplot,
-            'data1dint': self._datahistplot,
-            'model': self._modelplot,
-            'model1dint': self._modelhistplot,
-            'source': self._sourceplot,
-            'source1dint': self._sourcehistplot,
-            'fit': self._fitplot,
-            'resid': self._residplot,
-            'ratio': self._ratioplot,
-            'delchi': self._delchiplot,
-            'chisqr': self._chisqrplot,
-            'psf': self._psfplot,
-            'kernel': self._kernelplot,
-            'compsource': self._compsrcplot,
-            'compmodel': self._compmdlplot
+            'data': [self._dataplot, self._datahistplot],
+            'model': [self._modelplot, self._modelhistplot],
+            'source': [self._sourceplot, self._sourcehistplot],
+            'fit': [self._fitplot],
+            'resid': [self._residplot],
+            'ratio': [self._ratioplot],
+            'delchi': [self._delchiplot],
+            'chisqr': [self._chisqrplot],
+            'psf': [self._psfplot],
+            'kernel': [self._kernelplot],
+            'compsource': [self._compsrcplot],
+            'compmodel': [self._compmdlplot]
         }
 
         self._plot_type_names = {
@@ -11993,21 +11990,25 @@ class Session(NoNewAttributesAfterInit):
     def _set_plot_item(self, plottype, item, value):
         keys = list(self._plot_types.keys())
 
-        if plottype.strip().lower() != "all":
-            if plottype not in keys:
+        plottype = plottype.strip().lower()
+        if plottype != "all":
+            if plottype not in self._plot_types:
                 raise sherpa.utils.err.PlotErr(
                     'wrongtype', plottype, str(keys))
+
             keys = [plottype]
 
         for key in keys:
-            plot = self._plot_types[key]
-            try:
-                plot.plot_prefs[item] = value
-            except AttributeError:
+            for plot in self._plot_types[key]:
+                # This could be a "line" or "histogram" style plot.
+                #
                 try:
-                    plot.histo_prefs[item] = value
+                    plot.plot_prefs[item] = value
                 except AttributeError:
-                    pass
+                    try:
+                        plot.histo_prefs[item] = value
+                    except AttributeError:
+                        pass
 
     def set_xlog(self, plottype="all"):
         """New plots will display a logarithmically-scaled X axis.


### PR DESCRIPTION
# Summary

Fix the set_xlog/ylog routines for PHA and 1D integrated datasets. Fixes #981

# Details

The first commit adds tests that show issue #981. They require matplotlib (since you only see the problem when
you create the plot, not with the data returned by get_data_plot). Tests that fail are marked as xfail. Unfortunately, thanks to the
way the tests are structured, several tests are marked as xfail even though they pass, but I think that's okay here.

The second commit just moves to a "more Pythonic" approach (just access the attributes we need, handling any possible error, rather than look for a particular class hierarchy).

The third commit handles the set_x/y[log|linear] routine for DataPHA objects. It also fixes a subtle bug introduced in #931 where use of the clean method would not have reset the plot options for DataPA objects (a test has been added to check this fix).

The fourth commit changes the tests since they can be run without requiring matplotlib. This requires a little bit of work as we now have to query a preference setting rather than ask the axis what the scaling is, which ends up requiring more knowledge of the internal data structures.

The fifth commit just extends the number of plot types that get tested.

The sixth commit fixes the problem for the Data1DInt data type, by adding entries to the _plot_types dictionary. This only fixes the case when the 'all' option (the default) is used: it wouldn't work for 'set_xlog("data")' for Data1DInt datasets.

The seventh commit adds more tests. In particular it adds tests for the 'set_xlog("data")' command (which are marked as xfail).

The eighth commit fixes the set_xlog/ylog calls for DataPHA classes and also addresses the set_xlog('data') and set_ylog('model') style options for all data types by changing the _plot_types dictionary so the values are a list of plot types rather than a single plot type. This means we can identify all the data types as "data" rather than having data, astrodata, data1dint, ... It means we can remove the _set_plot_type method in sherpa.astro.ui.Session since it can now just use the parent classes method.

The last commit are typos and noting an apparently-odd construct that Warren noted in the tests. 