### PR TITLE
XMM/RGS triggers a notice/ignore bug because channels are in reverse-energy order in RMF

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3612,7 +3612,7 @@ class DataPHA(Data1D):
 
         # Ensure the data is in ascending order for create_expr.
         #
-        if self.units == 'wavelength':
+        if len(x) > 0 and x[-1] < x[0]:
             x = x[::-1]
             mask = mask[::-1]
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3759,8 +3759,8 @@ class DataPHA(Data1D):
             umax = max(hc / elo[[0, -1]])
         else:
             # assume channel units
-            umin = min(self.channel[0], self.channel[-1])
-            umax = max(self.channel[0], self.channel[-1])
+            umin = self.channel[0]
+            umax = self.channel[-1]
 
         assert umin < umax, (self.units, umin, umax)
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3748,15 +3748,19 @@ class DataPHA(Data1D):
             return
 
         if self.units == 'energy':
-            umin = elo[0]
-            umax = ehi[-1]
+            # It's not guaranteed that channels are in increasing energy
+            # but we can certainly assume that they are monotonic.
+            # Thus, the min of the first and last entry is the minimum
+            # energy of the elo array
+            umin = min(elo[0], elo[-1])
+            umax = max(ehi[0], ehi[-1])
         elif self.units == 'wavelength':
-            umin = hc / ehi[-1]
-            umax = hc / elo[0]
+            umin = min(hc / ehi[[0, -1]])
+            umax = max(hc / elo[[0, -1]])
         else:
             # assume channel units
-            umin = self.channel[0]
-            umax = self.channel[-1]
+            umin = min(self.channel[0], self.channel[-1])
+            umax = max(self.channel[1], self.channel[-1])
 
         assert umin < umax, (self.units, umin, umax)
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3760,7 +3760,7 @@ class DataPHA(Data1D):
         else:
             # assume channel units
             umin = min(self.channel[0], self.channel[-1])
-            umax = max(self.channel[1], self.channel[-1])
+            umax = max(self.channel[0], self.channel[-1])
 
         assert umin < umax, (self.units, umin, umax)
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -871,22 +871,6 @@ def test_pha_grouping_changed_filter_1160(make_test_pha):
     assert d4 == pytest.approx([2, 3])
 
 
-def test_pha_reverse_sorted():
-    '''This case for a PHA set with reverse sorted channels is a little
-    non-sensical, but it is a very easy way to hit the problem in #1163.
-
-    Really, we want to test that with a larger test that reads real XMM
-    data, which uses reverse energy ordering (see next test).
-
-    So, if thise tests starts to fail, but the next one passes, this one can
-    probably be removed. It's here now because it's fast, easy, and does not
-    require the large test data.
-    '''
-    d = DataPHA('x', np.array([4, 3, 2, 1, 0]), np.array([5, 4, 3, 2, 1]))
-    d.notice(2, 4)
-    assert len(d.get_dep(filter=True)) == 3
-
-
 @requires_fits
 @requires_data
 def test_xmmrgs_notice(make_data_path):

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -908,7 +908,7 @@ def test_xmmrgs_notice(make_data_path):
     session.set_analysis('wave')
     session.notice(18.8, 19.2)
     dat = session.get_data()
-    assert len(dat.get_dep(filter=True)) == 40
+    assert len(dat.get_dep(filter=True)) == 41
 
     dat.ignore(10, 19.)
     assert len(dat.get_dep(filter=True)) == 20

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -899,8 +899,8 @@ def test_xmmrgs_notice(make_data_path):
     dat.units = 'wave'
     dat.notice(18.8, 19.2)
     assert len(dat.get_dep(filter=True)) == 41
-    assert dat.get_filter(format='%.2f') == '19.20:18.80'
+    assert dat.get_filter(format='%.2f') == '18.80:19.20'
 
     dat.ignore(10, 19.)
     assert len(dat.get_dep(filter=True)) == 20
-    assert dat.get_filter(format='%.2f') == '19.20:19.01'
+    assert dat.get_filter(format='%.2f') == '19.01:19.20'

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -887,28 +887,20 @@ def test_pha_reverse_sorted():
     assert len(d.get_dep(filter=True)) == 3
 
 
-@pytest.fixture
-def read_test_image(make_data_path):
-    from sherpa.astro.io import read_image
-    filename = 'acisf07999_000N001_r0035_regevt3_srcimg.fits'
-    d = read_image(make_data_path(filename))
-    d.name = 'test.img'
-    return d
-
-
 @requires_fits
 @requires_data
 def test_xmmrgs_notice(make_data_path):
     '''Test that notice and ignore works on XMMRGS dataset, which is
     ordered in increasing wavelength, not energy'''
-    from sherpa.astro.ui.utils import Session
-    session = Session()
-    session.load_data(make_data_path('xmmrgs/P0112880201R1S004SRSPEC1003.FTZ'))
-    session.load_rmf(make_data_path('xmmrgs/P0112880201R1S004RSPMAT1003.FTZ'))
-    session.set_analysis('wave')
-    session.notice(18.8, 19.2)
-    dat = session.get_data()
+    from sherpa.astro.io import read_pha, read_rmf
+    dat = read_pha(make_data_path('xmmrgs/P0112880201R1S004SRSPEC1003.FTZ'))
+    rmf = read_rmf(make_data_path('xmmrgs/P0112880201R1S004RSPMAT1003.FTZ'))
+    dat.set_rmf(rmf)
+    dat.units = 'wave'
+    dat.notice(18.8, 19.2)
     assert len(dat.get_dep(filter=True)) == 41
+    assert dat.get_filter(format='%.2f') == '19.20:18.80'
 
     dat.ignore(10, 19.)
     assert len(dat.get_dep(filter=True)) == 20
+    assert dat.get_filter(format='%.2f') == '19.20:19.01'


### PR DESCRIPTION
# Summary
Recent work on the ignore / notice logic in #1127 implicitly assumes that the energy grid in PHA/ARF/RMF files is in increasing order, which does not hold true for XMM/RGS data.

*The problem was introduced in #1127, which is not yet included in any released version, so a separate changelog entry for this PR might not be necessary?*

# Details
Since #1127 Sherpa errors out at https://github.com/sherpa/sherpa/pull/1127/files#diff-39d64572ec8588c14cccff43dc2d85801af7524041351c8434f80963e847204bR3569

Before #1127, XMM data could be read, noticed, and ignored by sherpa. This PR fixes that and adds tests.

Note that CI will fail until https://github.com/sherpa/sherpa-test-data/pull/25 is merged, which adds the required XMM data files for the test.
