### PR TITLE
Update fwhm calculation

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -599,15 +599,15 @@ def test_stats_all(run_thread, fix_xspec):
 def test_lev3fft(run_thread, clean_astro_ui):
     tlocals = run_thread('lev3fft', scriptname='bar.py')
 
-    assert tlocals['src'].fwhm.val == approx(0.0442234, 1e-4)
-    assert tlocals['src'].xpos.val == approx(150.015, 1e-4)
-    assert tlocals['src'].ypos.val == approx(2.66494, 1e-4)
-    assert tlocals['src'].ampl.val == approx(1.56384, 1e-4)
-    assert tlocals['bkg'].c0.val == approx(-1.51662, 1e-4)
+    assert tlocals['src'].fwhm.val == approx(1.6304283807465337e-05)
+    assert tlocals['src'].xpos.val == approx(150.014516168296)
+    assert tlocals['src'].ypos.val == approx(2.6650092327584507)
+    assert tlocals['src'].ampl.val == approx(97.24051178672816)
+    assert tlocals['bkg'].c0.val == approx(0.02087374459610318)
 
     fres = ui.get_fit_results()
-    assert fres.istatval == approx(19496.3, rel=1e-4)
-    assert fres.statval == approx(592.32647, rel=1e-4)
+    assert fres.istatval == approx(6456.0299149344855)
+    assert fres.statval == approx(612.1496898022738, rel=1e-4)
     assert fres.numpoints == 3307
     assert fres.dof == 3302
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2310,12 +2310,18 @@ def get_fwhm(y, x, xhi=None):
     If there are multiple peaks of the same height then
     the first peak is used.
     """
+
     y_argmax = y.argmax()
     half_max_val = y[y_argmax] / 2.0
     x_max = x[y_argmax]
     for ii, val in enumerate(y[y_argmax:]):
         if val < half_max_val:
-            return 2.0 * ii
+            return 2.0 * (x[ii + y_argmax] - x_max)
+
+    # What is the best thing to do here? This does not handle
+    # the case where all x values are negative, as the location
+    # isn't meaningful as a result.
+    #
     return x_max
 
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2291,7 +2291,7 @@ def get_fwhm(y, x, xhi=None):
     Parameters
     ----------
     y, x : array_like
-       The data points.
+       The data points. The x array must be in ascending order.
     xhi : None or array_like, optional
        If given then the x array is taken to be the low-edge
        of each bin.
@@ -2307,22 +2307,60 @@ def get_fwhm(y, x, xhi=None):
 
     Notes
     -----
-    If there are multiple peaks of the same height then
-    the first peak is used.
+    If there are multiple peaks of the same height then the first peak
+    is used.
+
+    The approach is to find the maximum position and then extend out
+    to the first bins which fall below half the height. The difference
+    of the two points is used. If only one side falls below the value
+    then twice this separation is used. If the half-height is not
+    reached then the value is set to be half the width of the
+    x array. In all cases the upper-edge of the x arrays is ignored,
+    if given.
     """
 
     y_argmax = y.argmax()
     half_max_val = y[y_argmax] / 2.0
     x_max = x[y_argmax]
-    for ii, val in enumerate(y[y_argmax:]):
-        if val < half_max_val:
-            return 2.0 * (x[ii + y_argmax] - x_max)
 
-    # What is the best thing to do here? This does not handle
-    # the case where all x values are negative, as the location
-    # isn't meaningful as a result.
+    # Where do the values fall below the half-height?
     #
-    return x_max
+    flags = (y - half_max_val) < 0
+
+    # Find the distances from these points to the
+    # maximum location.
+    #
+    dist = x[flags] - x_max
+
+    # We want the maximum value of the negative distances,
+    # and the minimum value of the positive distances.
+    # There's no guarantee either exist.
+    #
+    try:
+        ldist = -1 * max(dist[dist < 0])
+    except ValueError:
+        ldist = None
+
+    try:
+        rdist = min(dist[dist > 0])
+    except ValueError:
+        rdist = None
+
+    # If we have both HWHM values then sum them and use that,
+    # otherwise if we have one then double it.
+    #
+    if ldist is not None and rdist is not None:
+        return ldist + rdist
+
+    if ldist is not None:
+        return 2 * ldist
+
+    if rdist is not None:
+        return 2 * rdist
+
+    # Pick half the width of the X array, purely as a guess.
+    #
+    return (x.max() - x.min()) / 2
 
 
 def guess_fwhm(y, x, xhi=None, scale=1000):

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -360,12 +360,12 @@ fwhm_y_right = numpy.asarray([46, 45, 40, 16, 20, 7, 6, 5, 3, 7])
 fwhm_y_flat = numpy.ones(fwhm_x.size)
 
 @pytest.mark.parametrize("x,y,expected",
-                         [(fwhm_x, fwhm_y_both, 6),
-                          (fwhm_x - 200, fwhm_y_both, 6),
+                         [(fwhm_x, fwhm_y_both, 80),
+                          (fwhm_x - 200, fwhm_y_both, 80),
                           (fwhm_x, fwhm_y_left, 100),
                           (fwhm_x - 200, fwhm_y_left, -100),
-                          (fwhm_x, fwhm_y_right, 6),
-                          (fwhm_x - 200, fwhm_y_right, 6),
+                          (fwhm_x, fwhm_y_right, 70),
+                          (fwhm_x - 200, fwhm_y_right, 70),
                           (fwhm_x, fwhm_y_flat, 10),
                           (fwhm_x - 200, fwhm_y_flat, -190)])
 def test_get_fwhm(x, y, expected):

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -353,6 +353,9 @@ def test_pad_bounding_box_mask_too_large():
 # negative, so run the test with x and x-200 (where all bins are
 # negative).
 #
+# If the values are <= 0 then we just use the fall-through value
+# of half the x range.
+#
 fwhm_x = numpy.asarray([10, 22, 30, 45, 50, 61, 70, 90, 100, 120])
 fwhm_y_both = numpy.asarray([9, 28, 25, 52, 53, 49, 33, 10, 10, 6])
 fwhm_y_left = numpy.asarray([10, 5, 3, 5, 7, 13, 8, 42, 57, 43])
@@ -367,7 +370,9 @@ fwhm_y_flat = numpy.ones(fwhm_x.size)
                           (fwhm_x, fwhm_y_right, 70),
                           (fwhm_x - 200, fwhm_y_right, 70),
                           (fwhm_x, fwhm_y_flat, 55),
-                          (fwhm_x - 200, fwhm_y_flat, 55)])
+                          (fwhm_x - 200, fwhm_y_flat, 55),
+                          (fwhm_x, - fwhm_y_both, 55),
+                          (fwhm_x, fwhm_y_both - fwhm_y_both.max(), 55)])
 def test_get_fwhm(x, y, expected):
     """Check the FWHM algorithm."""
 

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -360,14 +360,14 @@ fwhm_y_right = numpy.asarray([46, 45, 40, 16, 20, 7, 6, 5, 3, 7])
 fwhm_y_flat = numpy.ones(fwhm_x.size)
 
 @pytest.mark.parametrize("x,y,expected",
-                         [(fwhm_x, fwhm_y_both, 80),
-                          (fwhm_x - 200, fwhm_y_both, 80),
-                          (fwhm_x, fwhm_y_left, 100),
-                          (fwhm_x - 200, fwhm_y_left, -100),
+                         [(fwhm_x, fwhm_y_both, 60),
+                          (fwhm_x - 200, fwhm_y_both, 60),
+                          (fwhm_x, fwhm_y_left, 60),
+                          (fwhm_x - 200, fwhm_y_left, 60),
                           (fwhm_x, fwhm_y_right, 70),
                           (fwhm_x - 200, fwhm_y_right, 70),
-                          (fwhm_x, fwhm_y_flat, 10),
-                          (fwhm_x - 200, fwhm_y_flat, -190)])
+                          (fwhm_x, fwhm_y_flat, 55),
+                          (fwhm_x - 200, fwhm_y_flat, 55)])
 def test_get_fwhm(x, y, expected):
     """Check the FWHM algorithm."""
 

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -22,7 +22,8 @@ from numpy.testing import assert_almost_equal, assert_array_equal, \
 
 import pytest
 
-from sherpa.utils import _utils, is_binary_file, pad_bounding_box
+from sherpa.utils import _utils, is_binary_file, pad_bounding_box, \
+    get_fwhm
 from sherpa.utils.testing import requires_data
 
 
@@ -333,3 +334,42 @@ def test_pad_bounding_box_mask_too_large():
     # ignored).
     exp = numpy.asarray([0, 1, 2, 3, 4, 0, 0, 0, 0, 0]).astype(numpy.float64)
     assert_array_equal(ans, exp)
+
+
+# This is a gaussian with FWHM of 50 positioned so we can get
+# values from both sides, the left only, the right only, and then
+# a flat distribution. For reference the model was:
+#   (gauss1d + scale1d)
+#     Param        Type          Value          Min          Max      Units
+#     -----        ----          -----          ---          ---      -----
+#     gauss1d.fwhm thawed           50  1.17549e-38  3.40282e+38
+#     gauss1d.pos  thawed           12 -3.40282e+38  3.40282e+38
+#     gauss1d.ampl thawed           50 -3.40282e+38  3.40282e+38
+#     scale1d.c0   thawed            5 -3.40282e+38  3.40282e+38
+#
+# for pos=52, 105, 12 - and then poisson noise was added.
+#
+# The width is irrelevant of whether the X axis is positive or
+# negative, so run the test with x and x-200 (where all bins are
+# negative).
+#
+fwhm_x = numpy.asarray([10, 22, 30, 45, 50, 61, 70, 90, 100, 120])
+fwhm_y_both = numpy.asarray([9, 28, 25, 52, 53, 49, 33, 10, 10, 6])
+fwhm_y_left = numpy.asarray([10, 5, 3, 5, 7, 13, 8, 42, 57, 43])
+fwhm_y_right = numpy.asarray([46, 45, 40, 16, 20, 7, 6, 5, 3, 7])
+fwhm_y_flat = numpy.ones(fwhm_x.size)
+
+@pytest.mark.parametrize("x,y,expected",
+                         [(fwhm_x, fwhm_y_both, 6),
+                          (fwhm_x - 200, fwhm_y_both, 6),
+                          (fwhm_x, fwhm_y_left, 100),
+                          (fwhm_x - 200, fwhm_y_left, -100),
+                          (fwhm_x, fwhm_y_right, 6),
+                          (fwhm_x - 200, fwhm_y_right, 6),
+                          (fwhm_x, fwhm_y_flat, 10),
+                          (fwhm_x - 200, fwhm_y_flat, -190)])
+def test_get_fwhm(x, y, expected):
+    """Check the FWHM algorithm."""
+
+    ans = get_fwhm(y, x)
+    assert ans == pytest.approx(expected)


### PR DESCRIPTION
# Summary

Update the estimation of FWHM for 1D profiles, and hence the guess method for Gauss1D and related routines. The 2D models use the same routine, so see these changes, but they are known to require more work.

# Details

The FWHM estimation used by the `guess` method of models is based on `sherpa.utils.get_fwhm`. This was changed in #741 but I believe it had an error, as discussed at https://github.com/sherpa/sherpa/issues/875#issuecomment-746378325

We add explicit tests of `get_fwhm` that show the problem (essentially that the index value is used rather than a value appropriate for the axis, although when the simple test fails you end up with the position of the maximum value).

I then apply an improvement suggested at https://github.com/sherpa/sherpa/issues/875#issuecomment-746678714 which improves some of the tests but not all of them.

I then rework the `get_fwhm` algorithm so that it calculates the HWHM for both sides of the peak and then

- if both are found, returns the sum
- if only one is found (as the peak is too close to one edge) then returns 2 * HWHM
- if neither is found (the data never drops to half the peak height) then return half the width of the X array as a heuristic

I then have to update the lev3fft test, but as discussed in that commit (@9b006f3) I strongly believe this will need to be redone because I would hope we accept #1030

I have added an explicit check for negative values and if found we just fall through to the default case. It would be nice to handle this case (for absorption features) but it is tricky to handle generically, so let's just be explicit here about the requirement of this only being intended for positive peaks.

Is this worth taking, or should we just implement #875 (although I think we want to add some of the functionality in this PR, to add tests).