### PR TITLE
Add a CI run using the released CIAO

### DIFF
--- a/.github/scripts/setup_conda_ciao.sh
+++ b/.github/scripts/setup_conda_ciao.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash -e
+#
+
+# edit the setup.cfg file; break up into a lot of separate commands!
+CFG=setup.cfg
+sed -i -e 's|#disable-|disable-|' ${CFG}
+sed -i -e 's|#fftw=local|fftw=local|' ${CFG}
+sed -i -e 's|#fftw-include_dirs=build/include|fftw-include_dirs='${ASCDS_LIB}'/../include|' ${CFG}
+sed -i -e 's|#fftw-lib-dirs=build/lib|fftw-lib-dirs='${ASCDS_LIB}'|' ${CFG}
+sed -i -e 's|#fftw-libraries=fftw3|fftw-libraries=fftw3|' ${CFG}
+
+sed -i -e 's|#region=local|region=local|' ${CFG}
+sed -i -e 's|#region-include_dirs=build/include|region-include_dirs='${ASCDS_LIB}'/../include|' ${CFG}
+sed -i -e 's|#region-lib-dirs=build/lib|region-lib-dirs='${ASCDS_LIB}'|' ${CFG}
+sed -i -e 's|#region-libraries=region|region-libraries=region ascdm|' ${CFG}
+
+sed -i -e 's|#wcs=local|wcs=local|' ${CFG}
+sed -i -e 's|#wcs-include_dirs=build/include|wcs-include_dirs='${ASCDS_LIB}'/../include|' ${CFG}
+sed -i -e 's|#wcs-lib-dirs=build/lib|wcs-lib-dirs='${ASCDS_LIB}'|' ${CFG}
+sed -i -e 's|#wcs-libraries=wcs|wcs-libraries=wcs|' ${CFG}
+
+sed -i -e 's|#with-xspec=True|with-xspec=True|' ${CFG}
+sed -i -e 's|#xspec_version = 12.9.0|xspec_version = 12.10.1|' ${CFG}
+sed -i -e 's|#xspec_lib_dirs = None|xspec_lib_dirs = '${ASCDS_LIB}'|' ${CFG}
+sed -i -e 's|#xspec_include_dirs = None|xspec_include_dirs = '${ASCDS_LIB}'/../include|' ${CFG}
+
+# Show the differences
+git diff ${CFG}

--- a/.github/scripts/test_ciao.sh
+++ b/.github/scripts/test_ciao.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash -e
+
+# We need to set up a Sherpa configuration file which uses the crates I/O
+# backend.
+#
+cp sherpa/sherpa.rc $HOME/.sherpa-standalone.rc
+
+echo "Sherpa is using the configuration file:"
+python -c 'import sherpa; print(sherpa.get_config());'
+
+pytest --cov sherpa --cov-report term || exit 1
+codecov
+
+# Run smoke test
+cd $HOME
+sherpa_smoke -x -d -f pycrates || exit 1

--- a/.github/workflows/ci-conda-ciao-workflow.yml
+++ b/.github/workflows/ci-conda-ciao-workflow.yml
@@ -1,0 +1,59 @@
+name: Conda+CIAO CI
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Linux (Python 3.8)
+            os: ubuntu-latest 
+            python-version: 3.8
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        submodules: 'True'
+
+    - name: Cache conda
+      uses: actions/cache@v2
+      env:
+        # Increase this value to reset cache if the hashed file has not changed
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('etc/ciao-environment.yml') }}
+
+    - name: Setup Conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: build
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        use-only-tar-bz2: true
+        environment-file: etc/ciao-environment.yml
+
+    - name: Configure the Sherpa build
+      env:
+        PYTHONVER: ${{ matrix.python-version }}
+      run: |
+        source .github/scripts/setup_conda_ciao.sh
+
+    - name: Build Sherpa
+      env:
+        PYTHON_LDFLAGS: " " 
+      run: |
+        pip install -e .
+
+    - name: Tests
+      run: |
+        source .github/scripts/test_ciao.sh

--- a/etc/ciao-environment.yml
+++ b/etc/ciao-environment.yml
@@ -1,0 +1,21 @@
+channels:
+  - https://cxc.cfa.harvard.edu/conda/ciao
+  - defaults
+dependencies:
+  - python=3.8
+  - ciao
+  - ds9
+  - gcc_linux-64
+  - gxx_linux-64
+  - gfortran_linux-64
+  - libgfortran-ng
+  - matplotlib
+  - numpy
+  - pip
+  - xpa
+  - xspec-modelsonly
+  - pip:
+    - pytest
+    - pytest-cov
+    - pytest-xvfb
+    - codecov


### PR DESCRIPTION
I've closed this and replaced it by #1378 - I'll leave the branch as is, rather than deleting it, in case it contains useful nuggets.

# Summary

Add a GitHub Action to build Sherpa against the released version of CIAO - including XSPEC and DS9 - and run tests. It is limited to Python 3.8, Linux at this time.

# Details

Use the Linux Python 3.8 conda build of CIAO to build and test Sherpa. This is an experiment, so all support for macOS has been removed, and we don't need to test out various options and package versions like we do with the existing CI runs.

We also try and build with a "more modern" setup, at least as much as our current setup.py will let us. For instance, an environment file is used to define the conda environment, but it is "restricted", since we do not list all needed packages, nor do we add versions.

The conda setup is meant to be cached. We really should also cache the pip installation to, but that is significantly smaller
(and quicker to download). I have not tried the conda cache on the existing conda workflow.

The following is left-over from an earlier version of this PR, which also updated the existing workflows to use the new miniconda setup; this has been moved to #1099

The rework of the existing conda workflow has moved the conda configuration to etc/environment-<platform>.yml files to simplify the download (we try to have everything in one place). There are actually issues with the conda workflow (not really from this PR)

 - I've had to rely on the conda pytest packages rather than use pip, as there were problems when mixing the two
 - I've tried really hard to move to a more-modern build setup (build with pip, test with pytest) but this just kept on failing for a number of reasons and I've decided (having tried this before) that we need to fix this issue separately
 - the existing case of install-type=install and test=submodule is problematic, since the test run (which uses setuptools) actually ends up re-building the code (because it needs a develop build). So we should review changing these to install-type=develop or improving the build

# Note 1

It's not obvious to me that the cache is working. 

- we start with https://github.com/sherpa/sherpa/pull/1067/checks?check_run_id=1745703284 which ran successfully and the cache code (at the start) talks about the token Linux-conda-0-70482747ec13967fcc01802d074e79d2740bb2e57ec75dff78f6426f256542b9
- we now have the run for this PR, which should be "identical": https://github.com/sherpa/sherpa/pull/1069/checks?check_run_id=1745886765 and it also notes that there's no cache for key Linux-conda-0-70482747ec13967fcc01802d074e79d2740bb2e57ec75dff78f6426f256542b9 - which is the same key (which it should be, by construction)
- So why is there no associated cache?

Hmm, later builds do seem to use the cache - e.g. in one of the runs I now see

Cache Size: ~2128 MB (2231173644 B)
/bin/tar -xz -f /home/runner/work/_temp/6de33b34-0148-4522-b718-cdae12edb213/cache.tgz -C /home/runner/conda_pkgs_dir
Cache restored from key: Linux-conda-0-70482747ec13967fcc01802d074e79d2740bb2e57ec75dff78f6426f256542b9 

# Note 2

By using conda we artificially inflate the conda download stats. We *could* set up a separate channel which contains CIAO but is intended only for testing (e.g. doesn't have all platforms/python versions, may miss some packages we can live without, ...).

# Note 3

It would be great to have a forward-looking build using the latest development code, but that's out-of-scope for this PR...

# Note 4

What is in scope is thinking about what happens when we get to the end of the CIAO development cycle, and using the released CIAO version would not work because of updates/fixes/... to the code means the tests using the released code would fail. We can temporarily disable these tests (I would hope), but is there a better way?

# Note 5

I believe the large increase in coverage is from two parts

- the crates_backend module is now exercised
- the use of pytest to run the tests for a "fulll" build means more "top-level" lines get reported as covered then you get from using `python setup.py test` because of some-reason-with-when-the-tracing-gets-injected-into-the-code

which is why the `regrid` modue sees an almost 9% boost - you can see from https://codecov.io/gh/sherpa/sherpa/compare/6cbbb07a2918eea951af1e50b2ea598a9b33bc56...f5b74f4a869f0b9f43948ab4fb57dd37b79359eb/src/sherpa/models/regrid.py that the increase is down to function definition lines being counted that weren't before. Not really relevant, but I've long tried to track down differences between the coverage reports we were getting here and those I was running, and I think I understand now.