### PR TITLE
Add parameter-based tests for the PSF model

### DIFF
--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -44,10 +44,11 @@ from sherpa.models.model import ArithmeticModel, \
     ArithmeticConstantModel, BinaryOpModel
 from sherpa.astro.instrument import ARF1D, ARFModelNoPHA, ARFModelPHA, \
     Response1D, RMF1D, RMFModelNoPHA, RMFModelPHA, \
-    RSPModelNoPHA, RSPModelPHA, create_arf, create_delta_rmf
+    RSPModelNoPHA, RSPModelPHA, create_arf, create_delta_rmf, \
+    PSFModel
 from sherpa.fit import Fit
 from sherpa.astro.data import DataPHA, DataRMF
-from sherpa.models.basic import Const1D, Polynom1D, PowLaw1D
+from sherpa.models.basic import Box1D, Const1D, Polynom1D, PowLaw1D
 from sherpa.utils.err import DataErr
 from sherpa.utils.testing import requires_xspec, requires_data, requires_fits
 
@@ -1700,3 +1701,46 @@ def test_create_rmf(make_data_path):
     assert len(datarmf._nch) == 1039
     assert len(datarmf.n_grp) == 900
     assert datarmf._rsp.shape[0] == 380384
+
+
+# Several tests from sherpa/tests/test_instrument.py repeated to check out
+# the astro-version of PSFModel
+#
+def test_psf1d_empty_pars():
+    """What does .pars mean for an empty PSFModel?"""
+
+    m = PSFModel()
+    assert m.pars == ()
+
+
+def test_psf1d_pars():
+    """What does .pars mean for a PSFModel?"""
+
+    b = Box1D()
+    m = PSFModel(kernel=b)
+    assert m.pars == ()
+
+
+def test_psf1d_convolved_pars():
+    """What does .pars mean for a PSFModel applied to a model?"""
+
+    b1 = Box1D('b1')
+    m = PSFModel(kernel=b1)
+    b2 = Box1D('b2')
+    c = m(b2)
+
+    b1.xlow = 1
+    b1.xhi = 10
+    b1.ampl = 0.2
+
+    b2.xlow = 4
+    b2.xhi = 8
+    b2.ampl = 0.4
+
+    bpars = b1.pars + b2.pars
+    assert len(bpars) == 6
+
+    cpars = c.pars
+    assert len(cpars) == 6
+    for bpar, cpar in zip(bpars, cpars):
+        assert cpar == bpar

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021
-#        Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -411,6 +411,16 @@ def _create_tail_grid(axis_list):
 
 
 class PSFModel(Model):
+    """Convolve a model by another model or data set.
+
+    Notes
+    -----
+    A number of attributes are displayed as parameters, if set, but
+    are not handled as parameters. The attributes are: kernel, size,
+    centre, and origin.
+
+    """
+
     def __init__(self, name='psfmodel', kernel=None):
         self._name = name
         self._size = None

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -95,6 +95,17 @@ def test_psf1d_show():
     check(out, 5, CENTER)
     check(out, 6, RADIAL)
     check(out, 7, NORM)
+
+
+def test_psf1d_no_kernel():
+    """Error out if there's no kernel"""
+
+    m = PSFModel('bob')
+    b = Box1D()
+    with pytest.raises(PSFErr) as exc:
+        m(b)
+
+    assert "PSF kernel has not been set" == str(exc.value)
 
 
 def test_psf1d_fold_no_kernel():

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -97,6 +97,46 @@ def test_psf1d_show():
     check(out, 7, NORM)
 
 
+def test_psf1d_empty_pars():
+    """What does .pars mean for an empty PSFModel?"""
+
+    m = PSFModel()
+    assert m.pars == ()
+
+
+def test_psf1d_pars():
+    """What does .pars mean for a PSFModel?"""
+
+    b = Box1D()
+    m = PSFModel(kernel=b)
+    assert m.pars == ()
+
+
+def test_psf1d_convolved_pars():
+    """What does .pars mean for a PSFModel applied to a model?"""
+
+    b1 = Box1D('b1')
+    m = PSFModel(kernel=b1)
+    b2 = Box1D('b2')
+    c = m(b2)
+
+    b1.xlow = 1
+    b1.xhi = 10
+    b1.ampl = 0.2
+
+    b2.xlow = 4
+    b2.xhi = 8
+    b2.ampl = 0.4
+
+    bpars = b1.pars + b2.pars
+    assert len(bpars) == 6
+
+    cpars = c.pars
+    assert len(cpars) == 6
+    for bpar, cpar in zip(bpars, cpars):
+        assert cpar == bpar
+
+
 def test_psf1d_no_kernel():
     """Error out if there's no kernel"""
 


### PR DESCRIPTION
# Summary

Adds several tests of edge-case handling of parameters for PSF convolution models.

# Details

This was meant to solve #1109 but "Eek. Turns out to not-at-all-be-easy™ so this may just morph into some basic tests..." so we have some test if I ever do work out how to improve #1109.