### PR TITLE
XSPEC: support etable table models

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9658,12 +9658,17 @@ class Session(sherpa.ui.utils.Session):
 
         return (x, y)
 
-    def load_xstable_model(self, modelname, filename):
+    def load_xstable_model(self, modelname, filename, etable=False):
         """Load a XSPEC table model.
 
-        Create an additive (``atable``, [1]_) or multiplicative
-        (``mtable``, [2]_) XSPEC table model component. These models
-        may have multiple model parameters.
+        Create an additive (``atable``, [1]_), multiplicative
+        (``mtable``, [2]_), or exponential (``etable``, [3]_) XSPEC
+        table model component. These models may have multiple model
+        parameters.
+
+        .. versionchanged:: 4.13.1
+           The etable argument has been added to allow exponential table
+           models to be used.
 
         Parameters
         ----------
@@ -9671,7 +9676,10 @@ class Session(sherpa.ui.utils.Session):
            The identifier for this model component.
         filename : str
            The name of the FITS file containing the data, which should
-           match the XSPEC table model definition [3]_.
+           match the XSPEC table model definition [4]_.
+        etable : bool, optional
+           Set if this is an etable (as there's no way to determine this
+           from the file itself). Defaults to False.
 
         Raises
         ------
@@ -9690,7 +9698,7 @@ class Session(sherpa.ui.utils.Session):
         Notes
         -----
         NASA's HEASARC site contains a link to community-provided
-        XSPEC table models [4]_.
+        XSPEC table models [5]_.
 
         References
         ----------
@@ -9699,9 +9707,11 @@ class Session(sherpa.ui.utils.Session):
 
         .. [2] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
 
-        .. [3] http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
+        .. [3] http://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelEtable.html
 
-        .. [4] https://heasarc.gsfc.nasa.gov/xanadu/xspec/newmodels.html
+        .. [4] http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html
+
+        .. [5] https://heasarc.gsfc.nasa.gov/xanadu/xspec/newmodels.html
 
         Examples
         --------
@@ -9714,6 +9724,10 @@ class Session(sherpa.ui.utils.Session):
         >>> set_source(xsphabs.gal * xtbl)
         >>> print(xtbl)
 
+        Load in an XSPEC etable model
+
+        >>> load_xstable_model('etbl', 'etable.mod', etable=True)
+
         """
 
         try:
@@ -9722,7 +9736,7 @@ class Session(sherpa.ui.utils.Session):
             # TODO: what is the best error to raise here?
             raise ImportErr('notsupported', 'XSPEC') from exc
 
-        tablemodel = xspec.read_xstable_model(modelname, filename)
+        tablemodel = xspec.read_xstable_model(modelname, filename, etable=etable)
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9666,7 +9666,7 @@ class Session(sherpa.ui.utils.Session):
         table model component. These models may have multiple model
         parameters.
 
-        .. versionchanged:: 4.13.1
+        .. versionchanged:: 4.13.2
            The etable argument has been added to allow exponential table
            models to be used.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -739,6 +739,10 @@ def read_xstable_model(modelname, filename, etable=False):
     XSPEC additive (atable, [1]_), multiplicative (mtable, [2]_), and
     exponential (etable, [3]_) table models are supported.
 
+    .. versionchanged:: 4.13.2
+       The etable argument has been added to allow exponential table
+       models to be used.
+
     Parameters
     ----------
     modelname : str
@@ -908,6 +912,10 @@ class XSTableModel(XSModel):
     as a table model [1]_. This class provides a low-level
     way to access this functionality. A simpler interface is provided
     by ``read_xstable_model`` and ``sherpa.astro.ui.load_xstable_model``.
+
+    .. versionchanged:: 4.13.2
+       The etable argument has been added to allow exponential table
+       models to be used.
 
     Parameters
     ----------


### PR DESCRIPTION
# Summary

Allow XSPEC ETABLE table model files to be read by load_xstable_model by setting the etable parameter. For example if model.fits is an ETABLE XSPEC model then it would be loaded with

    load_xstable_model('emdl', 'model.fits', etable=True)

If the `etable` argument is not given then the model will be treated as a MTABLE model. 

# Details

Unfortunately there's no way to tell from a table-model file whether it's multipicative (mtable) or exponential (etable), so out-of-band information is required (the user has to explicitly say what type is being used). The default assumes mtable.

Note that there is no support added to load_table_model, as the support for XSPEC table models there has been deprecated for a long time.

Note there's no test of this functionality, and I'm not 100% happy with the interface.If etable models could be determined automatically then it would be okay, but maybe we should have something like

  - read_xstable_atable
  - read_xstable_mtable
  - read_xstable_etable

Then again, as the number of "etable" models is low, perhaps it's okay with

  - read_xstable_model(modname, filename, etable=True)

for this case.