### PR TITLE
Improve sherpa.citation (fix #994 #987)

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -119,6 +119,26 @@ can be activated and Sherpa can be build from source.
 How do I ...
 ============
 
+Update the Zenodo citation information
+--------------------------------------
+
+The :py:func:`sherpa.citation` function returns citation information
+taken from the `Zenodo records for Sherpa <https://doi.org/10.5281/zenodo.593753>`_.
+It can query the Zenodo API, but it also contains a list of known
+releases in the ``sherpa._get_citation_hardcoded`` routine. To add
+to this list (for when there's been a new release), run the
+``scripts/make_zenodo_release.py`` script with the version number
+and add the screen output to the list in ``_get_citation_hardcoded``.
+
+For example, using release 4.12.2 would create (the author list has been
+simplified)::
+
+  % ./scripts/make_zenodo_release.py 4.12.2
+      add(version='4.12.2', title='sherpa/sherpa: Sherpa 4.12.2',
+          date=todate(2020, 10, 27),
+          authors=['Doug Burke', 'Omar Laurino', ... 'Todd'],
+          idval='4141888')
+
 Add a new notebook
 ------------------
 

--- a/scripts/make_zenodo_release.py
+++ b/scripts/make_zenodo_release.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+"""
+Usage:
+
+  ./make_zenodo_release.py [version]
+
+Aim:
+
+Create the release information for the sherpa._get_citation_hardcoded
+routine. The output is to the screen, for manual inclusion.
+
+If version is not given, all entries are included (which may
+include CIAO releases), otherwise a version number like '4.12.2'
+is expected.
+
+"""
+
+import datetime
+import json
+import ssl
+from urllib.request import Request, urlopen
+
+
+def download_json(url):
+    """Return the JSON data.
+
+    Parameters
+    ----------
+    url : str
+        The URL to process.
+
+    Returns
+    -------
+    response : dict
+        The data in JSON.
+
+    """
+
+    req = Request(url)
+    context = ssl._create_unverified_context()
+
+    # Do not bother trapping errors
+    res = urlopen(req, context=context)
+    return json.load(res)
+
+
+def make_zenodo_citation(jsdata):
+    """Convert Zenodo record to a citation.
+
+    Prints the record to stdout.
+
+    Parameters
+    ----------
+    jsdata : object
+        A Zenodo record.
+
+    """
+
+    created = jsdata['created']
+    mdata = jsdata['metadata']
+    idval = jsdata['id']
+
+    created = created.split('T')[0]
+    isoformat = '%Y-%m-%d'
+    date = datetime.datetime.strptime(created, isoformat)
+
+    version = mdata['version']
+    title = mdata['title']
+    creators = mdata['creators']
+
+    authors = [c['name'] for c in creators]
+
+    print(f"    add(version='{version}', title='{title}',")
+    print(f"        date=todate({date.year}, {date.month}, {date.day}),")
+    print(f"        authors={authors},")
+    print(f"        idval='{idval}')")
+
+
+def dump_zenodo(version):
+    """Access Zenodo for the version information.
+
+    Parameters
+    ----------
+    version : str or None
+        The version string (e.g. '4.12.2'). If None then all versions
+        are reported.
+    """
+
+    url = 'https://zenodo.org/api/records/?q=conceptrecid:"593753"&all_versions=True&sort=mostrecent'
+    while True:
+        jsdata = download_json(url)
+        for hit in jsdata['hits']['hits']:
+            if version is None or hit['metadata']['version'] == version:
+                make_zenodo_citation(hit)
+                if version is not None:
+                    return
+
+        try:
+            url = jsdata['links']['next']
+
+            # Add in the necessary all_versions tag: see
+            # https://github.com/zenodo/zenodo/issues/1662
+            #
+            if 'all_versions=True' not in url:
+                url += '&all_versions=True'
+
+        except KeyError:
+            return
+
+
+if __name__ == "__main__":
+
+    import sys
+    if len(sys.argv) > 2:
+        sys.stderr.write(f"Usage: {sys.argv[0]} [version]\n")
+        sys.exit(1)
+
+    if len(sys.argv) == 2:
+        version = sys.argv[1]
+    else:
+        version = None
+
+    dump_zenodo(version)

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2014, 2015, 2016, 2019, 2020
+#  Copyright (C) 2007, 2014, 2015, 2016, 2019, 2020, 2021
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -180,6 +180,15 @@ def _get_citation_hardcoded(version):
         assert version not in cite
         cite[version] = dict(**kwargs)
         cite[version]['version'] = version
+
+    add(version='4.13.0', title='sherpa/sherpa: Sherpa 4.13.0',
+        date=todate(2021, 1, 8),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',
+                 'Marie-Terrell', 'Hans Moritz Günther', 'Aneta Siemiginowska',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Christoph Deil',
+                 'Brigitta Sipőcz', 'Johannes Buchner', 'Iva Laginja',
+                 'Katrin Leinweber', 'nplee', 'Todd'],
+        idval='4428938')
 
     add(version='4.12.2', title='sherpa/sherpa: Sherpa 4.12.2',
         date=todate(2020, 10, 27),

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -402,7 +402,7 @@ def _get_citation_zenodo_failure(failed):
         The failure message.
 
     """
-    out = 'There was a problem retireving the data from Zenodo:\n'
+    out = 'There was a problem retrieving the data from Zenodo:\n'
     out += failed
     out += '\n\n'
     out += DEFAULT_CITATION

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -164,29 +164,15 @@ def _get_citation_hardcoded(version):
     citation : str or None
         Citation information if known, otherwise None.
 
+    Notes
+    -----
+    The entries can be created with the script:
+    scripts/make_zenodo_release.py
+
     """
 
     def todate(year, mnum, dnum):
         return datetime.datetime(year, mnum, dnum)
-
-    db = 'DougBurke'
-    ol = 'Omar Laurino'
-    dn = 'dtnguyen2'
-    ta = 'Tom Aldcroft'
-    an = 'Aneta Siemiginowska'
-
-    jb = 'Jamie Budynkiewicz'
-    cd = 'Christoph Deil'
-    bs = 'Brigitta Sipocz'
-
-    wm = 'wmclaugh'
-
-    kl = 'Katrin Leinweber'
-
-    mt = 'Marie-Terrell'
-    bs2 = 'Brigitta Sipőcz'
-    hm = 'Hans Moritz Günther'
-    td = 'Todd'
 
     cite = {}
 
@@ -195,58 +181,95 @@ def _get_citation_hardcoded(version):
         cite[version] = dict(**kwargs)
         cite[version]['version'] = version
 
-    add(version='4.8.0', title='sherpa: Sherpa 4.8.0',
-        date=todate(2016, 1, 27),
-        authors=[db, ol, dn, ta, an],
-        idval='45243')
-    add(version='4.8.1', title='sherpa: Sherpa 4.8.1',
-        date=todate(2016, 4, 15),
-        authors=[db, ol, dn, ta, jb, an, cd, bs],
-        idval='49832')
-    add(version='4.8.2', title='sherpa: Sherpa 4.8.2',
-        date=todate(2016, 9, 23),
-        authors=[db, ol, dn, jb, ta, an, cd, wm, bs],
-        idval='154744')
-
-    add(version='4.9.0', title='sherpa/sherpa: Sherpa 4.9.0',
-        date=todate(2017, 1, 27),
-        authors=[db, ol, dn, jb, ta, an, wm, cd, bs],
-        idval='260416')
-    add(version='4.9.1', title='sherpa/sherpa: Sherpa 4.9.1',
-        date=todate(2017, 8, 3),
-        authors=[db, ol, dn, jb, ta, an, wm, cd, bs],
-        idval='838686')
-
-    add(version='4.10.0', title='sherpa/sherpa: Sherpa 4.10.0',
-        date=todate(2018, 5, 1),
-        authors=[db, ol, dn, jb, ta, an, wm, cd, bs],
-        idval='1245678')
-    add(version='4.10.1', title='sherpa/sherpa: Sherpa 4.10.1',
-        date=todate(2018, 10, 16),
-        authors=[db, ol, dn, jb, ta, an, wm, bs, cd, kl],
-        idval='1463962')
-    add(version='4.10.2', title='sherpa/sherpa: Sherpa 4.10.2',
-        date=todate(2018, 12, 14),
-        authors=[db, ol, dn, jb, ta, an, cd, wm, bs, kl],
-        idval='2275738')
-
-    add(version='4.11.0', title='sherpa/sherpa: Sherpa 4.11.0',
-        date=todate(2019, 2, 20),
-        authors=[db, ol, dn, jb, ta, an, cd, wm, bs, kl],
-        idval='2573885')
-    add(version='4.11.1', title='sherpa/sherpa: Sherpa 4.11.1',
-        date=todate(2019, 8, 1),
-        authors=[db, ol, dn, jb, ta, an, cd, wm, bs, kl],
-        idval='3358134')
-
-    add(version='4.12.0', title='sherpa/sherpa: Sherpa 4.12.0',
-        date=todate(2020, 1, 30),
-        authors=[db, ol, dn, wm, jb, ta, an, cd, mt, bs2, hm, td, kl],
-        idval='3631574')
+    add(version='4.12.2', title='sherpa/sherpa: Sherpa 4.12.2',
+        date=todate(2020, 10, 27),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',
+                 'Hans Moritz Günther', 'Marie-Terrell', 'Aneta Siemiginowska',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Christoph Deil',
+                 'Brigitta Sipőcz', 'Johannes Buchner', 'Iva Laginja',
+                 'Katrin Leinweber', 'nplee', 'Todd'],
+        idval='4141888')
     add(version='4.12.1', title='sherpa/sherpa: Sherpa 4.12.1',
         date=todate(2020, 7, 14),
-        authors=[db, ol, wm, dn, mt, hm, jb, an, ta, cd, bs2, kl, td],
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',
+                 'Marie-Terrell', 'Hans Moritz Günther', 'Jamie Budynkiewicz',
+                 'Aneta Siemiginowska', 'Tom Aldcroft', 'Christoph Deil',
+                 'Brigitta Sipőcz', 'Katrin Leinweber', 'Todd'],
         idval='3944985')
+    add(version='4.12.0', title='sherpa/sherpa: Sherpa 4.12.0',
+        date=todate(2020, 1, 30),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2', 'wmclaugh',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'Christoph Deil', 'Marie-Terrell', 'Brigitta Sipőcz',
+                 'Hans Moritz Günther', 'Todd', 'Katrin Leinweber'],
+        idval='3631574')
+
+    add(version='4.11.1', title='sherpa/sherpa: Sherpa 4.11.1',
+        date=todate(2019, 8, 1),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'Christoph Deil', 'wmclaugh', 'Brigitta Sipocz',
+                 'Katrin Leinweber'],
+        idval='3358134')
+    add(version='4.11.0', title='sherpa/sherpa: Sherpa 4.11.0',
+        date=todate(2019, 2, 20),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'Christoph Deil', 'wmclaugh', 'Brigitta Sipocz',
+                 'Katrin Leinweber'],
+        idval='2573885')
+
+    add(version='4.10.2', title='sherpa/sherpa: Sherpa 4.10.2',
+        date=todate(2018, 12, 14),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'Christoph Deil', 'wmclaugh', 'Brigitta Sipocz',
+                 'Katrin Leinweber'],
+        idval='2275738')
+    add(version='4.10.1', title='sherpa/sherpa: Sherpa 4.10.1',
+        date=todate(2018, 10, 16),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'wmclaugh', 'Brigitta Sipocz', 'Christoph Deil',
+                 'Katrin Leinweber'],
+        idval='1463962')
+    add(version='4.10.0', title='sherpa/sherpa: Sherpa 4.10.0',
+        date=todate(2018, 5, 11),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'wmclaugh', 'Christoph Deil', 'Brigitta Sipocz'],
+        idval='1245678')
+
+    add(version='4.9.1', title='sherpa/sherpa: Sherpa 4.9.1',
+        date=todate(2017, 8, 3),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'wmclaugh', 'Christoph Deil', 'Brigitta Sipocz'],
+        idval='838686')
+    add(version='4.9.0', title='sherpa/sherpa: Sherpa 4.9.0',
+        date=todate(2017, 1, 27),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'wmclaugh', 'Christoph Deil', 'Brigitta Sipocz'],
+        idval='260416')
+
+    add(version='4.8.2', title='sherpa/sherpa: Sherpa 4.8.2',
+        date=todate(2016, 9, 23),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Aneta Siemiginowska',
+                 'Christoph Deil', 'wmclaugh', 'Brigitta Sipocz'],
+        idval='154744')
+    add(version='4.8.1', title='sherpa: Sherpa 4.8.1',
+        date=todate(2016, 4, 15),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2', 'Tom Aldcroft',
+                 'Jamie Budynkiewicz', 'Aneta Siemiginowska', 'Christoph Deil',
+                 'Brigitta Sipocz'],
+        idval='49832')
+    add(version='4.8.0', title='sherpa: Sherpa 4.8.0',
+        date=todate(2016, 1, 27),
+        authors=['Doug Burke', 'Omar Laurino', 'dtnguyen2', 'Tom Aldcroft',
+                 'Aneta Siemiginowska'],
+        idval='45243')
 
     kwargs = cite.get(version, None)
     if kwargs is None:


### PR DESCRIPTION
# Summary

Fixes the sherpa.citation() command with its default argument (issue #994) and adds release 4.12.2 to the hard-coded list of releases. A typo in a warning message was fixed (#987).

# Details

I had not realised Zenodo was doing pagination and, because I also had not set a "most-recent" order on the query the 4.12.2 response wasn't being included in the first set of results, and so wasn't being found. We now iterate through the pages (working around https://github.com/zenodo/zenodo/issues/1662) if the requested version isn't found (and the search order has been changed so that the latest version is returned first, which means the paging mechanism shouldn't be needed as long as the hard-coded list is kept up to date).

I've added developer documentation describing how to update the sherpa._get_citation_hardcoded routine to add new releases, and added the `scripts/make_zenodo_citation.py` script which will print out the needed update to stdout.
