### PR TITLE
reword remark on normalization of Lorentz function

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -569,14 +569,14 @@ class Lorentz1D(RegriddableModel1D):
     -----
     The functional form of the model for points is::
 
-        f(x) =                A * fwhm
+        f(x) =              ampl * fwhm
                --------------------------------------
                2 * pi * (0.25 * fwhm^2 + (x - pos)^2)
 
-           A = ampl / integral f(x) dx
-
     and for an integrated grid it is the integral of this over
     the bin.
+
+    The area under the function as defined above is 1 if ampl is 1.
     """
 
     def __init__(self, name='lorentz1d'):


### PR DESCRIPTION
I was confused by the text as that implies that an additional normalization step takes place. It sounds as if Sherpa calculates the integral, when in fact, the Lorentz function already integrates to 1 for ampl = 1. That's why there is the factor 2 pi in there, which ensures that integral f(x) dx = 1.

@DougBurke As a side note: This is a case that would really profit from writing the equation in LaTeX and activating MathJax for the sphinx build. I was very tempted to just do that and see what happens, but then I realized the the ahelp pages are now also build from the doc strings, and I have no idea if they can deal with that, so I figured I just ask before I do anything about it.