### PR TITLE
Test: fix XSPEC test that needs a requires_data decorator

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -782,6 +782,8 @@ def test_xspec_model_requires_bins_very_low_level(clsname):
 
 
 @requires_xspec
+@requires_data
+@requires_fits
 def test_xspec_tablemodel_requires_bin_edges(make_data_path, clean_astro_ui):
     """Check we can not call a table model with a single grid.
 


### PR DESCRIPTION
Turns out I've already created this PR, not that long ago (#1131) so I'm closing this.

# Summary

Fix a test that would error out if XSPEC support was compiled but the test data directory was not available.

# Details

In the unlikely event you have XSPEC support compiled in but have not installed the test data then this test would fail with a helpful message pointing out you need to add requires_data. So I have done that.