### PR TITLE
CI: pip submodule test to report coverage

### DIFF
--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         python setup.py ${{ matrix.install-type }}
 
-    - name: ${{ matrix.test-data }} test data with pytest
+    - name: sherpa_test with test-data=${{ matrix.test-data }}
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
       env:
         TEST: ${{ matrix.test-data }}

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -32,6 +32,13 @@ jobs:
             fits-pkg: 'astropy'
             test-data: none
 
+          - name: Linux Build (submodule data w/o Matplotlib or Xspec)
+            os: ubuntu-latest
+            python-version: 3.7
+            numpy-pkg: 'numpy'
+            install-type: develop 
+            fits-pkg: 'astropy'
+            test-data: submodule
 
     steps:
     - name: Checkout Code
@@ -72,7 +79,7 @@ jobs:
         sherpa_test || exit 1
 
     - name: Submodule test with pytest
-      if: matrix.test-data == 'submoule'
+      if: matrix.test-data == 'submodule'
       run: |
         pip install -r test_requirements.txt
         pip install pytest-cov codecov

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -78,6 +78,7 @@ jobs:
         pip install pytest-cov codecov
         cd ${HOME}
         pytest --cov=sherpa
+        codecov
 
     - name: Smoke Test
       env: 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         pip install -r test_requirements.txt
         pip install pytest-cov codecov
-        cd ${HOME}
+        # cd ${HOME}
         pytest --cov=sherpa
         codecov
 


### PR DESCRIPTION
# Summary

Report the coverage data from the pip CI run. This only changes the GitHub Actions runs.

# Details

Let's report the coverage data. I don't expect it to catch anything "new" (i.e. not in other runs from the conda CI), but we may as well collect the data as we create it.