### PR TITLE
WIP move to a more-extensible system for plot types

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -821,7 +821,7 @@ def check_bkg_fit(plotfunc, isfit=True):
     assert isinstance(mplot, BkgModelPHAHistogram)
 
     # check the "source" plots are not set
-    for plot in [ui._session._dataplot, ui._session._modelplot]:
+    for plot in [ui._session._modelplot]:
         assert plot.x is None
         assert plot.y is None
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -820,11 +820,6 @@ def check_bkg_fit(plotfunc, isfit=True):
     assert isinstance(dplot, BkgDataPlot)
     assert isinstance(mplot, BkgModelPHAHistogram)
 
-    # check the "source" plots are not set
-    for plot in [ui._session._modelplot]:
-        assert plot.x is None
-        assert plot.y is None
-
     xlabel = 'Channel' if plotfunc == ui.plot_bkg_fit else ''
 
     # check plot basics

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -822,7 +822,7 @@ def check_bkg_fit(plotfunc, isfit=True):
     fplot = ui.get_bkg_fit_plot(recalc=False)
     mplot = fplot.modelplot
 
-    dplot = ui._session._plot_store['bkg'][0]
+    dplot = ui._session._plot_store['bkg']()
 
     # Since we are checking the store object, we can just check
     # that the data object matches that stored in the fit
@@ -871,7 +871,7 @@ def check_bkg_resid(plotfunc, isfit=True):
     for pfs, pdname in [([ui.plot_bkg_delchi, ui.plot_bkg_fit_delchi], "bkgdelchi"),
                         ([ui.plot_bkg_ratio, ui.plot_bkg_fit_ratio], "bkgratio"),
                         ([ui.plot_bkg_resid, ui.plot_bkg_fit_resid], "bkgresid")]:
-        pd = ui._session._plot_store[pdname][0]
+        pd = ui._session._plot_store[pdname]()
         if plotfunc in pfs:
             assert plot is None  # a precaution
             plot = pd
@@ -924,11 +924,11 @@ def check_bkg_chisqr(plotfunc, isfit=True):
 
     # check the "other" background plots are not set
     for pdname in ["bkgdelchi", "bkgratio", "bkgresid"]:
-        pd = ui._session._plot_store[pdname][0]
+        pd = ui._session._plot_store[pdname]()
         assert pd.x is None
         assert pd.y is None
 
-    plot = ui._session._plot_store['bkgchisqr'][0]
+    plot = ui._session._plot_store['bkgchisqr']()
     assert plot.x is not None
     assert plot.y is not None
 
@@ -948,16 +948,16 @@ def check_bkg_model(plotfunc, isfit=True):
 
     # check the "other" background plots are not set
     for pdname in ["bkgdelchi", "bkgratio", "bkgresid", "bkgchisqr"]:
-        pd = ui._session._plot_store[pdname][0]
+        pd = ui._session._plot_store[pdname]()
         assert pd.x is None
         assert pd.y is None
 
-    splot = ui._session._plot_store['bkgsource'][0]
+    splot = ui._session._plot_store['bkgsource']()
     assert splot.xlo is None
     assert splot.xhi is None
     assert splot.y is None
 
-    plot = ui._session._plot_store['bkgmodel'][0]
+    plot = ui._session._plot_store['bkgmodel']()
     assert isinstance(plot, BkgModelHistogram)
     assert plot.xlo is not None
     assert plot.xhi is not None
@@ -975,17 +975,17 @@ def check_bkg_source(plotfunc, isfit=True):
 
     # check the "other" background plots are not set
     for pdname in ["bkgdelchi", "bkgratio", "bkgresid", "bkgchisqr"]:
-        pd = ui._session._plot_store[pdname][0]
+        pd = ui._session._plot_store[pdname]()
         assert pd.x is None
         assert pd.y is None
 
     # check the background model is not set
-    bplot = ui._session._plot_store['bkgmodel'][0]
+    bplot = ui._session._plot_store['bkgmodel']()
     assert bplot.xlo is None
     assert bplot.xhi is None
     assert bplot.y is None
 
-    plot = ui._session._plot_store['bkgsource'][0]
+    plot = ui._session._plot_store['bkgsource']()
     assert isinstance(plot, BkgSourcePlot)
     assert plot.xlo is not None
     assert plot.xhi is not None

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -815,8 +815,21 @@ def check_bkg_fit(plotfunc, isfit=True):
     (e.g. the pixel display/PNG output).
     """
 
+    # Originally the model plot was stored as an attribute of
+    # the session class, but this has now changed and the only
+    # access is via the bkg_fit plot object.
+    #
+    fplot = ui.get_bkg_fit_plot(recalc=False)
+    mplot = fplot.modelplot
+
     dplot = ui._session._plot_store['bkg'][0]
-    mplot = ui._session._bkgmodelplot
+
+    # Since we are checking the store object, we can just check
+    # that the data object matches that stored in the fit
+    # object.
+    #
+    assert fplot.dataplot == dplot
+
     assert isinstance(dplot, BkgDataPlot)
     assert isinstance(mplot, BkgModelPHAHistogram)
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -815,7 +815,7 @@ def check_bkg_fit(plotfunc, isfit=True):
     (e.g. the pixel display/PNG output).
     """
 
-    dplot = ui._session._bkgdataplot
+    dplot = ui._session._plot_store['bkg'][0]
     mplot = ui._session._bkgmodelplot
     assert isinstance(dplot, BkgDataPlot)
     assert isinstance(mplot, BkgModelPHAHistogram)
@@ -855,9 +855,10 @@ def check_bkg_resid(plotfunc, isfit=True):
 
     # check the "other" background plots are not set
     plot = None
-    for pfs, pd in [([ui.plot_bkg_delchi, ui.plot_bkg_fit_delchi], ui._session._bkgdelchiplot),
-                    ([ui.plot_bkg_ratio, ui.plot_bkg_fit_ratio], ui._session._bkgratioplot),
-                    ([ui.plot_bkg_resid, ui.plot_bkg_fit_resid], ui._session._bkgresidplot)]:
+    for pfs, pdname in [([ui.plot_bkg_delchi, ui.plot_bkg_fit_delchi], "bkgdelchi"),
+                        ([ui.plot_bkg_ratio, ui.plot_bkg_fit_ratio], "bkgratio"),
+                        ([ui.plot_bkg_resid, ui.plot_bkg_fit_resid], "bkgresid")]:
+        pd = ui._session._plot_store[pdname][0]
         if plotfunc in pfs:
             assert plot is None  # a precaution
             plot = pd
@@ -909,13 +910,12 @@ def check_bkg_chisqr(plotfunc, isfit=True):
     """Is the background residual displayed?"""
 
     # check the "other" background plots are not set
-    for pd in [ui._session._bkgdelchiplot,
-               ui._session._bkgratioplot,
-               ui._session._bkgresidplot]:
+    for pdname in ["bkgdelchi", "bkgratio", "bkgresid"]:
+        pd = ui._session._plot_store[pdname][0]
         assert pd.x is None
         assert pd.y is None
 
-    plot = ui._session._bkgchisqrplot
+    plot = ui._session._plot_store['bkgchisqr'][0]
     assert plot.x is not None
     assert plot.y is not None
 
@@ -934,18 +934,17 @@ def check_bkg_model(plotfunc, isfit=True):
     """Is the background model displayed?"""
 
     # check the "other" background plots are not set
-    for pd in [ui._session._bkgdelchiplot,
-               ui._session._bkgratioplot,
-               ui._session._bkgresidplot,
-               ui._session._bkgchisqrplot]:
+    for pdname in ["bkgdelchi", "bkgratio", "bkgresid", "bkgchisqr"]:
+        pd = ui._session._plot_store[pdname][0]
         assert pd.x is None
         assert pd.y is None
 
-    assert ui._session._bkgsourceplot.xlo is None
-    assert ui._session._bkgsourceplot.xhi is None
-    assert ui._session._bkgsourceplot.y is None
+    splot = ui._session._plot_store['bkgsource'][0]
+    assert splot.xlo is None
+    assert splot.xhi is None
+    assert splot.y is None
 
-    plot = ui._session._bkgmodelhisto
+    plot = ui._session._plot_store['bkgmodel'][0]
     assert isinstance(plot, BkgModelHistogram)
     assert plot.xlo is not None
     assert plot.xhi is not None
@@ -962,19 +961,18 @@ def check_bkg_source(plotfunc, isfit=True):
     """Is the background source model displayed?"""
 
     # check the "other" background plots are not set
-    for pd in [ui._session._bkgdelchiplot,
-               ui._session._bkgratioplot,
-               ui._session._bkgresidplot,
-               ui._session._bkgchisqrplot]:
+    for pdname in ["bkgdelchi", "bkgratio", "bkgresid", "bkgchisqr"]:
+        pd = ui._session._plot_store[pdname][0]
         assert pd.x is None
         assert pd.y is None
 
     # check the background model is not set
-    assert ui._session._bkgmodelhisto.xlo is None
-    assert ui._session._bkgmodelhisto.xhi is None
-    assert ui._session._bkgmodelhisto.y is None
+    bplot = ui._session._plot_store['bkgmodel'][0]
+    assert bplot.xlo is None
+    assert bplot.xhi is None
+    assert bplot.y is None
 
-    plot = ui._session._bkgsourceplot
+    plot = ui._session._plot_store['bkgsource'][0]
     assert isinstance(plot, BkgSourcePlot)
     assert plot.xlo is not None
     assert plot.xhi is not None

--- a/sherpa/astro/ui/tests/test_session_copy.py
+++ b/sherpa/astro/ui/tests/test_session_copy.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -153,7 +153,6 @@ class Session(sherpa.ui.utils.Session):
         self._astrosourceplot = sherpa.astro.plot.SourcePlot()
         self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
         self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
-        self._modelhisto = sherpa.astro.plot.ModelHistogram()
         self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
 
         # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
@@ -191,6 +190,7 @@ class Session(sherpa.ui.utils.Session):
         # Add PHA plot types. This is ugly.
         #
         self._plot_store['data'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.DataPHAPlot()
+        self._plot_store['model'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.ModelHistogram()
 
         self._plot_types['order'] = [self._orderplot]
         self._plot_types['energy'] = [self._energyfluxplot]
@@ -199,7 +199,6 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['compmodel'].append(self._astrocompmdlplot)
 
         self._plot_types['source'].append(self._astrosourceplot)
-        self._plot_types['model'].append(self._modelhisto)
         self._plot_types['arf'] = [self._arfplot]
         self._plot_types['bkg'] = [self._bkgdataplot]
         self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
@@ -10315,22 +10314,6 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
     # Plotting
     ###########################################################################
-
-    def get_model_plot(self, id=None, recalc=True):
-        try:
-            d = self.get_data(id)
-        except IdentifierErr:
-            return super().get_model_plot(id, recalc=recalc)
-
-        if isinstance(d, sherpa.astro.data.DataPHA):
-            plotobj = self._modelhisto
-            if recalc:
-                plotobj.prepare(d, self.get_model(id), self.get_stat())
-            return plotobj
-
-        return super().get_model_plot(id, recalc=recalc)
-
-    get_model_plot.__doc__ = sherpa.ui.utils.Session.get_model_plot.__doc__
 
     # also in sherpa.utils, but without the lo/hi arguments
     def get_source_plot(self, id=None, lo=None, hi=None, recalc=True):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -150,7 +150,6 @@ class Session(sherpa.ui.utils.Session):
         self._background_models = {}
         self._background_sources = {}
 
-        self._dataphaplot = sherpa.astro.plot.DataPHAPlot()
         self._astrosourceplot = sherpa.astro.plot.SourcePlot()
         self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
         self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
@@ -199,7 +198,6 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['compsource'].append(self._astrocompsrcplot)
         self._plot_types['compmodel'].append(self._astrocompmdlplot)
 
-        self._plot_types['data'].append(self._dataphaplot)
         self._plot_types['source'].append(self._astrosourceplot)
         self._plot_types['model'].append(self._modelhisto)
         self._plot_types['arf'] = [self._arfplot]

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -150,18 +150,6 @@ class Session(sherpa.ui.utils.Session):
         self._background_models = {}
         self._background_sources = {}
 
-        self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
-
-        # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
-        self._bkgdataplot = sherpa.astro.plot.BkgDataPlot()
-        self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
-        self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
-        self._bkgchisqrplot = sherpa.astro.plot.BkgChisqrPlot()
-        self._bkgdelchiplot = sherpa.astro.plot.BkgDelchiPlot()
-        self._bkgresidplot = sherpa.astro.plot.BkgResidPlot()
-        self._bkgratioplot = sherpa.astro.plot.BkgRatioPlot()
-        self._bkgsourceplot = sherpa.astro.plot.BkgSourcePlot()
-
         # This is a new dictionary of XSPEC module settings.  It
         # is meant only to be populated by the save function, so
         # that the user's XSPEC settings can be saved in the pickle
@@ -194,15 +182,21 @@ class Session(sherpa.ui.utils.Session):
         self._plot_store['photon'] = (sherpa.astro.plot.PhotonFluxHistogram(), None)
         self._plot_store['arf'] = (sherpa.astro.plot.ARFPlot(), None)
 
+        # BkgDataPlot is currently the same as DataPHAPlot; is it worth
+        # keeping?
+        self._plot_store['bkg'] = (sherpa.astro.plot.BkgDataPlot(), None)
+        self._plot_store['bkgmodel'] = (sherpa.astro.plot.BkgModelHistogram(), None)
+        self._plot_store['bkgsource'] = (sherpa.astro.plot.BkgSourcePlot(), None)
+
+        self._plot_store['bkgratio'] = (sherpa.astro.plot.BkgRatioPlot(), None)
+        self._plot_store['bkgresid'] = (sherpa.astro.plot.BkgResidPlot(), None)
+        self._plot_store['bkgdelchi'] = (sherpa.astro.plot.BkgDelchiPlot(), None)
+        self._plot_store['bkgchisqr'] = (sherpa.astro.plot.BkgChisqrPlot(), None)
+
         # TODO: remove
-        self._plot_types['bkg'] = [self._bkgdataplot]
-        self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
+        self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
+        self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
         self._plot_types['bkgfit'] = [self._bkgfitplot]
-        self._plot_types['bkgsource'] = [self._bkgsourceplot]
-        self._plot_types['bkgratio'] = [self._bkgratioplot]
-        self._plot_types['bkgresid'] = [self._bkgresidplot]
-        self._plot_types['bkgdelchi'] = [self._bkgdelchiplot]
-        self._plot_types['bkgchisqr'] = [self._bkgchisqrplot]
 
         self._plot_type_names['order'] = 'order'
         # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
@@ -10783,7 +10777,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgmodelhisto
+        plotobj = self._plot_store['bkgmodel'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -10848,7 +10842,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgdataplot
+        plotobj = self._plot_store['bkg'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_stat())
@@ -10939,7 +10933,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgsourceplot
+        plotobj = self._plot_store['bkgsource'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_source(id, bkg_id),
@@ -10996,7 +10990,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgresidplot
+        plotobj = self._plot_store['bkgresid'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11053,7 +11047,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgratioplot
+        plotobj = self._plot_store['bkgratio'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11111,7 +11105,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgdelchiplot
+        plotobj = self._plot_store['bkgdelchi'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11169,7 +11163,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgchisqrplot
+        plotobj = self._plot_store['bkgchisqr'][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -161,10 +161,6 @@ class Session(sherpa.ui.utils.Session):
         self._bkgresidplot = sherpa.astro.plot.BkgResidPlot()
         self._bkgratioplot = sherpa.astro.plot.BkgRatioPlot()
         self._bkgsourceplot = sherpa.astro.plot.BkgSourcePlot()
-        self._arfplot = sherpa.astro.plot.ARFPlot()
-        self._orderplot = sherpa.astro.plot.OrderPlot()
-        self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
-        self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
 
         # This is a new dictionary of XSPEC module settings.  It
         # is meant only to be populated by the save function, so
@@ -193,11 +189,12 @@ class Session(sherpa.ui.utils.Session):
         self._plot_store['compsource'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.ComponentSourcePlot()
         self._plot_store['compmodel'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.ComponentModelPlot()
 
-        self._plot_types['order'] = [self._orderplot]
-        self._plot_types['energy'] = [self._energyfluxplot]
-        self._plot_types['photon'] = [self._photonfluxplot]
+        self._plot_store['order'] = (sherpa.astro.plot.OrderPlot(), None)
+        self._plot_store['energy'] = (sherpa.astro.plot.EnergyFluxHistogram(), None)
+        self._plot_store['photon'] = (sherpa.astro.plot.PhotonFluxHistogram(), None)
+        self._plot_store['arf'] = (sherpa.astro.plot.ARFPlot(), None)
 
-        self._plot_types['arf'] = [self._arfplot]
+        # TODO: remove
         self._plot_types['bkg'] = [self._bkgdataplot]
         self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
         self._plot_types['bkgfit'] = [self._bkgfitplot]
@@ -10581,7 +10578,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._orderplot
+        plotobj = self._plot_store['order'][0]
         if recalc:
             plotobj.prepare(self._get_pha_data(id),
                             self.get_model(id), orders=orders)
@@ -10635,7 +10632,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._arfplot
+        plotobj = self._plot_store['arf'][0]
         if not recalc:
             return plotobj
 
@@ -11333,13 +11330,15 @@ class Session(sherpa.ui.utils.Session):
         ...                          id=1, otherids=(2, 3, 4))
 
         """
+
+        plotobj = self._plot_store['energy'][0]
         if recalc:
-            self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
+            self._prepare_energy_flux_plot(plotobj, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
-        return self._energyfluxplot
+        return plotobj
 
     def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
@@ -11468,13 +11467,15 @@ class Session(sherpa.ui.utils.Session):
         ...                          id=1, otherids=(2, 3, 4))
 
         """
+
+        plotobj = self._plot_store['photon'][0]
         if recalc:
-            self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
+            self._prepare_photon_flux_plot(plotobj, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
-        return self._photonfluxplot
+        return plotobj
 
     def plot_arf(self, id=None, resp_id=None, replot=False, overplot=False,
                  clearwindow=True, **kwargs):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10394,36 +10394,27 @@ class Session(sherpa.ui.utils.Session):
         # - no stat argument and adds lo and hi arguments - which makes it
         # hard to use generic code here.
         #
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
-
-        plotobj = self._get_plotobj('source', d)
+        plotobj, data = self._get_plotobj('source', id, recalc=recalc)
         if not recalc:
             return plotobj
 
         src = self.get_source(id)
         try:
-            plotobj.prepare(d, src, lo=lo, hi=hi)
+            plotobj.prepare(data, src, lo=lo, hi=hi)
         except TypeError:
-            plotobj.prepare(d, src, stat=self.get_stat())
+            plotobj.prepare(data, src, stat=self.get_stat())
 
         return plotobj
 
     def get_fit_plot(self, id=None, recalc=True):
 
-        try:
-            d = self._get_pha_data(id)
-        except (ArgumentErr, IdentifierErr):
-            # Try to use the superclass for as much logic as possible
-            return super().get_fit_plot(id, recalc=recalc)
-
-        plotobj = self._get_plotobj('fit', d)
+        plotobj, data = self._get_plotobj('fit', id, recalc=recalc)
         if not recalc:
             return plotobj
+
+        if not isinstance(data, sherpa.astro.data.DataPHA):
+            # This repeats some of the calls we have already made
+            return super().get_fit_plot(id, recalc=recalc)
 
         dataobj = self.get_data_plot(id, recalc=recalc)
 
@@ -10431,7 +10422,7 @@ class Session(sherpa.ui.utils.Session):
         #
         # modelobj = self.get_model_plot(id, recalc=recalc)
         modelobj = sherpa.astro.plot.ModelPHAHistogram()
-        modelobj.prepare(d, self.get_model(id), stat=self.get_stat())
+        modelobj.prepare(data, self.get_model(id), stat=self.get_stat())
 
         plotobj.prepare(dataobj, modelobj)
         return plotobj

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -29,7 +29,7 @@ import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, \
     create_non_delta_rmf, has_pha_response
 from sherpa.ui.utils import _check_type
-from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
+from sherpa.utils import ObjectStore, SherpaInt, SherpaFloat, sao_arange, \
     send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
@@ -170,30 +170,30 @@ class Session(sherpa.ui.utils.Session):
 
         # Add PHA plot types. This is ugly.
         #
-        self._plot_store['data'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.DataPHAPlot()
-        self._plot_store['model'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.ModelHistogram()
-        self._plot_store['source'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.SourcePlot()
+        self._plot_store['data'].add(sherpa.astro.data.DataPHA, sherpa.astro.plot.DataPHAPlot())
+        self._plot_store['model'].add(sherpa.astro.data.DataPHA, sherpa.astro.plot.ModelHistogram())
+        self._plot_store['source'].add(sherpa.astro.data.DataPHA, sherpa.astro.plot.SourcePlot())
 
-        self._plot_store['compsource'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.ComponentSourcePlot()
-        self._plot_store['compmodel'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.ComponentModelPlot()
+        self._plot_store['compsource'].add(sherpa.astro.data.DataPHA, sherpa.astro.plot.ComponentSourcePlot())
+        self._plot_store['compmodel'].add(sherpa.astro.data.DataPHA, sherpa.astro.plot.ComponentModelPlot())
 
-        self._plot_store['order'] = (sherpa.astro.plot.OrderPlot(), None)
-        self._plot_store['energy'] = (sherpa.astro.plot.EnergyFluxHistogram(), None)
-        self._plot_store['photon'] = (sherpa.astro.plot.PhotonFluxHistogram(), None)
-        self._plot_store['arf'] = (sherpa.astro.plot.ARFPlot(), None)
+        self._plot_store['order'] = ObjectStore(sherpa.astro.plot.OrderPlot())
+        self._plot_store['energy'] = ObjectStore(sherpa.astro.plot.EnergyFluxHistogram())
+        self._plot_store['photon'] = ObjectStore(sherpa.astro.plot.PhotonFluxHistogram())
+        self._plot_store['arf'] = ObjectStore(sherpa.astro.plot.ARFPlot())
 
         # BkgDataPlot is currently the same as DataPHAPlot; is it worth
         # keeping?
-        self._plot_store['bkg'] = (sherpa.astro.plot.BkgDataPlot(), None)
-        self._plot_store['bkgmodel'] = (sherpa.astro.plot.BkgModelHistogram(), None)
-        self._plot_store['bkgsource'] = (sherpa.astro.plot.BkgSourcePlot(), None)
+        self._plot_store['bkg'] = ObjectStore(sherpa.astro.plot.BkgDataPlot())
+        self._plot_store['bkgmodel'] = ObjectStore(sherpa.astro.plot.BkgModelHistogram())
+        self._plot_store['bkgsource'] = ObjectStore(sherpa.astro.plot.BkgSourcePlot())
 
-        self._plot_store['bkgratio'] = (sherpa.astro.plot.BkgRatioPlot(), None)
-        self._plot_store['bkgresid'] = (sherpa.astro.plot.BkgResidPlot(), None)
-        self._plot_store['bkgdelchi'] = (sherpa.astro.plot.BkgDelchiPlot(), None)
-        self._plot_store['bkgchisqr'] = (sherpa.astro.plot.BkgChisqrPlot(), None)
+        self._plot_store['bkgratio'] = ObjectStore(sherpa.astro.plot.BkgRatioPlot())
+        self._plot_store['bkgresid'] = ObjectStore(sherpa.astro.plot.BkgResidPlot())
+        self._plot_store['bkgdelchi'] = ObjectStore(sherpa.astro.plot.BkgDelchiPlot())
+        self._plot_store['bkgchisqr'] = ObjectStore(sherpa.astro.plot.BkgChisqrPlot())
 
-        self._plot_store['bkgfit'] = (sherpa.astro.plot.BkgFitPlot(), None)
+        self._plot_store['bkgfit'] = ObjectStore(sherpa.astro.plot.BkgFitPlot())
 
         self._plot_type_names['order'] = 'order'
         # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
@@ -10569,7 +10569,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['order'][0]
+        plotobj = self._plot_store['order']()
         if recalc:
             plotobj.prepare(self._get_pha_data(id),
                             self.get_model(id), orders=orders)
@@ -10623,7 +10623,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['arf'][0]
+        plotobj = self._plot_store['arf']()
         if not recalc:
             return plotobj
 
@@ -10708,7 +10708,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgfit'][0]
+        plotobj = self._plot_store['bkgfit']()
         if not recalc:
             return plotobj
 
@@ -10775,7 +10775,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgmodel'][0]
+        plotobj = self._plot_store['bkgmodel']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -10840,7 +10840,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkg'][0]
+        plotobj = self._plot_store['bkg']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_stat())
@@ -10931,7 +10931,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgsource'][0]
+        plotobj = self._plot_store['bkgsource']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_source(id, bkg_id),
@@ -10988,7 +10988,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgresid'][0]
+        plotobj = self._plot_store['bkgresid']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11045,7 +11045,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgratio'][0]
+        plotobj = self._plot_store['bkgratio']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11103,7 +11103,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgdelchi'][0]
+        plotobj = self._plot_store['bkgdelchi']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11161,7 +11161,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['bkgchisqr'][0]
+        plotobj = self._plot_store['bkgchisqr']()
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11323,7 +11323,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['energy'][0]
+        plotobj = self._plot_store['energy']()
         if recalc:
             self._prepare_energy_flux_plot(plotobj, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
@@ -11460,7 +11460,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._plot_store['photon'][0]
+        plotobj = self._plot_store['photon']()
         if recalc:
             self._prepare_photon_flux_plot(plotobj, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -189,6 +189,10 @@ class Session(sherpa.ui.utils.Session):
 
         self._pyblocxs = sherpa.astro.sim.MCMC()
 
+        # Add PHA plot types. This is ugly.
+        #
+        self._plot_store['data'][1][sherpa.astro.data.DataPHA] = sherpa.astro.plot.DataPHAPlot()
+
         self._plot_types['order'] = [self._orderplot]
         self._plot_types['energy'] = [self._energyfluxplot]
         self._plot_types['photon'] = [self._photonfluxplot]
@@ -10313,22 +10317,6 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
     # Plotting
     ###########################################################################
-
-    def get_data_plot(self, id=None, recalc=True):
-        try:
-            d = self.get_data(id)
-        except IdentifierErr:
-            return super().get_data_plot(id, recalc=recalc)
-
-        if isinstance(d, sherpa.astro.data.DataPHA):
-            plotobj = self._dataphaplot
-            if recalc:
-                plotobj.prepare(d, self.get_stat())
-            return plotobj
-
-        return super().get_data_plot(id, recalc=recalc)
-
-    get_data_plot.__doc__ = sherpa.ui.utils.Session.get_data_plot.__doc__
 
     def get_model_plot(self, id=None, recalc=True):
         try:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -193,10 +193,7 @@ class Session(sherpa.ui.utils.Session):
         self._plot_store['bkgdelchi'] = (sherpa.astro.plot.BkgDelchiPlot(), None)
         self._plot_store['bkgchisqr'] = (sherpa.astro.plot.BkgChisqrPlot(), None)
 
-        # TODO: remove
-        self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
-        self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
-        self._plot_types['bkgfit'] = [self._bkgfitplot]
+        self._plot_store['bkgfit'] = (sherpa.astro.plot.BkgFitPlot(), None)
 
         self._plot_type_names['order'] = 'order'
         # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
@@ -10711,7 +10708,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgfitplot
+        plotobj = self._plot_store['bkgfit'][0]
         if not recalc:
             return plotobj
 
@@ -10720,7 +10717,8 @@ class Session(sherpa.ui.utils.Session):
         # We don't use get_bkg_model_plot as that uses the ungrouped data
         # modelobj = self.get_bkg_model_plot(id, bkg_id, recalc=recalc)
 
-        modelobj = self._bkgmodelplot
+        # As with plot_fit we create the plot object for the model here.
+        modelobj = sherpa.astro.plot.BkgModelPHAHistogram()
         modelobj.prepare(self.get_bkg(id, bkg_id),
                          self.get_bkg_model(id, bkg_id),
                          self.get_stat())

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -530,10 +530,10 @@ def test_plot_model_arbitrary_grid_integrated(session):
         ui.set_model(regrid_model)
         ui.plot_model()
 
-        # should this use ui.get_model_plot()?
-        assert ui._modelhistplot.xlo == pytest.approx(x[0])
-        assert ui._modelhistplot.xhi == pytest.approx(x[1])
-        assert ui._modelhistplot.y == pytest.approx(yy)
+        mplot = ui.get_model_plot()
+        assert mplot.xlo == pytest.approx(x[0])
+        assert mplot.xhi == pytest.approx(x[1])
+        assert mplot.y == pytest.approx(yy)
 
     tmp = numpy.arange(1, 5, 1)
     x = tmp[:-1], tmp[1:]

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -497,8 +497,12 @@ def test_source_component_arbitrary_grid(session):
         ui.set_source(regrid_model)
 
         ui.plot_source_component(regrid_model)
-        assert (ui._compsrcplot.x == x).all()
-        assert ui._compsrcplot.y == pytest.approx(yy)
+
+        # We use the default plot type here.
+        #
+        cplot = ui._plot_store['compsource'][0]
+        assert (cplot.x == x).all()
+        assert cplot.y == pytest.approx(yy)
 
     x = [1, 2, 3]
     y = [1, 2, 3]
@@ -575,10 +579,13 @@ def test_source_component_arbitrary_grid_int(session):
     regrid_model = model.regrid(*re_x)
     ui.plot_source_component(regrid_model)
 
-    # should this use ui.get_source_component_plot()?
-    assert ui._compsrchistplot.xlo == pytest.approx(x[0])
-    assert ui._compsrchistplot.xhi == pytest.approx(x[1])
-    assert ui._compsrchistplot.y == pytest.approx([0.0, 0.0, 0.0])
+    # Since this is Data1DInt then we use one of the options, and not
+    # the default, plot object.
+    #
+    cplot = ui._plot_store['compsource'][1][Data1DInt]
+    assert cplot.xlo == pytest.approx(x[0])
+    assert cplot.xhi == pytest.approx(x[1])
+    assert cplot.y == pytest.approx([0.0, 0.0, 0.0])
 
 
 def test_numpy_histogram_density_vs_normed(clean_astro_ui):

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -500,7 +500,7 @@ def test_source_component_arbitrary_grid(session):
 
         # We use the default plot type here.
         #
-        cplot = ui._plot_store['compsource'][0]
+        cplot = ui._plot_store['compsource']()
         assert (cplot.x == x).all()
         assert cplot.y == pytest.approx(yy)
 
@@ -582,7 +582,8 @@ def test_source_component_arbitrary_grid_int(session):
     # Since this is Data1DInt then we use one of the options, and not
     # the default, plot object.
     #
-    cplot = ui._plot_store['compsource'][1][Data1DInt]
+    d = ui.get_data(1)
+    cplot = ui._plot_store['compsource'](d)
     assert cplot.xlo == pytest.approx(x[0])
     assert cplot.xhi == pytest.approx(x[1])
     assert cplot.y == pytest.approx([0.0, 0.0, 0.0])

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -803,7 +803,8 @@ def test_prefs_change_session_objects_fit(clean_ui):
     about what we expect/want to happen.
     """
 
-    plotobj = ui._session._fitplot
+    # We use the default plot type here
+    plotobj = ui._session._plot_store['fit'][0]
     assert plotobj.dataplot is None
     assert plotobj.modelplot is None
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -241,7 +241,7 @@ def check_example(xlabel='x'):
     """Check that the data plot has not changed"""
 
     # We use the default plot type here
-    dplot = ui._session._plot_store['data'][0]
+    dplot = ui._session._plot_store['data']()
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -261,7 +261,7 @@ def check_example_changed(xlabel='x'):
     """
 
     # We use the default plot type here
-    dplot = ui._session._plot_store['data'][0]
+    dplot = ui._session._plot_store['data']()
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -290,7 +290,7 @@ def check_model(xlabel='x'):
     """Check that the model plot has not changed"""
 
     # We use the default plot type here
-    mplot = ui._session._plot_store['model'][0]
+    mplot = ui._session._plot_store['model']()
     check_model_plot(mplot,
                      title='Model', xlabel=xlabel)
 
@@ -301,7 +301,7 @@ def check_model_changed(xlabel='x'):
     Assumes change_model has been called
     """
 
-    mplot = ui._session._plot_store['model'][0]
+    mplot = ui._session._plot_store['model']()
     check_model_plot(mplot,
                      title='Model', xlabel=xlabel,
                      modelval=41)
@@ -311,7 +311,7 @@ def check_source():
     """Check that the source plot has not changed"""
 
     # We use the default plot type here
-    splot = ui._session._plot_store['source'][0]
+    splot = ui._session._plot_store['source']()
     check_model_plot(splot,
                      title='Source')
 
@@ -323,7 +323,7 @@ def check_source_changed():
     """
 
     # We use the default plot type here
-    splot = ui._session._plot_store['source'][0]
+    splot = ui._session._plot_store['source']()
     check_model_plot(splot,
                      title='Source', modelval=41)
 
@@ -332,7 +332,7 @@ def check_resid(title='Residuals for example'):
     """Check that the resid plot has not changed"""
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['resid'][0]
+    rplot = ui._session._plot_store['resid']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -349,7 +349,7 @@ def check_resid_changed(title='Residuals for example'):
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['resid'][0]
+    rplot = ui._session._plot_store['resid']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -366,7 +366,7 @@ def check_resid_changed2(title='Residuals for example'):
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['resid'][0]
+    rplot = ui._session._plot_store['resid']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -380,7 +380,7 @@ def check_ratio(title='Ratio of Data to Model for example'):
     """Check that the ratio plot has not changed"""
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['ratio'][0]
+    rplot = ui._session._plot_store['ratio']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -398,7 +398,7 @@ def check_ratio_changed():
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['ratio'][0]
+    rplot = ui._session._plot_store['ratio']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == 'Ratio of Data to Model for example'
@@ -416,7 +416,7 @@ def check_ratio_changed2(title='Ratio of Data to Model for example'):
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['ratio'][0]
+    rplot = ui._session._plot_store['ratio']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -431,7 +431,7 @@ def check_delchi(title='Sigma Residuals for example'):
     """Check that the delchi plot has not changed"""
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['delchi'][0]
+    rplot = ui._session._plot_store['delchi']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -451,7 +451,7 @@ def check_delchi_changed(title='Sigma Residuals for example'):
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['delchi'][0]
+    rplot = ui._session._plot_store['delchi']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -471,7 +471,7 @@ def check_delchi_changed2(title='Sigma Residuals for example'):
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['delchi'][0]
+    rplot = ui._session._plot_store['delchi']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -488,7 +488,7 @@ def check_chisqr():
     """Check that the chisqr plot has not changed"""
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['chisqr'][0]
+    rplot = ui._session._plot_store['chisqr']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -508,7 +508,7 @@ def check_chisqr_changed():
     """
 
     # We use the default plot type here
-    rplot = ui._session._plot_store['chisqr'][0]
+    rplot = ui._session._plot_store['chisqr']()
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -776,7 +776,7 @@ def test_prefs_change_session_objects(getprefs, ptype, plotfunc, clean_ui):
     # parametrize list, as the ui._session object is changed by
     # the clean_ui fixture.
     #
-    session = ui._session._plot_store[ptype][0]  # use default
+    session = ui._session._plot_store[ptype]()  # use default
 
     # All but the last assert are just to check things are behaving
     # as expected (and stuck into one routine rather than have a
@@ -815,7 +815,7 @@ def test_prefs_change_session_objects_fit(clean_ui):
     """
 
     # We use the default plot type here
-    plotobj = ui._session._plot_store['fit'][0]
+    plotobj = ui._session._plot_store['fit']()
     assert plotobj.dataplot is None
     assert plotobj.modelplot is None
 
@@ -836,8 +836,8 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # We have already checked this in previous tests, but
     # just in case
     #
-    dplot = ui._session._plot_store['data'][0]
-    mplot = ui._session._plot_store['model'][0]
+    dplot = ui._session._plot_store['data']()
+    mplot = ui._session._plot_store['model']()
     assert dplot.plot_prefs['xlog']
     assert mplot.plot_prefs['ylog']
 
@@ -1044,7 +1044,7 @@ def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     # clean call done by the clean_ui fixture will reset the
     # plot objects).
     #
-    prefs = ui._session._plot_store[plotobj][0].plot_prefs  # use the default plot
+    prefs = ui._session._plot_store[plotobj]().plot_prefs  # use the default plot
 
     setup_example(None)
 
@@ -1076,8 +1076,8 @@ def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     # it worth it, as we end up digging around in the internals
     # of the session object?
     #
-    rprefs = ui._session._plot_store[plotobj][0].plot_prefs  # use the default plot
-    dprefs = ui._session._plot_store['data'][0].plot_prefs  # use the default plot
+    rprefs = ui._session._plot_store[plotobj]().plot_prefs  # use the default plot
+    dprefs = ui._session._plot_store['data']().plot_prefs  # use the default plot
 
     setup_example(None)
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -43,7 +43,7 @@ from sherpa.plot import CDFPlot, DataPlot, FitPlot, ModelPlot, \
     DataContour, ModelContour, SourceContour, ResidContour, \
     RatioContour, FitContour, LRHistogram, \
     ModelHistogramPlot, ResidPlot, RatioPlot, DelchiPlot, ChisqrPlot, \
-    DataHistogramPlot
+    DataHistogramPlot, SplitPlot
 
 from sherpa.stats import Chi2Gehrels
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
@@ -2183,6 +2183,33 @@ def test_get_pvalue_plot(session, caplog):
     check_pvalue(caplog, p)
 
 
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_plot_pvalue_requires_null_model(session):
+    """We need a null_model argument"""
+
+    s = session()
+    with pytest.raises(TypeError) as te:
+        # We add conv_model (to an invalid value) to avoid having
+        # to set up a dataset
+        s.plot_pvalue(None, None, conv_model=True)
+
+    assert str(te.value) == 'null model cannot be None'
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_plot_pvalue_requires_alt_model(session):
+    """We need a alt_model argument"""
+
+    s = session()
+    with pytest.raises(TypeError) as te:
+        # We add conv_model (to an invalid value) to avoid having
+        # to set up a dataset. Similarly all we need is null_model
+        # to be set, not that it's set properly
+        s.plot_pvalue(False, None, conv_model=True)
+
+    assert str(te.value) == 'alternative model cannot be None'
+
+
 @requires_plotting
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_plot_pvalue(session, caplog):
@@ -2217,6 +2244,20 @@ def test_plot_pvalue(session, caplog):
 
     p = s.get_pvalue_plot(recalc=False)
     check_pvalue(caplog, p)
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_split_plot(session):
+    """Check we can call get_split_plot.
+
+    Limited checking of the result.
+    """
+
+    s = session()
+    splot = s.get_split_plot()
+    assert isinstance(splot, SplitPlot)
+    assert splot.rows == 2
+    assert splot.cols == 1
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -310,7 +310,9 @@ def check_model_changed(xlabel='x'):
 def check_source():
     """Check that the source plot has not changed"""
 
-    check_model_plot(ui._session._sourceplot,
+    # We use the default plot type here
+    splot = ui._session._plot_store['source'][0]
+    check_model_plot(splot,
                      title='Source')
 
 
@@ -320,7 +322,9 @@ def check_source_changed():
     Assumes change_model has been called
     """
 
-    check_model_plot(ui._session._sourceplot,
+    # We use the default plot type here
+    splot = ui._session._plot_store['source'][0]
+    check_model_plot(splot,
                      title='Source', modelval=41)
 
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1049,8 +1049,12 @@ def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     # clean call done by the clean_ui fixture will reset the
     # plot objects).
     #
+    # The attempt is to make this plot-end agnostic, but is
+    # it worth it, as we end up digging around in the internals
+    # of the session object?
+    #
     rprefs = getattr(ui._session, plotobj).plot_prefs
-    dprefs = ui._session._dataplot.plot_prefs
+    dprefs = ui._session._plot_store['data'][0].plot_prefs  # use the default plot
 
     setup_example(None)
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -331,7 +331,8 @@ def check_source_changed():
 def check_resid(title='Residuals for example'):
     """Check that the resid plot has not changed"""
 
-    rplot = ui._session._residplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['resid'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -347,7 +348,8 @@ def check_resid_changed(title='Residuals for example'):
     Assumes that change_model has been called
     """
 
-    rplot = ui._session._residplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['resid'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -363,7 +365,8 @@ def check_resid_changed2(title='Residuals for example'):
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._residplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['resid'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -376,7 +379,8 @@ def check_resid_changed2(title='Residuals for example'):
 def check_ratio(title='Ratio of Data to Model for example'):
     """Check that the ratio plot has not changed"""
 
-    rplot = ui._session._ratioplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['ratio'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -393,7 +397,8 @@ def check_ratio_changed():
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._ratioplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['ratio'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == 'Ratio of Data to Model for example'
@@ -410,7 +415,8 @@ def check_ratio_changed2(title='Ratio of Data to Model for example'):
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._ratioplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['ratio'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -424,7 +430,8 @@ def check_ratio_changed2(title='Ratio of Data to Model for example'):
 def check_delchi(title='Sigma Residuals for example'):
     """Check that the delchi plot has not changed"""
 
-    rplot = ui._session._delchiplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['delchi'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -443,7 +450,8 @@ def check_delchi_changed(title='Sigma Residuals for example'):
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._delchiplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['delchi'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -462,7 +470,8 @@ def check_delchi_changed2(title='Sigma Residuals for example'):
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._delchiplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['delchi'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -478,7 +487,8 @@ def check_delchi_changed2(title='Sigma Residuals for example'):
 def check_chisqr():
     """Check that the chisqr plot has not changed"""
 
-    rplot = ui._session._chisqrplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['chisqr'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -497,7 +507,8 @@ def check_chisqr_changed():
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._chisqrplot
+    # We use the default plot type here
+    rplot = ui._session._plot_store['chisqr'][0]
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -1018,8 +1029,8 @@ def test_get_kernel_plot_recalc(session):
 
 @requires_plotting
 @pytest.mark.parametrize("plotobj,plotfunc",
-                         [("_residplot", ui.plot_resid),
-                          ("_delchiplot", ui.plot_delchi)
+                         [("resid", ui.plot_resid),
+                          ("delchi", ui.plot_delchi)
                           ])
 def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?
@@ -1033,7 +1044,7 @@ def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     # clean call done by the clean_ui fixture will reset the
     # plot objects).
     #
-    prefs = getattr(ui._session, plotobj).plot_prefs
+    prefs = ui._session._plot_store[plotobj][0].plot_prefs  # use the default plot
 
     setup_example(None)
 
@@ -1050,8 +1061,8 @@ def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
 
 @requires_plotting
 @pytest.mark.parametrize("plotobj,plotfunc",
-                         [("_residplot", ui.plot_fit_resid),
-                          ("_delchiplot", ui.plot_fit_delchi)
+                         [("resid", ui.plot_fit_resid),
+                          ("delchi", ui.plot_fit_delchi)
                           ])
 def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?"""
@@ -1065,7 +1076,7 @@ def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     # it worth it, as we end up digging around in the internals
     # of the session object?
     #
-    rprefs = getattr(ui._session, plotobj).plot_prefs
+    rprefs = ui._session._plot_store[plotobj][0].plot_prefs  # use the default plot
     dprefs = ui._session._plot_store['data'][0].plot_prefs  # use the default plot
 
     setup_example(None)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -24,6 +24,10 @@ these - or most of them - can be run even when there is no plot backend.
 
 There is a start to make these tests run on both Session classes,
 but there's much to do.
+
+The direct access to the plot objects is not ideal, as it makes these
+tests susceptible to internal changes (but on the plus side, we will
+be warned if the internals change!).
 """
 
 import logging
@@ -236,7 +240,8 @@ def change_fit(idval):
 def check_example(xlabel='x'):
     """Check that the data plot has not changed"""
 
-    dplot = ui._session._dataplot
+    # We use the default plot type here
+    dplot = ui._session._plot_store['data'][0]
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -255,7 +260,8 @@ def check_example_changed(xlabel='x'):
     Assumes change_example has been called
     """
 
-    dplot = ui._session._dataplot
+    # We use the default plot type here
+    dplot = ui._session._plot_store['data'][0]
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -734,7 +740,7 @@ _mplot = (ui.get_model_plot_prefs, "_modelplot", ui.plot_model)
 
 @requires_plotting
 @pytest.mark.parametrize("getprefs,attr,plotfunc",
-                         [_dplot, _mplot])
+                         [pytest.param(*_dplot, marks=pytest.mark.xfail), _mplot])
 def test_prefs_change_session_objects(getprefs, attr, plotfunc, clean_ui):
     """Is a plot-preference change also reflected in the session object?
 
@@ -808,7 +814,8 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # We have already checked this in previous tests, but
     # just in case
     #
-    assert ui._session._dataplot.plot_prefs['xlog']
+    dplot = ui._session._plot_store['data'][0]
+    assert dplot.plot_prefs['xlog']
     assert ui._session._modelplot.plot_prefs['ylog']
 
     # Now check that the fit plot has picked up these changes;
@@ -819,7 +826,7 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # which is less restrictive, but for not check the
     # equality
     #
-    assert plotobj.dataplot is ui._session._dataplot
+    assert plotobj.dataplot is dplot
     assert plotobj.modelplot is ui._session._modelplot
 
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -301,6 +301,8 @@ class Session(NoNewAttributesAfterInit):
                                     OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.DataHistogramPlot()}))
         self._plot_store['model'] = (sherpa.plot.ModelPlot(),
                                      OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.ModelHistogramPlot()}))
+        self._plot_store['source'] = (sherpa.plot.SourcePlot(),
+                                     OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.SourceHistogramPlot()}))
 
         self._compmdlplot = sherpa.plot.ComponentModelPlot()
         self._compmdlhistplot = sherpa.plot.ComponentModelHistogramPlot()
@@ -311,8 +313,6 @@ class Session(NoNewAttributesAfterInit):
         # self._comptmplmdlplot = sherpa.plot.ComponentTemplateModelPlot()
         self._comptmplsrcplot = sherpa.plot.ComponentTemplateSourcePlot()
 
-        self._sourceplot = sherpa.plot.SourcePlot()
-        self._sourcehistplot = sherpa.plot.SourceHistogramPlot()
         self._fitplot = sherpa.plot.FitPlot()
         self._residplot = sherpa.plot.ResidPlot()
         self._delchiplot = sherpa.plot.DelchiPlot()
@@ -343,7 +343,7 @@ class Session(NoNewAttributesAfterInit):
         self._plot_types = {
             'data': [], # moved to _plot_store
             'model': [], # moved to _plot_store
-            'source': [self._sourceplot, self._sourcehistplot],
+            'source': [], # moved to _plot_store
             'fit': [self._fitplot],
             'resid': [self._residplot],
             'ratio': [self._ratioplot],
@@ -10981,6 +10981,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
+        # We could rely on get_source error-ing out, but the error
+        # message is slightly different (mentioning get_model rather
+        # than get_model_plot).
+        #
         id = self._fix_id(id)
         mdl = self._models.get(id, None)
         if mdl is not None:
@@ -10995,13 +10999,9 @@ class Session(NoNewAttributesAfterInit):
                 raise ie
             d = None
 
-        if isinstance(d, sherpa.data.Data1DInt):
-            plotobj = self._sourcehistplot
-        else:
-            plotobj = self._sourceplot
-
+        plotobj = self._get_plotobj('source', d)
         if recalc:
-            plotobj.prepare(d, self.get_source(id), self.get_stat())
+            plotobj.prepare(d, self.get_source(id), stat=self.get_stat())
 
         return plotobj
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -332,14 +332,18 @@ class Session(NoNewAttributesAfterInit):
         self._plot_store['trace'] = ObjectStore(sherpa.plot.TracePlot())
         self._plot_store['scatter'] = ObjectStore(sherpa.plot.ScatterPlot())
 
-        self._datacontour = sherpa.plot.DataContour()
-        self._modelcontour = sherpa.plot.ModelContour()
-        self._sourcecontour = sherpa.plot.SourceContour()
-        self._fitcontour = sherpa.plot.FitContour()
-        self._residcontour = sherpa.plot.ResidContour()
-        self._ratiocontour = sherpa.plot.RatioContour()
-        self._psfcontour = sherpa.plot.PSFContour()
-        self._kernelcontour = sherpa.plot.PSFKernelContour()
+        # For the contour plots we currently have no specialised cases so we
+        # do not need to go to the effort to use an ObjectStore here.
+        #
+        self._contour_store = {}
+        self._contour_store['data'] = sherpa.plot.DataContour()
+        self._contour_store['model'] = sherpa.plot.ModelContour()
+        self._contour_store['source'] = sherpa.plot.SourceContour()
+        self._contour_store['fit'] = sherpa.plot.FitContour()
+        self._contour_store['resid'] = sherpa.plot.ResidContour()
+        self._contour_store['ratio'] = sherpa.plot.RatioContour()
+        self._contour_store['psf'] = sherpa.plot.PSFContour()
+        self._contour_store['kernel'] = sherpa.plot.PSFKernelContour()
 
         self._intproj = sherpa.plot.IntervalProjection()
         self._intunc = sherpa.plot.IntervalUncertainty()
@@ -374,17 +378,6 @@ class Session(NoNewAttributesAfterInit):
             'model_component': 'model_component',
             'compsource': 'source_component',
             'compmodel': 'model_component',
-        }
-
-        self._contour_types = {
-            'data': self._datacontour,
-            'model': self._modelcontour,
-            'source': self._sourcecontour,
-            'fit': self._fitcontour,
-            'resid': self._residcontour,
-            'ratio': self._ratiocontour,
-            'psf': self._psfcontour,
-            'kernel': self._kernelcontour
         }
 
         self._contour_type_names = {
@@ -11536,7 +11529,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._datacontour
+        plotobj = self._contour_store['data']
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_stat())
         return plotobj
@@ -11634,7 +11627,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._modelcontour
+        plotobj = self._contour_store['model']
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11682,7 +11675,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._sourcecontour
+        plotobj = self._contour_store['source']
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
         return plotobj
@@ -11784,7 +11777,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._fitcontour
+        plotobj = self._contour_store['fit']
 
         dataobj = self.get_data_contour(id, recalc=recalc)
         modelobj = self.get_model_contour(id, recalc=recalc)
@@ -11837,7 +11830,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._residcontour
+        plotobj = self._contour_store['resid']
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11886,7 +11879,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._ratiocontour
+        plotobj = self._contour_store['ratio']
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11930,7 +11923,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._psfcontour
+        plotobj = self._contour_store['psf']
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
@@ -11975,7 +11968,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._kernelcontour
+        plotobj = self._contour_store['kernel']
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -300,9 +300,6 @@ class Session(NoNewAttributesAfterInit):
         self._plot_store['data'] = (sherpa.plot.DataPlot(),
                                     OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.DataHistogramPlot()}))
 
-        self._dataplot = sherpa.plot.DataPlot()
-        self._datahistplot = sherpa.plot.DataHistogramPlot()
-
         self._modelplot = sherpa.plot.ModelPlot()
         self._modelhistplot = sherpa.plot.ModelHistogramPlot()
 
@@ -345,7 +342,7 @@ class Session(NoNewAttributesAfterInit):
         self._regunc = sherpa.plot.RegionUncertainty()
 
         self._plot_types = {
-            'data': [self._dataplot, self._datahistplot],
+            'data': [], # moved to _plot_store
             'model': [self._modelplot, self._modelhistplot],
             'source': [self._sourceplot, self._sourcehistplot],
             'fit': [self._fitplot],

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -303,6 +303,7 @@ class Session(NoNewAttributesAfterInit):
                                      OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.ModelHistogramPlot()}))
         self._plot_store['source'] = (sherpa.plot.SourcePlot(),
                                      OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.SourceHistogramPlot()}))
+        self._plot_store['fit'] = (sherpa.plot.FitPlot(), OrderedByMRO())
 
         self._compmdlplot = sherpa.plot.ComponentModelPlot()
         self._compmdlhistplot = sherpa.plot.ComponentModelHistogramPlot()
@@ -313,7 +314,6 @@ class Session(NoNewAttributesAfterInit):
         # self._comptmplmdlplot = sherpa.plot.ComponentTemplateModelPlot()
         self._comptmplsrcplot = sherpa.plot.ComponentTemplateSourcePlot()
 
-        self._fitplot = sherpa.plot.FitPlot()
         self._residplot = sherpa.plot.ResidPlot()
         self._delchiplot = sherpa.plot.DelchiPlot()
         self._chisqrplot = sherpa.plot.ChisqrPlot()
@@ -344,7 +344,7 @@ class Session(NoNewAttributesAfterInit):
             'data': [], # moved to _plot_store
             'model': [], # moved to _plot_store
             'source': [], # moved to _plot_store
-            'fit': [self._fitplot],
+            'fit': [], # moved to _plot_store
             'resid': [self._residplot],
             'ratio': [self._ratioplot],
             'delchi': [self._delchiplot],
@@ -11285,14 +11285,21 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._fitplot
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+
+            d = None
+
+        plotobj = self._get_plotobj('fit', d)
+        if not recalc:
+            return plotobj
 
         dataobj = self.get_data_plot(id, recalc=recalc)
         modelobj = self.get_model_plot(id, recalc=recalc)
-
-        if recalc:
-            plotobj.prepare(dataobj, modelobj)
-
+        plotobj.prepare(dataobj, modelobj)
         return plotobj
 
     def get_resid_plot(self, id=None, recalc=True):

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -305,6 +305,11 @@ class Session(NoNewAttributesAfterInit):
                                      OrderedByMRO({sherpa.data.Data1DInt: sherpa.plot.SourceHistogramPlot()}))
         self._plot_store['fit'] = (sherpa.plot.FitPlot(), OrderedByMRO())
 
+        self._plot_store['resid'] = (sherpa.plot.ResidPlot(), OrderedByMRO())
+        self._plot_store['ratio'] = (sherpa.plot.RatioPlot(), OrderedByMRO())
+        self._plot_store['delchi'] = (sherpa.plot.DelchiPlot(), OrderedByMRO())
+        self._plot_store['chisqr'] = (sherpa.plot.ChisqrPlot(), OrderedByMRO())
+
         self._compmdlplot = sherpa.plot.ComponentModelPlot()
         self._compmdlhistplot = sherpa.plot.ComponentModelHistogramPlot()
 
@@ -314,10 +319,6 @@ class Session(NoNewAttributesAfterInit):
         # self._comptmplmdlplot = sherpa.plot.ComponentTemplateModelPlot()
         self._comptmplsrcplot = sherpa.plot.ComponentTemplateSourcePlot()
 
-        self._residplot = sherpa.plot.ResidPlot()
-        self._delchiplot = sherpa.plot.DelchiPlot()
-        self._chisqrplot = sherpa.plot.ChisqrPlot()
-        self._ratioplot = sherpa.plot.RatioPlot()
         self._psfplot = sherpa.plot.PSFPlot()
         self._kernelplot = sherpa.plot.PSFKernelPlot()
         self._lrplot = sherpa.plot.LRHistogram()
@@ -345,10 +346,10 @@ class Session(NoNewAttributesAfterInit):
             'model': [], # moved to _plot_store
             'source': [], # moved to _plot_store
             'fit': [], # moved to _plot_store
-            'resid': [self._residplot],
-            'ratio': [self._ratioplot],
-            'delchi': [self._delchiplot],
-            'chisqr': [self._chisqrplot],
+            'resid': [], # moved to _plot_store
+            'ratio': [], # moved to _plot_store
+            'delchi': [], # moved to _plot_store
+            'chisqr': [], # moved to _plot_store
             'psf': [self._psfplot],
             'kernel': [self._kernelplot],
             'compsource': [self._compsrcplot],
@@ -11357,10 +11358,19 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._residplot
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
 
+            d = None
+
+        plotobj = self._get_plotobj('resid', d)
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(d, self.get_model(id), self.get_stat())
         return plotobj
 
     def get_delchi_plot(self, id=None, recalc=True):
@@ -11419,11 +11429,21 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._delchiplot
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
 
+            d = None
+
+        plotobj = self._get_plotobj('delchi', d)
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(d, self.get_model(id), self.get_stat())
         return plotobj
+
 
     def get_chisqr_plot(self, id=None, recalc=True):
         """Return the data used by plot_chisqr.
@@ -11481,10 +11501,19 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._chisqrplot
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
 
+            d = None
+
+        plotobj = self._get_plotobj('chisqr', d)
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(d, self.get_model(id), self.get_stat())
         return plotobj
 
     def get_ratio_plot(self, id=None, recalc=True):
@@ -11543,10 +11572,19 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._ratioplot
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
 
+            d = None
+
+        plotobj = self._get_plotobj('ratio', d)
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(d, self.get_model(id), self.get_stat())
         return plotobj
 
     def get_data_contour(self, id=None, recalc=True):


### PR DESCRIPTION
This has been replaced by #1516 but I'll leave this around as the approach is slightly different, in case we want to discuss the differences.

# Summary

Internal change to plotting in sherpa.ui and sherpa.astro.ui. As a result there are small changes in the allowed identifiers for datasets. TBD should be able to list the changes

# Details

I've pulled out one change to #1175 but left in this PR (will probably remove at a later time).

Rather than having the per-plot objects at the top level of the session class, which makes it hard to identify what plots are
used in what places, and hard to write somewhat-generic code, place the plots into a dictionary. There was a partial attempt at improving this in #906 and #931 with the _plot_types dictionary, and this attempts to take that idea and apply it fully:

 - the _plot_store dictionary is used to define the "names" of the plots (e.g. "plot", "model", ...) but it is not yet clear
   about composite plots like "fit". The same change is made for _contour_store.
 - each entry is a `sherpa.utils.ObjectStore` item which is used to select the most appropriate object (in this case the plot class)
   given the data object (e.g. `Data1DInt` or `DataPHA`). There are many cases where this is excessive - as we only have
   a single plot type - but there's no attempt to optimize (either run time or for the person reading the code) this use case

Identifying the "most appropriate" type relies on having a common base case for all the data objects, so we can use the MRO depth for the class to select the largest depth that does not exceed the depth of the data object being queried.

The most user-facing change is in the selection of valid identifiers for a data set (and is actually already merged as part of #1105; I need to check if there's any remaining changes in this PR). Since we want to be able to say

    plot('data', identifier)

then we currently restrict identifier so that it does not match the valid set of plot types that can be sent to `plot` (and ditto for `contour`, but it turns out that contour doesn't add new plot types so we can just think about plots). However, this check isn't direct tied to the plot code, and so it has possibly drifted apart (as plot types were changed or added, I guess). Since we know have a "single" source that defines the plot types (the `_plot_store` dictionary) we can use that in the "is a valid identifier". That is a simplification, as - for reasons I'm not sure about - we actually use a different dictionary (which is related to _plot_store), but the idea is the same (and it may be something we can simplify here too).

---

## Examples

Here are examples where the code has changed::

### Example

`get_data_plot` from `sherp/ui/utils.py` has changed from:

```
try:
    is_int = isinstance(self.get_data(id), sherpa.data.Data1DInt)
except IdentifierErr as ie:
    if recalc:
        raise ie

    is_int = False

if is_int:
    plotobj = self._datahistplot
else:
    plotobj = self._dataplot

if recalc:
    plotobj.prepare(self.get_data(id), self.get_stat())
return plotobj
```

to

```
plotobj, data = self._get_plotobj('data', id, recalc=recalc)
if recalc:
    plotobj.prepare(data, self.get_stat())
return plotobj
```

and logic has been moved to the `clean` which defines

```
        self._plot_store = {}
        self._plot_store['data'] = ObjectStore(sherpa.plot.DataPlot())
        self._plot_store['data'].add(sherpa.data.Data1DInt, sherpa.plot.DataHistogramPlot())
```

### Example

The following routine (`get_data_plot`) from sherpa/astro/ui/utils.py has been removed

```
    def get_data_plot(self, id=None, recalc=True):
        try:
            d = self.get_data(id)
        except IdentifierErr:
            return super().get_data_plot(id, recalc=recalc)

        if isinstance(d, sherpa.astro.data.DataPHA):
            plotobj = self._dataphaplot
            if recalc:
                plotobj.prepare(d, self.get_stat())
            return plotobj

        return super().get_data_plot(id, recalc=recalc)
```

This is because we've added the following logic to `clean`, which means we can use the `get_data_plot` routine from sherpa/ui/utils.py (which was shown in the previous example):

```
        # Add PHA plot types. This is ugly.
        #        
       self._plot_store['data'].add(sherpa.astro.data.DataPHA, sherpa.astro.plot.DataPHAPlot())
```

### Example

An example where it isn't as obvious an improvement: `get_fit_plot` from `sherpa/astro/ui/utils.py` which has changed from

```
    def get_fit_plot(self, id=None, recalc=True):

        plotobj = self._fitplot
        if not recalc:
            return plotobj

        d = self.get_data(id)
        if isinstance(d, sherpa.astro.data.DataPHA):

            dataobj = self.get_data_plot(id, recalc=recalc)

            # We don't use get_model_plot as that uses the ungrouped data
            #    modelobj = self.get_model_plot(id)
            # but we do want to use a histogram plot, not _modelplot.
            # modelobj = self._modelplot

            # Should this object be stored in self? There's
            # no way to get it by API (apart from get_fit_plot).
            #
            modelobj = sherpa.astro.plot.ModelPHAHistogram()
            modelobj.prepare(d, self.get_model(id),
                             self.get_stat())

            plotobj.prepare(dataobj, modelobj)
            return plotobj

        return super().get_fit_plot(id, recalc=recalc)
```

to

```
    def get_fit_plot(self, id=None, recalc=True):

        plotobj, data = self._get_plotobj('fit', id, recalc=recalc)
        if not recalc:
            return plotobj

        if not isinstance(data, sherpa.astro.data.DataPHA):
            # This repeats some of the calls we have already made
            return super().get_fit_plot(id, recalc=recalc)

        dataobj = self.get_data_plot(id, recalc=recalc)

        # Unlike the normal fit plot we use a specialised model class.
        #
        # modelobj = self.get_model_plot(id, recalc=recalc)
        modelobj = sherpa.astro.plot.ModelPHAHistogram()
        modelobj.prepare(data, self.get_model(id), stat=self.get_stat())

        plotobj.prepare(dataobj, modelobj)
        return plotobj
```

---

## Test changes

One of the largest changes is in the tests, as some were directly accessing the fields we have now moved into the `_plot_store` object. The intent of these tests is to check the matplotlib backend is "doing the right thing" without actually having to check the hardcopy output (e.g. PNG or SVG output), so instead want to be able to check the plot objects are filled with the correct data (a common check is to make sure that the `xlog` or `ylog` settings are as expected). It is not always obvious that these checks are meaningful after the changes (in particular the model part of a "fit" plot with PHA data, which is handled specially and doesn't really fit into the plot system).

---

# Notes

There has been a change to template models, but it is not-at-all obvious to me that this  has made things "worse" as there appears to be a  difference between how sherpa.ui and sherpa.astro.ui were handling things:

## Template models

The old `sherpa.ui.utils.get_source_component_plot` included the logic

```
        if isinstance(model, sherpa.models.TemplateModel):
            plotobj = self._comptmplsrcplot
        elif isinstance(d, sherpa.data.Data1DInt):
            plotobj = self._compsrchistplot
        else:
            plotobj = self._compsrcplot
```

where `_comptmplsrcplot` was an instance of `sherpa.plot.ComponentTemplateSourcePlot` (note that there was commented-out code for the "model" version using `ComponentTemplateModelPlot`). Note that this logic is ignored for PHA data because we have for `sherpa.astro.ui.utils.get_source_component_plot` the following:

```
    def get_source_component_plot(self, id, model=None, recalc=True):
        if model is None:
            id, model = model, id
        self._check_model(model)
        if isinstance(model, string_types):
            model = self._eval_model_expression(model)

        try:
            d = self.get_data(id)
        except IdentifierErr as ie:
            if recalc:
                raise ie
            d = None

        if isinstance(d, sherpa.astro.data.DataPHA):
            plotobj = self._astrocompsrcplot
            if recalc:
                plotobj.prepare(d, model, self.get_stat())
            return plotobj

        return super().get_source_component_plot(id, model=model, recalc=recalc)
```

That is, if it's a `DataPHA` object then we skip the template-model check. So I argue that we need to review what the template model plot classes are meant to be for and when they should be applied (e.g. what happens if you have a composite model?). If we do need to worry about handling template-models specially then the approach used in this PR probably goes out of the window (or needs major work).
 