### PR TITLE
Add error checking for exceptional cases for sample_flux

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -578,19 +578,11 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
             session.set_full_model(id, orig_model)
             mystat.append(session.calc_stat(id))
             #####################################
-        oflxiflx = [oflx, iflx]
 
-        myconfidence = (1.0 - confidence / 100.0) / 2.0
+        hwidth = confidence / 2
         result = []
-
-        for x in oflxiflx:
-            sf = numpy.sort(x)
-            median = numpy.median(sf)
-            upconfidence_index = int((1.0 - myconfidence) * size - 1)
-            loconfidence_index = int(myconfidence * size - 1)
-            upconfidence = sf[upconfidence_index]
-            loconfidence = sf[loconfidence_index]
-            result.append(numpy.array([median, upconfidence, loconfidence]))
+        for x in [oflx, iflx]:
+            result.append(numpy.percentile(x, [50, 50 + hwidth, 50 - hwidth]))
 
         for lbl, arg in zip(['original model', 'model component'], result):
             med, usig, lsig = arg

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -530,19 +530,14 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
                      confidence):
 
     def simulated_pars_within_ranges(mysamples, mysoftmins, mysoftmaxs):
-        num = len(mysoftmins)
-        for ii in range(num):
-            ii1 = ii + 1
-            tmp = (mysamples[:, ii1] > mysoftmins[ii])
-            selpmasym = mysamples[tmp]
-            tmp = (selpmasym[:, ii1] < mysoftmaxs[ii])
-            mysamples = selpmasym[tmp]
+
+        for i, (pmin, pmax) in enumerate(zip(mysoftmins, mysoftmaxs), 1):
+            parvals = mysamples[:, i]
+            tmp = (parvals > pmin) & (parvals < pmax)
+            mysamples = mysamples[tmp]
+
         return mysamples
 
-    def print_sample_result(title, arg):
-
-        print('%s = %g, + %g, - %g' % (title, arg[0], arg[1] - arg[0],
-                                       arg[0] - arg[2]))
     #
     # For later restoration
     #
@@ -550,7 +545,6 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
     orig_model_vals = fit.model.thawedpars
 
     orig_source = session.get_source(id)
-    orig_source_vals = orig_source.thawedpars
 
     logger = logging.getLogger("sherpa")
     orig_log_level = logger.level
@@ -598,8 +592,10 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
             loconfidence = sf[loconfidence_index]
             result.append(numpy.array([median, upconfidence, loconfidence]))
 
-        print_sample_result('original model flux', result[0])
-        print_sample_result('model component flux', result[1])
+        for lbl, arg in zip(['original model', 'model component'], result):
+            med, usig, lsig = arg
+            msg = '{} flux = {:g}, + {:g}, - {:g}'.format(lbl, med, usig - med, med - lsig)
+            print(msg)
 
         sampletmp = numpy.zeros((samples.shape[0], 1), dtype=samples.dtype)
         samples = numpy.concatenate((samples, sampletmp), axis=1)

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -2323,7 +2323,7 @@ def test_sample_flux_pha_bkg(idval, make_data_path, clean_astro_ui,
     # Note that I am slightly concerned that the background flux has been
     # calculated using the source response, not the background response.
     # This is too hard to identify with this dataset. We need a test which
-    # has drastically different background response (nad maybe exposure
+    # has drastically different background response (and maybe exposure
     # time).
     #
     sflux = ui.calc_energy_flux(id=idval, lo=1, hi=5)

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -29,7 +29,7 @@ import pytest
 from sherpa.astro import ui
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_plotting, requires_xspec
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, IOErr, \
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, IdentifierErr, IOErr, \
     ModelErr
 import sherpa.astro.utils
 
@@ -2209,3 +2209,137 @@ def test_sample_flux_pha_component(idval, make_data_path, clean_astro_ui,
     # No missing values (statistic is set for all bins)
     #
     assert (vals[:, 4] > 0).all()
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("idval", [1, 2])
+def test_sample_flux_pha_bkg_no_source(idval, make_data_path, clean_astro_ui,
+                                       hide_logging, reset_seed):
+    """Can we get the flux for the background fit when there's no source model?"""
+
+    np.random.seed(287241)
+
+    niter = 100
+
+    ui.load_pha(idval, make_data_path('3c273.pi'))
+    ui.ignore(None, 0.8)
+    ui.ignore(7, None)
+
+    ui.set_bkg_source(idval, ui.powlaw1d.bpl)
+
+    bpl = ui.get_model_component('bpl')
+    bpl.gamma = 0.54
+    bpl.ampl = 6.4e-6
+
+    ui.fit_bkg(idval)
+
+    # At the moment we need a source model (I guess to get the
+    # covariance), so this fails.
+    #
+    with pytest.raises(IdentifierErr) as exc:
+        ui.sample_flux(id=idval, bkg_id=1,
+                       lo=1, hi=5, num=niter,
+                       correlated=False)
+
+    assert str(exc.value) == 'model stack is empty'
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+@pytest.mark.parametrize("idval", [1, 2])
+def test_sample_flux_pha_bkg(idval, make_data_path, clean_astro_ui,
+                             hide_logging, reset_seed):
+    """Can we get the flux for the background fit.
+
+    In this case we have a source fit that has also been run,
+    so the error analysis should be fine.
+    """
+
+    ui.set_stat('chi2datavar')
+    ui.set_method('levmar')
+
+    niter = 100
+
+    ui.load_pha(idval, make_data_path('3c273.pi'))
+
+    # Need to ungroup so we can use the mask attribute
+    ui.ungroup(idval)
+    ui.ignore(None, 0.8)
+    ui.ignore(7, None)
+
+    d = ui.get_data(idval)
+    b = ui.get_bkg(idval)
+
+    # We need to do it this way (background first)
+    ui.group_counts(num=20, id=idval, bkg_id=1, tabStops=~b.mask)
+    ui.group_counts(num=20, id=idval, tabStops=~d.mask)
+
+    ui.set_bkg_source(idval, ui.powlaw1d.bpl)
+    ui.set_source(idval, ui.xswabs.gabs * ui.powlaw1d.pl)
+
+    bpl = ui.get_model_component('bpl')
+    bpl.gamma = 0.54
+    bpl.ampl = 6.4e-6
+
+    pl = ui.get_model_component('pl')
+    pl.gamma = 2.0
+    pl.ampl = 2e-4
+
+    gabs = ui.get_model_component('gabs')
+    gabs.nh = 0.05
+    gabs.nh.freeze()
+
+    ui.fit_bkg(idval)
+    ui.fit(idval)
+
+    # We don't try to run covar or get the statistic values
+    # (the API doesn't make that easy for background fits).
+    #
+
+    # Use the same seed for both runs.
+    #
+    np.random.seed(287247)
+    bflux1, bflux2, bvals = ui.sample_flux(id=idval, bkg_id=1,
+                                           lo=1, hi=5, num=niter,
+                                           correlated=False)
+
+    np.random.seed(287247)
+    flux1, flux2, vals = ui.sample_flux(id=idval,
+                                        lo=1, hi=5, num=niter,
+                                        correlated=False)
+
+    assert flux2 == pytest.approx(flux1)
+    assert bflux2 == pytest.approx(bflux1)
+
+    assert np.log10(flux1) == pytest.approx([-12.31348652, -12.28200881, -12.34610975])
+    assert np.log10(bflux1) == pytest.approx([-13.15241991, -12.97986006, -13.31382087])
+
+    # Just check that the flux we've got is close to the one calculated by
+    # calc_energy_flux. This is just to test the values we have checked for
+    # the median value of flux1 and bflux1.
+    #
+    # Note that I am slightly concerned that the background flux has been
+    # calculated using the source response, not the background response.
+    # This is too hard to identify with this dataset. We need a test which
+    # has drastically different background response (nad maybe exposure
+    # time).
+    #
+    sflux = ui.calc_energy_flux(id=idval, lo=1, hi=5)
+    bflux = ui.calc_energy_flux(id=idval, bkg_id=1, lo=1, hi=5)
+
+    assert np.log10(sflux) == pytest.approx(-12.310733810154623)
+    assert np.log10(bflux) == pytest.approx(-13.110679628882489)
+
+    # The random parameters are assumed to be the same. In reality the
+    # background doesn't need to include the source dataset but that's an
+    # issue to look at later.
+    #
+    assert bvals.shape == (101, 7)
+    assert vals.shape == (101, 7)
+
+    # For the value checks we need to drop the first column, which has the
+    # fluxes.
+    #
+    assert (bvals[:, 1:] == vals[:, 1:]).all()

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -768,7 +768,7 @@ def test_sample_foo_flux_not_a_model(method, make_data_path, clean_astro_ui):
 
     setup_sample(1, make_data_path, fit=False)
     with pytest.raises(AttributeError) as exc:
-         method(lo=0.5, hi=7, num=1, model='x')
+        method(lo=0.5, hi=7, num=1, model='x')
 
     assert str(exc.value) == "'str' object has no attribute 'thawedpars'"
 
@@ -786,7 +786,7 @@ def test_sample_foo_flux_invalid_model(method, make_data_path,
     setup_sample(1, make_data_path, fit=False)
     mdl = ui.create_model_component('powlaw1d', 'p1')
     with pytest.raises(ArgumentErr) as exc:
-         method(lo=0.5, hi=7, num=1, model=mdl)
+        method(lo=0.5, hi=7, num=1, model=mdl)
 
     assert str(exc.value) == "Invalid src: 'model contains term not in fit'"
 

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1290,7 +1290,6 @@ def test_sample_flux_invalid_model(hide_logging, make_data_path, clean_astro_ui)
     assert res[2].shape == (2, 4)
 
 
-@pytest.mark.xfail  # no error is raised
 @pytest.mark.parametrize("conf", [0, 100.1])
 def test_sample_flux_invalid_confidence(conf):
     """What happens when confidence is outside the range (0, 100]?

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -30,7 +30,7 @@ from sherpa.astro import ui
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_plotting, requires_xspec
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, IOErr, \
-    ModelErr, SherpaErr
+    ModelErr
 import sherpa.astro.utils
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -2100,8 +2100,8 @@ def test_sample_flux_errors(make_data_path, clean_astro_ui,
     elo = fmed - flsig
     ehi = fusig - fmed
     assert fmed == pytest.approx(77.27966775437665)
-    assert elo == pytest.approx(9.86485842683382)
-    assert ehi == pytest.approx(11.40548578502279)
+    assert elo == pytest.approx(9.773389936230018)
+    assert ehi == pytest.approx(11.417501513386611)
 
     # The last column of res[2] is the statistic value for a row -
     # although due to filtering we don't know which row without some

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13384,9 +13384,10 @@ class Session(sherpa.ui.utils.Session):
                                               numcores=numcores,
                                               bkg_id=bkg_id)
 
-        return sherpa.astro.flux.calc_sample_flux(id, lo, hi, self, fit, data,
-                                                  samples, modelcomponent,
-                                                  confidence)
+        return sherpa.astro.flux.calc_sample_flux(id=id, lo=lo, hi=hi, session=self,
+                                                  fit=fit, data=data, samples=samples,
+                                                  modelcomponent=modelcomponent,
+                                                  confidence=confidence)
 
     def eqwidth(self, src, combo, id=None, lo=None, hi=None, bkg_id=None,
                 error=False, params=None, otherids=(), niter=1000,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13361,6 +13361,9 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
+        if (confidence <= 0) or (confidence > 100):
+            raise ArgumentErr('bad', 'confidence', 'must be > 0 and <= 100')
+
         if not Xrays:
             raise NotImplementedError("sample_flux(Xrays=False) is currently unsupported")
 


### PR DESCRIPTION
# Summary

Ensure that sample_flux errors out if the Xrays argument is False (as this code path is currently broken) or if the confidence argument is invalid.

Internal code clean up fixes #286

# Details

This is broken out of #754 to make the changes more manageable. 

Note that the switch to using numpy.percentile, for calculating the limits of a distribution, changes the results slightly (see the test changes in 9f13e86). I have not looked at the existing code to work out "which is better", as I tend to think that the library function will have less gotchas than a hand-written version, but we probably should think about this. 

Some of the changes - in particular parts of 4c458ef - will be reworked in a later PR once I get time to finish them.