### PR TITLE
Add contextmanager and docs on how to control the output level of sherpa

### DIFF
--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -6,13 +6,39 @@ Utility routines
 .. todo::
 
    This section needs looking at.
+   Should they be documented here or elsewhere?
 
 There are a number of utility routines provided by Sherpa that may
-be useful. Should they be documented here or elsewhere?
-
-Unfortunately it is not always obvious whether a routine is for use
+be useful. Unfortunately it is not always obvious whether a routine is for use
 with the Object-Oriented API or the Session API.
 
+Contolling the verbosity of Sherpa
+==================================
+
+Sherpa uses `Python logging
+<https://docs.python.org/3/library/logging.htm>`_ for most
+messages. This allows the user to redirected the output to a file or
+suppress it by setting the logging level. The following example will
+globally change the level for all sherpa moduls, such that debug and
+informational messages are no longer displayed:
+
+  >>> import logging
+  >>> sherpalog = logging.getLogger('sherpa')
+  >>> sherpalog.setLevel('WARNING')
+
+Sherpa also provides a context manager to change the logging level
+only for a specific portion of the code. This can be used, e.g., to
+hide the long default output printed after fitting a model:
+
+  >>> from sherpa.utils.logging import SherpaVerbosity
+  >>> import numpy as np
+  >>> from sherpa.astro import ui
+  >>> ui.load_arrays("mydata", np.arange(5), np.ones(5))
+  >>> ui.set_model("mydata", "polynom1d.poly")
+  >>> with SherpaVerbosity('WARNING'):
+  ...    ui.fit("mydata")
+
+ 
 Reference/API
 =============
 

--- a/sherpa/astro/utils/tests/test_smoke.py
+++ b/sherpa/astro/utils/tests/test_smoke.py
@@ -23,14 +23,14 @@ import pytest
 from sherpa import smoke
 
 
-def test_success():
+def test_success(hide_logging):
     try:
         smoke()
     except SystemExit:
         pytest.fail("smoke test should have passed")
 
 
-def test_failure():
+def test_failure(hide_logging):
     with pytest.raises(SystemExit) as cm:
         smoke(require_failure=True)
 
@@ -38,7 +38,7 @@ def test_failure():
 
 
 @mock.patch.dict('sys.modules', astropy=None)
-def test_fits_failure():
+def test_fits_failure(hide_logging):
     with pytest.raises(SystemExit) as cm:
         smoke(fits="astropy")
 
@@ -46,7 +46,7 @@ def test_fits_failure():
 
 
 @mock.patch.dict('sys.modules', values={"sherpa.astro.xspec": None})
-def test_xspec_failure():
+def test_xspec_failure(hide_logging):
     with pytest.raises(SystemExit) as cm:
         smoke(xspec=True)
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -507,6 +507,10 @@ def reset_seed(request):
 def hide_logging():
     """Set Sherpa's logging to ERROR for the test.
 
+    This code is somehwat redundant with the decorator 
+    in utils/logging:SherpaVerbosity and, should this
+    fixture ever need to be redone, it might be worth 
+    investigating if the same decorator can be used.
     """
 
     logger = logging.getLogger('sherpa')

--- a/sherpa/utils/logging.py
+++ b/sherpa/utils/logging.py
@@ -18,6 +18,7 @@
 #
 import logging
 import sys
+import contextlib
 
 
 def config_logger(name, level=logging.WARNING, stream=sys.stdout, template=None):
@@ -39,7 +40,7 @@ def config_logger(name, level=logging.WARNING, stream=sys.stdout, template=None)
     return logger
 
 
-class SherpaVerbosity():
+class SherpaVerbosity(contextlib.AbstractContextManager):
     '''Set the output logging level for sherpa as a context.
 
     This changes the logging level globally for all modules in sherpa.

--- a/sherpa/utils/logging.py
+++ b/sherpa/utils/logging.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015-2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -37,3 +37,26 @@ def config_logger(name, level=logging.WARNING, stream=sys.stdout, template=None)
     logger.propagate = False
 
     return logger
+
+
+class SherpaVerbosity():
+    '''Set the output logging level for sherpa as a context.
+
+    This changes the logging level globally for all modules in sherpa.
+
+    Parameters
+    ----------
+    loglevel : string or int
+        New level for logging. Allowed strings are
+        ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, and ``CRITICAL``
+    '''
+    def __init__(self, level):
+        self.level = level
+        self.sherpalog = logging.getLogger('sherpa')
+
+    def __enter__(self):
+        self.old = self.sherpalog.level
+        self.sherpalog.setLevel(self.level)
+
+    def __exit__(self, *args):
+        self.sherpalog.setLevel(self.old)

--- a/sherpa/utils/tests/test_logging.py
+++ b/sherpa/utils/tests/test_logging.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -25,19 +25,15 @@ from sherpa.astro import ui
 
 
 def test_logging_verbosity_contextmanager(caplog):
-    # Previous tests might have changed this to a non-default
-    # level already. So, we first make sure the root logger
-    # is set right.
-    sherpalogger = logging.getLogger('sherpa')
-    sherpalogger.setLevel('WARNING')
 
-    logger = logging.getLogger('sherpa.some_module')
-    logger.warning('1: should be seen')
-    assert len(caplog.records) == 1
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        logger = logging.getLogger('sherpa.some_module')
+        logger.warning('1: should be seen')
+        assert len(caplog.records) == 1
 
-    with SherpaVerbosity('ERROR'):
-        logger.warning('2: Should not be seen')
-    assert len(caplog.records) == 1
+        with SherpaVerbosity('ERROR'):
+            logger.warning('2: Should not be seen')
+        assert len(caplog.records) == 1
 
-    logger.warning('3: should be seen')
-    assert len(caplog.records) == 2
+        logger.warning('3: should be seen')
+        assert len(caplog.records) == 2

--- a/sherpa/utils/tests/test_logging.py
+++ b/sherpa/utils/tests/test_logging.py
@@ -25,6 +25,12 @@ from sherpa.astro import ui
 
 
 def test_logging_verbosity_contextmanager(caplog):
+    # Previous tests might have changed this to a non-default
+    # level already. So, we first make sure the root logger
+    # is set right.
+    sherpalogger = logging.getLogger('sherpa')
+    sherpalogger.setLevel('WARNING')
+
     logger = logging.getLogger('sherpa.some_module')
     logger.warning('1: should be seen')
     assert len(caplog.records) == 1

--- a/sherpa/utils/tests/test_logging.py
+++ b/sherpa/utils/tests/test_logging.py
@@ -23,9 +23,9 @@ import sherpa
 from sherpa.utils.logging import config_logger, SherpaVerbosity
 from sherpa.astro import ui
 
-logger = logging.getLogger('sherpa.some_module')
 
 def test_logging_verbosity_contextmanager(caplog):
+    logger = logging.getLogger('sherpa.some_module')
     logger.warning('1: should be seen')
     assert len(caplog.records) == 1
 

--- a/sherpa/utils/tests/test_logging.py
+++ b/sherpa/utils/tests/test_logging.py
@@ -1,0 +1,37 @@
+#
+#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+import pytest
+import logging
+import numpy as np
+import sherpa
+from sherpa.utils.logging import config_logger, SherpaVerbosity
+from sherpa.astro import ui
+
+logger = logging.getLogger('sherpa.some_module')
+
+def test_logging_verbosity_contextmanager(caplog):
+    logger.warning('1: should be seen')
+    assert len(caplog.records) == 1
+
+    with SherpaVerbosity('ERROR'):
+        logger.warning('2: Should not be seen')
+    assert len(caplog.records) == 1
+
+    logger.warning('3: should be seen')
+    assert len(caplog.records) == 2


### PR DESCRIPTION
# Summary
Sherpa uses logging for much of its output, this adds a docs and a context manager for controlling the output level for a particular piece of code.

# More details 
In particular the fit and error estimation routines print a lot of stuff to the screen like fit results or the confidence range for every parameter as it's calculated. That's convenient for interactive use, but can clutter output in the script or notebook. Using python's logging infrastructure the level of logging can be adjusted directly, this PR adds docs for that and a context manager to change the logging level only for a few lines of code (e.g. the lines where fit or confidence are called.)

fixes #1032