### PR TITLE
Update load_data to match load_pha for PHA2 data

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_supports_pha2.py
+++ b/sherpa/astro/ui/tests/test_astro_supports_pha2.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -110,12 +110,13 @@ def validate_pha(d, bkg=True):
 
 @requires_data
 @requires_fits
+@pytest.mark.parametrize("loader", [ui.load_pha, ui.load_data])
 @pytest.mark.parametrize("id0,ids",
                          [(None, [1,2,3,4,5,6,7,8,9,10,11,12]),
                           (1, [1,2,3,4,5,6,7,8,9,10,11,12]),
                           (100, [100,101,102,103,104,105,106,107,108,109,110,111]),
                           ("x", ["x1","x2","x3","x4","x5","x6","x7","x8","x9","x10","x11","x12"])])
-def test_load_pha2(id0, ids, make_data_path, caplog, clean_astro_ui):
+def test_load_pha2(loader, id0, ids, make_data_path, caplog, clean_astro_ui):
     """Basic test that a pha2 file can be read in."""
 
     basename = '3c120_pha2'
@@ -126,9 +127,9 @@ def test_load_pha2(id0, ids, make_data_path, caplog, clean_astro_ui):
     # The file is stored gzip-encoded
     infile = make_data_path(basename)
     if id0 is None:
-        ui.load_pha(infile)
+        loader(infile)
     else:
-        ui.load_pha(id0, infile)
+        loader(id0, infile)
 
     pha_ids = ui.list_data_ids()
     assert len(pha_ids) == 12


### PR DESCRIPTION
# Summary

Ensure that `load_data` behaves like `load_pha` when given a PHA2 dataset.

# Details

I hadn't realized when writing #856 that the `load_data` call could be used to load in PHA2 data. This rectifies this (and ensures the same logic is used by both functions).

# Example

With CIAO 4.13 we have the following, where the id argument to `load_data` is unused for PHA2 data.

```
sherpa In [1]: load_pha('x', '3c120_pha2')
WARNING: systematic errors were not found in file '3c120_pha2'
statistical errors were found in file '3c120_pha2'
but not used; to use them, re-read with use_errors=True
read background_up into a dataset from file 3c120_pha2
read background_down into a dataset from file 3c120_pha2
Multiple data sets have been input: x1-x12

sherpa In [2]: load_data('x', '3c120_pha2')
WARNING: systematic errors were not found in file '3c120_pha2'
statistical errors were found in file '3c120_pha2'
but not used; to use them, re-read with use_errors=True
read background_up into a dataset from file 3c120_pha2
read background_down into a dataset from file 3c120_pha2
Multiple data sets have been input: 1-12
```

With this PR this becomes (note that the id's are now x1 to x12 rather than 1 to 12):

```
In [3]: load_data('x', 'sherpa-test-data/sherpatest/3c120_pha2')
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c120_pha2'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c120_pha2'
but not used; to use them, re-read with use_errors=True
read background_up into a dataset from file sherpa-test-data/sherpatest/3c120_pha2
read background_down into a dataset from file sherpa-test-data/sherpatest/3c120_pha2
Multiple data sets have been input: x1-x12
```