### PR TITLE
Cleanup multi plot code

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3611,7 +3611,7 @@ def test_plot_fit_resid_set_xlog(idval, plottype, xscale, clean_astro_ui):
     """Check that set_xlog handling for plot_fit_resid.
 
     What is the X-axis scaling when you call set_xlog(plottype)?
-    We use a rannge of plottypes as the behavior is not always
+    We use a range of plot types as the behavior is not always
     obvious, so let's ensure we test them.
     """
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3579,3 +3579,94 @@ def test_set_plot_opt_explicit_astro():
     assert fig.axes[3].get_yscale() == 'linear'
 
     plt.close(fig)
+
+
+def check_plot2_xscale(xscale):
+    """Are there two plots, y-axis linear, x axis set?
+
+    Any test using this needs @requires_pylab
+    """
+
+    from matplotlib import pyplot as plt
+
+    fig = plt.gcf()
+    axes = fig.axes
+    assert len(axes) == 2
+    assert axes[0].xaxis.get_label().get_text() == ''
+
+    assert axes[0].xaxis.get_scale() == xscale
+    assert axes[0].yaxis.get_scale() == 'linear'
+
+    assert axes[1].xaxis.get_scale() == xscale
+    assert axes[1].yaxis.get_scale() == 'linear'
+
+
+@requires_pylab
+@pytest.mark.parametrize("idval", [None, "bob"])
+@pytest.mark.parametrize("plottype,xscale", [('data', 'log'),
+                                             ('resid', 'log'),
+                                             ('bkg', 'linear'),
+                                             ('bkgresid', 'linear')])
+def test_plot_fit_resid_set_xlog(idval, plottype, xscale, clean_astro_ui):
+    """Check that set_xlog handling for plot_fit_resid.
+
+    What is the X-axis scaling when you call set_xlog(plottype)?
+    We use a rannge of plottypes as the behavior is not always
+    obvious, so let's ensure we test them.
+    """
+
+    setup_example(idval)
+    ui.set_xlog(plottype)
+    ui.plot_fit_resid(idval)
+    check_plot2_xscale(xscale)
+
+
+@requires_pylab
+@pytest.mark.parametrize("idval", [None, "bob"])
+@pytest.mark.parametrize("plottype,xscale", [('data', 'linear'),
+                                             ('resid', 'linear'),
+                                             ('bkg', 'log'),
+                                             ('bkgresid', 'log')])
+def test_plot_bkg_fit_resid_set_xlog(idval, plottype, xscale, clean_astro_ui):
+    """Check that set_xlog handling for plot_bkg_fit_resid.
+
+    This logic could be added to test_plot_fit_resid_set_xlog but it
+    would complicate the setup, so we duplicate the code.
+
+    """
+
+    setup_example_bkg_model(idval)
+    ui.set_xlog(plottype)
+    ui.plot_bkg_fit_resid(idval)
+    check_plot2_xscale(xscale)
+
+
+@requires_pylab
+@pytest.mark.parametrize("plot,yscale", [('data', 'linear'),
+                                         ('ratio', 'linear'),
+                                         ('fit', 'linear'),
+                                         ('bkg', 'log'),
+                                         ('bkg_resid', 'linear'),
+                                         ('bkg_fit', 'log')])
+def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
+    """Check y axis after_ylog('bkg').
+
+    The idea is to check how separate the "background" from
+    "non-background" plots are.  I use ylog since other tests have
+    used xlog.
+
+    """
+
+    from matplotlib import pyplot as plt
+
+    setup_example_bkg_model(1)
+    ui.set_ylog('bkg')
+
+    pfunc = getattr(ui, f'plot_{plot}')
+    pfunc()
+
+    fig = plt.gcf()
+    axes = fig.axes
+    assert len(axes) == 1
+    assert axes[0].xaxis.get_scale() == 'linear'
+    assert axes[0].yaxis.get_scale() == yscale

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12430,11 +12430,14 @@ class Session(sherpa.ui.utils.Session):
             self._jointplot.plottop(plot1, overplot=overplot,
                                     clearwindow=clearwindow, **kwargs)
 
+            # Unlike the plot version we can assume we are dealing
+            # with histogram plots here.
+            #
             oldval = plot2.plot_prefs['xlog']
-            if (('xlog' in self._bkgdataplot.histo_prefs and
-                 self._bkgdataplot.histo_prefs['xlog']) or
-                ('xlog' in self._bkgmodelplot.histo_prefs and
-                 self._bkgmodelplot.histo_prefs['xlog'])):
+            dprefs = plot1.dataplot.histo_prefs
+            mprefs = plot1.modelplot.histo_prefs
+
+            if dprefs['xlog'] or mprefs['xlog']:
                 plot2.plot_prefs['xlog'] = True
 
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -2717,3 +2717,62 @@ def test_plot_fit_xxx_overplot_pylab(ptype, caplog):
         l0 = axes[idx].lines
         assert l0[0].get_xydata() == pytest.approx(l0[2].get_xydata())
         assert l0[1].get_xydata() == pytest.approx(l0[3].get_xydata())
+
+
+@requires_pylab
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_plot_fit_resid_handles_data_log(idval, clean_ui):
+    """Check that log handling is correct: data=log
+
+    See also test_plot_fit_resid_handles_resid_log.
+
+    I thought we had tests of this, but apparently not.
+    """
+
+    from matplotlib import pyplot as plt
+
+    setup_example(idval)
+    ui.set_xlog('data')
+    ui.plot_fit_resid(idval)
+
+    fig = plt.gcf()
+    axes = fig.axes
+    assert len(axes) == 2
+    assert axes[0].xaxis.get_label().get_text() == ''
+
+    assert axes[0].xaxis.get_scale() == 'log'
+    assert axes[0].yaxis.get_scale() == 'linear'
+
+    assert axes[1].xaxis.get_scale() == 'log'
+    assert axes[1].yaxis.get_scale() == 'linear'
+
+
+@requires_pylab
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_plot_fit_resid_handles_resid_log(idval, clean_ui):
+    """Check that log handling is correct: resid=log
+
+    We need to decide whether we want the residual setting to override
+    the linear display of the fit plot here. At present the code is
+    that if resid has xlog set then both will be drawn logged (since
+    the X axis is shared via a sharex=True argument to plt.subplots)
+    but we may decide this should change.
+
+    """
+
+    from matplotlib import pyplot as plt
+
+    setup_example(idval)
+    ui.set_xlog('resid')
+    ui.plot_fit_resid(idval)
+
+    fig = plt.gcf()
+    axes = fig.axes
+    assert len(axes) == 2
+    assert axes[0].xaxis.get_label().get_text() == ''
+
+    assert axes[0].xaxis.get_scale() == 'log'
+    assert axes[0].yaxis.get_scale() == 'linear'
+
+    assert axes[1].xaxis.get_scale() == 'log'
+    assert axes[1].yaxis.get_scale() == 'linear'

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13266,19 +13266,22 @@ class Session(NoNewAttributesAfterInit):
             # plot (i.e. it is assumed that this is a fit plot)
             # use a log scale.
             #
-            # DJB believes that the following preference check is
-            # more-complicated than it needs to be: it should be
-            # sufficient to just use the preferences in the
-            # plot1 and plot2 objects, rather than dig around
-            # in the self.{_data/_model}plot structures (as they
-            # should be the same object), but we do not have enough
-            # tests to check this.
+            # This is complicated by the need to access the individual
+            # plot preferences of plot1, and then check for different
+            # types of plot objects.
             #
             oldval = plot2.plot_prefs['xlog']
-            if (('xlog' in self._dataplot.plot_prefs and
-                 self._dataplot.plot_prefs['xlog']) or
-                ('xlog' in self._modelplot.plot_prefs and
-                 self._modelplot.plot_prefs['xlog'])):
+            try:
+                dprefs = plot1.dataplot.histo_prefs
+            except AttributeError:
+                dprefs = plot1.dataplot.plot_prefs
+
+            try:
+                mprefs = plot1.modelplot.histo_prefs
+            except AttributeError:
+                mprefs = plot1.modelplot.plot_prefs
+
+            if dprefs['xlog'] or mprefs['xlog']:
                 plot2.plot_prefs['xlog'] = True
 
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)


### PR DESCRIPTION
# Summary

Rework the code that handles the plot_fit_xxx and plot_bkg_fit_xxx calls. There should be no user-visible changes.

# Details

I noted in #626 - in particular aa472cbbbe1d1074ead8b6328a37393b9f39fe77 - that the handling of "jointplot" could be improved but that there wasn't enough tests of the functionality. This tries to fix both.

The aim is to avoid direct access to the plot objects (e.g. self._dataplot and self._modelplot) and instead use less-specialised functions to get them (in this case we can use the actual plot objects that are being used to create the plots). We can also assume that all the plot types support the `xlog` setting so there's no need to check for it and, in the background case, we know we are dealing with histogram-style plots so saving some accessor shenanighans.