### PR TITLE
Consolidate and harmonize the validation of dataset identifiers

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -85,7 +85,7 @@ def test_id_checks_session(session, setting):
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
-@pytest.mark.parametrize("setting", ['cdf', 'lr', 'pdf', 'scatter', 'trace'])
+@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace'])
 def test_id_checks_session_unexpected(session, setting):
     """These identifiers are allowed. Should they be?"""
 
@@ -99,7 +99,7 @@ def test_id_checks_session_unexpected(session, setting):
                          [(Session, True), (AstroSession, False)])
 @pytest.mark.parametrize("setting", ['arf', 'bkg', 'bkgchisqr', 'bkgdelchi', 'bkgfit',
                                      'bkgmodel', 'bkgratio', 'bkgresid', 'bkgsource',
-                                     'energy', 'order', 'photon'])
+                                     'order'])
 def test_id_checks_astro_session(session, success, setting):
     """Do some common identifiers fail for astro but not default?"""
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -67,13 +67,43 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
 
     def _fix_background_id(self, id, bkg_id):
-        """Check the background id
+        """Validate the background id.
+
+        The identifier has the same restrictions as the dataset
+        identifier.
+
+        Parameters
+        ----------
+        id : int or str or None
+            The dataset identifier. This is only used if bkg_id is
+            None and must refer to a DataPHA dataset.
+        bkg_id : int or str or None
+            The identifier to check. If None then the default backround
+            identifier will be used, taken from the id dataset.
+
+        Returns
+        -------
+        bkg_id : int or str
+            The background identifier to use (it will only differ from
+            the input parameter was set to None).
+
+        Raises
+        ------
+        sherpa.utils.err.ArgumentTypeErr
+            If the identifier was not a string or an integer.
+        sherpa.utils.err.IdentifierErr
+            If the identifier was invalid.
+
+        See Also
+        --------
+        _fix_id
 
         Notes
         -----
-        Since there is currently no way to set the default
-        background id of the DataPHA class (e.g. in unpack_pha)
-        we do not use the _default_id setting here.
+        Since there is currently no way to set the default background
+        id of the DataPHA class (e.g. in unpack_pha) we do not use the
+        _default_id setting here.
+
         """
 
         if bkg_id is None:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -85,13 +85,8 @@ class Session(sherpa.ui.utils.Session):
 
             # return self._default_id
 
-        if not self._valid_id(bkg_id):
-            raise ArgumentTypeErr('intstr')
-        badkeys = self._plot_types.keys() | self._contour_types.keys()
-        if bkg_id in badkeys:
-            raise IdentifierErr('badid', bkg_id)
-
-        return bkg_id
+        # We rely on the validation made by _fix_id
+        return self._fix_id(bkg_id)
 
     def __setstate__(self, state):
         if '_background_sources' not in state:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -87,7 +87,8 @@ class Session(sherpa.ui.utils.Session):
 
         if not self._valid_id(bkg_id):
             raise ArgumentTypeErr('intstr')
-        if bkg_id in self._plot_types.keys() or bkg_id in self._contour_types.keys():
+        badkeys = self._plot_types.keys() | self._contour_types.keys()
+        if bkg_id in badkeys:
             raise IdentifierErr('badid', bkg_id)
 
         return bkg_id

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1307,7 +1307,7 @@ class Session(NoNewAttributesAfterInit):
         if not self._valid_id(id):
             raise ArgumentTypeErr('intstr')
 
-        badkeys = self._plot_types.keys() | self._contour_types.keys()
+        badkeys = self._plot_type_names.keys() | self._contour_type_names.keys()
         if id in badkeys:
             raise IdentifierErr('badid', id)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1268,7 +1268,8 @@ class Session(NoNewAttributesAfterInit):
             return self._default_id
         if not self._valid_id(id):
             raise ArgumentTypeErr('intstr')
-        if id in self._plot_types.keys() or id in self._contour_types.keys():
+        badkeys = self._plot_types.keys() | self._contour_types.keys()
+        if id in badkeys:
             raise IdentifierErr('badid', id)
         return id
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1264,13 +1264,53 @@ class Session(NoNewAttributesAfterInit):
         return (_is_integer(id) or isinstance(id, string_types))
 
     def _fix_id(self, id):
+        """Validate the dataset id.
+
+        The identifier can be any string or integer except for the
+        plot and contour types that are supported by the `plot` and
+        `contour` methods.
+
+        Parameters
+        ----------
+        id : int or str or None
+            The dataset identifier. If set to None then the default
+            identifier, returned by `get_default_id`, is used.
+
+        Returns
+        -------
+        id : int or str
+            The identifier to use (it will only differ from the input
+            parameter was set to None).
+
+        Raises
+        ------
+        sherpa.utils.err.ArgumentTypeErr
+            If the identifier was not a string or an integer.
+        sherpa.utils.err.IdentifierErr
+            If the identifier was invalid.
+
+        See Also
+        --------
+        get_default_id, set_default_id
+
+        Notes
+        -----
+        Since there is currently no way to set the default background
+        id of the DataPHA class (e.g. in unpack_pha) we do not use the
+        _default_id setting here.
+
+        """
+
         if id is None:
             return self._default_id
+
         if not self._valid_id(id):
             raise ArgumentTypeErr('intstr')
+
         badkeys = self._plot_types.keys() | self._contour_types.keys()
         if id in badkeys:
             raise IdentifierErr('badid', id)
+
         return id
 
     def _get_item(self, id, itemdict, itemdesc, errdesc):


### PR DESCRIPTION
# Summary

Simplify the code used to validate dataset identifiers. Several names can no-longer be used as an identifier ('astrocompmodel', 'astrocompsource', 'astrodata', 'astromodel', 'astrosource', 'model_component', and 'source_component') and two can now be used ('energy' and 'photon').

# Details

It's long been a mystery to me over why some identifiers are "protected" so let's try and clear this up! This came out of PR #1089 but is a stand-alone change that I think is useful to have.

For users, this changes the set of valid/invalid keywords (the following is the logic used by `_fix_id`):

```
>>> from sherpa.astro.ui imoort *
>>> old = _session._plot_types.keys() | _session._contour_types.keys()
>>> new =  _session._plot_type_names.keys() | _session._contour_type_names.keys()
```

So the new symbols which can no longer be used as an identifier are:

```
>>> new.difference(old)
{'astrocompmodel',
 'astrocompsource',
 'astrodata',
 'astromodel',
 'astrosource',
 'model_component',
 'source_component'}
```

The following symbols used to be protected but are now allowed:

```
>>> old.difference(new)
{'energy', 'photon'}
```

## Why do we even validate the identifiers?

There is the question of why we even need to invalidate certain identifiers, since shouldn't everything essentially be namespaced so there's no possibility of confusion? I believe it's needed to support the `plot` and `contour` commands since these functions take

    type1 [, arg1_1, arg1_2, ...], type2 [, arg2_1, arg2_2,...], ... 

where `argn_1` is essentially always going to be a dataset identifier (technically it needed't be, but it often is). So, with a command like

    plot('data', 'fit')

is this to show two plots - e.g. `plot_data()` and `plot_fit()` - or is it the same as `plot_data('fit')`? We choose the former by making sure that we can't use a "plot type" as the identifier (in this case `fit`).

## Why do we need to change?

Unfortunately our code seems to actually validate against a slightly-different set of terms than the ones actually used in the `plot` and `contour` commands (which relies on the _plot_type_names dictionary)

 In CIAO 4.13 we can create the same plot three ways

```
sherpa In [6]: plot_data()

sherpa In [7]: plot('data')

sherpa In [8]: plot('astrodata')
```

(the reason for astrodata vs data is historical and I think was meaningful (but confusing) prior to #931 (or related conmits).

Note that we can not use `data` as an identifier (we get an `IdentifierErr`) but we can use `astrodata`, which seems wrong.

```
sherpa In [9]: load_pha('data', '3c273.pi')
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi
IdentifierErr: identifier 'data' is a reserved word

sherpa In [10]: load_pha('astrodata', '3c273.pi')
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi
```

## Open question

There is the question whether we should drop these `astroXXX` plot options. Note that in CIAO 4.12 we get confusing behavior:
`astrodata` is not supported but `astromodel` is, and returns a different plot to `model` in the `plot`call (#906 and #931 cleaned up some of this and, I believe, invalidated the need for the `astroXXX` options):

```
sherpa412 In [11]: plot('astrodata')
ArgumentErr: 'astrodata' is not a valid plot type

sherpa412 In [18]: plot('model')

sherpa412 In [19]: plot('astromodel')
/home/dburke/anaconda/envs/ciao412/lib/python3.7/site-packages/sherpa/plot/pylab_backend.py:330: MatplotlibDeprecationWarning: Passing the drawstyle with the linestyle as a single string is deprecated since Matplotlib 3.1 and support will be removed in 3.3; please pass the drawstyle separately using the drawstyle keyword argument to Line2D or set_drawstyle() method (or ds/set_ds()).
  zorder=zorder)

```


# Comparing behavior

For reference, the existing behavior is


## plot_fit()

### CIAO 4.12

![ciao412-fit](https://user-images.githubusercontent.com/224638/107791606-24e16900-6d22-11eb-9242-eff2e1177a27.png)

### CIAO 4.13

![ciao413-fit](https://user-images.githubusercontent.com/224638/107791602-2448d280-6d22-11eb-9691-c737f8cb3fc6.png)

## plot_model()

### CIAO 4.12

![ciao412-model](https://user-images.githubusercontent.com/224638/107791605-24e16900-6d22-11eb-978d-645cd6ae282d.png)

### CIAO 4.13

![ciao413-model](https://user-images.githubusercontent.com/224638/107791600-2448d280-6d22-11eb-89b0-c25d022d4acc.png)

## plot('model')

We can see that in 4.12 this produces a different plot to `plot_model`.

### CIAO 4.12

![ciao412-plot-model](https://user-images.githubusercontent.com/224638/107791604-24e16900-6d22-11eb-94c2-49e5d1fb0d4b.png)

### CIAO 4.13

![ciao413-plot-model](https://user-images.githubusercontent.com/224638/107791599-2448d280-6d22-11eb-9ddb-654611984242.png)

## plot('astromodel')

The astromodel plot in 4.12 matches the `plot_model` call.

### CIAO 4.12

![ciao412-plot-astromodel](https://user-images.githubusercontent.com/224638/107791603-2448d280-6d22-11eb-904d-bd4a64f52820.png)

### CIAO 4.13

![ciao413-plot-astromodel](https://user-images.githubusercontent.com/224638/107791598-23b03c00-6d22-11eb-8c44-6d57394791dc.png)



