### PR TITLE
Replace error message "too few columns" with a more generic word

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1329,7 +1329,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
-        raise IOErr('wrongcolnumber', str(len(fields)), str(len(args)))
+        raise IOErr('wrongcolnumber', len(args), len(fields))
 
     for val, name in zip(args, fields):
         _set_column(tbl, name, val)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1329,7 +1329,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
-        raise IOErr('wrongcolnumber', len(args), len(fields))
+        raise IOErr('wrongnumcols', len(args), len(fields))
 
     for val, name in zip(args, fields):
         _set_column(tbl, name, val)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1329,7 +1329,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
-        raise IOErr('toomanycols', str(len(fields)), str(len(args)))
+        raise IOErr('wrongcolnumber', str(len(fields)), str(len(args)))
 
     for val, name in zip(args, fields):
         _set_column(tbl, name, val)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1169,7 +1169,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
-        raise IOErr("wrongcolnumber", str(len(fields)), str(len(args)))
+        raise IOErr("wrongcolnumber", len(args), len(fields))
 
     cols = []
     for val, name in zip(args, fields):

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1169,7 +1169,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
-        raise IOErr("wrongcolnumber", len(args), len(fields))
+        raise IOErr("wrongnumcols", len(args), len(fields))
 
     cols = []
     for val, name in zip(args, fields):

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1169,7 +1169,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
     if len(args) != len(fields):
-        raise IOErr("toomanycols", str(len(fields)), str(len(args)))
+        raise IOErr("wrongcolnumber", str(len(fields)), str(len(args)))
 
     cols = []
     for val, name in zip(args, fields):

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -236,7 +236,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
     colkeys = list(colkeys)
 
     if len(names) > len(args):
-        raise IOErr('toomanycols')
+        raise IOErr('wrongcolnumber')
 
     assert(len(names) <= len(args))
 

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -236,7 +236,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
     colkeys = list(colkeys)
 
     if len(names) > len(args):
-        raise IOErr('wrongcolnumber', len(args), len(names))
+        raise IOErr('wrongnumcols', len(args), len(names))
 
     assert(len(names) <= len(args))
 

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -236,7 +236,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
     colkeys = list(colkeys)
 
     if len(names) > len(args):
-        raise IOErr('wrongcolnumber')
+        raise IOErr('wrongcolnumber', len(args), len(names))
 
     assert(len(names) <= len(args))
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -6439,7 +6439,8 @@ class Session(NoNewAttributesAfterInit):
                                                require_floats=False)
 
         if len(names) > len(cols):
-            raise sherpa.utils.err.IOErr('wrongcolnumber')
+            raise sherpa.utils.err.IOErr('wrongcolnumber',
+                                         len(cols), len(names))
 
         names = [name.strip().lower() for name in names]
 
@@ -6486,7 +6487,7 @@ class Session(NoNewAttributesAfterInit):
                 tm.ampl.freeze()
                 templates.append(tm)
             else:
-                raise sherpa.utils.err.IOErr('wrongcolnumber', str(tnames), '2')
+                raise sherpa.utils.err.IOErr('wrongcolnumber', 2, len(tnames))
 
         assert(len(templates) == parvals.shape[0])
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -6439,7 +6439,7 @@ class Session(NoNewAttributesAfterInit):
                                                require_floats=False)
 
         if len(names) > len(cols):
-            raise sherpa.utils.err.IOErr('wrongcolnumber',
+            raise sherpa.utils.err.IOErr('wrongnumcols',
                                          len(cols), len(names))
 
         names = [name.strip().lower() for name in names]
@@ -6487,7 +6487,7 @@ class Session(NoNewAttributesAfterInit):
                 tm.ampl.freeze()
                 templates.append(tm)
             else:
-                raise sherpa.utils.err.IOErr('wrongcolnumber', 2, len(tnames))
+                raise sherpa.utils.err.IOErr('wrongnumcols', 2, len(tnames))
 
         assert(len(templates) == parvals.shape[0])
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -6439,7 +6439,7 @@ class Session(NoNewAttributesAfterInit):
                                                require_floats=False)
 
         if len(names) > len(cols):
-            raise sherpa.utils.err.IOErr('toomanycols')
+            raise sherpa.utils.err.IOErr('wrongcolnumber')
 
         names = [name.strip().lower() for name in names]
 
@@ -6486,7 +6486,7 @@ class Session(NoNewAttributesAfterInit):
                 tm.ampl.freeze()
                 templates.append(tm)
             else:
-                raise sherpa.utils.err.IOErr('toomanycols', str(tnames), '2')
+                raise sherpa.utils.err.IOErr('wrongcolnumber', str(tnames), '2')
 
         assert(len(templates) == parvals.shape[0])
 

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -279,7 +279,7 @@ class IOErr(SherpaErr):
             'badarray': "'%s' must be a Numpy array, list, or tuple",
             'notascii': "file '%s' does not appear to be ASCII",
             'noparamcols': 'No parameter columns found in %s',
-            'wrongcolnumber': "Received wrong number of column names: %s, required: %s",
+            'wrongcolnumber': "Expected %d columns but found %d",
             'reqcol': "Required column '%s' not found in %s",
             'badcol': "unable to read required column %s from file",
             'badimg': 'unable to read required image %s from file',

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -279,7 +279,7 @@ class IOErr(SherpaErr):
             'badarray': "'%s' must be a Numpy array, list, or tuple",
             'notascii': "file '%s' does not appear to be ASCII",
             'noparamcols': 'No parameter columns found in %s',
-            'wrongcolnumber': "Expected %d columns but found %d",
+            'wrongnumcols': "Expected %d columns but found %d",
             'reqcol': "Required column '%s' not found in %s",
             'badcol': "unable to read required column %s from file",
             'badimg': 'unable to read required image %s from file',

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -279,7 +279,7 @@ class IOErr(SherpaErr):
             'badarray': "'%s' must be a Numpy array, list, or tuple",
             'notascii': "file '%s' does not appear to be ASCII",
             'noparamcols': 'No parameter columns found in %s',
-            'toomanycols': "Received more column names: %s, than required: %s",
+            'wrongcolnumber': "Received wrong number of column names: %s, required: %s",
             'reqcol': "Required column '%s' not found in %s",
             'badcol': "unable to read required column %s from file",
             'badimg': 'unable to read required image %s from file',


### PR DESCRIPTION
# Summary
Change the wording of an error message. Potentially breaking if someone tests for the wording of the error message in their code, but certainly more correct.

# Details
Change is required, because it could also be "too many" instead of "too few" columns

fixes #244

Can wait till after 4.13.1 is out.