### PR TITLE
Update XQuartz for GH Actions workflow

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -83,16 +83,16 @@ jobs:
     - name: Install XQuartz on macOS
       if: runner.os == 'macOS'
       run: |
-        curl -LO https://dl.bintray.com/xquartz/downloads/XQuartz-2.7.11.dmg
-        hdiutil attach XQuartz-2.7.11.dmg
-        cd /Volumes/XQuartz-2.7.11
-        sudo installer -pkg /Volumes/XQuartz-2.7.11/XQuartz.pkg -target /
+        curl -LO https://github.com/XQuartz/XQuartz/releases/download/XQuartz-2.8.1/XQuartz-2.8.1.dmg
+        hdiutil attach XQuartz-2.8.1.dmg
+        cd /Volumes/XQuartz-2.8.1
+        sudo installer -pkg /Volumes/XQuartz-2.8.1/XQuartz.pkg -target /
         if [ $? != 0 ] ; then
             exit 1
         fi
         cd -
-        hdiutil detach /Volumes/XQuartz-2.7.11
-        rm XQuartz-2.7.11.dmg
+        hdiutil detach /Volumes/XQuartz-2.8.1
+        rm XQuartz-2.8.1.dmg
 
     - name: Conda Testing Setup (Xspec and DS9)
       shell: bash


### PR DESCRIPTION
xQuartz is now available on GitHub and the old version is no longer accessible via the old bintray link. This PR updates the xQuartz download location and version for the GitHub Actions Conda tests.