### PR TITLE
Add missing collection-API methods to Meta

### DIFF
--- a/sherpa/astro/io/meta.py
+++ b/sherpa/astro/io/meta.py
@@ -40,6 +40,15 @@ class Meta(NoNewAttributesAfterInit):
     def __setitem__(self, name, val):
         self.__header[name] = val
 
+    def __contains__(self, item):
+        return item in self.__header
+
+    def __len__(self):
+        return len(self.__header)
+
+    def __iter__(self):
+        return self.__header.__iter__()
+
     def get(self, name, default=None):
         return self.__header.get(name, default)
 
@@ -58,11 +67,14 @@ class Meta(NoNewAttributesAfterInit):
         return keys
 
     def has_key(self, key):
-        return key in self.__header
+        "obj in key should be used instead"
+        return self.__contains__(key)
 
     def values(self):
         return [self.__header[key] for key in self.keys()]
 
+    # NOTE: this does not return a copy of the Meta object.
+    #       Is this intentional?
     def copy(self):
         return self.__header.copy()
 

--- a/sherpa/astro/io/tests/test_meta.py
+++ b/sherpa/astro/io/tests/test_meta.py
@@ -28,12 +28,14 @@ import pytest
 
 from sherpa.utils.testing import requires_fits
 
+
 @requires_fits
 def test_empty():
     """An empty store is empty."""
 
     from sherpa.astro.io.meta import Meta
     store = Meta()
+    assert len(store) == 0
     assert len(store.keys()) == 0
 
 
@@ -43,7 +45,8 @@ def test_key_does_not_exist():
 
     from sherpa.astro.io.meta import Meta
     store = Meta()
-    assert not store.has_key("key")
+    assert "key" not in store
+    assert not store.has_key('key')
 
 
 @requires_fits
@@ -55,7 +58,9 @@ def test_add_keyword(value):
     store = Meta()
     store['key'] = value
     assert store.keys() == ['key']
+    assert "key" in store
     assert store.has_key('key')
+    assert len(store) == 1
     assert len(store.values()) == 1
 
     svalue = store['key']
@@ -244,3 +249,24 @@ def test_str_multi():
     assert lines[2] == ' a             = 23'
     assert lines[3] == ' outfile       = /tmp/b.fits'
     assert lines[4] == ' xkey          =  y  y'
+
+
+@requires_fits
+def test_iter():
+
+    from sherpa.astro.io.meta import Meta
+    store = Meta()
+    store['Xkey'] = 'X X'
+    store['xkey'] = ' y  y'
+    store['a'] = 23
+    store['INFILE'] = 'none'
+    store['outfile'] = '/tmp/b.fits'
+
+    assert len(store) == 5
+
+    keys = set()
+    for k in iter(store):
+        assert k not in keys
+        keys.add(k)
+
+    assert keys == set(['a', 'outfile', 'xkey', 'INFILE', 'Xkey'])


### PR DESCRIPTION
# Summary

Improve the Meta API to better-match the collections API.

# Details

The idea was to remove a warning identified by flake8 (the use of .has_key) but this method has been left in for the moment. Instead I've added methods so that it more-closely follows the collections API (e.g. len and `__contains__`).

One reason for this PR is that I have to ask whether we really need the Meta object, as all it is is a dictionary. The only difference is that it has a FITS-style `__str__` method, which could be handled by a function, and an odd copy routine (which returns a copu of the underlying dict, not the Meta class).

As an example, the has_key method doesn't seem to be used in out code base.