### PR TITLE
The sample_flux routine now returns the correct information for the clip column

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -546,7 +546,9 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
        id and session arguments have been removed and the
        modelcomponent argument can now be set to None. The statistic
        value is now returned for each row, even those that were
-       excluded from the flux calculation.
+       excluded from the flux calculation. The information on what
+       rows were excluded is now set, rather than reporting those rows
+       that exceeded the hard parameter limits.
 
     Parameters
     ----------
@@ -594,8 +596,8 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
         parameter. The rows of this array contain the flux value for
         the iteration (for the full source model), the parameter
         values, a flag indicating whether any parameter in that row
-        was clipped to the hard-limits of the parameter, and the
-        statistic value for this set of parameters.
+        was clipped (and so was excluded from the flux calculation),
+        and the statistic value for this set of parameters.
 
     See Also
     --------
@@ -603,10 +605,6 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
 
     Notes
     -----
-    This function is in the process of being documented and
-    re-written, as it contains a lot of redundancy and the semantics
-    of some of the options are unclear.
-
     The summary output displayed by this routine - giving the median
     and confidence ranges - is controlled by the standard Sherpa
     logging instance, and can be hidden by changing the logging to a
@@ -651,6 +649,12 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
                 iflx[nn] = calc_energy_flux(data, modelcomponent, lo=lo, hi=hi)
 
             mystat[nn, 0] = fit.calc_stat()
+
+            # Replace the input "clipped" value (from clip='hard') with
+            # the calculated clip here (essentially clip='soft'),
+            # remembering to invert the flag.
+            #
+            samples[nn, -1] = 0 if valid[nn] else 1
 
     finally:
         fit.model.thawedpars = thawedpars

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -2529,12 +2529,7 @@ def test_sample_flux_pha_full_model(idval, make_data_path, clean_astro_ui,
                        id=idval, lo=1, hi=5, num=niter,
                        correlated=False, scales=scal)
 
-    toks = str(ie.value).split('\n')
-    assert len(toks) == 3
-    assert toks[0] == 'Convolved model'
-    assert toks[1].startswith("'apply_rmf(apply_arf((38564.6")
-    assert toks[1].endswith(" * (const1d.scal * powlaw1d.p1))))'")
-    assert toks[2] ==  f' is set for dataset {idval}. You should use get_model instead.'
+    assert str(ie.value) == 'Please use calc_energy_flux as set_full_model was used'
 
 
 @requires_data
@@ -2542,14 +2537,7 @@ def test_sample_flux_pha_full_model(idval, make_data_path, clean_astro_ui,
 @pytest.mark.parametrize("idval", [1, 2])
 def test_sample_flux_pha_bkg_full_model(idval, make_data_path, clean_astro_ui,
                                         hide_logging, reset_seed, caplog):
-    """When using set_bkg_full_model we error out. Is it a nice error?
-
-    This is meant to be the background version of
-    test_sample_flux_pha_full_model but it errors out differently and
-    it's not clear whether this is a different code path or I'm
-    setting up the fit wrong.
-
-    """
+    """When using set_bkg_full_model we error out. Is it a nice error?"""
 
     np.random.seed(9783)
 
@@ -2582,9 +2570,9 @@ def test_sample_flux_pha_bkg_full_model(idval, make_data_path, clean_astro_ui,
 
     scal = ui.get_covar_results().parmaxes
 
-    with pytest.raises(ModelErr) as me:
+    with pytest.raises(IdentifierErr) as ie:
         ui.sample_flux(modelcomponent=bpl, bkg_id=1,
                        id=idval, lo=1, hi=5, num=niter,
                        correlated=False, scales=scal)
 
-    assert str(me.value) == f'background model 1 for data set {idval} has not been set'
+    assert str(ie.value) == 'Please use calc_energy_flux as set_bkg_full_model was used'

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -2108,15 +2108,12 @@ def test_sample_flux_457(make_data_path, clean_astro_ui,
     assert flux1.shape == (3, )
     assert vals.shape == (niter + 1, 6)
 
-    # Although 17 rows were "hard clipped" (this was found in earlier versions
-    # of the code which returned the hard-clipped setting), there are no
-    # soft-clipped values, which is what vals[:, -2] now reports.
+    # There are 17 "clipped" rows.
     #
     clipped = vals[:, -2] != 0
-    assert clipped.sum() == 0
+    assert clipped.sum() == 17
 
-    # A check for issue #751 (although this particular case didn't show the
-    # issue as there are no soft-clipped rows).
+    # A check for issue #751.
     #
     stats = vals[:, -1]
     assert (stats > 0).sum() == (niter + 1)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13391,6 +13391,8 @@ class Session(sherpa.ui.utils.Session):
            soft limits, as this could cause an over-estimation of the
            flux when a parameter is only an upper limit. The statistic
            value is now returned for each row, even those that were
+           excluded from the flux calculation. The last-but-one column
+           of the returned `vals` array now records the rows that were
            excluded from the flux calculation.
 
         Parameters
@@ -13454,9 +13456,9 @@ class Session(sherpa.ui.utils.Session):
            free parameters and num is the `num` parameter. The rows of
            this array contain the flux value for the iteration (for
            the full source model), the parameter values, a flag
-           indicating whether any parameter in that row was clipped to
-           the hard-limits of the parameter, and the statistic value
-           for this set of parameters.
+           indicating whether any parameter in that row was clipped
+           (and so was excluded from the flux calculation), and the
+           statistic value for this set of parameters.
 
         See Also
         --------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13556,7 +13556,7 @@ class Session(sherpa.ui.utils.Session):
                                             bkg_id=bkg_id)
         else:
             samples = self.sample_energy_flux(lo=lo, hi=hi, id=id, num=niter,
-                                              scales=scales, clip='hard',
+                                              scales=scales, clip='soft',
                                               correlated=correlated,
                                               numcores=numcores,
                                               bkg_id=bkg_id)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13528,22 +13528,17 @@ class Session(sherpa.ui.utils.Session):
         if not Xrays:
             raise NotImplementedError("sample_flux(Xrays=False) is currently unsupported")
 
-        ids, fit = self._get_fit(id)
-        data = self.get_data(id)
-        src = None
+        _, fit = self._get_fit(id)
         if bkg_id is not None:
             data = self.get_bkg(id, bkg_id)
-            src = self.get_bkg_source(id, bkg_id)
         else:
-            src = self.get_source(id)
+            data = self.get_data(id)
 
-        if modelcomponent is None:
-            modelcomponent = src
+        if (modelcomponent is not None) and \
+           not isinstance(modelcomponent, sherpa.models.model.Model):
+            raise ArgumentTypeErr('badarg', 'modelcomponent', 'a model')
 
         correlated = sherpa.utils.bool_cast(correlated)
-
-        if not isinstance(modelcomponent, sherpa.models.model.Model):
-            raise ArgumentTypeErr('badarg', 'modelcomponent', 'a model')
 
         # Why is this +1? The original comment was
         # "num+1 cause sample energy flux is under-reporting its result?"


### PR DESCRIPTION
# Summary

The sample_flux routine now returns correct information for the clip column (that is, it matches the clipping done by this routine). There may be changes to the reported error ranges because of this change.

The sample_flux routine will now point users to calc_energy_flux if set_full_model or set_bkg_full_model was used (as it uses the source model to calculate the statistics which it can't identify from a "full model" expressio). Fixes #966.

# Details

The `calc_sample_flux` function - a "low level" routine in `sherpa.astro.flux` - can be sent `modelcomponent=None` so it is obvious when the "unabsorbed" and "absorbed" fluxes are actually the same.

Ever since #866 landed the `sample_flux` routine returned a clip column that doesn't match what the routine does. We fix that here. A consequence of this is that we get a subtly different median/errors calculated when we hit a case where the parameter values have fallen outside the soft limits: previously the values were excluded but they are now included which tweaks the distribution slightly [**TODO** need to check this statement]

The fix for #966 is included here as I honestly don't have the energy to handle multiple PRs for functionality that I've been waiting over 6 months to get looked at. The fix for #966 is a bit ugly, as we have to ask for information we don't need and we don't have a nice API (I think) to identify when a "full model" is in use (e.g. the error classes raised for the source vs bkg case are different).

---

# Example

With the following script (note, it turns out to not show the main point of this PR but is instructive anyway to understand the changes that have been going on in `sample_flux` since CIAO 4.12):

```
import numpy as np
from sherpa.astro.ui import *

np.random.seed(1783)

load_pha('sherpa-test-data/sherpatest/3c273.pi')
notice(0.4, 6)

set_source(xsphabs.gal * powlaw1d.pl)
fit()

f1, f2, pars = sample_flux(pl, num=10)

print("")
print(f"Number masked: {pars[:, -2].sum()}")

print("# Iteration mask nH statistic")
for i, (mask, stat, nh) in enumerate(zip(pars[:, -2], pars[:, -1], pars[:, 1]), 1):
    print(f"{i:2d}  {int(mask):1d}  {nh:.4f}  {stat}")
```

then in CIAO 4.13 I get the following (and there are a number of issues with the output that are not related to this PR but have been fixed in `main` as I'm about to describe):

```
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
Dataset               = 1
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 5.43148e+10
Final fit statistic   = 21.78 at function evaluation 255
Data points           = 42
Degrees of freedom    = 39
Probability [Q-value] = 0.988288
Reduced statistic     = 0.558462
Change in statistic   = 5.43148e+10
   gal.nH         0.0142957    +/- 0.0940199
   pl.gamma       1.95164      +/- 0.171985
   pl.ampl        0.000184129  +/- 1.7539e-05
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: hard minimum hit for parameter gal.nH
WARNING: Covariance failed for 'gal.nH', trying Confidence...
gal.nH lower bound:     -----
gal.nH upper bound:     0.0446962
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
original model flux = 9.36103e-13, + 2.09487e-13, - 2.74571e-13
model component flux = 1.35762e-12, + 8.94485e-14, - 2.63429e-13

Number masked: 3.0
# Iteration mask nH statistic
 1  0  0.0153  22.074275610444808
 2  1  0.0000  30.293462367621604
 3  0  0.0265  33.102269142733135
 4  1  0.0000  69.09519054432509
 5  0  0.0758  34.71601379862959
 6  0  0.0977  31.717372812591037
 7  1  0.0000  30.670132360021412
 8  0  0.0775  28.637858608992246
 9  0  0.0475  0.0
10  0  0.0213  0.0
11  0  0.0434  0.0
```

As an aside, if I use CIAO 4.12 then I get the same output for the flux rows and statistic column, but we don't provide the "mask" column as this was added in CIAO 4.13 (or Sherpa 4.12.something).

If I use the `main` branch then I get [here showing differences to the CIAO 4.13 output], which show

a) many of the repeated WARNING messages are no-longer generated
b) the median and one-sigma errors are different; this is because we now use numpy for calculating the percentiles rather than our code and they give different numbers [here we only have 11 flux values so the difference appears large]. However, this isn't the full story as shown below
c) we no-longer have any statistic bins with 0 in them

```
 WARNING: Covariance failed for 'gal.nH', trying Confidence...
 gal.nH lower bound:    -----
 gal.nH upper bound:    0.0446962
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
-original model flux = 9.36103e-13, + 2.09487e-13, - 2.74571e-13
-model component flux = 1.35762e-12, + 8.94485e-14, - 2.63429e-13
+original model flux = 1.11755e-12, + 2.15811e-13, - 2.19039e-13
+model component flux = 1.36636e-12, + 1.85307e-13, - 1.62047e-13

 Number masked: 3.0
 # Iteration mask nH statistic
  1  0  0.0153  22.074275610444808
- 2  1  0.0000  30.293462367621604
- 3  0  0.0265  33.102269142733135
- 4  1  0.0000  69.09519054432509
- 5  0  0.0758  34.71601379862959
- 6  0  0.0977  31.717372812591037
- 7  1  0.0000  30.670132360021412
- 8  0  0.0775  28.637858608992246
- 9  0  0.0475  0.0
-10  0  0.0213  0.0
-11  0  0.0434  0.0
+ 2  1  0.0000  31.773760670194623
+ 3  0  0.0265  30.293462367621604
+ 4  1  0.0000  37.42705248212813
+ 5  0  0.0758  33.102269142733135
+ 6  0  0.0977  69.09519054432509
+ 7  1  0.0000  26.077901060016888
+ 8  0  0.0775  34.71601379862959
+ 9  0  0.0475  31.717372812591037
+10  0  0.0213  30.670132360021412
+11  0  0.0434  28.637858608992246
```

If I compare this PR to the `main` branch then the difference is

```
 WARNING: Covariance failed for 'gal.nH', trying Confidence...
 gal.nH lower bound:    -----
 gal.nH upper bound:    0.0446962
-original model flux = 1.11755e-12, + 2.15811e-13, - 2.19039e-13
-model component flux = 1.36636e-12, + 1.85307e-13, - 1.62047e-13
+original model flux = 9.36103e-13, + 2.85049e-13, - 4.64372e-14
+model component flux = 1.35762e-12, + 1.62419e-13, - 9.16943e-14

 Number masked: 3.0
 # Iteration mask nH statistic
```

so the flux values have changed again, and are actually closer to the original values - but not identical, as this is the difference between the CIAO 4.13 and PR outputs ***just** for the flux lines

```
-original model flux = 9.36103e-13, + 2.09487e-13, - 2.74571e-13
-model component flux = 1.35762e-12, + 8.94485e-14, - 2.63429e-13
+original model flux = 9.36103e-13, + 2.85049e-13, - 4.64372e-14
+model component flux = 1.35762e-12, + 1.62419e-13, - 9.16943e-14
```

So the median value is now the same as it was in CIAO 4.13 but the sigma values have changed. If I change the number of iterations from 10 to 1000 (to get a better handle on the distribution) the difference in these limits is smaller (the - lines are CIAO 4.13 and the + lines are this PR), so I'm not too bothered about this difference (this difference because in 4.13 we dropped the rows which were outside the soft limits but we now include them in the distribution after moving the parameter value to the soft-limit boundary):

```
-original model flux = 1.03093e-12, + 1.62163e-13, - 1.58581e-13
-model component flux = 1.40432e-12, + 1.1435e-13, - 1.20281e-13
+original model flux = 1.03093e-12, + 1.62851e-13, - 1.5572e-13
+model component flux = 1.40432e-12, + 1.15212e-13, - 1.19412e-13
```