### PR TITLE
Allow command-line arguments for sherpa_test

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -43,7 +43,10 @@ cd /home
 sherpa_smoke ${smokevars} || exit 1
 
 # Run regression tests using sherpa_test
-if [ ${TEST} == package ] || [ ${TEST} == none ];
-    then cd $HOME
-    sherpa_test || exit 1
+if [ ${TEST} == package ] || [ ${TEST} == none ]; then
+    cd $HOME;
+    conda install -yq pytest-cov codecov;
+    # This automatically picks up the sherpatest modile when TEST==package
+    sherpa_test --cov sherpa --cov-report term || exit 1;
+    codecov;
 fi

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -864,9 +864,15 @@ def _install_test_deps():
 
 
 def clitest():
+    """The sherpa_test endpoint."""
+
     plugins = _install_test_deps()
     import pytest
     import os
-    sherpa_dir = os.path.dirname(__file__)
-    errno = pytest.main([sherpa_dir, '-rs'], plugins=plugins)  # passing the plugins that have been installed "now".
+
+    # Add in command-line arguments to allow configuring the Sherpa tests
+    args = [os.path.dirname(__file__), '-rs'] + sys.argv[1:]
+
+    # passing the plugins that have been installed "now".
+    errno = pytest.main(args, plugins=plugins)
     sys.exit(errno)

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,17 +17,21 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import unittest
+import logging
+import os
+import sys
 from tempfile import NamedTemporaryFile
+import unittest
+
+from numpy.testing import assert_almost_equal
 
 from sherpa.astro import ui
 from sherpa.utils.testing import has_package_from_list
-from numpy.testing import assert_almost_equal
-import logging
-import sys
-import os
 
 logger = logging.getLogger("sherpa")
+
+# We use unittest rather than pytest so we have a test that can be run
+# without requiring external packages.
 
 
 def run(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):


### PR DESCRIPTION
# Summary

Allow command-line arguments to be passed to the sherpa_test script. This allows running optional tests (e.g. the `--runzenodo` argument) and to configure the pytest configuration (e.g. to run coverage checks with `--cov sherpa`).

# Details

Passing the command-line arguments through to the pytest machinery was easy. It allowed me to turn on coverage checks for the `sherpa_test` calls made in our Travis runs, which means a small bump in the test coverage (since these tests tend to be run without all the optional modules, so we get to check the fall-through code paths). Note that the way the `travis/test.sh` script is set up we get either a coverage run from `sherpa_test` or from the `python setup.py test` route, not both with the same setup. [with the change to GitHub actions we don't appear to see this bump so it may be that some other test was added which covered these cases]

The code has been rebased to apply to the GitHub actions code (fortunately the new version is very similar to the travis version so the update was easy). Of couse it now looks like the coverage has decreased, but that really doesn't make much sense.And now it's back to no change...

I did try some experiments with switching the tests to use `pytest` rather than `python setup.py test` but this fails as the build can't find the _utils module (a longstanding oddity that is easy to trigger with CI but harder to reliably diagnose manually...). So I dropped those changes.