### PR TITLE
Use the logging infrastructure for sample_flux output

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -583,27 +583,6 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
 
         logger.setLevel(orig_log_level)
 
-        hwidth = confidence / 2
-        result = []
-        for x in [oflx, iflx]:
-            result.append(numpy.percentile(x, [50, 50 + hwidth, 50 - hwidth]))
-
-        for lbl, arg in zip(['original model', 'model component'], result):
-            med, usig, lsig = arg
-            msg = '{} flux = {:g}, + {:g}, - {:g}'.format(lbl, med, usig - med, med - lsig)
-            logger.info(msg)
-
-        sampletmp = numpy.zeros((samples.shape[0], 1), dtype=samples.dtype)
-        samples = numpy.concatenate((samples, sampletmp), axis=1)
-
-        for index in range(size):
-            samples[index][-1] = mystat[index]
-
-        # samples = numpy.delete( samples, (size), axis=0 )
-        result.append(samples)
-
-        return result
-
     finally:
 
         # Why do we set both full_model and source here?
@@ -614,3 +593,24 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
         session.set_source(id, orig_source)
 
         logger.setLevel(orig_log_level)
+
+    hwidth = confidence / 2
+    result = []
+    for x in [oflx, iflx]:
+        result.append(numpy.percentile(x, [50, 50 + hwidth, 50 - hwidth]))
+
+    for lbl, arg in zip(['original model', 'model component'], result):
+        med, usig, lsig = arg
+        msg = '{} flux = {:g}, + {:g}, - {:g}'.format(lbl, med, usig - med, med - lsig)
+        logger.info(msg)
+
+    sampletmp = numpy.zeros((samples.shape[0], 1), dtype=samples.dtype)
+    samples = numpy.concatenate((samples, sampletmp), axis=1)
+
+    for index in range(size):
+        samples[index][-1] = mystat[index]
+
+    # samples = numpy.delete( samples, (size), axis=0 )
+    result.append(samples)
+
+    return result

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -565,6 +565,8 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
         iflx = numpy.zeros(size)  # intrinsic/unabsorbed flux
         thawedpars = [par for par in fit.model.pars if not par.frozen]
 
+        logger.setLevel(logging.ERROR)
+
         mystat = []
         for nn in range(size):
             session.set_source(id, orig_source)
@@ -579,6 +581,8 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
             mystat.append(session.calc_stat(id))
             #####################################
 
+        logger.setLevel(orig_log_level)
+
         hwidth = confidence / 2
         result = []
         for x in [oflx, iflx]:
@@ -587,7 +591,7 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
         for lbl, arg in zip(['original model', 'model component'], result):
             med, usig, lsig = arg
             msg = '{} flux = {:g}, + {:g}, - {:g}'.format(lbl, med, usig - med, med - lsig)
-            print(msg)
+            logger.info(msg)
 
         sampletmp = numpy.zeros((samples.shape[0], 1), dtype=samples.dtype)
         samples = numpy.concatenate((samples, sampletmp), axis=1)
@@ -604,6 +608,7 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
 
         # Why do we set both full_model and source here?
         #
+        logger.setLevel(logging.ERROR)
         session.set_full_model(id, orig_model)
         fit.model.thawedpars = orig_model_vals
         session.set_source(id, orig_source)

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -38,6 +38,7 @@ from sherpa.sim import NormalParameterSampleFromScaleMatrix, \
     NormalParameterSampleFromScaleVector
 from sherpa.models.model import SimulFitModel
 
+info = logging.getLogger(__name__).info
 
 __all__ = ['calc_flux', 'sample_flux', 'calc_sample_flux']
 
@@ -602,7 +603,7 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
     for lbl, arg in zip(['original model', 'model component'], result):
         med, usig, lsig = arg
         msg = '{} flux = {:g}, + {:g}, - {:g}'.format(lbl, med, usig - med, med - lsig)
-        logger.info(msg)
+        info(msg)
 
     sampletmp = numpy.zeros((samples.shape[0], 1), dtype=samples.dtype)
     samples = numpy.concatenate((samples, sampletmp), axis=1)

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1511,7 +1511,15 @@ def test_sample_flux_pha_num1(idval, make_data_path, clean_astro_ui,
         flux1, flux2, vals = ui.sample_flux(id=idval, lo=1, hi=5, num=1,
                                             correlated=False, scales=scal)
 
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 2
+    msgs = []
+    for rec in caplog.record_tuples:
+        assert rec[0] == 'sherpa'  # we use sherpa, not sherpa.astro.flux here
+        assert rec[1] == logging.INFO
+        msgs.append(rec[2])
+
+    assert msgs[0] == 'original model flux = 5.06365e-13, + 3.21673e-14, - 3.21673e-14'
+    assert msgs[1] == 'model component flux = 5.06365e-13, + 3.21673e-14, - 3.21673e-14'
 
     assert np.all(flux1 == flux2)
     assert len(flux1) == 3
@@ -1954,7 +1962,15 @@ def test_sample_flux_751_752(idval, make_data_path, clean_astro_ui,
         flux1, flux2, vals = ui.sample_flux(id=idval, lo=1, hi=5, num=niter,
                                             correlated=False, scales=scal)
 
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 2
+    msgs = []
+    for rec in caplog.record_tuples:
+        assert rec[0] == 'sherpa'  # we use sherpa, not sherpa.astro.flux here
+        assert rec[1] == logging.INFO
+        msgs.append(rec[2])
+
+    assert msgs[0] == 'original model flux = 4.90527e-13, + 6.93747e-14, - 6.25625e-14'
+    assert msgs[1] == 'model component flux = 4.90527e-13, + 6.93747e-14, - 6.25625e-14'
 
     # as modelcomponent is None, first two arguments should be the same
     assert np.all(flux1 == flux2)
@@ -2180,7 +2196,13 @@ def test_sample_flux_pha_component(idval, make_data_path, clean_astro_ui,
                                             id=idval, lo=1, hi=5, num=niter,
                                             correlated=False, scales=scal)
 
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 2
+    msgs = []
+    for rec in caplog.record_tuples:
+        msgs.append(rec[2])
+
+    assert msgs[0] == 'original model flux = 4.78484e-13, + 7.8702e-14, - 5.87503e-14'
+    assert msgs[1] == 'model component flux = 5.98105e-13, + 9.83775e-14, - 7.34378e-14'
 
     # check the source model hasn't been changed (note: do not use
     # pytest.approx as expect the same value, but can switch if

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1547,6 +1547,40 @@ def test_sample_flux_pha_num1(idval, make_data_path, clean_astro_ui,
 
 @requires_data
 @requires_fits
+def test_sample_flux_nologging(make_data_path, clean_astro_ui,
+                               hide_logging, reset_seed, caplog):
+    """Check the example code (using SherpaVerbosity).
+
+    We just want to check we get no logging output. We don't
+    check anything else.
+    """
+
+    np.random.seed(3704)
+
+    gamma0 = 1.95014
+    ampl0 = 1.77506e-4
+    stat0 = 16.270233678440196
+
+    ui.load_pha(1, make_data_path('3c273.pi'))
+    ui.subtract(1)
+    ui.ignore(None, 1)
+    ui.ignore(7, None)
+    ui.set_source(1, ui.powlaw1d.p1)
+    ui.fit(1)
+    ui.covar(1)
+
+    assert len(caplog.records) == 0
+
+    scal = ui.get_covar_results().parmaxes
+    with SherpaVerbosity('WARN'):
+        ui.sample_flux(id=1, lo=1, hi=5, num=1,
+                       correlated=False)
+
+    assert len(caplog.records) == 0
+
+
+@requires_data
+@requires_fits
 @requires_xspec
 @pytest.mark.parametrize("method", [ui.sample_energy_flux, ui.sample_photon_flux])
 @pytest.mark.parametrize("correlated,scales3",

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1514,7 +1514,7 @@ def test_sample_flux_pha_num1(idval, make_data_path, clean_astro_ui,
     assert len(caplog.records) == 2
     msgs = []
     for rec in caplog.record_tuples:
-        assert rec[0] == 'sherpa'  # we use sherpa, not sherpa.astro.flux here
+        assert rec[0] == 'sherpa.astro.flux'
         assert rec[1] == logging.INFO
         msgs.append(rec[2])
 
@@ -1965,7 +1965,7 @@ def test_sample_flux_751_752(idval, make_data_path, clean_astro_ui,
     assert len(caplog.records) == 2
     msgs = []
     for rec in caplog.record_tuples:
-        assert rec[0] == 'sherpa'  # we use sherpa, not sherpa.astro.flux here
+        assert rec[0] == 'sherpa.astro.flux'
         assert rec[1] == logging.INFO
         msgs.append(rec[2])
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13331,7 +13331,7 @@ class Session(sherpa.ui.utils.Session):
         median and confidence ranges - is controlled by the standard
         Sherpa logging instance, and can be hidden by changing the
         logging to a level greater than "INFO" (e.g. with
-        sherpa.utils.logging.SherpaVerbosity).
+        `sherpa.utils.logging.SherpaVerbosity`).
 
         Examples
         --------
@@ -13368,7 +13368,7 @@ class Session(sherpa.ui.utils.Session):
 
         Run sample_flux after changing the logging level, so that the
         screen output from sample_flux is not displayed. We use the
-        SherpaVerbosity function from sherpa.utils.logging to
+        SherpaVerbosity function from `sherpa.utils.logging` to
         only change the logging level while runnng sample_flux:
 
         >>> from sherpa.utils.logging import SherpaVerbosity

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13250,7 +13250,8 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.13.1
            The `id` parameter is now used if set (previously the
-           default dataset was always used).
+           default dataset was always used). The screen output is now
+           controlled by the Sherpa logging setup.
 
         Parameters
         ----------
@@ -13329,7 +13330,8 @@ class Session(sherpa.ui.utils.Session):
         The summary output displayed by this routine - giving the
         median and confidence ranges - is controlled by the standard
         Sherpa logging instance, and can be hidden by changing the
-        logging to a level greater than "INFO".
+        logging to a level greater than "INFO" (e.g. with
+        sherpa.utils.logging.SherpaVerbosity).
 
         Examples
         --------
@@ -13365,15 +13367,13 @@ class Session(sherpa.ui.utils.Session):
         >>> ans = sample_flux(correlated=True, scales=cmatrix, num=500)
 
         Run sample_flux after changing the logging level, so that the
-        screen output from sample_flux is not displayed. Afterwards
-        the level is set to the "INFO" level (which is the default
-        level for Sherpa):
+        screen output from sample_flux is not displayed. We use the
+        SherpaVerbosity function from sherpa.utils.logging to
+        only change the logging level while runnng sample_flux:
 
-        >>> import logging
-        >>> lgr = logging.getLogger('sherpa')
-        >>> lgr.setLevel(logging.WARN)
-        >>> ans = sample_flux(num=1000, lo=0.5, hi=7)
-        >>> lgr.setLevel(logging.INFO)
+        >>> from sherpa.utils.logging import SherpaVerbosity
+        >>> with SherpaVerbosity('WARN'):
+        ...     ans = sample_flux(num=1000, lo=0.5, hi=7)
 
         """
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13326,6 +13326,11 @@ class Session(sherpa.ui.utils.Session):
         -----
         Setting the Xrays parameter to False is currently unsupported.
 
+        The summary output displayed by this routine - giving the
+        median and confidence ranges - is controlled by the standard
+        Sherpa logging instance, and can be hidden by changing the
+        logging to a level greater than "INFO".
+
         Examples
         --------
 
@@ -13358,6 +13363,17 @@ class Session(sherpa.ui.utils.Session):
 
         >>> cmatrix = get_covar_results().extra_output
         >>> ans = sample_flux(correlated=True, scales=cmatrix, num=500)
+
+        Run sample_flux after changing the logging level, so that the
+        screen output from sample_flux is not displayed. Afterwards
+        the level is set to the "INFO" level (which is the default
+        level for Sherpa):
+
+        >>> import logging
+        >>> lgr = logging.getLogger('sherpa')
+        >>> lgr.setLevel(logging.WARN)
+        >>> ans = sample_flux(num=1000, lo=0.5, hi=7)
+        >>> lgr.setLevel(logging.INFO)
 
         """
 


### PR DESCRIPTION
# Summary

The screen output from sample_flux is now generated by the Sherpa logger and so can be hidden by the user if required.

# Details

This is pulled out of #754 and was coincidentally asked for by @hamogu in reviewing #1078

The sample_flux code still contains some other logging code related to hiding messages during the flux calculation. There are other changes from #754 that will improve that part of the code.
