### PR TITLE
Fix save_data when the output file exists

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -414,7 +414,6 @@ def check_clobber(outpath, func):
     assert new == old
 
 
-@pytest.mark.xfail(reason='fall through does not work')
 def test_save_data_data1d_no_clobber(tmp_path):
     """save_data: does clobber=False work? Data1D"""
 
@@ -427,7 +426,6 @@ def test_save_data_data1d_no_clobber(tmp_path):
     check_clobber(out, ui.save_data)
 
 
-@pytest.mark.xfail(reason='fall through does not work')
 @requires_fits
 def test_save_data_datapha_no_clobber(tmp_path):
     """save_data: does clobber=False work? DataPHA"""
@@ -450,7 +448,6 @@ def test_save_data_datapha_no_clobber(tmp_path):
     check_clobber(out, ui.save_data)
 
 
-@pytest.mark.xfail(reason='fall through does not work')
 @requires_fits
 def test_save_pha_no_clobber(tmp_path):
     """save_pha: does clobber=False work?"""
@@ -474,7 +471,7 @@ def test_save_pha_no_clobber(tmp_path):
 
 
 @requires_fits
-@pytest.mark.parametrize("writer", [pytest.param(ui.save_data, marks=pytest.mark.xfail), ui.save_image])
+@pytest.mark.parametrize("writer", [ui.save_data, ui.save_image])
 def test_save_image_no_clobber(writer, tmp_path):
     """save_image: does clobber=False work?"""
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -414,6 +414,7 @@ def check_clobber(outpath, func):
     assert new == old
 
 
+@requires_fits
 def test_save_data_data1d_no_clobber(tmp_path):
     """save_data: does clobber=False work? Data1D"""
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -3882,7 +3882,7 @@ class Session(sherpa.ui.utils.Session):
             args = [obj.x, obj.y]
             fields = ["X", str(objtype).upper()]
 
-        sherpa.astro.io.write_arrays(filename, args, fields, **kwargs)
+        sherpa.astro.io.write_arrays(filename, args, fields=fields, **kwargs)
 
 # To fix bug report 13536, save many kinds of data to ASCII by default,
 # and let user override if they want FITS (or vice-versa).  The new defaults
@@ -3969,7 +3969,8 @@ class Session(sherpa.ui.utils.Session):
         """
         clobber = sherpa.utils.bool_cast(clobber)
         ascii = sherpa.utils.bool_cast(ascii)
-        sherpa.astro.io.write_arrays(filename, args, fields, ascii, clobber)
+        sherpa.astro.io.write_arrays(filename, args, fields=fields,
+                                     ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different API
     def save_source(self, id, filename=None, bkg_id=None, ascii=False,
@@ -4718,7 +4719,7 @@ class Session(sherpa.ui.utils.Session):
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
 
-        sherpa.astro.io.write_pha(filename, d, ascii, clobber)
+        sherpa.astro.io.write_pha(filename, d, ascii=ascii, clobber=clobber)
 
     def save_grouping(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
         """Save the grouping scheme to a file.
@@ -4801,7 +4802,8 @@ class Session(sherpa.ui.utils.Session):
             raise DataErr('nogrouping', id)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.grouping],
-                                     ['CHANNEL', 'GROUPS'], ascii, clobber)
+                                     fields=['CHANNEL', 'GROUPS'], ascii=ascii,
+                                     clobber=clobber)
 
     def save_quality(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
         """Save the quality array to a file.
@@ -4884,7 +4886,8 @@ class Session(sherpa.ui.utils.Session):
             raise DataErr('noquality', id)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.quality],
-                                     ['CHANNEL', 'QUALITY'], ascii, clobber)
+                                     fields=['CHANNEL', 'QUALITY'], ascii=ascii,
+                                     clobber=clobber)
 
     # DOC-TODO: setting ascii=True is not supported for crates
     # and in pyfits it seems to just be a 1D array (needs thinking about)
@@ -4953,7 +4956,7 @@ class Session(sherpa.ui.utils.Session):
         _check_type(filename, string_types, 'filename', 'a string')
 
         sherpa.astro.io.write_image(filename, self.get_data(id),
-                                    ascii, clobber)
+                                    ascii=ascii, clobber=clobber)
 
     # DOC-TODO: the output for an image is "excessive"
     def save_table(self, id, filename=None, ascii=False, clobber=False):
@@ -5022,7 +5025,7 @@ class Session(sherpa.ui.utils.Session):
         _check_type(filename, string_types, 'filename', 'a string')
 
         sherpa.astro.io.write_table(filename, self.get_data(id),
-                                    ascii, clobber)
+                                    ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils
     def save_data(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -5118,7 +5118,7 @@ class Session(sherpa.ui.utils.Session):
                 try:
                     sherpa.astro.io.write_table(filename, d, ascii=ascii,
                                                 clobber=clobber)
-                except:
+                except IOErr:
                     # If this errors out then so be it
                     sherpa.io.write_data(filename, d, clobber=clobber)
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -5105,16 +5105,19 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
 
         try:
-            sherpa.astro.io.write_pha(filename, d, ascii, clobber)
+            sherpa.astro.io.write_pha(filename, d, ascii=ascii,
+                                      clobber=clobber)
         except IOErr:
             try:
-                sherpa.astro.io.write_image(filename, d, ascii, clobber)
+                sherpa.astro.io.write_image(filename, d, ascii=ascii,
+                                            clobber=clobber)
             except IOErr:
                 try:
-                    sherpa.astro.io.write_table(filename, d, ascii, clobber)
+                    sherpa.astro.io.write_table(filename, d, ascii=ascii,
+                                                clobber=clobber)
                 except:
                     # If this errors out then so be it
-                    sherpa.io.write_data(filename, d, clobber)
+                    sherpa.io.write_data(filename, d, clobber=clobber)
 
     def pack_pha(self, id=None):
         """Convert a PHA data set into a file structure.


### PR DESCRIPTION
# Summary

Fix problems when `save_data` is used with `clobber=False` but the output file already exists. Fixes #1071 

# Details

As @wmclaugh pointed out in my previous attempt to fix #1071 (in
PR #1066) the actual problem was a lot simpler - the optional
arguments were not being set correctly. This commit addresses this
(fixing the problematic line and other lines which were okay but
could show this problem if their callnig convention was changed).

The tests added in #1067 have had their xfail labels removed.

This also changes the logic from

    try/except IOErr
    try/except IOErr
    try/except

to one where we require IOErr for the exception in all cases (the idea is that we only fall through to the other cases if there's an IO error so it's not obvious why we don't require that in the last case). There is a possibility that sherpa.astro.io.write_table may throw a non-IOErr that we want to catch here, but there's no documentation in the sherpa.astro.io module to support or deny this.

# Example

The example from #1071 now fails with

```
... lots of traceback ...

<ipython-input-5-c455dca1b657> in <module>
----> 1 save_data('x')

<string> in save_data(id, filename, bkg_id, ascii, clobber)

~/sherpa/sherpa-master/sherpa/astro/ui/utils.py in save_data(self, id, filename, bkg_id, ascii, clobber)
   5118                 except:
   5119                     # If this errors out then so be it
-> 5120                     sherpa.io.write_data(filename, d, clobber=clobber)
   5121
   5122     def pack_pha(self, id=None):

~/sherpa/sherpa-master/sherpa/io.py in write_data(filename, dataset, fields, sep, comment, clobber, linebreak, format)
    535             cols.append(field)
    536
--> 537     write_arrays(filename, cols, col_names, sep, comment, clobber,
    538                  linebreak, format)

~/sherpa/sherpa-master/sherpa/io.py in write_arrays(filename, args, fields, sep, comment, clobber, linebreak, format)
    438     """
    439     if os.path.isfile(filename) and not clobber:
--> 440         raise IOErr("filefound", filename)
    441
    442     if not numpy.iterable(args) or len(args) == 0:

IOErr: file 'x' exists and clobber is not set
```

rather than the message it used to create, namely

```
TypeError: 'bool' object is not iterable
```