### PR TITLE
Logging tweaks

### DIFF
--- a/docs/overview/logging.rst
+++ b/docs/overview/logging.rst
@@ -1,0 +1,27 @@
+*******************************
+The sherpa.utils.logging module
+*******************************
+
+.. currentmodule:: sherpa.utils.logging
+
+.. automodule:: sherpa.utils.logging
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      SherpaVerbosity
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      config_logger
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram:: SherpaVerbosity
+   :parts: 1

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -26,9 +26,11 @@ informational messages are no longer displayed:
   >>> sherpalog = logging.getLogger('sherpa')
   >>> sherpalog.setLevel('WARNING')
 
-Sherpa also provides a context manager to change the logging level
-only for a specific portion of the code. This can be used, e.g., to
-hide the long default output printed after fitting a model:
+Sherpa also provides a context manager -
+:py:class:`~sherpa.utils.logging.SherpaVerbosity` - to change the
+logging level only for a specific portion of the code. This can be
+used, e.g., to hide the long default output printed after fitting a
+model:
 
   >>> from sherpa.utils.logging import SherpaVerbosity
   >>> import numpy as np
@@ -38,7 +40,7 @@ hide the long default output printed after fitting a model:
   >>> with SherpaVerbosity('WARNING'):
   ...    ui.fit("mydata")
 
- 
+
 Reference/API
 =============
 
@@ -47,6 +49,7 @@ Reference/API
 
    sherpa
    err
+   logging
    utils
    testing
    io


### PR DESCRIPTION
# Summary

Include the sherpa.utils.logging module in the documentation and update a test to use the caplog feature of `pytest` (the code had been written to work with python 2.7 version of unittest).

# Details

This was developed as part of #1161 but is un-related so can be reviewed separately, and hopefully quickly.