### PR TITLE
flake8 F811 - fix repeated test names

### DIFF
--- a/sherpa/astro/io/tests/test_meta.py
+++ b/sherpa/astro/io/tests/test_meta.py
@@ -157,7 +157,7 @@ def test_keyword_order():
 
 
 @requires_fits
-def test_key_pop():
+def test_key_pop_known():
     """Can pop a known value"""
 
     from sherpa.astro.io.meta import Meta
@@ -170,7 +170,7 @@ def test_key_pop():
 
 
 @requires_fits
-def test_key_pop():
+def test_key_pop_unknown():
     """Can pop an unknown"""
 
     from sherpa.astro.io.meta import Meta

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -2558,55 +2558,6 @@ def test_data1d_plot_model(cls, plottype, extraargs, title):
 @requires_pylab
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
-@pytest.mark.parametrize("plottype,extraargs,title,plotcls",
-                         [("model", [], "Model",
-                           sherpa.plot.ModelPlot),
-                          ("model_component", ['mdl'],
-                           "Model component: polynom1d.mdl",
-                           sherpa.plot.ComponentModelPlot),
-                          ("source", [], "Source",
-                           sherpa.plot.SourcePlot),
-                          ("source_component", ['mdl'],
-                           "Source model component: polynom1d.mdl",
-                           sherpa.plot.ComponentSourcePlot)])
-def test_data1dint_get_model_plot(cls, plottype, extraargs, title, plotcls):
-    """Check we can plot a Data1DInt model.
-
-    For the Data1DInt case source and model return the
-    same plots apart for the title.
-
-    Note that we test both Session classes here.
-    """
-
-    from matplotlib import pyplot as plt
-
-    xlo = np.asarray([10, 12, 16, 20, 22])
-    xhi = np.asarray([12, 16, 19, 22, 26])
-    y = np.asarray([50, 54, 58, 60, 64])
-    yexp = np.asarray([22, 56, 52.5, 42, 96])
-
-    s = cls()
-    s._add_model_types(sherpa.models.basic)
-
-    s.load_arrays(1, xlo, xhi, y, Data1DInt)
-
-    mdl = s.create_model_component('polynom1d', 'mdl')
-    mdl.c0 = 0
-    mdl.c1 = 1
-
-    s.set_source(mdl)
-
-    plot = getattr(s, "get_{}_plot".format(plottype))(*extraargs)
-
-    assert isinstance(plot, plotcls)
-    assert plot.title == title
-    assert plot.x == pytest.approx((xlo + xhi) / 2)
-    assert plot.y == pytest.approx(yexp)
-
-
-@requires_pylab
-@pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
                          [("model", [], "Model"),
                           ("model_component", ['tmdl'],
@@ -2713,6 +2664,8 @@ def test_data1dint_get_model_plot(cls, plottype, extraargs, title, plotcls):
 
     assert isinstance(plot, plotcls)
     assert plot.title == title
+    # NOTE: we add an x mid-point
+    assert plot.x == pytest.approx((xlo + xhi) / 2)
     assert plot.xlo == pytest.approx(xlo)
     assert plot.xhi == pytest.approx(xhi)
     assert plot.y == pytest.approx(yexp)

--- a/sherpa/optmethods/tests/test_ncoresopt.py
+++ b/sherpa/optmethods/tests/test_ncoresopt.py
@@ -81,7 +81,7 @@ def test_decanom(opt, npar=2):
 def test_dodecal(opt, npar=3):
     tst_opt(opt, _tstoptfct.dodecal, npar)
 
-@pytest.mark.slow    
+@pytest.mark.slow
 @pytest.mark.parametrize("opt", [NCORES_NM, NCORES_DE])
 def test_DixonPrice(opt, npar=5):
     tst_opt(opt, _tstoptfct.DixonPrice, npar)
@@ -90,7 +90,7 @@ def test_DixonPrice(opt, npar=5):
 def test_Hansen(opt, npar=2):
     tst_opt(opt, _tstoptfct.Hansen, npar)
 
-@pytest.mark.slow    
+@pytest.mark.slow
 @pytest.mark.parametrize("opt", [NCORES_NM, NCORES_DE])
 def test_Holzman2(opt, npar=3):
     tst_opt(opt, _tstoptfct.Holzman2, npar)
@@ -108,28 +108,25 @@ def test_McCormick(opt, npar=2):
 def test_Michalewicz(opt, npar=2):
     tst_opt(opt, _tstoptfct.Michalewicz, npar)
 
-@pytest.mark.parametrize("opt", [NCORES_NM])
-def test_Paviani(opt, npar=10):
-    tst_opt(opt, _tstoptfct.Paviani, npar)
+def test_Paviani_nm(npar=10):
+    tst_opt(NCORES_NM, _tstoptfct.Paviani, npar)
 
 @pytest.mark.slow
-def test_Paviani(npar=10):
+def test_Paviani_de(npar=10):
     tst_opt(NCORES_DE, _tstoptfct.Paviani, npar)
 
-@pytest.mark.parametrize("opt", [NCORES_NM])
-def test_Rastrigin(opt, npar=4):
-    tst_opt(opt, _tstoptfct.Rastrigin, npar)
+def test_Rastrigin_nm(npar=4):
+    tst_opt(NCORES_NM, _tstoptfct.Rastrigin, npar)
 
 @pytest.mark.slow
-def test_Rastrigin(npar=4):
+def test_Rastrigin_de(npar=4):
     tst_opt(NCORES_DE, _tstoptfct.Rastrigin, npar)
-    
-@pytest.mark.parametrize("opt", [NCORES_NM, NCORES_DE])
-def test_seqp(opt, npar=2):
-    tst_opt(opt, _tstoptfct.seqp, npar)
+
+def test_seqp_nm(npar=2):
+    tst_opt(NCORES_NM, _tstoptfct.seqp, npar)
 
 @pytest.mark.slow
-def test_seqp(npar=2):
+def test_seqp_de(npar=2):
     tst_opt(NCORES_DE, _tstoptfct.seqp, npar)
 
 @pytest.mark.parametrize("opt", [NCORES_NM, NCORES_DE])
@@ -139,5 +136,3 @@ def test_Shubert(opt, npar=2):
 @pytest.mark.parametrize("opt", [NCORES_NM, NCORES_DE])
 def test_Trecanni(opt, npar=2):
     tst_opt(opt, _tstoptfct.Trecanni, npar)
-
-    

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -133,56 +133,72 @@ def setup():
 def test_student_t(setup):
     sim.multivariate_t(setup.mu, setup.cov, setup.dof, setup.num)
 
+
 def test_cauchy(setup):
     sim.multivariate_cauchy(setup.mu, setup.cov, setup.num)
+
 
 def test_parameter_scale_vector(setup):
     ps = sim.ParameterScaleVector()
     ps.get_scales(setup.fit)
 
+
 def test_parameter_scale_matrix(setup):
     ps = sim.ParameterScaleMatrix()
     ps.get_scales(setup.fit)
+
 
 def test_uniform_parameter_sample(setup):
     up = sim.UniformParameterSampleFromScaleVector()
     up.get_sample(setup.fit, num=setup.num)
 
+
 def test_normal_parameter_sample_vector(setup):
     np = sim.NormalParameterSampleFromScaleVector()
     np.get_sample(setup.fit, num=setup.num)
+
 
 def test_normal_parameter_sample_matrix(setup):
     np = sim.NormalParameterSampleFromScaleMatrix()
     np.get_sample(setup.fit, num=setup.num)
 
+
 def test_t_parameter_sample_matrix(setup):
     np = sim.StudentTParameterSampleFromScaleMatrix()
     np.get_sample(setup.fit, setup.dof, num=setup.num)
+
 
 def test_uniform_sample(setup):
     up = sim.UniformSampleFromScaleVector()
     up.get_sample(setup.fit, num=setup.num)
 
+
+# This used to have the same name as test_uniform_sample,
+# so it has been renamed. Neither apparent to do much
+# testing.
+#
+def test_uniform_sample2(setup):
+    sim.uniform_sample(setup.fit, num=setup.num)
+
+
 def test_normal_sample_vector(setup):
     np = sim.NormalSampleFromScaleVector()
     np.get_sample(setup.fit, num=setup.num)
+
 
 def test_normal_sample_matrix(setup):
     np = sim.NormalSampleFromScaleMatrix()
     np.get_sample(setup.fit, num=setup.num)
 
+
 def test_t_sample_matrix(setup):
     np = sim.StudentTSampleFromScaleMatrix()
     np.get_sample(setup.fit, setup.num, setup.dof)
 
-# TODO: this overwrites the test_uniform_sample routine above,
-#       should one be renamed?
-def test_uniform_sample(setup):
-    sim.uniform_sample(setup.fit, num=setup.num)
 
 def test_normal_sample(setup):
     sim.normal_sample(setup.fit, num=setup.num, correlate=False)
+
 
 def test_normal_sample_correlated(setup):
     sim.normal_sample(setup.fit, num=setup.num, correlate=True)

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -135,7 +135,7 @@ def test_models_filtered(mtype):
 
 
 @requires_xspec
-def test_models_all():
+def test_models_all_xspec():
     """Check all models are returned"""
 
     import sherpa.astro.xspec


### PR DESCRIPTION
# Summary

Clean up of several test files to fix repeated test names.

# Details

A few of our tests had repeated names so I have either fixed them to have different names or (in one case) removed a test (and moved one check from that outdated test).

This was found while reviewing lint fixes reported by flake8.
