### PR TITLE
Improve the grouping/filtering tests

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1427,6 +1427,11 @@ class DataPHA(Data1D):
         self.areascal = areascal
         self.header = header
         self._grouped = (grouping is not None)
+        # _original_groups is set False if the grouping is changed via
+        # the _dynamic_groups method. This is currently only used by the
+        # serialization code (sherpa.astro.ui.serialize) to determine
+        # whether to write out the grouping data.
+        #
         self._original_groups = True
         self._subtracted = False
         self._response_ids = []

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1269,8 +1269,9 @@ class DataPHA(Data1D):
     .. [2] Private communication with Keith Arnaud
 
     """
-    _fields = ("name", "channel", "counts", "bin_lo", "bin_hi", "grouping", "quality",
-               "exposure", "backscal", "areascal")
+    _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'bin_lo', 'bin_hi', 'grouping', 'quality',
+               'exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate', 'plot_fac', 'response_ids',
+               'background_ids')
 
     def _get_grouped(self):
         return self._grouped
@@ -1407,10 +1408,6 @@ class DataPHA(Data1D):
 
     background_ids = property(_get_background_ids, _set_background_ids,
                               doc='IDs of defined background data sets')
-
-    _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'bin_lo', 'bin_hi', 'grouping', 'quality',
-               'exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate', 'plot_fac', 'response_ids',
-               'background_ids')
 
     def __init__(self, name, channel, counts, staterror=None, syserror=None,
                  bin_lo=None, bin_hi=None, grouping=None, quality=None,

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -516,8 +516,8 @@ class OrderPlot(ModelHistogram):
                 self.colors.append(top_color)
                 top_color = hex(int(top_color, 16) - jump)
 
-        if not self.use_default_colors and len(colors) != len(orders):
-            raise PlotErr('ordercolors', len(orders), len(colors))
+        if not self.use_default_colors and len(self.colors) != len(self.orders):
+            raise PlotErr('ordercolors', len(self.orders), len(self.colors))
 
         old_filter = parse_expr(data.get_filter())
         old_group = data.grouped
@@ -547,6 +547,8 @@ class OrderPlot(ModelHistogram):
             for order in self.orders:
                 self.xlo.append(xlo)
                 self.xhi.append(xhi)
+                # QUS: why check that response_ids > 2 and not 1 here?
+                #
                 if len(data.response_ids) > 2:
                     if order < 1 or order > len(model.rhs.orders):
                         raise PlotErr('notorder', order)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -816,3 +816,56 @@ def test_pha_invalid_units(invalid, make_test_pha):
         pha.units = invalid
 
     assert str(de.value) == f"unknown quantity: '{invalid}'"
+
+
+def test_pha_grouping_changed_no_filter_1160(make_test_pha):
+    """What happens when the grouping is changed?
+
+    See also test_pha_grouping_changed_filter_1160
+    """
+
+    pha = make_test_pha
+    d1 = pha.get_dep(filter=True)
+    assert d1 == pytest.approx([1, 2, 0, 3])
+
+    # grouping set but not grouped
+    pha.grouping = [1, 1, 1, 1]
+    d2 = pha.get_dep(filter=True)
+    assert d2 == pytest.approx([1, 2, 0, 3])
+
+    # now grouped
+    pha.grouped = True
+    d3 = pha.get_dep(filter=True)
+    assert d3 == pytest.approx([1, 2, 0, 3])
+
+    pha.grouping = [1, 1, -1, 1]
+    d4 = pha.get_dep(filter=True)
+    assert d4 == pytest.approx([1, 2, 3])
+
+
+@pytest.mark.xfail
+def test_pha_grouping_changed_filter_1160(make_test_pha):
+    """What happens when the grouping is changed?
+
+    See also test_pha_grouping_changed_filter_1160
+    """
+
+    pha = make_test_pha
+    pha.notice(2, 5)
+
+    d1 = pha.get_dep(filter=True)
+    assert d1 == pytest.approx([2, 0, 3])
+
+    # grouping set but not grouped
+    pha.grouping = [1, 1, 1, 1]
+    d2 = pha.get_dep(filter=True)
+    assert d2 == pytest.approx([2, 0, 3])
+
+    # now grouped
+    pha.grouped = True
+    d3 = pha.get_dep(filter=True)
+    assert d3 == pytest.approx([2, 0, 3])
+
+    pha.grouping = [1, 1, -1, 1]
+    d4 = pha.get_dep(filter=True)
+    assert d4 == pytest.approx([2, 3])

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3692,3 +3692,45 @@ def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
     assert len(axes) == 1
     assert axes[0].xaxis.get_scale() == 'linear'
     assert axes[0].yaxis.get_scale() == yscale
+
+
+@requires_plotting
+def test_pha_model_plot_filter_range_manual_1024(clean_astro_ui):
+    """Check if issue #1024 is fixed.
+
+    The problem was that the PHA model plot was resetting the
+    range so that the notice call ended up not changing anything.
+    Unfortunately this does not show up in the "manual" case,
+    because the data is not grouped, so you have to rely on
+    test_pha_model_plot_filter_range_1024.
+    """
+
+    setup_example(None)
+    ui.set_analysis('energy')
+
+    ui.plot_model()
+    ui.notice(0.77, 1.125)
+
+    f = ui.get_filter()
+    assert f == '0.775000000000:1.210000000000'
+
+
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+@requires_plotting
+def test_pha_model_plot_filter_range_1024(make_data_path, clean_astro_ui):
+    """Check if issue #1024 is fixed.
+
+    Unlike test_pha_model_plot_fitler_range_manual_1024
+    this test does show issue #1024.
+    """
+
+    ui.load_pha(make_data_path('3c273.pi'))
+    ui.set_source(ui.powlaw1d.pl)
+
+    ui.plot_model()
+    ui.notice(0.5, 5)
+
+    f = ui.get_filter()
+    assert f == '0.518300011754:4.869099855423'


### PR DESCRIPTION
# Summary

Add a number of tests for corner cases of filtering and grouping of PHA data.

# Details

This has been broken out of #1161. It is essentially all new tests which I developed to exercise changes I made in #1161 but are useful to have however we address things.

There are three code changes

- the removal of a duplicated field from the DataPHA class
- added a comment about an undocumented field in the DataPHA class
- fixed a bug in the OrderPlot class (used by `plot_order`); given we haven't really documented this option I don't think it's worth documenting this fix in the summary