### PR TITLE
Bump DS9 version to 8.2 for CI

### DIFF
--- a/.github/scripts/setup_xspec_ds9.sh
+++ b/.github/scripts/setup_xspec_ds9.sh
@@ -38,7 +38,7 @@ download () {
 
 ### DS9 and XPA
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.1.tar.gz
+ds9_tar=ds9.${ds9_os}.8.2.tar.gz
 xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
 
 # Fetch them


### PR DESCRIPTION
# Summary

Bump DS9 version used in CI tests from 8.1 to 8.2.
