### PR TITLE
WIP Remove excess brackets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers=
 python_requires = ~=3.8
 zip_safe = False
 install_requires =
-    numpy
+    numpy>=1.13
 
 tests_require =
     pytest-xvfb

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1170,10 +1170,10 @@ def test_rsp_matrix_call(analysis, arfexp, phaexp):
 
     if phaexp:
         exposure = pha_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = '{} * flat'.format(exposure)
     elif arfexp:
         exposure = arf_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = '{} * flat'.format(exposure)
     else:
         exposure = 1.0
         mdl_label = 'flat'
@@ -1247,10 +1247,10 @@ def test_rsp_normf_call(arfexp, phaexp):
 
     if phaexp:
         exposure = pha_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = '{} * flat'.format(exposure)
     elif arfexp:
         exposure = arf_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = '{} * flat'.format(exposure)
     else:
         exposure = 1.0
         mdl_label = 'flat'
@@ -1312,7 +1312,7 @@ def test_rsp_no_arf_matrix_call(analysis, phaexp):
 
     if phaexp:
         exposure = pha_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = '{} * flat'.format(exposure)
     else:
         exposure = 1.0
         mdl_label = 'flat'

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022
+#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1169,7 +1169,7 @@ def test_show_bkg_source_output():
 
     toks = out.getvalue().split("\n")
     assert toks[0] == "Background Model: 1:1"
-    assert toks[1] == "apply_rmf((200.0 * lorentz1d.other))"
+    assert toks[1] == "apply_rmf(200.0 * lorentz1d.other)"
     assert toks[2] == "   Param        Type          Value          Min          Max      Units"
     assert toks[3] == "   -----        ----          -----          ---          ---      -----"
     assert toks[4] == "   other.fwhm   thawed           10            0  3.40282e+38           "
@@ -1186,7 +1186,7 @@ def test_show_bkg_source_output():
 
     toks = out.getvalue().split("\n")
     assert toks[0] == "Background Model: 1:1"
-    assert toks[1] == "apply_rmf((200.0 * lorentz1d.other))"
+    assert toks[1] == "apply_rmf(200.0 * lorentz1d.other)"
     assert toks[2] == "   Param        Type          Value          Min          Max      Units"
     assert toks[3] == "   -----        ----          -----          ---          ---      -----"
     assert toks[4] == "   other.fwhm   thawed           10            0  3.40282e+38           "

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1202,7 +1202,7 @@ def test_pileup_model(make_data_path, clean_astro_ui):
     # Check pileup is added to get_model
     #
     mlines = str(ui.get_model('pileup')).split('\n')
-    assert mlines[0] == 'apply_rmf(jdpileup.jdp((xswabs.amdl * powlaw1d.pl)))'
+    assert mlines[0] == 'apply_rmf(jdpileup.jdp(xswabs.amdl * powlaw1d.pl))'
     assert mlines[3].strip() == 'jdp.alpha    thawed         0.95            0            1'
     assert mlines[5].strip() == 'jdp.f        thawed         0.91          0.9            1'
     assert mlines[11].strip() == 'pl.gamma     thawed         1.97          -10           10'
@@ -1236,11 +1236,11 @@ def test_pileup_model(make_data_path, clean_astro_ui):
 
     toks = mlines[0].split()
     assert len(toks) == 5
-    assert toks[0].startswith('apply_rmf(apply_arf((38564.608')
+    assert toks[0].startswith('apply_rmf(apply_arf(38564.608')
     assert toks[1] == '*'
-    assert toks[2] == '(xswabs.amdl'
+    assert toks[2] == 'xswabs.amdl'
     assert toks[3] == '*'
-    assert toks[4] == 'powlaw1d.pl))))'
+    assert toks[4] == 'powlaw1d.pl))'
 
     assert mlines[4].strip() == 'pl.gamma     thawed         1.97          -10           10'
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -172,11 +172,11 @@ def test_setup_pha1_file_models(id, make_data_path, clean_astro_ui, hide_logging
     assert ui.list_model_components() == ['bpl', 'pl']
 
     smdl = ui.get_model(id)
-    assert smdl.name == 'apply_rmf(apply_arf((1234.5 * (powlaw1d.pl + (0.5 * powlaw1d.bpl)))))'
+    assert smdl.name == 'apply_rmf(apply_arf(1234.5 * (powlaw1d.pl + 0.5 * powlaw1d.bpl)))'
     assert ui.list_model_components() == ['bpl', 'pl']
 
     bmdl = ui.get_bkg_model(id)
-    assert bmdl.name == 'apply_rmf(apply_arf((5432.1 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(5432.1 * powlaw1d.bpl))'
     assert ui.list_model_components() == ['bpl', 'pl']
 
 
@@ -252,15 +252,15 @@ def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_log
     assert estr == str(exc.value)
 
     bmdl = ui.get_bkg_model(id)
-    assert bmdl.name == 'apply_rmf(apply_arf((1000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(1000.0 * powlaw1d.bpl))'
 
     ui.set_bkg_source(id, ui.polynom1d.bpl2, bkg_id=2)
 
     bmdl = ui.get_bkg_model(id, bkg_id=1)
-    assert bmdl.name == 'apply_rmf(apply_arf((1000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(1000.0 * powlaw1d.bpl))'
 
     bmdl = ui.get_bkg_model(id, bkg_id=2)
-    assert bmdl.name == 'apply_rmf(apply_arf((2000.0 * polynom1d.bpl2)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(2000.0 * polynom1d.bpl2))'
 
     smdl = ui.get_model(id)
 
@@ -270,23 +270,21 @@ def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_log
     toks = smdl.name.split('(')
     assert toks[0] == 'apply_rmf'
     assert toks[1] == 'apply_arf'
-    assert toks[2] == ''
-    assert toks[3] == '100.0 * '
-    assert toks[4] == ''
-    assert toks[5] == 'powlaw1d.pl + '
+    assert toks[2] == '100.0 * '
 
     # The scale factors here are half of the values above, as there are
     # now two background components.
     #
-    x1 = '0.125 * powlaw1d.bpl)) + '
-    x2 = '0.0625 * polynom1d.bpl2)))))'
+    x1 = '0.125 * powlaw1d.bpl + '
+    x2 = '0.0625 * polynom1d.bpl2)))'
 
-    y1 = '0.0625 * polynom1d.bpl2)) + '
-    y2 = '0.125 * powlaw1d.bpl)))))'
+    y1 = '0.0625 * polynom1d.bpl2 + '
+    y2 = '0.125 * powlaw1d.bpl)))'
 
-    assert toks[6] in [x1, y1]
-    assert toks[7] in [x2, y2]
-    assert len(toks) == 8
+    assert toks[3] in ['powlaw1d.pl + ' + x1 + x2,
+                       'powlaw1d.pl + ' + x2 + x1]
+
+    assert len(toks) == 4
 
     assert ui.list_model_components() == ['bpl', 'bpl2', 'pl']
 
@@ -325,13 +323,13 @@ def test_setup_pha1_file_models_two_single(id, make_data_path, clean_astro_ui, h
     ui.set_bkg_source(id, ui.powlaw1d.bpl, bkg_id=2)
 
     bmdl = ui.get_bkg_model(id, bkg_id=1)
-    assert bmdl.name == 'apply_rmf(apply_arf((1000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(1000.0 * powlaw1d.bpl))'
 
     bmdl = ui.get_bkg_model(id, bkg_id=2)
-    assert bmdl.name == 'apply_rmf(apply_arf((2000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(2000.0 * powlaw1d.bpl))'
 
     smdl = ui.get_model(id)
-    assert smdl.name == 'apply_rmf(apply_arf((100.0 * (powlaw1d.pl + (0.1875 * powlaw1d.bpl)))))'
+    assert smdl.name == 'apply_rmf(apply_arf(100.0 * (powlaw1d.pl + 0.1875 * powlaw1d.bpl)))'
 
     assert ui.list_model_components() == ['bpl', 'pl']
 
@@ -743,14 +741,14 @@ def test_pha1_eval_vector_show(clean_astro_ui):
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     bmdl = ui.get_bkg_model()
-    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(1000.0 * box1d.bmdl1)'
 
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     smdl = ui.get_model()
 
-    src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (scale1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src = 'apply_arf(100.0 * box1d.smdl)'
+    src += ' + scale1 * apply_arf(100.0 * box1d.bmdl1)'
 
     assert smdl.name == src
 
@@ -873,17 +871,17 @@ def test_pha1_eval_vector_show_two(clean_astro_ui):
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     bmdl = ui.get_bkg_model()
-    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(1000.0 * box1d.bmdl1)'
 
     bmdl = ui.get_bkg_model(bkg_id=2)
-    assert bmdl.name == 'apply_arf((750.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(750.0 * box1d.bmdl1)'
 
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     smdl = ui.get_model()
 
-    src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (scale1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src = 'apply_arf(100.0 * box1d.smdl)'
+    src += ' + scale1 * apply_arf(100.0 * box1d.bmdl1)'
 
     assert smdl.name == src
 
@@ -931,10 +929,10 @@ def test_pha1_eval_vector_show_two_separate(clean_astro_ui):
     assert ui.list_model_components() == ['bmdl1', 'bmdl2', 'smdl']
 
     bmdl = ui.get_bkg_model('foo')
-    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(1000.0 * box1d.bmdl1)'
 
     bmdl = ui.get_bkg_model('foo', bkg_id=2)
-    assert bmdl.name == 'apply_arf((750.0 * const1d.bmdl2))'
+    assert bmdl.name == 'apply_arf(750.0 * const1d.bmdl2)'
 
     assert ui.list_model_components() == ['bmdl1', 'bmdl2', 'smdl']
 
@@ -943,15 +941,15 @@ def test_pha1_eval_vector_show_two_separate(clean_astro_ui):
     # The ordering of this test can depend on the Python version
     # (before Python 3.7).
     #
-    src = '((apply_arf((100.0 * box1d.smdl))'
+    src = 'apply_arf(100.0 * box1d.smdl)'
 
     src1 = src
-    src1 += ' + (scalefoo_1 * apply_arf((100.0 * box1d.bmdl1))))'
-    src1 += ' + (scalefoo_2 * apply_arf((100.0 * const1d.bmdl2))))'
+    src1 += ' + scalefoo_1 * apply_arf(100.0 * box1d.bmdl1)'
+    src1 += ' + scalefoo_2 * apply_arf(100.0 * const1d.bmdl2)'
 
     src2 = src
-    src2 += ' + (scalefoo_1 * apply_arf((100.0 * const1d.bmdl2))))'
-    src2 += ' + (scalefoo_2 * apply_arf((100.0 * box1d.bmdl1))))'
+    src2 += ' + scalefoo_1 * apply_arf(100.0 * const1d.bmdl2)'
+    src2 += ' + scalefoo_2 * apply_arf(100.0 * box1d.bmdl1)'
 
     assert smdl.name in [src1, src2]
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2022
+#  Copyright (C) 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1257,8 +1257,8 @@ def check_pha1_model_component_plot(mplot, mdl):
     # so do not use an equality check but something a bit-more forgiving
     # (could use a regexp but not worth it).
     #
-    assert mplot.title.startswith('Model component: apply_rmf(apply_arf((38564.60')
-    assert mplot.title.endswith(' * powlaw1d.pl)))')
+    assert mplot.title.startswith('Model component: apply_rmf(apply_arf(38564.60')
+    assert mplot.title.endswith(' * powlaw1d.pl))')
 
     # This may change if we change the filtering/grouping code
     # Note that the model is evaluated on the un-grouped data.

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -344,7 +344,7 @@ gal.nH.frozen  = False
 
 ######### Set Source, Pileup and Background Models
 
-set_source(1, (xsphabs.gal * (powlaw1d.pl + xsapec.src)))
+set_source(1, xsphabs.gal * (powlaw1d.pl + xsapec.src))
 
 
 
@@ -475,7 +475,7 @@ ggal.nH.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_source("grp", (xsphabs.ggal * powlaw1d.gpl))
+set_source("grp", xsphabs.ggal * powlaw1d.gpl)
 
 
 
@@ -711,9 +711,9 @@ bpoly.offset.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_source("bgrp", (xsphabs.ggal * powlaw1d.gpl))
+set_source("bgrp", xsphabs.ggal * powlaw1d.gpl)
 
-set_bkg_source("bgrp", (steplo1d.bstep + polynom1d.bpoly), bkg_id=1)
+set_bkg_source("bgrp", steplo1d.bstep + polynom1d.bpoly, bkg_id=1)
 
 
 ######### XSPEC Module Settings
@@ -847,7 +847,7 @@ mymodel.m.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_source(3, (sin.sin_model + usermodel.mymodel))
+set_source(3, sin.sin_model + usermodel.mymodel)
 
 """
 
@@ -1027,7 +1027,7 @@ bmdl.c0.frozen  = False
 
 ######### Set Source, Pileup and Background Models
 
-set_source(1, (gauss2d.gmdl + scale2d.bmdl))
+set_source(1, gauss2d.gmdl + scale2d.bmdl)
 
 """
 
@@ -1489,7 +1489,7 @@ def test_restore_pha_basic(make_data_path):
     assert ui.get_data().subtracted, 'Data should be subtracted'
 
     src_expr = ui.get_source()
-    assert src_expr.name == '(xsphabs.gal * (powlaw1d.pl + xsapec.src))'
+    assert src_expr.name == 'xsphabs.gal * (powlaw1d.pl + xsapec.src)'
     assert ui.xsphabs.gal.name == 'xsphabs.gal'
     assert ui.powlaw1d.pl.name == 'powlaw1d.pl'
     assert ui.xsapec.src.name == 'xsapec.src'
@@ -1532,7 +1532,7 @@ def test_restore_pha_grouped(make_data_path):
     assert_array_equal(qual, q, err_msg='grouping column')
 
     src_expr = ui.get_source('grp')
-    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+    assert src_expr.name == 'xsphabs.ggal * powlaw1d.gpl'
     assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
     assert ui.xsphabs.ggal.nh.val == 2.0
     assert ui.powlaw1d.gpl.gamma.max == 5.0
@@ -1593,10 +1593,10 @@ def test_restore_pha_back(make_data_path):
     # TODO: check noticed range
 
     src_expr = ui.get_source('bgrp')
-    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+    assert src_expr.name == 'xsphabs.ggal * powlaw1d.gpl'
 
     bg_expr = ui.get_bkg_source('bgrp')
-    assert bg_expr.name == '(steplo1d.bstep + polynom1d.bpoly)'
+    assert bg_expr.name == 'steplo1d.bstep + polynom1d.bpoly'
 
     assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
     assert ui.polynom1d.bpoly.c0.frozen, "is bpoly.c0 frozen?"
@@ -1632,7 +1632,7 @@ def test_restore_usermodel():
     #
     # src_expr = ui.get_source(3)
     src_expr = ui.get_model(3)
-    assert src_expr.name == '(sin.sin_model + usermodel.mymodel)'
+    assert src_expr.name == 'sin.sin_model + usermodel.mymodel'
     mymodel = ui.get_model_component("mymodel")
     assert mymodel.m.frozen, "is mymodel.m frozen?"
     assert mymodel.c.val == 2.0

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -586,7 +586,7 @@ def test_xspec_con_ui_cflux(make_data_path, clean_astro_ui, restore_xspec_settin
     ui.set_source('random', 'xsphabs.gal * xscflux.sflux(powlaw1d.pl)')
     mdl = ui.get_source('random')
 
-    assert mdl.name == '(xsphabs.gal * xscflux.sflux(powlaw1d.pl))'
+    assert mdl.name == 'xsphabs.gal * xscflux.sflux(powlaw1d.pl)'
     assert len(mdl.pars) == 7
     assert mdl.pars[0].fullname == 'gal.nH'
     assert mdl.pars[1].fullname == 'sflux.Emin'
@@ -662,7 +662,7 @@ def test_xspec_con_ui_shift(make_data_path, clean_astro_ui, restore_xspec_settin
     ui.set_source(ui.xsphabs.gal * ui.xszashift.zsh(msource))
     mdl = ui.get_source()
 
-    assert mdl.name == '(xsphabs.gal * xszashift.zsh((box1d.box + const1d.bgnd)))'
+    assert mdl.name == 'xsphabs.gal * xszashift.zsh(box1d.box + const1d.bgnd)'
     assert len(mdl.pars) == 6
     assert mdl.pars[0].fullname == 'gal.nH'
     assert mdl.pars[1].fullname == 'zsh.Redshift'
@@ -759,7 +759,7 @@ def test_xspec_con_ui_shift_regrid(make_data_path, clean_astro_ui, restore_xspec
 
     # What should the string representation be?
     #
-    assert mdl.name == '(xsphabs.gal * regrid1d(xszashift.zsh((box1d.box + const1d.bgnd))))'
+    assert mdl.name == 'xsphabs.gal * regrid1d(xszashift.zsh(box1d.box + const1d.bgnd))'
 
     assert len(mdl.pars) == 6
     assert mdl.pars[0].fullname == 'gal.nH'

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1124,6 +1124,7 @@ class ArithmeticModel(Model):
 
     # Unary operations
     __neg__ = _make_unop(numpy.negative, '-')
+    __pos__ = _make_unop(numpy.positive, '+')
     __abs__ = _make_unop(numpy.absolute, 'abs')
 
     # Binary operations

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1657,10 +1657,17 @@ def op_to_precedence(op):
         The precedence of the operator. Any unsupported operator is
         mapped to None (e.g. numpy.absolute).
 
-
     Notes
     -----
     See the description of precedence at [1]_.
+
+    The precedence level starts at 0 for the subtract operator, but
+    the numeric value is not guaranteed. It is important that the
+    subtract operator has the lowest value, since we use some run-time
+    decoding to allow precedence values less than this (they are
+    associated with negatively-associated expressions that are
+    themselves subtracted from a term). This is handled in
+    sherpa.models.tokens.simplify_brackets.
 
     Refs
     ----

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -58,6 +58,17 @@ def test_basic_unop_neg():
     assert mdl.ndim == 2
 
 
+def test_basic_unop_pos():
+
+    cpt = basic.Polynom2D()
+    mdl = +cpt
+
+    assert mdl.name == '+(polynom2d)'
+    assert mdl.op == np.positive
+    assert mdl.opstr == '+'
+    assert mdl.ndim == 2
+
+
 def test_basic_unop_abs_raw():
 
     cpt = basic.Polynom2D()
@@ -147,6 +158,33 @@ def test_eval_op():
 
     got = mdl(x)
     assert got == pytest.approx(expected)
+
+
+def test_eval_add_sub_op():
+    """Another version of test_eval_op focussed on + and - unary ops"""
+
+    x = np.asarray([2, 4, 5, 6, 7])
+
+    m1 = basic.Const1D("c")
+    m1.c0 = 10
+
+    m2 = basic.Polynom1D("p")
+    m2.c0 = 5
+    m2.c1 = 1
+
+    m3 = basic.Box1D("b")
+    m3.xlow = 5
+    m3.xhi = 6
+
+    mdl = m1 - (+m2 - m3)
+    assert mdl.ndim == 1
+
+    assert mdl.name == "(c - (+(p) - b))"
+
+    bins = np.arange(2, 10, 2)
+    yexp = m1(bins) + m3(bins) - m2(bins)
+    y = mdl(bins)
+    assert y == pytest.approx(yexp)
 
 
 def test_combine_models1d():

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -281,3 +282,85 @@ def test_load_table_model(make_data_path):
     s.load_table_model('tbl', make_data_path('double.dat'))
     tbl = s.get_model_component('tbl')
     assert tbl.ndim is None
+
+
+class TestBrackets:
+    """Provide a set of model instances for the tests."""
+
+    a = basic.Const1D('a')
+    b = basic.Const1D('b')
+    c = basic.Const1D('c')
+    d = basic.Const1D('d')
+
+    # It would be nice to instead use a principled set of states,
+    # but let's just try a somewhat-random set of expressions.
+    #
+    @pytest.mark.parametrize("model,expected",
+                             [(a, "a"),
+                              (abs(a), "abs(a)"),
+                              (abs(a) + b, "(abs(a) + b)"),
+                              (b + abs(a), "(b + abs(a))"),
+                              (abs(a + b), "abs((a + b))"),
+                              (abs(a + b * c), "abs((a + (b * c)))"),
+                              (abs(a - b * c), "abs((a - (b * c)))"),
+                              (abs((a + b) * c), "abs(((a + b) * c))"),
+                              (abs((a - b) * c), "abs(((a - b) * c))"),
+                              (abs((a - b) / c), "abs(((a - b) / c))"),
+                              (abs((a * b) - c), "abs(((a * b) - c))"),
+                              (abs((a / b) - c), "abs(((a / b) - c))"),
+                              (a * abs(b * (c + d)), "(a * abs((b * (c + d))))"),
+                              (abs(b * (c + d)) * (a + d), "(abs((b * (c + d))) * (a + d))"),
+                              (-a, "-(a)"),
+                              (-a + b, "(-(a) + b)"),
+                              (-(a + b), "-((a + b))"),
+                              (-(a * b), "-((a * b))"),
+                              (-(a - b), "-((a - b))"),
+                              (-(a * b - c), "-(((a * b) - c))"),
+                              (-(a - b * c), "-((a - (b * c)))"),
+                              (a - a - b, "((a - a) - b)"),
+                              (a - (a - b), "(a - (a - b))"),
+                              (a - (b - (c - d)), '(a - (b - (c - d)))'),
+                              (a - (b + (c - d)), '(a - (b + (c - d)))'),
+                              (b - (c + d), '(b - (c + d))'),
+                              ((a - b) - (c + d), '((a - b) - (c + d))'),
+                              (a - (b - (c + d)), '(a - (b - (c + d)))'),
+                              (a - (b + (c + d)), '(a - (b + (c + d)))'),
+                              (2 * (a + b) - c * 3, "((2.0 * (a + b)) - (c * 3.0))"),
+                              (abs(2 * (a + b) - c * 3), "abs(((2.0 * (a + b)) - (c * 3.0)))"),
+                              (a + a, "(a + a)"),
+                              (a * b, "(a * b)"),
+                              (a - a, "(a - a)"),
+                              (a / b, "(a / b)"),
+                              (a + b + c, "((a + b) + c)"),
+                              (a * b * c, "((a * b) * c)"),
+                              ((a * b) + c, "((a * b) + c)"),
+                              ((a + b) * c, "((a + b) * c)"),
+                              (a + (b * c), "(a + (b * c))"),
+                              (a * (b + c), "(a * (b + c))"),
+                              ((a + b) * (c + d), "((a + b) * (c + d))"),
+                              ((a * b) * (c + d), "((a * b) * (c + d))"),
+                              ((a + b) * (c * d), "((a + b) * (c * d))"),
+                              ((a + (b * c) + d), "((a + (b * c)) + d)"),
+                              (100 * a * (b + c), "((100.0 * a) * (b + c))"),
+                              (100 * (a * (b + c)), "(100.0 * (a * (b + c)))"),
+                              (a + b + 2 * c + d + a, "((((a + b) + (2.0 * c)) + d) + a)"),
+                              (a + b + c * 2 + d + a, "((((a + b) + (c * 2.0)) + d) + a)"),
+                              (a + b * (c - 2) + d + a, "(((a + (b * (c - 2.0))) + d) + a)"),
+                              (a + b * (2 - c) + d + a, "(((a + (b * (2.0 - c))) + d) + a)"),
+                              ((a + b + c) + (c + b + d + a), "(((a + b) + c) + (((c + b) + d) + a))"),
+                              ((a + b + c) + (c + b - d + a), "(((a + b) + c) + (((c + b) - d) + a))"),
+                              ((a + b + c) + (c + b - abs(d) + a), "(((a + b) + c) + (((c + b) - abs(d)) + a))"),
+                              ((a + b + c) * (c + b + d + a), "(((a + b) + c) * (((c + b) + d) + a))"),
+                              ((a + b + c) * (c + b - d + a), "(((a + b) + c) * (((c + b) - d) + a))"),
+                              ((a + b + c) * (c + b - abs(d) + a), "(((a + b) + c) * (((c + b) - abs(d)) + a))"),
+                              ((a * b * c) * (c + b + d + a), "(((a * b) * c) * (((c + b) + d) + a))"),
+                              ((a + b + c) * (c * b * d * a), "(((a + b) + c) * (((c * b) * d) * a))"),
+                              ((a + b + c) * (c * b + d * a), "(((a + b) + c) * ((c * b) + (d * a)))"),
+                              (2 * a * 2, "((2.0 * a) * 2.0)"),
+                              (a * 2 * 2, "((a * 2.0) * 2.0)"),
+                              (2 * a + 2 * (b + c - 4) * 3, "((2.0 * a) + ((2.0 * ((b + c) - 4.0)) * 3.0))")
+                             ])
+    def test_brackets(self, model, expected):
+        """Do we get the expected number of brackets?"""
+
+        assert model.name == expected

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -41,7 +41,7 @@ def test_basic_unop_neg_raw():
     cpt = basic.Polynom2D()
     mdl = UnaryOpModel(cpt, np.negative, '<->')
 
-    assert mdl.name == '<->(polynom2d)'
+    assert mdl.name == '<->polynom2d'
     assert mdl.op == np.negative
     assert mdl.opstr == '<->'
     assert mdl.ndim == 2
@@ -52,7 +52,7 @@ def test_basic_unop_neg():
     cpt = basic.Polynom2D()
     mdl = -cpt
 
-    assert mdl.name == '-(polynom2d)'
+    assert mdl.name == '-polynom2d'
     assert mdl.op == np.negative
     assert mdl.opstr == '-'
     assert mdl.ndim == 2
@@ -63,7 +63,7 @@ def test_basic_unop_pos():
     cpt = basic.Polynom2D()
     mdl = +cpt
 
-    assert mdl.name == '+(polynom2d)'
+    assert mdl.name == '+polynom2d'
     assert mdl.op == np.positive
     assert mdl.opstr == '+'
     assert mdl.ndim == 2
@@ -101,7 +101,7 @@ def test_basic_binop_raw(op):
     mdl = BinaryOpModel(l, r, op, 'xOx')
 
     assert isinstance(mdl, BinaryOpModel)
-    assert mdl.name == '(polynom2d xOx gauss2d)'
+    assert mdl.name == 'polynom2d xOx gauss2d'
     assert mdl.op == op
     assert mdl.opstr == 'xOx'
     assert len(mdl.parts) == 2
@@ -122,7 +122,7 @@ def test_basic_binop(op, opstr):
     mdl = op(l, r)
 
     assert isinstance(mdl, BinaryOpModel)
-    assert mdl.name == f'(polynom2d {opstr} gauss2d)'
+    assert mdl.name == f'polynom2d {opstr} gauss2d'
     assert mdl.op == op
     assert mdl.opstr == opstr
     assert len(mdl.parts) == 2
@@ -160,6 +160,7 @@ def test_eval_op():
     assert got == pytest.approx(expected)
 
 
+@pytest.mark.xfail
 def test_eval_add_sub_op():
     """Another version of test_eval_op focussed on + and - unary ops"""
 
@@ -179,7 +180,8 @@ def test_eval_add_sub_op():
     mdl = m1 - (+m2 - m3)
     assert mdl.ndim == 1
 
-    assert mdl.name == "(c - (+(p) - b))"
+    # FAIL: the following reports "c - +p - b"
+    assert mdl.name == "c - (+p - b)"
 
     bins = np.arange(2, 10, 2)
     yexp = m1(bins) + m3(bins) - m2(bins)
@@ -338,6 +340,10 @@ class FakeResponse1D:
         return RSPModelNoPHA(self.arf, self.rmf, self.arf.exposure * model)
 
 
+def xfail(m, e):
+    return pytest.param(m, e, marks=pytest.mark.xfail)
+
+
 class TestBrackets:
     """Provide a set of model instances for the tests."""
 
@@ -372,90 +378,90 @@ class TestBrackets:
     @pytest.mark.parametrize("model,expected",
                              [(a, "a"),
                               (abs(a), "abs(a)"),
-                              (abs(a) + b, "(abs(a) + b)"),
-                              (b + abs(a), "(b + abs(a))"),
-                              (abs(a + b), "abs((a + b))"),
-                              (abs(a + b * c), "abs((a + (b * c)))"),
-                              (abs(a - b * c), "abs((a - (b * c)))"),
-                              (abs((a + b) * c), "abs(((a + b) * c))"),
-                              (abs((a - b) * c), "abs(((a - b) * c))"),
-                              (abs((a - b) / c), "abs(((a - b) / c))"),
-                              (abs((a * b) - c), "abs(((a * b) - c))"),
-                              (abs((a / b) - c), "abs(((a / b) - c))"),
-                              (a * abs(b * (c + d)), "(a * abs((b * (c + d))))"),
-                              (abs(b * (c + d)) * (a + d), "(abs((b * (c + d))) * (a + d))"),
-                              (-a, "-(a)"),
-                              (-a + b, "(-(a) + b)"),
-                              (-(a + b), "-((a + b))"),
-                              (-(a * b), "-((a * b))"),
-                              (-(a - b), "-((a - b))"),
-                              (-(a * b - c), "-(((a * b) - c))"),
-                              (-(a - b * c), "-((a - (b * c)))"),
-                              (a - a - b, "((a - a) - b)"),
-                              (a - (a - b), "(a - (a - b))"),
-                              (a - (b - (c - d)), '(a - (b - (c - d)))'),
-                              (a - (b + (c - d)), '(a - (b + (c - d)))'),
-                              (b - (c + d), '(b - (c + d))'),
-                              ((a - b) - (c + d), '((a - b) - (c + d))'),
-                              (a - (b - (c + d)), '(a - (b - (c + d)))'),
-                              (a - (b + (c + d)), '(a - (b + (c + d)))'),
-                              (2 * (a + b) - c * 3, "((2.0 * (a + b)) - (c * 3.0))"),
-                              (abs(2 * (a + b) - c * 3), "abs(((2.0 * (a + b)) - (c * 3.0)))"),
-                              (a + a, "(a + a)"),
-                              (a * b, "(a * b)"),
-                              (a - a, "(a - a)"),
-                              (a / b, "(a / b)"),
-                              (a + b + c, "((a + b) + c)"),
-                              (a * b * c, "((a * b) * c)"),
-                              ((a * b) + c, "((a * b) + c)"),
-                              ((a + b) * c, "((a + b) * c)"),
-                              (a + (b * c), "(a + (b * c))"),
-                              (a * (b + c), "(a * (b + c))"),
-                              ((a + b) * (c + d), "((a + b) * (c + d))"),
-                              ((a * b) * (c + d), "((a * b) * (c + d))"),
-                              ((a + b) * (c * d), "((a + b) * (c * d))"),
-                              ((a + (b * c) + d), "((a + (b * c)) + d)"),
-                              (100 * a * (b + c), "((100.0 * a) * (b + c))"),
-                              (100 * (a * (b + c)), "(100.0 * (a * (b + c)))"),
-                              (a + b + 2 * c + d + a, "((((a + b) + (2.0 * c)) + d) + a)"),
-                              (a + b + c * 2 + d + a, "((((a + b) + (c * 2.0)) + d) + a)"),
-                              (a + b * (c - 2) + d + a, "(((a + (b * (c - 2.0))) + d) + a)"),
-                              (a + b * (2 - c) + d + a, "(((a + (b * (2.0 - c))) + d) + a)"),
-                              ((a + b + c) + (c + b + d + a), "(((a + b) + c) + (((c + b) + d) + a))"),
-                              ((a + b + c) + (c + b - d + a), "(((a + b) + c) + (((c + b) - d) + a))"),
-                              ((a + b + c) + (c + b - abs(d) + a), "(((a + b) + c) + (((c + b) - abs(d)) + a))"),
-                              ((a + b + c) * (c + b + d + a), "(((a + b) + c) * (((c + b) + d) + a))"),
-                              ((a + b + c) * (c + b - d + a), "(((a + b) + c) * (((c + b) - d) + a))"),
-                              ((a + b + c) * (c + b - abs(d) + a), "(((a + b) + c) * (((c + b) - abs(d)) + a))"),
-                              ((a * b * c) * (c + b + d + a), "(((a * b) * c) * (((c + b) + d) + a))"),
-                              ((a + b + c) * (c * b * d * a), "(((a + b) + c) * (((c * b) * d) * a))"),
-                              ((a + b + c) * (c * b + d * a), "(((a + b) + c) * ((c * b) + (d * a)))"),
-                              (2 * a * 2, "((2.0 * a) * 2.0)"),
-                              (a * 2 * 2, "((a * 2.0) * 2.0)"),
-                              (2 * a + 2 * (b + c - 4) * 3, "((2.0 * a) + ((2.0 * ((b + c) - 4.0)) * 3.0))"),
-                              (tm * (a + b) + tm * (a * b),
-                               '((tm * (a + b)) + (tm * (a * b)))'),
-                              (tm * (a + b) + tm * (a * (b + 3)),
-                               '((tm * (a + b)) + (tm * (a * (b + 3.0))))'),
-                              (cm(a) + b, '(cm(a) + b)'),
-                              (a * cm(b + c), '(a * cm((b + c)))'),
+                              (abs(a) + b, "abs(a) + b"),
+                              (b + abs(a), "b + abs(a)"),
+                              (abs(a + b), "abs(a + b)"),
+                              (abs(a + b * c), "abs(a + b * c)"),
+                              (abs(a - b * c), "abs(a - b * c)"),
+                              (abs((a + b) * c), "abs((a + b) * c)"),
+                              (abs((a - b) * c), "abs((a - b) * c)"),
+                              (abs((a - b) / c), "abs((a - b) / c)"),
+                              (abs((a * b) - c), "abs(a * b - c)"),
+                              (abs((a / b) - c), "abs(a / b - c)"),
+                              (a * abs(b * (c + d)), "a * (abs(b * (c + d)))"),  # Note the un-needed bracket pair
+                              (abs(b * (c + d)) * (a + d), "(abs(b * (c + d))) * (a + d)"),  # Note the un-needed bracket pair
+                              (-a, "-a"),
+                              (-a + b, "-a + b"),
+                              (-(a + b), "-(a + b)"),
+                              (-(a * b), "-(a * b)"),
+                              (-(a - b), "-(a - b)"),
+                              (-(a * b - c), "-(a * b - c)"),
+                              (-(a - b * c), "-(a - b * c)"),
+                              (a - a - b, "a - a - b"),
+                              xfail(a - (a - b), "a - (a - b)"),
+                              xfail(a - (b - (c - d)), 'a - (b - (c - d))'),
+                              xfail(a - (b + (c - d)), 'a - (b + c - d)'),
+                              xfail(b - (c + d), 'b - (c + d)'),
+                              xfail((a - b) - (c + d), 'a - b - (c + d)'),
+                              xfail(a - (b - (c + d)), 'a - (b - (c + d))'),
+                              xfail(a - (b + (c + d)), 'a - (b + c + d)'),
+                              xfail(2 * (a + b) - c * 3, "2.0 * (a + b) - c * 3.0"),
+                              xfail(abs(2 * (a + b) - c * 3), "abs(2.0 * (a + b) - c * 3.0)"),
+                              (a + a, "a + a"),
+                              (a * b, "a * b"),
+                              (a - a, "a - a"),
+                              (a / b, "a / b"),
+                              (a + b + c, "a + b + c"),
+                              (a * b * c, "a * b * c"),
+                              ((a * b) + c, "a * b + c"),
+                              ((a + b) * c, "(a + b) * c"),
+                              (a + (b * c), "a + b * c"),
+                              (a * (b + c), "a * (b + c)"),
+                              ((a + b) * (c + d), "(a + b) * (c + d)"),
+                              ((a * b) * (c + d), "a * b * (c + d)"),
+                              ((a + b) * (c * d), "(a + b) * c * d"),
+                              ((a + (b * c) + d), "a + b * c + d"),
+                              (100 * a * (b + c), "100.0 * a * (b + c)"),
+                              (100 * (a * (b + c)), "100.0 * (a * (b + c))"),  # Note the un-needed bracket pair
+                              (a + b + 2 * c + d + a, "a + b + 2.0 * c + d + a"),
+                              (a + b + c * 2 + d + a, "a + b + c * 2.0 + d + a"),
+                              (a + b * (c - 2) + d + a, "((a + (b * (c - 2.0))) + d) + a"),  # Note the un-needed bracket pairs
+                              (a + b * (2 - c) + d + a, "((a + (b * (2.0 - c))) + d) + a"),  # Note the un-needed bracket pairs
+                              ((a + b + c) + (c + b + d + a), "a + b + c + c + b + d + a"),
+                              ((a + b + c) + (c + b - d + a), "a + b + c + ((c + b - d) + a)"),
+                              ((a + b + c) + (c + b - abs(d) + a), "a + b + c + ((c + b - abs(d)) + a)"),  # Note the un-needed bracket pairs
+                              ((a + b + c) * (c + b + d + a), "(a + b + c) * (c + b + d + a)"),
+                              ((a + b + c) * (c + b - d + a), "(a + b + c) * ((c + b - d) + a)"),  # Note the un-needed bracket pair
+                              ((a + b + c) * (c + b - abs(d) + a), "(a + b + c) * ((c + b - abs(d)) + a)"),  # Note the un-needed bracket pair
+                              ((a * b * c) * (c + b + d + a), "a * b * c * (c + b + d + a)"),
+                              ((a + b + c) * (c * b * d * a), "(a + b + c) * c * b * d * a"),
+                              ((a + b + c) * (c * b + d * a), "(a + b + c) * (c * b + d * a)"),
+                              (2 * a * 2, "2.0 * a * 2.0"),
+                              (a * 2 * 2, "a * 2.0 * 2.0"),
+                              (2 * a + 2 * (b + c - 4) * 3, "2.0 * a + ((2.0 * (b + c - 4.0)) * 3.0)"),   # Note the un-needed bracket pair
+                              xfail(tm * (a + b) + tm * (a * b),
+                               'tm * (a + b) + tm * a * b'),
+                              xfail(tm * (a + b) + tm * (a * (b + 3)),
+                               'tm * (a + b) + tm * (a * (b + 3.0))'),  # Note the un-needed bracket
+                              (cm(a) + b, 'cm(a) + b'),
+                              (a * cm(b + c), 'a * cm(b + c)'),
                               (a + cm(b + 2 * d + c),
-                               '(a + cm(((b + (2.0 * d)) + c)))'),
+                               'a + cm(b + 2.0 * d + c)'),
                               (arf(b * (c * d)) + d,
-                               "(apply_arf((100.0 * (b * (c * d)))) + d)"),
+                               "apply_arf(100.0 * b * c * d) + d"),
                               (a + 2 * arf(b * (c + d)),
-                               "(a + (2.0 * apply_arf((100.0 * (b * (c + d))))))"),
+                               "a + 2.0 * apply_arf(100.0 * (b * (c + d)))"),  # Note the un-needed bracket
                               (a + 2 * rmf(b * (c + d)),
-                               "(a + (2.0 * apply_rmf((b * (c + d)))))"),
+                               "a + 2.0 * apply_rmf(b * (c + d))"),
                               # Manually combining RMF1D and ARF1D is interesting as we would normally
                               # use RSPModelNoPHA
                               (a * rmf(arf(a * (b + c * d))) + d * arf(a + b),
-                               '((a * apply_rmf(apply_arf((100.0 * (a * (b + (c * d))))))) + (d * apply_arf((100.0 * (a + b)))))'),
+                               'a * apply_rmf(apply_arf(100.0 * (a * (b + c * d)))) + d * apply_arf(100.0 * (a + b))'),  # Note the un-needed bracket
                               # Repeat but with rsp instead
                               (a * rsp(a * (b + c * d)) + d * arf(a + b),
-                               '((a * apply_rmf(apply_arf((100.0 * (a * (b + (c * d))))))) + (d * apply_arf((100.0 * (a + b)))))'),
+                               'a * apply_rmf(apply_arf(100.0 * (a * (b + c * d)))) + d * apply_arf(100.0 * (a + b))'),  # Note the un-needed bracket
                               (arf(b * (c + d)),
-                               "apply_arf((100.0 * (b * (c + d))))")
+                               "apply_arf(100.0 * (b * (c + d)))")  # Note the un-needed bracket
                              ])
     def test_brackets(self, model, expected):
         """Do we get the expected number of brackets?"""

--- a/sherpa/models/tokens.py
+++ b/sherpa/models/tokens.py
@@ -93,7 +93,7 @@ class TokenLeft(Token):
         super().__init__('(')
 
     def __repr__(self):
-        return f'TokenLeft({self.counter}, {self.precedence}, {self.left})'
+        return f'TokenLeft({self.counter}, {self.precedence}, left={self.left})'
 
 
 class TokenRight(Token):
@@ -113,7 +113,7 @@ class TokenRight(Token):
         super().__init__(')')
 
     def __repr__(self):
-        return f'TokenRight({self.counter}, {self.precedence}, {self.right})'
+        return f'TokenRight({self.counter}, {self.precedence}, right={self.right})'
 
 
 class Store:
@@ -283,7 +283,20 @@ def left_token(store, model, leftprec=None):
         rtokens = left_token(store, rhs, oprec)
 
         if oprec is not None and rprec is not None and oprec == ZERO_PRECEDENCE and rprec == ZERO_PRECEDENCE:
+
+            # HACK for testing
+            assert oprec == 0
+            assert rprec == 0
+
+            # I was going down as I go into the expression (so -1, -2, -3...)
+            # but now I want to try -n, -(n+1), ..., -1. One hack is to use the
+            # number of terms as the starting counter value - you don't end
+            # up at -1 but that should be okay.
+            #
+
             ctr = -1
+            # ctr0 = -len(rtokens) - 1
+            # ctr = ctr0
             for token in rtokens:
                 if not hasattr(token, 'precedence'):
                     continue
@@ -292,11 +305,20 @@ def left_token(store, model, leftprec=None):
                     # Not sure about this
                     if token.precedence <= ctr:
                         ctr = token.precedence - 1
+                        # raise NotImplementedError('not sure now')
 
                     token.precedence = ctr
                     ctr -= 1
+                    # ctr += 1
 
-            rprec = ctr  # Not sure about this
+            # rprec = ctr  # Not sure about this
+            # rprec = ctr0  # Not sure about this
+
+            #maybe it is just oprec I needed to change, and can go back to counting down
+            # NOPITY NOPE NOPE
+
+            # oprec = ctr0 - 1  # is this right? completely guessing now
+            oprec = ctr  # is this right? completely guessing now
 
         rterms = bracket(store, rtokens, rprec, left=oprec)
 

--- a/sherpa/models/tokens.py
+++ b/sherpa/models/tokens.py
@@ -1,0 +1,445 @@
+#
+#  Copyright (C) 2021, 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Helper routines to reduce the number of brackets in a model expression.
+
+The model expression is a tree, but it's easier (to me) to deal with
+a list, so we create a stream of tokens:
+
+  - term (i.e. a single model instance or a numeric term)
+  - operator
+  - left bracket
+  - right bracket.
+"""
+
+import numpy as np
+
+__all__ = ('simplify', )
+
+
+class Token:
+    """Represent a model expression as tokens."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return self.name
+
+    # __repr__ is for debugging only
+    def __repr__(self):
+        return f'{self.__class__.__name__}("{self.name}")'
+
+
+class TokenTerm(Token):
+    """A term"""
+
+    pass
+
+
+class TokenOp(Token):
+    """An operator"""
+
+    def __init__(self, name, precedence):
+        self.precedence = precedence
+        super().__init__(name)
+
+
+class TokenUnOp(TokenOp):
+    """A unary operator"""
+
+    pass
+
+
+class TokenBinOp(TokenOp):
+    """A binary operator"""
+
+    pass
+
+
+class TokenLeft(Token):
+    """A left bracket
+
+    We are sent the operator precedence to the left of the bracket
+    (may be None) and the operator precedence for the
+    exclosed term.
+
+    """
+
+    def __init__(self, ctr, precedence, left=None):
+        self.counter = ctr
+        self.precedence = precedence
+        self.left = left
+        super().__init__('(')
+
+    def __repr__(self):
+        return f'TokenLeft({self.counter}, {self.precedence}, {self.left})'
+
+
+class TokenRight(Token):
+    """A right bracket
+
+    We are sent the operator precedence for the exclosed term and
+    operator precedence to the right of the bracket. It is expected
+    that the right operator precedence is not set when the object
+    is created.
+
+    """
+
+    def __init__(self, ctr, precedence, right=None):
+        self.counter = ctr
+        self.precedence = precedence
+        self.right = right
+        super().__init__(')')
+
+    def __repr__(self):
+        return f'TokenRight({self.counter}, {self.precedence}, {self.right})'
+
+
+class Store:
+    """Supply an increasing integer value."""
+
+    def __init__(self):
+        self.store = 0
+
+    def get_counter(self):
+        """Return the counter and increase the state"""
+
+        ctr = self.store
+        self.store += 1
+        return ctr
+
+
+def bracket(store, tokens, precedence, left=None):
+    """Add brackets around an expression.
+
+    Parameters
+    ----------
+    store : Store instance
+        Used to create matching brackets.
+    tokens : list of Token
+        The expression to wrap.
+    precedence : int
+        The precedence of the expression
+    left : int or None, optional
+        The precedence to the left of this bracket.
+    force : bool, optional
+        If True then the bracket is always added.
+
+    Notes
+    -----
+    This makes a small simplification, as we don't add brackets around
+    a term.
+
+    """
+
+    # Is this needed or does it just simplify some things but at the
+    # expense of complicating others?
+    if len(tokens) == 1 and isinstance(tokens[0], TokenTerm):
+        return tokens
+
+    ctr = store.get_counter()
+    return [TokenLeft(ctr, precedence, left)] + tokens + [TokenRight(ctr, precedence)]
+
+
+def left_token(store, model, leftprec=None):
+    """Tokenize the expression but do not process the right brackets.
+
+    Parameters
+    ----------
+    store : Store instance
+        Used to create matching brackets.
+    model : Model instance
+    leftprec : int or None, optional
+        The precedence to the left of the expression.
+
+    Returns
+    -------
+    tokens : list of Token
+        The converted stream.
+
+    Notes
+    -----
+    A pass needs to be made to the output to add in the correct "right
+    precedence" for TokenRight elements. This is done by right_token.
+
+    """
+
+    # Rather than use instance checks, try to use a more-Pythonic
+    # approach. UnaryOp models have a single parts element, BinaryOp
+    # have two, and others have no parts element. Alternatively we
+    # could have looked for .arg (unary) or .lhs and .rhs (binary).
+    # However, there are other composite models with 1 value that do
+    # not follow UnaryUpModel, so just access the parts array.
+    #
+    try:
+        parts = model.parts
+    except AttributeError:
+        return [TokenTerm(model._orig_name)]
+
+    # UnaryOpModel and BinaryOpModel require processing their contents,
+    # but other Composite models may not require any analysis (they
+    # send in the constituent .name attribute to some model-specific
+    # string). We use the presense of the op attribute as a
+    # way to say "this is a *OpModel" case.
+    #
+    if not hasattr(model, 'op'):
+        return [TokenTerm(model._orig_name)]
+
+    if len(parts) == 1:
+        try:
+            oprec = model.precedence
+        except AttributeError:
+            oprec = None
+
+        out = [TokenUnOp(model.opstr, oprec)]
+
+        # Note: we remove the left-precedence here as it should be
+        # "separate" from the existing left-precedence.
+        #
+        tokens = left_token(store, model.parts[0], None)
+
+        # For functions we require a bracket, so we can just treat this
+        # as a term. For operators we would like to remove excess brackets,
+        # but the rules for the binary operator don't work here. A
+        # simple solution is to only remove brackets when a single term
+        # is being operated on.
+        #
+        # I think that we could just check the length and we do not need
+        # the isinstance check, but leave in.
+        if model.op in [np.negative, np.positive] and len(tokens) == 1 \
+           and isinstance(tokens[0], TokenTerm):
+            rhs = tokens
+        else:
+            rhs = [TokenTerm('(')] + tokens + [TokenTerm(')')]
+
+        return out + rhs
+
+    if len(parts) == 2:
+        lhs = model.parts[0]
+        rhs = model.parts[1]
+        try:
+            lprec = lhs.get_precedence()
+        except AttributeError:
+            lprec = None
+
+        try:
+            rprec = rhs.get_precedence()
+        except AttributeError:
+            rprec = None
+
+        try:
+            oprec = model.precedence
+        except AttributeError:
+            # We may need a precedence value here?
+            oprec = None
+
+        ltokens = left_token(store, lhs, leftprec)
+        lterms = bracket(store, ltokens, lprec, left=leftprec)
+
+        rtokens = left_token(store, rhs, oprec)
+        rterms = bracket(store, rtokens, rprec, left=oprec)
+
+        out = [TokenBinOp(model.opstr, oprec)]
+        return lterms + out + rterms
+
+    # We should never get here, but if we do, do not error out, just
+    # do nothing.
+    #
+    return [TokenTerm(model._orig_name)]
+
+
+def right_token(tokens):
+    """Process a list of tokens to add the right-bracket precedences.
+
+    Parameters
+    ----------
+    tokens : list of Tokens
+
+    Returns
+    -------
+    tokens : list of Tokens
+
+    """
+
+    # - reverse the list
+    # - precedence = None
+    # - loop through each element
+    #   - if TokenOp, set precedence to this value and copy over
+    #   - if TokenRight, update the right precedence
+    #   - otherwise copy over
+    # - reverse the list
+    #
+    out = []
+    precedence = None
+    for tok in tokens[::-1]:
+
+        # Do we want unary-op precedences to pass through? Probably.
+        if isinstance(tok, TokenOp):
+            precedence = tok.precedence
+
+        if not isinstance(tok, TokenRight):
+            out.append(tok)
+            continue
+
+        out.append(TokenRight(tok.counter, tok.precedence, right=precedence))
+
+    return out[::-1]
+
+
+def tokenize(model):
+    """Convert a model expression into tokens.
+
+    This converts the tree structure into a list.
+
+    Parameters
+    ----------
+    model : Model instance
+        The model expression
+
+    Returns
+    -------
+    tokens : list of Token
+        The expression converted to tokens
+
+    """
+
+    store = Store()
+    return right_token(left_token(store, model))
+
+
+def simplify_brackets(tokens):
+    """Remove excess brackets.
+
+    Parameters
+    ----------
+    tokens : list of Token
+        The output of tokenize.
+
+    Returns
+    -------
+    expr : string
+        The model expression
+    """
+
+    # Need to extract the left and right precedences for each
+    # bracket pair.
+    #
+    brackets = {}
+    for tok in tokens:
+        if isinstance(tok, TokenLeft):
+            assert tok.counter not in brackets
+            brackets[tok.counter] = {'left': tok.left}
+            continue
+
+        if isinstance(tok, TokenRight):
+            brackets[tok.counter]['right'] = tok.right
+            continue
+
+    # Add each term to the output stream unless it's a bracket,
+    # in which case compare the precedence stored within the
+    # expression to the left/right operators.
+    #
+    out = ""
+    for tok in tokens:
+        if isinstance(tok, TokenTerm):
+            out += tok.name
+            continue
+
+        if isinstance(tok, TokenUnOp):
+            out += f'{tok.name}'
+            continue
+
+        if isinstance(tok, TokenBinOp):
+            out += f' {tok.name} '
+            continue
+
+        assert isinstance(tok, (TokenLeft, TokenRight))
+
+        # I have removed the simplification in bracket which means we
+        # now have terms without a precedence.
+        #
+        if tok.precedence is None:
+            # drop the bracket
+            continue
+
+        b = brackets[tok.counter]
+        lprec = b['left']
+        rprec = b['right']
+
+        # We want to check if the precedence within the bracket is
+        # less than either the left or right brackets. This is
+        # slightly complicated by the presence of None, as we want to
+        # ignore these values.
+        #
+        lnone = lprec is None
+        rnone = rprec is None
+        if lnone and rnone:
+            continue
+
+        if lnone:
+            external = rprec
+        elif rnone:
+            external = lprec
+        else:
+            external = min(lprec, rprec)
+
+        if tok.precedence < external:
+            out += tok.name
+
+    return out
+
+
+def simplify(expr):
+    """Remove excess brackets.
+
+    Parameters
+    ----------
+    expr : Model instance
+        The model.
+
+    Returns
+    -------
+    expr : string
+        The model expression
+
+    Notes
+    -----
+
+    A complex expression will call simplify multiple times since each
+    sub-element (e.g. BinaryOpModel) will access the model's name
+    attribute.  Some composite models, such as RSPModel, create a name
+    using a format like
+
+        apply_rmf(apply_arf(xxx.name))
+
+    where xxx is the sub-component, and others like BinaryOpModel use
+
+        (lhs.name op rhs.name)
+
+    """
+
+    # This is not a perfect check, but it should catch obvious problems.
+    #
+    if isinstance(expr, str):
+        raise ValueError(f"simplify sent a string: {expr}")
+
+    toks = tokenize(expr)
+    return simplify_brackets(toks)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1694,7 +1694,7 @@ def test_fit_str_single(stat):
     out = str(fit)
 
     expected = [("data", "test"),
-                ("model", "((poly * step) + bg)"),
+                ("model", "poly * step + bg"),
                 ("stat", stat.__name__),
                 ("method", "LevMar"),
                 ("estmethod", "Covariance")]

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021, 2022
+#  Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -201,7 +201,7 @@ def test_guess_warns_no_guess_no_argument(caplog, clean_ui):
     lname, lvl, msg = caplog.record_tuples[0]
     assert lname == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "WARNING: No guess found for (dummy + dummy)"
+    assert msg == "WARNING: No guess found for dummy + dummy"
 
 
 class Parameter2(Parameter):


### PR DESCRIPTION
# Summary

Remove mathematically un-necessary brackets when displaying a model expression.

The code is there but more tests need adding and some clean up may be possible

The main problem at this time is that "a - (b - c)" gets converted to "a - b - c", which is not-quite-right™.

# Details

The `name` field of the `sherpa.models.model.Model` class is changed so that

- it is now a property (terminology?)
- the supplied value is stored as _name (and currently unused)
- access to `name` will now call the `sherpa.models.token.simplify` routine to be called on the stored model

The `simplify` routine is the routine that removes excess brackets, and is described below. Note that sub-classes of `Model` can override the `name` attribute so that you can have logic like (from `sherpa.astro.insrument` classes deriving from `CompositeModel`):

        CompositeModel.__init__(self, f'apply_rmf(apply_arf({model.name}))', (model,))

Although how this actually works is actually surprising to me, since this ends up setting the `_name` field which isn't then used. So I need to go back and review it, but it does seem to work... It also probably explains why some brackets have not been removed in the `get_model` output below.

TODO.

The basic idea is taken from https://stackoverflow.com/questions/18400741/remove-redundant-parentheses-from-an-arithmetic-expression


# Concerns

The logic is hidden away (the user doesn't interact with it), but it is technically possible for this to either break code (some condition isn't followed leading to a perfectly-valid expression to error out) or it removes a bracket that it shouldn't have. The latter is more concerning, as there's several parts to this work which means it isn't an easily-verified algorithm. My approach is to add a bunch of tests to catch possible problems. It would be nice to use some form of fuzzing or property testing approach.

# Example

Here's a source expression with a lot of terms in the current code:

```
sherpa In [3]: get_source()
Out[3]: <BinaryOpModel model instance '((xsconstant.m1 * xstbabs.m2) * ((((((((((((((((((((xsbremss.m3 + xsbremss.m4) + xsbremss.m5) + xsbremss.m6) + xsgaussian.m7) + xsgaussian.m8) + xsgaussian.m9) + xsgaussian.m10) + xsgaussian.m11) + xsgaussian.m12) + xsgaussian.m13) + xsgaussian.m14) + xsgaussian.m15) + xsgaussian.m16) + xsgaussian.m17) + xsgaussian.m18) + xsgaussian.m19) + xsgaussian.m20) + xsgaussian.m21) + xsgaussian.m22) + xsgaussian.m23))'>

sherpa In [4]: get_source().name
Out[4]: '((xsconstant.m1 * xstbabs.m2) * ((((((((((((((((((((xsbremss.m3 + xsbremss.m4) + xsbremss.m5) + xsbremss.m6) + xsgaussian.m7) + xsgaussian.m8) + xsgaussian.m9) + xsgaussian.m10) + xsgaussian.m11) + xsgaussian.m12) + xsgaussian.m13) + xsgaussian.m14) + xsgaussian.m15) + xsgaussian.m16) + xsgaussian.m17) + xsgaussian.m18) + xsgaussian.m19) + xsgaussian.m20) + xsgaussian.m21) + xsgaussian.m22) + xsgaussian.m23))'

sherpa In [5]: get_model()
Out[5]: <RSPModelPHA model instance 'apply_rmf(apply_arf((49922.938362591 * ((xsconstant.m1 * xstbabs.m2) * ((((((((((((((((((((xsbremss.m3 + xsbremss.m4) + xsbremss.m5) + xsbremss.m6) + xsgaussian.m7) + xsgaussian.m8) + xsgaussian.m9) + xsgaussian.m10) + xsgaussian.m11) + xsgaussian.m12) + xsgaussian.m13) + xsgaussian.m14) + xsgaussian.m15) + xsgaussian.m16) + xsgaussian.m17) + xsgaussian.m18) + xsgaussian.m19) + xsgaussian.m20) + xsgaussian.m21) + xsgaussian.m22) + xsgaussian.m23)))))'>
```

and here's how it displays in this PR

```
In [7]: get_source()
Out[7]: <BinaryOpModel model instance 'xsconstant.m1 * xstbabs.m2 * (xsbremss.m3 + xsbremss.m4 + xsbremss.m5 + xsbremss.m6 + xsgaussian.m7 + xsgaussian.m8 + xsgaussian.m9 + xsgaussian.m10 + xsgaussian.m11 + xsgaussian.m12 + xsgaussian.m13 + xsgaussian.m14 + xsgaussian.m15 + xsgaussian.m16 + xsgaussian.m17 + xsgaussian.m18 + xsgaussian.m19 + xsgaussian.m20 + xsgaussian.m21 + xsgaussian.m22 + xsgaussian.m23)'>

In [8]: get_source().name
Out[8]: 'xsconstant.m1 * xstbabs.m2 * (xsbremss.m3 + xsbremss.m4 + xsbremss.m5 + xsbremss.m6 + xsgaussian.m7 + xsgaussian.m8 + xsgaussian.m9 + xsgaussian.m10 + xsgaussian.m11 + xsgaussian.m12 + xsgaussian.m13 + xsgaussian.m14 + xsgaussian.m15 + xsgaussian.m16 + xsgaussian.m17 + xsgaussian.m18 + xsgaussian.m19 + xsgaussian.m20 + xsgaussian.m21 + xsgaussian.m22 + xsgaussian.m23)'

In [9]: get_model()
Out[9]: <RSPModelPHA model instance 'apply_rmf(apply_arf(49922.938362591 * (xsconstant.m1 * xstbabs.m2 * (xsbremss.m3 + xsbremss.m4 + xsbremss.m5 + xsbremss.m6 + xsgaussian.m7 + xsgaussian.m8 + xsgaussian.m9 + xsgaussian.m10 + xsgaussian.m11 + xsgaussian.m12 + xsgaussian.m13 + xsgaussian.m14 + xsgaussian.m15 + xsgaussian.m16 + xsgaussian.m17 + xsgaussian.m18 + xsgaussian.m19
+ xsgaussian.m20 + xsgaussian.m21 + xsgaussian.m22 + xsgaussian.m23))))'>
```

Note it's not perfect, since `texp * (m1 * m2 * ...)` could be simplified to `texp * m1 * m2 * ...`