### PR TITLE
Address NumPy 1.20 bool/int/float deprecation warnings

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2008, 2015, 2016, 2017, 2018, 2019, 2020, 2021
-#            Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -3840,7 +3840,7 @@ class DataIMG(Data2D):
         # region.
         #
         mask = reg.mask(self.get_x0(), self.get_x1())
-        mask = mask.astype(numpy.bool)
+        mask = mask.astype(bool)
 
         # Apply the new mask to the existing mask.
         #

--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -630,7 +630,7 @@ def calc_sample_flux(lo, hi, fit, data, samples, modelcomponent,
     softmaxs = fit.model.thawedparmaxes
 
     # We have to use columns 1 to n-1 of samples
-    valid = numpy.ones(samples.shape[0], dtype=numpy.bool)
+    valid = numpy.ones(samples.shape[0], dtype=bool)
     for col, pmin, pmax in zip(samples.T[1:-1], softmins, softmaxs):
         valid &= (col >= pmin) & (col <= pmax)
 

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -757,7 +757,7 @@ def get_rmf_data(arg, make_copy=False):
                 # n_chan can be an unsigned integer. Adding a Python
                 # integer to a NumPy unsigned integer appears to return
                 # a float.
-                end = start + numpy.int(nc)
+                end = start + int(nc)
 
                 # "perfect" RMFs may have mrow as a scalar
                 try:

--- a/sherpa/astro/sim/pragbayes.py
+++ b/sherpa/astro/sim/pragbayes.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2016, 2017, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2017, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -185,13 +186,13 @@ class WalkWithSubIters(Walk):
         niter = self.niter
         nelem = niter + 1
 
-        proposals = np.zeros((nelem, npars), dtype=np.float)
+        proposals = np.zeros((nelem, npars), dtype=float)
         proposals[0] = pars.copy()
 
-        stats = np.zeros(nelem, dtype=np.float)
+        stats = np.zeros(nelem, dtype=float)
         stats[0] = stat
 
-        acceptflag = np.zeros(nelem, dtype=np.bool)
+        acceptflag = np.zeros(nelem, dtype=bool)
 
         # Iterations
         # - no burn in at present

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021
-#        Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -70,7 +70,7 @@ class test_filter_energy_grid(SherpaTestCase):
         2.71560001e+00, 2.86159992e+00, 3.08060002e+00, 3.38720012e+00,
         3.56240010e+00, 3.79600000e+00, 4.02960014e+00, 4.24860001e+00,
         4.71579981e+00, 5.02239990e+00, 5.37279987e+00, 5.89839983e+00,
-        6.57000017e+00, 9.86960030e+00], np.float)
+        6.57000017e+00, 9.86960030e+00], float)
 
     _emax = np.array([
         0.2482, 0.3066, 0.46720001, 0.56940001, 0.64240003,
@@ -82,7 +82,7 @@ class test_filter_energy_grid(SherpaTestCase):
         2.58419991, 2.71560001, 2.86159992, 3.08060002, 3.38720012,
         3.5624001, 3.796, 4.02960014, 4.24860001, 4.71579981,
         5.0223999, 5.37279987, 5.89839983, 6.57000017, 9.8696003,
-        14.95040035], np.float)
+        14.95040035], float)
 
     def setUp(self):
         self.old_level = logger.getEffectiveLevel()
@@ -158,7 +158,7 @@ class test_filter_energy_grid_reversed(SherpaTestCase):
         0.37154216, 0.36742872, 0.3641032, 0.36167556, 0.35983625,
         0.35634032, 0.35248783, 0.35085678, 0.34843227, 0.34669766,
         0.34418666, 0.33912122, 0.33720407, 0.33505177, 0.33279634,
-        0.33081138, 0.32847831, 0.32592943, 0.3111549], np.float)
+        0.33081138, 0.32847831, 0.32592943, 0.3111549], float)
 
     _emax = np.array([
         3.06803656, 2.39196181, 2.35973215, 2.34076023, 2.30973101,
@@ -201,7 +201,7 @@ class test_filter_energy_grid_reversed(SherpaTestCase):
         0.37347662, 0.37154216, 0.36742872, 0.3641032, 0.36167556,
         0.35983625, 0.35634032, 0.35248783, 0.35085678, 0.34843227,
         0.34669766, 0.34418666, 0.33912122, 0.33720407, 0.33505177,
-        0.33279634, 0.33081138, 0.32847831, 0.32592943], np.float)
+        0.33279634, 0.33081138, 0.32847831, 0.32592943], float)
 
     def setUp(self):
         self.pha = DataPHA('', np.arange(204, dtype=float) + 1.,
@@ -1030,7 +1030,7 @@ def test_pha_mask_filtered(infile, size, nset, make_data_path):
     pha.notice(0.5, 7)
     pha.ignore(2, 3)
 
-    assert pha.mask.dtype == np.bool
+    assert pha.mask.dtype == bool
     assert pha.mask.size == size
     assert pha.mask.sum() == nset
 
@@ -1279,11 +1279,11 @@ def test_grouping_filtering_binning(analysis, make_data_path):
     assert (pha.grouping == expected).all()
 
     # This is based on the energy results
-    expected = np.zeros(21, dtype=np.bool)
+    expected = np.zeros(21, dtype=bool)
     expected[1:9] = True
     assert (pha.mask == expected).all()
 
-    expected = np.zeros(1024, dtype=np.bool)
+    expected = np.zeros(1024, dtype=bool)
     expected[50:450] = True
     assert (pha.get_mask() == expected).all()
 
@@ -1358,7 +1358,7 @@ def test_notice_energy_grouping(make_data_path):
     # channels 69 - 404, which maps to indices 68,..,403
     # or 68:404.
     #
-    mask = np.zeros(1024, dtype=np.bool)
+    mask = np.zeros(1024, dtype=bool)
     mask[68:404] = True
 
     assert pha.get_mask() == pytest.approx(mask)
@@ -1388,7 +1388,7 @@ def test_notice_channel_grouping(make_data_path):
 
     # This now creates the expected range.
     #
-    mask = np.zeros(1024, dtype=np.bool)
+    mask = np.zeros(1024, dtype=bool)
     mask[68:404] = True
 
     assert pha.get_mask() == pytest.approx(mask)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2020, 2021
-#        Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -287,7 +287,7 @@ def test_416_c():
 
     # the second grouped bin has a quality of 2 as
     # it only contains 1 count
-    quality = np.zeros(10, dtype=np.int)
+    quality = np.zeros(10, dtype=int)
     quality[5] = 2
     assert pha.quality == pytest.approx(quality)
 
@@ -605,7 +605,7 @@ def test_img_get_bounding_mask_filtered(make_test_image):
     ans = d.get_bounding_mask()
     print(np.where(ans[0]))
 
-    mask = np.zeros(5 * 7, dtype=np.bool)
+    mask = np.zeros(5 * 7, dtype=bool)
     for i in [3,  8,  9, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 22, 23, 24,
               25, 26, 31]:
         mask[i] = True
@@ -687,13 +687,13 @@ def check_ignore_ignore(d):
     shape1 = 'ellipse(4260,3840,3,2,0)'
     d.notice2d(shape1, ignore=True)
 
-    mask1 = ~Region(shape1).mask(d.x0, d.x1).astype(np.bool)
+    mask1 = ~Region(shape1).mask(d.x0, d.x1).astype(bool)
     assert d.mask == pytest.approx(mask1)
 
     shape2 = 'rect(4258,3830,4264,3841)'
     d.notice2d(shape2, ignore=True)
 
-    mask2 = ~Region(shape2).mask(d.x0, d.x1).astype(np.bool)
+    mask2 = ~Region(shape2).mask(d.x0, d.x1).astype(bool)
     assert d.mask == pytest.approx(mask1 & mask2)
 
     shape2 = shape2.replace('rect', 'rectangle')
@@ -707,13 +707,13 @@ def check_ignore_ignore2(d):
     shape1 = 'ellipse(4260,3840,3,2,0)'
     d.notice2d(shape1, ignore=True)
 
-    mask1 = ~Region(shape1).mask(d.x0, d.x1).astype(np.bool)
+    mask1 = ~Region(shape1).mask(d.x0, d.x1).astype(bool)
     assert d.mask == pytest.approx(mask1)
 
     shape2 = 'rect(4258,3830,4264,3841)'
     d.notice2d(shape2, ignore=True)
 
-    mask2 = ~Region(shape2).mask(d.x0, d.x1).astype(np.bool)
+    mask2 = ~Region(shape2).mask(d.x0, d.x1).astype(bool)
     assert d.mask == pytest.approx(mask1 & mask2)
 
     shape2 = shape2.replace('rect', 'rectangle')

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -172,12 +172,8 @@ def test_read_pha_fails_rmf(make_data_path):
     assert emsg in str(excinfo.value)
 
 
-def validate_replacement_warning(ws, rtype, label, is_known_warning):
+def validate_replacement_warning(ws, rtype, label):
     """Check that there is one expected warning."""
-
-    # Filter out the "allowed" warnings.
-    #
-    ws = [w for w in ws if not is_known_warning(w)]
 
     assert len(ws) == 1
     w = ws[0]
@@ -190,7 +186,7 @@ def validate_replacement_warning(ws, rtype, label, is_known_warning):
 
 @requires_data
 @requires_fits
-def test_read_arf(make_data_path, is_known_warning):
+def test_read_arf(make_data_path):
     """Can we read in a Swift ARF."""
 
     infile = make_data_path(ARFFILE)
@@ -199,7 +195,7 @@ def test_read_arf(make_data_path, is_known_warning):
         warnings.simplefilter("always")
         arf = io.read_arf(infile)
 
-    validate_replacement_warning(ws, 'ARF', infile, is_known_warning)
+    validate_replacement_warning(ws, 'ARF', infile)
 
     assert isinstance(arf, DataARF)
 
@@ -267,7 +263,7 @@ def test_read_arf_fails_rmf(make_data_path):
 
 @requires_data
 @requires_fits
-def test_read_rmf(make_data_path, is_known_warning):
+def test_read_rmf(make_data_path):
     """Can we read in a Swift RMF."""
 
     infile = make_data_path(RMFFILE)
@@ -276,7 +272,7 @@ def test_read_rmf(make_data_path, is_known_warning):
         warnings.simplefilter("always")
         rmf = io.read_rmf(infile)
 
-    validate_replacement_warning(ws, 'RMF', infile, is_known_warning)
+    validate_replacement_warning(ws, 'RMF', infile)
 
     assert isinstance(rmf, DataRMF)
 
@@ -367,7 +363,7 @@ def test_read_rmf_fails_arf(make_data_path):
 
 @requires_data
 @requires_fits
-def test_can_use_swift_data(make_data_path, is_known_warning):
+def test_can_use_swift_data(make_data_path):
     """A basic check that we can read in and use the Swift data.
 
     Unlike the previous tests, that directly access the io module,
@@ -388,14 +384,14 @@ def test_can_use_swift_data(make_data_path, is_known_warning):
         warnings.simplefilter("always")
         ui.load_rmf(rmffile)
 
-    validate_replacement_warning(ws, 'RMF', rmffile, is_known_warning)
+    validate_replacement_warning(ws, 'RMF', rmffile)
 
     arffile = make_data_path(ARFFILE)
     with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter("always")
         ui.load_arf(arffile)
 
-    validate_replacement_warning(ws, 'ARF', arffile, is_known_warning)
+    validate_replacement_warning(ws, 'ARF', arffile)
 
     assert ui.get_analysis() == 'energy'
 

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -88,7 +89,7 @@ def test_sourceplot():
                        9993, 9994, 9994, 9995, 9996, 9996, 9997, 9997,
                        9997, 9998, 9998])
 
-    assert (sp.y.astype(np.int) == yexp).all()
+    assert (sp.y.astype(int) == yexp).all()
     # sp.plot()
 
 

--- a/sherpa/astro/ui/tests/test_astro_supports_pha2.py
+++ b/sherpa/astro/ui/tests/test_astro_supports_pha2.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -413,7 +414,7 @@ def test_746(make_data_path, clean_astro_ui):
 
     # Add in the line
     d10 = ui.get_data(10)
-    idx = np.arange(4068, 4075, dtype=np.int)
+    idx = np.arange(4068, 4075, dtype=int)
     d10.counts[idx] = [1, 1, 1, 2, 3, 1, 1]
 
     # group the data

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -110,13 +110,13 @@ def test_calc_flux_pha_bin_edges(clean_astro_ui):
     faked data that is made to make the behavior "obvious".
     """
 
-    chans = np.arange(1, 11, 1, dtype=np.int)
-    counts = np.zeros(chans.size, dtype=np.int)
+    chans = np.arange(1, 11, 1, dtype=int)
+    counts = np.zeros(chans.size, dtype=int)
 
     # "perfect" response
     energies = np.arange(1, 12, 1)
     elo, ehi = energies[:-1], energies[1:]
-    flat = np.ones(chans.size, dtype=np.int)
+    flat = np.ones(chans.size, dtype=int)
 
     d = ui.DataPHA('example', chans, counts)
     arf = ui.create_arf(elo, ehi, flat)
@@ -181,13 +181,13 @@ def test_calc_flux_pha_density_bin_edges(clean_astro_ui):
     faked data that is made to make the behavior "obvious".
     """
 
-    chans = np.arange(1, 11, 1, dtype=np.int)
-    counts = np.zeros(chans.size, dtype=np.int)
+    chans = np.arange(1, 11, 1, dtype=int)
+    counts = np.zeros(chans.size, dtype=int)
 
     # "perfect" response
     energies = np.arange(1, 12, 1)
     elo, ehi = energies[:-1], energies[1:]
-    flat = np.ones(chans.size, dtype=np.int)
+    flat = np.ones(chans.size, dtype=int)
 
     d = ui.DataPHA('example', chans, counts)
     arf = ui.create_arf(elo, ehi, flat)

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -2800,7 +2800,7 @@ def test_data1dint_plot_model(cls, plottype, extraargs, title):
 
     # Check for nan
     #
-    good = np.ones(11, dtype=np.bool)
+    good = np.ones(11, dtype=bool)
     good[6] = False
     assert np.isfinite(xplot) == pytest.approx(good)
     assert np.isfinite(yplot) == pytest.approx(good)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021
-#                Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -116,10 +116,6 @@ known_warnings = {
             r'np.asscalar\(a\) is deprecated since NumPy v1.16, use a.item\(\) instead',
             r"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working",
 
-            # numpy 1.20 bool/float issue
-            r'`np.bool` is a deprecated alias for the builtin `bool`. .*',
-            r'`np.int` is a deprecated alias for the builtin `int`. .*',
-            r'`np.float` is a deprecated alias for the builtin `float`. .*',
         ],
     UserWarning:
         [

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -423,7 +424,7 @@ def projection(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
     #  searched on
     upper_limits = numpy.array([])        # Upper limits for parameters
     #  searched on
-    eflags = numpy.array([], numpy.int)   # Fail status after search for
+    eflags = numpy.array([], int)         # Fail status after search for
     # each parameter
     nfits = 0                             # Total number of fits
 
@@ -476,7 +477,7 @@ def projection(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
         append = numpy.append
         lower_limits = numpy.array([])
         upper_limits = numpy.array([])
-        eflags = numpy.array([], numpy.int)
+        eflags = numpy.array([], int)
         nfits = 0
         for i in range(numsearched):
             singlebounds = func(i, limit_parnums[i])

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -724,7 +724,7 @@ class IterFit(NoNewAttributesAfterInit):
         # Keep record of current and previous statistics;
         # when these are within some tolerace, Primini's method
         # is done.
-        previous_stat = np.float32(np.finfo(np.float32).max)
+        previous_stat = np.finfo(np.float32).max
         current_stat = statfunc(pars)[0]
         nfev = 0
         iters = 0

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -27,7 +27,7 @@ from functools import wraps
 import numpy as np
 
 from numpy import arange, array, abs, iterable, sqrt, where, \
-    ones_like, isnan, isinf, any, int
+    ones_like, isnan, isinf, any
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, \
     bool_cast, is_in, is_iterable, list_to_open_interval, sao_fcmp
 from sherpa.utils.err import FitErr, EstErr, SherpaErr

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -703,7 +703,7 @@ class IterFit(NoNewAttributesAfterInit):
         # Get tolerance, max number of iterations from the
         # dictionary for Primini's method
         tol = self.itermethod_opts['tol']
-        if type(tol) != int and type(tol) != np.float:
+        if type(tol) != int and type(tol) != float:
             raise SherpaErr(
                 "'tol' value for Primini's method must be a number")
         maxiters = self.itermethod_opts['maxiters']
@@ -835,7 +835,7 @@ class IterFit(NoNewAttributesAfterInit):
             raise SherpaErr("'maxiters' must be one or greater")
 
         hrej = self.itermethod_opts['hrej']
-        if type(hrej) != int and type(hrej) != np.float:
+        if type(hrej) != int and type(hrej) != float:
             raise SherpaErr(
                 "'hrej' value for sigma rejection method must be a number")
         if hrej <= 0:
@@ -844,7 +844,7 @@ class IterFit(NoNewAttributesAfterInit):
         lrej = self.itermethod_opts['lrej']
         # FIXME: [OL] There are more reliable ways of checking if an object
         # is (not) a number.
-        if type(lrej) != int and type(lrej) != np.float:
+        if type(lrej) != int and type(lrej) != float:
             raise SherpaErr(
                 "'lrej' value for sigma rejection method must be a number")
         if lrej <= 0:

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -24,8 +24,10 @@ import signal
 
 from functools import wraps
 
+import numpy as np
+
 from numpy import arange, array, abs, iterable, sqrt, where, \
-    ones_like, isnan, isinf, float, float32, finfo, any, int
+    ones_like, isnan, isinf, any, int
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, \
     bool_cast, is_in, is_iterable, list_to_open_interval, sao_fcmp
 from sherpa.utils.err import FitErr, EstErr, SherpaErr
@@ -701,7 +703,7 @@ class IterFit(NoNewAttributesAfterInit):
         # Get tolerance, max number of iterations from the
         # dictionary for Primini's method
         tol = self.itermethod_opts['tol']
-        if type(tol) != int and type(tol) != float:
+        if type(tol) != int and type(tol) != np.float:
             raise SherpaErr(
                 "'tol' value for Primini's method must be a number")
         maxiters = self.itermethod_opts['maxiters']
@@ -722,7 +724,7 @@ class IterFit(NoNewAttributesAfterInit):
         # Keep record of current and previous statistics;
         # when these are within some tolerace, Primini's method
         # is done.
-        previous_stat = float32(finfo(float32).max)
+        previous_stat = np.float32(np.finfo(np.float32).max)
         current_stat = statfunc(pars)[0]
         nfev = 0
         iters = 0
@@ -833,7 +835,7 @@ class IterFit(NoNewAttributesAfterInit):
             raise SherpaErr("'maxiters' must be one or greater")
 
         hrej = self.itermethod_opts['hrej']
-        if type(hrej) != int and type(hrej) != float:
+        if type(hrej) != int and type(hrej) != np.float:
             raise SherpaErr(
                 "'hrej' value for sigma rejection method must be a number")
         if hrej <= 0:
@@ -842,7 +844,7 @@ class IterFit(NoNewAttributesAfterInit):
         lrej = self.itermethod_opts['lrej']
         # FIXME: [OL] There are more reliable ways of checking if an object
         # is (not) a number.
-        if type(lrej) != int and type(lrej) != float:
+        if type(lrej) != int and type(lrej) != np.float:
             raise SherpaErr(
                 "'lrej' value for sigma rejection method must be a number")
         if lrej <= 0:
@@ -1254,7 +1256,7 @@ class Fit(NoNewAttributesAfterInit):
 
         # check if any parameter values are at boundaries,
         # and warn user.
-        tol = finfo(float32).eps
+        tol = np.finfo(np.float32).eps
         param_warnings = ""
         for par in self.model.pars:
             if not par.frozen:

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1962,7 +1962,7 @@ class Integrator1D(CompositeModel, RegriddableModel1D):
 class Integrate1D(RegriddableModel1D):
 
     def __init__(self, name='integrate1d'):
-        tol = numpy.finfo(float).eps  # should this be DBL_EPSILON?
+        tol = DBL_EPSILON
         self.epsabs = Parameter(name, 'epsabs', tol, alwaysfrozen=True)
         self.epsrel = Parameter(name, 'epsrel', 0, alwaysfrozen=True)
         self.maxeval = Parameter(name, 'maxeval', 10000, alwaysfrozen=True)

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -45,7 +45,7 @@ __all__ = ('Box1D', 'Const1D', 'Cos', 'Delta1D', 'Erf', 'Erfc', 'Exp', 'Exp10',
            'NormGauss2D', 'Polynom2D', 'Scale2D', 'UserModel', 'TableModel',
            'Integrate1D')
 
-DBL_EPSILON = numpy.finfo(numpy.float).eps
+DBL_EPSILON = numpy.finfo(float).eps
 
 
 class Box1D(RegriddableModel1D):
@@ -1962,7 +1962,7 @@ class Integrator1D(CompositeModel, RegriddableModel1D):
 class Integrate1D(RegriddableModel1D):
 
     def __init__(self, name='integrate1d'):
-        tol = numpy.finfo(float).eps
+        tol = numpy.finfo(float).eps  # should this be DBL_EPSILON?
         self.epsabs = Parameter(name, 'epsabs', tol, alwaysfrozen=True)
         self.epsrel = Parameter(name, 'epsrel', 0, alwaysfrozen=True)
         self.maxeval = Parameter(name, 'maxeval', 10000, alwaysfrozen=True)

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2017, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2017, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -41,8 +42,8 @@ __all__ = ('Parameter', 'CompositeParameter', 'ConstantParameter',
 # hugeval = 1.0e+38
 #
 # Use FLT_TINY and FLT_MAX
-tinyval = numpy.float(numpy.finfo(numpy.float32).tiny)
-hugeval = numpy.float(numpy.finfo(numpy.float32).max)
+tinyval = float(numpy.finfo(numpy.float32).tiny)
+hugeval = float(numpy.finfo(numpy.float32).max)
 
 
 def _make_set_limit(name):

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -68,7 +69,7 @@ class Strategy:
         arg[-1] = self.func(arg[:-1])
         tmp = numpy.empty(self.npar + 2)
         tmp[1:] = arg[:]
-        if numpy.float_(numpy.finfo(numpy.float_).max) == arg[-1]:
+        if numpy.finfo(numpy.float_).max == arg[-1]:
             tmp[0] = 0
         else:
             tmp[0] = 1

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -126,8 +127,7 @@ class Opt:
 
         def func_bounds_wrapper(x, *args):
             if self._outside_limits(x, xmin, xmax):
-                FUNC_MAX = np.float_(np.finfo(np.float_).max)
-                return FUNC_MAX
+                return np.finfo(np.float_).max
             return func(x, *args)
 
         return func_bounds_wrapper

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -1153,7 +1153,7 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
         def __init__(self, func, fvec, pars):
             self.func = func
             self.fvec = fvec
-            epsmch = numpy.float_(numpy.finfo(numpy.float).eps)
+            epsmch = numpy.float_(numpy.finfo(float).eps)
             self.eps = numpy.sqrt(max(epsmch, epsfcn))
             self.h = self.calc_h(pars)
             self.pars = numpy.copy(pars)

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -93,9 +93,7 @@ EPSILON = numpy.float_(numpy.finfo(numpy.float32).eps)
 # has exceeded parameter boundaries.  All the optimizers expect double
 # precision arguments, so we use numpy.float_ instead of SherpaFloat.
 #
-# As of numpy 0.9.5, 'max' is a 0-D array, which seems like a bug.
-#
-FUNC_MAX = numpy.float_(numpy.finfo(numpy.float_).max)
+FUNC_MAX = numpy.finfo(numpy.float_).max
 
 
 def _check_args(x0, xmin, xmax):
@@ -1153,7 +1151,7 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
         def __init__(self, func, fvec, pars):
             self.func = func
             self.fvec = fvec
-            epsmch = numpy.float_(numpy.finfo(float).eps)
+            epsmch = numpy.finfo(float).eps
             self.eps = numpy.sqrt(max(epsmch, epsfcn))
             self.h = self.calc_h(pars)
             self.pars = numpy.copy(pars)

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2011, 2015, 2016, 2018, 2019, 2020, 2021
-#      Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -219,7 +219,7 @@ from sherpa.optmethods import LevMar
 info = logging.getLogger("sherpa").info
 _log = logging.getLogger("sherpa")
 
-_tol = numpy.finfo(numpy.float).eps
+_tol = numpy.finfo(float).eps
 
 string_types = (str, )
 

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -202,13 +203,13 @@ class Walk():
         niter = self.niter
         nelem = niter+1
 
-        proposals = np.zeros((nelem, npars), dtype=np.float)
+        proposals = np.zeros((nelem, npars), dtype=float)
         proposals[0] = pars.copy()
 
-        stats = np.zeros(nelem, dtype=np.float)
+        stats = np.zeros(nelem, dtype=float)
         stats[0] = stat
 
-        acceptflag = np.zeros(nelem, dtype=np.bool)
+        acceptflag = np.zeros(nelem, dtype=bool)
 
         # Iterations
         # - no burn in at present

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -340,7 +341,7 @@ class ParameterSample(NoNewAttributesAfterInit):
         """
 
         niter = samples.shape[0]
-        clipped = numpy.zeros(niter, dtype=numpy.bool)
+        clipped = numpy.zeros(niter, dtype=bool)
         if clip == 'none':
             return clipped
 

--- a/sherpa/sim/simulate.py
+++ b/sherpa/sim/simulate.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2010, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -38,7 +39,7 @@ logger = logging.getLogger("sherpa")
 debug = logger.debug
 info = logger.info
 
-_tol = numpy.finfo(numpy.float).eps
+_tol = numpy.finfo(float).eps
 
 __all__ = ('LikelihoodRatioTest', 'LikelihoodRatioResults')
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -260,9 +261,9 @@ def setup_pha_single(scalar, usestat, usesys, flo, fhi,
     # The channel starts at 1 just to follow the expected PHA
     # behavior, but it should not matter here.
     #
-    channels = np.arange(1, 6, dtype=np.int)
-    src_counts = np.asarray([14, 15, 11, 3, 8], dtype=np.int)
-    bg_counts = np.asarray([2, 0, 2, 3, 4], dtype=np.int)
+    channels = np.arange(1, 6, dtype=int)
+    src_counts = np.asarray([14, 15, 11, 3, 8], dtype=int)
+    bg_counts = np.asarray([2, 0, 2, 3, 4], dtype=int)
 
     # TODO: can add a grouping flag; if given use a larger set of bins and set
     # up grouping
@@ -1385,7 +1386,7 @@ def test_fit_calc_stat_wstat_grouped_single(flo, fhi, expected):
     """
 
     nbins = 20
-    channels = np.arange(1, nbins + 1, dtype=np.int)
+    channels = np.arange(1, nbins + 1, dtype=int)
     src_counts = (10 + 5 * np.sin(channels / 2.0)).astype(np.int8)
     bg_counts = np.ones(nbins, dtype=np.int8)
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1902,8 +1902,8 @@ def dataspace2d(dim):
         raise TypeError("dimensions should be > 0, found dim0 %s dim1 %s"
                         % (dim[0], dim[1]))
 
-    x0 = numpy.arange(dim[0], dtype=numpy.float) + 1.0
-    x1 = numpy.arange(dim[1], dtype=numpy.float) + 1.0
+    x0 = numpy.arange(dim[0], dtype=float) + 1.0
+    x1 = numpy.arange(dim[1], dtype=float) + 1.0
 
     x0, x1 = numpy.meshgrid(x0, x1)
     shape = tuple(x0.shape)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
-#     Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -3079,7 +3079,7 @@ class NumDerivFowardPartial(NumDeriv):
     def __call__(self, x, h, *args):
 
         if 0.0 == h:
-            h = pow(numpy.float_(numpy.finfo(numpy.float32)).eps, 1.0 / 3.0)
+            h = pow(numpy.finfo(numpy.float32).eps, 1.0 / 3.0)
 
         ith = args[0]
         jth = args[1]
@@ -3144,7 +3144,7 @@ class NumDerivCentralPartial(NumDeriv):
     def __call__(self, x, h, *args):
 
         if 0.0 == h:
-            h = pow(numpy.float_(numpy.finfo(numpy.float32)).eps, 1.0 / 3.0)
+            h = pow(numpy.finfo(numpy.float32).eps, 1.0 / 3.0)
 
         ith = args[0]
         jth = args[1]
@@ -4058,7 +4058,7 @@ def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
 
         xc = xa
         fc = fa
-        DBL_EPSILON = numpy.float_(numpy.finfo(numpy.float32).eps)
+        DBL_EPSILON = numpy.finfo(numpy.float32).eps
         while nfev[0] < maxfev:
 
             prev_step = xb - xa

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1400,7 +1400,7 @@ def create_expr(vals, mask=None, format='%s', delim='-'):
         # Ensure we have a boolean array to make indexing behave sensibly
         # (NumPy 1.17 or so changed behavior related to this).
         #
-        mask = numpy.asarray(mask, dtype=numpy.bool)
+        mask = numpy.asarray(mask, dtype=bool)
 
         # Ensure that the vals and mask array match: the number of
         # mask=True elements should equal the number of input values.
@@ -1605,7 +1605,7 @@ def quantile(sorted_array, f):
     n = sorted_array.size
 
     q = (n - 1) * f
-    i = numpy.int(numpy.floor(q))
+    i = int(numpy.floor(q))
     delta = q - i
 
     return (1.0 - delta) * sorted_array[i] + delta * sorted_array[i + 1]

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -347,7 +347,7 @@ def test_filter_bins_scalar_array_empty():
     """Edge case: do we care about this result?"""
 
     f = utils.filter_bins([1], [2], [[]])
-    assert f.dtype == numpy.bool
+    assert f.dtype == bool
     assert len(f) == 0
 
 
@@ -574,15 +574,15 @@ def test_create_expr_empty():
 
 def test_create_expr_empty_mask():
     """What happens if the mask is all masked out"""
-    mask = numpy.zeros(5, dtype=numpy.bool)
+    mask = numpy.zeros(5, dtype=bool)
 
     out = utils.create_expr([], mask)
     assert out == ""
 
 
 @pytest.mark.parametrize("mask",
-                         [numpy.zeros(5, dtype=numpy.bool),
-                          numpy.ones(2, dtype=numpy.bool)])
+                         [numpy.zeros(5, dtype=bool),
+                          numpy.ones(2, dtype=bool)])
 def test_create_expr_mask_size_error(mask):
     """What happens when the mask][True] and vals arrays have different sizes?
 
@@ -617,7 +617,7 @@ def test_create_expr_mask():
     """Simple test of create_expr with an identity mask."""
 
     chans = numpy.arange(1, 10, dtype=numpy.int16)
-    mask = numpy.ones(9, dtype=numpy.bool)
+    mask = numpy.ones(9, dtype=bool)
     out = utils.create_expr(chans, mask)
     assert out == "1-9"
 
@@ -634,7 +634,7 @@ def test_create_expr_mask_delim():
     """Simple test of create_expr with an identity mask."""
 
     chans = numpy.arange(1, 10, dtype=numpy.int16)
-    mask = numpy.ones(9, dtype=numpy.bool)
+    mask = numpy.ones(9, dtype=bool)
     out = utils.create_expr(chans, mask, delim='::')
     assert out == "1::9"
 
@@ -810,7 +810,7 @@ def test_create_expr_mask_drop():
 def test_create_expr_mask_singlebin(idx):
     """mask all the things (but leave one bin)"""
 
-    filt = numpy.zeros(19, dtype=numpy.bool)
+    filt = numpy.zeros(19, dtype=bool)
     filt[idx] = True
 
     vals = numpy.arange(19) * 0.01 + 0.4
@@ -822,7 +822,7 @@ def test_create_expr_mask_singlebin(idx):
 def test_create_expr_mask_singlebins():
     """several single bin"""
 
-    filt = numpy.zeros(19, dtype=numpy.bool)
+    filt = numpy.zeros(19, dtype=bool)
     filt[0] = True
     filt[2] = True
     filt[16] = True


### PR DESCRIPTION
# Summary

NumPy 1.20 notes that numpy.bool, numpy.int, and numpy.float will be removed and users should just use bool, int, and float instead, so these symbols have been changed. This is a follow on to #1092

# Details

This change should future-proof ourselves against the upcoming numpy release that removes these deprecated symbols (I haven't loked to see if they've announced when that would be).

Thanks to sherpa/fit.py importing the symbols directly this was a little-bit more complex than a simple search and replacement (i.e. numpy.x/np.int -> int). Our code could probably do with a review of when a "generic" float vs a specific type (float32 or float64) is useful, but I think the default is to assume float64-like values.

I am not sure whether we have any CI tests with NumPy 1.20 (but I assume so otherwise why would we have needed #1092 ?).

Note that #1143 and #1144 both came out of this, but they are un-related.