### PR TITLE
Address upper limit issues with sample_flux (fix #457)

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -442,7 +442,7 @@ def sample_flux(fit, data, src,
 
     See Also
     --------
-    calc_flux
+    calc_flux, calc_sample_flux
 
     Notes
     -----
@@ -529,6 +529,85 @@ def sample_flux(fit, data, src,
 
 def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
                      confidence):
+    """Given a set of parameter samples, estimate the flux distribution.
+
+    This is similar to sample_flux but returns values for both the full
+    and component models (which can be the same). The set of parameter
+    samples is searched to remove rows where the parameters lie outside
+    the soft limits, and then this set of rows is used to calculate the
+    flux of the modelcomponent expression (the flux for the full model
+    is taken from the samples argument). The resulting set of fluxes is
+    used to calculate the median and the confidence range.
+
+    .. versionchanged:: 4.13.1
+       The clipping now includes parameters at the soft limits;
+       previously they were excluded which could cause problems with
+       parameters for which we can only calculate an upper limit.
+
+    Parameters
+    ----------
+    id : int or str
+        The dataset identifier. It must exist and have an associated model in
+        session.
+    lo : number or None, optional
+        The lower edge of the dataspace range for the flux calculation.
+        If None then the lower edge of the data grid is used.
+    hi : number or None, optional
+        The upper edge of the dataspace range for the flux calculation.
+        If None then the upper edge of the data grid is used.
+    session : sherpa.ui.utils.Session instance
+        Defines the data, model, and fit.
+    fit : sherpa.fit.Fit instance
+        The fit object. The src parameter is assumed to be a subset of
+        the fit.model expression (to allow for calculating the flux of
+        a model component), and the fit.data object matches the data
+        object. The fit.model argument is expected to include instrumental
+        models (for PHA data sets). These objects can represent
+        simultaneous fits (e.g. sherpa.data.DataSimulFit and
+        sherpa.models.model.SimulFitModel).
+    data : sherpa.data.Data subclass
+        The data object to use. This is not a DataSimulFit instance.
+    samples
+        The output of sample_flux for the data (assumed to have been
+        created with method=calc_energy_flux and clip='hard').
+    modelcomponent : sherpa.models.Arithmetic instance
+        The source model (without instrument response for PHA data) that
+        is used for calculating the flux. This is not a SimulFitModel
+        instance.
+    confidence : number
+        The confidence value to return, as a percentage (0-100).
+
+    Returns
+    -------
+    (fullflux, cptflux, vals)
+       The fullflux and cptflux arrays contain the results for
+       the full source model and the flux of the `modelcomponent`
+       argument (they can be the same). They have three elements
+       and give the median value, upper quartile, and lower
+       quartile values of the flux distribution. The vals array
+       has a shape of ``(num+1, N+2)``, where ``N`` is the number of
+       free parameters and num is the `num` parameter. The rows of
+       this array contain the flux value for the iteration (for
+       the full source model), the parameter values, and then the
+       statistic value for this set of parameters.
+
+    See Also
+    --------
+    calc_flux, calc_sample_flux
+
+    Notes
+    -----
+    This function is in the process of being documented and
+    re-written, as it contains a lot of redundancy and the semantics
+    of some of the options are unclear.
+
+    The summary output displayed by this routine - giving the median
+    and confidence ranges - is controlled by the standard Sherpa
+    logging instance, and can be hidden by changing the logging to a
+    level greater than "INFO" (e.g. with
+    `sherpa.utils.logging.SherpaVerbosity`).
+
+    """
 
     def simulated_pars_within_ranges(mysamples, mysoftmins, mysoftmaxs):
 

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2009, 2015, 2016, 2019, 2020, 2021
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -534,7 +534,7 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
 
         for i, (pmin, pmax) in enumerate(zip(mysoftmins, mysoftmaxs), 1):
             parvals = mysamples[:, i]
-            tmp = (parvals > pmin) & (parvals < pmax)
+            tmp = (parvals >= pmin) & (parvals <= pmax)
             mysamples = mysamples[tmp]
 
         return mysamples

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -574,22 +574,28 @@ def calc_sample_flux(id, lo, hi, session, fit, data, samples, modelcomponent,
         The source model (without instrument response for PHA data) that
         is used for calculating the flux. This is not a SimulFitModel
         instance.
-    confidence : number
-        The confidence value to return, as a percentage (0-100).
+    confidence : number, optional
+       The confidence level for the upper and lower values, as a
+       percentage (0 to 100). A value of 68.3 will return the
+       one-sigma range.
 
     Returns
     -------
     (fullflux, cptflux, vals)
-       The fullflux and cptflux arrays contain the results for
-       the full source model and the flux of the `modelcomponent`
-       argument (they can be the same). They have three elements
-       and give the median value, upper quartile, and lower
-       quartile values of the flux distribution. The vals array
-       has a shape of ``(num+1, N+2)``, where ``N`` is the number of
-       free parameters and num is the `num` parameter. The rows of
-       this array contain the flux value for the iteration (for
-       the full source model), the parameter values, and then the
-       statistic value for this set of parameters.
+        The fullflux and cptflux arrays contain the results for the
+        full source model and the flux of the `modelcomponent`
+        argument (they can be the same). They have three elements and
+        give the median value, the value containing 100 - confidence/2
+        of the data, and the fraction containing confidence/2 of the
+        flux distribution. For the default confidence argument of 68
+        this means the last two give the one-sigma upper and lower
+        bounds. The vals array has a shape of ``(num+1, N+3)``, where
+        ``N`` is the number of free parameters and num is the `num`
+        parameter. The rows of this array contain the flux value for
+        the iteration (for the full source model), the parameter
+        values, a flag indicating whether any parameter in that row
+        was clipped to the hard-limits of the parameter, and the
+        statistic value for this set of parameters.
 
     See Also
     --------

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -32,8 +32,8 @@ from sherpa.astro import ui
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_plotting, requires_xspec
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, IdentifierErr, IOErr, \
-    ModelErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, \
+    IdentifierErr, IOErr, ModelErr
 import sherpa.astro.utils
 
 
@@ -2080,13 +2080,13 @@ def test_sample_flux_457(make_data_path, clean_astro_ui,
                                         correlated=True, scales=scal)
 
     # Values taken from the screen output
-    assert flux1[0] == pytest.approx(7.5243e-13)
-    assert flux1[1] == pytest.approx(7.5243e-13 + 3.53865e-14)
-    assert flux1[2] == pytest.approx(7.5243e-13 - 3.01841e-14)
+    assert flux1[0] == pytest.approx(7.50199e-13)
+    assert flux1[1] == pytest.approx(7.50199e-13 + 3.64329e-14)
+    assert flux1[2] == pytest.approx(7.50199e-13 - 2.87033e-14)
 
-    assert flux2[0] == pytest.approx(8.26722e-13)
-    assert flux2[1] == pytest.approx(8.26722e-13 + 5.88881e-14)
-    assert flux2[2] == pytest.approx(8.26722e-13 - 4.99602e-14)
+    assert flux2[0] == pytest.approx(8.19482e-13)
+    assert flux2[1] == pytest.approx(8.19482e-13 + 5.42782e-14)
+    assert flux2[2] == pytest.approx(8.19482e-13 - 6.87875e-14)
 
     # unabsorbed flux should be >= absorbed.
     assert np.all(flux2 >= flux1)
@@ -2101,10 +2101,12 @@ def test_sample_flux_457(make_data_path, clean_astro_ui,
     assert (nhs[clipped] == 0).all()
     assert clipped.sum() == 17
 
-    # 100 + 1 - 17 values have a non-zero stat (as chi-square) because of #751
+    # Although there are 17 clipped values, they all have a non-zero statistic
+    # as the values have been clipped to the soft limits. So in this case
+    # issue #751 isn't an issue.
     #
     stats = vals[:, -1]
-    assert (stats > 0).sum() == (niter + 1 - 17)
+    assert (stats > 0).sum() == (niter + 1)
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2020, 2021
-#     Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1571,7 +1571,6 @@ def test_sample_flux_nologging(make_data_path, clean_astro_ui,
 
     assert len(caplog.records) == 0
 
-    scal = ui.get_covar_results().parmaxes
     with SherpaVerbosity('WARN'):
         ui.sample_flux(id=1, lo=1, hi=5, num=1,
                        correlated=False)
@@ -2040,6 +2039,72 @@ def test_sample_flux_751_752(idval, make_data_path, clean_astro_ui,
     stats = vals[:, -1]
     # assert (stats > 0).all()
     assert (stats > 0).sum() == 81
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_sample_flux_457(make_data_path, clean_astro_ui,
+                         hide_logging, reset_seed):
+    """What happens with upper-bounds?
+
+    The absorption is an upper limit, so check what happens
+    with the filtered data? Issue #457 noted that values at
+    the soft limits were not being included, causing a bias
+    (at least for this situation, when nh=0).
+
+    """
+
+    ui.set_default_id('bob')
+    ui.set_stat('chi2datavar')
+
+    # Try to ensure we get some clipping.
+    #
+    np.random.seed(8077)
+
+    # we want niter to be even so that the returned number of
+    # values (niter+1) is odd, as that makes the median check
+    # easier.
+    #
+    niter = 100
+
+    ui.load_pha(make_data_path('3c273.pi'))
+    ui.subtract()
+    ui.notice(0.5, 6)
+    ui.set_source(ui.xsphabs.gal * ui.powlaw1d.p1)
+    ui.fit()
+    ui.covar()
+    scal = ui.get_covar_results().extra_output
+
+    flux1, flux2, vals = ui.sample_flux(p1, lo=0.5, hi=7, num=niter,
+                                        correlated=True, scales=scal)
+
+    # Values taken from the screen output
+    assert flux1[0] == pytest.approx(7.5243e-13)
+    assert flux1[1] == pytest.approx(7.5243e-13 + 3.53865e-14)
+    assert flux1[2] == pytest.approx(7.5243e-13 - 3.01841e-14)
+
+    assert flux2[0] == pytest.approx(8.26722e-13)
+    assert flux2[1] == pytest.approx(8.26722e-13 + 5.88881e-14)
+    assert flux2[2] == pytest.approx(8.26722e-13 - 4.99602e-14)
+
+    # unabsorbed flux should be >= absorbed.
+    assert np.all(flux2 >= flux1)
+    assert flux1.shape == (3, )
+    assert vals.shape == (niter + 1, 6)
+
+    # How many clipped values are there?
+    #
+    clipped = vals[:, -2] == 1
+    nhs = vals[:, 1]
+    assert (nhs[~clipped] > 0).all()
+    assert (nhs[clipped] == 0).all()
+    assert clipped.sum() == 17
+
+    # 100 + 1 - 17 values have a non-zero stat (as chi-square) because of #751
+    #
+    stats = vals[:, -1]
+    assert (stats > 0).sum() == (niter + 1 - 17)
 
 
 @requires_data

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13314,23 +13314,28 @@ class Session(sherpa.ui.utils.Session):
            to convert to erg/cm^2/s. This should not be changed from
            the default value.
         confidence : number, optional
-           The confidence level for the upper and lower quartiles,
-           as a percentage. The default is 68, so as to return
+           The confidence level for the upper and lower values, as a
+           percentage (0 to 100). The default is 68, so as to return
            the one-sigma range.
 
         Returns
         -------
         (fullflux, cptflux, vals)
-           The fullflux and cptflux arrays contain the results for
-           the full source model and the flux of the `modelcomponent`
+           The fullflux and cptflux arrays contain the results for the
+           full source model and the flux of the `modelcomponent`
            argument (they can be the same). They have three elements
-           and give the median value, upper quartile, and lower
-           quartile values of the flux distribution. The vals array
-           has a shape of ``(num+1, N+2)``, where ``N`` is the number of
+           and give the median value, the value containing 100 -
+           confidence/2 of the data, and the fraction containing
+           confidence/2 of the flux distribution. For the default
+           confidence argument of 68 this means the last two give the
+           one-sigma upper and lower bounds. The vals array has a
+           shape of ``(num+1, N+3)``, where ``N`` is the number of
            free parameters and num is the `num` parameter. The rows of
            this array contain the flux value for the iteration (for
-           the full source model), the parameter values, and then the
-           statistic value for this set of parameters.
+           the full source model), the parameter values, a flag
+           indicating whether any parameter in that row was clipped to
+           the hard-limits of the parameter, and the statistic value
+           for this set of parameters.
 
         See Also
         --------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13258,15 +13258,19 @@ class Session(sherpa.ui.utils.Session):
         """Return the flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
-        from a normal distribution, evaluate the model, and sum the
-        model over the given range (the flux). Return the parameter
-        values used, together with the median, upper, and lower
-        quantiles of the flux distribution.
+        from a normal distribution, filter out samples that lie
+        outside the soft limits of the parameters, evaluate the model,
+        and sum the model over the given range (the flux). Return the
+        parameter values used, together with the median, upper, and
+        lower quantiles of the flux distribution.
 
         .. versionchanged:: 4.13.1
            The `id` parameter is now used if set (previously the
            default dataset was always used). The screen output is now
-           controlled by the Sherpa logging setup.
+           controlled by the Sherpa logging setup. The flux
+           calculation no-longer excludes samples at the parameter
+           soft limits, as this could cause an over-estimation of the
+           flux when a parameter is only an upper limit.
 
         Parameters
         ----------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13429,7 +13429,7 @@ class Session(sherpa.ui.utils.Session):
                                             bkg_id=bkg_id)
         else:
             samples = self.sample_energy_flux(lo=lo, hi=hi, id=id, num=niter,
-                                              scales=scales,
+                                              scales=scales, clip='hard',
                                               correlated=correlated,
                                               numcores=numcores,
                                               bkg_id=bkg_id)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -2651,7 +2651,7 @@ def test_fit_contour_recalc(session):
 @requires_pylab
 @pytest.mark.parametrize("ptype",
                          ["resid", "ratio", "delchi"])
-def test_plot_fit_xxx_pylab(ptype):
+def test_plot_fit_xxx_pylab(ptype, clean_ui):
     """Just ensure we can create a plot_fit_xxx call."""
 
     from matplotlib import pyplot as plt


### PR DESCRIPTION
# Summary

sample_flux no-longer excludes samples at the parameter bounds (soft) when calculating the flux distribution. This could lead to an over-estimation of the flux for upper limits (Fix #457).

# Address

This is pulled from #754 and there are more changes planned to clean up the code (as it is doing stuff it needn't do), but this is a nice improvement that is easy to review. It also adds some documentation.

Technically the flux distribution when there's an upper or lower limit could be underestimated or overestimated but it's easier to just say "overestimate" in the summary. We can see the overestimate in the test_sample_flux_457 test where the estimated flux values go from

```
assert flux1[0] == pytest.approx(7.5243e-13)
assert flux1[1] == pytest.approx(7.5243e-13 + 3.53865e-14)
assert flux1[2] == pytest.approx(7.5243e-13 - 3.01841e-14)

assert flux2[0] == pytest.approx(8.26722e-13)
assert flux2[1] == pytest.approx(8.26722e-13 + 5.88881e-14)
assert flux2[2] == pytest.approx(8.26722e-13 - 4.99602e-14)
```

to

```
assert flux1[0] == pytest.approx(7.50199e-13)
assert flux1[1] == pytest.approx(7.50199e-13 + 3.64329e-14)
assert flux1[2] == pytest.approx(7.50199e-13 - 2.87033e-14)

assert flux2[0] == pytest.approx(8.19482e-13)
assert flux2[1] == pytest.approx(8.19482e-13 + 5.42782e-14)
assert flux2[2] == pytest.approx(8.19482e-13 - 6.87875e-14)
```
