### PR TITLE
WIP Add a macOS Python 3.8 "full build" test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ jobs:
   fast_finish: true
   include:
     # macOS build
+    # Note that we use develop and not install since the latter seems to have problems with X
     - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER="3" XSPECVER="12.10.1n" TRAVIS_PYTHON_VERSION="3.7"
+      os: osx
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER="3" XSPECVER="12.10.1n" TRAVIS_PYTHON_VERSION="3.8"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.


### PR DESCRIPTION
# Summary

Add a macOS Python 3.8 test to Travis.

# Details

This keeps the existing macOS python 3.7 run as it is a safety check for the moment. A more-complete set of updates to the Travis testing will be made soon.