### PR TITLE
Read RMFs where N_CHAN is an array

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -735,7 +735,7 @@ def get_rmf_data(arg, make_copy=False):
         rowdata = []
         for mrow, ng, ncs in zip(matrix, n_grp, n_chan):
             # Need a RMF which ng>1 to test this with.
-            if ng == 1:
+            if np.isscalar(ncs):
                 ncs = [ncs]
 
             start = 0

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -735,7 +735,7 @@ def get_rmf_data(arg, make_copy=False):
         rowdata = []
         for mrow, ng, ncs in zip(matrix, n_grp, n_chan):
             # Need a RMF which ng>1 to test this with.
-            if np.isscalar(ncs):
+            if numpy.isscalar(ncs):
                 ncs = [ncs]
 
             start = 0


### PR DESCRIPTION
Summary
=======
Allow the pyfits backend to read a wider range of RMF files

Details
======
The old code checked the number of groups, and if that is 1
assumed that N_CHAN would be a scalar. However, the OGIP standard
also allows N_CHAN to the a fixed or variable length array.
In that case, this test is insufficient, because the number of channel subsets would be one in a single row, while still
be stored as array - in that case you end up with `[array([1])]` which will break the for loop below. (This is how I discovered the problem). 
In particular, this will happen if some rows have 1 channel
subset, but others have more than one.

Why is there no test added?
-------------------------------
I'm working on generating rmf files for Arcus, which need channel subsets. I'm not entirely certain that all details of that response are correct, so I don't want to add it to the test data. Instead, take this PR as old-fashioned reading of the OGIP specs and thinking how to map this to Python.