### PR TITLE
Reduce direct access to plot objects

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021
-#      Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -10231,34 +10231,6 @@ class Session(sherpa.ui.utils.Session):
     # Plotting
     ###########################################################################
 
-    def get_data_plot_prefs(self, id=None):
-
-        try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.astro.data.DataPHA):
-                return self._dataphaplot.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return super().get_data_plot_prefs(id)
-
-    get_data_plot_prefs.__doc__ = sherpa.ui.utils.Session.get_data_plot_prefs.__doc__
-
-    def get_model_plot_prefs(self, id=None):
-
-        try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.astro.data.DataPHA):
-                return self._modelhisto.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return super().get_model_plot_prefs(id)
-
-    get_model_plot_prefs.__doc__ = sherpa.ui.utils.Session.get_model_plot_prefs.__doc__
-
     def get_data_plot(self, id=None, recalc=True):
         try:
             d = self.get_data(id)
@@ -10367,7 +10339,13 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._astrosourceplot
             if recalc:
@@ -10414,7 +10392,13 @@ class Session(sherpa.ui.utils.Session):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._astrocompmdlplot
             if recalc:
@@ -10433,7 +10417,13 @@ class Session(sherpa.ui.utils.Session):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._astrocompsrcplot
             if recalc:

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -45,7 +45,7 @@ from sherpa.plot import CDFPlot, DataPlot, FitPlot, ModelPlot, \
     DataHistogramPlot
 
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
 from sherpa.utils.testing import requires_plotting, requires_pylab
 
 
@@ -1975,6 +1975,26 @@ def test_xxx_plot_nodata(ptype, extraargs, session):
     func = getattr(s, 'get_{}_plot'.format(ptype))
     retval = func(*extraargs, recalc=False)
     assert retval.y is None
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype,extraargs",
+                         [('model', []), ('model_component', ['mdl']),
+                          ('source', []), ('source_component', ['mdl'])])
+def test_xxx_plot_nodata_recalc(ptype, extraargs, session):
+    """Basic testing of get_xxx_plot when there's no data and recalc=True"""
+
+    s = session()
+    s._add_model_types(basic)
+
+    mdl = s.create_model_component('polynom1d', 'mdl')
+    mdl.c0 = 10
+    mdl.c1 = 1
+    s.set_source(mdl)
+
+    func = getattr(s, 'get_{}_plot'.format(ptype))
+    with pytest.raises(IdentifierErr):
+        func(*extraargs)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -146,9 +146,6 @@ def test_plot_prefs_xxx(session, ptype, arg):
     defaults to 'False'; b) each plot type has this setting; c) we
     do not need to check all settings.
 
-    Some tests fail due to missing plot preferences when there's
-    no plotting backend (e.g. missing 'xlog' settings), so skip
-    these tests in this case.
     """
 
     s = session()
@@ -1958,6 +1955,26 @@ def test_data_plot_recalc(session):
     assert p.xlo == pytest.approx([20, 30, 40])
     assert p.xhi == pytest.approx([25, 40, 60])
     assert p.y == pytest.approx([10, 12, 14])
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype,extraargs",
+                         [('model', []), ('model_component', ['mdl']),
+                          ('source', []), ('source_component', ['mdl'])])
+def test_xxx_plot_nodata(ptype, extraargs, session):
+    """Basic testing of get_xxx_plot when there's no data"""
+
+    s = session()
+    s._add_model_types(basic)
+
+    mdl = s.create_model_component('polynom1d', 'mdl')
+    mdl.c0 = 10
+    mdl.c1 = 1
+    s.set_source(mdl)
+
+    func = getattr(s, 'get_{}_plot'.format(ptype))
+    retval = func(*extraargs, recalc=False)
+    assert retval.y is None
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -10538,7 +10538,10 @@ class Session(NoNewAttributesAfterInit):
         #
         try:
             is_int = isinstance(self.get_data(id), sherpa.data.Data1DInt)
-        except IdentifierErr:
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+
             is_int = False
 
         if is_int:
@@ -10664,15 +10667,11 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
+        plot = self.get_data_plot(id, recalc=False)
         try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.data.Data1DInt):
-                return self._datahistplot.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return self._dataplot.plot_prefs
+            return plot.histo_prefs
+        except AttributeError:
+            return plot.plot_prefs
 
     # also in sherpa.astro.utils (copies this docstring)
     def get_model_plot(self, id=None, recalc=True):
@@ -10708,7 +10707,13 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.data.Data1DInt):
             plotobj = self._modelhistplot
         else:
@@ -10778,7 +10783,13 @@ class Session(NoNewAttributesAfterInit):
                                 "\n is set for dataset {}.".format(id) +
                                 " You should use get_model_plot instead.")
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.data.Data1DInt):
             plotobj = self._sourcehistplot
         else:
@@ -10853,7 +10864,13 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.data.Data1DInt):
             plotobj = self._compmdlhistplot
         else:
@@ -10928,7 +10945,13 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(model, sherpa.models.TemplateModel):
             plotobj = self._comptmplsrcplot
         elif isinstance(d, sherpa.data.Data1DInt):
@@ -10994,15 +11017,11 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
+        plot = self.get_model_plot(id, recalc=False)
         try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.data.Data1DInt):
-                return self._modelhistplot.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return self._modelplot.plot_prefs
+            return plot.histo_prefs
+        except AttributeError:
+            return plot.plot_prefs
 
     def get_fit_plot(self, id=None, recalc=True):
         """Return the data used to create the fit plot.
@@ -11416,7 +11435,7 @@ class Session(NoNewAttributesAfterInit):
         >>> contour_data()
 
         """
-        return self._datacontour.contour_prefs
+        return self.get_data_contour(id, recalc=False).contour_prefs
 
     def get_model_contour(self, id=None, recalc=True):
         """Return the data used by contour_model.
@@ -11562,7 +11581,7 @@ class Session(NoNewAttributesAfterInit):
         >>> contour_model(overcontour=True)
 
         """
-        return self._modelcontour.contour_prefs
+        return self.get_model_contour(id, recalc=False).contour_prefs
 
     def get_fit_contour(self, id=None, recalc=True):
         """Return the data used by contour_fit.
@@ -13614,10 +13633,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_pdf_plot isn't very
-        # useful here.
-        #
-        plotobj = self._pdfplot
+        plotobj = self.get_pdf_plot()
         if not replot:
             plotobj.prepare(points, bins, normed, xlabel, name)
 
@@ -13685,10 +13701,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_cdf_plot isn't very
-        # useful here.
-        #
-        plotobj = self._cdfplot
+        plotobj = self.get_cdf_plot()
         if not replot:
             plotobj.prepare(points, xlabel, name)
 
@@ -13763,10 +13776,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_trace_plot isn't very
-        # useful here.
-        #
-        plotobj = self._traceplot
+        plotobj = self.get_trace_plot()
         if not replot:
             plotobj.prepare(points, xlabel, name)
 
@@ -13838,10 +13848,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_scatter_plot isn't very
-        # useful here.
-        #
-        plotobj = self._scatterplot
+        plotobj = self.get_scatter_plot()
         if not replot:
             plotobj.prepare(x, y, xlabel, ylabel, name)
 


### PR DESCRIPTION
# Summary

Changes to the internals of the plot code, to access information via methods rather than direct access, which improves encapsulation and reduces code repetition.

# Details

This is another "small" change from the larger "plot rework" I'm doing (e.g. #1089).

There's two parts in the commit

a) Accessors

The simple case is something like `get_data_contour_prefs` which has gone from

    return self._datacontour.contour_prefs

to

    return self.get_data_contour(id, recalc=False).contour_prefs

The real benefit is for plots which have more-complex requirements (e.g. data plots require a DataPHA check in the astro-ui layer and then falling through to the ui layer where there's a check for Data1DInt). By using the `get_<>_plot/contour` calls rather than direct access we can avoid repeating this logic and, in some cases, avoid the need for subclassing the routines in the first place.

b) In a number of routines the data-accessor has been changed so that it no-longer errors out if the dataset does not exist. 


The change is basically from `d = get_data(id)` to

```
try:
    d = get_data(id)
except IdentifierErr as ie:
    if recalc:
        raise ie
    d = None
```

I added a test to check this functionality (it's related to source/model/source_component/model_component plots).