### PR TITLE
minor rework of image handling for ui layer 

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -80,7 +80,10 @@ the `pytest-xdist <https://pypi.org/project/pytest-xdist>`_ module
   pytest -n auto
 
 will autoselect the number of cores, an explicit number can also be given
-(``pytest -n 4``).
+(``pytest -n 4``). Note that if you have :term:`DS9` and :term:`XPA`
+installed then it is possible that the DS9 tests may fail when running
+tests in parallel (since multiple tests can end up over-writing the
+DS9 data before it can be checked).
 
 Test coverage can be included as part of the tests by installing the
 `coverage <https://coverage.readthedocs.io/en/latest/index.html>`_

--- a/docs/plots/image.rst
+++ b/docs/plots/image.rst
@@ -1,0 +1,29 @@
+***********************
+The sherpa.image module
+***********************
+
+.. currentmodule:: sherpa.image
+
+.. automodule:: sherpa.image
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      Image
+      DataImage
+      ModelImage
+      ComponentModelImage
+      SourceImage
+      ComponentSourceImage
+      RatioImage
+      ResidImage
+      PSFImage
+      PSFKernelImage
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram::   Image DataImage ModelImage ComponentModelImage SourceImage ComponentSourceImage RatioImage ResidImage PSFImage PSFKernelImage
+   :parts: 1

--- a/docs/plots/index.rst
+++ b/docs/plots/index.rst
@@ -30,11 +30,11 @@ The basic approach to creating a visualization using these classes is:
  - and plot the data with the
    :py:meth:`~sherpa.plot.Plot.plot` or
    :py:meth:`~sherpa.plot.Contour.contour`
-   methods (or the 
+   methods (or the
    :py:meth:`~sherpa.plot.Plot.overplot`,
    and
    :py:meth:`~sherpa.plot.Contour.overcontour` variants).
-   
+
 .. note::
 
    The `sherpa.plot` module also includes error-estimation
@@ -129,10 +129,10 @@ classes:
     (base - line)
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       base.c0      thawed           10 -3.40282e+38  3.40282e+38           
-       line.fwhm    thawed           25  1.17549e-38  3.40282e+38           
-       line.pos     thawed           22 -3.40282e+38  3.40282e+38           
-       line.ampl    thawed           10 -3.40282e+38  3.40282e+38           
+       base.c0      thawed           10 -3.40282e+38  3.40282e+38
+       line.fwhm    thawed           25  1.17549e-38  3.40282e+38
+       line.pos     thawed           22 -3.40282e+38  3.40282e+38
+       line.ampl    thawed           10 -3.40282e+38  3.40282e+38
 
 Displaying the model
 --------------------
@@ -142,7 +142,7 @@ With a Sherpa model, we can now use the
 the data plot, the
 :py:meth:`~sherpa.plot.ModelPlot.prepare` method requires
 the data *and* the model:
-   
+
     >>> from sherpa.plot import ModelPlot
     >>> mplot = ModelPlot()
     >>> mplot.prepare(d, mdl)
@@ -270,4 +270,4 @@ Reference/API
 
    plot
    astroplot
-   
+   image

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -40,10 +40,9 @@ __all__ = ('Image', 'DataImage', 'ModelImage', 'RatioImage',
            'ResidImage', 'PSFImage', 'PSFKernelImage', 'SourceImage',
            'ComponentModelImage', 'ComponentSourceImage')
 
-__metaclass__ = type
-
 
 class Image(NoNewAttributesAfterInit):
+    """Base class for sending image data to an external viewer."""
 
     def __init__(self):
         NoNewAttributesAfterInit.__init__(self)

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -17,6 +17,20 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""Support image display with an external display tool.
+
+At present the only supported application is DS9 [DS9]_, which is
+connected to via XPA [XPA]_.
+
+References
+----------
+
+..  [DS9] SAOImageDS9, "An image display and visualization tool for astronomical data", https://ds9.si.edu/
+
+..  [XPA] "The XPA Messaging System", https://hea-www.harvard.edu/saord/xpa/
+
+"""
+
 import numpy
 from sherpa.utils import NoNewAttributesAfterInit, bool_cast
 

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -225,13 +225,14 @@ def test_get_model_component_image_with_convolution(session):
     assert obj.eqpos is None
     assert obj.sky is None
 
-    # Note that the convolution component is NOT applied
-    # to the data!
-    y = d.eval_model(m.parts[0]).reshape((9, 9))
+    # Note that the convolution component is applied
+    # to the data.
+    psf = s.get_model_component('psf')
+    y = d.eval_model(psf(m.parts[0])).reshape((9, 9))
     assert obj.y == pytest.approx(y)
 
     # sanity check
-    assert y[3, 3] == pytest.approx(100.0)
+    assert y[3, 3] == pytest.approx(42.25302)
 
 
 @requires_ds9

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -18,9 +18,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-"""Basic tests of the miage functionality in sherpa.ui. The hope is that we
+"""Basic tests of the image functionality in sherpa.ui. The hope is that we
 can run some tests even without DS9/XPA available. Although tests are
-run sith both the base and Astro session classes, there's no tests of
+run with both the base and Astro session classes, there's no tests of
 Astro-specific functionality (e.g. DataIMG).
 
 Notes

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,0 +1,692 @@
+#
+#  Copyright (C) 2021
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Basic tests of the miage functionality in sherpa.ui. The hope is that we
+can run some tests even without DS9/XPA available. Although tests are
+run sith both the base and Astro session classes, there's no tests of
+Astro-specific functionality (e.g. DataIMG).
+
+Notes
+-----
+A number of tests send data to an external DS9 process (which will be
+started if needed) and then check the values displayed by the process.
+These tests are highly-likely to fail if the tests are run in
+parallel, such as with
+
+    pytest -n auto
+
+as there is no support in our DS9 interface to either create a new DS9
+instance per worker, or to "lock" a DS9 so that the tests can be run
+in serial.
+
+"""
+
+import logging
+
+import numpy as np
+
+import pytest
+
+from sherpa.ui.utils import Session as BaseSession
+from sherpa.astro.ui.utils import Session as AstroSession
+
+from sherpa.data import Data2D
+from sherpa.models import basic
+
+from sherpa.stats import Chi2Gehrels
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
+from sherpa.utils.testing import requires_ds9
+
+
+def example_data():
+    """Create an example data set."""
+
+    x1, x0 = np.mgrid[-4:5, 6:15]
+
+    shp = x1.shape
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = 100 / (1 + np.sqrt((x0 - 11)**2 + (x1 + 2)**2))
+
+    return Data2D('example', x0, x1, y, shape=shp)
+
+
+def example_model():
+    """Create an example data set."""
+
+    gmdl = basic.Gauss2D('gmdl')
+    gmdl.xpos = 9
+    gmdl.ypos = -1
+    gmdl.fwhm = 3
+    gmdl.ampl = 100
+
+    cmdl = basic.Const2D()
+    cmdl.c0 = 2
+
+    return gmdl + cmdl
+
+
+def example_psf():
+    """Create an example PSF."""
+
+    # Note that the PSF coordinates have to match the data.
+    #
+    psf = basic.Box2D()
+    psf.xlow = 8
+    psf.xhi = 12
+    psf.ylow = 0
+    psf.yhi = 3
+    return psf
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("shape", [None, (9, 9)])
+def test_load_arrays2d(session, shape):
+    """Does load_arrays work with 2D data?"""
+
+    d = example_data()
+
+    s = session()
+    if shape is None:
+        s.load_arrays(1, d.x0, d.x1, d.y, Data2D)
+    else:
+        s.load_arrays(1, d.x0, d.x1, d.y, shape, Data2D)
+
+    got = s.get_data()
+    assert isinstance(got, Data2D)
+
+    # use pytest.approx even though expect equality here as it's
+    # easier to read the output if there's an error rather than
+    # np.all(a == b)
+    #
+    assert got.x0 == pytest.approx(d.x0)
+    assert got.x1 == pytest.approx(d.x1)
+    assert got.y == pytest.approx(d.y)
+    if shape is None:
+        assert got.shape is None
+    else:
+        assert got.shape == pytest.approx(shape)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_data_image(session):
+    from sherpa.image import DataImage
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+
+    obj = s.get_data_image()
+    assert isinstance(obj, DataImage)
+    assert obj.name == 'Data'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = d.y.reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[2, 5] == pytest.approx(100.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_model_image(session):
+    from sherpa.image import ModelImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    obj = s.get_model_image()
+    assert isinstance(obj, ModelImage)
+    assert obj.name == 'Model'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = d.eval_model(m).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[3, 3] == pytest.approx(102.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_model_component_image(session):
+    from sherpa.image import ComponentModelImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    # rely on m being (gmdl + cmdl) and we want the
+    # gaussian component.
+    #
+    obj = s.get_model_component_image(m.parts[0])
+    assert isinstance(obj, ComponentModelImage)
+    assert obj.name == 'Model_component'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = d.eval_model(m.parts[0]).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[3, 3] == pytest.approx(100.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_model_component_image_with_convolution(session):
+    """What happens if there's a convolution component in play?"""
+
+    from sherpa.image import ComponentModelImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('psf', p)
+    s.set_psf('psf')
+
+    # rely on m being (gmdl + cmdl) and we want the
+    # gaussian component.
+    #
+    obj = s.get_model_component_image(m.parts[0])
+    assert isinstance(obj, ComponentModelImage)
+    assert obj.name == 'Model_component'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    # Note that the convolution component is NOT applied
+    # to the data!
+    y = d.eval_model(m.parts[0]).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[3, 3] == pytest.approx(100.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_source_image(session):
+    """Note that here there's no difference of source and model"""
+    from sherpa.image import SourceImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    obj = s.get_source_image()
+    assert isinstance(obj, SourceImage)
+    assert obj.name == 'Source'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = d.eval_model(m).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[3, 3] == pytest.approx(102.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_source_component_image(session):
+    """Note that here there's no difference of source and model"""
+    from sherpa.image import ComponentSourceImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    obj = s.get_source_component_image(m.parts[0])
+    assert isinstance(obj, ComponentSourceImage)
+    assert obj.name == 'Source_component'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = d.eval_model(m.parts[0]).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[3, 3] == pytest.approx(100.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_source_component_image_with_convolution(session):
+    """There is a difference thanks to the PSF"""
+    from sherpa.image import ComponentSourceImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('psf', p)
+    s.set_psf(psf)
+
+    obj = s.get_source_component_image(m.parts[0])
+    assert isinstance(obj, ComponentSourceImage)
+    assert obj.name == 'Source_component'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    # Note that the PSF convolution is not applied here
+    y = d.eval_model(m.parts[0]).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[3, 3] == pytest.approx(100.0)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_resid_image(session):
+    from sherpa.image import ResidImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    obj = s.get_resid_image()
+    assert isinstance(obj, ResidImage)
+    assert obj.name == 'Residual'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = (d.y - d.eval_model(m)).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check the two peaks: data and model
+    assert y[2, 5] == pytest.approx(76.5689)
+    assert y[3, 3] == pytest.approx(-71.0983)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_ratio_image(session):
+    from sherpa.image import RatioImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    obj = s.get_ratio_image()
+    assert isinstance(obj, RatioImage)
+    assert obj.name == 'Ratio'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = (d.y / d.eval_model(m)).reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check the two peaks: data and model
+    assert y[2, 5] == pytest.approx(4.26783)
+    assert y[3, 3] == pytest.approx(0.302958)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_psf_image(session):
+    from sherpa.image import PSFImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('pmdl', p)
+    s.set_psf('pmdl')
+
+    obj = s.get_psf_image()
+    assert isinstance(obj, PSFImage)
+    assert obj.name == 'box2d'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    y = np.zeros((9, 9))
+    y[5:7, 3:6] = 1
+    assert obj.y == pytest.approx(y)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_get_kernel_image(session):
+    from sherpa.image import PSFKernelImage
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('pmdl', p)
+    s.set_psf('pmdl')
+
+    obj = s.get_kernel_image()
+    assert isinstance(obj, PSFKernelImage)
+    assert obj.name == 'PSF_Kernel'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    # Unlike the PSF, this is normalized to 1 by default
+    y = np.zeros((9, 9))
+    y[5:7, 3:6] = 1 / 6
+    assert obj.y == pytest.approx(y)
+
+
+def check_xpa(backend, command, expected):
+    """Do we get the expected response?"""
+
+    ans = backend.xpaget(command)
+    assert ans == expected
+
+
+def check_xpa_data(backend):
+    grid = '30.9017\n100\n50\n50\n33.3333\n41.4214\n'
+    check_xpa(backend, 'data image 6 3 3 2 yes', grid)
+
+
+def check_xpa_model(backend):
+    grid = '2.72334\n23.4311\n6.59292\n31.1632\n2.53156\n8.25\n'
+    check_xpa(backend, 'data image 6 3 3 2 yes', grid)
+
+
+def check_xpa_model_component(backend):
+    # This is check_xpa_model values - 2 (and a tweak because of
+    # the number of dp in one bin)
+    grid = '0.72334\n21.4311\n4.59292\n29.1632\n0.531559\n6.25\n'
+    check_xpa(backend, 'data image 6 3 3 2 yes', grid)
+
+
+def check_xpa_model_component_with_convolution(backend):
+    # This is check_xpa_model values - 2 and then convolved by
+    # the PSF (which is purposefully strange)
+    grid = '1.20076\n6.4275\n2.13285\n18.631\n0.414249\n6.18236\n'
+    check_xpa(backend, 'data image 6 3 3 2 yes', grid)
+
+
+def check_xpa_resid(backend):
+    grid = '28.1784\n76.5689\n43.4071\n18.8368\n30.8018\n33.1714\n'
+    check_xpa(backend, 'data image 6 3 3 2 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_data(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+
+    s.image_data()
+
+    check_xpa(backend, 'tile', 'no\n')
+    check_xpa_data(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_model(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_model()
+
+    check_xpa(backend, 'tile', 'no\n')
+    check_xpa_model(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_model_component(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_model_component(m.parts[0])
+
+    check_xpa(backend, 'tile', 'no\n')
+    check_xpa_model_component(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_model_component_with_convolution(session):
+    """The convolution component changes the data."""
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('psf', p)
+    s.set_psf(psf)
+
+    s.image_model_component(m.parts[0])
+
+    check_xpa(backend, 'tile', 'no\n')
+    check_xpa_model_component_with_convolution(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_source(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_source()
+
+    check_xpa(backend, 'tile', 'no\n')
+
+    # In this case the values are the same as test_image_model
+    check_xpa_model(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_source_component(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_source_component(m.parts[0])
+
+    check_xpa(backend, 'tile', 'no\n')
+
+    # In this case the values are the same as test_image_model_component
+    check_xpa_model_component(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_source_component_with_convolution(session):
+    """Unlike model, this does not change the component."""
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('psf', p)
+    s.set_psf(psf)
+
+    s.image_source_component(m.parts[0])
+
+    check_xpa(backend, 'tile', 'no\n')
+    check_xpa_model_component(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_resid(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_resid()
+
+    check_xpa(backend, 'tile', 'no\n')
+    check_xpa_resid(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_ratio(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_ratio()
+
+    check_xpa(backend, 'tile', 'no\n')
+
+    grid = '11.347\n4.26783\n7.58389\n1.60446\n13.1671\n5.02077\n'
+    check_xpa(backend, 'data image 6 3 3 2 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_fit(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    s.image_fit()
+
+    # Technically the frame values could differ depending on what
+    # previous checks have been run.
+    #
+    check_xpa(backend, 'tile', 'yes\n')
+    check_xpa(backend, 'frame', '3\n')
+    check_xpa(backend, 'frame active', '1 2 3 \n')
+
+    # Check frame 1 - data
+    #       frame 2 - model
+    #       frame 3 - resif
+    backend.xpaset('frame 1')
+    check_xpa_data(backend)
+    backend.xpaset('frame 2')
+    check_xpa_model(backend)
+    backend.xpaset('frame 3')
+    check_xpa_resid(backend)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_psf(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('pmdl', p)
+    s.set_psf('pmdl')
+    s.image_psf()
+
+    check_xpa(backend, 'tile', 'no\n')
+
+    # Check a different region than other tests
+    grid = '0\n1\n0\n1\n1\n0\n0\n0\n1\n1\n0\n0\n1\n0\n0\n0\n'
+    check_xpa(backend, 'data image 4 5 4 4 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_image_kernel(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    p = example_psf()
+
+    s.set_data(d)
+    s.set_source(m)
+    s.load_psf('pmdl', p)
+    s.set_psf('pmdl')
+    s.image_kernel()
+
+    check_xpa(backend, 'tile', 'no\n')
+
+    # Check the same reagion as test_image_psf
+    grid = '0\n0.166667\n0\n0.166667\n0.166667\n0\n0\n0\n0.166667\n0.166667\n0\n0\n0.166667\n0\n0\n0\n'
+    check_xpa(backend, 'data image 4 5 4 4 yes', grid)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -15617,6 +15617,11 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(model, string_types):
             model = self._eval_model_expression(model)
 
+        # Ensure the convolution models get applied
+        is_source = self._get_model_status(id)[1]
+        model = self._add_convolution_models(id, self.get_data(id),
+                                             model, is_source)
+
         self._prepare_imageobj(id, self._mdlcompimage, model=model)
         return self._mdlcompimage
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -15917,7 +15917,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_data_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     def image_model(self, id=None, newframe=False, tile=False):
         """Display the model for a data set in the image viewer.
@@ -15989,7 +15989,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_model_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     def image_source_component(self, id, model=None, newframe=False,
                                tile=False):
@@ -16067,7 +16067,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_source_component_image(id, model)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     def image_model_component(self, id, model=None, newframe=False, tile=False):
         """Display a component of the model in the image viewer.
@@ -16145,7 +16145,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_model_component_image(id, model)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     def image_source(self, id=None, newframe=False, tile=False):
         """Display the source expression for a data set in the image viewer.
@@ -16216,7 +16216,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_source_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     # DOC-TODO: does newframe make sense here?
     def image_fit(self, id=None, newframe=True, tile=True, deleteframes=True):
@@ -16364,7 +16364,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_resid_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     def image_ratio(self, id=None, newframe=False, tile=False):
         """Display the ratio (data/model) for a data set in the image viewer.
@@ -16423,7 +16423,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_ratio_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     # DOC-TODO: what gets displayed when there is no PSF?
     def image_psf(self, id=None, newframe=False, tile=False):
@@ -16479,7 +16479,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_psf_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     # DOC-TODO: what gets displayed when there is no PSF?
     # DOC-TODO: where to point to for PSF/kernel discussion/description
@@ -16537,7 +16537,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         imageobj = self.get_kernel_image(id)
-        imageobj.image(shape=None, newframe=newframe, tile=tile)
+        imageobj.image(newframe=newframe, tile=tile)
 
     # Manage these functions (open, close, delete frames, regions, XPA)
     # through unbound functions of the Image class--always talking to


### PR DESCRIPTION
# Summary

Improve the testing of DS9 from the UI layer and change how image objects (used to send data to DS9) are stored in the session class, following similar changes to plots and contours. It fixes a discrepancy between the image_model_component and get_model_component_image routines.

The sherpa.image module has been added to the documentation.

# Details

This extends the previous changes (eg #1175, #931, #906 and the WIP #1089) to the image set of commands. Fortunately, as with contours (#1175) it is an uneventful change - there are two main parts

1. rather than have self._fooimage, self._barimage, ... we have self._image_types as a dictionary with keys for foo, bar, ... which makes it easier to identify and find these objects
2. access to these objects is now always done by the get_foo_image class, which has the responsibility for calling it's prepare_image method correctly. This has two advantages in that we only ever have to get this logic right once per image type (see below for  a discussion of where we were not actually doing it right before), and it is much easier to over-ride in subclasses (although for the image case we don't actually do this)

The documentation changes are minimal - it really just adds the sherpa.image to the list of documented modules but does not add any description of the classes as I do not have time to do that here and it would be better done in a separate PR like #1172 does for the DataPHA class.

Tests are added to make sure these code paths are covered. We do have existing DS9 tests but they are at a lower level than these tests from the UI layer. In writing these tests I realized there was a bug in that image_model_component() and get_model_component_image() weren't using the same data (the image_mode_component was including any convolution component whereas get_model_component_image wasn't). The solution is to fix get_model_component_image and then make image_model_component use it, rather than having multiple ways of setting the data. The tests cover this case (so when the BUGFIX commit is hit one of the tests had to be changed).

Note that these tests can not reliably be combined with pytest-xdist, so

    pytest -n auto

may fail on these tests. This is because we only create a single DS9 instance which is then connected to by all the tests, resulting in potential corruption if two DS9 tests are run at the same time (the state is undefined in this case). We could look at supporting a per-instance DS9 connection, but that is a large change. For now, if you have DS9 and XPA installed then I suggest you have to run the tests serially. This is also (probably) true of the existing DS9 tests, it's just that no-one has really run into this combination before (and with more ds9 tests there's more chance for test collision). I've added a note to the pytest-xdist section of the developer docs. 