### PR TITLE
Improve test cases for source plots with PHA data

### DIFF
--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -274,7 +274,7 @@ class SourcePlot(HistogramPlot):
         sqr = to_latex('^2')
 
         self.xlabel = f'{self.units.capitalize()} ({quant})'
-        self.ylabel = '%s  Photons/sec/cm' + sqr + '%s'
+        self.ylabel = f'%s  Photons/sec/cm{sqr}%s'
 
         if data.plot_fac == 0:
             self.y /= xmid

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -245,9 +245,17 @@ class SourcePlot(HistogramPlot):
             self.units = "energy"
 
         self.xlabel = data.get_xlabel()
-        self.title = 'Source Model of %s' % data.name
+        self.title = f'Source Model of {data.name}'
         self.xlo, self.xhi = data._get_indep(filter=False)
+
+        # Why do we not apply the mask at the end of prepare?
+        #
         self.mask = filter_bins((lo,), (hi,), (self.xlo,))
+
+        # The source model is assumed to not contain an instrument model,
+        # and so it evaluates the expected number of photons/cm^2/s in
+        # each bin (or it can be thought of as a 1 second exposure).
+        #
         self.y = src(self.xlo, self.xhi)
         prefix_quant = 'E'
         quant = 'keV'
@@ -265,23 +273,21 @@ class SourcePlot(HistogramPlot):
 
         sqr = to_latex('^2')
 
-        self.xlabel = '%s (%s)' % (self.units.capitalize(), quant)
+        self.xlabel = f'{self.units.capitalize()} ({quant})'
         self.ylabel = '%s  Photons/sec/cm' + sqr + '%s'
 
         if data.plot_fac == 0:
             self.y /= xmid
-            self.ylabel = self.ylabel % ('f(%s)' % prefix_quant,
-                                         '/%s ' % quant)
+            self.ylabel = self.ylabel % (f'f({prefix_quant})',
+                                         f'/{quant} ')
 
         elif data.plot_fac == 1:
-            self.ylabel = self.ylabel % ('%s f(%s)' % (prefix_quant,
-                                                       prefix_quant), '')
+            self.ylabel = self.ylabel % (f'{prefix_quant} f({prefix_quant})', '')
 
         elif data.plot_fac == 2:
             self.y *= xmid
-            self.ylabel = self.ylabel % ('%s%s f(%s)' % (prefix_quant, sqr,
-                                                         prefix_quant),
-                                         ' %s ' % quant)
+            self.ylabel = self.ylabel % (f'{prefix_quant}{sqr} f({prefix_quant})',
+                                         f' {quant} ')
         else:
             raise PlotErr('plotfac', 'Source', data.plot_fac)
 
@@ -610,9 +616,9 @@ class FluxHistogram(ModelHistogram):
             flux = array2string(asarray(self.flux), separator=',',
                                 precision=4, suppress_small=False)
 
-        return '\n'.join(['modelvals = {}'.format(vals),
-                          'clipped = {}'.format(clip),
-                          'flux = {}'.format(flux),
+        return '\n'.join([f'modelvals = {vals}',
+                          f'clipped = {clip}',
+                          f'flux = {flux}',
                           ModelHistogram.__str__(self)])
 
     def prepare(self, fluxes, bins):
@@ -648,8 +654,7 @@ class EnergyFluxHistogram(FluxHistogram):
     def __init__(self):
         FluxHistogram.__init__(self)
         self.title = "Energy flux distribution"
-        self.xlabel = "Energy flux (ergs cm{} sec{})".format(
-            to_latex('^{-2}'), to_latex('^{-1}'))
+        self.xlabel = f"Energy flux (ergs cm{to_latex('^{-2}')} sec{to_latex('^{-1}')})"
         self.ylabel = "Frequency"
 
 
@@ -659,6 +664,5 @@ class PhotonFluxHistogram(FluxHistogram):
     def __init__(self):
         FluxHistogram.__init__(self)
         self.title = "Photon flux distribution"
-        self.xlabel = "Photon flux (Photons cm{} sec{})".format(
-            to_latex('^{-2}'), to_latex('^{-1}'))
+        self.xlabel = f"Photon flux (Photons cm{to_latex('^{-2}')} sec{to_latex('^{-1}')})"
         self.ylabel = "Frequency"

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -36,11 +36,10 @@ from sherpa import stats
 from sherpa.utils.err import IOErr
 
 
-def check_sourceplot_energy(sp, rate=True, factor=0):
+def check_sourceplot_energy(sp, factor=0):
     """Check for test_sourceplot/test_sourceplot_channel
 
-    rate determines if the plot is for a "rate" or "counts",
-    although at the moment it does not change anything.
+    Note that the rate setting does not change these tests.
     """
 
     assert sp.xlabel == 'Energy (keV)'
@@ -106,7 +105,7 @@ def check_sourceplot_energy(sp, rate=True, factor=0):
     assert sp.y == pytest.approx(yexp)
 
 
-def check_sourceplot_wavelength(sp, rate=True, factor=0):
+def check_sourceplot_wavelength(sp, factor=0):
     """Check for test_sourceplot_wavelength.
 
     See check_sourceplot_energy.
@@ -240,7 +239,7 @@ def test_sourceplot_counts(caplog):
         sp.prepare(data, src)
 
     assert len(caplog.records) == 0
-    check_sourceplot_energy(sp, rate=False)
+    check_sourceplot_energy(sp)
 
 
 @pytest.mark.parametrize("factor", [1, 2])
@@ -390,7 +389,7 @@ def test_sourceplot_wavelength_counts(caplog):
         sp.prepare(data, src)
 
     assert len(caplog.records) == 0
-    check_sourceplot_wavelength(sp, rate=False)
+    check_sourceplot_wavelength(sp)
 
 
 # Low-level test of the DataPlot prepare method for PHA style analysis

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -34,7 +34,6 @@ from sherpa.data import Data1D
 from sherpa.models.basic import Const1D, Gauss1D, Polynom1D
 from sherpa import stats
 from sherpa.utils.err import IOErr
-from sherpa.utils.testing import requires_pylab
 
 
 def check_sourceplot_energy(sp, rate=True, factor=0):
@@ -464,7 +463,6 @@ def test_plot_fail_with_non_pha(ptype):
     assert str(exc.value) == "data set 'tst' does not contain a PHA spectrum"
 
 
-@requires_pylab
 @requires_data
 @requires_fits
 def test_dataphahistogram_prepare_wavelength(make_data_path):
@@ -503,7 +501,6 @@ def test_dataphahistogram_prepare_wavelength(make_data_path):
     assert plot.y == pytest.approx(yexp)
 
 
-@requires_pylab
 @requires_data
 @requires_fits
 def test_modelphahistogram_prepare_wavelength(make_data_path):
@@ -537,7 +534,6 @@ def test_modelphahistogram_prepare_wavelength(make_data_path):
     assert plot.y.size == 9
 
 
-@requires_pylab
 @requires_data
 @requires_fits
 def test_sourceplot_prepare_wavelength(make_data_path):
@@ -561,7 +557,9 @@ def test_sourceplot_prepare_wavelength(make_data_path):
     plot.prepare(pha, mdl)
 
     assert plot.xlabel == 'Wavelength (Angstrom)'
-    assert plot.ylabel == 'f(lambda)  Photons/sec/cm$^2$/Angstrom '
+    assert plot.ylabel.startswith('f(lambda)  Photons/sec/cm')
+    assert plot.ylabel.find('^2') != -1
+    assert plot.ylabel.endswith('/Angstrom ')
     assert plot.title == 'Source Model of my-name.pi'
 
     # data is inverted

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -121,7 +121,7 @@ def check_sourceplot_wavelength(sp, rate=True, factor=0):
         assert sp.ylabel.startswith('lambda f(lambda)  Photons/sec/cm')
         assert sp.ylabel.find('/Angstrom ') == -1
     elif factor == 2:
-        # This says lmabda^2 f(lambda) ... but the exact format depends on
+        # This says lambda^2 f(lambda) ... but the exact format depends on
         # the back end
         assert sp.ylabel.startswith('lambda')
         assert sp.ylabel.find('^2') != -1

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -17,6 +17,9 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+import logging
+
 import numpy as np
 
 import pytest
@@ -34,13 +37,146 @@ from sherpa.utils.err import IOErr
 from sherpa.utils.testing import requires_pylab
 
 
-def test_sourceplot():
+def check_sourceplot_energy(sp, rate=True, factor=0):
+    """Check for test_sourceplot/test_sourceplot_channel
+
+    rate determines if the plot is for a "rate" or "counts",
+    although at the moment it does not change anything.
+    """
+
+    assert sp.xlabel == 'Energy (keV)'
+
+    # the following depends on the backend
+    # assert sp.ylabel == 'f(E)  Photons/sec/cm$^2$/keV'
+    if factor == 0:
+        assert sp.ylabel.startswith('f(E)  Photons/sec/cm')
+        assert sp.ylabel.endswith('/keV ')
+    elif factor == 1:
+        assert sp.ylabel.startswith('E f(E)  Photons/sec/cm')
+        assert sp.ylabel.find('/keV ') == -1
+    else:
+        raise RuntimeError("unsupported factor")
+
+    assert sp.title == 'Source Model of '
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    assert sp.xlo == pytest.approx(bins[:-1])
+    assert sp.xhi == pytest.approx(bins[1:])
+
+    # The check of the values is just to check that things are going
+    # as expected, rather than a test from first principles.
+    #
+    yexp = np.asarray([9998.300959, 9997.9935414, 9997.63869638,
+                       9997.23070803, 9996.76346026, 9996.2304594, 9995.62486769,
+                       9994.9395488, 9994.16712626, 9993.30005567, 9992.33071112,
+                       9991.25148615, 9990.05490914, 9988.73377265, 9987.28127577,
+                       9985.69117819, 9983.95796409, 9982.07701351, 9980.04477839,
+                       9977.85895997, 9975.51868378, 9973.02466824, 9970.37938236,
+                       9967.58718801, 9964.65446216, 9961.58969431, 9958.40355487,
+                       9955.10893021, 9951.72092088, 9948.25679985, 9944.73592864,
+                       9941.17962987, 9937.6110159, 9934.05477423, 9930.53691143,
+                       9927.08445867, 9923.7251427, 9920.48702778, 9917.39813433,
+                       9914.48604166, 9911.77748224, 9909.29793588, 9907.07123238,
+                       9905.11917118, 9903.4611666, 9902.11392658, 9901.09117249,
+                       9900.40340655, 9900.05773225, 9900.05773225, 9900.40340655,
+                       9901.09117249, 9902.11392658, 9903.4611666, 9905.11917118,
+                       9907.07123238, 9909.29793588, 9911.77748224, 9914.48604166,
+                       9917.39813433, 9920.48702778, 9923.7251427, 9927.08445867,
+                       9930.53691143, 9934.05477423, 9937.6110159, 9941.17962987,
+                       9944.73592864, 9948.25679985, 9951.72092088, 9955.10893021,
+                       9958.40355487, 9961.58969431, 9964.65446216, 9967.58718801,
+                       9970.37938236, 9973.02466824, 9975.51868378, 9977.85895997,
+                       9980.04477839, 9982.07701351, 9983.95796409, 9985.69117819,
+                       9987.28127577, 9988.73377265, 9990.05490914, 9991.25148615,
+                       9992.33071112, 9993.30005567, 9994.16712626, 9994.9395488,
+                       9995.62486769, 9996.2304594, 9996.76346026, 9997.23070803,
+                       9997.63869638, 9997.9935414, 9998.300959, 9998.5662520])
+
+    if factor == 1:
+        yexp *= 0.1
+
+    assert sp.y == pytest.approx(yexp)
+
+
+def check_sourceplot_wavelength(sp, rate=True, factor=0):
+    """Check for test_sourceplot_wavelength.
+
+    See check_sourceplot_energy.
+    """
+
+    assert sp.xlabel == 'Wavelength (Angstrom)'
+
+    if factor == 0:
+        assert sp.ylabel.startswith('f(lambda)  Photons/sec/cm')
+        assert sp.ylabel.endswith('/Angstrom ')
+    elif factor == 1:
+        assert sp.ylabel.startswith('lambda f(lambda)  Photons/sec/cm')
+        assert sp.ylabel.find('/Angstrom ') == -1
+    else:
+        raise RuntimeError("unsupported factor")
+
+    assert sp.title == 'Source Model of '
+
+    # Use the code from DataPHA to convert from keV to Angstroms.
+    #
+    ebins = np.arange(0.1, 10.1, 0.1)
+    lbins = DataPHA._hc / ebins
+    assert sp.xlo == pytest.approx(lbins[:-1])
+    assert sp.xhi == pytest.approx(lbins[1:])
+
+    # Although the same model as check_sourceplot_energy the
+    # interpretation of the model params means that there is no simple
+    # conversion of the values used in that case, so we have a
+    # different set of expected values.
+    #
+    yexp = np.asarray([10000., 10000., 10000., 10000., 10000., 10000.,
+                       9999.99999864, 9999.99949354, 9999.97224156,
+                       9999.55447151, 9996.86451659, 9987.51382359,
+                       9966.695068 , 9933.27750675, 9891.33791156,
+                       9847.93710785, 9809.78226046, 9781.16179805,
+                       9763.58920097, 9756.46908383, 9758.02782873,
+                       9766.08494609, 9778.54263095, 9793.6274431,
+                       9809.96473056, 9826.55998249, 9842.73898966,
+                       9858.07743665, 9872.33534744, 9885.40252063,
+                       9897.25609947, 9907.92910978, 9917.48798344,
+                       9926.01701814, 9933.60797703, 9940.3533812,
+                       9946.34238774, 9951.65843565, 9956.37807112,
+                       9960.57053782, 9964.29784539, 9967.61512156,
+                       9970.57111803, 9973.20878565, 9975.56586528,
+                       9977.67546184, 9979.56658298, 9981.26463295,
+                       9982.79185821, 9984.16774487, 9985.40937017,
+                       9986.5317114, 9987.54791625, 9988.46953851,
+                       9989.30674326, 9990.06848503, 9990.76266241,
+                       9991.39625226, 9991.97542597, 9992.50565038,
+                       9992.99177532, 9993.43810959, 9993.84848703,
+                       9994.22632392, 9994.57466896, 9994.89624683,
+                       9995.19349616, 9995.46860277, 9995.72352864,
+                       9995.96003731, 9996.17971622, 9996.3839962,
+                       9996.57416871, 9996.75140095, 9996.9167492,
+                       9997.07117061, 9997.21553359, 9997.35062702,
+                       9997.47716842, 9997.59581118, 9997.70715101,
+                       9997.81173162, 9997.9100499 , 9998.00256036,
+                       9998.0896793 , 9998.17178835, 9998.24923778,
+                       9998.32234937, 9998.39141906, 9998.45671928,
+                       9998.51850107, 9998.57699596, 9998.63241771,
+                       9998.68496386, 9998.73481709, 9998.78214653,
+                       9998.82710888, 9998.86984944, 9998.91050307])
+
+    if factor == 1:
+        yexp *= (lbins[:-1] - lbins[1:])
+
+    assert sp.y == pytest.approx(yexp)
+
+
+def test_sourceplot(caplog):
 
     bins = np.arange(0.1, 10.1, 0.1)
     data = DataPHA('', np.arange(10), np.ones(10),
                    bin_lo=bins[:-1].copy(),
                    bin_hi=bins[1:].copy())
     data.units = "energy"
+    assert data.rate
+    assert data.plot_fac == 0
 
     # use a model that is "okay" to use with keV bins
     #
@@ -54,43 +190,188 @@ def test_sourceplot():
     m2.ampl = 0.1
 
     sp = SourcePlot()
-    sp.prepare(data, src)
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
 
-    # add in several asserts to check that something has been
-    # added to the object
+    assert len(caplog.records) == 0
+    check_sourceplot_energy(sp)
+
+
+def test_sourceplot_counts(caplog):
+    """test_sourceplot but when rate=False is chosen"""
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    data = DataPHA('', np.arange(10), np.ones(10),
+                   bin_lo=bins[:-1].copy(),
+                   bin_hi=bins[1:].copy())
+    data.units = "energy"
+    data.rate = False
+
+    # Note that the model evaluation in done in Angstroms
     #
-    assert sp.xlabel == 'Energy (keV)'
+    m1 = Const1D('bgnd')
+    m2 = Gauss1D('abs1')
+    src = 100 * m1 * (1 - m2) * 10000
 
-    # the following depends on the backend
-    # assert sp.ylabel == 'f(E)  Photons/sec/cm$^2$/keV'
+    m1.c0 = 0.01
+    m2.pos = 5.0
+    m2.fwhm = 4.0
+    m2.ampl = 0.1
 
-    assert sp.title == 'Source Model of '
+    sp = SourcePlot()
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
 
-    assert sp.xlo == pytest.approx(bins[:-1])
-    assert sp.xhi == pytest.approx(bins[1:])
+    assert len(caplog.records) == 0
+    check_sourceplot_energy(sp, rate=False)
 
-    # The check of the values is just to check that things are going
-    # as expected, so the model values have been adjusted so that
-    # an "integer" check can be used with enough precision to make
-    # sure that the model is being evaluated correctly, but without
-    # a very-high-precision check
+
+def test_sourceplot_fac1(caplog):
+    """Change plot factor to 1 for test_sourceplot"""
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    data = DataPHA('', np.arange(10), np.ones(10),
+                   bin_lo=bins[:-1].copy(),
+                   bin_hi=bins[1:].copy())
+    data.units = "energy"
+    data.plot_fac = 1
+    assert data.rate
+
+    # use a model that is "okay" to use with keV bins
     #
-    yexp = np.asarray([9998, 9997, 9997, 9997, 9996, 9996, 9995, 9994,
-                       9994, 9993, 9992, 9991, 9990, 9988, 9987, 9985,
-                       9983, 9982, 9980, 9977, 9975, 9973, 9970, 9967,
-                       9964, 9961, 9958, 9955, 9951, 9948, 9944, 9941,
-                       9937, 9934, 9930, 9927, 9923, 9920, 9917, 9914,
-                       9911, 9909, 9907, 9905, 9903, 9902, 9901, 9900,
-                       9900, 9900, 9900, 9901, 9902, 9903, 9905, 9907,
-                       9909, 9911, 9914, 9917, 9920, 9923, 9927, 9930,
-                       9934, 9937, 9941, 9944, 9948, 9951, 9955, 9958,
-                       9961, 9964, 9967, 9970, 9973, 9975, 9977, 9980,
-                       9982, 9983, 9985, 9987, 9988, 9990, 9991, 9992,
-                       9993, 9994, 9994, 9995, 9996, 9996, 9997, 9997,
-                       9997, 9998, 9998])
+    m1 = Const1D('bgnd')
+    m2 = Gauss1D('abs1')
+    src = 100 * m1 * (1 - m2) * 10000
 
-    assert (sp.y.astype(int) == yexp).all()
-    # sp.plot()
+    m1.c0 = 0.01
+    m2.pos = 5.0
+    m2.fwhm = 4.0
+    m2.ampl = 0.1
+
+    sp = SourcePlot()
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
+
+    assert len(caplog.records) == 0
+    check_sourceplot_energy(sp, factor=1)
+
+
+def test_sourceplot_channels(caplog):
+    """Although we ask for channels we get energy units"""
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    data = DataPHA('', np.arange(10), np.ones(10),
+                   bin_lo=bins[:-1].copy(),
+                   bin_hi=bins[1:].copy())
+    data.units = "channel"
+
+    # use a model that is "okay" to use with keV bins
+    #
+    m1 = Const1D('bgnd')
+    m2 = Gauss1D('abs1')
+    src = 100 * m1 * (1 - m2) * 10000
+
+    m1.c0 = 0.01
+    m2.pos = 5.0
+    m2.fwhm = 4.0
+    m2.ampl = 0.1
+
+    sp = SourcePlot()
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
+
+    assert len(caplog.records) == 1
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == 'sherpa.astro.plot'
+    assert lvl == logging.WARN
+    assert msg == 'Channel space is unappropriate for the PHA unfolded source model,\nusing energy.'
+
+    check_sourceplot_energy(sp)
+
+
+def test_sourceplot_wavelength(caplog):
+    """Check we get wavelength units"""
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    data = DataPHA('', np.arange(10), np.ones(10),
+                   bin_lo=bins[:-1].copy(),
+                   bin_hi=bins[1:].copy())
+    data.units = "wave"
+
+    # Note that the model evaluation in done in Angstroms
+    #
+    m1 = Const1D('bgnd')
+    m2 = Gauss1D('abs1')
+    src = 100 * m1 * (1 - m2) * 10000
+
+    m1.c0 = 0.01
+    m2.pos = 5.0
+    m2.fwhm = 4.0
+    m2.ampl = 0.1
+
+    sp = SourcePlot()
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
+
+    assert len(caplog.records) == 0
+    check_sourceplot_wavelength(sp)
+
+
+def test_sourceplot_wavelength_fac1(caplog):
+    """Change plot factor to 1 for test_sourceplot_wavelength"""
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    data = DataPHA('', np.arange(10), np.ones(10),
+                   bin_lo=bins[:-1].copy(),
+                   bin_hi=bins[1:].copy())
+    data.units = "wavelength"
+    data.plot_fac = 1
+    assert data.rate
+
+    m1 = Const1D('bgnd')
+    m2 = Gauss1D('abs1')
+    src = 100 * m1 * (1 - m2) * 10000
+
+    m1.c0 = 0.01
+    m2.pos = 5.0
+    m2.fwhm = 4.0
+    m2.ampl = 0.1
+
+    sp = SourcePlot()
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
+
+    assert len(caplog.records) == 0
+    check_sourceplot_wavelength(sp, factor=1)
+
+
+def test_sourceplot_wavelength_counts(caplog):
+    """test_sourceplot_wavelength but when rate=False is chosen"""
+
+    bins = np.arange(0.1, 10.1, 0.1)
+    data = DataPHA('', np.arange(10), np.ones(10),
+                   bin_lo=bins[:-1].copy(),
+                   bin_hi=bins[1:].copy())
+    data.units = "wave"
+    data.rate = False
+
+    # use a model that is "okay" to use with keV bins
+    #
+    m1 = Const1D('bgnd')
+    m2 = Gauss1D('abs1')
+    src = 100 * m1 * (1 - m2) * 10000
+
+    m1.c0 = 0.01
+    m2.pos = 5.0
+    m2.fwhm = 4.0
+    m2.ampl = 0.1
+
+    sp = SourcePlot()
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        sp.prepare(data, src)
+
+    assert len(caplog.records) == 0
+    check_sourceplot_wavelength(sp, rate=False)
 
 
 # Low-level test of the DataPlot prepare method for PHA style analysis

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -54,6 +54,13 @@ def check_sourceplot_energy(sp, rate=True, factor=0):
     elif factor == 1:
         assert sp.ylabel.startswith('E f(E)  Photons/sec/cm')
         assert sp.ylabel.find('/keV ') == -1
+    elif factor == 2:
+        # This says E^2 f(E) ... but the exact format depends on
+        # the back end
+        assert sp.ylabel.startswith('E')
+        assert sp.ylabel.find('^2') != -1
+        assert sp.ylabel.find(' f(E)  Photons/sec/cm') != -1
+        assert sp.ylabel.find('/keV ') == -1
     else:
         raise RuntimeError("unsupported factor")
 
@@ -94,6 +101,8 @@ def check_sourceplot_energy(sp, rate=True, factor=0):
 
     if factor == 1:
         yexp *= 0.1
+    elif factor == 2:
+        yexp *= 0.01
 
     assert sp.y == pytest.approx(yexp)
 
@@ -111,6 +120,13 @@ def check_sourceplot_wavelength(sp, rate=True, factor=0):
         assert sp.ylabel.endswith('/Angstrom ')
     elif factor == 1:
         assert sp.ylabel.startswith('lambda f(lambda)  Photons/sec/cm')
+        assert sp.ylabel.find('/Angstrom ') == -1
+    elif factor == 2:
+        # This says lmabda^2 f(lambda) ... but the exact format depends on
+        # the back end
+        assert sp.ylabel.startswith('lambda')
+        assert sp.ylabel.find('^2') != -1
+        assert sp.ylabel.find(' f(lambda)  Photons/sec/cm') != -1
         assert sp.ylabel.find('/Angstrom ') == -1
     else:
         raise RuntimeError("unsupported factor")
@@ -164,6 +180,8 @@ def check_sourceplot_wavelength(sp, rate=True, factor=0):
 
     if factor == 1:
         yexp *= (lbins[:-1] - lbins[1:])
+    elif factor == 2:
+        yexp *= (lbins[:-1] - lbins[1:])**2
 
     assert sp.y == pytest.approx(yexp)
 
@@ -226,15 +244,16 @@ def test_sourceplot_counts(caplog):
     check_sourceplot_energy(sp, rate=False)
 
 
-def test_sourceplot_fac1(caplog):
-    """Change plot factor to 1 for test_sourceplot"""
+@pytest.mark.parametrize("factor", [1, 2])
+def test_sourceplot_facn(factor, caplog):
+    """Change plot factor for test_sourceplot"""
 
     bins = np.arange(0.1, 10.1, 0.1)
     data = DataPHA('', np.arange(10), np.ones(10),
                    bin_lo=bins[:-1].copy(),
                    bin_hi=bins[1:].copy())
     data.units = "energy"
-    data.plot_fac = 1
+    data.plot_fac = factor
     assert data.rate
 
     # use a model that is "okay" to use with keV bins
@@ -253,7 +272,7 @@ def test_sourceplot_fac1(caplog):
         sp.prepare(data, src)
 
     assert len(caplog.records) == 0
-    check_sourceplot_energy(sp, factor=1)
+    check_sourceplot_energy(sp, factor=factor)
 
 
 def test_sourceplot_channels(caplog):
@@ -317,15 +336,16 @@ def test_sourceplot_wavelength(caplog):
     check_sourceplot_wavelength(sp)
 
 
-def test_sourceplot_wavelength_fac1(caplog):
-    """Change plot factor to 1 for test_sourceplot_wavelength"""
+@pytest.mark.parametrize("factor", [1, 2])
+def test_sourceplot_wavelength_facn(factor, caplog):
+    """Change plot factor for test_sourceplot_wavelength"""
 
     bins = np.arange(0.1, 10.1, 0.1)
     data = DataPHA('', np.arange(10), np.ones(10),
                    bin_lo=bins[:-1].copy(),
                    bin_hi=bins[1:].copy())
     data.units = "wavelength"
-    data.plot_fac = 1
+    data.plot_fac = factor
     assert data.rate
 
     m1 = Const1D('bgnd')
@@ -342,7 +362,7 @@ def test_sourceplot_wavelength_fac1(caplog):
         sp.prepare(data, src)
 
     assert len(caplog.records) == 0
-    check_sourceplot_wavelength(sp, factor=1)
+    check_sourceplot_wavelength(sp, factor=factor)
 
 
 def test_sourceplot_wavelength_counts(caplog):

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1786,8 +1786,11 @@ def test_bug920(units, xlabel, ylabel, xlo, xhi, clean_astro_ui, basic_pha1):
     assert mplot3.y == pytest.approx(mplot1.y)
 
 
-def validate_flux_histogram(fhist):
-    """Limited checks for test_pha1_plot_foo_flux/test_pha1_get_foo_flux_hist"""
+def validate_flux_histogram(fhist, energy):
+    """Limited checks for test_pha1_plot_foo_flux/test_pha1_get_foo_flux_hist
+
+    histtype is 'Photon' or 'Energy'
+    """
 
     assert fhist is not None
     assert isinstance(fhist, FluxHistogram)
@@ -1807,16 +1810,33 @@ def validate_flux_histogram(fhist):
     assert fmin == pytest.approx(fhist.xlo[0])
     assert fmax == pytest.approx(fhist.xhi[-1])
 
+    # Check labels. The label depends on the plot backend through the
+    # use of LaTeX.
+    #
+    if energy:
+        assert fhist.xlabel.startswith('Energy flux (ergs cm')
+    else:
+        assert fhist.xlabel.startswith('Photon flux (Photons cm')
+
+    assert fhist.xlabel.find(' sec') > 20
+    assert fhist.xlabel.endswith(')')
+
+    assert fhist.ylabel == 'Frequency'
+    if energy:
+        assert fhist.title == 'Energy flux distribution'
+    else:
+        assert fhist.title == 'Photon flux distribution'
+
 
 @requires_plotting
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("plotfunc,getfunc",
-                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
-                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
+@pytest.mark.parametrize("energy,plotfunc,getfunc",
+                         [(True, ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (False, ui.plot_photon_flux, ui.get_photon_flux_hist)])
 @pytest.mark.parametrize("correlated", [False, True])
-def test_pha1_plot_foo_flux(plotfunc, getfunc, correlated, clean_astro_ui, basic_pha1):
+def test_pha1_plot_foo_flux(energy, plotfunc, getfunc, correlated, clean_astro_ui, basic_pha1):
     """Can we call plot_energy/photon_flux and then the get_ func (recalc=False)
 
     We extend the basic_pha1 test by including an XSPEC
@@ -1848,17 +1868,17 @@ def test_pha1_plot_foo_flux(plotfunc, getfunc, correlated, clean_astro_ui, basic
     # and bins arguments have been changed from their default values).
     #
     res = getfunc(recalc=False)
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
 
 @requires_plotting
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("plotfunc,getfunc",
-                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
-                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
-def test_pha1_plot_foo_flux_recalc(plotfunc, getfunc, clean_astro_ui, basic_pha1):
+@pytest.mark.parametrize("energy,plotfunc,getfunc",
+                         [(True, ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (False, ui.plot_photon_flux, ui.get_photon_flux_hist)])
+def test_pha1_plot_foo_flux_recalc(energy, plotfunc, getfunc, clean_astro_ui, basic_pha1):
     """Just check we can call recalc on the routine
 
     """
@@ -1882,17 +1902,17 @@ def test_pha1_plot_foo_flux_recalc(plotfunc, getfunc, clean_astro_ui, basic_pha1
     # and bins arguments have been changed from their default values).
     #
     res = getfunc(recalc=False)
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
 
 @requires_plotting
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("getfunc", [ui.get_energy_flux_hist,
-                                     ui.get_photon_flux_hist])
+@pytest.mark.parametrize("energy,getfunc", [(True, ui.get_energy_flux_hist),
+                                            (False, ui.get_photon_flux_hist)])
 @pytest.mark.parametrize("correlated", [False, True])
-def test_pha1_get_foo_flux_hist(getfunc, correlated, clean_astro_ui, basic_pha1):
+def test_pha1_get_foo_flux_hist(energy, getfunc, correlated, clean_astro_ui, basic_pha1):
     """Can we call get_energy/photon_flux_hist?
 
     See test_pha1_plot_foo_flux.
@@ -1911,7 +1931,7 @@ def test_pha1_get_foo_flux_hist(getfunc, correlated, clean_astro_ui, basic_pha1)
     # number of iterations.
     #
     res = getfunc(lo=0.5, hi=2, num=200, bins=20, correlated=correlated)
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
 
 @requires_plotting
@@ -2144,10 +2164,10 @@ def test_pha1_plot_foo_flux_model(plotfunc, getfunc, ratio,
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("plotfunc,getfunc",
-                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
-                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
-def test_pha1_plot_foo_flux_soft(plotfunc, getfunc, clean_astro_ui, basic_pha1):
+@pytest.mark.parametrize("energy,plotfunc,getfunc",
+                         [(True, ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (False, ui.plot_photon_flux, ui.get_photon_flux_hist)])
+def test_pha1_plot_foo_flux_soft(energy, plotfunc, getfunc, clean_astro_ui, basic_pha1):
     """Check we can send clip=soft
     """
 
@@ -2169,7 +2189,7 @@ def test_pha1_plot_foo_flux_soft(plotfunc, getfunc, clean_astro_ui, basic_pha1):
     # and bins arguments have been changed from their default values).
     #
     res = getfunc(recalc=False)
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
     # check we have clip information and assume at least one bin is
     # clipped (expect ~ 40 of 200 from testing this)
@@ -2185,10 +2205,10 @@ def test_pha1_plot_foo_flux_soft(plotfunc, getfunc, clean_astro_ui, basic_pha1):
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("plotfunc,getfunc",
-                         [(ui.plot_energy_flux, ui.get_energy_flux_hist),
-                          (ui.plot_photon_flux, ui.get_photon_flux_hist)])
-def test_pha1_plot_foo_flux_none(plotfunc, getfunc, clean_astro_ui, basic_pha1):
+@pytest.mark.parametrize("energy, plotfunc,getfunc",
+                         [(True, ui.plot_energy_flux, ui.get_energy_flux_hist),
+                          (False, ui.plot_photon_flux, ui.get_photon_flux_hist)])
+def test_pha1_plot_foo_flux_none(energy, plotfunc, getfunc, clean_astro_ui, basic_pha1):
     """Check we can send clip=none
 
     Copy of test_pha1_plot_foo_flux_none
@@ -2212,7 +2232,7 @@ def test_pha1_plot_foo_flux_none(plotfunc, getfunc, clean_astro_ui, basic_pha1):
     # and bins arguments have been changed from their default values).
     #
     res = getfunc(recalc=False)
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
     # check we have clip information but that it's all zeros
     clip = res.clipped
@@ -2227,9 +2247,9 @@ def test_pha1_plot_foo_flux_none(plotfunc, getfunc, clean_astro_ui, basic_pha1):
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("getfunc", [ui.get_energy_flux_hist,
-                                     ui.get_photon_flux_hist])
-def test_pha1_get_foo_flux_soft(getfunc, clean_astro_ui, basic_pha1):
+@pytest.mark.parametrize("energy,getfunc", [(True, ui.get_energy_flux_hist),
+                                            (False, ui.get_photon_flux_hist)])
+def test_pha1_get_foo_flux_soft(energy, getfunc, clean_astro_ui, basic_pha1):
     """Can we send clip=soft?
     """
 
@@ -2243,7 +2263,7 @@ def test_pha1_get_foo_flux_soft(getfunc, clean_astro_ui, basic_pha1):
 
     res = getfunc(lo=0.5, hi=2, num=200, bins=20, correlated=False,
                   clip='soft')
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
     # check we have clip information and assume at least one bin is
     # clipped (expect ~ 40 of 200 from testing this)
@@ -2259,9 +2279,9 @@ def test_pha1_get_foo_flux_soft(getfunc, clean_astro_ui, basic_pha1):
 @requires_fits
 @requires_data
 @requires_xspec
-@pytest.mark.parametrize("getfunc", [ui.get_energy_flux_hist,
-                                     ui.get_photon_flux_hist])
-def test_pha1_get_foo_flux_none(getfunc, clean_astro_ui, basic_pha1):
+@pytest.mark.parametrize("energy, getfunc", [(True, ui.get_energy_flux_hist),
+                                             (False, ui.get_photon_flux_hist)])
+def test_pha1_get_foo_flux_none(energy, getfunc, clean_astro_ui, basic_pha1):
     """Can we send clip=none?
 
     Copy of test_pha1_get_foo_flux_soft
@@ -2277,7 +2297,7 @@ def test_pha1_get_foo_flux_none(getfunc, clean_astro_ui, basic_pha1):
 
     res = getfunc(lo=0.5, hi=2, num=200, bins=20, correlated=False,
                   clip='none')
-    validate_flux_histogram(res)
+    validate_flux_histogram(res, energy)
 
     # check we have clip information and all are 0
     clip = res.clipped

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -105,9 +105,8 @@ def calc_errors(ys):
     return Chi2Gehrels.calc_staterror(ys)
 
 
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
-def test_get_fit_plot(idval):
+def test_get_fit_plot(idval, clean_ui):
     """Basic testing of get_fit_plot
     """
 
@@ -603,10 +602,9 @@ _plot_change_opts = [(p['plot'], p['change'], p['check_changed'])
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("pfunc, checkfunc", _plot_opts)
-def test_plot_xxx(idval, pfunc, checkfunc):
+def test_plot_xxx(idval, pfunc, checkfunc, clean_ui):
     """Can we call a plot_xxx routine?
 
     There is limited testing that the plot call worked (this
@@ -640,10 +638,9 @@ def test_plot_xxx(idval, pfunc, checkfunc):
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("plotfunc,changefunc,checkfunc", _plot_replot_opts)
-def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc):
+def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc, clean_ui):
     """Can we plot, change data, plot with replot and see no difference?
 
     Parameters
@@ -685,10 +682,9 @@ def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc):
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("plotfunc,changefunc,checkfunc", _plot_change_opts)
-def test_plot_xxx_change(idval, plotfunc, changefunc, checkfunc):
+def test_plot_xxx_change(idval, plotfunc, changefunc, checkfunc, clean_ui):
     """Can we plot, change data, plot and see a difference?
 
     Unlike test_plot_xxx_replot, this does not set replot to True,
@@ -737,10 +733,9 @@ _mplot = (ui.get_model_plot_prefs, "_modelplot", ui.plot_model)
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("getprefs,attr,plotfunc",
                          [_dplot, _mplot])
-def test_prefs_change_session_objects(getprefs, attr, plotfunc):
+def test_prefs_change_session_objects(getprefs, attr, plotfunc, clean_ui):
     """Is a plot-preference change also reflected in the session object?
 
     This is intended to test an assumption that will be used in the
@@ -783,8 +778,7 @@ def test_prefs_change_session_objects(getprefs, attr, plotfunc):
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
-def test_prefs_change_session_objects_fit():
+def test_prefs_change_session_objects_fit(clean_ui):
     """Is plot-preference change reflected in the fitplot session object?
 
     This is test_prefs_change_session_objects but for the _fitplot
@@ -1004,12 +998,11 @@ def test_get_kernel_plot_recalc(session):
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("plotobj,plotfunc",
                          [("_residplot", ui.plot_resid),
                           ("_delchiplot", ui.plot_delchi)
                           ])
-def test_plot_resid_ignores_ylog(plotobj, plotfunc):
+def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?
 
     Note that plot_chisqr is not included in support for ignoring
@@ -1037,12 +1030,11 @@ def test_plot_resid_ignores_ylog(plotobj, plotfunc):
 
 
 @requires_plotting
-@pytest.mark.usefixtures("clean_ui")
 @pytest.mark.parametrize("plotobj,plotfunc",
                          [("_residplot", ui.plot_fit_resid),
                           ("_delchiplot", ui.plot_fit_delchi)
                           ])
-def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc):
+def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?"""
 
     # access it this way to ensure have access to the actual
@@ -2703,6 +2695,7 @@ def test_plot_fit_xxx_pylab(ptype, clean_ui):
 
     fig = plt.gcf()
     axes = fig.axes
+
     assert len(axes) == 2
     assert axes[0].xaxis.get_label().get_text() == ''
 
@@ -2723,7 +2716,7 @@ def test_plot_fit_xxx_pylab(ptype, clean_ui):
 @requires_pylab
 @pytest.mark.parametrize("ptype",
                          ["resid", "ratio", "delchi"])
-def test_plot_fit_xxx_overplot_pylab(ptype, caplog):
+def test_plot_fit_xxx_overplot_pylab(ptype, caplog, clean_ui):
     """Just ensure we can create a plot_fit_xxx(overplot=True) call."""
 
     from matplotlib import pyplot as plt


### PR DESCRIPTION
# Summary

Add additional test cases for source plots with PHA data to check out rarely-used combinations.

# Notes

This was originally intended to address #1087 - hence the addition of tests - but I'm now not sure what to do with that issue, so (unless we get some communal insight soon) it makes sense to at least add the tests.

As sherpa.astro.plot.SourcePlot does not use the "normal" routines for evaluating the data to plot (that is, using the to_plot method of the data object) we need to check the behavior for a number of cases like

  - changing units
  - changing rate
  - changing the factor setting

The test has also changed from using integer values for comparison back to an approximate equality test due to changes in how the data is compared (e.g. multiplying by the bin width, particularly for the wavelength check).