### PR TITLE
WIP Simplify plot preference access

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -12435,16 +12435,17 @@ class Session(sherpa.ui.utils.Session):
             # Unlike the plot version we can assume we are dealing
             # with histogram plots here.
             #
-            oldval = plot2.plot_prefs['xlog']
-            dprefs = plot1.dataplot.histo_prefs
-            mprefs = plot1.modelplot.histo_prefs
+            prefs2 = plot2.get_prefs()
+            oldval = prefs2['xlog']
+            dprefs = plot1.dataplot.get_prefs()
+            mprefs = plot1.modelplot.get_prefs()
 
             if dprefs['xlog'] or mprefs['xlog']:
-                plot2.plot_prefs['xlog'] = True
+                prefs2['xlog'] = True
 
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)
 
-            plot2.plot_prefs['xlog'] = oldval
+            prefs2['xlog'] = oldval
         except:
             sherpa.plot.exceptions()
             raise

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021
-#      Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -10231,34 +10231,6 @@ class Session(sherpa.ui.utils.Session):
     # Plotting
     ###########################################################################
 
-    def get_data_plot_prefs(self, id=None):
-
-        try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.astro.data.DataPHA):
-                return self._dataphaplot.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return super().get_data_plot_prefs(id)
-
-    get_data_plot_prefs.__doc__ = sherpa.ui.utils.Session.get_data_plot_prefs.__doc__
-
-    def get_model_plot_prefs(self, id=None):
-
-        try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.astro.data.DataPHA):
-                return self._modelhisto.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return super().get_model_plot_prefs(id)
-
-    get_model_plot_prefs.__doc__ = sherpa.ui.utils.Session.get_model_plot_prefs.__doc__
-
     def get_data_plot(self, id=None, recalc=True):
         try:
             d = self.get_data(id)
@@ -10367,7 +10339,13 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._astrosourceplot
             if recalc:
@@ -10414,7 +10392,13 @@ class Session(sherpa.ui.utils.Session):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._astrocompmdlplot
             if recalc:
@@ -10433,7 +10417,13 @@ class Session(sherpa.ui.utils.Session):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.astro.data.DataPHA):
             plotobj = self._astrocompsrcplot
             if recalc:

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021
-#      Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -258,6 +258,18 @@ class Plot(NoNewAttributesAfterInit):
         self.plot_prefs = self.plot_prefs.copy()
         NoNewAttributesAfterInit.__init__(self)
 
+    def get_prefs(self):
+        """Return the preferences dictionary.
+
+        The returned value can be edited to change the stored data.
+
+        Returns
+        -------
+        prefs : dict
+
+        """
+        return self.plot_prefs
+
     @staticmethod
     def vline(x, ymin=0, ymax=1,
               linecolor=None, linestyle=None, linewidth=None,
@@ -351,6 +363,18 @@ class Contour(NoNewAttributesAfterInit):
         self.contour_prefs = self.contour_prefs.copy()
         NoNewAttributesAfterInit.__init__(self)
 
+    def get_prefs(self):
+        """Return the preferences dictionary.
+
+        The returned value can be edited to change the stored data.
+
+        Returns
+        -------
+        prefs : dict
+
+        """
+        return self.contour_prefs
+
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
         return merge_settings(self.contour_prefs, kwargs)
@@ -383,6 +407,18 @@ class Point(NoNewAttributesAfterInit):
         """
         self.point_prefs = self.point_prefs.copy()
         NoNewAttributesAfterInit.__init__(self)
+
+    def get_prefs(self):
+        """Return the preferences dictionary.
+
+        The returned value can be edited to change the stored data.
+
+        Returns
+        -------
+        prefs : dict
+
+        """
+        return self.point_prefs
 
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
@@ -429,6 +465,18 @@ class Histogram(NoNewAttributesAfterInit):
         """
         self.histo_prefs = self.histo_prefs.copy()
         NoNewAttributesAfterInit.__init__(self)
+
+    def get_prefs(self):
+        """Return the preferences dictionary.
+
+        The returned value can be edited to change the stored data.
+
+        Returns
+        -------
+        prefs : dict
+
+        """
+        return self.histo_prefs
 
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
@@ -965,6 +1013,19 @@ class SplitPlot(Plot, Contour):
         self.reset(rows, cols)
         Plot.__init__(self)
         Contour.__init__(self)
+
+    # Since Plot and Contour both have get_prefs let's be explicit
+    def get_prefs(self):
+        """Return the preferences dictionary.
+
+        The returned value can be edited to change the stored data.
+
+        Returns
+        -------
+        prefs : dict
+
+        """
+        return self.plot_prefs
 
     def __str__(self):
         return (('rows   = %s\n' +
@@ -1598,7 +1659,7 @@ class ComponentModelPlot(ModelPlot):
 
 class ComponentModelHistogramPlot(ModelHistogramPlot):
 
-    # Is this the correct setting?
+    # TODO: Is this the correct setting? Shouldn't it change histo_prefs?
     plot_prefs = backend.get_component_plot_defaults()
 
     def prepare(self, data, model, stat=None):
@@ -1654,7 +1715,7 @@ class ComponentSourcePlot(SourcePlot):
 
 class ComponentSourceHistogramPlot(SourceHistogramPlot):
 
-    # Is this the correct setting?
+    # TODO: Is this the correct setting? Shouldn't it change histo_prefs?
     plot_prefs = backend.get_component_plot_defaults()
 
     def prepare(self, data, model, stat=None):
@@ -2441,6 +2502,19 @@ class Confidence2D(DataContour, Point):
         self.stat = None
         self.numcores = None
         DataContour.__init__(self)
+
+    # Since DataContour and Point both have get_prefs let's be explicit
+    def get_prefs(self):
+        """Return the preferences dictionary.
+
+        The returned value can be edited to change the stored data.
+
+        Returns
+        -------
+        prefs : dict
+
+        """
+        return self.contour_prefs
 
     def __setstate__(self, state):
         self.__dict__.update(state)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -45,7 +45,7 @@ from sherpa.plot import CDFPlot, DataPlot, FitPlot, ModelPlot, \
     DataHistogramPlot
 
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
 from sherpa.utils.testing import requires_plotting, requires_pylab
 
 
@@ -1975,6 +1975,26 @@ def test_xxx_plot_nodata(ptype, extraargs, session):
     func = getattr(s, 'get_{}_plot'.format(ptype))
     retval = func(*extraargs, recalc=False)
     assert retval.y is None
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype,extraargs",
+                         [('model', []), ('model_component', ['mdl']),
+                          ('source', []), ('source_component', ['mdl'])])
+def test_xxx_plot_nodata_recalc(ptype, extraargs, session):
+    """Basic testing of get_xxx_plot when there's no data and recalc=True"""
+
+    s = session()
+    s._add_model_types(basic)
+
+    mdl = s.create_model_component('polynom1d', 'mdl')
+    mdl.c0 = 10
+    mdl.c1 = 1
+    s.set_source(mdl)
+
+    func = getattr(s, 'get_{}_plot'.format(ptype))
+    with pytest.raises(IdentifierErr):
+        func(*extraargs)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -146,9 +146,6 @@ def test_plot_prefs_xxx(session, ptype, arg):
     defaults to 'False'; b) each plot type has this setting; c) we
     do not need to check all settings.
 
-    Some tests fail due to missing plot preferences when there's
-    no plotting backend (e.g. missing 'xlog' settings), so skip
-    these tests in this case.
     """
 
     s = session()
@@ -1958,6 +1955,26 @@ def test_data_plot_recalc(session):
     assert p.xlo == pytest.approx([20, 30, 40])
     assert p.xhi == pytest.approx([25, 40, 60])
     assert p.y == pytest.approx([10, 12, 14])
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype,extraargs",
+                         [('model', []), ('model_component', ['mdl']),
+                          ('source', []), ('source_component', ['mdl'])])
+def test_xxx_plot_nodata(ptype, extraargs, session):
+    """Basic testing of get_xxx_plot when there's no data"""
+
+    s = session()
+    s._add_model_types(basic)
+
+    mdl = s.create_model_component('polynom1d', 'mdl')
+    mdl.c0 = 10
+    mdl.c1 = 1
+    s.set_source(mdl)
+
+    func = getattr(s, 'get_{}_plot'.format(ptype))
+    retval = func(*extraargs, recalc=False)
+    assert retval.y is None
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10667,11 +10667,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plot = self.get_data_plot(id, recalc=False)
-        try:
-            return plot.histo_prefs
-        except AttributeError:
-            return plot.plot_prefs
+        return self.get_data_plot(id, recalc=False).get_prefs()
 
     # also in sherpa.astro.utils (copies this docstring)
     def get_model_plot(self, id=None, recalc=True):
@@ -11017,11 +11013,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plot = self.get_model_plot(id, recalc=False)
-        try:
-            return plot.histo_prefs
-        except AttributeError:
-            return plot.plot_prefs
+        return self.get_model_plot(id, recalc=False).get_prefs()
 
     def get_fit_plot(self, id=None, recalc=True):
         """Return the data used to create the fit plot.
@@ -12019,15 +12011,8 @@ class Session(NoNewAttributesAfterInit):
 
         for key in keys:
             for plot in self._plot_types[key]:
-                # This could be a "line" or "histogram" style plot.
-                #
-                try:
-                    plot.plot_prefs[item] = value
-                except AttributeError:
-                    try:
-                        plot.histo_prefs[item] = value
-                    except AttributeError:
-                        pass
+                prefs = plot.get_prefs()
+                prefs[item] = value
 
     def set_xlog(self, plottype="all"):
         """New plots will display a logarithmically-scaled X axis.
@@ -13289,23 +13274,17 @@ class Session(NoNewAttributesAfterInit):
             # plot preferences of plot1, and then check for different
             # types of plot objects.
             #
-            oldval = plot2.plot_prefs['xlog']
-            try:
-                dprefs = plot1.dataplot.histo_prefs
-            except AttributeError:
-                dprefs = plot1.dataplot.plot_prefs
-
-            try:
-                mprefs = plot1.modelplot.histo_prefs
-            except AttributeError:
-                mprefs = plot1.modelplot.plot_prefs
+            prefs2 = plot2.get_prefs()
+            oldval = prefs2['xlog']
+            dprefs = plot1.dataplot.get_prefs()
+            mprefs = plot1.modelplot.get_prefs()
 
             if dprefs['xlog'] or mprefs['xlog']:
-                plot2.plot_prefs['xlog'] = True
+                prefs2['xlog'] = True
 
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)
 
-            plot2.plot_prefs['xlog'] = oldval
+            prefs2['xlog'] = oldval
         except:
             sherpa.plot.exceptions()
             raise

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -10538,7 +10538,10 @@ class Session(NoNewAttributesAfterInit):
         #
         try:
             is_int = isinstance(self.get_data(id), sherpa.data.Data1DInt)
-        except IdentifierErr:
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+
             is_int = False
 
         if is_int:
@@ -10664,15 +10667,11 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
+        plot = self.get_data_plot(id, recalc=False)
         try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.data.Data1DInt):
-                return self._datahistplot.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return self._dataplot.plot_prefs
+            return plot.histo_prefs
+        except AttributeError:
+            return plot.plot_prefs
 
     # also in sherpa.astro.utils (copies this docstring)
     def get_model_plot(self, id=None, recalc=True):
@@ -10708,7 +10707,13 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.data.Data1DInt):
             plotobj = self._modelhistplot
         else:
@@ -10778,7 +10783,13 @@ class Session(NoNewAttributesAfterInit):
                                 "\n is set for dataset {}.".format(id) +
                                 " You should use get_model_plot instead.")
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.data.Data1DInt):
             plotobj = self._sourcehistplot
         else:
@@ -10853,7 +10864,13 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(d, sherpa.data.Data1DInt):
             plotobj = self._compmdlhistplot
         else:
@@ -10928,7 +10945,13 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
-        d = self.get_data(id)
+        try:
+            d = self.get_data(id)
+        except IdentifierErr as ie:
+            if recalc:
+                raise ie
+            d = None
+
         if isinstance(model, sherpa.models.TemplateModel):
             plotobj = self._comptmplsrcplot
         elif isinstance(d, sherpa.data.Data1DInt):
@@ -10994,15 +11017,11 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
+        plot = self.get_model_plot(id, recalc=False)
         try:
-            d = self.get_data(id)
-            if isinstance(d, sherpa.data.Data1DInt):
-                return self._modelhistplot.histo_prefs
-
-        except IdentifierErr:
-            pass
-
-        return self._modelplot.plot_prefs
+            return plot.histo_prefs
+        except AttributeError:
+            return plot.plot_prefs
 
     def get_fit_plot(self, id=None, recalc=True):
         """Return the data used to create the fit plot.
@@ -11416,7 +11435,7 @@ class Session(NoNewAttributesAfterInit):
         >>> contour_data()
 
         """
-        return self._datacontour.contour_prefs
+        return self.get_data_contour(id, recalc=False).contour_prefs
 
     def get_model_contour(self, id=None, recalc=True):
         """Return the data used by contour_model.
@@ -11562,7 +11581,7 @@ class Session(NoNewAttributesAfterInit):
         >>> contour_model(overcontour=True)
 
         """
-        return self._modelcontour.contour_prefs
+        return self.get_model_contour(id, recalc=False).contour_prefs
 
     def get_fit_contour(self, id=None, recalc=True):
         """Return the data used by contour_fit.
@@ -13614,10 +13633,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_pdf_plot isn't very
-        # useful here.
-        #
-        plotobj = self._pdfplot
+        plotobj = self.get_pdf_plot()
         if not replot:
             plotobj.prepare(points, bins, normed, xlabel, name)
 
@@ -13685,10 +13701,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_cdf_plot isn't very
-        # useful here.
-        #
-        plotobj = self._cdfplot
+        plotobj = self.get_cdf_plot()
         if not replot:
             plotobj.prepare(points, xlabel, name)
 
@@ -13763,10 +13776,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_trace_plot isn't very
-        # useful here.
-        #
-        plotobj = self._traceplot
+        plotobj = self.get_trace_plot()
         if not replot:
             plotobj.prepare(points, xlabel, name)
 
@@ -13838,10 +13848,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        # Unlike most plot_xxx routines, get_scatter_plot isn't very
-        # useful here.
-        #
-        plotobj = self._scatterplot
+        plotobj = self.get_scatter_plot()
         if not replot:
             plotobj.prepare(x, y, xlabel, ylabel, name)
 


### PR DESCRIPTION
# Summary

Add an explicit get_prefs method to return the plot preferences.

# Details

The idea is to see whether we can simplify access to the plot preferences, which I think this does. The question is whether this is the sensible way to do this, versus just adding a ui-layer function like

```
def get_prefs(plotobj):
    try:
        return plotobj.histo_prefs
    except AttributeError:
        return plotobj.plot_prefs
```

which is less generic but probably does most of what we need. Alternatively, should I go the whole way and add a `Preferences` class with a single `get_prefs` entry and then use multiple inheritance to pull it into the plot classes?