### PR TITLE
A minor cleanup of estmethods 

### DIFF
--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -351,11 +351,10 @@ def covariance(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
     # simpler inv function for inverting matrices does not appear to
     # have the same issue.
 
-    invfunc = numpy.linalg.inv
     inv_info = None
 
     try:
-        inv_info = invfunc(info)
+        inv_info = numpy.linalg.inv(info)
 
     except numpy.linalg.linalg.LinAlgError:
         # catch the SVD exception and exit gracefully
@@ -363,14 +362,8 @@ def covariance(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
         inv_info[:] = numpy.nan
 
     except:
-        # Compatibility with pre-0.9.8 numpy
-        if hasattr(numpy.linalg, 'pinv'):
-            invfunc = numpy.linalg.pinv
-        else:
-            invfunc = numpy.linalg.generalized_inverse
-
         try:
-            inv_info = invfunc(info)
+            inv_info = numpy.linalg.pinv(info)
         except numpy.linalg.linalg.LinAlgError:
             # catch the SVD exception and exit gracefully
             inv_info = numpy.zeros_like(info)

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -413,20 +413,10 @@ def covariance(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
 def projection(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
                tol, maxiters, remin, limit_parnums, stat_cb, fit_cb,
                report_progress, get_par_name, do_parallel, numcores):
-    i = 0                                 # Iterate through parameters
-    #  to be searched on
-    numsearched = len(limit_parnums)      # Number of parameters to be
-    #  searched on (*not* number
-    #  of thawed parameters, just
-    #  number we are searching on
-    #  (i.e., len(limit_parnums))
-    lower_limits = numpy.array([])        # Lower limits for parameters
-    #  searched on
-    upper_limits = numpy.array([])        # Upper limits for parameters
-    #  searched on
-    eflags = numpy.array([], int)         # Fail status after search for
-    # each parameter
-    nfits = 0                             # Total number of fits
+
+    # Number of parameters to be searched on (*not* number of thawed
+    # parameters, just number we are searching on)
+    numsearched = len(limit_parnums)
 
     # _est_funcs.projection can be called on any subset of the thawed
     # parameters.  So we made a change here to call _est_funcs.projection
@@ -441,9 +431,6 @@ def projection(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
     # upon exiting the while loop, constructing a new tuple to return.
     # SMD 03/17/2009
 
-    # Keep references to numpy.append, _est_funcs.projection, because
-    # we call these functions every time through the loop.
-    append = numpy.append
     proj_func = _est_funcs.projection
 
     def func(i, singleparnum, lock=None):
@@ -474,17 +461,17 @@ def projection(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
         do_parallel = False
 
     if not do_parallel:
-        append = numpy.append
-        lower_limits = numpy.array([])
-        upper_limits = numpy.array([])
-        eflags = numpy.array([], int)
+        lower_limits = numpy.zeros(numsearched)
+        upper_limits = numpy.zeros(numsearched)
+        eflags = numpy.zeros(numsearched, dtype=int)
         nfits = 0
-        for i in range(numsearched):
-            singlebounds = func(i, limit_parnums[i])
-            lower_limits = append(lower_limits, singlebounds[0])
-            upper_limits = append(upper_limits, singlebounds[1])
-            eflags = append(eflags, singlebounds[2])
+        for i, pnum in enumerate(limit_parnums):
+            singlebounds = func(i, pnum)
+            lower_limits[i] = singlebounds[0]
+            upper_limits[i] = singlebounds[1]
+            eflags[i] = singlebounds[2]
             nfits = nfits + singlebounds[3]
+
         return (lower_limits, upper_limits, eflags, nfits, None)
 
     return parallel_est(func, limit_parnums, pars, numcores)

--- a/sherpa/estmethods/tests/test_estmethods.py
+++ b/sherpa/estmethods/tests/test_estmethods.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2018, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2018, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,8 +20,9 @@
 
 import numpy
 
+import pytest
+
 from sherpa.estmethods import Covariance, Projection
-from sherpa.utils.testing import SherpaTestCase
 
 
 # Test data arrays -- together this makes a line best fit with a
@@ -103,73 +105,99 @@ def fitter(scb, pars, parmins, parmaxs):
     return (1, pars, scb(pars)[0])
 
 
-class test_estmethods(SherpaTestCase):
+def test_covar_failures1():
+    with pytest.raises(TypeError):
+        Covariance().compute(None, fitter, fittedpars,
+                             minpars, maxpars,
+                             hardminpars, hardmaxpars,
+                             limit_parnums, freeze_par, thaw_par,
+                             report_progress)
 
-    def test_covar_failures(self):
-        self.assertRaises(TypeError, Covariance().compute,
-                          None, fitter, fittedpars,
+
+def test_covar_failures2():
+    with pytest.raises(RuntimeError):
+        Covariance().compute(stat, fitter, None, minpars, maxpars,
+                             hardminpars, hardmaxpars, limit_parnums, freeze_par,
+                             thaw_par, report_progress, get_par_name)
+
+
+def test_covar_failures3():
+    with pytest.raises(RuntimeError):
+        Covariance().compute(stat, fitter, numpy.array([1, 2]),
+                             minpars, maxpars, hardminpars, hardmaxpars,
+                             limit_parnums, freeze_par, thaw_par,
+                             report_progress, get_par_name)
+
+
+def test_covar_failures4():
+    with pytest.raises(RuntimeError):
+        Covariance().compute(stat, fitter, fittedpars, numpy.array([1, 2]),
+                             maxpars, hardminpars, hardmaxpars, limit_parnums,
+                             freeze_par, thaw_par, report_progress, get_par_name)
+
+
+def test_projection_failures1():
+    with pytest.raises(TypeError):
+        Projection().compute(stat, None, fittedpars, minpars, maxpars,
+                             hardminpars, hardmaxpars, limit_parnums, freeze_par,
+                             thaw_par, report_progress, get_par_name)
+
+
+def test_projection_failures2():
+    with pytest.raises(RuntimeError):
+        Projection().compute(stat, fitter, None, minpars, maxpars,
+                             hardminpars, hardmaxpars, limit_parnums,
+                             freeze_par, thaw_par, report_progress, get_par_name)
+
+
+def test_projection_failures3():
+    with pytest.raises(RuntimeError):
+        Projection().compute(stat, fitter, numpy.array([1, 2]),
+                             minpars, maxpars, hardminpars, hardmaxpars,
+                             limit_parnums, freeze_par, thaw_par,
+                             report_progress, get_par_name)
+
+
+def test_projection_failures4():
+    with pytest.raises(RuntimeError):
+        Projection().compute(stat, fitter, fittedpars, numpy.array([1, 2]),
+                             maxpars, hardminpars, hardmaxpars, limit_parnums,
+                             freeze_par, thaw_par, report_progress, get_par_name)
+
+
+def test_covar():
+    standard = numpy.array([[0.4935702,  0.06857833, numpy.nan],
+                            [0.06857833, 0.26405554, numpy.nan],
+                            [numpy.nan,  numpy.nan,  2.58857314]])
+
+    cov = Covariance()
+    results = cov.compute(stat, None, fittedpars,
                           minpars, maxpars,
                           hardminpars, hardmaxpars,
-                          limit_parnums, freeze_par, thaw_par, report_progress)
-
-        self.assertRaises(RuntimeError, Covariance().compute,
-                          stat, fitter, None, minpars, maxpars,
-                          hardminpars, hardmaxpars, limit_parnums, freeze_par,
-                          thaw_par, report_progress, get_par_name)
-
-        self.assertRaises(RuntimeError, Covariance().compute,
-                          stat, fitter, numpy.array([1, 2]),
-                          minpars, maxpars, hardminpars, hardmaxpars,
                           limit_parnums, freeze_par, thaw_par,
                           report_progress, get_par_name)
 
-        self.assertRaises(RuntimeError, Covariance().compute,
-                          stat, fitter, fittedpars, numpy.array([1, 2]),
-                          maxpars, hardminpars, hardmaxpars, limit_parnums,
-                          freeze_par, thaw_par, report_progress, get_par_name)
+    # These tests used to have a tolerance of 1e-4 but it appears to
+    # be able to use a more-restrictive tolerance.
+    #
+    expected = standard.diagonal()
+    assert results[1] == pytest.approx(expected)
 
-    def test_projection_failures(self):
-        self.assertRaises(TypeError, Projection().compute,
-                          stat, None, fittedpars, minpars, maxpars,
-                          hardminpars, hardmaxpars, limit_parnums, freeze_par,
-                          thaw_par, report_progress, get_par_name)
 
-        self.assertRaises(RuntimeError, Projection().compute,
-                          stat, fitter, None, minpars, maxpars,
-                          hardminpars, hardmaxpars, limit_parnums,
-                          freeze_par, thaw_par, report_progress, get_par_name)
+def test_projection():
+    standard_elo = numpy.array([-0.39973743, -0.26390339, -2.08784716])
+    standard_ehi = numpy.array([0.39580942,  0.26363223,  2.08789851])
 
-        self.assertRaises(RuntimeError, Projection().compute,
-                          stat, fitter, numpy.array([1, 2]),
-                          minpars, maxpars, hardminpars, hardmaxpars,
-                          limit_parnums, freeze_par, thaw_par,
-                          report_progress, get_par_name)
+    proj = Projection()
+    results = proj.compute(stat, fitter, fittedpars,
+                           minpars, maxpars,
+                           hardminpars, hardmaxpars,
+                           limit_parnums, freeze_par, thaw_par,
+                           report_progress, get_par_name)
 
-        self.assertRaises(RuntimeError, Projection().compute,
-                          stat, fitter, fittedpars, numpy.array([1, 2]),
-                          maxpars, hardminpars, hardmaxpars, limit_parnums,
-                          freeze_par, thaw_par, report_progress, get_par_name)
-
-    def test_covar(self):
-        standard = numpy.array([[0.4935702,  0.06857833, numpy.nan],
-                                [0.06857833, 0.26405554, numpy.nan],
-                                [numpy.nan,  numpy.nan,  2.58857314]])
-        results = Covariance().compute(stat, None, fittedpars,
-                                       minpars, maxpars,
-                                       hardminpars, hardmaxpars,
-                                       limit_parnums, freeze_par, thaw_par,
-                                       report_progress, get_par_name)
-        self.assertEqualWithinTol(standard.diagonal(),
-                                  # results[2].diagonal(), 1e-4)
-                                  results[1], 1e-4)
-
-    def test_projection(self):
-        standard_elo = numpy.array([-0.39973743, -0.26390339, -2.08784716])
-        standard_ehi = numpy.array([0.39580942,  0.26363223,  2.08789851])
-        results = Projection().compute(stat, fitter, fittedpars,
-                                       minpars, maxpars,
-                                       hardminpars, hardmaxpars,
-                                       limit_parnums, freeze_par, thaw_par,
-                                       report_progress, get_par_name)
-        self.assertEqualWithinTol(standard_elo, results[0], 1e-4)
-        self.assertEqualWithinTol(standard_ehi, results[1], 1e-4)
+    # These tests used to have a tolerance of 1e-4 but it appears to
+    # be able to use a more-restrictive tolerance (given that the
+    # "fitter" doesn't do a fit here).
+    #
+    assert results[0] == pytest.approx(standard_elo)
+    assert results[1] == pytest.approx(standard_ehi)

--- a/sherpa/estmethods/tests/test_estmethods.py
+++ b/sherpa/estmethods/tests/test_estmethods.py
@@ -165,6 +165,8 @@ def test_projection_failures4():
                              freeze_par, thaw_par, report_progress, get_par_name)
 
 
+# Unlike projection, covariance does not have a "parallel" option.
+#
 def test_covar():
     standard = numpy.array([[0.4935702,  0.06857833, numpy.nan],
                             [0.06857833, 0.26405554, numpy.nan],
@@ -184,11 +186,17 @@ def test_covar():
     assert results[1] == pytest.approx(expected)
 
 
-def test_projection():
+# There is no guarantee we can run with parallel=True but try to do so.
+#
+@pytest.mark.parametrize("parallel", [True, False])
+def test_projection(parallel):
     standard_elo = numpy.array([-0.39973743, -0.26390339, -2.08784716])
     standard_ehi = numpy.array([0.39580942,  0.26363223,  2.08789851])
 
     proj = Projection()
+    proj.parallel = parallel
+    assert proj.parallel == parallel
+
     results = proj.compute(stat, fitter, fittedpars,
                            minpars, maxpars,
                            hardminpars, hardmaxpars,


### PR DESCRIPTION
# Summary

A minor cleanup of the sherpa.estmethods code.

# Details

In writing #1138 I noticed a couple of issues with the code in sherpa/estmethods. This is not a complete scrub through of the module, but includes

- moving tests from `SherpaTestCase` to `pytest`
- removal of code talking about supporting Numpy 0.98 as we do not support such an old release
- a cleanup to `projection` to only define arrays when we need to (when `parallel` is `False`) and to avoid building up a list to then convert to NumPy when we know the size needed for the NumPy array 
- improve coverage of `projection` by testing out both the `parallel=True` and `False` branches (at least for those machines which have multiple cores and so can run the parallel code).