### PR TITLE
Minor test updates

### DIFF
--- a/sherpa/astro/sim/tests/test_astro_sim.py
+++ b/sherpa/astro/sim/tests/test_astro_sim.py
@@ -210,7 +210,9 @@ def test_pragbayes_pcaarf_limits(sampler, setup, caplog, reset_seed):
     pmins = np.asarray(covar_results.parmins)
     pmaxs = np.asarray(covar_results.parmaxes)
 
-    fit.model = myabs * mypl
+    # Make sure we add the response
+    rsp = Response1D(fit.data)
+    fit.model = rsp(myabs * mypl)
 
     fit.model.thawedpars = pvals
     fit.model.thawedparmins = pvals + 2 * pmins  # pmins are < 0

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -136,8 +136,7 @@ class SmokeTest(unittest.TestCase):
         self.y = np.asarray([1, 2, 3])
 
     def tearDown(self):
-        if hasattr(self, "old_level"):
-            logger.setLevel(self._old_level)
+        logger.setLevel(self._old_level)
 
     def test_fit(self):
         """

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -23,6 +23,7 @@ import sys
 from tempfile import NamedTemporaryFile
 import unittest
 
+import numpy as np
 from numpy.testing import assert_almost_equal
 
 from sherpa.astro import ui
@@ -130,8 +131,9 @@ class SmokeTest(unittest.TestCase):
         folder = os.path.dirname(datastack.__file__)
         self.fits = os.path.join(folder, "tests", "data", "acisf07867_000N001_r0002_pha3.fits")
 
-        self.x = [1, 2, 3]
-        self.y = [1, 2, 3]
+        self.x = np.asarray([1, 2, 3])
+        self.x2 = self.x + 1
+        self.y = np.asarray([1, 2, 3])
 
     def tearDown(self):
         if hasattr(self, "old_level"):
@@ -175,13 +177,13 @@ class SmokeTest(unittest.TestCase):
         This test proves that the xspec extension properly works, and that there are no obvious building, linking, or
         environment issues that would prevent the xspec model from running.
         """
-        ui.load_arrays(1, self.x, self.y)
+        ui.load_arrays(1, self.x, self.x2, self.y, ui.Data1DInt)
         ui.set_source("xspowerlaw.p")
         ui.set_method("moncar")
         ui.set_stat("chi2xspecvar")
         ui.fit()
         model = ui.get_model_component("p")
-        expected = [-1.3686404, 0.5687635]
+        expected = [-1.2940997851602858, 0.5969328003146177]
         observed = [model.PhoIndex.val, model.norm.val]
         assert_almost_equal(observed, expected)
 


### PR DESCRIPTION
# Summary

Minor updates to the test code, including a small enhancement to the tests run by the `smoke_test` command.

# Details

This has been broken out of #947 as they are simpler to review and are not directly related to that PR.

The main change here is in the first commit, which tweaks the test added in #893 to include a response, to make it a more realistic test. This is more a check that various parts of the MCMC analysis work together, and we don't actually test the parameter values, so technically it isn't needed, but it doesn't seem sensible to fit a model that has no chance of matching the data.

The remaining commits just update the "smoke test" code to be a bit-more robust (calling clean in the setup and teardown methods); avoid an un-needed attribute check at teardown (as we add the attribute at setup); use lo and hi energy bins for the XSPEC model and ensure we have a dof > 0 for the test; and expand the I/O check to make sure the results are sensible (note that the idea of the smoke test is not to do any strenuous testing, just to check that it appears to work, so there's always a choice of how much testing to do, but  I think it makes sense that the I/O tests do a little bit beyond not fallnig over).