### PR TITLE
Add instruction for source build on Mac, that were previously only part of our internal release notes.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -390,7 +390,7 @@ be used when building and installing Sherpa.
    (Note that on MacOS, "gcc" is usally just an alias to Clang. Unless
    you specifically intall a gcc from a different source, you are
    likely to run into this problem, even if you believe that your
-   compiler is invoced with `gcc`.)
+   compiler is invoked with `gcc`.)
 
 
 A standard installation

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -387,8 +387,8 @@ be used when building and installing Sherpa.
 
      CFLAGS='-Wno-implicit-function-declaration'
 
-   (Note that on MacOS, "gcc" is usally just an alias to Clang. Unless
-   you specifically intall a gcc from a different source, you are
+   (Note that on MacOS, "gcc" is usually just an alias to Clang. Unless
+   you specifically install a gcc from a different source, you are
    likely to run into this problem, even if you believe that your
    compiler is invoked with `gcc`.)
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -84,7 +84,7 @@ Citing Sherpa
 -------------
 
 Information on citing Sherpa can be found from the
-`CITATION document <https://github.com/sherpa/sherpa/blob/master/CITATION>`_
+`CITATION document <https://github.com/sherpa/sherpa/blob/main/CITATION>`_
 in the Sherpa repository, or from the
 `Sherpa Zenodo page <https://doi.org/10.5281/zenodo.593753>`_.
 
@@ -167,7 +167,7 @@ or from
 either a release version,
 such as the
 `4.10.0 <https://github.com/sherpa/sherpa/tree/4.10.0>`_ tag,
-or the ``master`` branch (which is not guaranteed to be stable).
+or the ``main`` branch (which is not guaranteed to be stable).
 
 For example::
 
@@ -377,6 +377,21 @@ be used when building and installing Sherpa.
      export PYTHON_LDFLAGS=' '
 
    That is, the variable is set to a space, not the empty string.
+
+.. note::
+
+   Additionally, if you are building with Clang version 12, you will
+   encounter build issues in the region area related to an implicit
+   declaration. If so, pre-pending the following to your pip install
+   or python setup.py install line should resolve the build issues::
+
+     CFLAGS='-Wno-implicit-function-declaration'
+
+   (Note that on MacOS, "gcc" is usally just an alias to Clang. Unless
+   you specifically intall a gcc from a different source, you are
+   likely to run into this problem, even if you believe that your
+   compiler is invoced with `gcc`.)
+
 
 A standard installation
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
 Add instruction for source build on Mac, that were previously only part of the internal release notes.
   
fixes #1141
[skip ci]
(Because it does not touch any code files.)