### PR TITLE
PHA filtering changes

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3487,6 +3487,11 @@ class DataPHA(Data1D):
 
         ignore = bool_cast(ignore)
 
+        # This condition is checked for in the _data_space.filter call
+        # at the end of the method, but it is easier to enforce it
+        # here so we do not need to worry about possible type errors
+        # when comparing string and number values.
+        #
         for val, label in zip([lo, hi], ['lower', 'upper']):
             if isinstance(val, str):
                 # match the error seen from other data classes here

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1760,8 +1760,8 @@ class DataPHA(Data1D):
         group = bool_cast(group)
 
         if self.units == 'channel':
-            elo = self.channel - 0.5
-            ehi = self.channel + 0.5
+            elo = self.channel
+            ehi = self.channel + 1
         else:
             arf, rmf = self.get_response(response_id)
             if (self.bin_lo is not None) and (self.bin_hi is not None):
@@ -1779,8 +1779,8 @@ class DataPHA(Data1D):
                 elo = arf.energ_lo
                 ehi = arf.energ_hi
             else:
-                elo = self.channel - 0.5
-                ehi = self.channel + 0.5
+                elo = self.channel
+                ehi = self.channel + 1
 
         # If the data are grouped, then we should group up
         # the energy bins as well.  E.g., if group 1 is

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1964,13 +1964,19 @@ class DataPHA(Data1D):
         return vals
 
     def _wavelength_to_channel(self, val):
+        """Convert a wavelength to group or channel number.
+
+        Note that values of 0 or less are replaced by a
+        small value (~1e-38).
+
+        """
         tiny = numpy.finfo(numpy.float32).tiny
         vals = numpy.asarray(val)
         if vals.shape == ():
-            if vals == 0.0:
+            if vals <= 0.0:
                 vals = tiny
         else:
-            vals[vals == 0.0] = tiny
+            vals[vals <= 0.0] = tiny
         vals = self._hc / vals
         return self._energy_to_channel(vals)
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -29,7 +29,7 @@ import warnings
 import numpy
 
 from sherpa.data import Data1DInt, Data2D, Data, Data2DInt, Data1D, \
-    IntegratedDataSpace2D
+    IntegratedDataSpace2D, _check
 from sherpa.models.regrid import EvaluationSpace1D
 from sherpa.utils.err import DataErr, ImportErr
 from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
@@ -1407,6 +1407,10 @@ class DataPHA(Data1D):
     def __init__(self, name, channel, counts, staterror=None, syserror=None,
                  bin_lo=None, bin_hi=None, grouping=None, quality=None,
                  exposure=None, backscal=None, areascal=None, header=None):
+
+        channel = _check(channel)
+        counts = _check(counts)
+
         self.channel = channel
         self.counts = counts
         self.bin_lo = bin_lo

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1341,7 +1341,7 @@ class DataPHA(Data1D):
         self._units = units
 
     units = property(_get_units, _set_units,
-                     doc='Units of the independent axis')
+                     doc="Units of the independent axis: one of 'channel', 'energy', 'wavelength'.")
 
     def _get_rate(self):
         return self._rate
@@ -1466,7 +1466,7 @@ class DataPHA(Data1D):
     """The identifier for the response component when not set."""
 
     def set_analysis(self, quantity, type='rate', factor=0):
-        """Return the units used when fitting spectral data.
+        """Set the units used when fitting and plotting spectral data.
 
         Parameters
         ----------
@@ -1493,7 +1493,9 @@ class DataPHA(Data1D):
 
         >>> pha.set_analysis('energy')
 
-        >>> pha.set_analysis('wave', type='counts' factor=1)
+        >>> pha.set_analysis('wave', type='counts', factor=1)
+        >>> pha.units
+        'wavelength'
 
         """
         self.plot_fac = factor

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1758,28 +1758,29 @@ class DataPHA(Data1D):
     # twice is an error.
     def _get_ebins(self, response_id=None, group=True):
         group = bool_cast(group)
-        arf, rmf = self.get_response(response_id)
-        if (self.bin_lo is not None) and (self.bin_hi is not None):
-            elo = self.bin_lo
-            ehi = self.bin_hi
-            if (elo[0] > elo[-1]) and (ehi[0] > ehi[-1]):
-                elo = self._hc / self.bin_hi
-                ehi = self._hc / self.bin_lo
-        elif rmf is not None:
-            if (rmf.e_min is None) or (rmf.e_max is None):
-                raise DataErr('noenergybins', 'RMF')
-            elo = rmf.e_min
-            ehi = rmf.e_max
-        elif arf is not None:
-            elo = arf.energ_lo
-            ehi = arf.energ_hi
-        else:
-            elo = self.channel - 0.5
-            ehi = self.channel + 0.5
 
         if self.units == 'channel':
             elo = self.channel - 0.5
             ehi = self.channel + 0.5
+        else:
+            arf, rmf = self.get_response(response_id)
+            if (self.bin_lo is not None) and (self.bin_hi is not None):
+                elo = self.bin_lo
+                ehi = self.bin_hi
+                if (elo[0] > elo[-1]) and (ehi[0] > ehi[-1]):
+                    elo = self._hc / self.bin_hi
+                    ehi = self._hc / self.bin_lo
+            elif rmf is not None:
+                if (rmf.e_min is None) or (rmf.e_max is None):
+                    raise DataErr('noenergybins', 'RMF')
+                elo = rmf.e_min
+                ehi = rmf.e_max
+            elif arf is not None:
+                elo = arf.energ_lo
+                ehi = arf.energ_hi
+            else:
+                elo = self.channel - 0.5
+                ehi = self.channel + 0.5
 
         # If the data are grouped, then we should group up
         # the energy bins as well.  E.g., if group 1 is

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1887,3 +1887,35 @@ def test_pha_notice_errors_out_on_string_range(lo, hi, emsg, ignore):
 
     err = f'strings not allowed in {emsg} bound list'
     assert str(de.value) == err
+
+
+def test_pha_creation_warns_about_non_numpy_channel(recwarn):
+    """What happens if the channel array is not a NumPy array?
+
+    At the moment there is no warning for the independent axis.
+    """
+
+    chans = [1, 2, 3]
+    counts = np.ones(3)
+    d = DataPHA('tmp', chans, counts)
+
+    assert len(recwarn) == 0
+
+    assert not isinstance(d.x, np.ndarray)
+    assert not isinstance(d.channel, np.ndarray)
+
+    assert d.channel == pytest.approx(chans)
+
+
+def test_pha_creation_warns_about_non_numpy_counts():
+    """What happens if the counts array is not a NumPy array?"""
+
+    chans = np.asarray([1, 2, 3])
+    counts = [1, 0, 1]
+    with pytest.warns(UserWarning, match=r'Converting array \[1, 0, 1\] to numpy array\.'):
+        d = DataPHA('tmp', chans, counts)
+
+    assert isinstance(d.y, np.ndarray)
+    assert not isinstance(d.counts, np.ndarray)
+
+    assert d.counts == pytest.approx(counts)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1514,10 +1514,10 @@ def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 8000, '99.3224'),
+                         [(-5, 8000, '0.9991:99.3224'),
                           (20, 8000, '20.4628:99.3224'),
-                          (-5, 15, ''),
-                          (-20, -5, '99.3224'),
+                          (-5, 15, '0.9991:14.7688'),
+                          (-20, -5, '0.9991'),
                           (8000, 9000, '99.3224')])
 def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1535,10 +1535,10 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 8000, '1544.0123'),
+                         [(-5, 8000, '0.8297:1544.0123'),
                           (20, 8000, '19.9813:1544.0123'),
-                          (-5, 15, ''),
-                          (-20, -5, '1544.0123'),
+                          (-5, 15, '0.8297:15.0302'),
+                          (-20, -5, '0.8297'),
                           (8000, 9000, '1544.0123')])
 def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1640,10 +1640,10 @@ def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, '0.9991:44.6951'),
+                         [(-5, 2000, ''),
                           (20, 2000, '0.9991:18.4610'),
-                          (-5, 15, '0.9991:99.3224'),
-                          (-20, -5, '0.9991:44.6951'),
+                          (-5, 15, '15.4401:99.3224'),
+                          (-20, -5, '1.5084:99.3224'),
                           (2000, 3000, '0.9991:44.6951')])
 def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1661,10 +1661,10 @@ def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, '0.8297:566.1378'),
+                         [(-5, 2000, ''),
                           (20, 2000, '0.8297:19.5220'),
-                          (-5, 15, '0.8297:1544.0123'),
-                          (-20, -5, '0.8297:566.1378'),
+                          (-5, 15, '15.3010:1544.0123'),
+                          (-20, -5, '0.8305:1544.0123'),
                           (2000, 3000, '0.8297:566.1378')])
 def test_ignore_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1796,7 +1796,7 @@ def test_energy_conversion_ungrouped_invalid(argval, expected, make_data_path):
 
 @requires_data
 @requires_fits
-@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 46), (20000, 1)])
+@pytest.mark.parametrize("argval,expected", [(-1, 46), (0, 46), (20000, 1)])
 def test_wave_conversion_grouped_invalid(argval, expected, make_data_path):
     """See test_channel_conversion_grouped_invalid but for energy units.
 
@@ -1816,7 +1816,7 @@ def test_wave_conversion_grouped_invalid(argval, expected, make_data_path):
 
 @requires_data
 @requires_fits
-@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 1024), (20000, 1)])
+@pytest.mark.parametrize("argval,expected", [(-1, 1024), (0, 1024), (20000, 1)])
 def test_wave_conversion_ungrouped_invalid(argval, expected, make_data_path):
     """See test_wave_conversion_grouped_invalid
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1407,8 +1407,8 @@ def test_notice_channel_grouping(make_data_path):
                          [(-5, 2000, '9:850'),
                           (30, 2000, '27:850'),
                           (-5, 350, '9:356'),
-                          (-20, -5, '9'),
-                          (2000, 3000, '')])
+                          (-20, -5, '9:850'),
+                          (2000, 3000, '9:850')])
 def test_notice_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results
 
@@ -1453,8 +1453,8 @@ def test_notice_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 2000, '1:1024'),
                           (30, 2000, '30:1024'),
                           (-5, 350, '1:350'),
-                          (-20, -5, ''),
-                          (2000, 3000, '')])
+                          (-20, -5, '1:1024'),
+                          (2000, 3000, '1:1024')])
 def test_notice_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results
     """
@@ -1475,8 +1475,8 @@ def test_notice_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_da
                          [(-5, 2000, '0.1248:12.4100'),
                           (0.7, 2000, '0.6716:12.4100'),
                           (-5, 4.2, '0.1248:4.1391'),
-                          (-20, -5, '0.1248'),
-                          (2000, 3000, '12.4100')])
+                          (-20, -5, '0.1248:12.4100'),
+                          (2000, 3000, '0.1248:12.4100')])
 def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1496,8 +1496,8 @@ def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 2000, '0.0080:14.9431'),
                           (0.7, 2000, '0.6935:14.9431'),
                           (-5, 4.2, '0.0080:4.1975'),
-                          (-20, -5, '0.0080'),
-                          (2000, 3000, '14.9431')])
+                          (-20, -5, '0.0080:14.9431'),
+                          (2000, 3000, '0.0080:14.9431')])
 def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1517,7 +1517,7 @@ def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
                          [(-5, 8000, '0.9991:99.3224'),
                           (20, 8000, '20.4628:99.3224'),
                           (-5, 15, '0.9991:14.7688'),
-                          (-20, -5, '0.9991'),
+                          (-20, -5, '0.9991:99.3224'),
                           (8000, 9000, '99.3224')])
 def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1538,7 +1538,7 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 8000, '0.8297:1544.0123'),
                           (20, 8000, '19.9813:1544.0123'),
                           (-5, 15, '0.8297:15.0302'),
-                          (-20, -5, '0.8297'),
+                          (-20, -5, '0.8297:1544.0123'),
                           (8000, 9000, '1544.0123')])
 def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1559,7 +1559,7 @@ def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_
                          [(-5, 2000, ''),
                           (30, 2000, '9:19'),
                           (-5, 350, '386:850'),
-                          (-20, -5, '19:850'),
+                          (-20, -5, '9:850'),
                           (2000, 3000, '9:850')])
 def test_ignore_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1601,8 +1601,8 @@ def test_ignore_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_da
                          [(-5, 2000, ''),
                           (0.8, 2000, '0.1248:0.7665'),
                           (-5, 3.5, '3.6792:12.4100'),
-                          (-20, -5, '0.2774:12.4100'),
-                          (2000, 3000, '0.1248:8.2198')])
+                          (-20, -5, '0.1248:12.4100'),
+                          (2000, 3000, '0.1248:12.4100')])
 def test_ignore_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1622,8 +1622,8 @@ def test_ignore_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 2000, ''),
                           (0.8, 2000, '0.0080:0.7811'),
                           (-5, 3.5, '3.5113:14.9431'),
-                          (-20, -5, '0.0219:14.9431'),
-                          (2000, 3000, '0.0080:14.9285')])
+                          (-20, -5, '0.0080:14.9431'),
+                          (2000, 3000, '0.0080:14.9431')])
 def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1643,7 +1643,7 @@ def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
                          [(-5, 2000, ''),
                           (20, 2000, '0.9991:18.4610'),
                           (-5, 15, '15.4401:99.3224'),
-                          (-20, -5, '1.5084:99.3224'),
+                          (-20, -5, '0.9991:99.3224'),
                           (2000, 3000, '0.9991:44.6951')])
 def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1664,7 +1664,7 @@ def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 2000, ''),
                           (20, 2000, '0.8297:19.5220'),
                           (-5, 15, '15.3010:1544.0123'),
-                          (-20, -5, '0.8305:1544.0123'),
+                          (-20, -5, '0.8297:1544.0123'),
                           (2000, 3000, '0.8297:566.1378')])
 def test_ignore_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1874,3 +1874,16 @@ def test_get_background_scale_missing_option(is_bkg, option, expected):
 
     scale = d.get_background_scale()
     assert scale == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("lo,hi,emsg", [("1:20", None, 'lower'), (None, "2", 'upper'), ("0.5", "7", 'lower')])
+@pytest.mark.parametrize("ignore", [False, True])
+def test_pha_notice_errors_out_on_string_range(lo, hi, emsg, ignore):
+    """Check we get an error if lo or hi are strings."""
+
+    d = DataPHA('tmp', np.arange(3), np.arange(3))
+    with pytest.raises(DataErr) as de:
+        d.notice(lo, hi, ignore=ignore)
+
+    err = f'strings not allowed in {emsg} bound list'
+    assert str(de.value) == err

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1401,17 +1401,13 @@ def test_notice_channel_grouping(make_data_path):
     assert pha.get_filter(format='%.4f', group=False) == '69:404'
 
 
-def xfail(*args):
-    return pytest.param(*args, marks=pytest.mark.xfail)
-
-
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
                          [(-5, 2000, '9:850'),
                           (30, 2000, '27:850'),
                           (-5, 350, '9:356'),
-                          xfail(-20, -5, ''),
+                          (-20, -5, '9'),
                           (2000, 3000, '')])
 def test_notice_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results
@@ -1479,8 +1475,8 @@ def test_notice_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_da
                          [(-5, 2000, '0.1248:12.4100'),
                           (0.7, 2000, '0.6716:12.4100'),
                           (-5, 4.2, '0.1248:4.1391'),
-                          xfail(-20, -5, ''),
-                          xfail(2000, 3000, '')])
+                          (-20, -5, '0.1248'),
+                          (2000, 3000, '12.4100')])
 def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1500,8 +1496,8 @@ def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
                          [(-5, 2000, '0.0080:14.9431'),
                           (0.7, 2000, '0.6935:14.9431'),
                           (-5, 4.2, '0.0080:4.1975'),
-                          xfail(-20, -5, ''),
-                          xfail(2000, 3000, '')])
+                          (-20, -5, '0.0080'),
+                          (2000, 3000, '14.9431')])
 def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1518,11 +1514,11 @@ def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [xfail(-5, 8000, '0.9991:99.3224'),
+                         [(-5, 8000, '99.3224'),
                           (20, 8000, '20.4628:99.3224'),
-                          xfail(-5, 15, '0.9991:14.7688'),
-                          xfail(-20, -5, ''),
-                          xfail(8000, 9000, '')])
+                          (-5, 15, ''),
+                          (-20, -5, '99.3224'),
+                          (8000, 9000, '99.3224')])
 def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1539,11 +1535,11 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [xfail(-5, 8000, '0.8297:1544.0123'),
+                         [(-5, 8000, '1544.0123'),
                           (20, 8000, '19.9813:1544.0123'),
-                          xfail(-5, 15, '0.8297:15.0302'),
-                          xfail(-20, -5, ''),
-                          xfail(8000, 9000, '')])
+                          (-5, 15, ''),
+                          (-20, -5, '1544.0123'),
+                          (8000, 9000, '1544.0123')])
 def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1563,7 +1559,7 @@ def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_
                          [(-5, 2000, ''),
                           (30, 2000, '9:19'),
                           (-5, 350, '386:850'),
-                          xfail(-20, -5, '9:850'),
+                          (-20, -5, '19:850'),
                           (2000, 3000, '9:850')])
 def test_ignore_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1605,8 +1601,8 @@ def test_ignore_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_da
                          [(-5, 2000, ''),
                           (0.8, 2000, '0.1248:0.7665'),
                           (-5, 3.5, '3.6792:12.4100'),
-                          xfail(-20, -5, '0.1248:12.4100'),
-                          xfail(2000, 3000, '0.1248:12.4100')])
+                          (-20, -5, '0.2774:12.4100'),
+                          (2000, 3000, '0.1248:8.2198')])
 def test_ignore_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 
@@ -1644,11 +1640,11 @@ def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [xfail(-5, 2000, ''),
+                         [(-5, 2000, '0.9991:44.6951'),
                           (20, 2000, '0.9991:18.4610'),
-                          xfail(-5, 15, '15.4401:99.3224'),
-                          xfail(-20, -5, '0.9991:99.3224'),
-                          xfail(2000, 3000, '0.9991:99.3224')])
+                          (-5, 15, '0.9991:99.3224'),
+                          (-20, -5, '0.9991:44.6951'),
+                          (2000, 3000, '0.9991:44.6951')])
 def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1582,6 +1582,27 @@ def test_ignore_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
                          [(-5, 2000, ''),
+                          (30, 2000, '1:29'),
+                          (-5, 350, '351:1024'),
+                          (-20, -5, '1:1024'),
+                          (2000, 3000, '1:1024')])
+def test_ignore_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
+    """Check what happens with silly results"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.ungroup()
+    pha.set_analysis('channel')
+
+    pha.ignore(lo, hi)
+    assert pha.get_filter() == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("lo,hi,expected",
+                         [(-5, 2000, ''),
                           (0.8, 2000, '0.1248:0.7665'),
                           (-5, 3.5, '3.6792:12.4100'),
                           xfail(-20, -5, '0.1248:12.4100'),
@@ -1593,6 +1614,27 @@ def test_ignore_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
 
     pha = read_pha(make_data_path('3c273.pi'))
 
+    pha.set_analysis('energy')
+
+    pha.ignore(lo, hi)
+    assert pha.get_filter(format='%.4f') == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("lo,hi,expected",
+                         [(-5, 2000, ''),
+                          (0.8, 2000, '0.0080:0.7811'),
+                          (-5, 3.5, '3.5113:14.9431'),
+                          (-20, -5, '0.0219:14.9431'),
+                          (2000, 3000, '0.0080:14.9285')])
+def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
+    """Check what happens with silly results"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.ungroup()
     pha.set_analysis('energy')
 
     pha.ignore(lo, hi)
@@ -1614,6 +1656,27 @@ def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 
     pha = read_pha(make_data_path('3c273.pi'))
 
+    pha.set_analysis('wave')
+
+    pha.ignore(lo, hi)
+    assert pha.get_filter(format='%.4f') == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("lo,hi,expected",
+                         [(-5, 2000, '0.8297:566.1378'),
+                          (20, 2000, '0.8297:19.5220'),
+                          (-5, 15, '0.8297:1544.0123'),
+                          (-20, -5, '0.8297:566.1378'),
+                          (2000, 3000, '0.8297:566.1378')])
+def test_ignore_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
+    """Check what happens with silly results"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.ungroup()
     pha.set_analysis('wave')
 
     pha.ignore(lo, hi)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021
-#        Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1420,12 +1420,53 @@ def test_notice_channel_grouping_outofbounds(lo, hi, expected, make_data_path):
     last bin (because it gets reset to the limit), which we
     probably do not want (for the low edge, for the upper
     edge we are probably lucky due to < rather than >=).
+
+    The groups are such that the first group has channels
+    1-17 and the last group 677-1024, which have mid-points
+    9 and 850.5, hence the 9:850 as the default filter.
+
+    >>> pha.apply_grouping(pha.channel, pha._min)
+    array([  1.,  18.,  22.,  33.,  40.,  45.,  49.,  52.,  55.,  57.,  60.,
+            62.,  66.,  69.,  72.,  76.,  79.,  83.,  89.,  97., 102., 111.,
+           117., 125., 131., 134., 140., 144., 151., 157., 165., 178., 187.,
+           197., 212., 233., 245., 261., 277., 292., 324., 345., 369., 405.,
+           451., 677.])
+
+    >>> pha.apply_grouping(pha.channel, pha._max)
+    array([  17.,   21.,   32.,   39.,   44.,   48.,   51.,   54.,   56.,
+             59.,   61.,   65.,   68.,   71.,   75.,   78.,   82.,   88.,
+             96.,  101.,  110.,  116.,  124.,  130.,  133.,  139.,  143.,
+            150.,  156.,  164.,  177.,  186.,  196.,  211.,  232.,  244.,
+            260.,  276.,  291.,  323.,  344.,  368.,  404.,  450.,  676.,
+           1024.])
+
     """
 
     from sherpa.astro.io import read_pha
 
     pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('channel')
 
+    pha.notice(lo, hi)
+    assert pha.get_filter() == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("lo,hi,expected",
+                         [(-5, 2000, '1:1024'),
+                          (30, 2000, '30:1024'),
+                          (-5, 350, '1:350'),
+                          (-20, -5, ''),
+                          (2000, 3000, '')])
+def test_notice_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
+    """Check what happens with silly results
+    """
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.ungroup()
     pha.set_analysis('channel')
 
     pha.notice(lo, hi)
@@ -1456,6 +1497,27 @@ def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
+                         [(-5, 2000, '0.0080:14.9431'),
+                          (0.7, 2000, '0.6935:14.9431'),
+                          (-5, 4.2, '0.0080:4.1975'),
+                          xfail(-20, -5, ''),
+                          xfail(2000, 3000, '')])
+def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
+    """Check what happens with silly results"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.ungroup()
+    pha.set_analysis('energy')
+
+    pha.notice(lo, hi)
+    assert pha.get_filter(format='%.4f') == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("lo,hi,expected",
                          [xfail(-5, 8000, '0.9991:99.3224'),
                           (20, 8000, '20.4628:99.3224'),
                           xfail(-5, 15, '0.9991:14.7688'),
@@ -1468,6 +1530,27 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 
     pha = read_pha(make_data_path('3c273.pi'))
 
+    pha.set_analysis('wave')
+
+    pha.notice(lo, hi)
+    assert pha.get_filter(format='%.4f') == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("lo,hi,expected",
+                         [xfail(-5, 8000, '0.8297:1544.0123'),
+                          (20, 8000, '19.9813:1544.0123'),
+                          xfail(-5, 15, '0.8297:15.0302'),
+                          xfail(-20, -5, ''),
+                          xfail(8000, 9000, '')])
+def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
+    """Check what happens with silly results"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.ungroup()
     pha.set_analysis('wave')
 
     pha.notice(lo, hi)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1889,7 +1889,7 @@ def test_pha_notice_errors_out_on_string_range(lo, hi, emsg, ignore):
     assert str(de.value) == err
 
 
-def test_pha_creation_warns_about_non_numpy_channel(recwarn):
+def test_pha_creation_warns_about_non_numpy_channel():
     """What happens if the channel array is not a NumPy array?
 
     At the moment there is no warning for the independent axis.
@@ -1897,12 +1897,11 @@ def test_pha_creation_warns_about_non_numpy_channel(recwarn):
 
     chans = [1, 2, 3]
     counts = np.ones(3)
-    d = DataPHA('tmp', chans, counts)
+    with pytest.warns(UserWarning, match=r'Converting array \[1, 2, 3\] to numpy array\.'):
+        d = DataPHA('tmp', chans, counts)
 
-    assert len(recwarn) == 0
-
-    assert not isinstance(d.x, np.ndarray)
-    assert not isinstance(d.channel, np.ndarray)
+    assert isinstance(d.x, np.ndarray)
+    assert isinstance(d.channel, np.ndarray)
 
     assert d.channel == pytest.approx(chans)
 
@@ -1916,6 +1915,6 @@ def test_pha_creation_warns_about_non_numpy_counts():
         d = DataPHA('tmp', chans, counts)
 
     assert isinstance(d.y, np.ndarray)
-    assert not isinstance(d.counts, np.ndarray)
+    assert isinstance(d.counts, np.ndarray)
 
     assert d.counts == pytest.approx(counts)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1719,6 +1719,121 @@ def test_channel_changing_limits(make_data_path):
     assert pha.get_filter(group=False) == expected2
 
 
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 1), (20000, 1024)])
+def test_channel_conversion_grouped_invalid(argval, expected, make_data_path):
+    """What happens for channel conversion when argument is too small/large?
+
+    The _to_channel routine is changed when the units are changed.
+    Check what happens when a value exceeds the channel range.
+
+    It would be nice to create a PHA dataset but there's too many
+    moving parts so use a file.
+
+    This behavior is implicitly tested in routines like
+    test_ignore_channel_grouping_outofbounds but here we
+    add an explicit test to check what is happening.
+    """
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('channel')
+
+    x = pha._to_channel(argval)
+    assert x == expected
+
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("argval", [-1, 0, 20000])
+def test_channel_conversion_ungrouped_invalid(argval, make_data_path):
+    """See test_channel_conversion_grouped_invalid"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('channel')
+    pha.ungroup()
+
+    x = pha._to_channel(argval)
+    assert x == argval
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 1), (20000, 46)])
+def test_energy_conversion_grouped_invalid(argval, expected, make_data_path):
+    """See test_channel_conversion_grouped_invalid but for energy units."""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('energy')
+
+    x = pha._to_channel(argval)
+    assert x == expected
+
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 1), (20000, 1024)])
+def test_energy_conversion_ungrouped_invalid(argval, expected, make_data_path):
+    """See test_energy_conversion_grouped_invalid"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('energy')
+    pha.ungroup()
+
+    x = pha._to_channel(argval)
+    assert x == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 46), (20000, 1)])
+def test_wave_conversion_grouped_invalid(argval, expected, make_data_path):
+    """See test_channel_conversion_grouped_invalid but for energy units.
+
+    It is not obvious why argval=-1 returns a different value to
+    argval=0.
+    """
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('wavelen')
+
+    x = pha._to_channel(argval)
+    assert x == expected
+
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("argval,expected", [(-1, 1), (0, 1024), (20000, 1)])
+def test_wave_conversion_ungrouped_invalid(argval, expected, make_data_path):
+    """See test_wave_conversion_grouped_invalid
+
+    It is not obvious why argval=-1 returns a different value to
+    argval=0.
+    """
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.set_analysis('wavelen')
+    pha.ungroup()
+
+    x = pha._to_channel(argval)
+    assert x == expected
+
+
 def test_get_background_scale_is_none():
     """We get None when there's no background"""
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -72,17 +72,15 @@ def test_get_filter_is_empty():
     assert pha.get_filter() == 'No noticed bins'
 
 
-@pytest.mark.xfail
 def test_need_numpy_channels():
-    """We need to convert the  input to NumPy arrrays.
-
-    This should be done in the constructor to DataPHA, but
-    for now error out if not set.
+    """We didn't used to convert channels to a NumPy array which broke
+    this logic - the ignore line would error out due to an operation on
+    self.channel
     """
 
     pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
     assert pha.get_filter() == '1:3'
-    # This errors out with a TypeError on 'elo = self.channel - 0.5'
+
     pha.ignore()
     assert pha.get_filter() == 'No noticed bins'
 
@@ -168,11 +166,12 @@ def test_288_b():
     assert pha.mask == pytest.approx([True, False, True])
 
 
-@pytest.mark.xfail
 def test_grouping_non_numpy():
-    """Historically the group* calls will fail oddly if y is not numpy
+    """Historically the group* calls would fail oddly if y is not numpy
 
     TypeError: grpNumCounts() Could not parse input arguments, please check input for correct type(s)
+
+    This has now been addressed but the test has been left in.
     """
 
     x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1533,14 +1533,16 @@ def test_get_axes_datapha_no_response():
 
     I have noted that it's unclear whether the bin edges are
     1-2, 2-3, 3-4 or 0.5-1.5, 1.5-2.5, 2.5-3.5. Let's test
-    the status quo here.
+    the status quo here. It used to return the latter (bin edges
+    at half-integer values) but in the Sherpa 4.13 development
+    it was changed to use integer values (the former case).
     """
 
     ui.load_arrays(1, [1, 2, 3], [1, 2, 3], ui.DataPHA)
     ax = ui.get_axes()
     assert len(ax) == 2
-    assert ax[0] == pytest.approx([0.5, 1.5, 2.5])
-    assert ax[1] == pytest.approx([1.5, 2.5, 3.5])
+    assert ax[0] == pytest.approx([1, 2, 3])
+    assert ax[1] == pytest.approx([2, 3, 4])
 
 
 def test_get_axes_datapha_rmf():

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -961,11 +961,12 @@ def restore():
     try:
         exec(output)
         success = True
-        e = "no exception"
+        exc = "no exception"
     except Exception as e:
         success = False
+        exc = str(e)
 
-    assert success, "exception={}".format(e)
+    assert success, "exception={}".format(exc)
 
 
 def setup_pha_basic(make_data_path):

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -437,25 +437,24 @@ class Filter():
         if array is None:
             return
 
+        # Note that mask may not be a boolean but an array.
         if self.mask is False:
             raise DataErr('notmask')
 
-        if self.mask is not True:  # mask is not False and not True, so it's something else we'll try to use as an array
-            array = numpy.asarray(array)
-            if array.shape != self.mask.shape:
-                raise DataErr('mismatch', 'mask', 'data array')
-            return array[self.mask]
+        if self.mask is True:
+            return array
 
-        return array
+        array = numpy.asarray(array)
+        if array.shape != self.mask.shape:
+            raise DataErr('mismatch', 'mask', 'data array')
+        return array[self.mask]
 
     def notice(self, mins, maxes, axislist, ignore=False):
         ignore = bool_cast(ignore)
-        if str in [type(min) for min in mins]:
-            raise DataErr('typecheck', 'lower bound')
-        elif str in [type(max) for max in maxes]:
-            raise DataErr('typecheck', 'upper bound')
-        elif str in [type(axis) for axis in axislist]:
-            raise DataErr('typecheck', 'grid')
+        for vals, label in zip([mins, maxes, axislist],
+                               ['lower bound', 'upper bound', 'grid']):
+            if any([isinstance(val, str) for val in vals]):
+                raise DataErr('typecheck', label)
 
         mask = filter_bins(mins, maxes, axislist)
 

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2019, 2020, 2021 Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -1200,3 +1201,33 @@ def test_manual_setting_mask():
     with pytest.raises(DataErr) as e:
         d.mask = None
     assert 'True, False, or a mask array' in str(e.value)
+
+
+def test_data_filter_no_data():
+    """Check we get a excludes-all-data error"""
+
+    x = numpy.asarray([1, 2, 5])
+    d = Data1D('x', x, x)
+    assert d.mask
+    d.ignore()
+    assert d.mask is False
+
+    with pytest.raises(DataErr) as de:
+        d.apply_filter([1, 2, 3])
+
+    assert str(de.value) == 'mask excludes all data'
+
+
+@pytest.mark.parametrize("vals", [4, [4], [[2, 3, 4]], [[2, 3], [3, 2]]])
+def test_data_filter_invalid_size(vals):
+    """Check we get a size-mismatch error"""
+
+    x = numpy.asarray([1, 2, 5])
+    d = Data1D('x', x, x)
+    d.ignore(None, 2)
+    assert d.mask == pytest.approx([False, False, True])
+
+    with pytest.raises(DataErr) as de:
+        d.apply_filter(vals)
+
+    assert str(de.value) == 'size mismatch between mask and data array'

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1231,3 +1231,19 @@ def test_data_filter_invalid_size(vals):
         d.apply_filter(vals)
 
     assert str(de.value) == 'size mismatch between mask and data array'
+
+
+@pytest.mark.parametrize("lo,hi,emsg", [("1:20", None, 'lower'), (None, "2", 'upper'), ("0.5", "7", 'lower')])
+@pytest.mark.parametrize("ignore", [False, True])
+def test_data1d_notice_errors_out_on_string_range(lo, hi, emsg, ignore):
+    """Check we get an error if lo or hi are strings."""
+
+    xlo = numpy.asarray([1, 2, 5])
+    xhi = numpy.asarray([2, 3, 8])
+    y = numpy.zeros(3)
+    d = Data1D('tmp', xlo, xhi, y)
+    with pytest.raises(DataErr) as de:
+        d.notice(lo, hi, ignore=ignore)
+
+    err = f'strings not allowed in {emsg} bound list'
+    assert str(de.value) == err

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2017, 2018, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -27,7 +28,7 @@ sherpa/astro/ui/tests/test_astro_ui_unit.py
 import pytest
 
 from sherpa import ui
-from sherpa.utils.err import ArgumentTypeErr
+from sherpa.utils.err import ArgumentTypeErr, IdentifierErr
 
 
 # This is part of #397
@@ -76,3 +77,20 @@ def test_check_ids_not_none(func):
         func(None)
 
     assert str(exc.value) == "'ids' must be an identifier or list of identifiers"
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("func", [ui.notice, ui.ignore])
+@pytest.mark.parametrize("lo,hi", [(1, 5), (1, None), (None, 5), (None, None),
+                                   ("1:5", None)])
+def test_filter_no_data_is_an_error(func, lo, hi, clean_ui):
+    """Does applying a filter lead to an error?
+
+    This test was added because it was noted that an update for Python 3
+    had lead to an error state not being reached.
+    """
+
+    with pytest.raises(IdentifierErr) as ie:
+        func(lo, hi)
+
+    assert str(ie.value) == 'No data sets found'

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -79,7 +79,6 @@ def test_check_ids_not_none(func):
     assert str(exc.value) == "'ids' must be an identifier or list of identifiers"
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("func", [ui.notice, ui.ignore])
 @pytest.mark.parametrize("lo,hi", [(1, 5), (1, None), (None, 5), (None, None),
                                    ("1:5", None)])

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -70,11 +70,16 @@ def test_all_has_no_repeated_elements():
 
 
 @pytest.mark.parametrize("func", [ui.notice_id, ui.ignore_id])
-def test_check_ids_not_none(func):
-    """Check they error out when id is None"""
+@pytest.mark.parametrize("lo", [None, 1, "1:5"])
+def test_check_ids_not_none(func, lo):
+    """Check they error out when id is None
+
+    There used to be the potential for different behavior depending
+    if the lo argument was a string or not,hence the check.
+    """
 
     with pytest.raises(ArgumentTypeErr) as exc:
-        func(None)
+        func(None, lo)
 
     assert str(exc.value) == "'ids' must be an identifier or list of identifiers"
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4729,10 +4729,10 @@ class Session(NoNewAttributesAfterInit):
         array([5, 7])
 
         """
+        if len(self._data) == 0:
+            raise IdentifierErr("nodatasets")
         if lo is not None and type(lo) in (str, numpy.string_):
             return self._notice_expr(lo, **kwargs)
-        if self._data.items() == []:
-            raise IdentifierErr("nodatasets")
         for d in self._data.values():
             d.notice(lo, hi, **kwargs)
 
@@ -4816,8 +4816,6 @@ class Session(NoNewAttributesAfterInit):
 
         """
         kwargs['ignore'] = True
-        if lo is not None and type(lo) in (str, numpy.string_):
-            return self._notice_expr(lo, **kwargs)
         self.notice(lo, hi, **kwargs)
 
     # DOC-NOTE: inclusion of bkg_id is technically wrong, as it

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4969,8 +4969,6 @@ class Session(NoNewAttributesAfterInit):
 
         """
         kwargs['ignore'] = True
-        if lo is not None and type(lo) in (str, numpy.string_):
-            return self._notice_expr_id(ids, lo, **kwargs)
         self.notice_id(ids, lo, hi, **kwargs)
 
     ###########################################################################


### PR DESCRIPTION
# Summary

Improve some corner cases for filtering PHA data, including fixing #921 (channel bounds are integers, not half-integers).

# Details

I had originally started out trying to work on #1081 but there turns out to be a number of small corner cases that it makes sense to address. They could be spun out into separate PRs but as they all deal with the same code the rebasing would be excessive, and some of the fixes build on each other.

The things to think about are

a - should the ui layer ignore and notice error out if there's no data? The code had an explicit check for it but it was wrong, so never fired. Given some of our recent work to allow things like multiple calls to subtract not error-ing out then we may want to keep the existing behavior (i.e. the command is essentially a no-op). This would be an easy change to make to this PR.

b - should we allow negative wavelength or energy values in filters? We explicitly support a value of 0 since responses can sometimes contain this (even if against the OGIP standard) and it acts as a nice "smaller-than-everything" value (even if we can use None for that). This PR supports handling negative wavelengths "sensibly" but maybe this should error out. I am reluctant in this PR to actually make that change since I worry about testing it out (and it may be only me who thinks to break the system in this way)

c - the last significant change in this PR adds a bunch of assert statements into the filter code to check that I understand the code (there are odd times when the code decides to allow lo and hi to be swapped and there's no commentary on why this is done, so I don't know if it's just pointless defensive coding or there's some underlying reason to do with our grating responses which the code just doesn't make clear). These asserts should be removed but I'd like to see something like the SDS regression tests run through this code first to make sure we've covered our bases.

The changes are

- internal code clean up (relatively minor, but this is obviously old code that has been changed over time)
- ignore and filter will now report an error if there are no datasets loaded (it might be argued that doing nothing in this case is okay, but the code was meant to report an error, presumably lost in the python 2 to 3 conversions, given the code change)
- ensures that for units=channel the edges are channel,channel+1 not channel-0.5,channel+0.5
- handle negative wavelengths the same way we handle 0 (maybe we should error out in this case?)
- turn a filter range where both low and high limits lie outside the valid range and are both either less than or greater than the valid range into no-ops - previously the first or last bin would get filtered which was surprising (particularly when coupled with the negative wavelength handling)
- explicitly error out if given a string range: the idea is that the support for strings is only in the ui layer and at the object layer you only deal with numbers (or None) - it makes the DataPHA code better match the standard data classes and is a very-minor improvement in code clarity. Actually, I've since discovered that the original code did end up error-ing out if given a string, but thanks to refactoring the code it helps to add an explicit check for this case.
- the channels and counts arrays are converted to NumPy arrays if they are not when a DataPHA object is created - this is not an issue for people loading in a PHA file but can be for those few of us who are creating DataPHA objects directly - as the change cleans up some odd cases (there may be some decision on handling of masked arrays but I feel that can be worked o separately, and may not even be an issue)

# Examples

## ignore/filter with no data

In CIAO 4.13 we have (the `ignore_id` behavior is just included to show this does not change)

```
sherpa In [1]: ignore()

sherpa In [2]: ignore_id(1, None, None)
IdentifierErr: data set 1 has not been set
```

and with this PR we get

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: ignore()
... ignoring traceback

IdentifierErr: No data sets found

In [3]: ignore_id(1, None, None)
... ignoring traceback

IdentifierErr: data set 1 has not been set
```

## channel +/- 1 vs 0.5

In CIAO 4.13 we have (this is issue #921)

```
sherpa In [3]: d = DataPHA('x', np.arange(1, 4), np.asarray([1, 2, 0]))

sherpa In [4]: d._get_ebins()
Out[4]: (array([0.5, 1.5, 2.5]), array([1.5, 2.5, 3.5]))
```

and now we have

```
In [4]: d = DataPHA('x', np.arange(1, 4), np.asarray([1, 2, 0]))

In [5]: d._get_ebins()
Out[5]: (array([1, 2, 3]), array([2, 3, 4]))
```

As mentioned, this is an internal routine.

In both cases (before and after this change) we haven't changed the DataPHA plots since it uses integer values for the xlo and xhi values (shown below is the CIAO 4.13 output, it's the same after thie PR)

```
sherpa In [2]: set_analysis('channel')

sherpa In [3]: get_data_plot().xlo
Out[3]:
array([  1.,  18.,  22.,  33.,  40.,  45.,  49.,  52.,  55.,  57.,  60.,
        62.,  66.,  69.,  72.,  76.,  79.,  83.,  89.,  97., 102., 111.,
       117., 125., 131., 134., 140., 144., 151., 157., 165., 178., 187.,
       197., 212., 233., 245., 261., 277., 292., 324., 345., 369., 405.,
       451., 677.])

sherpa In [4]: get_data_plot().xhi
Out[4]:
array([  18.,   22.,   33.,   40.,   45.,   49.,   52.,   55.,   57.,
         60.,   62.,   66.,   69.,   72.,   76.,   79.,   83.,   89.,
         97.,  102.,  111.,  117.,  125.,  131.,  134.,  140.,  144.,
        151.,  157.,  165.,  178.,  187.,  197.,  212.,  233.,  245.,
        261.,  277.,  292.,  324.,  345.,  369.,  405.,  451.,  677.,
       1025.])
```

## converting to numpy arrays

In CIAO 4.13 we have the following - note that there's a comment about converting the counts array (the [1,2,0] array) to Numpy but it turns out d.counts is still a list (it's only d.y that is changed, and we don't use really use the .y fie when accessig data from DataPHA). Also note that the internal _get_ebins routine fails.

```
sherpa In [1]: d = DataPHA('x', [1, 2, 3], [1, 2, 0])
/home/dburke/anaconda/envs/ciao413/lib/python3.8/site-packages/sherpa/data.py:50: UserWarning: Converting array [1, 2, 0] to numpy array.
  warnings.warn("Converting array {} to numpy array.".format(array))

sherpa In [2]: print(d)
name           = x
channel        = [1, 2, 3]
counts         = [1, 2, 0]
staterror      = None
syserror       = None
bin_lo         = None
bin_hi         = None
grouping       = None
quality        = None
exposure       = None
backscal       = None
areascal       = None
grouped        = False
subtracted     = False
units          = channel
rate           = True
plot_fac       = 0
response_ids   = []
background_ids = []

sherpa In [3]: type(d.channel)
Out[3]: list

sherpa In [4]: type(d.counts)
Out[4]: list

sherpa In [5]: type(d.x)
Out[5]: list

sherpa In [6]: type(d.y)
Out[6]: numpy.ndarray

sherpa In [7]: d._get_ebins()
TypeError: unsupported operand type(s) for -: 'list' and 'float'
```

With this patch we get the following (both channel and counts are stored as NumPy arrays and _get_ebins no longer errors out):

```
In [1]: from sherpa.astro.data import DataPHA

In [2]: d = DataPHA('x', [1, 2, 3], [1, 2, 0])
/home/dburke/sherpa/sherpa-master/sherpa/data.py:50: UserWarning: Converting array [1, 2, 3] to numpy array.
  warnings.warn("Converting array {} to numpy array.".format(array))
/home/dburke/sherpa/sherpa-master/sherpa/data.py:50: UserWarning: Converting array [1, 2, 0] to numpy array.
  warnings.warn("Converting array {} to numpy array.".format(array))

In [3]: print(d)
name           = x
channel        = Int64[3]
counts         = Int64[3]
staterror      = None
syserror       = None
bin_lo         = None
bin_hi         = None
grouping       = None
quality        = None
exposure       = None
backscal       = None
areascal       = None
grouped        = False
subtracted     = False
units          = channel
rate           = True
plot_fac       = 0
response_ids   = []
background_ids = []

In [4]: type(d.channel)
Out[4]: numpy.ndarray

In [5]: type(d.counts)
Out[5]: numpy.ndarray

In [6]: type(d.x)
Out[6]: numpy.ndarray

In [7]: type(d.y)
Out[7]: numpy.ndarray

In [8]: d._get_ebins()
Out[8]: (array([1, 2, 3]), array([2, 3, 4]))
```

## filtering with silly values

In CIAO 4.13 we have

```
sherpa In [2]: set_analysis('wave')

sherpa In [3]: get_filter()
Out[3]: '0.999066753912:99.322428665279'

sherpa In [4]: ignore(0, 2)

sherpa In [5]: get_filter()
Out[5]: '2.200017578690:99.322428665279'

sherpa In [6]: notice()

sherpa In [7]: ignore(-1, 2)

sherpa In [8]: get_filter()
Out[8]: '0.999066753912:99.322428665279'
```

whereas we now have

```
In [4]: set_analysis('wave')

In [5]: get_filter()
Out[5]: '0.999066753912:99.322428665279'

In [6]: ignore(0, 2)

In [7]: get_filter()
Out[7]: '2.200017578690:99.322428665279'

In [8]: notice()

In [9]: ignore(-1, 2)

In [10]: get_filter()
Out[10]: '2.200017578690:99.322428665279'
```

Notice that the negative wavelength is treated like 0 now whereas in CIAO 4.13 it didn't appear to do anything (note that the behavior depended on the data range and what values you used)

## filtering with "excessive" values

If you gave a filter with both low and high values "outside" the data range then the first or last bin could get filtered, as shown in the example below. We now just drop the filter in this condition.

With CIAO 4.13, even though I've said ignore 2000 to 2000 keV we actually end up losing the last group - here ~8 to ~12 keV

```
sherpa In [9]: notice()

sherpa In [10]: set_analysis('energy')

sherpa In [11]: get_filter()
Out[11]: '0.124829999695:12.410000324249'

sherpa In [12]: ignore(2000, 3000)

sherpa In [13]: get_filter()
Out[13]: '0.124829999695:8.219800233841'
```

The new behavior is to do nothing

```
In [11]: notice()

In [12]: set_analysis('energy')

In [13]: get_filter()
Out[13]: '0.124829999695:12.410000324249'

In [14]: ignore(2000, 3000)

In [15]: get_filter()
Out[15]: '0.124829999695:12.410000324249'
```

## string filtering check

This only deals with the `notice` and `ignore` methods of the `DataPHA` class - you can still give strings to the `notice` and `ignore` functions from the ui layer. It also doesn't change the user behavior - that is the following is from CIAO 4.13 and we still have the same error raised, it's just now done earlier

```
In [5]: pha.notice("0.5:2.0")
---------------------------------------------------------------------------
DataErr                                   Traceback (most recent call last)
<ipython-input-5-05cff9c3672d> in <module>
----> 1 pha.notice("0.5:2.0")

~/anaconda/envs/ciao413/lib/python3.8/site-packages/sherpa/astro/data.py in notice(self, lo, hi, ignore, bkg_id)
   3456                 # do nothing (other than display an INFO message).
   3457                 #
-> 3458                 bkg.notice(lo, hi, ignore)
   3459             finally:
   3460                 bkg.units = old_bkg_units

~/anaconda/envs/ciao413/lib/python3.8/site-packages/sherpa/astro/data.py in notice(self, lo, hi, ignore, bkg_id)
   3507         groups = self.apply_grouping(self.channel,
   3508                                      self._make_groups)
-> 3509         self._data_space.filter.notice((lo,), (hi,),
   3510                                        (groups,), ignore)
   3511

~/anaconda/envs/ciao413/lib/python3.8/site-packages/sherpa/data.py in notice(self, mins, maxes, axislist, ignore)
    453         ignore = bool_cast(ignore)
    454         if str in [type(min) for min in mins]:
--> 455             raise DataErr('typecheck', 'lower bound')
    456         elif str in [type(max) for max in maxes]:
    457             raise DataErr('typecheck', 'upper bound')

DataErr: strings not allowed in lower bound list
```

whereas this PR throws the error earlier

```
In [3]: pha.notice("0.5:2.0")
---------------------------------------------------------------------------
DataErr                                   Traceback (most recent call last)
<ipython-input-3-05cff9c3672d> in <module>
----> 1 pha.notice("0.5:2.0")

~/sherpa/sherpa-master/sherpa/astro/data.py in notice(self, lo, hi, ignore, bkg_id)
   3794             if isinstance(val, str):
   3795                 # match the error seen from other data classes here
-> 3796                 raise DataErr('typecheck', f'{label} bound')
   3797
   3798         # If any background IDs are actually given, then impose

DataErr: strings not allowed in lower bound list
```
