### PR TITLE
WIP Track actual pha filter ranges

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1233,7 +1233,6 @@ class DataPHA(Data1D):
     syserror
     bin_lo
     bin_hi
-    grouping
     quality
     exposure
     backscal
@@ -1335,7 +1334,9 @@ class DataPHA(Data1D):
             self._filter_recreate()
 
     grouping = property(_get_grouping, _set_grouping,
-                        doc='The grouping scheme.')
+                        doc='The grouping scheme.\n\nAn array, matching the ' +
+                        'channels attribute, where a 1 means the start\n' +
+                        'of a group and -1 continues the previous group.')
 
     def _get_subtracted(self):
         return self._subtracted

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -33,7 +33,7 @@ from sherpa.data import Data1DInt, Data2D, Data, Data2DInt, Data1D, \
 from sherpa.models.regrid import EvaluationSpace1D
 from sherpa.utils.err import DataErr, ImportErr
 from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
-    create_expr, parse_expr, bool_cast, rebin, filter_bins
+    create_expr, bool_cast, rebin, filter_bins
 from sherpa.utils import formatting
 
 # There are currently (Sep 2015) no tests that exercise the code that
@@ -1281,12 +1281,13 @@ class DataPHA(Data1D):
             raise DataErr('nogrouping', self.name)
 
         if self._grouped == val:
+            # TODO: check if this is sensible
             return
 
         self._grouped = val
 
         # Apply the existing filters, recreating the list as we go along.
-        # This used to obly be done if self.mask was set but now rely
+        # This used to only be done if self.mask was set but now rely
         # on the filter store to determine what needs to be re-evaluated.
         #
         self._filter_recreate()
@@ -1558,7 +1559,7 @@ class DataPHA(Data1D):
         # when we create it the first notice call will clear the
         # _filter_store list, resulting in the list being rebuilt.
         # We could avoid doing this but by going through notice we
-        # aim to keep al the invariants.
+        # aim to keep all the invariants.
         #
         ounits = self.units
         ostore = self._filter_store[:]

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1426,6 +1426,11 @@ class DataPHA(Data1D):
         self.areascal = areascal
         self.header = header
         self._grouped = (grouping is not None)
+        # _original_groups is set False if the grouping is changed via
+        # the _dynamic_groups method. This is currently only used by the
+        # serialization code (sherpa.astro.ui.serialize) to determine
+        # whether to write out the grouping data.
+        #
         self._original_groups = True
         self._subtracted = False
         self._response_ids = []

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1281,7 +1281,9 @@ class DataPHA(Data1D):
             raise DataErr('nogrouping', self.name)
 
         if self._grouped == val:
-            # TODO: check if this is sensible
+            # The _set_grouping call recognizes when the grouping array
+            # is changed and _filter_recreate is called, so we can
+            # do nothing here if the grouped setting is unchanged.
             return
 
         self._grouped = val

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1268,8 +1268,9 @@ class DataPHA(Data1D):
     .. [2] Private communication with Keith Arnaud
 
     """
-    _fields = ("name", "channel", "counts", "bin_lo", "bin_hi", "grouping", "quality",
-               "exposure", "backscal", "areascal")
+    _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'bin_lo', 'bin_hi', 'grouping', 'quality',
+               'exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate', 'plot_fac', 'response_ids',
+               'background_ids')
 
     def _get_grouped(self):
         return self._grouped
@@ -1406,10 +1407,6 @@ class DataPHA(Data1D):
 
     background_ids = property(_get_background_ids, _set_background_ids,
                               doc='IDs of defined background data sets')
-
-    _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'bin_lo', 'bin_hi', 'grouping', 'quality',
-               'exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate', 'plot_fac', 'response_ids',
-               'background_ids')
 
     def __init__(self, name, channel, counts, staterror=None, syserror=None,
                  bin_lo=None, bin_hi=None, grouping=None, quality=None,

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -225,11 +225,10 @@ class ModelHistogram(ModelPHAHistogram):
 
         finally:
             data.units = ounits
-            data.group()
 
-            # Recreate the filter
+            # Recalculate the filtering
             data._filter_store = ostate
-            data._filter_recreate()
+            data.group()
 
         # temporary check for #1024 being fixed
         old_filter2 = parse_expr(data.get_filter())
@@ -592,11 +591,10 @@ class OrderPlot(ModelHistogram):
         finally:
             if ogroup:
                 data.units = ounits
-                data.group()
 
-                # Recreate the filter
+                # Recalculate the filtering
                 data._filter_store = ostate
-                data._filter_recreate()
+                data.group()
 
         self.title = 'Model Orders %s' % str(self.orders)
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -587,17 +587,20 @@ class OrderPlot(ModelHistogram):
                 data._filter_store = ostate
                 data.group()
 
-        self.title = 'Model Orders %s' % str(self.orders)
+        self.title = f'Model Orders {self.orders}'
 
         if len(self.xlo) != len(self.y):
             raise PlotErr("orderarrfail")
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         default_color = self.histo_prefs['linecolor']
-        count = 0
+        first = True
         for xlo, xhi, y, color in \
                 zip(self.xlo, self.xhi, self.y, self.colors):
-            if count != 0:
+            if first:
+                # QUS: why do we not set linecolor to color here?
+                first = False
+            else:
                 overplot = True
                 self.histo_prefs['linecolor'] = color
 
@@ -606,7 +609,6 @@ class OrderPlot(ModelHistogram):
                            xlabel=self.xlabel, ylabel=self.ylabel,
                            overplot=overplot, clearwindow=clearwindow,
                            **kwargs)
-            count += 1
 
         self.histo_prefs['linecolor'] = default_color
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -509,8 +509,8 @@ class OrderPlot(ModelHistogram):
                 self.colors.append(top_color)
                 top_color = hex(int(top_color, 16) - jump)
 
-        if not self.use_default_colors and len(colors) != len(orders):
-            raise PlotErr('ordercolors', len(orders), len(colors))
+        if not self.use_default_colors and len(self.colors) != len(self.orders):
+            raise PlotErr('ordercolors', len(self.orders), len(self.colors))
 
         old_filter = parse_expr(data.get_filter())
         old_group = data.grouped
@@ -540,6 +540,8 @@ class OrderPlot(ModelHistogram):
             for order in self.orders:
                 self.xlo.append(xlo)
                 self.xhi.append(xhi)
+                # QUS: why check that response_ids > 2 and not 1 here?
+                #
                 if len(data.response_ids) > 2:
                     if order < 1 or order > len(model.rhs.orders):
                         raise PlotErr('notorder', order)

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -193,11 +193,6 @@ class ModelHistogram(ModelPHAHistogram):
             super().prepare(data, model, stat=stat)
             return
 
-        # Safety check that the filtering doesn't change anything
-        # (see #1024)
-        #
-        old_filter1 = parse_expr(data.get_filter())
-
         # We want to use the channel range that the grouped data
         # uses, not the requested filter range, as the latter is
         # going to use less channels in the un-grouped range.
@@ -229,10 +224,6 @@ class ModelHistogram(ModelPHAHistogram):
             # Recalculate the filtering
             data._filter_store = ostate
             data.group()
-
-        # temporary check for #1024 being fixed
-        old_filter2 = parse_expr(data.get_filter())
-        assert old_filter1 == old_filter2, (old_filter1, old_filter2)
 
 
 class SourcePlot(HistogramPlot):

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1249,7 +1249,7 @@ def test_grouping_filter(analysis, make_data_path):
     # test_grouping_filtering_binning.
     #
     pha.group_width(50)
-    dep = np.array([213, 136,  79,  47,  47,  29,  27, 18])
+    dep = np.array([136,  79,  47,  47,  29,  27, 18])
     assert pha.get_dep(filter=True) == pytest.approx(dep)
 
 
@@ -1306,7 +1306,7 @@ def test_grouping_filtering_binning(analysis, make_data_path):
     #   i=20  14.6000 - 14.9504
     #
     expected = np.zeros(21, dtype=bool)
-    expected[1:9] = True
+    expected[2:9] = True
     assert (pha.mask == expected).all()
 
     # For the ungrouped-data we have, selecting
@@ -1334,7 +1334,7 @@ def test_grouping_filtering_binning(analysis, make_data_path):
     #   i=480   7.0080 -  7.0226
     #
     expected = np.zeros(1024, dtype=bool)
-    expected[50:450] = True
+    expected[100:450] = True
     assert (pha.get_mask() == expected).all()
 
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1751,17 +1751,18 @@ def test_channel_changing_limits(make_data_path):
     #
     pha.notice(60, 350)
 
+    expected0 = '60:350'
     expected1 = '60:356'
     expected2 = '60:368'
     assert pha.get_filter() == expected1
     assert pha.get_filter(group=False) == expected2
 
-    # We now return the full filter range of the
-    # group, even when group=False.
+    # We now return the requested range as there's no grouping
+    # to expand it.
     #
     pha.ungroup()
-    assert pha.get_filter() == expected2
-    assert pha.get_filter(group=False) == expected2
+    assert pha.get_filter() == expected0
+    assert pha.get_filter(group=False) == expected0
 
     # We go back to the original filter
     pha.group()
@@ -1955,8 +1956,8 @@ def test_energy_filter_notice_ignore_ungrouped(make_data_path):
     assert pha.mask == pytest.approx(pha.get_mask())
 
     expected = np.zeros(1024, dtype=bool)
-    expected[32:68] = True
-    expected[139:676] = True
+    expected[34:68] = True
+    expected[137:480] = True
     assert pha.get_mask() == pytest.approx(expected)
 
 
@@ -2009,14 +2010,13 @@ def test_energy_filter_roundtrip(make_data_path):
 
     pha.ungroup()
     f2 = pha.get_filter()
-    assert f2 == '0.474500000477:0.985500007868,2.036700010300:9.862299919128'
+    assert f2 == '0.503699988127:0.985500007868,2.007500052452:7.000699996948'
 
     pha.group()
     f3 = pha.get_filter()
     assert f3 == expected
 
 
-@pytest.mark.xfail
 @requires_data
 @requires_fits
 def test_energy_filter_ordering(make_data_path):

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -816,3 +816,56 @@ def test_pha_invalid_units(invalid, make_test_pha):
         pha.units = invalid
 
     assert str(de.value) == f"unknown quantity: '{invalid}'"
+
+
+def test_pha_grouping_changed_no_filter_1160(make_test_pha):
+    """What happens when the grouping is changed?
+
+    See also test_pha_grouping_changed_filter_1160
+    """
+
+    pha = make_test_pha
+    d1 = pha.get_dep(filter=True)
+    assert d1 == pytest.approx([1, 2, 0, 3])
+
+    # grouping set but not grouped
+    pha.grouping = [1, 1, 1, 1]
+    d2 = pha.get_dep(filter=True)
+    assert d2 == pytest.approx([1, 2, 0, 3])
+
+    # now grouped
+    pha.grouped = True
+    d3 = pha.get_dep(filter=True)
+    assert d3 == pytest.approx([1, 2, 0, 3])
+
+    pha.grouping = [1, 1, -1, 1]
+    d4 = pha.get_dep(filter=True)
+    assert d4 == pytest.approx([1, 2, 3])
+
+
+@pytest.mark.xfail
+def test_pha_grouping_changed_filter_1160(make_test_pha):
+    """What happens when the grouping is changed?
+
+    See also test_pha_grouping_changed_filter_1160
+    """
+
+    pha = make_test_pha
+    pha.notice(2, 5)
+
+    d1 = pha.get_dep(filter=True)
+    assert d1 == pytest.approx([2, 0, 3])
+
+    # grouping set but not grouped
+    pha.grouping = [1, 1, 1, 1]
+    d2 = pha.get_dep(filter=True)
+    assert d2 == pytest.approx([2, 0, 3])
+
+    # now grouped
+    pha.grouped = True
+    d3 = pha.get_dep(filter=True)
+    assert d3 == pytest.approx([2, 0, 3])
+
+    pha.grouping = [1, 1, -1, 1]
+    d4 = pha.get_dep(filter=True)
+    assert d4 == pytest.approx([2, 3])

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -843,7 +843,6 @@ def test_pha_grouping_changed_no_filter_1160(make_test_pha):
     assert d4 == pytest.approx([1, 2, 3])
 
 
-@pytest.mark.xfail
 def test_pha_grouping_changed_filter_1160(make_test_pha):
     """What happens when the grouping is changed?
 
@@ -869,3 +868,33 @@ def test_pha_grouping_changed_filter_1160(make_test_pha):
     pha.grouping = [1, 1, -1, 1]
     d4 = pha.get_dep(filter=True)
     assert d4 == pytest.approx([2, 3])
+
+
+def test_pha_remove_grouping(make_test_pha):
+    """Check we can remove the grouping array."""
+
+    pha = make_test_pha
+    assert pha.grouping is None
+    assert not pha.grouped
+
+    pha.grouping = [1, -1, 1, -1]
+    assert not pha.grouped
+    pha.grouped = True
+    d1 = pha.get_dep(filter=True)
+    assert d1 == pytest.approx([3, 3])
+
+    pha.grouping = None
+    assert not pha.grouped
+    d2 = pha.get_dep(filter=True)
+    assert d2 == pytest.approx([1, 2, 0, 3])
+
+
+@pytest.mark.parametrize("grouping", [True, [1, 1], np.ones(10)])
+def test_pha_grouping_size(grouping, make_test_pha):
+    """Check we error out if grouping has the wrong size"""
+
+    pha = make_test_pha
+    with pytest.raises(DataErr) as de:
+        pha.grouping = grouping
+
+    assert str(de.value) == 'size mismatch between channel and grouping'

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -23,14 +23,15 @@ import pytest
 
 from sherpa.utils.testing import requires_data, requires_fits
 
-from sherpa.astro.data import DataPHA
+from sherpa.astro.data import DataARF, DataPHA
+from sherpa.astro.instrument import create_delta_rmf
 from sherpa.astro.plot import SourcePlot, \
-    DataPHAPlot, ModelPHAHistogram
+    DataPHAPlot, ModelPHAHistogram, OrderPlot
 from sherpa.astro import plot as aplot
 from sherpa.data import Data1D
-from sherpa.models.basic import Const1D, Gauss1D, Polynom1D
+from sherpa.models.basic import Const1D, Gauss1D, Polynom1D, PowLaw1D
 from sherpa import stats
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import IOErr, PlotErr
 from sherpa.utils.testing import requires_pylab
 
 
@@ -349,3 +350,110 @@ def test_pha_model_with_gaps_977():
     # before #977 is fixed.
     #
     assert (xlo[1:] == xhi[:-1]).all()
+
+
+# Based on sherpa/astro/ui/tests/test_astro_plot.py
+#
+_data_chan = np.linspace(1, 10, 10, dtype=np.int8)
+_data_counts = np.asarray([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                          dtype=np.int8)
+
+_arf = np.asarray([0.8, 0.8, 0.9, 1.0, 1.1, 1.1, 0.7, 0.6, 0.6, 0.6])
+
+# Using a "perfect" RMF, in that there's a one-to-one mapping
+# from channel to energy. I use a non-uniform grid to make
+# it obvious when the bin width is being used: when using a
+# constant bin width like 0.1 keV the factor of 10 is too easy
+# to confuse for other terms.
+#
+_energies = np.linspace(0.5, 1.5, 11)
+_energies = np.asarray([0.5, 0.65, 0.75, 0.8, 0.9, 1., 1.1, 1.12, 1.3, 1.4, 1.5])
+_energies_lo = _energies[:-1]
+_energies_hi = _energies[1:]
+
+
+def example_pha_data():
+    """Create an example data set."""
+
+    etime = 1201.0
+    d = DataPHA('example', _data_chan.copy(),
+                _data_counts.copy(),
+                exposure=etime,
+                backscal=0.2)
+
+    a = DataARF('example-arf',
+                _energies_lo.copy(),
+                _energies_hi.copy(),
+                _arf.copy(),
+                exposure=etime)
+
+    r = create_delta_rmf(_energies_lo.copy(),
+                         _energies_hi.copy(),
+                         e_min=_energies_lo.copy(),
+                         e_max=_energies_hi.copy(),
+                         offset=1, name='example-rmf')
+
+    d.set_arf(a)
+    d.set_rmf(r)
+    return d
+
+
+@pytest.mark.parametrize("orders", [None, [1]])
+def test_orderplot_checks_colors_explicit_orders(orders):
+    """Check we raise a PlotErr.
+
+    We check both the default orders setting (None) and an explicit
+    setting as, when writing this test, I found an error in the
+    handling of the None case.
+
+    """
+
+    oplot = OrderPlot()
+
+    pha = example_pha_data()
+    model = PowLaw1D('example-pl')
+
+    with pytest.raises(PlotErr) as pe:
+        oplot.prepare(pha, model, orders=orders, colors=['green', 'orange'])
+
+    assert str(pe.value) == "orders list length '1' does not match colors list length '2'"
+
+
+def test_orderplot_check_title():
+    """Is the title set?"""
+
+    oplot = OrderPlot()
+
+    pha = example_pha_data()
+    model = PowLaw1D('example-pl')
+
+    assert oplot.title is 'Model'
+    oplot.prepare(pha, model)
+    assert oplot.title == 'Model Orders [1]'
+
+
+def test_orderplot_check_range():
+    """Are the x/y values as expected?
+
+    Note that this is not a proper test as the dataset only
+    contains a single response. However, the code is not
+    clear as what is meant to happen with multiple responses
+    so do not spend too much time on this test here.
+    """
+
+    oplot = OrderPlot()
+
+    pha = example_pha_data()
+    model = Const1D('example-mdl')
+
+    oplot.prepare(pha, model, orders=[2])
+    assert len(oplot.xlo) == 1
+    assert len(oplot.xhi) == 1
+    assert len(oplot.y) == 1
+
+    assert oplot.xlo[0] == pytest.approx(np.arange(1, 11))
+    assert oplot.xhi[0] == pytest.approx(np.arange(2, 12))
+
+    # constant model / exposure time
+    yexp = np.ones(10) / 1201
+    assert oplot.y[0] == pytest.approx(yexp)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -418,19 +418,19 @@ def test_bug38_filtering_grouping(make_data_path):
 
     pha.group_width(40)
 
-    assert pha.get_filter(group=True, format='%.4f') == '0.8760:2.6280,3.7960:6.7160'
-    assert pha.get_filter(group=False, format='%.4f') == '0.5913:2.9127,3.5113:7.0007'
+    assert pha.get_filter(group=True, format='%.4f') == '0.8760:2.6280,4.3800:6.1320'
+    assert pha.get_filter(group=False, format='%.4f') == '0.5913:2.9127,4.0953:6.4167'
 
     assert pha.mask.size == 26
-    assert pha.mask.sum() == 10
+    assert pha.mask.sum() == 8
     assert pha.mask[1:5].all()
-    assert pha.mask[6:12].all()
+    assert pha.mask[7:11].all()
 
     # get the ungrouped mask
     mask = pha.get_mask()
-    assert mask.sum() == 10 * 40
+    assert mask.sum() == 8 * 40
     assert mask[40:200].all()
-    assert mask[240:480].all()
+    assert mask[280:440].all()
 
     # check filtered bins
     elo_all, ehi_all = pha._get_ebins(group=False)

--- a/sherpa/astro/ui/tests/test_astro_ui_multi_response.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_multi_response.py
@@ -32,6 +32,9 @@ import numpy as np
 
 import pytest
 
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_plotting
+
 from sherpa.astro import ui
 from sherpa.astro.instrument import create_arf
 from sherpa.astro.data import DataRMF
@@ -452,3 +455,89 @@ def test_eval_multi_arfrmf_reorder(clean_astro_ui):
     ui.set_arf(id=1, arf=arf1, resp_id=1)
 
     check_eval_multi_arfrmf()
+
+
+@requires_data
+@requires_fits
+@requires_plotting
+def test_plot_order_multi(make_data_path, clean_astro_ui):
+    """Rather than fake data, use a known dataset.
+
+    Here we pretend we have tree orders but with the same
+    response (except that the ARF is 0.5, 0.4, 0.25 of the
+    normal ARF).
+    """
+
+    pha = make_data_path('3c273.pi')
+    ui.load_pha(pha)
+
+    # It has already loaded in one response
+    arf = ui.get_arf(resp_id=1)
+    arf.specresp *= 0.5
+
+    for order, scale in enumerate([0.4, 0.25], 2):
+        ui.load_arf(make_data_path('3c273.arf'), resp_id=order)
+        ui.load_rmf(make_data_path('3c273.rmf'), resp_id=order)
+
+        arf = ui.get_arf(resp_id=order)
+        arf.specresp *= scale
+
+    ui.set_source(ui.powlaw1d.pl)
+
+    ui.notice(0.5, 7)
+    ui.ignore(3, 4)
+
+    fplot = ui.get_fit_plot()
+    oplot = ui.get_order_plot()
+
+    # The idea is to compare the X range of plot_fit to plot_order
+    # (but accessed just using the plot objects rather than creating
+    # an actual plot).
+    #
+    # First some safety checks
+    assert fplot.dataplot.xlo == pytest.approx(fplot.modelplot.xlo)
+    assert fplot.dataplot.xhi == pytest.approx(fplot.modelplot.xhi)
+
+    assert len(oplot.xlo) == 3
+    assert len(oplot.xhi) == 3
+    assert len(oplot.y) == 3
+
+    assert oplot.xlo[1] == pytest.approx(oplot.xlo[0])
+    assert oplot.xlo[2] == pytest.approx(oplot.xlo[0])
+
+    assert oplot.xhi[1] == pytest.approx(oplot.xhi[0])
+    assert oplot.xhi[2] == pytest.approx(oplot.xhi[0])
+
+    # We know the y values are 0.5, 0.4, 0.25 times the original arf
+    # so we can compare them.
+    #
+    assert oplot.y[1] == pytest.approx(oplot.y[0] * 0.4 / 0.5)
+    assert oplot.y[2] == pytest.approx(oplot.y[0] * 0.25 / 0.5)
+
+    xlo = oplot.xlo[0]
+    xhi = oplot.xhi[0]
+    assert len(xlo) == 564
+    assert xlo[0] == pytest.approx(0.46720001101493835)
+    assert xhi[-1] == pytest.approx(9.869600296020508)
+
+    # The model plot is technically drawn the same way as the order plot
+    # (ungrouped) but it uses different code (sherpa.astro.plot.ModelHistogram)
+    # so let's compare.
+    #
+    mplot = ui.get_model_plot()
+    assert mplot.xlo[0] == pytest.approx(0.46720001101493835)
+    assert mplot.xhi[-1] == pytest.approx(9.869600296020508)
+
+    # Also compare to the fit plot (which is grouped)
+    #
+    assert fplot.modelplot.xlo[0] == pytest.approx(0.46720001101493835)
+    assert fplot.modelplot.xhi[-1] == pytest.approx(9.869600296020508)
+
+    # How does the overall model plot y values compare to the three
+    # orders?
+    #
+    # Unfortunately the selected groups are different so can not
+    # directly compare.
+    #
+    # y = oplot.y[0] + oplot.y[1] + oplot.y[2]
+    # assert y == pytest.approx(mplot.y)

--- a/sherpa/astro/ui/tests/test_astro_ui_multi_response.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_multi_response.py
@@ -536,8 +536,5 @@ def test_plot_order_multi(make_data_path, clean_astro_ui):
     # How does the overall model plot y values compare to the three
     # orders?
     #
-    # Unfortunately the selected groups are different so can not
-    # directly compare.
-    #
-    # y = oplot.y[0] + oplot.y[1] + oplot.y[2]
-    # assert y == pytest.approx(mplot.y)
+    y = oplot.y[0] + oplot.y[1] + oplot.y[2]
+    assert y == pytest.approx(mplot.y)

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3695,7 +3695,6 @@ def test_pha_model_plot_filter_range_manual_1024(clean_astro_ui):
     assert f == '0.775000000000:1.210000000000'
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 @requires_plotting

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3672,3 +3672,45 @@ def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
     assert len(axes) == 1
     assert axes[0].xaxis.get_scale() == 'linear'
     assert axes[0].yaxis.get_scale() == yscale
+
+
+@requires_plotting
+def test_pha_model_plot_filter_range_manual_1024(clean_astro_ui):
+    """Check if issue #1024 is fixed.
+
+    The problem was that the PHA model plot was resetting the
+    range so that the notice call ended up not changing anything.
+    Unfortunately this does not show up in the "manual" case,
+    because the data is not grouped, so you have to rely on
+    test_pha_model_plot_filter_range_1024.
+    """
+
+    setup_example(None)
+    ui.set_analysis('energy')
+
+    ui.plot_model()
+    ui.notice(0.77, 1.125)
+
+    f = ui.get_filter()
+    assert f == '0.775000000000:1.210000000000'
+
+
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+@requires_plotting
+def test_pha_model_plot_filter_range_1024(make_data_path, clean_astro_ui):
+    """Check if issue #1024 is fixed.
+
+    Unlike test_pha_model_plot_fitler_range_manual_1024
+    this test does show issue #1024.
+    """
+
+    ui.load_pha(make_data_path('3c273.pi'))
+    ui.set_source(ui.powlaw1d.pl)
+
+    ui.plot_model()
+    ui.notice(0.5, 5)
+
+    f = ui.get_filter()
+    assert f == '0.518300011754:4.869099855423'

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -23,6 +23,8 @@ import logging
 
 import pytest
 
+import numpy as np
+
 from sherpa.astro import ui
 from sherpa.utils.testing import requires_data, requires_fits
 
@@ -164,3 +166,99 @@ def test_filter_bad_notice_361(make_data_path):
     ui.notice(0.5, 8.0)
     s1 = ui.calc_stat()
     assert s1 == pytest.approx(stats['0.5-8.0'])
+
+
+@requires_fits
+@requires_data
+def test_filter_bad_ungrouped(make_data_path, clean_astro_ui):
+    """Check behavior when the data is ungrouped.
+
+    This is a test of the current behavior, to check that
+    values still hold. It may be necessary to change this
+    test if we change the quality handling.
+    """
+
+    infile = make_data_path('q1127_src1_grp30.pi')
+    ui.load_pha(infile)
+    pha = ui.get_data()
+    assert pha.quality_filter is None
+    assert pha.mask is True
+
+    assert ui.get_dep().shape == (439, )
+    ui.ungroup()
+    assert ui.get_dep().shape == (1024, )
+    assert pha.quality_filter is None
+    assert pha.mask is True
+
+    ui.ignore_bad()
+    assert ui.get_dep().shape == (1024, )
+    assert pha.quality_filter is None
+
+    expected = np.ones(1024, dtype=bool)
+    expected[996:1025] = False
+    assert pha.mask == pytest.approx(expected)
+
+    # At this point we've changed the mask array so Sherpa thinks
+    # we've applied a filter, so a notice is not going to change
+    # anything. See issue #1169
+    #
+    ui.notice(0.5, 7)
+    assert pha.mask == pytest.approx(expected)
+
+    # We need to ignore to change the mask.
+    #
+    ui.ignore(None, 0.5)
+    ui.ignore(7, None)
+    expected[0:35] = False
+    expected[479:1025] = False
+    assert pha.mask == pytest.approx(expected)
+
+
+@requires_fits
+@requires_data
+def test_filter_bad_grouped(make_data_path, clean_astro_ui):
+    """Check behavior when the data is grouped.
+
+    This is a test of the current behavior, to check that
+    values still hold. It may be necessary to change this
+    test if we change the quality handling.
+    """
+
+    infile = make_data_path('q1127_src1_grp30.pi')
+    ui.load_pha(infile)
+    pha = ui.get_data()
+    assert pha.quality_filter is None
+    assert pha.mask is True
+
+    assert ui.get_dep().shape == (439, )
+    assert pha.quality_filter is None
+    assert pha.mask is True
+
+    # The last group is marked as quality=2 and so calling
+    # ignore_bad means we lose that group.
+    #
+    ui.ignore_bad()
+    assert ui.get_dep().shape == (438, )
+    assert pha.mask is True
+
+    expected = np.ones(1024, dtype=bool)
+    expected[996:1025] = False
+    assert pha.quality_filter == pytest.approx(expected)
+
+    # What happens when we filter the data? Unlike #1169
+    # we do change the noticed range.
+    #
+    ui.notice(0.5, 7)
+    assert pha.quality_filter == pytest.approx(expected)
+
+    # The mask has been filtered to remove the bad channels
+    # (this is grouped data)
+    expected = np.ones(438, dtype=bool)
+    expected[0:15] = False
+    expected[410:438] = False
+    assert pha.mask == pytest.approx(expected)
+
+    expected = np.ones(996, dtype=bool)
+    expected[0:34] = False
+    expected[481:996] = False
+    assert pha.get_mask() == pytest.approx(expected)


### PR DESCRIPTION
WIP - this is likely to need reworking if #1208, #1215, #1216 ... get merged.

This PR contains commits that have also been added as #1168 #1171 #1172 #1173 - I have removed the code fro 1168, 1172, and 1173 from this PR (1171 sets up tests that then get changed so it's still needed). 

# Summary

Track the requested filter range of PHA data sets so that when the dataset is ungrouped, or the grouping scheme is changed, then the filters can be re-applied. This makes the resulting filters better match the intent of the user. Fixes #1024 and #1160 in the process. There have been documentation updates and additions.

This is a breaking change, in that a set of commands like the following (e.g. a notice then ignore followed by a group change) can lead to a slightly-different range of data being included:

    load_pha('3c273.pi')
    group_counts(10)
    notice(0.5, 7)
    notice(1.1, 1.2)
    get_filter()
    -> '0.489099994302:1.058499991894,1.255600035191:8.314700126648'

    group_counts(20)
    get_filter()
    -> '0.510999992490:1.058499991894,1.211799979210:10.110499858856'  BEFORE THIS PR
    -> '0.510999992490:1.058499991894,1.335900008678:10.110499858856'  WITH THIS PR

Because of this, commands like `plot_model` and `plot_order` can show slightly-different channel ranges.

There is no change to the handling of quality channels, and hence the `ignore_bad` command.

# Details

This work places the logic in the DataPHA class, which makes sense as this is where we have to deal with mapping from units to channels and grouping. There are two places that functionality could go - somewhere further up the Data inheritance chain, or in the Filter class - but I don't think they fit. It should be thought about though when reviewing this PR.

I had originally tried tracking the exact channel range that matches the filter requests - e.g. if notice(0.5, 7) maps to channels 53 to 470 but thanks to groups we end up using 48 to 590 then I tracked the 53-470 range in a structure similar to the _filter_store. These channel ranges were then used when changing grouping or switching grouping on or off. However, this didn't seem to work out well: it's the mapping that an individual command has to do when deciding what to do with those channels in the edge bins which are partially selected and partially un-selected - in my previous approach I'd lost the sense of whether it was a notice or ignore and this was a problem. I could take the part where the filter is stored in channel units (which would avoid some work), but a nice feature of the current approach is that it uses notice/ignore so all the constraints and updates they make are done for us, rather than having to worry about the book-keeping.

When a `DataPHA` object is created we add

        # Track the requested noticed/ignored data range, so that it
        # can be re-created when swaping between grouped and ungrouped
        # data.
        #
        # We start off with an explicit "notice everything" call, as this
        # means less special cases. At least, that's the hope.
        self._filter_store = [(None, None, 'channel', False)]

The idea is that each `notice` or `ignore` call appends to this store, adding the low, high, current units, and a flag indicating if it's an `ignore call`. This is done by the `_filter_add` method: it's only used once, shown below, in the `notice` method so we could just avoid the method but I liked the chance to add some text to the method, and wasn't sure how many times it would be used.

        # Add the requested filter setting, *before* it is converted
        # into a channel range.
        #
        self._filter_add(lo, hi, ignore)

Note that `_filter_add` has a special case when it erases the existing `_filter_store` array - this is when `lo=hi=None`, i.e. the user is requesting the whole range either be noticed or ignored. At this point we reset the store to `[(None, None, 'channel', ignore)]` (essentially the same as when we created the `DataPHA` object. All other cases just append to the store. Note that we could be clever here and identify any call that ends up filtering all the data - e.g. `notice(0, 1000000)` or when all the existing filters end up mapping to either including or excluding all data - but I have not done that. Thanks to how filtering and grouping works, a user could end up removing all bins thanks to a particular grouping scheme, but if we went ungrouped we'd still have data. We could handle a user request of lo/hi values that exceed the range (i.e. treat them as we do `lo=hi=None`) but I don't think it's worth it - the existing `notice` logic is messy enough as is for what is potentially a small space and time saving.

This is all that `notice` and `filter` do - just add each filter to the store. An important invariant is that the first element of `_filter_store` is `(None, None, 'channel', ignore)` - i.e. it either selects all channels or removes all channels. This means that subsequent commands (which we're about to talk about) work on a known state.

The 'grouped' setting - handled by the `_set_group` method has changed slightly and is now

    def _set_grouped(self, val):
        val = bool(val)

        if val and self.grouping is None:
            raise DataErr('nogrouping', self.name)

        if self._grouped == val:
            return

        self._grouped = val

        # Apply the existing filters, recreating the list as we go along.
        # This used to obly be done if self.mask was set but now rely
        # on the filter store to determine what needs to be re-evaluated.
        #
        self._filter_recreate()

The change is that the method used to end with:

        # As the grouping status is being changed, we need to reset the mask
        # to be correct size, while still noticing groups within the filter
        #
        if numpy.iterable(self.mask):
            old_filter = self.get_filter(group=val)
            self._grouped = val
            self.ignore()
            for vals in parse_expr(old_filter):
                self.notice(*vals)

         self._grouped = val

So the difference is that the logic for recreating the filter has been moved to the `_filter_recreate` method and that we now always do it if the grouping has changed. But what if the grouped fllag has not changed (but is True) but the actual grouping data has changed (this is issue #1160). Well, I have turned the `grouping` attribute, which stores the grouping data, into a property with the following setter:

```
    def _set_grouping(self, val):
        if val is None:
            # Should we clear the quality array too?
            self._grouping = None
            if self.grouped:
                self.grouped = False

            return

        # We should have more validation of quantities in the DataPHA
        # case, so add some basic ones here. The chosen errors could
        # well be changed; this is a first pass.
        #
        if self.channel is None:
            # Technically we could have grouping with no channels but
            # it doesn't make much sense (DJB is hoping to change __init__
            # to require channel and counts to be set).
            #
            raise DataErr('ogip-error', 'dataset', self.name,
                          'has no channels')

        val = numpy.asarray(val)
        try:
            if len(self.channel) != len(val):
                raise DataErr('mismatch', 'channel', 'grouping')
        except TypeError:
            # if val is a scalar
            raise DataErr('mismatch', 'channel', 'grouping')

        self._grouping = val

        # Recreate the filter if the grouping is set.
        #
        if self.grouped:
            self._filter_recreate()
```

This means that if we change the groupnig array we end up calling `_fitler_recreate`. I have also added some sanity checks on the array (something I think we should do more of in the `DataPHA` object).

The issue of what to do with the `quality` array and `ignore_bad` is currently ignored.

The `_filter_recreate` method - which is now used in other places, unike `_filter_add`, re-applies the requested filter. Previously we calculated the filter range as a string, parsed it to a bunch of notice statements, and then ran it. Instead we can re-run the actual `notice` and `ignore` calls the user made - which will then be evaluated with the new grouping scheme (or the ungrouped data). This is an easy command to write - we just have to deal with unit changes:

    def _filter_recreate(self):
        """Re-apply the current set of filters.

        This is intended to be used if the grouping has been changed:
        that is turning on or off the grouping or the grouping scheme
        has changed. It will attempt to create the overall filter
        as close to the user-requested range as possible.

        """

        # The _filter_store array is designed so that it starts with
        # either a "notice all" or "ignore all" command. Therefore
        # when we create it the first notice call will clear the
        # _filter_store list, resulting in the list being rebuilt.
        # We could avoid doing this but by going through notice we
        # aim to keep al the invariants.
        #
        ounits = self.units
        ostore = self._filter_store[:]
        try:
            for lo, hi, units, ignore in ostore:
                self.units = units
                self.notice(lo, hi, ignore)

        finally:
            self.units = ounits

Note that as `ostore` starts with `(None, None, ...)` - as previously mentioned - then the first `self.notice` call is going to hit `_filter_add` with the `lo=hi=None` case which will delete the existing `_filter_store` array. So, we end up re-creating the `_filter_store` array (and is why we explicitly copy it into a separate variable `ostore`). This is a little subtle, and I don't know if the commentary above is enough for when we come back in a year.

I think this is conceptually nicer than converting a filter range to a string and then deconstructing that to get the required limits. Note that there is actually still a use case for this particular logic (`sherpa.astro.plot.ModelHistogram.prepare` where we want to get a range as close to the range used by the grouped data as we can, rather than the range that more-closely matches the user-requested range).

An important part of the design is that I looked at the  implementation of the `notice` method and decided that there is enough complexity there that while it might be useful to store "lower-level" details of the filter state to allow a more-surgical version of `_filter_recreate` (e.g. not having to mess around with changing the `units` setting) this is potentially dangerous, and it is better to stay at this "higher" level.

I was planning to address the ignore_bad command and the handling of quality channels here, but as I looked into it:

a) the logic is separated from the notice/ignore command so it can be tackled separately
b) it's looking to be a big issue (e.g. #1166) that is better handled in a separate PR

# What to worry about?

What happens if a user tries to direct modify the mask array - e.g. `pha.mask[0] = True`? This approach doesn't know about this.

The old system, which converts the mask into a filter expression (e.g. `0.5:2.1,2.2:8.0`) is okay if you directly edit the mask array. So this is a major problem with this new approach. Dang it. We *could* say "don't edit the mask attribute" for DataPHA objects, but that strikes me as a poor compromise. So I think 'll try to add some subset of the changes here for testing and documentation purposes while I mull on things.

