### PR TITLE
Update lev3fft test to use PHYSICAL not WCS

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -599,15 +599,15 @@ def test_stats_all(run_thread, fix_xspec):
 def test_lev3fft(run_thread, clean_astro_ui):
     tlocals = run_thread('lev3fft', scriptname='bar.py')
 
-    assert tlocals['src'].fwhm.val == approx(1.6304283807465337e-05)
-    assert tlocals['src'].xpos.val == approx(150.014516168296)
-    assert tlocals['src'].ypos.val == approx(2.6650092327584507)
-    assert tlocals['src'].ampl.val == approx(97.24051178672816)
-    assert tlocals['bkg'].c0.val == approx(0.02087374459610318)
+    assert tlocals['src'].fwhm.val == approx(1.48914, rel=1e-5)
+    assert tlocals['src'].xpos.val == approx(3142.84, rel=1e-5)
+    assert tlocals['src'].ypos.val == approx(4519.72, rel=1e-5)
+    assert tlocals['src'].ampl.val == approx(9.11268, rel=1e-5)
+    assert tlocals['bkg'].c0.val == approx(0.0118703, rel=1e-5)
 
     fres = ui.get_fit_results()
-    assert fres.istatval == approx(6456.0299149344855)
-    assert fres.statval == approx(612.1496898022738, rel=1e-4)
+    assert fres.istatval == approx(6483.84, rel=1e-5)
+    assert fres.statval == approx(558.987, rel=1e-4)
     assert fres.numpoints == 3307
     assert fres.dof == 3302
 


### PR DESCRIPTION
# Summary

Update a 2D image test to use physical rather than WCS coordinates for the fit.

# Details

It is not clear why we use WCS for fitting, since it is known that WCS fitting isn't great, particularly when you have a convolution model like the PSF components used here.

This is being done to make some work on FWHM-related guess code easier (since without this change the guess in the updated code will return a FWHM in degrees (i.e. small) which messes up the fit).

Note that technically the new version is a "better" fit (the statistic value is smaller, 559 vs 592) but as the data is very ropey I'm not sure how much  weight we should give this.

We need https://github.com/sherpa/sherpa-test-data/pull/24 merged before we can accept this. I can't guarantee I've got that part right with the submodule. In fact I'm reasonably sure I haven't, but I can fix that once https://github.com/sherpa/sherpa-test-data/pull/24 is merged. The tests currently fail because of this botched change (thanks to things having changed sine the PR was made last year).