### PR TITLE
Added docstring and removed unused no-op class

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -35,7 +35,7 @@ from . import _modelfcts
 __all__ = ('Atten', 'BBody', 'BBodyFreq', 'Beta1D', 'BPL1D', 'Dered', 'Edge',
            'LineBroad', 'Lorentz1D', 'Voigt1D', 'PseudoVoigt1D', 'NormBeta1D', 'Schechter',
            'Beta2D', 'DeVaucouleurs2D', 'HubbleReynolds', 'Lorentz2D',
-           'JDPileup', 'MultiResponseSumModel', 'Sersic2D', 'Disk2D',
+           'JDPileup', 'Sersic2D', 'Disk2D',
            'Shell2D')
 
 
@@ -1387,10 +1387,6 @@ class JDPileup(RegriddableModel1D):
                            frame_time, alpha, g0, num_regions, psf_frac, model)
         self._results = out[1:]
         return out[0]
-
-
-class MultiResponseSumModel(ArithmeticModel):
-    pass
 
 
 class Sersic2D(RegriddableModel2D):

--- a/sherpa/astro/models/tests/test_astro_model.py
+++ b/sherpa/astro/models/tests/test_astro_model.py
@@ -45,8 +45,8 @@ def test_create_and_evaluate():
            clsobj in EXCLUDED_MODEL_CLASSES:
             continue
 
-        # These have a very different interface than the others
-        if cls in ('JDPileup', 'MultiResponseSumModel'):
+        # This has a very different interface than the others
+        if cls == 'JDPileup':
             continue
 
         m = clsobj()

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2016, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2008, 2016, 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -66,6 +66,44 @@ def get_xspec_position(y, x, xhi=None):
 
 
 def compile_energy_grid(arglist):
+    '''Combine several grids (energy, channel, wavelength) into one
+
+    This function combines several grids into one, such that the model
+    does not have to be evaluated several times, just because the same energy
+    point occurs in every grid.
+
+    This function works under the assumption that evaluating the model
+    is expensive and it is is worthwhile to do some bookkeeping to be
+    able to derive the model for all intervals needed with the minimum
+    number of model points.
+
+    Parameters
+    ----------
+    arglist : list of tuples
+        The list contains the input energy grids. Each tuple is a pair
+        of arrays specifying the lower and upper limits for the bins in
+        each input grid.
+
+    Returns
+    -------
+    out : list
+        The elements of the list are:
+        - elo : array of lower bin values
+        - ehi : array of upper bin values
+        - htable : list of tuples, in the same format as the input.
+             The entries in ``htable`` are indices into ``elo`` and ``ehi``
+             that return the original input arrays.
+
+    Examples
+    --------
+
+    >>> compile_energy_grid([([1,3,5], [3, 5, 7]), ([0, 1, 2], [1, 2, 3])])
+    [array([0, 1, 2, 3, 5]),
+     array([1, 2, 3, 5, 7]),
+     [(array([1, 3, 4], dtype=int32), array([2, 3, 4], dtype=int32)),
+      (array([0, 1, 2], dtype=int32), array([0, 1, 2], dtype=int32))]]
+
+    '''
     elo = numpy.unique(numpy.concatenate([indep[0] for indep in arglist]))
     ehi = numpy.unique(numpy.concatenate([indep[1] for indep in arglist]))
 
@@ -73,13 +111,10 @@ def compile_energy_grid(arglist):
     in_ehi = numpy.setdiff1d(ehi, elo)
     if len(in_elo) > 1:
         ehi = numpy.concatenate((ehi, in_elo[-(len(in_elo) - 1):]))
+        ehi.sort()
     if len(in_ehi) > 1:
         elo = numpy.concatenate((elo, in_ehi[0:len(in_ehi) - 1]))
-
-    # FIXME since numpy.unique calls sort() underneath, may not need to
-    # sort again here...
-    elo.sort()
-    ehi.sort()
+        elo.sort()
 
     # determine index intervals using binary search in large src model
     # for n_th ARF energy bounds and populate a table to use later for

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -110,10 +110,10 @@ def compile_energy_grid(arglist):
     in_elo = numpy.setdiff1d(elo, ehi)
     in_ehi = numpy.setdiff1d(ehi, elo)
     if len(in_elo) > 1:
-        ehi = numpy.concatenate((ehi, in_elo[-(len(in_elo) - 1):]))
+        ehi = numpy.concatenate((ehi, in_elo[1:]))
         ehi.sort()
     if len(in_ehi) > 1:
-        elo = numpy.concatenate((elo, in_ehi[0:len(in_ehi) - 1]))
+        elo = numpy.concatenate((elo, in_ehi[:- 1]))
         elo.sort()
 
     # determine index intervals using binary search in large src model

--- a/sherpa/astro/utils/tests/test_astro_utils.py
+++ b/sherpa/astro/utils/tests/test_astro_utils.py
@@ -53,3 +53,14 @@ def test_compile_energy_grid():
     assert np.all(elo == [0, 1, 2, 3, 5])
     assert np.all(ehi == [1, 2, 3, 5, 7])
     assert np.all(htable[0][0] == [1, 3, 4])
+
+
+def test_compile_energy_grid_3inputs():
+    '''Test more than two input grids'''
+    elo, ehi, htable = compile_energy_grid([([1, 3, 5], [3, 5, 7]),
+                                            ([0, 1, 2], [1, 2, 3]),
+                                            ([0.5, 5.5, 7.5], [5.5, 7.5, 9])])
+    assert np.allclose(elo, [0., 0.5, 1., 2., 3., 5., 5.5, 7., 7.5])
+    assert np.allclose(ehi, [0.5, 1., 2., 3., 5., 5.5, 7., 7.5, 9.])
+    assert np.all(htable[0][0] == [2, 4, 5])
+    assert np.all(htable[2][1] == [5, 7, 8])

--- a/sherpa/astro/utils/tests/test_astro_utils.py
+++ b/sherpa/astro/utils/tests/test_astro_utils.py
@@ -17,10 +17,10 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+import numpy as np
 import pytest
 
-from sherpa.astro.utils import is_in
+from sherpa.astro.utils import is_in, compile_energy_grid
 
 LONGVALS = [100, 249, 400, 450, 500, 601, 1024]
 SHORTVALS = [100, 249, 601, 1024]
@@ -43,3 +43,13 @@ def test_is_in_long(lo, hi):
 def test_not_in_short():
     # 'hidden' interval case w/ *no* noticed channels inside
     assert not is_in(SHORTVALS, 250, 600)
+
+
+def test_compile_energy_grid():
+    '''This test just executes the doc string. Once we activate doctests,
+    this test can be removed.'''
+    elo, ehi, htable = compile_energy_grid([([1, 3, 5], [3, 5, 7]),
+                                            ([0, 1, 2], [1, 2, 3])])
+    assert np.all(elo == [0, 1, 2, 3, 5])
+    assert np.all(ehi == [1, 2, 3, 5, 7])
+    assert np.all(htable[0][0] == [1, 3, 4])


### PR DESCRIPTION
# Summary
Remove `sherpa.astro.models.MultiResponseSumModel`, which did nothing and seems to be unused (except in a test that explicitly skip this class). 

Add a doctring to an internal function.

# Details
It's confusing to have such a no-op class with the same name as the  `sherpa.astro.instrument.MultiResponseSumModel`, which does things. I suspect that the `sherpa.astro.models.MultiResponseSumModel` was put in as a place-holder and then forgotten, but maybe the full tests show me a use case that I've overlooked before.

## Notes
This is part of my attempt to get a specific plot to work for a dataset with multiple responses and I spend so much time to understand what these functions do, that I wanted to document it. More might be coming as I dig deeper, but following @DougBurke lead, I'm going to open smaller PRs that are easier to review rather than one big one that combines many different aspects.

Timing: I'm opening this PR now because I need a specific feature so I'm looking into the code now and might as well push it up so I don't forget about it. It can sit on github until after 4.13.1 is out.