### PR TITLE
Address reg_proj and reg_unc failures (fix #1093)

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021
-#      Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -2515,6 +2515,23 @@ class Confidence2D(DataContour, Point):
 
     def _region_init(self, fit, par0, par1):
 
+        # Issue #1093 points out that if min or max is a tuple
+        # we can have a problem, as below the code can assign
+        # to an element of one of them. So ensure we have a list
+        # not a tuple.
+        #
+        if self.min is not None:
+            try:
+                self.min = list(self.min)
+            except TypeError:
+                raise ConfidenceErr('badarg', 'Parameter limits', 'a list') from None
+
+        if self.max is not None:
+            try:
+                self.max = list(self.max)
+            except TypeError:
+                raise ConfidenceErr('badarg', 'Parameter limits', 'a list') from None
+
         self.stat = fit.calc_stat()
         self.xlabel = par0.fullname
         self.ylabel = par1.fullname
@@ -2562,10 +2579,6 @@ class Confidence2D(DataContour, Point):
 
                 if max1 is not None and not numpy.isnan(max1):
                     self.max[1] = par1.val + max1
-
-            # check user limits for errors
-            if numpy.isscalar(self.min) or numpy.isscalar(self.max):
-                raise ConfidenceErr('badarg', 'Parameter limits', 'a list')
 
             for i in [0, 1]:
                 v = (self.max[i] + self.min[i]) / 2.

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -713,9 +713,7 @@ def test_region_xxx_validates_invalid_input(ptype, kwargs, setup_confidence):
 @pytest.mark.parametrize("ptype", ['ru', 'rp'])
 @pytest.mark.parametrize("kwargs",
                          [{'min': [0, 0]}, {'max': [120, 1e-3]},
-                          pytest.param({'min': (0, 0)}, marks=pytest.mark.xfail),
-                          pytest.param({'max': (120, 1e-3)}, marks=pytest.mark.xfail),
-                         ])
+                          {'min': (0, 0)}, {'max': (120, 1e-3)}])
 def test_region_xxx_issue_1093(ptype, kwargs, setup_confidence):
     """Using min=(0,20) fails when the min value is < param min (or > param max)
 

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021
-#     Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,7 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.models import basic
 from sherpa import plot as sherpaplot
 from sherpa.data import Data1D, Data1DInt
+from sherpa.utils.err import ConfidenceErr
 from sherpa.utils.testing import requires_data, requires_plotting
 
 
@@ -653,3 +654,116 @@ def test_histogram_empty_x():
 
     dp = sherpaplot.DataHistogramPlot()
     assert dp.x is None
+
+
+@pytest.mark.parametrize("cls", [sherpaplot.RegionUncertainty,
+                                 sherpaplot.RegionProjection])
+def test_show_region_xxx(cls):
+    """Are different sequence types handled okay?
+
+    There's no a-priori reason why we choose a particular
+    serialization scheme, so just check we have something tested.
+
+    """
+
+    plot = cls()
+    plot.prepare(nloop=(21, 21), sigma=[1, 1.6])
+    toks = str(plot).split('\n')
+    assert toks[0] == "x0      = None"
+    assert toks[1] == "x1      = None"
+    assert toks[2] == "y       = None"
+    assert toks[3] == "min     = None"
+    assert toks[4] == "max     = None"
+    assert toks[5] == "nloop   = (21, 21)"
+    assert toks[6] == "fac     = 4"
+    assert toks[7] == "delv    = None"
+    assert toks[8] == "log     = (False, False)"
+    assert toks[9] == "sigma   = [1, 1.6]"
+    assert toks[10] == "parval0 = None"
+    assert toks[11] == "parval1 = None"
+    assert toks[12] == "levels  = None"
+    assert len(toks) == 13
+
+
+@pytest.mark.parametrize("ptype", ['ru', 'rp'])
+@pytest.mark.parametrize("kwargs",
+                         [{"min": 2},
+                          #{"min": [1, 2, 3]},   does not check too-many values
+                          {"max": 2},
+                          #{"max": [1, 2, 3]},
+                          {"min": (10, 10), "max": (0, 20)},
+                          {"min": (10, 10), "max": (20, 0)},
+                          {"nloop": 2},
+                          {"nloop": (0, 10)},
+                          {"nloop": (10, 0)},
+                          #{"nloop": [2, 3, 4]},
+                         ])
+def test_region_xxx_validates_invalid_input(ptype, kwargs, setup_confidence):
+    """Do we do some simple checks on invalid inputs."""
+
+    plotobj = getattr(setup_confidence, ptype)
+
+    with pytest.raises(ConfidenceErr):
+        plotobj.prepare(**kwargs)
+        plotobj.calc(setup_confidence.f,
+                     setup_confidence.g1.fwhm,
+                     setup_confidence.g1.ampl)
+
+
+@pytest.mark.parametrize("ptype", ['ru', 'rp'])
+@pytest.mark.parametrize("kwargs",
+                         [{'min': [0, 0]}, {'max': [120, 1e-3]},
+                          pytest.param({'min': (0, 0)}, marks=pytest.mark.xfail),
+                          pytest.param({'max': (120, 1e-3)}, marks=pytest.mark.xfail),
+                         ])
+def test_region_xxx_issue_1093(ptype, kwargs, setup_confidence):
+    """Using min=(0,20) fails when the min value is < param min (or > param max)
+
+    We do not do a lot of testing of the result, we are just primarily
+    checking that the code ran.
+
+    """
+
+    plotobj = getattr(setup_confidence, ptype)
+
+    setup_confidence.g1.fwhm.max = 100
+
+    plotobj.prepare(nloop=(2, 2), **kwargs)
+    plotobj.calc(setup_confidence.f,
+                 setup_confidence.g1.fwhm,
+                 setup_confidence.g1.ampl)
+
+    assert len(plotobj.x0) == 4
+    assert len(plotobj.x1) == 4
+    assert len(plotobj.y) == 4
+
+
+@pytest.mark.parametrize("ptype", ['ru', 'rp'])
+@pytest.mark.parametrize("kwargs",
+                         [{'min': (18, 16), 'max': (19, 17),
+                           'nloop': (2, 2), 'sigma': (1, 1.6)},
+                          {'min': [18, 16], 'max': [19, 17],
+                           'nloop': [2, 2], 'sigma': [1, 1.6]}])
+def test_region_xxx_set_vars(ptype, kwargs, setup_confidence):
+    """Are different sequence types handled okay?
+
+    The idea is to check that using a tuple or a list returns
+    the same answer.
+    """
+
+    plotobj = getattr(setup_confidence, ptype)
+    plotobj.prepare(**kwargs)
+    plotobj.calc(setup_confidence.f,
+                 setup_confidence.g1.fwhm,
+                 setup_confidence.g1.ampl)
+
+    # We just want to check we are using the same data.
+    #
+    assert plotobj.x0 == pytest.approx([18, 19, 18, 19])
+    assert plotobj.x1 == pytest.approx([16, 16, 17, 17])
+
+    # Given that using projection vs uncertainty we can't be exact
+    # in this check, hence the relatively large absolute tolerance.
+    #
+    assert plotobj.y == pytest.approx([36.82967813, 35.94869461,
+                                       35.90482971, 35.85479384], abs=1e-4)

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -328,7 +328,7 @@ def test_regproj(old_numpy_printing, override_plot_backend):
     assert '<div class="dataname">y</div><div class="dataval">[ 306.854444  282.795953  259.744431  237.699877  216.662291  196.631674\n' in r
 
     assert '<div class="dataname">levels</div><div class="dataval">[  3.606863   7.491188  13.140272]</div>' in r
-    assert '<div class="dataname">min</div><div class="dataval">(-2, -1)</div>' in r
-    assert '<div class="dataname">max</div><div class="dataval">(2, 2)</div>' in r
+    assert '<div class="dataname">min</div><div class="dataval">[-2, -1]</div>' in r
+    assert '<div class="dataname">max</div><div class="dataval">[2, 2]</div>' in r
 
     assert '<div class="dataname">nloop</div><div class="dataval">(10, 20)</div>' in r


### PR DESCRIPTION
# Summary

Calls to reg_proj and reg_unc could error out when the min or max arguments were set to tuples rather than lists. The code now converts these attributes to lists, which can result in changes to the string output of the objects (use of '[]' brackets rather than '()'). Fixes #1093 

# Details

It's not as simple as "can not use a tuple" for the arguments, it depends on whether the given limit falls outside the parameter range. The solution is to force a list for these two attributes. This is technically a breaking change - and can change the string output of the objects - but any code that would be affected by such a change is very fragile and un-pythonic. I do not see it worth trying to address this in a way that doesn't change the nature of the min and max attributes. 

## Notes

The master branch - used below - has "issues" in how the string works, so this doesn't really change things: notice how `nloop` and `min` change between tuple and list syntax

```
In [17]: reg_proj(gal.nh, pl.gamma, nloop=(3, 3))
WARNING: hard minimum hit for parameter gal.nH

In [18]: print(get_reg_proj())
x0      = [0.    ,0.1113,0.2226,0.    ,0.1113,0.2226,0.    ,0.1113,0.2226]
x1      = [1.4304,1.4304,1.4304,2.0262,2.0262,2.0262,2.622 ,2.622 ,2.622 ]
y       = [ 63.0483, 91.7543,115.9756, 24.0955, 27.6376, 47.9389, 89.163 , 44.2356,
  35.3306]
min     = [0.         1.43040219]
max     = [0.22264918 2.62199793]
nloop   = (3, 3)
fac     = 4
delv    = None
log     = (False, False)
sigma   = (1, 2, 3)
parval0 = 0.038698399515105134
parval1 = 2.0262000615662874
levels  = [24.01673537 27.90106075 33.55014452]

In [19]: reg_proj(gal.nh, pl.gamma, nloop=[3, 3])
WARNING: hard minimum hit for parameter gal.nH

In [20]: print(get_reg_proj())
x0      = [0.    ,0.1113,0.2226,0.    ,0.1113,0.2226,0.    ,0.1113,0.2226]
x1      = [1.4304,1.4304,1.4304,2.0262,2.0262,2.0262,2.622 ,2.622 ,2.622 ]
y       = [ 63.0483, 91.7543,115.9756, 24.0955, 27.6376, 47.9389, 89.163 , 44.2356,
  35.3306]
min     = [0.         1.43040219]
max     = [0.22264918 2.62199793]
nloop   = [3, 3]
fac     = 4
delv    = None
log     = (False, False)
sigma   = (1, 2, 3)
parval0 = 0.038698399515105134
parval1 = 2.0262000615662874
levels  = [24.01673537 27.90106075 33.55014452]

In [24]: reg_proj(gal.nh, pl.gamma, nloop=[3, 3], min=(0, 1.6), max=(0.15, 2.4))

In [25]: print(get_reg_proj())
x0      = [0.   ,0.075,0.15 ,0.   ,0.075,0.15 ,0.   ,0.075,0.15 ]
x1      = [1.6,1.6,1.6,2. ,2. ,2. ,2.4,2.4,2.4]
y       = [41.1802,58.8727,77.3439,23.3004,24.1865,35.5988,57.3776,33.2215,27.4341]
min     = (0, 1.6)
max     = (0.15, 2.4)
nloop   = [3, 3]
fac     = 4
delv    = None
log     = (False, False)
sigma   = (1, 2, 3)
parval0 = 0.038698399515105134
parval1 = 2.0262000615662874
levels  = [24.01673537 27.90106075 33.55014452]

```