### PR TITLE
Simplify implementation of pyfits backend

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -736,7 +736,7 @@ def get_rmf_data(arg, make_copy=False):
         rowdata = []
         for mrow, ng, ncs in zip(matrix, n_grp, n_chan):
             # Need a RMF which ng>1 to test this with.
-            if ng == 1:
+            if numpy.isscalar(ncs):
                 ncs = [ncs]
 
             start = 0


### PR DESCRIPTION
These are the general steps that we can take to reduce the code:

- replace table writing with the `astropy.table.Table` interface
- replace table reading with the same interface
- Can we use `astropy.wcs` instead of the WCS implemented here?

At least as of now, this implemenation is not identical to pycrates
any longer, e.g.
- an astropy specific warning is emitted for file operations
  (e.g. file not found, clobber=False and file exists).
  I think that's OK.
- The creates backend automatically tries to add ".gz" if the filename
  is not found. That requires and extra try .. except that I did not
  put in yet (maybe as a decorator for file reading functions)
- Should header be written? Should keywords that are None be written?
  The pyfits code has opinions on this, this implementation simply
  chooses the path of least resistance. If really needed, thos could be
  added back in.

This is a WIP, I'm putting it up here for general discussion and so I
don't forget. The reason I'm looking at this at all (why youch working code?)
is that I needed and ARF/RMF reader/writer for a different project and was
hoping to use the implementation that's alrady in Sherpa. So, I had to
understand what's in here first.

Also related to
- #1070 (at least astropy table can read from URLs and
  read/write to streams).
- #878

closes #841

Note: We could always leave the pyfits backend untouched (safe!) and move
this to a new backend "astropy". That way we can collect some real world
experience and see if it breaks too much. While I don't think we should
maintain both pyfits backend and this indefinitely, there is little harm
in having both for an extended pariod of time (assuming I ever finish this PR!)

Todo

- [ ] Table reading (especially RMF/ARF!)
- [ ] image reading / writing
- [ ] modify tests because this throws different exceptions now (but may we don't have to text all branches any longer, since astropy itself tests, e.g. that overwrite=False does not overwrite an existing file.