### PR TITLE
Docs: note Python version and new build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![Build Status](https://travis-ci.org/sherpa/sherpa.svg?branch=master)](https://travis-ci.org/sherpa/sherpa)
+![Build Status: Conda](https://github.com/sherpa/sherpa/workflows/Conda%20CI/badge.svg)
+![Build Status: Pip](https://github.com/sherpa/sherpa/workflows/Pip%20CI/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.5,3.6,3.7-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.6,3.7,3.8-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -70,9 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.5, 3.6, and 3.7. It is
-expected that it will work with Python 3.8 but testing has been
-limited.
+Sherpa is tested against Python versions 3.6, 3.7, and 3.8.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -81,7 +80,7 @@ Using Anaconda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.5, 3.6, and 3.7. It can be installed with the `conda`
+Python 3.6, 3.7, and 3.8. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c sherpa sherpa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,9 +37,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.5, 3.6, and 3.7.
-It is expected that it will work with Python 3.8 but testing has been
-limited.
+and is compatible with Python versions 3.6, 3.7, and 3.8.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,8 +27,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.5, 3.6, or 3.7 (there has been limited testing with
-  Python 3.8)
+* Python 3.6, 3.7, or 3.8
 * NumPy (the exact lower limit has not been determined,
   but it is likely to be 1.7.0 or later)
 * Linux or OS-X (patches to add Windows support are welcome)
@@ -137,7 +136,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.5, 3.6, 3.7
+* Python versions: 3.6, 3.7, 3.8
 * Python packages: ``setuptools``, ``numpy``
 * System: ``gcc``, ``g++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these


### PR DESCRIPTION
Report the Python versions as being 3.6, 3.7, and 3.8 both in the
text and the badge.

Updated the build status badge to

  - now track GitHub Actions rather than Travis CI
  - two versions: one for conda and one for pip (as they are
    separate actions)