### PR TITLE
RTD: install more packages via pip

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,9 +7,9 @@ channels:
 dependencies:
   - python=3.7
   - numpy
-  - sphinx-astropy
   - pandoc
-  - ipykernel
   - pip
   - pip:
+    - ipykernel
     - nbsphinx
+    - sphinx-astropy


### PR DESCRIPTION
There's a tension between pip and conda, with conda often being
behind pip. At the moment this appears to cause a problem with
indirect requirements - namely parso and jedi - which causes the
RTD build to fail. Hopefully moving to pip for most of the
Python packages will help.