### PR TITLE
Fix some remaining master/main renames

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,8 +273,8 @@ source_suffix = '.rst'
 #
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'Sherpa'
@@ -343,7 +343,7 @@ pygments_style = 'sphinx'
 todo_include_todos = False
 
 # Graphviz based on values from AstroPy - see
-# https://github.com/astropy/sphinx-astropy/blob/master/sphinx_astropy/conf/v1.py
+# https://github.com/astropy/sphinx-astropy/blob/main/sphinx_astropy/conf/v1.py
 #
 graphviz_output_format = "svg"
 
@@ -508,7 +508,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Sherpa.tex', 'Sherpa Documentation',
+    (main_doc, 'Sherpa.tex', 'Sherpa Documentation',
      'Chandra X-ray Center', 'manual'),
 ]
 
@@ -550,7 +550,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'sherpa', 'Sherpa Documentation',
+    (main_doc, 'sherpa', 'Sherpa Documentation',
      [author], 1)
 ]
 
@@ -565,7 +565,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Sherpa', 'Sherpa Documentation',
+    (main_doc, 'Sherpa', 'Sherpa Documentation',
      author, 'Sherpa',
      'Sherpa is a modeling and fitting environment for Python.',
      'Miscellaneous'),

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -84,7 +84,7 @@ Citing Sherpa
 -------------
 
 Information on citing Sherpa can be found from the
-`CITATION document <https://github.com/sherpa/sherpa/blob/master/CITATION>`_
+`CITATION document <https://github.com/sherpa/sherpa/blob/main/CITATION>`_
 in the Sherpa repository, or from the
 `Sherpa Zenodo page <https://doi.org/10.5281/zenodo.593753>`_.
 
@@ -167,7 +167,7 @@ or from
 either a release version,
 such as the
 `4.10.0 <https://github.com/sherpa/sherpa/tree/4.10.0>`_ tag,
-or the ``master`` branch (which is not guaranteed to be stable).
+or the ``main`` branch (which is not guaranteed to be stable).
 
 For example::
 

--- a/sherpa/_version.py
+++ b/sherpa/_version.py
@@ -111,7 +111,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose=False):
         # refs/heads/ and refs/tags/ prefixes that would let us distinguish
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
-        # "stabilization", as well as "HEAD" and "master".
+        # "stabilization", as well as "HEAD" and "main".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs-tags))


### PR DESCRIPTION
# Summary
replace some master -> main strings

# Details
Mostly, I do this to correct the docs/install.rst page, but while
I was at it I replaced a few more, mostly in the comments.
And then thee is an unrelated renaming `master_doc` -> `main_doc`
for a variable in sphinx's `conf.py` which I renames just for good
measure and because it was easier to change thme all then to think
too hard if that one should stay.

[skip ci]
(rtd build will run nevertheless and there are no code changes except
for sphinx)