### PR TITLE
Fix save_data when the output file exists

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -25,7 +25,7 @@ import numpy
 
 import pycrates
 
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import ClobberErr, IOErr
 from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat, is_binary_file
 from sherpa.astro.utils import resp_init
 from sherpa.astro.io.meta import Meta
@@ -1163,7 +1163,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
                    packup=False):
 
     if not packup and os.path.isfile(filename) and not clobber:
-        raise IOErr('filefound', filename)
+        raise ClobberErr(filename)
 
     img = pycrates.IMAGECrate()
 
@@ -1237,7 +1237,7 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
                    ascii=False, clobber=False, packup=False):
 
     if not packup and os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     tbl = pycrates.TABLECrate()
 
@@ -1265,7 +1265,7 @@ def set_pha_data(filename, data, col_names, header=None,
                  ascii=False, clobber=False, packup=False):
 
     if not packup and os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     phadataset = pycrates.phacratedataset.PHACrateDataset()
 
@@ -1305,7 +1305,7 @@ def set_pha_data(filename, data, col_names, header=None,
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
     if os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     if not numpy.iterable(args) or len(args) == 0:
         raise IOErr('noarrayswrite')

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -46,7 +46,7 @@ from numpy.compat import basestring
 from astropy.io import fits
 from astropy.io.fits.column import _VLF
 
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import ClobberErr, IOErr
 from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat
 import sherpa.utils
 from sherpa.io import get_ascii_data, write_arrays
@@ -1003,7 +1003,7 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
                    ascii=False, clobber=False, packup=False):
 
     if not packup and os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     col_names = list(col_names)
     col_names.remove("name")
@@ -1046,7 +1046,7 @@ def set_pha_data(filename, data, col_names, header=None,
                  ascii=False, clobber=False, packup=False):
 
     if not packup and os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     hdrlist = _create_header(header)
 
@@ -1069,7 +1069,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
                    packup=False):
 
     if not packup and not clobber and os.path.isfile(filename):
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     if ascii:
         set_arrays(filename, [data['pixels'].ravel()],
@@ -1136,7 +1136,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         return
 
     if not clobber and os.path.isfile(filename):
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     if not numpy.iterable(args) or len(args) == 0:
         raise IOErr('noarrayswrite')

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -654,12 +654,16 @@ def test_chi2(make_data_path, clean_astro_ui):
     assert stat12 == 'chi2'
 
 
+@requires_fits
 @pytest.mark.parametrize("session", [sherpa.ui.utils.Session,
                                      sherpa.astro.ui.utils.Session])
 def test_save_arrays_clobber(session, tmp_path):
     """Check that save_arrays will not clobber.
 
     For fun check both sessions here.
+
+    Only the astro session requires the FITS backend but it would
+    make the test significantly messier to handle both.
     """
 
     out = tmp_path / 'out.dat'
@@ -672,12 +676,16 @@ def test_save_arrays_clobber(session, tmp_path):
     assert out.read_text() == 'A line'
 
 
+@requires_fits
 @pytest.mark.parametrize("session", [sherpa.ui.utils.Session,
                                      sherpa.astro.ui.utils.Session])
 def test_save_arrays_nodata(session, tmp_path):
     """Check that save_arrays errors out.
 
     For fun check both sessions here.
+
+    Only the astro session requires the FITS backend but it would
+    make the test significantly messier to handle both.
     """
 
     out = tmp_path / 'out.dat'

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -414,13 +414,16 @@ def check_clobber(outpath, func):
     assert new == old
 
 
+@requires_fits
 def test_save_data_data1d_no_clobber(tmp_path):
-    """save_data: does clobber=False work? Data1D"""
+    """save_data: does clobber=False work? Data1D
+
+    Even though writing out an ASCII file we need the io backend.
+    """
 
     ui.load_arrays(1, [1, 2, 3], [5, 4, 3], ui.Data1D)
 
     out = tmp_path / "data.dat"
-    outfile = str(out)
 
     out.write_text('some text')
     check_clobber(out, ui.save_data)

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -414,7 +414,6 @@ def check_clobber(outpath, func):
     assert new == old
 
 
-@pytest.mark.xfail(reason='fall through does not work')
 def test_save_data_data1d_no_clobber(tmp_path):
     """save_data: does clobber=False work? Data1D"""
 
@@ -427,7 +426,6 @@ def test_save_data_data1d_no_clobber(tmp_path):
     check_clobber(out, ui.save_data)
 
 
-@pytest.mark.xfail(reason='fall through does not work')
 @requires_fits
 def test_save_data_datapha_no_clobber(tmp_path):
     """save_data: does clobber=False work? DataPHA"""
@@ -450,7 +448,6 @@ def test_save_data_datapha_no_clobber(tmp_path):
     check_clobber(out, ui.save_data)
 
 
-@pytest.mark.xfail(reason='fall through does not work')
 @requires_fits
 def test_save_pha_no_clobber(tmp_path):
     """save_pha: does clobber=False work?"""
@@ -474,7 +471,7 @@ def test_save_pha_no_clobber(tmp_path):
 
 
 @requires_fits
-@pytest.mark.parametrize("writer", [pytest.param(ui.save_data, marks=pytest.mark.xfail), ui.save_image])
+@pytest.mark.parametrize("writer", [ui.save_data, ui.save_image])
 def test_save_image_no_clobber(writer, tmp_path):
     """save_image: does clobber=False work?"""
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -33,8 +33,8 @@ import pytest
 from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.astro import ui
 from sherpa.utils import poisson_noise
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
-    IdentifierErr, IOErr, ModelErr, StatErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, ClobberErr, \
+    DataErr, IdentifierErr, IOErr, ModelErr, StatErr
 from sherpa.utils.testing import requires_data, requires_fits
 
 
@@ -402,7 +402,7 @@ def check_clobber(outpath, func):
     old = outpath.read_text()
 
     # check it clobbers
-    with pytest.raises(IOErr) as exc:
+    with pytest.raises(ClobberErr) as exc:
         func(str(outpath))
 
     emsg = str(exc.value)

--- a/sherpa/astro/ui/tests/test_session_copy.py
+++ b/sherpa/astro/ui/tests/test_session_copy.py
@@ -102,6 +102,21 @@ def test_save_clobber_check(session, tmp_path):
     assert out.read_text() == 'x'
 
 
+# Apparently sherpa.ui.utils does not have save_all
+@pytest.mark.parametrize("session", [AstroSession])
+def test_save_all_clobber_check(session, tmp_path):
+    """save_all does not clobber"""
+
+    out = tmp_path / 'save.file'
+    out.write_text('x')
+
+    s = session()
+    with pytest.raises(ClobberErr):
+        s.save_all(str(out))
+
+    assert out.read_text() == 'x'
+
+
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_load_template_not_binary(session, tmp_path):
     """load_template_model doesn't like binary files"""

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -31,7 +31,7 @@ from sherpa.astro.instrument import create_arf, create_delta_rmf, \
 from sherpa.ui.utils import _argument_type_error, _check_type
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
     send_to_pager
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, ClobberErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.data import Data1D, Data1DAsymmetricErrs
 import sherpa.astro.all
@@ -14585,7 +14585,7 @@ class Session(sherpa.ui.utils.Session):
                 if sherpa.utils.bool_cast(clobber):
                     os.remove(outfile)
                 else:
-                    raise IOErr('filefound', outfile)
+                    raise ClobberErr(outfile)
 
             with open(outfile, 'w') as fh:
                 serialize.save_all(self, fh)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -5080,12 +5080,18 @@ class Session(sherpa.ui.utils.Session):
 
         try:
             sherpa.astro.io.write_pha(filename, d, ascii, clobber)
+        except ClobberErr:
+            raise
         except IOErr:
             try:
                 sherpa.astro.io.write_image(filename, d, ascii, clobber)
+            except ClobberErr:
+                raise
             except IOErr:
                 try:
                     sherpa.astro.io.write_table(filename, d, ascii, clobber)
+                except ClobberErr:
+                    raise
                 except:
                     # If this errors out then so be it
                     sherpa.io.write_data(filename, d, clobber)

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021
+#      Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -22,7 +23,7 @@ import os
 import numpy
 
 from sherpa.utils import SherpaFloat, get_num_args, is_binary_file
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import ClobberErr, IOErr
 from sherpa.data import Data1D, BaseData
 
 
@@ -437,7 +438,7 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
 
     """
     if os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+        raise ClobberErr(filename)
 
     if not numpy.iterable(args) or len(args) == 0:
         raise IOErr('noarrayswrite')

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -33,7 +33,7 @@ from sherpa.models.basic import TableModel
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
-    IdentifierErr, ModelErr, SessionErr
+    ClobberErr, IdentifierErr, IOErr, ModelErr, SessionErr
 
 from sherpa import get_config
 
@@ -460,7 +460,7 @@ class Session(NoNewAttributesAfterInit):
         clobber = sherpa.utils.bool_cast(clobber)
 
         if os.path.isfile(filename) and not clobber:
-            raise sherpa.utils.err.IOErr("filefound", filename)
+            raise ClobberErr(filename)
 
         fout = open(filename, 'wb')
         try:
@@ -6391,14 +6391,14 @@ class Session(NoNewAttributesAfterInit):
         """
 
         if sherpa.utils.is_binary_file(templatefile):
-            raise sherpa.utils.err.IOErr('notascii', templatefile)
+            raise IOErr('notascii', templatefile)
 
         names, cols = sherpa.io.read_file_data(templatefile,
                                                sep=sep, comment=comment,
                                                require_floats=False)
 
         if len(names) > len(cols):
-            raise sherpa.utils.err.IOErr('toomanycols')
+            raise IOErr('toomanycols')
 
         names = [name.strip().lower() for name in names]
 
@@ -6424,20 +6424,20 @@ class Session(NoNewAttributesAfterInit):
         parvals = numpy.asarray(parvals).T
 
         if len(parvals) == 0:
-            raise sherpa.utils.err.IOErr('noparamcols', templatefile)
+            raise IOErr('noparamcols', templatefile)
 
         if filenames is None:
-            raise sherpa.utils.err.IOErr('reqcol', 'filename', templatefile)
+            raise IOErr('reqcol', 'filename', templatefile)
 
         if modelflags is None:
-            raise sherpa.utils.err.IOErr('reqcol', 'modelflag', templatefile)
+            raise IOErr('reqcol', 'modelflag', templatefile)
 
         templates = []
         for filename in filenames:
             tnames, tcols = sherpa.io.read_file_data(filename,
                                                      sep=sep, comment=comment)
             if len(tcols) == 1:
-                raise sherpa.utils.err.IOErr('onecolneedtwo', filename)
+                raise IOErr('onecolneedtwo', filename)
             elif len(tcols) == 2:
                 tm = TableModel(filename)
                 tm.method = method  # interpolation method
@@ -6445,7 +6445,7 @@ class Session(NoNewAttributesAfterInit):
                 tm.ampl.freeze()
                 templates.append(tm)
             else:
-                raise sherpa.utils.err.IOErr('toomanycols', str(tnames), '2')
+                raise IOErr('toomanycols', str(tnames), '2')
 
         assert(len(templates) == parvals.shape[0])
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020, 2021
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -41,7 +41,7 @@ import numpy.fft
 #       this module; is this intentional?
 from sherpa.utils._utils import hist1d, hist2d
 from sherpa.utils import _utils, _psf
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import ClobberErr
 
 from sherpa import get_config
 
@@ -4180,7 +4180,7 @@ def send_to_pager(txt, filename=None, clobber=False):
     # Assume a filename
     clobber = bool_cast(clobber)
     if os.path.isfile(filename) and not clobber:
-        raise IOErr('filefound', filename)
+        raise ClobberErr(filename)
 
     with open(filename, 'w') as fh:
         print(txt, file=fh)

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -268,9 +268,6 @@ class IOErr(SherpaErr):
     dict = {'openfailed': '%s',
             'setcolfailed': 'setting column %s has failed with %s',
             'nokeyword': "file '%s' does not have a '%s' keyword",
-            # filefound is not expected to be used directly, as the
-            # ClobberErr sub-class should be used instead.
-            'filefound': "file '%s' exists and clobber is not set",
             'filenotfound': "file '%s' not found",
             'badfile': "'%s' is not a filename or %s",
             'noarrs': 'No input array(s) found',
@@ -315,8 +312,10 @@ class ClobberErr(IOErr):
     Make it easy to identify a failure due to the clobber check.
     """
 
+    dict = {'filefound': "file '%s' exists and clobber is not set"}
+
     def __init__(self, filename):
-        IOErr.__init__(self, 'filefound', filename)
+        SherpaErr.__init__(self, ClobberErr.dict, 'filefound', filename)
 
 
 class ModelErr(SherpaErr):

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2017, 2019, 2020
+#  Copyright (C) 2010, 2016, 2017, 2019, 2020, 2021
 #      Smithsonian Astrophysical Observatory
 #
 #
@@ -25,7 +25,7 @@ Sherpa specific exceptions
 __all__ = ('EstErr', 'FitErr', 'SherpaErr', 'ArgumentErr',
            'ArgumentTypeErr', 'IdentifierErr', 'NotImplementedErr',
            'ImportErr', 'ParameterErr', 'DataErr', 'PSFErr', 'InstrumentErr',
-           'IOErr', 'ModelErr', 'PlotErr', 'StatErr', 'DS9Err',
+           'IOErr', 'ClobberErr', 'ModelErr', 'PlotErr', 'StatErr', 'DS9Err',
            'ConfidenceErr', 'SessionErr')
 
 
@@ -268,6 +268,8 @@ class IOErr(SherpaErr):
     dict = {'openfailed': '%s',
             'setcolfailed': 'setting column %s has failed with %s',
             'nokeyword': "file '%s' does not have a '%s' keyword",
+            # filefound is not expected to be used directly, as the
+            # ClobberErr sub-class should be used instead.
             'filefound': "file '%s' exists and clobber is not set",
             'filenotfound': "file '%s' not found",
             'badfile': "'%s' is not a filename or %s",
@@ -305,6 +307,16 @@ class IOErr(SherpaErr):
 
     def __init__(self, key, *args):
         SherpaErr.__init__(self, IOErr.dict, key, *args)
+
+
+class ClobberErr(IOErr):
+    """Special-case the clobber check.
+
+    Make it easy to identify a failure due to the clobber check.
+    """
+
+    def __init__(self, filename):
+        IOErr.__init__(self, 'filefound', filename)
 
 
 class ModelErr(SherpaErr):

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -160,6 +160,7 @@ class FitErr(SherpaErr):
     dict = {'statnotforbackgsub': '%s statistics cannot be used with background subtracted data',
             'binhas0': 'zeros found in uncertainties, consider using calculated uncertainties',
             'nobins': 'no noticed bins found in data set',
+            # noclobererr overlaps with ClobberErr
             'noclobererr': "'%s' exists, and clobber==False",
             'nothawedpar': 'model has no thawed parameters',
             'needchi2': '%s method requires a deviates array; use a chi-square  statistic', }


### PR DESCRIPTION
# Summary

Fix problems when `save_data` is used with `clobber=False` but the output file already exists. Fixes #1071 

# Details 

A new sub-class  of IOErr is introduced to represent the "clobber error" as this makes it easier to check for, since we can now easily check for this error with a symbol, rather than looking at the error message text, with code like

    try:
        bob()
    except ClobberErr:
        raise
    except IOErr:
        fred()

It would be Interesting to think if there's a better way to achieve this.

The coverage looks poor because I changed a bunch of lines of the form

    raise sherpa.utils.err.IOErr(..)

to

    raise IOErr(..)

(as IOErr is in scope), and there is no coverage for these lines. I've tried to add some, but not all.