### PR TITLE
Update Travis tests to cfitsio 4.49 and xspec 12.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   fast_finish: true
   include:
     # macOS build
-    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER="3" XSPECVER="12.10.1n" TRAVIS_PYTHON_VERSION="3.7"
+    - env: INSTALL_TYPE=develop FITS="astropy" TEST=submodule MATPLOTLIBVER="3" XSPECVER="12.10.1s" TRAVIS_PYTHON_VERSION="3.7"
       os: osx
     # Barebone build to check tests pass when most of the tests must be skipped.
     # We need to use TEST=none to remove the test-data submodule.
@@ -15,11 +15,13 @@ jobs:
     # been bumped to "nearly latest" versions
     - env: INSTALL_TYPE=develop TEST=none NUMPYVER="1.17" TRAVIS_PYTHON_VERSION="3.8"
     # Full build (including ds9 and xspec), Python 3.5, setup.py develop, astropy, matplotlib 2
-    - env: XSPECVER="12.10.1n" NUMPYVER="1.11" FITS="astropy pytest-openfiles<=0.4.0 pytest-doctestplus<=0.5.0" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER="2" TRAVIS_PYTHON_VERSION="3.5"
-    # As above, Python 3.6, setup.py install, xspec 12.10
-    - env: XSPECVER="12.10.1n" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="2" TRAVIS_PYTHON_VERSION="3.6"
+    - env: XSPECVER="12.10.1s" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=develop TEST=submodule MATPLOTLIBVER="2" TRAVIS_PYTHON_VERSION="3.5"
+    # As above, Python 3.6, setup.py install, xspec 12.11.1
+    - env: XSPECVER="12.11.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="2" TRAVIS_PYTHON_VERSION="3.6"
     # As above, python 3.7, numpy 1.15, matplotlib 3
-    - env: XSPECVER="12.10.1n" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="3" TRAVIS_PYTHON_VERSION="3.7"
+    - env: XSPECVER="12.11.1" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="3" TRAVIS_PYTHON_VERSION="3.7"
+    # As above, python 3.8, numpy 1.15, matplotlib 3
+    - env: XSPECVER="12.11.1" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="3" TRAVIS_PYTHON_VERSION="3.8"
     # We now buid all PRs on RTD thanks to their hook, so we
     # do not need to run a separate test here.
     # - env: DOCS=true INSTALL_TYPE=build_sphinx TEST=none TRAVIS_PYTHON_VERSION="3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ jobs:
     - env: XSPECVER="12.11.1" NUMPYVER="1.11" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="2" TRAVIS_PYTHON_VERSION="3.6"
     # As above, python 3.7, numpy 1.15, matplotlib 3
     - env: XSPECVER="12.11.1" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="3" TRAVIS_PYTHON_VERSION="3.7"
-    # As above, python 3.8, numpy 1.15, matplotlib 3
-    - env: XSPECVER="12.11.1" NUMPYVER="1.15" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="3" TRAVIS_PYTHON_VERSION="3.8"
+    # As above, python 3.8, numpy 1.19, matplotlib 3
+    - env: XSPECVER="12.11.1" NUMPYVER="1.19" FITS="astropy" INSTALL_TYPE=install TEST=submodule MATPLOTLIBVER="3" TRAVIS_PYTHON_VERSION="3.8"
     # We now buid all PRs on RTD thanks to their hook, so we
     # do not need to run a separate test here.
     # - env: DOCS=true INSTALL_TYPE=build_sphinx TEST=none TRAVIS_PYTHON_VERSION="3.7"

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -2,7 +2,8 @@
 
 # Environment
 sherpa_channel=sherpa
-xspec_channel=xspec/channel/dev
+#Switch from "dev" to "test" to avoid needing to rebase old PRs prior to pinning cfitsio in xspec
+xspec_channel="xspec/label/test"
 miniconda=$HOME/miniconda
 
 if [[ ${TRAVIS_OS_NAME} == linux ]];

--- a/travis/setup_xspec_ds9.sh
+++ b/travis/setup_xspec_ds9.sh
@@ -62,6 +62,9 @@ xspec_library_path=${xspec_root}/lib/
 xspec_include_path=${xspec_root}/include/
 
 case "${XSPECVER}" in
+  12.11.1*)
+      xspec_version_string="12.11.1"
+      ;;
   12.10.1*)
       xspec_version_string="12.10.1"
       ;;


### PR DESCRIPTION
Xspec now requires fgsl and the fftw fortran wrappers. This now places a minimum gfortran build requirement for Xspec of ~5.x ([for Fortran 2008 C_LOC support](https://heasarc.gsfc.nasa.gov/lheasoft/issues.html)). 
This gfortran version requirement is an issue because the latest version of gfortran available in defaults for Conda on macOS is 4.8.5. A ticket was submitted to Anaconda to hopefully increase the gfortran support of macOS, but that may take a while (as not many people need it or they use Conda-forge). 
For now, we can proceed with adding Xspec 12.11.1 testing for Sherpa on Linux with future methods to be tested in later updates.
This PR switches some of the travis tests (some linux tests only) to use Xspec 12.11.1 and cfitsio 3.49. All other Travis tests have also been updated to use xspec 12.10.1s and cfitsio 3.49. 
The xspec_channel used for testing was also switched from "xspec/label/test" to "xspec/label/dev" for testing purposes and to avoid needing to rebase old PRs if the Conda packages were uploaded before this PR was merged. That is the case because the old Xspec packages used for testing do not have cfitsio pinned properly, so any old PRs using 12.10.1n for testing would attempt to pick up the cfitsio update and would run into library issues. This issue has been rectified for CIAO using automated pins through "run_exports" in the cfitsio and xspec-modelsonly recipes and brought here to resolve this issue moving forward. If we want, we can migrate "xspec/label/test" back to "xspec/label/dev", but any old PRs may need to be rebased and the new packages on the "xspec" Conda channel would need a "dev" label. 