### PR TITLE
Numpy 1.20 warnings

### DIFF
--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -172,7 +172,12 @@ def test_read_pha_fails_rmf(make_data_path):
     assert emsg in str(excinfo.value)
 
 
-def validate_replacement_warning(ws, rtype, label):
+def validate_replacement_warning(ws, rtype, label, is_known_warning):
+    """Check that there is one expected warning."""
+
+    # Filter out the "allowed" warnings.
+    #
+    ws = [w for w in ws if not is_known_warning(w)]
 
     assert len(ws) == 1
     w = ws[0]
@@ -185,7 +190,7 @@ def validate_replacement_warning(ws, rtype, label):
 
 @requires_data
 @requires_fits
-def test_read_arf(make_data_path):
+def test_read_arf(make_data_path, is_known_warning):
     """Can we read in a Swift ARF."""
 
     infile = make_data_path(ARFFILE)
@@ -194,7 +199,7 @@ def test_read_arf(make_data_path):
         warnings.simplefilter("always")
         arf = io.read_arf(infile)
 
-    validate_replacement_warning(ws, 'ARF', infile)
+    validate_replacement_warning(ws, 'ARF', infile, is_known_warning)
 
     assert isinstance(arf, DataARF)
 
@@ -262,7 +267,7 @@ def test_read_arf_fails_rmf(make_data_path):
 
 @requires_data
 @requires_fits
-def test_read_rmf(make_data_path):
+def test_read_rmf(make_data_path, is_known_warning):
     """Can we read in a Swift RMF."""
 
     infile = make_data_path(RMFFILE)
@@ -271,7 +276,7 @@ def test_read_rmf(make_data_path):
         warnings.simplefilter("always")
         rmf = io.read_rmf(infile)
 
-    validate_replacement_warning(ws, 'RMF', infile)
+    validate_replacement_warning(ws, 'RMF', infile, is_known_warning)
 
     assert isinstance(rmf, DataRMF)
 
@@ -362,7 +367,7 @@ def test_read_rmf_fails_arf(make_data_path):
 
 @requires_data
 @requires_fits
-def test_can_use_swift_data(make_data_path):
+def test_can_use_swift_data(make_data_path, is_known_warning):
     """A basic check that we can read in and use the Swift data.
 
     Unlike the previous tests, that directly access the io module,
@@ -383,14 +388,14 @@ def test_can_use_swift_data(make_data_path):
         warnings.simplefilter("always")
         ui.load_rmf(rmffile)
 
-    validate_replacement_warning(ws, 'RMF', rmffile)
+    validate_replacement_warning(ws, 'RMF', rmffile, is_known_warning)
 
     arffile = make_data_path(ARFFILE)
     with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter("always")
         ui.load_arf(arffile)
 
-    validate_replacement_warning(ws, 'ARF', arffile)
+    validate_replacement_warning(ws, 'ARF', arffile, is_known_warning)
 
     assert ui.get_analysis() == 'energy'
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -143,18 +143,11 @@ known_warnings = {
          # See https://github.com/ContinuumIO/anaconda-issues/issues/6678
          r"numpy.dtype size changed, may indicate binary " +
          r"incompatibility. Expected 96, got 88",
-         # I am getting the following from astropy with at least python 2.7 during the conda tests
-         r"numpy.ufunc size changed, may indicate binary "
+         # See https://github.com/numpy/numpy/pull/432
+         r"numpy.ufunc size changed",
+         # numpy 1.20 shows this in some tests
+         r"numpy.ndarray size changed, may indicate binary "
          ],
-    VisibleDeprecationWarning:
-        [],
-}
-
-# Since Sherpa now requires Python 3.5 at a minumum, the following
-# are always added, but kept as a separate dict and then merged
-# to make it clearer where they came from.
-#
-python3_warnings = {
     ResourceWarning:
         [
             r"unclosed file .*king_kernel.txt.* closefd=True>",
@@ -174,19 +167,9 @@ python3_warnings = {
             r"unclosed file .*/model.dat'.* closefd=True>",
             r"unclosed file .*/resid.out'.* closefd=True>",
         ],
-    RuntimeWarning:
-        [r"invalid value encountered in sqrt",
-         # See https://github.com/ContinuumIO/anaconda-issues/issues/6678
-         r"numpy.dtype size changed, may indicate binary " +
-         r"incompatibility. Expected 96, got 88",
-         # See https://github.com/numpy/numpy/pull/432
-         r"numpy.ufunc size changed",
-         # numpy 1.20 shows this in some tests
-         r"numpy.ndarray size changed, may indicate binary "
-         ],
+    VisibleDeprecationWarning:
+        [],
 }
-known_warnings.update(python3_warnings)
-
 
 if have_astropy:
     astropy_warnings = {

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -144,7 +144,7 @@ known_warnings = {
          r"numpy.dtype size changed, may indicate binary " +
          r"incompatibility. Expected 96, got 88",
          # I am getting the following from astropy with at least python 2.7 during the conda tests
-         r"numpy.ufunc size changed, may indicate binary ",
+         r"numpy.ufunc size changed, may indicate binary "
          ],
     VisibleDeprecationWarning:
         [],
@@ -180,7 +180,9 @@ python3_warnings = {
          r"numpy.dtype size changed, may indicate binary " +
          r"incompatibility. Expected 96, got 88",
          # See https://github.com/numpy/numpy/pull/432
-         r"numpy.ufunc size changed"
+         r"numpy.ufunc size changed",
+         # numpy 1.20 shows this in some tests
+         r"numpy.ndarray size changed, may indicate binary "
          ],
 }
 known_warnings.update(python3_warnings)


### PR DESCRIPTION
# Summary

Avoid test failures due to new warnings added by NumPy 1.20

# Details

This does not "fix" the underlying code, but does allow us to run the CI tests to see things still pass. Further changes will need to be made to address the deprecations that NumPy 1.20 is now warning about.

An example of the tests failing without these tests is https://github.com/sherpa/sherpa/pull/1089/commits/ff3853748ebdd1982459527c53b72fb15197e6c7