### PR TITLE
Minor code cleanup of sherpa.astro.ui.utils

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -847,6 +847,21 @@ def test_load_multi_arfsrmfs(make_data_path, clean_astro_ui):
     ui.load_multi_rmfs(1, [rmf, rmf], [1, 2])
     ui.load_multi_rmfs(2, [rmf, rmf], [1, 2])
 
+    # Check multiple responses have been loaded
+    #
+    d1 = ui.get_data(1)
+    d2 = ui.get_data(2)
+    assert d1.response_ids == [1, 2]
+    assert d2.response_ids == [1, 2]
+
+    # Unfortunately we load the same response so it's hard
+    # to tell the difference here!
+    #
+    assert ui.get_arf(resp_id=1).name == arf
+    assert ui.get_arf(resp_id=2).name == arf
+    assert ui.get_rmf(2, resp_id=1).name == rmf
+    assert ui.get_rmf(2, resp_id=2).name == rmf
+
     ui.notice(0.5, 7)
     ui.subtract(1)
     ui.subtract(2)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -33,7 +33,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import RMFModelPHA
 from sherpa.astro import ui
 from sherpa.data import Data1D
-from sherpa.utils.err import DataErr, IdentifierErr, StatErr
+from sherpa.utils.err import ArgumentErr, DataErr, IdentifierErr, StatErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_group, requires_xspec
@@ -814,6 +814,23 @@ def test_bug_316(make_data_path, clean_astro_ui):
 
     assert xmin == pytest.approx(2.0)
     assert xmax == pytest.approx(7.01)
+
+
+@pytest.mark.parametrize("loadfunc", [ui.load_multi_arfs, ui.load_multi_rmfs])
+@pytest.mark.parametrize("idval", [None, 1, 'xx'])
+def test_load_multi_xxx_invalid_args(loadfunc, idval):
+    """Check we error out if the files and ids do not match."""
+
+    files = ['a', 'b', 'c']
+    rids = [1, 2]
+
+    with pytest.raises(ArgumentErr) as exc:
+        if idval is None:
+            loadfunc(files, rids)
+        else:
+            loadfunc(idval, files, rids)
+
+    assert str(exc.value) == 'A response ID is required for each file'
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1355,6 +1355,55 @@ def test_load_grouping(idval, clean_astro_ui, tmp_path):
     assert y == pytest.approx([2, 3])
 
 
+@pytest.mark.parametrize("idval", [None, 1, 'xx'])
+def test_group_already_grouped(idval):
+    """Does group still work if the data is already grouped?"""
+
+    x = [1, 2, 3]
+    y = [0, 4, 3]
+    if idval is None:
+        ui.load_arrays(1, x, y, ui.DataPHA)
+        ui.set_grouping([1, -1, 1])
+    else:
+        ui.load_arrays(idval, x, y, ui.DataPHA)
+        ui.set_grouping(idval, [1, -1, 1])
+
+    data = ui.get_data(idval)
+    assert not data.grouped
+
+    ui.group(idval)
+    assert data.grouped
+
+    ui.group(idval)
+    assert ui.get_dep(idval) == pytest.approx([2, 3])
+
+
+@pytest.mark.parametrize("idval", [None, 1, 'xx'])
+def test_subtract_already_subtracted(idval):
+    """Does subtract still work if the data is already subtracted?"""
+
+    x = [1, 2, 3]
+    y = [0, 4, 3]
+    ui.load_arrays('bgnd', x, y, ui.DataPHA)
+    bkg = ui.get_data('bgnd')
+
+    if idval is None:
+        ui.load_arrays(1, x, y, ui.DataPHA)
+        ui.set_bkg(bkg)
+    else:
+        ui.load_arrays(idval, x, y, ui.DataPHA)
+        ui.set_bkg(idval, bkg)
+
+    data = ui.get_data(idval)
+    assert not data.subtracted
+
+    ui.subtract(idval)
+    assert data.subtracted
+
+    ui.subtract(idval)
+    assert ui.get_dep(idval) == pytest.approx([0, 0, 0])
+
+
 def test_get_axes_data1d():
     ui.load_arrays(1, [2, 10, 20], [1, 2, 3])
     ax = ui.get_axes()

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1404,6 +1404,18 @@ def test_subtract_already_subtracted(idval):
     assert ui.get_dep(idval) == pytest.approx([0, 0, 0])
 
 
+@pytest.mark.parametrize("callfunc", [ui.group, ui.subtract])
+def test_xxx_not_pha(callfunc):
+    """Just check that these commands require a PHA dataset"""
+
+    ui.load_arrays(1, [1, 2, 3], [4, 5, 6])
+
+    with pytest.raises(ArgumentErr) as exc:
+        callfunc()
+
+    assert str(exc.value) == 'data set 1 does not contain PHA data'
+
+
 def test_get_axes_data1d():
     ui.load_arrays(1, [2, 10, 20], [1, 2, 3])
     ax = ui.get_axes()

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1353,3 +1353,101 @@ def test_load_grouping(idval, clean_astro_ui, tmp_path):
     y = ui.get_dep(idval)
     assert y.shape == (2, )
     assert y == pytest.approx([2, 3])
+
+
+def test_get_axes_data1d():
+    ui.load_arrays(1, [2, 10, 20], [1, 2, 3])
+    ax = ui.get_axes()
+    assert len(ax) == 1
+    assert ax[0] == pytest.approx([2, 10, 20])
+
+
+def test_get_axes_data1dint():
+    ui.load_arrays(1, [2, 10, 20], [10, 12, 22], [1, 2, 3], ui.Data1DInt)
+    ax = ui.get_axes()
+    assert len(ax) == 2
+    assert ax[0] == pytest.approx([2, 10, 20])
+    assert ax[1] == pytest.approx([10, 12, 22])
+
+
+def test_get_axes_datapha_no_response():
+    """Since we have no response this is a bit odd.
+
+    I have noted that it's unclear whether the bin edges are
+    1-2, 2-3, 3-4 or 0.5-1.5, 1.5-2.5, 2.5-3.5. Let's test
+    the status quo here.
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [1, 2, 3], ui.DataPHA)
+    ax = ui.get_axes()
+    assert len(ax) == 2
+    assert ax[0] == pytest.approx([0.5, 1.5, 2.5])
+    assert ax[1] == pytest.approx([1.5, 2.5, 3.5])
+
+
+def test_get_axes_datapha_rmf():
+    """RMF only"""
+
+    ui.load_arrays(1, [1, 2, 3], [1, 2, 3], ui.DataPHA)
+
+    ebins = np.asarray([0.1, 0.2, 0.4, 0.8])
+    elo = ebins[:-1]
+    ehi = ebins[1:]
+    ui.set_rmf(ui.create_rmf(elo, ehi, e_min=elo, e_max=ehi))
+
+    ax = ui.get_axes()
+    assert len(ax) == 2
+    assert ax[0] == pytest.approx([0.1, 0.2, 0.4])
+    assert ax[1] == pytest.approx([0.2, 0.4, 0.8])
+
+
+def test_get_axes_datapha_arf():
+    """ARF only"""
+
+    ui.load_arrays(1, [1, 2, 3], [1, 2, 3], ui.DataPHA)
+
+    ebins = np.asarray([0.1, 0.2, 0.4, 0.8])
+    elo = ebins[:-1]
+    ehi = ebins[1:]
+    ui.set_arf(ui.create_arf(elo, ehi))
+
+    ax = ui.get_axes()
+    assert len(ax) == 2
+    assert ax[0] == pytest.approx([0.1, 0.2, 0.4])
+    assert ax[1] == pytest.approx([0.2, 0.4, 0.8])
+
+
+def test_get_axes_datapha_rsp():
+    """Let's have a RMF and ARF for fun"""
+
+    ui.load_arrays(1, [1, 2, 3], [1, 2, 3], ui.DataPHA)
+
+    ebins = np.asarray([0.1, 0.2, 0.4, 0.8])
+    elo = ebins[:-1]
+    ehi = ebins[1:]
+    ui.set_arf(ui.create_arf(elo, ehi))
+    ui.set_rmf(ui.create_rmf(elo, ehi, e_min=elo, e_max=ehi))
+
+    ax = ui.get_axes()
+    assert len(ax) == 2
+    assert ax[0] == pytest.approx([0.1, 0.2, 0.4])
+    assert ax[1] == pytest.approx([0.2, 0.4, 0.8])
+
+
+def test_get_axes_dataimg_logical():
+    """We don't set up a coordinate system so we just get logical back"""
+
+    y, x = np.mgrid[-5:-1, 5:8]
+    x = x.flatten()
+    y = y.flatten()
+    z = np.zeros(x.size)
+
+    # Not sure what ordering the shape array is meant to have
+    # and whether there is an ordering to x, y, z values.
+    #
+    ui.load_arrays(1, x, y, z, (4, 3), ui.DataIMG)
+
+    ax = ui.get_axes()
+    assert len(ax) == 2
+    assert ax[0] == pytest.approx([1, 2, 3])
+    assert ax[1] == pytest.approx([1, 2, 3, 4])

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1277,8 +1277,8 @@ def test_delete_bkg_model_with_bkgid(id, clean_astro_ui):
     assert str(exc.value) == emsg
 
 
-@pytest.mark.parametrize("loadfunc", [ui.load_grouping, ui.load_quality])
 @requires_fits
+@pytest.mark.parametrize("loadfunc", [ui.load_grouping, ui.load_quality])
 def test_load_xxx_no_data(loadfunc, clean_astro_ui, tmp_path):
     """What happens when there's no data??"""
 
@@ -1291,8 +1291,8 @@ def test_load_xxx_no_data(loadfunc, clean_astro_ui, tmp_path):
     assert str(exc.value) == 'data set 2 has not been set'
 
 
-@pytest.mark.parametrize("loadfunc", [ui.load_grouping, ui.load_quality])
 @requires_fits
+@pytest.mark.parametrize("loadfunc", [ui.load_grouping, ui.load_quality])
 def test_load_xxx_not_pha(loadfunc, clean_astro_ui, tmp_path):
     """What happens with a non-PHA dataset?"""
 
@@ -1307,6 +1307,7 @@ def test_load_xxx_not_pha(loadfunc, clean_astro_ui, tmp_path):
     assert str(exc.value) == 'data set 2 does not contain PHA data'
 
 
+@requires_fits
 @pytest.mark.parametrize("idval", [None, 1, 'xx'])
 def test_load_grouping(idval, clean_astro_ui, tmp_path):
     """Simple grouping check"""

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1374,9 +1374,11 @@ def test_group_already_grouped(idval):
 
     ui.group(idval)
     assert data.grouped
+    assert ui.get_dep(idval) == pytest.approx([2, 3])
 
     ui.group(idval)
     assert ui.get_dep(idval) == pytest.approx([2, 3])
+    assert data.grouped
 
 
 @pytest.mark.parametrize("idval", [None, 1, 'xx'])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1433,26 +1433,19 @@ class Session(sherpa.ui.utils.Session):
                                             colkeys=colkeys,
                                             dstype=Data1DAsymmetricErrs,
                                             sep=sep, comment=comment))
-        datas = self.get_data(id)
 
-        def calc_err(data):
-            return data.y - data.elo, data.ehi - data.y
+        data = self.get_data(id)
 
-        def calc_staterror(data):
-            if func is numpy.average:
-                return func([data.elo, data.ehi], axis=0)
+        if not delta:
+            data.elo = data.y - data.elo
+            data.ehi = data.ehi - data.y
 
-            return func(data.elo, data.ehi)
-
-        if type(datas) is list:
-            for data in datas:
-                if not delta:
-                    data.elo, data.ehi = calc_err(data)
-                data.staterror = calc_staterror(data)
+        if func is numpy.average:
+            staterror = func([data.elo, data.ehi], axis=0)
         else:
-            if not delta:
-                datas.elo, datas.ehi = calc_err(datas)
-            datas.staterror = calc_staterror(datas)
+            staterror = func(data.elo, data.ehi)
+
+        data.staterror = staterror
 
     # DOC-NOTE: also in sherpa.utils
     def load_data(self, id, filename=None, *args, **kwargs):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1447,11 +1447,11 @@ class Session(sherpa.ui.utils.Session):
 
         if type(datas) is list:
             for data in datas:
-                if delta is False:
+                if not delta:
                     data.elo, data.ehi = calc_err(data)
                 data.staterror = calc_staterror(data)
         else:
-            if delta is False:
+            if not delta:
                 datas.elo, datas.ehi = calc_err(datas)
             datas.staterror = calc_staterror(datas)
 
@@ -4307,6 +4307,8 @@ class Session(sherpa.ui.utils.Session):
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
+
+        # Leave this check as d.mask is False since d.mask need not be a boolean
         if d.mask is False:
             raise DataErr('notmask')
         if not numpy.iterable(d.mask):
@@ -7339,7 +7341,7 @@ class Session(sherpa.ui.utils.Session):
 
             # Now check if data is already grouped, and send error message
             # if so
-        if not (data.grouped is True):
+        if not data.grouped:
             data.group()
 
     def set_grouping(self, id, val=None, bkg_id=None):
@@ -7772,7 +7774,7 @@ class Session(sherpa.ui.utils.Session):
 
             # Now check if data is already ungrouped, and send error message
             # if so
-        if (data.grouped is True):
+        if data.grouped:
             data.ungroup()
 
     # DOC-TODO: need to document somewhere that this ignores existing
@@ -8497,7 +8499,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_data(overplot=True)
 
         """
-        if (self._get_pha_data(id).subtracted is False):
+        if not self._get_pha_data(id).subtracted:
             self._get_pha_data(id).subtract()
 
     def unsubtract(self, id=None):
@@ -8548,7 +8550,7 @@ class Session(sherpa.ui.utils.Session):
         False
 
         """
-        if (self._get_pha_data(id).subtracted is True):
+        if self._get_pha_data(id).subtracted:
             self._get_pha_data(id).unsubtract()
 
     def fake_pha(self, id, arf, rmf, exposure, backscal=None, areascal=None,
@@ -13481,7 +13483,7 @@ class Session(sherpa.ui.utils.Session):
         if error:
 
             def is_numpy_ndarray(arg, name, npars, dim1=None):
-                if isinstance(arg, numpy.ndarray) is False:
+                if not isinstance(arg, numpy.ndarray):
                     msg = name + ' must be of type numpy.ndarray'
                     raise IOErr(msg)
                 shape = arg.shape

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1449,6 +1449,7 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     def load_data(self, id, filename=None, *args, **kwargs):
+        # pylint: disable=W1113
         """Load a data set from a file.
 
         This loads a data set from the file, trying in order
@@ -1953,8 +1954,10 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
+    #
     def load_filter(self, id, filename=None, bkg_id=None, ignore=False,
                     ncols=2, *args, **kwargs):
+        # pylint: disable=W1113
         """Load the filter array from a file and add to a data set.
 
         Parameters
@@ -2033,7 +2036,9 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: does ncols make sense here? (have removed for now)
     # DOC-TODO: prob. needs a review as the existing ahelp documentation
     # talks about 2 cols, but experimentation suggests 1 col.
+    #
     def load_grouping(self, id, filename=None, bkg_id=None, *args, **kwargs):
+        # pylint: disable=W1113
         """Load the grouping scheme from a file and add to a PHA data set.
 
         This function sets the grouping column but does not
@@ -2116,10 +2121,11 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
 
-        self.set_grouping(id,
-                          self._read_user_model(filename, *args, **kwargs)[1], bkg_id=bkg_id)
+        grouping = self._read_user_model(filename, *args, **kwargs)[1]
+        self.set_grouping(id, grouping, bkg_id=bkg_id)
 
     def load_quality(self, id, filename=None, bkg_id=None, *args, **kwargs):
+        # pylint: disable=W1113
         """Load the quality array from a file and add to a PHA data set.
 
         This function sets the quality column but does not
@@ -2269,6 +2275,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
     def load_staterror(self, id, filename=None, bkg_id=None, *args, **kwargs):
+        # pylint: disable=W1113
         """Load the statistical errors from a file.
 
         Read in a column or image from a file and use the values
@@ -2353,6 +2360,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils
     # DOC-NOTE: is ncols really 2 here? Does it make sense?
     def load_syserror(self, id, filename=None, bkg_id=None, *args, **kwargs):
+        # pylint: disable=W1113
         """Load the systematic errors from a file.
 
         Read in a column or image from a file and use the values
@@ -9645,7 +9653,9 @@ class Session(sherpa.ui.utils.Session):
     # also in sherpa.utils
     # DOC-NOTE: can filename be a crate/hdulist?
     # DOC-TODO: how to describe the supported args/kwargs (not just for this function)?
-    def load_table_model(self, modelname, filename, method=sherpa.utils.linear_interp, *args, **kwargs):
+    def load_table_model(self, modelname, filename,
+                         method=sherpa.utils.linear_interp, *args, **kwargs):
+        # pylint: disable=W1113
         """Load tabular or image data and use it as a model component.
 
         .. note:: Deprecated in Sherpa 4.9
@@ -9748,6 +9758,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: how to describe *args/**kwargs
     # DOC-TODO: how is the _y value used if set
     def load_user_model(self, func, modelname, filename=None, *args, **kwargs):
+        # pylint: disable=W1113
         """Create a user-defined model.
 
         Assign a name to a function; this name can then be used as any
@@ -9934,7 +9945,9 @@ class Session(sherpa.ui.utils.Session):
     # also in sherpa.utils
     # DOC-TODO: existing docs suggest that bkg_only can be set, but looking
     # at the code it is always set to False.
+    #
     def fit(self, id=None, *otherids, **kwargs):
+        # pylint: disable=W1113
         """Fit a model to one or more data sets.
 
         Use forward fitting to find the best-fit model to one or more
@@ -10022,6 +10035,7 @@ class Session(sherpa.ui.utils.Session):
         self._fit(id, *otherids, **kwargs)
 
     def fit_bkg(self, id=None, *otherids, **kwargs):
+        # pylint: disable=W1113
         """Fit a model to one or more background PHA data sets.
 
         Fit only the backgound components of PHA data sets.  This can
@@ -10099,6 +10113,7 @@ class Session(sherpa.ui.utils.Session):
         self._fit(id, *otherids, **kwargs)
 
     def _fit(self, id=None, *otherids, **kwargs):
+        # pylint: disable=W1113
         ids = f = None
         fit_bkg = False
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9638,9 +9638,9 @@ class Session(sherpa.ui.utils.Session):
 
         try:
             from sherpa.astro import xspec
-        except ImportError:
+        except ImportError as exc:
             # TODO: what is the best error to raise here?
-            raise ImportErr('notsupported', 'XSPEC')
+            raise ImportErr('notsupported', 'XSPEC') from exc
 
         tablemodel = xspec.read_xstable_model(modelname, filename)
         self._tbl_models.append(tablemodel)
@@ -9723,6 +9723,7 @@ class Session(sherpa.ui.utils.Session):
 
         try:
             if not sherpa.utils.is_binary_file(filename):
+                # TODO: use a Sherpa exception
                 raise Exception("Not a FITS file")
 
             self.load_xstable_model(modelname, filename)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -379,7 +379,7 @@ class Session(sherpa.ui.utils.Session):
                 data_str += bkg.__str__() + '\n\n'
 
                 for bk_rp_id in bkg.response_ids:
-                        # ARF or RMF could be None
+                    # ARF or RMF could be None
                     arf, rmf = bkg.get_response(bk_rp_id)
                     if rmf is not None:
                         data_str += ('Background RMF Data Set: %s:%s\n' %
@@ -1434,6 +1434,7 @@ class Session(sherpa.ui.utils.Session):
                                             dstype=Data1DAsymmetricErrs,
                                             sep=sep, comment=comment))
         datas = self.get_data(id)
+
         def calc_err(data):
             return data.y - data.elo, data.ehi - data.y
 
@@ -9845,6 +9846,7 @@ class Session(sherpa.ui.utils.Session):
     # Fitting
     ###########################################################################
 
+    # TODO: change bkg_ids default to None or some other "less-dangerous" value
     def _add_extra_data_and_models(self, ids, datasets, models, bkg_ids={}):
         for id, d in zip(ids, datasets):
             if isinstance(d, sherpa.astro.data.DataPHA):
@@ -9855,7 +9857,7 @@ class Session(sherpa.ui.utils.Session):
                         warning(('data set %r is background-subtracted; ' +
                                  'background models will be ignored') % id)
                 elif not (bkg_models or bkg_srcs):
-                    if d.background_ids and 'wstat' != self._current_stat.name:
+                    if d.background_ids and self._current_stat.name != 'wstat':
                         warning(('data set %r has associated backgrounds, ' +
                                  'but they have not been subtracted, ' +
                                  'nor have background models been set') % id)
@@ -13206,7 +13208,6 @@ class Session(sherpa.ui.utils.Session):
                                              numcores=numcores,
                                              samples=scales, clip=clip)
 
-
     # DOC-NOTE: are scales the variance or standard deviation?
     def sample_flux(self, modelcomponent=None, lo=None, hi=None, id=None,
                     num=1, scales=None, correlated=False,
@@ -13511,8 +13512,8 @@ class Session(sherpa.ui.utils.Session):
                 # Have enough stuff to generate samples
                 if isinstance(self._current_stat, (Cash, CStat, WStat)):
                     _, _, params = \
-                    self.get_draws(id, otherids=otherids, niter=niter,
-                                   covar_matrix=covar_matrix)
+                        self.get_draws(id, otherids=otherids, niter=niter,
+                                       covar_matrix=covar_matrix)
                 else:
                     sampler = NormalParameterSampleFromScaleMatrix()
                     tmp = sampler.get_sample(fit, covar_matrix, niter + 1)
@@ -13535,7 +13536,7 @@ class Session(sherpa.ui.utils.Session):
                 eqw[params_index] = \
                     sherpa.astro.utils.eqwidth(data, src, combo, lo, hi)
             median, lower, upper = sherpa.utils.get_error_estimates(eqw)
-            fit.model.thawedpars  = orig_par_vals
+            fit.model.thawedpars = orig_par_vals
             return median, lower, upper, params, eqw
 
         ####################################################

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -5735,9 +5735,7 @@ class Session(sherpa.ui.utils.Session):
         if len(filenames) != len(resp_ids):
             raise ArgumentErr('multirsp')
 
-        while len(filenames) > 0:
-            filename = filenames.pop(0)
-            resp_id = resp_ids.pop(0)
+        for filename, resp_id in zip(filenames, resp_ids):
             self.load_arf(id, filename, resp_id)
 
     def get_rmf(self, id=None, resp_id=None, bkg_id=None):
@@ -6201,9 +6199,7 @@ class Session(sherpa.ui.utils.Session):
         if len(filenames) != len(resp_ids):
             raise ArgumentErr('multirsp')
 
-        while len(filenames) > 0:
-            filename = filenames.pop(0)
-            resp_id = resp_ids.pop(0)
+        for filename, resp_id in zip(filenames, resp_ids):
             self.load_rmf(id, filename, resp_id)
 
     def get_bkg(self, id=None, bkg_id=None):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1335,10 +1335,8 @@ class Session(sherpa.ui.utils.Session):
                 try:
                     data = self.unpack_table(filename, *args, **kwargs)
                 except:
-                    try:
-                        data = self.unpack_ascii(filename, *args, **kwargs)
-                    except:
-                        raise
+                    # If this errors out then so be it
+                    data = self.unpack_ascii(filename, *args, **kwargs)
 
         return data
 
@@ -5065,10 +5063,8 @@ class Session(sherpa.ui.utils.Session):
                 try:
                     sherpa.astro.io.write_table(filename, d, ascii, clobber)
                 except:
-                    try:
-                        sherpa.io.write_data(filename, d, clobber)
-                    except:
-                        raise
+                    # If this errors out then so be it
+                    sherpa.io.write_data(filename, d, clobber)
 
     def pack_pha(self, id=None):
         """Convert a PHA data set into a file structure.
@@ -8765,11 +8761,8 @@ class Session(sherpa.ui.utils.Session):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
             except:
-                try:
-                    kernel = self.unpack_data(filename_or_model,
-                                              *args, **kwargs)
-                except:
-                    raise
+                kernel = self.unpack_data(filename_or_model,
+                                          *args, **kwargs)
 
         psf = sherpa.astro.instrument.PSFModel(modelname, kernel)
         if isinstance(kernel, sherpa.models.Model):
@@ -9574,14 +9567,12 @@ class Session(sherpa.ui.utils.Session):
                 y = sherpa.astro.io.backend.get_table_data(filename, *args,
                                                            **kwargs)[1].pop()
             except:
-                try:
-                    # unpack_data doesn't include a call to try
-                    # getting data from image, so try that here.
-                    data = self.unpack_image(filename, *args, **kwargs)
-                    # x = data.get_x()
-                    y = data.get_y()
-                except:
-                    raise
+                # unpack_data doesn't include a call to try
+                # getting data from image, so try that here.
+                data = self.unpack_image(filename, *args, **kwargs)
+                # x = data.get_x()
+                y = data.get_y()
+
         return (x, y)
 
     def load_xstable_model(self, modelname, filename):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -647,6 +647,8 @@ class Session(sherpa.ui.utils.Session):
 
         """
         # support non-integrated grids with inclusive boundaries
+        # We do NOT want to use an isinstance check since Data1DInt is
+        # derived from Data1D.
         if dstype in (sherpa.data.Data1D, sherpa.astro.data.DataPHA):
             stop += step
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9839,7 +9839,8 @@ class Session(sherpa.ui.utils.Session):
         usermodel.calc = func
         usermodel._file = filename
         if filename is not None:
-            x, usermodel._y = self._read_user_model(filename, *args, **kwargs)
+            _, usermodel._y = self._read_user_model(filename, *args, **kwargs)
+
         self._add_model_component(usermodel)
 
     ###########################################################################
@@ -12956,7 +12957,7 @@ class Session(sherpa.ui.utils.Session):
         >>> flux2_filt = flux2[v2[:, -1] == 0]
 
         """
-        ids, fit = self._get_fit(id, otherids=otherids)
+        _, fit = self._get_fit(id, otherids=otherids)
 
         if bkg_id is None:
             data = self.get_data(id)
@@ -13188,7 +13189,7 @@ class Session(sherpa.ui.utils.Session):
         >>> flux2_filt = flux2[v2[:, -1] == 0]
 
         """
-        ids, fit = self._get_fit(id, otherids=otherids)
+        _, fit = self._get_fit(id, otherids=otherids)
 
         if bkg_id is None:
             data = self.get_data(id)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -22,15 +22,12 @@ import logging
 import os
 import sys
 import warnings
-import operator
-
-from collections import defaultdict
-from functools import reduce
 
 import numpy
 
 import sherpa.ui.utils
-from sherpa.astro.instrument import create_arf, create_delta_rmf, create_non_delta_rmf
+from sherpa.astro.instrument import create_arf, create_delta_rmf, \
+    create_non_delta_rmf
 from sherpa.ui.utils import _argument_type_error, _check_type
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
     send_to_pager
@@ -249,7 +246,7 @@ class Session(sherpa.ui.utils.Session):
         >>> save('bestfit.sherpa', clobber=True)
 
         """
-        if (hasattr(sherpa.astro, "xspec")):
+        if hasattr(sherpa.astro, "xspec"):
             self._xspec_state = sherpa.astro.xspec.get_xsstate()
         else:
             self._xspec_state = None
@@ -300,8 +297,8 @@ class Session(sherpa.ui.utils.Session):
 
         """
         sherpa.ui.utils.Session.restore(self, filename)
-        if (hasattr(sherpa.astro, "xspec")):
-            if (self._xspec_state is not None):
+        if hasattr(sherpa.astro, "xspec"):
+            if self._xspec_state is not None:
                 sherpa.astro.xspec.set_xsstate(self._xspec_state)
                 self._xspec_state = None
 
@@ -5733,10 +5730,10 @@ class Session(sherpa.ui.utils.Session):
         filenames = list(filenames)
         resp_ids = list(resp_ids)
 
-        if (len(filenames) != len(resp_ids)):
+        if len(filenames) != len(resp_ids):
             raise ArgumentErr('multirsp')
 
-        while (len(filenames) > 0):
+        while len(filenames) > 0:
             filename = filenames.pop(0)
             resp_id = resp_ids.pop(0)
             self.load_arf(id, filename, resp_id)
@@ -6199,10 +6196,10 @@ class Session(sherpa.ui.utils.Session):
         filenames = list(filenames)
         resp_ids = list(resp_ids)
 
-        if (len(filenames) != len(resp_ids)):
+        if len(filenames) != len(resp_ids):
             raise ArgumentErr('multirsp')
 
-        while (len(filenames) > 0):
+        while len(filenames) > 0:
             filename = filenames.pop(0)
             resp_id = resp_ids.pop(0)
             self.load_rmf(id, filename, resp_id)
@@ -6591,7 +6588,7 @@ class Session(sherpa.ui.utils.Session):
         if id is not None:
             ids = [id]
 
-        if(len(ids) == 0):
+        if len(ids) == 0:
             raise IdentifierErr('nodatasets')
 
         for id in ids:
@@ -7070,7 +7067,7 @@ class Session(sherpa.ui.utils.Session):
         >>> notice2d_image(["src", "bg"])
 
         """
-        if (ids is None):
+        if ids is None:
             ids = self._default_id
         if self._valid_id(ids):
             ids = (ids,)
@@ -7085,9 +7082,9 @@ class Session(sherpa.ui.utils.Session):
             _check_type(self.get_data(id), sherpa.astro.data.DataIMG,
                         'img', 'a image data set')
             coord = self.get_coord(id)
-            if (coord == 'logical'):
+            if coord == 'logical':
                 coord = 'image'
-            if (coord == 'world'):
+            elif coord == 'world':
                 coord = 'wcs'
             regions = self.image_getregion(coord).replace(';', '')
             self.notice2d_id(id, regions)
@@ -7133,7 +7130,7 @@ class Session(sherpa.ui.utils.Session):
         >>> ignore2d_image(["src", "bg"])
 
         """
-        if (ids is None):
+        if ids is None:
             ids = self._default_id
         if self._valid_id(ids):
             ids = (ids,)
@@ -7148,9 +7145,9 @@ class Session(sherpa.ui.utils.Session):
             _check_type(self.get_data(id), sherpa.astro.data.DataIMG,
                         'img', 'a image data set')
             coord = self.get_coord(id)
-            if (coord == 'logical'):
+            if coord == 'logical':
                 coord = 'image'
-            if (coord == 'world'):
+            elif coord == 'world':
                 coord = 'wcs'
             regions = self.image_getregion(coord).replace(';', '')
             self.ignore2d_id(id, regions)
@@ -8669,13 +8666,13 @@ class Session(sherpa.ui.utils.Session):
         if rmf is None:
             raise DataErr('normffake', id)
 
-        if(type(rmf) in (str, numpy.string_)):
+        if type(rmf) in (str, numpy.string_):
             if os.path.isfile(rmf):
                 rmf = self.unpack_rmf(rmf)
             else:
                 raise IOErr("filenotfound", rmf)
 
-        if(arf is not None and type(arf) in (str, numpy.string_)):
+        if arf is not None and type(arf) in (str, numpy.string_):
             if os.path.isfile(arf):
                 arf = self.unpack_arf(arf)
             else:
@@ -9847,7 +9844,7 @@ class Session(sherpa.ui.utils.Session):
         usermodel = sherpa.models.UserModel(modelname)
         usermodel.calc = func
         usermodel._file = filename
-        if (filename is not None):
+        if filename is not None:
             x, usermodel._y = self._read_user_model(filename, *args, **kwargs)
         self._add_model_component(usermodel)
 
@@ -9885,7 +9882,7 @@ class Session(sherpa.ui.utils.Session):
 
                         bkg_model = bkg_models.get(bkg_id, None)
                         bkg_src = bkg_srcs.get(bkg_id, None)
-                        if (bkg_model is None and bkg_src is not None):
+                        if bkg_model is None and bkg_src is not None:
                             resp = sherpa.astro.instrument.Response1D(bkg_data)
                             bkg_model = resp(bkg_src)
                         models.append(bkg_model)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1440,8 +1440,8 @@ class Session(sherpa.ui.utils.Session):
         def calc_staterror(data):
             if func is numpy.average:
                 return func([data.elo, data.ehi], axis=0)
-            else:
-                return func(data.elo, data.ehi)
+
+            return func(data.elo, data.ehi)
 
         if type(datas) is list:
             for data in datas:
@@ -3273,11 +3273,14 @@ class Session(sherpa.ui.utils.Session):
         d = self.get_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             return d._get_ebins(group=False)
-        elif isinstance(d, (sherpa.data.Data2D,
-                            sherpa.astro.data.DataIMG)):
+
+        if isinstance(d, (sherpa.data.Data2D,
+                          sherpa.astro.data.DataIMG)):
             return d.get_axes()
+
         return d.get_indep()
 
     # DOC-NOTE: also in sherpa.utils
@@ -5254,11 +5257,11 @@ class Session(sherpa.ui.utils.Session):
             return create_delta_rmf(rmflo, rmfhi, offset=startchan,
                                     e_min=e_min, e_max=e_max, ethresh=ethresh,
                                     name=name)
-        else:
-            return create_non_delta_rmf(rmflo, rmfhi, fname,
-                                        offset=startchan, e_min=e_min,
-                                        e_max=e_max, ethresh=ethresh,
-                                        name=name)
+
+        return create_non_delta_rmf(rmflo, rmfhi, fname,
+                                    offset=startchan, e_min=e_min,
+                                    e_max=e_max, ethresh=ethresh,
+                                    name=name)
 
     def get_arf(self, id=None, resp_id=None, bkg_id=None):
         """Return the ARF associated with a PHA data set.
@@ -13535,8 +13538,7 @@ class Session(sherpa.ui.utils.Session):
             return median, lower, upper, params, eqw
 
         ####################################################
-        else:
-            return sherpa.astro.utils.eqwidth(data, src, combo, lo, hi)
+        return sherpa.astro.utils.eqwidth(data, src, combo, lo, hi)
 
     def calc_photon_flux(self, lo=None, hi=None, id=None, bkg_id=None,
                          model=None):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -3780,8 +3780,10 @@ class Session(sherpa.ui.utils.Session):
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
 
-        if type(d) in (sherpa.astro.data.DataIMG, sherpa.astro.data.DataIMGInt,
-                       sherpa.data.Data2D, sherpa.data.Data2DInt):
+        if isinstance(d, (sherpa.astro.data.DataIMG,
+                          sherpa.astro.data.DataIMGInt,
+                          sherpa.data.Data2D, sherpa.data.Data2DInt)):
+
             backup = d.y
             if objtype == 'delchi':
                 raise AttributeError("save_delchi() does not apply for images")
@@ -3821,8 +3823,8 @@ class Session(sherpa.ui.utils.Session):
 #        if type(d) in (sherpa.data.Data1DInt, sherpa.astro.data.DataPHA):
 #            args = [obj.xlo, obj.xhi, obj.y]
 #            fields = ["XLO", "XHI", str(objtype).upper()]
-        if (type(d) is sherpa.astro.data.DataPHA and
-                objtype in ('model', 'source')):
+        if isinstance(d, sherpa.astro.data.DataPHA) and \
+           objtype in ('model', 'source'):
             args = [obj.xlo, obj.xhi, obj.y]
             fields = ["XLO", "XHI", str(objtype).upper()]
         else:


### PR DESCRIPTION
# Summary

The `sherpa.astro.ui.utils` module has seen a number of minor clean-ups, addressing pylint-reported issues.

# Details

The aim was to address technical debt by applying pylint suggestions. Many of the lines changed were identified and tests added (and these have already been merged in #1067), so hopefully the coverage is high for these changes. Tests have been added for some of the un-tested changes.

This used to contain code that has been moved out to #1067, #1072, #1073