### PR TITLE
Switch default branch to main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 
 .template-linux-conda-build: &template_linux_conda_build
   <<: *template_conda_build
-  image: registry.gitlab.com/olaurino/sherpa-docker-build:master
+  image: registry.gitlab.com/olaurino/sherpa-docker-build:main
   tags:
     - sherpa
 
@@ -62,7 +62,7 @@ conda:
   stage: deploy
   tags:
       - sherpa
-  image: registry.gitlab.com/olaurino/sherpa-docker-build:master
+  image: registry.gitlab.com/olaurino/sherpa-docker-build:main
   dependencies:
       - linux-python3.6-conda-build
       - linux-python3.7-conda-build
@@ -85,23 +85,23 @@ conda:
   script:
       - cd /
       - curl -LO -k http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-      - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip # Hack, gitlab can't checkout the submodule from github
+      - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip # Hack, gitlab can't checkout the submodule from github
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
       - export PATH=~/miniconda/bin:$PATH
       - conda update -qq -y --all
       - conda create -n test36 --yes -q -c sherpa/label/dev python=3.6 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test36
-      - pip install /master.zip
+      - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
       - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test37
-      - pip install /master.zip
+      - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
       - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test38
-      - pip install /master.zip
+      - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
 
@@ -111,21 +111,21 @@ conda:
   stage: test deploy
   script:
     - cd /tmp
-    - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/master.zip
+    - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip
     - conda update -qq -y --all
     - conda create -n test36 --yes -q -c sherpa/label/dev python=3.6 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test36
-    - pip install master.zip
+    - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test
     - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test37
-    - pip install master.zip
+    - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test
     - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test38
-    - pip install master.zip
+    - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 
 .template-linux-conda-build: &template_linux_conda_build
   <<: *template_conda_build
-  image: registry.gitlab.com/olaurino/sherpa-docker-build:main
+  image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
   tags:
     - sherpa
 
@@ -62,7 +62,7 @@ conda:
   stage: deploy
   tags:
       - sherpa
-  image: registry.gitlab.com/olaurino/sherpa-docker-build:main
+  image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
   dependencies:
       - linux-python3.6-conda-build
       - linux-python3.7-conda-build
@@ -77,7 +77,7 @@ conda:
 
 .template-linux-test: &template-linux-test
   stage: test deploy
-  image: centos:6
+  image: centos:7
   variables:
       PAGER: 'less'
   before_script:
@@ -128,9 +128,6 @@ conda:
     - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test
-
-centos6-test:
-  <<: *template-linux-test
 
 centos7-test:
   <<: *template-linux-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ suggest using the [AstroPy
 guidelines](http://docs.astropy.org/en/latest/development/codeguide.html); the
 current Sherpa code base is slowly being converted to a single style.
 
-Once you open a pull request (which should be opened against the ``master``
+Once you open a pull request (which should be opened against the ``main``
 branch, not against any of the other branches), please make sure that you
 include the following:
 
@@ -75,7 +75,7 @@ without a failure.
 
 **Git branch**
 
-The changes should be made in a branch which is based off of the ``master``
+The changes should be made in a branch which is based off of the ``main``
 branch of the [Sherpa repository](https://github.com/sherpa/sherpa), and
 should have a descriptive name. For bug fixes, the name should include the
 bug ID and a short description of the bug fix. For new - or updated - 
@@ -85,19 +85,18 @@ Example: fix for [bug #64](https://github.com/sherpa/sherpa/issues/64)
 
     % git remote add upstream https://github.com/sherpa/sherpa
     % git fetch upstream
-    % git checkout -b bug-#64-comparison-to-None upstream/master
+    % git checkout -b bug-#64-comparison-to-None upstream/main
 
 Example: new functionality, such as
 [Setuptools not required](https://github.com/sherpa/sherpa/pull/65)
 
     % git remote add upstream https://github.com/sherpa/sherpa
     % git fetch upstream
-    % git checkout -b setuptools-not-required upstream/master
+    % git checkout -b setuptools-not-required upstream/main
 
 **Software versions**
 
-Development should use Python 3.6 or later (Sherpa does support Python 3.5,
-but this will be dropped soon).
+Development should use Python 3.6 or later.
 
 Ideally, NumPy support should be 1.6 or greater, but please include a comment
 if you need to restrict (or relax) this further.
@@ -107,9 +106,9 @@ dependencies must be highlighted, and should be made optional if at all possible
 
 **Testing**
 
-The Travis Continuous Integration service is used to test all pull requests
+GitHub Actions is used to test all pull requests
 (examples can be found at the [Sherpa
-page](https://travis-ci.org/sherpa/sherpa/)), and these tests must pass
+page](https://github.com/sherpa/sherpa/actions)), and these tests must pass
 before a pull request can be considered for inclusion in Sherpa.
 
 Ideally each pull request will come with new, or updated, tests to check

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Documentation for Sherpa is available at
 [Read The Docs](https://sherpa.readthedocs.io/)
 and also for [Sherpa in CIAO](http://cxc.harvard.edu/sherpa/).
 
-A [Quick Start Tutorial](http://nbviewer.ipython.org/github/sherpa/sherpa/tree/master/notebooks/SherpaQuickStart.ipynb)
+A [Quick Start Tutorial](http://nbviewer.ipython.org/github/sherpa/sherpa/tree/main/notebooks/SherpaQuickStart.ipynb)
 is included in the `notebooks` folder and can be opened with an `ipython notebook`.
 
 License


### PR DESCRIPTION
These updates will go along with out default branch update to "main".

This will need to happen just AFTER this repo and the "sherpa-test-data" repo have made the switch.

As with this process we will need to rebuild our docker container for building, we are also coupling a migration of our Conda build from CentOS 6 (which is EOL) to CentOS 7 and dropping our CentOS 6 test (which has been failing for GitLab).

Finally, this also includes minor documentation updates (CONTRIBUTING.md updates to switch to main, to reference GitHub Actions instead of Travis, and to remove a note about Python 3.5 support).