### PR TITLE
Support Matplotlib 3.4

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1232,7 +1233,8 @@ def test_img_contour_function_kwarg(clean_astro_ui, basic_img):
 
     for i, ax in enumerate(axes, 1):
 
-        assert ax.get_geometry() == (2, 2, i)
+        w = i - 1
+        assert ax.get_subplotspec().get_geometry() == (2, 2, w, w)
 
         assert ax.get_xscale() == 'linear'
         assert ax.get_yscale() == 'linear'

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2015, 2017, 2019, 2020, 2021
-#                Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -316,7 +316,6 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
                   color=color,
                   alpha=alpha,
                   linestyle='',
-                  drawstyle=drawstyle,
                   marker=marker,
                   markersize=markersize,
                   markerfacecolor=markerfacecolor,
@@ -446,7 +445,6 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
         objs = axes.errorbar(x, y, yerr, xerr,
                              color=color,
                              linestyle=linestyle,
-                             drawstyle=drawstyle,
                              marker=marker,
                              markersize=markersize,
                              markerfacecolor=markerfacecolor,

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1110,7 +1111,7 @@ def test_plot_single(session):
 
     ax = fig.axes[0]
 
-    assert ax.get_geometry() == (1, 1, 1)
+    assert ax.get_subplotspec().get_geometry() == (1, 1, 0, 0)
     assert ax.get_title() == ''
     assert ax.xaxis.get_label().get_text() == 'x'
     assert ax.yaxis.get_label().get_text() == 'y'
@@ -1124,7 +1125,7 @@ def test_plot_single(session):
 
     ax = fig.axes[0]
 
-    assert ax.get_geometry() == (1, 1, 1)
+    assert ax.get_subplotspec().get_geometry() == (1, 1, 0, 0)
     assert ax.get_title() == 'Model'
     assert ax.xaxis.get_label().get_text() == 'x'
     assert ax.yaxis.get_label().get_text() == 'y'
@@ -1176,7 +1177,8 @@ def test_plot_multiple(session):
                                                  'Data / Model']),
                                             1):
 
-        assert ax.get_geometry() == (2, 3, i)
+        w = i - 1
+        assert ax.get_subplotspec().get_geometry() == (2, 3, w, w)
         assert ax.get_title() == title
         assert ax.xaxis.get_label().get_text() == 'x'
         assert ax.yaxis.get_label().get_text() == ylabel
@@ -1223,7 +1225,7 @@ def test_contour_single(session):
 
     ax = fig.axes[0]
 
-    assert ax.get_geometry() == (1, 1, 1)
+    assert ax.get_subplotspec().get_geometry() == (1, 1, 0, 0)
     assert ax.get_title() == ''
     assert ax.xaxis.get_label().get_text() == 'x0'
     assert ax.yaxis.get_label().get_text() == 'x1'
@@ -1237,7 +1239,7 @@ def test_contour_single(session):
 
     ax = fig.axes[0]
 
-    assert ax.get_geometry() == (1, 1, 1)
+    assert ax.get_subplotspec().get_geometry() == (1, 1, 0, 0)
     assert ax.get_title() == 'Model'
     assert ax.xaxis.get_label().get_text() == 'x0'
     assert ax.yaxis.get_label().get_text() == 'x1'
@@ -1284,7 +1286,8 @@ def test_contour_multiple(session):
                                          'Ratio of Data to Model']),
                                     1):
 
-        assert ax.get_geometry() == (2, 3, i)
+        w = i - 1
+        assert ax.get_subplotspec().get_geometry() == (2, 3, w, w)
         assert ax.get_title() == title
         assert ax.xaxis.get_label().get_text() == 'x0'
         assert ax.yaxis.get_label().get_text() == 'x1'
@@ -1340,7 +1343,8 @@ def test_contour_xxx(plotfunc, title, pcls, session):
                                             ['', 'Residuals']),
                                         1):
 
-            assert ax.get_geometry() == (2, 1, i)
+            w = i - 1
+            assert ax.get_subplotspec().get_geometry() == (2, 1, w, w)
             assert ax.get_title() == title
             assert ax.xaxis.get_label().get_text() == 'x0'
             assert ax.yaxis.get_label().get_text() == 'x1'
@@ -1349,7 +1353,7 @@ def test_contour_xxx(plotfunc, title, pcls, session):
         assert len(fig.axes) == 1
 
         ax = fig.axes[0]
-        assert ax.get_geometry() == (1, 1, 1)
+        assert ax.get_subplotspec().get_geometry() == (1, 1, 0, 0)
         assert ax.get_title() == title
         assert ax.xaxis.get_label().get_text() == 'x0'
         assert ax.yaxis.get_label().get_text() == 'x1'


### PR DESCRIPTION
# Summary

Matplotlib 3.4 changes how the drawstyle argument is handled in some functions. This change removes the use of this argument for those functions. Fixes #1124

# Details

The change is easy - remove the `drawstyle` argument to the `axes.errorbar` calls. I haven't checked what happens with older matplotlib versions (e.g. 3.0 or so) for data plots with error bars, but the plots look the same for matplotlib 3.3 and 3.4.

There are also some changes to the tests as a function I had been using has now been marked as deprecated, causing the tests to fail because a deprecation warnnig was generated. I've changed these tests to use the suggested replacement. I would hope this works for old matplotlib versions (and the tests pass, but I haven't checked what matplotlib versions are in use in them).

