### PR TITLE
Fix serialization of iter method data - issue #997

### DIFF
--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -654,7 +654,7 @@ def _save_iter_method(state, fh=None):
         # is probably what we want but is a change, so leave
         # for now.
         # return 'set_iter_method_opt("{}", {})'.format(key, val)
-        return 'set_iter_method_opt("%s", %s)'.format(key, val)
+        return 'set_iter_method_opt("{}", {})'.format(str(key), str(val))
 
     _save_entries(state.get_iter_method_opt(), tostatement, fh)
     _output("", fh)
@@ -705,7 +705,7 @@ def _handle_usermodel(mod, modelname, fh=None):
     # in case getsource can return None, have check here
     if pycode is None:
         msg = "Unable to save Python code for user model " + \
-              "'{}' function {}".format(mod.name, )
+              "'{}' function {}".format(modelname, mod.calc.name)
         warning(msg)
         _output('print("{}")'.format(msg), fh)
         _output("def {}(*args):".format(mod.calc.name), fh)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016, 2019, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -645,16 +645,17 @@ def _save_iter_method(state, fh=None):
         return
 
     _output("\n######### Set Iterative Fitting Method\n", fh)
-    cmd = 'set_iter_method("%s")' % state.get_iter_method_name()
+    meth = state.get_iter_method_name()
+    cmd = f'set_iter_method("{meth}")'
     _output(cmd, fh)
     _output("", fh)
 
     def tostatement(key, val):
-        # TODO: Using .format() returns more decimal places, which
-        # is probably what we want but is a change, so leave
-        # for now.
-        # return 'set_iter_method_opt("{}", {})'.format(key, val)
-        return 'set_iter_method_opt("{}", {})'.format(str(key), str(val))
+        # There was a discussion here about the use of
+        # str(val) vs val - the number of decimal places - but it
+        # turns out for the test we only output integer values
+        # so it makes no difference.
+        return f'set_iter_method_opt("{key}", {val})'
 
     _save_entries(state.get_iter_method_opt(), tostatement, fh)
     _output("", fh)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -25,7 +25,6 @@ corresponding functions in sherpa.astro.ui.utils.
 #    set_full_model
 #    multiple sources
 #    linked parameters
-#    iter fit method
 #    check the noticed range after restoring it
 #    pha dataset; wavelength analysis
 #    pha2 dataset
@@ -138,6 +137,49 @@ set_method_opt("iquad", 1)
 set_method_opt("maxfev", 5000)
 set_method_opt("step", None)
 set_method_opt("verbose", 1)
+
+
+######### Set Model Components and Parameters
+
+
+
+######### Set Source, Pileup and Background Models
+
+"""
+
+_canonical_empty_iterstat = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+
+
+######### Set Statistic
+
+set_stat("leastsq")
+
+
+######### Set Fitting Method
+
+set_method("neldermead")
+
+set_method_opt("finalsimplex", 9)
+set_method_opt("ftol", 1.19209289551e-07)
+set_method_opt("initsimplex", 0)
+set_method_opt("iquad", 1)
+set_method_opt("maxfev", 5000)
+set_method_opt("step", None)
+set_method_opt("verbose", 1)
+
+
+######### Set Iterative Fitting Method
+
+set_iter_method("sigmarej")
+
+set_iter_method_opt("grow", 1)
+set_iter_method_opt("hrej", 3)
+set_iter_method_opt("lrej", 3)
+set_iter_method_opt("maxiters", 5)
 
 
 ######### Set Model Components and Parameters
@@ -820,6 +862,7 @@ else:
 
 _canonical_empty += _canonical_extra
 _canonical_empty_stats += _canonical_extra
+_canonical_empty_iterstat += _canonical_extra
 _canonical_pha_basic += _canonical_extra
 _canonical_pha_grouped += _canonical_extra
 _canonical_usermodel += _canonical_extra
@@ -1081,6 +1124,21 @@ def test_canonical_empty_stats():
     ui.set_method_opt('verbose', 1)
 
     compare(_canonical_empty_stats)
+
+
+def test_canonical_empty_iterstat():
+    "Check iterated-fit setting"
+
+    ui.set_stat('leastsq')
+
+    ui.set_method('simplex')
+    ui.set_method_opt('maxfev', 5000)
+    ui.set_method_opt('verbose', 1)
+
+    ui.set_iter_method('sigmarej')
+    ui.set_iter_method_opt('grow', 1)
+
+    compare(_canonical_empty_iterstat)
 
 
 @requires_data


### PR DESCRIPTION
# Summary

If set_iter_fit_method has been called with a value other than 'none' then the output of save_all would be incorrect for the options for the iter-fit method.

# Details

If an iterated-fit statistic was set then the serialization of the option data was wrong - ("%s", %s) rather than key and value. A test case has been added.

This was found when reviewing lint warnings generated with flake8.