### PR TITLE
XSPEC: require model evaluation to be sent low and high grid values

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021
-#         Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -848,6 +848,24 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
+        """Calculate the model given the parameters and grid.
+
+        Notes
+        -----
+        XSPEC models must always be evaluated with low and high bin
+        edges. Although supported by the XSPEC model interface the
+        ability to evaluate using an XSPEC-style grid (n+1 values for
+        n bins which we pad with a 0), we do not allow this here since
+        it complicates the handling of the regrid method.
+
+        Keyword arguments are ignored.
+        """
+
+        nargs = len(args)
+        if nargs != 3:
+            emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
+            raise TypeError(emsg)
+
         # Ensure output is finite (Keith Arnaud mentioned that XSPEC
         # does this as a check). This is done at this level (Python)
         # rather than in the C++ interface since:
@@ -971,6 +989,13 @@ class XSTableModel(XSModel):
 
     @modelCacher1d
     def calc(self, p, *args, **kwargs):
+
+        # Note the kwargs is ignored
+        nargs = 1 + len(args)
+        if nargs != 3:
+            emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
+            raise TypeError(emsg)
+
         # The function used depends on XSPEC version and, prior
         # to XSPEC 12.10.1, the type of table.
         #
@@ -987,16 +1012,15 @@ class XSTableModel(XSModel):
 
         if hasattr(_xspec, 'tabint'):
             tabtype = 'add' if self.addmodel else 'mul'
-            return _xspec.tabint(p,
-                                 filename=self.filename, tabtype=tabtype,
-                                 *args, **kwargs)
+            return _xspec.tabint(p, *args,
+                                 filename=self.filename, tabtype=tabtype)
 
         if self.addmodel:
             func = _xspec.xsatbl
         else:
             func = _xspec.xsmtbl
 
-        return func(p, filename=self.filename, *args, **kwargs)
+        return func(p, *args, filename=self.filename)
 
 
 class XSAdditiveModel(XSModel):
@@ -1132,13 +1156,16 @@ class XSConvolutionKernel(XSModel):
         *args
             The model grid. There should be two arrays (the low and
             high edges of the bin) to make sure the wrapped model is
-            evaluated correctly. One array can be used but this should
-            only be used when the wrapped model only contains XSPEC
-            models.
+            evaluated correctly.
         **kwargs
             At present all additional keyword arguments are dropped.
 
         """
+
+        nargs = 2 + len(args)
+        if nargs != 4:
+            emsg = f"calc() requires pars,rhs,lo,hi arguments, sent {nargs} arguments"
+            raise TypeError(emsg)
 
         npars = len(self.pars)
         lpars = pars[:npars]
@@ -1261,13 +1288,16 @@ class XSConvolutionModel(CompositeModel, XSModel):
         *args
             The model grid. There should be two arrays (the low and
             high edges of the bin) to make sure the wrapped model is
-            evaluated correctly. One array can be used but this should
-            only be used when the wrapped model only contains XSPEC
-            models.
+            evaluated correctly.
         **kwargs
             Additional keyword arguments.
 
         """
+
+        nargs = 1 + len(args)
+        if nargs != 3:
+            emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
+            raise TypeError(emsg)
 
         return self.wrapper.calc(p, self.model.calc,
                                  *args, **kwargs)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -75,6 +75,7 @@ References
 
 
 import string
+import warnings
 
 import numpy as np
 
@@ -864,7 +865,8 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
         nargs = len(args)
         if nargs != 3:
             emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
-            raise TypeError(emsg)
+            warnings.warn(emsg, FutureWarning)
+            # raise TypeError(emsg)
 
         # Ensure output is finite (Keith Arnaud mentioned that XSPEC
         # does this as a check). This is done at this level (Python)
@@ -994,7 +996,8 @@ class XSTableModel(XSModel):
         nargs = 1 + len(args)
         if nargs != 3:
             emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
-            raise TypeError(emsg)
+            warnings.warn(emsg, FutureWarning)
+            # raise TypeError(emsg)
 
         # The function used depends on XSPEC version and, prior
         # to XSPEC 12.10.1, the type of table.
@@ -1165,7 +1168,8 @@ class XSConvolutionKernel(XSModel):
         nargs = 2 + len(args)
         if nargs != 4:
             emsg = f"calc() requires pars,rhs,lo,hi arguments, sent {nargs} arguments"
-            raise TypeError(emsg)
+            warnings.warn(emsg, FutureWarning)
+            # raise TypeError(emsg)
 
         npars = len(self.pars)
         lpars = pars[:npars]
@@ -1297,7 +1301,8 @@ class XSConvolutionModel(CompositeModel, XSModel):
         nargs = 1 + len(args)
         if nargs != 3:
             emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
-            raise TypeError(emsg)
+            warnings.warn(emsg, FutureWarning)
+            # raise TypeError(emsg)
 
         return self.wrapper.calc(p, self.model.calc,
                                  *args, **kwargs)

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -338,7 +338,7 @@ def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_pa
 
     # Check when input array is too small (< 2 elements)
     with pytest.raises(TypeError):
-        mdl([0.1])
+        mdl([0.1], [0.2])
 
     # Check when input arrays are not the same size (when the
     # low and high bin edges are given)

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2020
-#         Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -378,12 +378,14 @@ def test_cflux_nbins():
 
     The test_cflux_calc_xxx routines do include a test of the number
     of bins, but that is just for a Data1DInt dataset, so the model
-    only ever gets called with explicit lo and hi edges. This test
-    calls the model directly to check both 1 and 2 argument variants.
+    only ever gets called with explicit lo and hi edges. Now that we
+    no-longer support evaluating the model with a single grid this
+    test may not add much power, but leave in for now.
 
     Notes
     -----
     There's no check of a non-contiguous grid.
+
     """
 
     from sherpa.astro import xspec
@@ -401,11 +403,8 @@ def test_cflux_nbins():
     nbins = elo.size
 
     def check_bins(lbl, mdl):
-        y1 = mdl(egrid)
-        y2 = mdl(elo, ehi)
-
-        assert y1.size == nbins + 1, '{}: egrid'.format(lbl)
-        assert y2.size == nbins, '{}: elo/ehi'.format(lbl)
+        y = mdl(elo, ehi)
+        assert y.size == nbins, f'{lbl}: elo/ehi'
 
     # verify assumptions
     #

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -724,11 +724,9 @@ def test_xspec_model_requires_bins(clsname):
 
     mdl = getattr(xspec, 'XS{}'.format(clsname))()
 
-    with pytest.raises(TypeError) as exc:
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
         mdl([0.1, 0.2, 0.3, 0.4])
-
-    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
-    assert str(exc.value) == emsg
 
 
 @requires_xspec
@@ -743,11 +741,9 @@ def test_xspec_model_requires_bins_low_level(clsname):
 
     mdl = getattr(xspec, 'XS{}'.format(clsname))()
 
-    with pytest.raises(TypeError) as exc:
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
         mdl.calc([p.val for p in mdl.pars], [0.1, 0.2, 0.3, 0.4])
-
-    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
-    assert str(exc.value) == emsg
 
 
 @requires_xspec
@@ -797,11 +793,9 @@ def test_xspec_tablemodel_requires_bin_edges(make_data_path, clean_astro_ui):
     ui.load_xstable_model('mdl', make_data_path('xspec-tablemodel-RCS.mod'))
     mdl = ui.get_model_component('mdl')
 
-    with pytest.raises(TypeError) as exc:
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
         mdl([0.1, 0.2, 0.3, 0.4])
-
-    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
-    assert str(exc.value) == emsg
 
 
 @requires_xspec
@@ -817,11 +811,9 @@ def test_xspec_convolutionmodel_requires_bin_edges():
     m2 = xs.XScflux()
     mdl = m2(m1)
 
-    with pytest.raises(TypeError) as exc:
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
         mdl([0.1, 0.2, 0.3, 0.4])
-
-    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
-    assert str(exc.value) == emsg
 
 
 @requires_xspec
@@ -837,11 +829,9 @@ def test_xspec_convolutionmodel_requires_bin_edges_low_level():
     m2 = xs.XScflux()
     mdl = m2(m1)
 
-    with pytest.raises(TypeError) as exc:
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
         mdl.calc([p.val for p in mdl.pars], [0.1, 0.2, 0.3, 0.4])
-
-    emsg = 'calc() requires pars,lo,hi arguments, sent 2 arguments'
-    assert str(exc.value) == emsg
 
 
 @requires_data


### PR DESCRIPTION
# Summary

XSPEC model classes must now be evaluated with bin edges - that is with low,high bins. The support for sending in a single grid and treating it a consecutive set of bins has been marked as deprecated from the model class interface. This feature is still supported for anyone evaluating the models directly from the sherpa.astro.xspec._xspec module or via the _calc method.

# Details

This was originally #947 but I have since split the PR into #1111 (has been merged) and this PR, with the integrate changes to come in a yet-to-be-determined PR.

XSPEC models, when evaluated by an instrument model, already use the two-argument form (ie send in low,high bin edges), so for the vast majority of use cases this does not change anything for users (that is, a user using `set_source`, `notice`, `fit`, `plot_fit` etc from the UI layer will not see any difference). The only tests that require changes are those that are designed to test the model evaluation (this is because previous PRs, such as #1111 and #946, have made the changes to ensure we use a response when we need to).

There is a possibility that downstream code will break because of this change, so rather than raising an error the code currently creates a `FutureWarning` message, which indicated to the user that things need to be changed. I chose `FutureWarning` rather than `DeprecationWarning` as it's harder to miss and, I believe but things seem to have changed around Python 3.7, is a closer match for the intended message (the semantics of the call has changed).

This actually makes a noticeable (but not spectacular) reduction in the time to run the Sherpa test suite (when you have XSPEC support enabled) since we no-longer have to run each XSPEC model with both one and two argument forms (although hard to show on CI as it is so dependent on the machine).

Normally I would argue that we shouldn't change something that works and could be being relied on, but

 - we have not explicitly documented the XSPEC behavior when sent a single grid, so it's not like we're "breaking an explicit contract"
 - combining XSPEC and non-XSPEC models - e.g. `XSphabs * PowLaw1D` - are currently tricky to understand what is going on when you evaluate the combined model and call it with a single argument
 - there are downstream changes related to model regridding that I believe are easier when we don't have the current behavior (this requires unraveling the `integrate` setting which is not well documented and was part of #947, but I've decided to separate the changes)

I do need to check the documentation (both docstrings and in docs/) to check they don't suggest this functionality is still possible.

# Example

With this PR we have the following behavior (note that the warning message is slightly confusing since it talks about the calc method, but unfortunately this is hard to catch sensibly; if we were throwing an error it would be easier to have a specific error message for the case used here):

```
>>> from sherpa.astro import xspec
>>> m1 = xspec.XSpowerlaw()
>>> m1([0.1, 0.2, 0.3], [0.2, 0.3, 0.4])
array([0.69314718, 0.40546511, 0.28768207])
>>> m1([0.1, 0.2, 0.3])
/home/dburke/sherpa/sherpa-master/sherpa/astro/xspec/__init__.py:868: FutureWarning: calc() requires pars,lo,hi arguments, sent 2 arguments
  warnings.warn(emsg, FutureWarning)
array([0.69314718, 0.40546511, 0.        ])
>>> m1([0.1, 0.2, 0.3])
array([0.69314718, 0.40546511, 0.        ])
```

The current behavior of this is

```
>>> from sherpa.astro import xspec
>>> m1 = xspec.XSpowerlaw()
>>> m1([0.1, 0.2, 0.3], [0.2, 0.3, 0.4])
array([0.69314718, 0.40546511, 0.28768207])
>>> m1([0.1, 0.2, 0.3])
array([0.69314718, 0.40546511, 0.        ])
```

An earlier version of the PR made it an error instead, as shown below:

```
>>> m1([0.1, 0.2, 0.3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-master/sherpa/models/model.py", line 304, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/models/model.py", line 95, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/xspec/__init__.py", line 867, in calc
    raise TypeError(emsg)
TypeError: calc() requires pars,lo,hi arguments, sent 2 arguments
```

# What about the integrate setting

Sherpa models have a `integrate` setting which indicates whether to evaluate the model actoss the grid or at a point (at least, that's my interpretation of this setting; it's not well documented in the code base what it's meant to do). Given this, perhaps XSPEC models

 - shouldn't allow the user to change the setting
 - have it fixed to `True` (although there is the fact that XSPEC multiplicative models technically act like `integrate=False`)

This isn't being done here (it was in #947), but I will add a PR for this (this has issues for how we handle the regrid support)