### PR TITLE
Allow fake_pha to be called with an identifier of None

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -30,10 +30,6 @@ from sherpa.astro import ui
 from sherpa.utils.err import DataErr,IOErr
 
 
-def xfail(arg):
-    return pytest.param(arg, marks=pytest.mark.xfail)
-
-
 @pytest.mark.parametrize("id", [None, 1, "faked"])
 def test_fake_pha_no_rmf(id, clean_astro_ui):
     """Check we error out if RMF is None."""
@@ -48,6 +44,7 @@ def test_fake_pha_no_rmf(id, clean_astro_ui):
     with pytest.raises(DataErr) as exc:
         ui.fake_pha(id, arf=None, rmf=None, exposure=1000.0)
 
+    id = 1 if id is None else id
     emsg = f'An RMF has not been found or supplied for data set {id}'
     assert str(exc.value) == emsg
 
@@ -90,7 +87,7 @@ def test_fake_pha_missing_arf(id, clean_astro_ui, tmp_path):
     assert str(exc.value) == f"file '{arf}' not found"
 
 
-@pytest.mark.parametrize("id", [xfail(None), 1, "faked"])
+@pytest.mark.parametrize("id", [None, 1, "faked"])
 def test_fake_pha_incompatible_rmf(id, clean_astro_ui):
     """Check we error out if RMF is wrong size."""
 
@@ -157,7 +154,7 @@ def test_fake_pha_basic(id, has_bkg, clean_astro_ui):
     assert faked.get_arf().name == 'test-arf'
     assert faked.get_rmf().name == 'delta-rmf'
 
-    if has_bkg and id is not None:
+    if has_bkg:
         assert faked.background_ids == ['faked-bkg']
         bkg = ui.get_bkg(id, 'faked-bkg')
         assert bkg.name == 'bkg'

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8630,18 +8630,23 @@ class Session(sherpa.ui.utils.Session):
         time, along with a Poisson noise term. A background component can
         be included.
 
+        .. versionchanged:: 4.13.1
+           Using an id parameter of None now means that the default
+           dataset identifier is used, rather than creating a
+           completely new dataset.
+
         Parameters
         ----------
         id : int or str
-           The identifier for the data set to create. If it
-           already exists then it is assumed to contain a PHA
-           data set and the counts will be over-written.
+           The identifier for the data set to create. If it already
+           exists then it is assumed to contain a PHA data set and the
+           counts will be over-written.
         arf : filename or ARF object
-           The name of the ARF, or an ARF data object (e.g.
-           as returned by `get_arf` or `unpack_arf`).
+           The name of the ARF, or an ARF data object (e.g.  as
+           returned by `get_arf` or `unpack_arf`).
         rmf : filename or RMF object
-           The name of the RMF, or an RMF data object (e.g.
-           as returned by `get_arf` or `unpack_arf`).
+           The name of the RMF, or an RMF data object (e.g.  as
+           returned by `get_arf` or `unpack_arf`).
         exposure : number
            The exposure time, in seconds.
         backscal : number, optional
@@ -8651,9 +8656,9 @@ class Session(sherpa.ui.utils.Session):
         grouping : array, optional
            The grouping array for the data (see `set_grouping`).
         grouped : bool, optional
-           Should the simulated data be grouped (see `group`)?
-           The default is ``False``. This value is only used if
-           the `grouping` parameter is set.
+           Should the simulated data be grouped (see `group`)?  The
+           default is ``False``. This value is only used if the
+           `grouping` parameter is set.
         quality : array, optional
            The quality array for the data (see `set_quality`).
         bkg : optional
@@ -8692,8 +8697,8 @@ class Session(sherpa.ui.utils.Session):
 
         Examples
         --------
-        Estimate the signal from a 5000 second observation using
-        the ARF and RMF from "src.arf" and "src.rmf" respectively:
+        Estimate the signal from a 5000 second observation using the
+        ARF and RMF from "src.arf" and "src.rmf" respectively:
 
         >>> set_source(1, xsphabs.gal * xsapec.clus)
         >>> gal.nh = 0.12
@@ -8723,6 +8728,7 @@ class Session(sherpa.ui.utils.Session):
         >>> save_pha('sim', 'sim.pi')
 
         """
+        id = self._fix_id(id)
         d = sherpa.astro.data.DataPHA('', None, None)
         if id in self._data:
             d = self._get_pha_data(id)


### PR DESCRIPTION
# Summary

The fake_pha command now treats id=None as the default id. This addresses #1064.

# Details

Shown in the examples is a minor improvement to the error message (reporting `1` rather than `None`). There are also other subtle issues which could arise: for example if dataset 1 has a background then calling `fake_pha(1,..)` would recognize the background whereas `fake_pha(None, ...)` would ignore the background.

I don't expect users to be calling `fake_pha` with `id=None`, but we may as well follow other routines. An alternative would be to require the `id` parameter to be specified, but that seems prescriptive.

# Example

An example of the error case: with CIAO 4.13 we get

```
sherpa In [4]: fake_pha(None, None, None, 100)
DataErr: An RMF has not been found or supplied for data set None
```

and with this PR (which has different logging hence sees more of the traceback):

```
In [4]: fake_pha(None, None, None, 100)
---------------------------------------------------------------------------
DataErr                                   Traceback (most recent call last)
<ipython-input-4-954b24257789> in <module>
----> 1 fake_pha(None, None, None, 100)

<string> in fake_pha(id, arf, rmf, exposure, backscal, areascal, grouping, grouped, quality, bkg)

~/sherpa/sherpa-play/sherpa/astro/ui/utils.py in fake_pha(self, id, arf, rmf, exposure, backscal, areascal, grouping, grouped, quality, bkg)
   8690
   8691         if rmf is None:
-> 8692             raise DataErr('normffake', id)
   8693
   8694         if type(rmf) in (str, numpy.string_):

DataErr: An RMF has not been found or supplied for data set 1
```