### PR TITLE
Add explicit get/set_datadir routines to sherpa.utils.testing

### DIFF
--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -47,7 +48,7 @@ from numpy.testing import assert_array_equal
 
 import pytest
 
-from sherpa.utils.testing import SherpaTestCase, requires_data, \
+from sherpa.utils.testing import get_datadir, requires_data, \
     requires_xspec, has_package_from_list, requires_fits, requires_group
 from sherpa.astro import ui
 # from sherpa.astro.ui import serialize
@@ -851,8 +852,7 @@ def add_datadir_path(output):
     """Replace any @@ characters by the value of self.datadir,
     making sure that the replacement text does not end in a /."""
 
-    # it would be nice not to use SherpaTestCase
-    dname = SherpaTestCase.datadir
+    dname = get_datadir()
     if dname.endswith('/'):
         dname = dname[:-1]
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -27,7 +27,7 @@ from numpy import VisibleDeprecationWarning
 
 import pytest
 
-from sherpa.utils.testing import SherpaTestCase
+from sherpa.utils.testing import get_datadir, set_datadir
 
 try:
     from astropy.io.fits.verify import VerifyWarning
@@ -280,7 +280,7 @@ def pytest_configure(config):
     try:
         path = config.getoption(TEST_DATA_OPTION)
         if path:
-            SherpaTestCase.datadir = path
+            set_datadir(path)
     except ValueError:  # option not defined from command line, no-op
         pass
 
@@ -299,7 +299,7 @@ def test_data_path():
     path : basestring
         The string with the path to the main test data folder.
     """
-    path = SherpaTestCase.datadir
+    path = get_datadir()
 
     if path is None:
         raise RuntimeError("Test needs the requires_data decorator")

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -17,10 +17,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import numpy
-import unittest
-import os
 import importlib
+import os
+import unittest
+
+import numpy
 
 from sherpa.utils._utils import sao_fcmp
 
@@ -32,7 +33,14 @@ except ImportError:
 
 
 def _get_datadir():
-    import os
+    """Return the location of the test data files, if installed.
+
+    Returns
+    -------
+    path : str or None
+        The path to the Sherpa test data directory or None.
+    """
+
     try:
         import sherpatest
         datadir = os.path.dirname(sherpatest.__file__)
@@ -50,13 +58,51 @@ def _get_datadir():
     return datadir
 
 
+DATADIR = _get_datadir()
+
+
+def set_datadir(datadir):
+    """Set the data directory.
+
+    Parameters
+    ----------
+    datadir : str
+        The name to the data directory. It must exist.
+
+    Raises
+    ------
+    OSError
+        If datadir is not a directory or is empty.
+
+    """
+
+    if not os.path.exists(datadir) or not os.listdir(datadir):
+        raise OSError("datadir={} is empty or not a directory".format(datadir))
+
+    global DATADIR
+    DATADIR = datadir
+
+
+def get_datadir():
+    """Return the data directory.
+
+    Returns
+    -------
+    datadir : str or None
+        The name to the data directory, if it exists.
+
+    """
+
+    return DATADIR
+
+
 class SherpaTestCase(unittest.TestCase):
     """
     Base class for Sherpa unit tests. The use of this class is deprecated in favor of pytest functions.
     """
 
     # The location of the Sherpa test data (it is optional)
-    datadir = _get_datadir()
+    datadir = DATADIR
 
     def make_path(self, *segments):
         """Add the segments onto the test data location.
@@ -186,7 +232,7 @@ if HAS_PYTEST:
 
          See PR #391 for why this is a function: https://github.com/sherpa/sherpa/pull/391
          """
-        condition = SherpaTestCase.datadir is None
+        condition = DATADIR is None
         msg = "required test data missing"
         return pytest.mark.skipif(condition, reason=msg)(test_function)
 

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -49,7 +49,8 @@ def _get_datadir():
             import sherpa
             datadir = os.path.join(os.path.dirname(sherpa.__file__), os.pardir,
                                    'sherpa-test-data', 'sherpatest')
-            if not os.path.exists(datadir) or not os.listdir(datadir):
+            if not os.path.exists(datadir) or not os.path.isdir(datadir) \
+               or not os.listdir(datadir):
                 # The dir is empty, maybe the submodule was not initialized
                 datadir = None
         except ImportError:
@@ -76,7 +77,8 @@ def set_datadir(datadir):
 
     """
 
-    if not os.path.exists(datadir) or not os.listdir(datadir):
+    if not os.path.exists(datadir) or not os.path.isdir(datadir) \
+       or not os.listdir(datadir):
         raise OSError("datadir={} is empty or not a directory".format(datadir))
 
     global DATADIR

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -101,9 +101,6 @@ class SherpaTestCase(unittest.TestCase):
     Base class for Sherpa unit tests. The use of this class is deprecated in favor of pytest functions.
     """
 
-    # The location of the Sherpa test data (it is optional)
-    datadir = DATADIR
-
     def make_path(self, *segments):
         """Add the segments onto the test data location.
 
@@ -120,9 +117,10 @@ class SherpaTestCase(unittest.TestCase):
            data directory is not set.
 
         """
-        if self.datadir is None:
+        datadir = get_datadir()
+        if datadir is None:
             return None
-        return os.path.join(self.datadir, *segments)
+        return os.path.join(datadir, *segments)
 
     # What is the benefit of this over numpy.testing.assert_allclose(),
     # which was added in version 1.5 of NumPy?
@@ -197,7 +195,7 @@ class SherpaTestCase(unittest.TestCase):
         scriptname = name + "-" + scriptname
         self.locals = {}
         cwd = os.getcwd()
-        os.chdir(self.datadir)
+        os.chdir(get_datadir())
         try:
             with open(scriptname, "rb") as fh:
                 cts = fh.read()

--- a/sherpa/utils/tests/test_utils_testing.py
+++ b/sherpa/utils/tests/test_utils_testing.py
@@ -83,7 +83,7 @@ def test_set_datadir():
     # Assume the current directory is a reasonable directory to use.
     #
     npath = os.getcwd()
-    assert opath != npath  # just a sanety check
+    assert opath != npath  # just a sanity check
     set_datadir(npath)
 
     assert get_datadir() == npath

--- a/sherpa/utils/tests/test_utils_testing.py
+++ b/sherpa/utils/tests/test_utils_testing.py
@@ -21,9 +21,11 @@
 Split out testing of parts of sherpa.utils.testing to here.
 """
 
+import os
+
 import pytest
 
-from sherpa.utils.testing import set_datadir
+from sherpa.utils.testing import get_datadir, set_datadir
 
 
 def test_set_datadir_does_not_exist(tmp_path):
@@ -61,3 +63,29 @@ def test_set_datadir_is_not_a_directory(tmp_path):
 
     assert str(exc.value).startswith('datadir=')
     assert str(exc.value).endswith('/is-a-file is empty or not a directory')
+
+
+def test_set_datadir():
+    """Check we can set it, then restore the previous setting."""
+
+    # Since set_datadir does not accept None, and I don't want to deal with
+    # the low-level internals of the testing module, skip this set if
+    # the directory is not set.
+    #
+    opath = get_datadir()
+    if opath is None:
+        pytest.skip("datadir is not set")
+
+    # Ideally we'd wrap this up so that a problem would not bleed into
+    # other tests, but this would be a fairly serious problem so do not
+    # bother at this time.
+    #
+    # Assume the current directory is a reasonable directory to use.
+    #
+    npath = os.getcwd()
+    assert opath != npath  # just a sanety check
+    set_datadir(npath)
+
+    assert get_datadir() == npath
+    set_datadir(opath)
+    assert get_datadir() != npath

--- a/sherpa/utils/tests/test_utils_testing.py
+++ b/sherpa/utils/tests/test_utils_testing.py
@@ -1,0 +1,63 @@
+#
+#  Copyright (C) 2021  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Split out testing of parts of sherpa.utils.testing to here.
+"""
+
+import pytest
+
+from sherpa.utils.testing import set_datadir
+
+
+def test_set_datadir_does_not_exist(tmp_path):
+    """We error out when the directory does not exist."""
+
+    d = tmp_path / "does-not-exist"
+
+    with pytest.raises(OSError) as exc:
+        set_datadir(d)
+
+    assert str(exc.value).startswith('datadir=')
+    assert str(exc.value).endswith('/does-not-exist is empty or not a directory')
+
+
+def test_set_datadir_is_empty(tmp_path):
+    """We error out when the directory is empty."""
+
+    d = tmp_path
+
+    with pytest.raises(OSError) as exc:
+        set_datadir(d)
+
+    assert str(exc.value).startswith('datadir=')
+    assert str(exc.value).endswith(' is empty or not a directory')
+
+
+def test_set_datadir_is_not_a_directory(tmp_path):
+    """We error out when the directory is actually a file."""
+
+    p = tmp_path / "is-a-file"
+    p.write_text('something')
+
+    with pytest.raises(OSError) as exc:
+        set_datadir(p)
+
+    assert str(exc.value).startswith('datadir=')
+    assert str(exc.value).endswith('/is-a-file is empty or not a directory')


### PR DESCRIPTION
# Summary

Internal changes to how the test data directory location is set and queried, including removing direct support from SherpaTestCase. Added tests for some of this functionality, and updated several test files to remove SherpaTestCase or use the new datadir functionality.

# Details

The main aim is to make sure we can drop the need for the SherpaTestCase object when setting and getting the data-directory path. It's part of my glacially-slow attempt at removing SherpaTestCase.

