### PR TITLE
Fix error with clobber=False for paging - issue #996

### DIFF
--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -40,9 +40,8 @@ import numpy.fft
 # Note: _utils.gsl_fcmp and _utils.ndtri are not exported from
 #       this module; is this intentional?
 from sherpa.utils._utils import hist1d, hist2d
-from sherpa.utils import _utils
-
-from sherpa.utils import _psf
+from sherpa.utils import _utils, _psf
+from sherpa.utils.err import IOErr
 
 from sherpa import get_config
 

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -38,20 +38,24 @@ def test_calc_ftest2():
                               _utils.calc_ftest(2 * [11], 2 * [16.3],
                                                 2 * [10], 2 * [10.2]))
 
+
 def test_calc_ftest_chi2_equal_0():
     with pytest.raises(TypeError) as excinfo:
         _utils.calc_ftest(11, 16.3, 10, 0.0)
     assert 'chisq_2[0] cannot be equal to 0:' in str(excinfo.value)
+
 
 def test_calc_ftest_dof2_equal_0():
     with pytest.raises(TypeError) as excinfo:
         _utils.calc_ftest(11, 16.3, 0, 10.0)
     assert 'dof_2[0] cannot be equal to 0:' in str(excinfo.value)
 
+
 def test_calc_ftest_dof1_equal_dof2():
     with pytest.raises(TypeError) as excinfo:
         _utils.calc_ftest(11, 16.3, 11, 10.0)
     assert 'dof_1[0] cannot be equal to dof_2[0]:' in str(excinfo.value)
+
 
 def test_calc_mlr():
     """


### PR DESCRIPTION
# Summary

Fix an error with clobber=False when the output file exists for several paging commands (e.g. show_data and sherpa.citation). Instead of getting a Sherpa `IOErr` being raised a NameError was being raised.

# Details

The problem was when the output file exists and clobber=False (the default value). Instead of getting an IOErr you'd get a NameError since IOErr wasn't in scope. Adding an import of `IOErr` fixes the problem. A test has been added to cover this case.

The bug was introduced in #634 when the paging code was moved from sherpa.ui.utils to sherpa.utils.