### PR TITLE
Hide AstroPy 4.2.1 FITS-related warnings

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021
-#    Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -39,6 +39,7 @@ References
 
 import logging
 import os
+import warnings
 
 import numpy
 from numpy.compat import basestring
@@ -285,7 +286,20 @@ def open_fits(filename):
        function.
     """
     fname = _infer_and_check_filename(filename)
-    return fits.open(fname)
+
+    # With AstroPy v4.2.1 we start to see warnings when this call
+    # fails (i.e. when the argument is not a FITS file).  This leads
+    # to spurious messages to the user, so we just remove all
+    # warnings. This may need tweaking at some point: ideally we would
+    # only want to hide the warnings when it is not a FITS file but
+    # show them when it is a FITS file.
+    #
+    # Note that this is not thread safe.
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', module='astropy.io.fits')
+        out = fits.open(fname)
+
+    return out
 
 
 def read_table_blocks(arg, make_copy=False):


### PR DESCRIPTION
# Summary

Hides warning messages created by AstroPy 4.2.1 when trying to read in FITS files.

# Details

astropy.io.fits.open now creates warning messages about invalid FITS
structures when given a non-FITS file. Unfortunately this leads to
a lot of confusing messages for the user of some of the top-level
routines - like sherpa.astro.io.load_data - when given an ASCII
file, since the code will try to load a FITS file multiple times
before trying as an ASCII file.

We avoid this by hiding all warnings from astropy.io.fits when
we try to open a FITS file. This means that we will not see useful
warnings that are generated when the input is a FITS file, but I
think that is a valid compromise. We could re-create the warnings,
as we can change to something like

    with warning.catch_warnings() as ws:
        out = fits.open(fname)
        for w in ws:
            <somehow recreate the w>

but it's not completely obvious how to recreate the warnings (as
AstroPy has over-ridden the warnings module and I did not feel
it's worth the effort to understand what's going on here).