### PR TITLE
Improve testing of sherpa.astro.ui.utils

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -94,12 +94,50 @@ def test_ui_ascii(setup_files):
 
 @requires_fits
 @requires_data
+def test_ui_ascii_noarg(setup_files, clean_astro_ui):
+    """Don't give a dataset id
+
+    It also lets us actually check the results of the load_table call
+    """
+    assert ui.list_data_ids() == []
+    ui.load_ascii(setup_files.ascii)
+    assert ui.list_data_ids() == [1]
+
+    d = ui.get_data()
+    assert d.name.endswith('sim.poisson.1.dat')
+    assert isinstance(d, ui.Data1D)
+    assert len(d.x) == 50
+    assert d.x[0:5] == pytest.approx([0.5, 1, 1.5, 2, 2.5])
+    assert d.y[0:5] == pytest.approx([27, 27, 20, 28, 27])
+
+
+@requires_fits
+@requires_data
 def test_ui_table(setup_files):
     ui.load_table(1, setup_files.fits)
     ui.load_table(1, setup_files.fits, 3)
     ui.load_table(1, setup_files.fits, 3, ["RMID", "SUR_BRI", "SUR_BRI_ERR"])
     ui.load_table(1, setup_files.fits, 4, ('R', "SUR_BRI", 'SUR_BRI_ERR'),
                   ui.Data1DInt)
+
+
+@requires_fits
+@requires_data
+def test_ui_table_noarg(setup_files, clean_astro_ui):
+    """Don't give a dataset id
+
+    It also lets us actually check the results of the load_table call
+    """
+    assert ui.list_data_ids() == []
+    ui.load_table(setup_files.fits, colkeys=['RMID', 'COUNTS'])
+    assert ui.list_data_ids() == [1]
+
+    d = ui.get_data()
+    assert d.name.endswith('1838_rprofile_rmid.fits')
+    assert isinstance(d, ui.Data1D)
+    assert len(d.x) == 38
+    assert d.x[0:5] == pytest.approx([12.5, 17.5, 22.5, 27.5, 32.5])
+    assert d.y[0:5] == pytest.approx([1529, 2014, 2385, 2158, 2013])
 
 
 def test_dataspace1d_data1dint(clean_astro_ui):
@@ -298,6 +336,16 @@ def test_ui_filter_ascii(setup_files):
     ui.load_filter(setup_files.filter_single_int_ascii, ignore=True)
 
 
+@requires_fits
+@requires_data
+def test_ui_filter_ascii_with_id(setup_files):
+    ui.load_filter(1, setup_files.filter_single_int_ascii)
+    assert ui.list_data_ids() == [1]
+
+    f = ui.get_filter()
+    assert f == '2.0000,4.0000,6.0000,8.0000,10.0000:250.0000,751.0000:1000.0000'
+
+
 # Test load_filter
 @requires_fits
 @requires_data
@@ -414,6 +462,22 @@ def test_image_12578_set_coord_bad_coord(make_data_path, clean_astro_ui):
     okmsg = "unknown coordinates: 'sky'\nValid options: " + \
             "logical, image, physical, world, wcs"
     assert okmsg in str(exc.value)
+
+
+@requires_data
+@requires_fits
+def test_image_with_id(make_data_path, clean_astro_ui):
+    """Call load_image with an identifier"""
+
+    img = make_data_path('img.fits')
+
+    assert ui.list_data_ids() == []
+    ui.load_image('ix', img)
+    assert ui.list_data_ids() == ['ix']
+
+    d = ui.get_data('ix')
+    assert isinstance(d, ui.DataIMG)
+    assert d.name.endswith('img.fits')
 
 
 # DJB notes (2020/02/29) that these tests used to not be run,

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -776,7 +776,7 @@ def test_save_pha(tmp_path):
 def test_save_model_ascii(savefunc, mtype, clean_astro_ui, tmp_path):
     """Can we write out data for save_source/model? Data1D and ASCII
 
-    As this is not a PHA dataset, the two shouldbe the same bar the
+    As this is not a PHA dataset, the two should be the same bar the
     header line.
     """
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -390,6 +390,31 @@ def test_save_delchi_image_fails(tmp_path):
     assert str(exc.value) == 'save_delchi() does not apply for images'
 
 
+def check_clobber(outpath, func):
+    """Does calling func raise a clobber error and not change the contents
+
+    Parameters
+    ----------
+    outpath : pathlib.Path instance
+    func : function reference
+        Called with a single string argument.
+    """
+
+    old = outpath.read_text()
+
+    # check it clobbers
+    with pytest.raises(IOErr) as exc:
+        func(str(outpath))
+
+    emsg = str(exc.value)
+    assert emsg.startswith("file '")
+    assert emsg.endswith("' exists and clobber is not set")
+
+    # Check the file hasn't changed
+    new = outpath.read_text()
+    assert new == old
+
+
 @pytest.mark.xfail(reason='fall through does not work')
 def test_save_data_data1d_no_clobber(tmp_path):
     """save_data: does clobber=False work? Data1D"""
@@ -400,14 +425,7 @@ def test_save_data_data1d_no_clobber(tmp_path):
     outfile = str(out)
 
     out.write_text('some text')
-
-    # check it clobbers
-    with pytest.raises(IOErr) as exc:
-        ui.save_data(outfile)
-
-    emsg = str(exc.value)
-    assert emsg.startswith("file '")
-    assert emsg.endswith("' exists and clobber is not set")
+    check_clobber(out, ui.save_data)
 
 
 @pytest.mark.xfail(reason='fall through does not work')
@@ -428,17 +446,9 @@ def test_save_data_datapha_no_clobber(tmp_path):
     ui.get_data().header = hdr
 
     out = tmp_path / "data.dat"
-    outfile = str(out)
 
     out.write_text('some text')
-
-    # check it clobbers
-    with pytest.raises(IOErr) as exc:
-        ui.save_data(outfile)
-
-    emsg = str(exc.value)
-    assert emsg.startswith("file '")
-    assert emsg.endswith("' exists and clobber is not set")
+    check_clobber(out, ui.save_data)
 
 
 @pytest.mark.xfail(reason='fall through does not work')
@@ -459,17 +469,9 @@ def test_save_pha_no_clobber(tmp_path):
     ui.get_data().header = hdr
 
     out = tmp_path / "data.dat"
-    outfile = str(out)
 
     out.write_text('some text')
-
-    # check it clobbers
-    with pytest.raises(IOErr) as exc:
-        ui.save_data(outfile)
-
-    emsg = str(exc.value)
-    assert emsg.startswith("file '")
-    assert emsg.endswith("' exists and clobber is not set")
+    check_clobber(out, ui.save_data)
 
 
 def check_output(out, colnames, rows):

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -70,7 +70,7 @@ def test_fake_pha_missing_rmf(id, clean_astro_ui, tmp_path):
 
 @pytest.mark.parametrize("id", [None, 1, "faked"])
 def test_fake_pha_missing_arf(id, clean_astro_ui, tmp_path):
-    """Check we error out if RMF is not valid."""
+    """Check we error out if ARF is not valid."""
 
     channels = np.arange(1, 4, dtype=np.int16)
     counts = np.ones(3, dtype=np.int16)
@@ -280,4 +280,4 @@ def test_fake_pha_no_data(id, clean_astro_ui):
     # is summing the counts (to average over the randomness)
     # and then a simple check
     #
-    assert faked.counts.sum() > 200
+    assert (faked.counts.sum() > 200) and (faked.counts.sum() < 10000)

--- a/sherpa/astro/ui/tests/test_eqwidth_err.py
+++ b/sherpa/astro/ui/tests/test_eqwidth_err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2018, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,12 +17,13 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
-import numpy
+import numpy as np
 
-from pytest import approx
+import pytest
 
 from sherpa.astro import ui
+from sherpa.utils.err import IOErr, SessionErr
+from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
 
 
 @requires_data
@@ -31,9 +32,9 @@ from sherpa.astro import ui
 def test_eqwith_err(make_data_path, restore_xspec_settings):
 
     def check(a0, a1, a2):
-        assert a0 == approx(0.16443033244310976, rel=1e-3)
-        assert a1 == approx(0.09205564216156815, rel=1e-3)
-        assert a2 == approx(0.23933118287470895, rel=1e-3)
+        assert a0 == pytest.approx(0.16443033244310976, rel=1e-3)
+        assert a1 == pytest.approx(0.09205564216156815, rel=1e-3)
+        assert a2 == pytest.approx(0.23933118287470895, rel=1e-3)
 
     ui.set_method('neldermead')
     ui.set_stat('cstat')
@@ -55,21 +56,21 @@ def test_eqwith_err(make_data_path, restore_xspec_settings):
 
     ui.fit()
 
-    numpy.random.seed(12345)
+    np.random.seed(12345)
     result = ui.eqwidth(p1, p1 + g1, error=True, niter=100)
     check(result[0], result[1], result[2])
     params = result[3]
 
-    numpy.random.seed(12345)
+    np.random.seed(12345)
     result = ui.eqwidth(p1, p1 + g1, error=True, params=params, niter=100)
     check(result[0], result[1], result[2])
 
     parvals = ui.get_fit_results().parvals
-    assert parvals[0] == approx(0.6111340686157877, rel=1.0e-3)
-    assert parvals[1] == approx(1.6409785803466297, rel=1.0e-3)
-    assert parvals[2] == approx(8.960926761312153e-05, rel=1.0e-3)
-    assert parvals[3] == approx(6.620017726014523, rel=1.0e-3)
-    assert parvals[4] == approx(1.9279114810359657e-06, rel=1.0e-3)
+    assert parvals[0] == pytest.approx(0.6111340686157877, rel=1.0e-3)
+    assert parvals[1] == pytest.approx(1.6409785803466297, rel=1.0e-3)
+    assert parvals[2] == pytest.approx(8.960926761312153e-05, rel=1.0e-3)
+    assert parvals[3] == pytest.approx(6.620017726014523, rel=1.0e-3)
+    assert parvals[4] == pytest.approx(1.9279114810359657e-06, rel=1.0e-3)
 
 
 @requires_data
@@ -78,9 +79,9 @@ def test_eqwith_err(make_data_path, restore_xspec_settings):
 def test_eqwith_err1(make_data_path, restore_xspec_settings):
 
     def check1(e0, e1, e2):
-        assert e0 == approx(0.028335201547206704, rel=1.0e-3)
-        assert e1 == approx(-0.00744118799274448756, rel=1.0e-3)
-        assert e2 == approx(0.0706249544851336, rel=1.0e-3)
+        assert e0 == pytest.approx(0.028335201547206704, rel=1.0e-3)
+        assert e1 == pytest.approx(-0.00744118799274448756, rel=1.0e-3)
+        assert e2 == pytest.approx(0.0706249544851336, rel=1.0e-3)
 
     ui.set_xsabund('angr')
     ui.set_xsxsect('bcmc')
@@ -95,16 +96,131 @@ def test_eqwith_err1(make_data_path, restore_xspec_settings):
     ui.freeze(g1.pos, g1.fwhm)
     ui.fit()
 
-    numpy.random.seed(2345)
+    np.random.seed(2345)
     e = ui.eqwidth(p1, p1 + g1, error=True, niter=100)
     check1(e[0], e[1], e[2])
     params = e[3]
 
-    numpy.random.seed(2345)
+    np.random.seed(2345)
     e = ui.eqwidth(p1, p1 + g1, error=True, params=params, niter=100)
     check1(e[0], e[1], e[2])
 
     parvals = ui.get_fit_results().parvals
-    assert parvals[0] == approx(1.9055272902160334, rel=1.0e-3)
-    assert parvals[1] == approx(0.00017387966749772638, rel=1.0e-3)
-    assert parvals[2] == approx(1.279415076070516e-05, rel=1.0e-3)
+    assert parvals[0] == pytest.approx(1.9055272902160334, rel=1.0e-3)
+    assert parvals[1] == pytest.approx(0.00017387966749772638, rel=1.0e-3)
+    assert parvals[2] == pytest.approx(1.279415076070516e-05, rel=1.0e-3)
+
+
+def test_eqwidth_err_needs_fit(clean_astro_ui):
+    """We get an error if fit has not been called"""
+
+    ui.load_arrays(2, [1, 5], [1, 12], ui.Data1D)
+
+    cmdl = ui.const1d.cmdl
+    pmdl = ui.polynom1d.pmdl
+    cmdl.c0 = 1.5
+    pmdl.c0 = -5
+    pmdl.c1 = 2
+    ui.set_source(2, cmdl + pmdl)
+
+    with pytest.raises(SessionErr) as exc:
+        ui.eqwidth(cmdl, cmdl + pmdl, id=2, error=True)
+
+    assert str(exc.value) == 'no fit has been performed'
+
+
+@pytest.mark.parametrize('arg', ['params', 'covar_matrix'])
+def test_eqwidth_err_arg_is_numpy(arg, clean_astro_ui):
+    """Ensure argument is a NumPy argument."""
+
+    ui.load_arrays('bob', [1, 5], [1, 12], ui.Data1D)
+
+    cmdl = ui.const1d.cmdl
+    pmdl = ui.polynom1d.pmdl
+    cmdl.c0 = 1.5
+    pmdl.c0 = -5
+    pmdl.c1 = 2
+    ui.set_source('bob', cmdl + pmdl)
+
+    ui.fit('bob')
+
+    arglist = {'id': 'bob', 'error': True, 'niter': 100, arg: 2.3}
+
+    with pytest.raises(IOErr) as exc:
+        ui.eqwidth(cmdl, cmdl + pmdl, **arglist)
+
+    assert str(exc.value) == f'{arg} must be of type numpy.ndarray'
+
+
+@pytest.mark.parametrize('arg', ['params', 'covar_matrix'])
+def test_eqwidth_err_arg_is_2d(arg, clean_astro_ui):
+    """Ensure argument is a 2D array."""
+
+    ui.load_arrays('bob', [1, 5], [1, 12], ui.Data1D)
+
+    cmdl = ui.const1d.cmdl
+    pmdl = ui.polynom1d.pmdl
+    cmdl.c0 = 1.5
+    pmdl.c0 = -5
+    pmdl.c1 = 2
+    ui.set_source('bob', cmdl + pmdl)
+
+    ui.fit('bob')
+
+    arglist = {'id': 'bob', 'error': True, 'niter': 100,
+               arg: np.arange(3)}
+
+    with pytest.raises(IOErr) as exc:
+        ui.eqwidth(cmdl, cmdl + pmdl, **arglist)
+
+    assert str(exc.value) == f'{arg} must be 2d numpy.ndarray'
+
+
+@pytest.mark.parametrize('arg', ['params', 'covar_matrix'])
+def test_eqwidth_err_arg_size(arg, clean_astro_ui):
+    """Ensure argument is the correct size."""
+
+    ui.load_arrays('bob', [1, 5], [1, 12], ui.Data1D)
+
+    cmdl = ui.const1d.cmdl
+    pmdl = ui.polynom1d.pmdl
+    cmdl.c0 = 1.5
+    pmdl.c0 = -5
+    pmdl.c1 = 2
+    ui.set_source('bob', cmdl + pmdl)
+
+    ui.fit('bob')
+
+    arglist = {'id': 'bob', 'error': True, 'niter': 100,
+               arg: np.arange(12).reshape(3, 4)}
+
+    with pytest.raises(IOErr) as exc:
+        ui.eqwidth(cmdl, cmdl + pmdl, **arglist)
+
+    assert str(exc.value) == f'{arg} must be of dimension (2, x)'
+
+
+def test_eqwidth_err_arg_square(clean_astro_ui):
+    """Ensure argument is square.
+
+    It looks like this is only checked for with covar_matrix argument
+    """
+
+    ui.load_arrays('bob', [1, 5], [1, 12], ui.Data1D)
+
+    cmdl = ui.const1d.cmdl
+    pmdl = ui.polynom1d.pmdl
+    cmdl.c0 = 1.5
+    pmdl.c0 = -5
+    pmdl.c1 = 2
+    ui.set_source('bob', cmdl + pmdl)
+
+    ui.fit('bob')
+
+    arglist = {'id': 'bob', 'error': True, 'niter': 100,
+               'covar_matrix': np.arange(12).reshape(2, 6)}
+
+    with pytest.raises(IOErr) as exc:
+        ui.eqwidth(cmdl, cmdl + pmdl, **arglist)
+
+    assert str(exc.value) == 'covar_matrix must be of dimension (2, 2)'

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2018, 2019, 2020
+#  Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021
 #                Smithsonian Astrophysical Observatory
 #
 #
@@ -19,7 +19,6 @@
 #
 
 import os
-import sys
 import re
 import logging
 
@@ -27,7 +26,6 @@ import pytest
 
 import numpy as np
 from numpy import VisibleDeprecationWarning
-import numpy as np
 
 from sherpa.utils.testing import SherpaTestCase
 
@@ -165,6 +163,11 @@ python3_warnings = {
             # added for sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
             r"unclosed file .*/dev/null.* closefd=True>",
             r"unclosed file .*table.txt.* closefd=True>",
+            # tests in sherpa/astro/ui/tests/test_astro_ui_unit.py
+            # seen in some macOS test runs (e.g. pip, not conda) and python 3.8
+            r"unclosed file .*/data.dat'.* closefd=True>",
+            r"unclosed file .*/model.dat'.* closefd=True>",
+            r"unclosed file .*/resid.out'.* closefd=True>",
         ],
     RuntimeWarning:
         [r"invalid value encountered in sqrt",
@@ -507,9 +510,9 @@ def reset_seed(request):
 def hide_logging():
     """Set Sherpa's logging to ERROR for the test.
 
-    This code is somehwat redundant with the decorator 
+    This code is somehwat redundant with the decorator
     in utils/logging:SherpaVerbosity and, should this
-    fixture ever need to be redone, it might be worth 
+    fixture ever need to be redone, it might be worth
     investigating if the same decorator can be used.
     """
 

--- a/sherpa/sim/tests/test_asymmetric.py
+++ b/sherpa/sim/tests/test_asymmetric.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -129,6 +129,18 @@ def test_load_ascii(filename, delta, make_data_path):
     infile = make_data_path(filename)
     ui.load_ascii_with_errors(1, infile, delta=delta)
     data = ui.get_data(1)
+    fit_asymmetric_err(RESULTS_BENCH_AVG, data)
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("filename, delta", [('gro.txt', False),
+                                             ('gro_delta.txt', True)])
+def test_load_ascii_defaultid(filename, delta, make_data_path):
+    """Use the default id"""
+    infile = make_data_path(filename)
+    ui.load_ascii_with_errors(infile, delta=delta)
+    data = ui.get_data()
     fit_asymmetric_err(RESULTS_BENCH_AVG, data)
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-pytest>=3.3,!=5.2.3
+pytest>=3.9,!=5.2.3
 pytest-xvfb


### PR DESCRIPTION
# Summary

Improve coverage of the sherpa.astro.ui.utils and require pytest 3.9.0 or later for testing Sherpa.

# Details

There is no functional change in this PR, just test additions. The addition of tests was primarily based on noting what areas of code that weren't being covered and by running tests with exceptions added to code paths to ensure they were being run. I have attempted to be systematic, but there are many routines and so not all cases are caught, but this is an improvement over the status quo.

The aim is to cover code identified by pylint, so that later PRs can just apply those changes and now we already have tests (e.g. #1062). I wanted to make sure we have the tests in first.

# Note

This PR bumps the minimum pytest version to 3.9.0 (we previously had it at 3.3) so that we can use the `tmp_path` fixture (an improvement over the existing `tmpdir` fixture). This was released late 2018, and there have been many pytest releases since, so I do not see this as a problem (the GitHub Actions runs all work).