### PR TITLE
Store the opstr of model combinations (unary and binary)

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020
+#  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020, 2021
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -719,6 +719,9 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
     arg : Model instance
         The model.
     op : function reference
+        The ufunc to apply to the model values.
+    opstr : str
+        The symbol used to represent the operator.
 
     See Also
     --------
@@ -739,6 +742,7 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
     def __init__(self, arg, op, opstr):
         self.arg = self.wrapobj(arg)
         self.op = op
+        self.opstr = opstr
         CompositeModel.__init__(self, ('%s(%s)' % (opstr, self.arg.name)),
                                 (self.arg,))
 
@@ -767,6 +771,9 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
     rhs : Model instance
         The right-hand sides of the expression.
     op : function reference
+        The ufunc which combines two array values.
+    opstr : str
+        The symbol used to represent the operator.
 
     See Also
     --------
@@ -789,6 +796,7 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
         self.lhs = self.wrapobj(lhs)
         self.rhs = self.wrapobj(rhs)
         self.op = op
+        self.opstr = opstr
 
         CompositeModel.__init__(self,
                                 ('(%s %s %s)' %

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -40,6 +40,7 @@ def test_basic_unop_neg_raw():
 
     assert mdl.name == '<->(polynom2d)'
     assert mdl.op == np.negative
+    assert mdl.opstr == '<->'
     assert mdl.ndim == 2
 
 
@@ -50,6 +51,7 @@ def test_basic_unop_neg():
 
     assert mdl.name == '-(polynom2d)'
     assert mdl.op == np.negative
+    assert mdl.opstr == '-'
     assert mdl.ndim == 2
 
 
@@ -60,6 +62,7 @@ def test_basic_unop_abs_raw():
 
     assert mdl.name == 'foo(polynom2d)'
     assert mdl.op == np.absolute
+    assert mdl.opstr == 'foo'
     assert mdl.ndim == 2
 
 
@@ -70,6 +73,7 @@ def test_basic_unop_abs():
 
     assert mdl.name == 'abs(polynom2d)'
     assert mdl.op == np.absolute
+    assert mdl.opstr == 'abs'
     assert mdl.ndim == 2
 
 
@@ -85,6 +89,7 @@ def test_basic_binop_raw(op):
     assert isinstance(mdl, BinaryOpModel)
     assert mdl.name == '(polynom2d xOx gauss2d)'
     assert mdl.op == op
+    assert mdl.opstr == 'xOx'
     assert len(mdl.parts) == 2
     assert mdl.parts[0] == l
     assert mdl.parts[1] == r
@@ -103,8 +108,9 @@ def test_basic_binop(op, opstr):
     mdl = op(l, r)
 
     assert isinstance(mdl, BinaryOpModel)
-    assert mdl.name == '(polynom2d {} gauss2d)'.format(opstr)
+    assert mdl.name == f'(polynom2d {opstr} gauss2d)'
     assert mdl.op == op
+    assert mdl.opstr == opstr
     assert len(mdl.parts) == 2
     assert mdl.parts[0] == l
     assert mdl.parts[1] == r


### PR DESCRIPTION
# Store

Store the operator string as well as the operator when creating the unary and binary operator expressions for models.

# Details

We store the string used to represent the operation as well as the operator now. Basic tests have been added to the existing operator tests.

There is no functionality that uses this feature yet. I have found it useful before when trying to extend Sherpa, and have work in progress (#1022, from which this was extracted) and planned PRs that use this functionality.

Note that the test has been updated to use a f-string which means that this requires Python 3.6. This update is not required, but
we have to drop Python 3.5 at some point!