### PR TITLE
Define physical constant hc in fewer places

### DIFF
--- a/docs/overview/astro.rst
+++ b/docs/overview/astro.rst
@@ -1,0 +1,15 @@
+***********************
+The sherpa.astro module
+***********************
+
+.. currentmodule:: sherpa.astro
+
+.. automodule:: sherpa.astro
+
+   .. rubric:: Constants
+
+   .. autosummary::
+      :toctree: api
+
+      charge_e
+      hc

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -53,4 +53,5 @@ Reference/API
    utils
    testing
    io
+   astro
    astro_io

--- a/sherpa/astro/__init__.py
+++ b/sherpa/astro/__init__.py
@@ -16,6 +16,14 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+'''Physical constants for astronomical spectra
+
+This module contains some physical constants needed to perform conversions
+that are common in the `sherpa.astro` module, e.g. from energy to wavelength.
+'''
 
 hc = 12.39841874  # nist.gov in [keV-Angstrom]
-charge_e = 1.60217653e-09  # elementary charge [ergs] 1 keV, nist.gov
+"""The product of Plank constant (h) and speed of light (c) using values from nist.gov in units appropriate for converting between keV and Angstroms."""
+
+charge_e = 1.60217653e-09
+'''elementary charge from nist.gov in units appropriate for converting between keV and erg.'''

--- a/sherpa/astro/__init__.py
+++ b/sherpa/astro/__init__.py
@@ -23,7 +23,7 @@ that are common in the `sherpa.astro` module, e.g. from energy to wavelength.
 '''
 
 hc = 12.39841874  # nist.gov in [keV-Angstrom]
-"""The product of Plank constant (h) and speed of light (c) using values from nist.gov in units appropriate for converting between keV and Angstroms."""
+"""The product of Planck constant (h) and speed of light (c) using values from nist.gov in units appropriate for converting between keV and Angstroms."""
 
 charge_e = 1.60217653e-09
 '''elementary charge from nist.gov in units appropriate for converting between keV and erg.'''

--- a/sherpa/astro/__init__.py
+++ b/sherpa/astro/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,4 +17,5 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-# Nothing in here yet
+hc = 12.39841874  # nist.gov in [keV-Angstrom]
+charge_e = 1.60217653e-09  # elementary charge [ergs] 1 keV, nist.gov

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -35,6 +35,7 @@ from sherpa.utils.err import DataErr, ImportErr
 from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
     create_expr, parse_expr, bool_cast, rebin, filter_bins
 from sherpa.utils import formatting
+from sherpa.astro import hc
 
 # There are currently (Sep 2015) no tests that exercise the code that
 # uses the compile_energy_grid symbols.
@@ -1837,8 +1838,8 @@ class DataPHA(Data1D):
             elo = self.bin_lo
             ehi = self.bin_hi
             if (elo[0] > elo[-1]) and (ehi[0] > ehi[-1]):
-                elo = self._hc / self.bin_hi
-                ehi = self._hc / self.bin_lo
+                elo = hc / self.bin_hi
+                ehi = hc / self.bin_lo
         else:
             arf, rmf = self.get_response(response_id)
             if rmf is not None:
@@ -1937,8 +1938,8 @@ class DataPHA(Data1D):
                 if self.units == 'wavelength':
                     return (elo, ehi)
 
-                elo = self._hc / self.bin_hi
-                ehi = self._hc / self.bin_lo
+                elo = hc / self.bin_hi
+                ehi = hc / self.bin_lo
 
         else:
             energylist = []
@@ -1974,8 +1975,8 @@ class DataPHA(Data1D):
 
         lo, hi = elo, ehi
         if self.units == 'wavelength':
-            lo = self._hc / ehi
-            hi = self._hc / elo
+            lo = hc / ehi
+            hi = hc / elo
 
         return (lo, hi)
 
@@ -2083,8 +2084,6 @@ class DataPHA(Data1D):
 
         return numpy.asarray(res, SherpaFloat)
 
-    _hc = 12.39841874  # nist.gov in [keV-Angstrom]
-
     def _channel_to_wavelength(self, val, group=True, response_id=None):
         tiny = numpy.finfo(numpy.float32).tiny
         vals = numpy.asarray(self._channel_to_energy(val, group, response_id))
@@ -2093,7 +2092,7 @@ class DataPHA(Data1D):
                 vals = tiny
         else:
             vals[vals == 0.0] = tiny
-        vals = self._hc / vals
+        vals = hc / vals
         return vals
 
     def _wavelength_to_channel(self, val):
@@ -2110,7 +2109,7 @@ class DataPHA(Data1D):
                 vals = tiny
         else:
             vals[vals <= 0.0] = tiny
-        vals = self._hc / vals
+        vals = hc / vals
         return self._energy_to_channel(vals)
 
     default_background_id = 1
@@ -3302,7 +3301,7 @@ class DataPHA(Data1D):
             if self.units == 'energy':
                 ebin = ehi - elo
             elif self.units == 'wavelength':
-                ebin = self._hc / elo - self._hc / ehi
+                ebin = hc / elo - hc / ehi
             elif self.units == 'channel':
                 ebin = ehi - elo
             else:
@@ -3688,8 +3687,8 @@ class DataPHA(Data1D):
             umin = elo[0]
             umax = ehi[-1]
         elif self.units == 'wavelength':
-            umin = self._hc / ehi[-1]
-            umax = self._hc / elo[0]
+            umin = hc / ehi[-1]
+            umax = hc / elo[0]
         else:
             # assume channel units
             umin = self.channel[0]
@@ -3767,8 +3766,8 @@ class DataPHA(Data1D):
         elo = self.apply_filter(elo, self._min)
         ehi = self.apply_filter(ehi, self._max)
         if self.units == "wavelength":
-            lo = self._hc / ehi
-            hi = self._hc / elo
+            lo = hc / ehi
+            hi = hc / elo
             elo = lo
             ehi = hi
         cnt = self.get_dep(True)

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -49,8 +49,8 @@ from sherpa.models.model import ArithmeticModel, CompositeModel, Model
 from sherpa.instrument import PSFModel as _PSFModel
 from sherpa.utils import NoNewAttributesAfterInit
 from sherpa.data import Data1D
-from sherpa.astro.data import DataARF, DataRMF, DataPHA, _notice_resp, \
-    DataIMG
+from sherpa.astro import hc
+from sherpa.astro.data import DataARF, DataRMF, _notice_resp, DataIMG
 from sherpa.utils import sao_fcmp, sum_intervals, sao_arange
 from sherpa.astro.utils import compile_energy_grid
 
@@ -142,7 +142,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
         self.elo, self.ehi = self.rmf.get_indep()
 
         # Wavelength grid (angstroms)
-        self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
+        self.lo, self.hi = hc / self.ehi, hc / self.elo
 
         # Assume energy as default spectral coordinates
         self.xlo, self.xhi = self.elo, self.ehi
@@ -191,7 +191,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
         self.elo, self.ehi = self.arf.get_indep()
 
         # Wavelength grid (angstroms)
-        self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
+        self.lo, self.hi = hc / self.ehi, hc / self.elo
 
         # Assume energy as default spectral coordinates
         self.xlo, self.xhi = self.elo, self.ehi
@@ -243,7 +243,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
         self.elo, self.ehi = self.arf.get_indep()
 
         # Wavelength grid (angstroms)
-        self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
+        self.lo, self.hi = hc / self.ehi, hc / self.elo
 
         # Assume energy as default spectral coordinates
         self.xlo, self.xhi = self.elo, self.ehi
@@ -291,8 +291,8 @@ class RMFModelPHA(RMFModel):
             # If PHA grid is in angstroms then convert to keV for
             # consistency
             if (bin_lo[0] > bin_lo[-1]) and (bin_hi[0] > bin_hi[-1]):
-                bin_lo = DataPHA._hc / pha.bin_hi
-                bin_hi = DataPHA._hc / pha.bin_lo
+                bin_lo = hc / pha.bin_hi
+                bin_hi = hc / pha.bin_lo
 
             # FIXME: What about filtered option?? bin_lo, bin_hi are
             # unfiltered??
@@ -305,7 +305,7 @@ class RMFModelPHA(RMFModel):
             self.elo, self.ehi = bin_lo, bin_hi
 
             # Wavelength grid (angstroms)
-            self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
+            self.lo, self.hi = hc / self.ehi, hc / self.elo
 
         # Assume energy as default spectral coordinates
         self.xlo, self.xhi = self.elo, self.ehi
@@ -395,8 +395,8 @@ class ARFModelPHA(ARFModel):
             # If PHA grid is in angstroms then convert to keV for
             # consistency
             if (bin_lo[0] > bin_lo[-1]) and (bin_hi[0] > bin_hi[-1]):
-                bin_lo = DataPHA._hc / pha.bin_hi
-                bin_hi = DataPHA._hc / pha.bin_lo
+                bin_lo = hc / pha.bin_hi
+                bin_hi = hc / pha.bin_lo
 
             # FIXME: What about filtered option?? bin_lo, bin_hi are
             # unfiltered??
@@ -503,8 +503,8 @@ class RSPModelPHA(RSPModel):
             # If PHA grid is in angstroms then convert to keV for
             # consistency
             if (bin_lo[0] > bin_lo[-1]) and (bin_hi[0] > bin_hi[-1]):
-                bin_lo = DataPHA._hc / pha.bin_hi
-                bin_hi = DataPHA._hc / pha.bin_lo
+                bin_lo = hc / pha.bin_hi
+                bin_hi = hc / pha.bin_lo
 
             # FIXME: What about filtered option?? bin_lo, bin_hi are
             # unfiltered??
@@ -895,7 +895,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
             grid.append(indep)
 
         self.elo, self.ehi, self.table = compile_energy_grid(grid)
-        self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
+        self.lo, self.hi = hc / self.ehi, hc / self.elo
 
     def startup(self, cache=False):
         pha = self.pha
@@ -962,8 +962,8 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
                 for model, args in zip(self.models, self.grid):
                     elo, ehi = lo, hi = args
                     if pha.units == 'wavelength':
-                        lo = DataPHA._hc / ehi
-                        hi = DataPHA._hc / elo
+                        lo = hc / ehi
+                        hi = hc / elo
                     vals.append(model(src(lo, hi)))
                 self.orders = vals
             # Fast
@@ -1042,7 +1042,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         self.rmf = rmf
 
         self.elo, self.ehi = rmf.get_indep()
-        self.lo, self.hi = DataPHA._hc / self.ehi, DataPHA._hc / self.elo
+        self.lo, self.hi = hc / self.ehi, hc / self.elo
         self.model = model
         self.otherargs = None
         self.otherkwargs = None

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -36,6 +36,7 @@ from sherpa.astro.utils import bounds_check
 from sherpa.utils.err import PlotErr, IOErr
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins, \
     sao_fcmp
+from sherpa.astro import hc
 
 warning = logging.getLogger(__name__).warning
 
@@ -134,8 +135,8 @@ class DataPHAPlot(sherpa.plot.DataHistogramPlot):
         self.xlo = data.apply_filter(elo, data._min)
         self.xhi = data.apply_filter(ehi, data._max)
         if data.units == 'wavelength':
-            self.xlo = data._hc / self.xlo
-            self.xhi = data._hc / self.xhi
+            self.xlo = hc / self.xlo
+            self.xhi = hc / self.xhi
 
         _check_hist_bins(self)
 
@@ -170,8 +171,8 @@ class ModelPHAHistogram(HistogramPlot):
         self.xlo = data.apply_filter(elo, data._min)
         self.xhi = data.apply_filter(ehi, data._max)
         if data.units == 'wavelength':
-            self.xlo = data._hc / self.xlo
-            self.xhi = data._hc / self.xhi
+            self.xlo = hc / self.xlo
+            self.xhi = hc / self.xhi
 
         _check_hist_bins(self)
 
@@ -395,8 +396,8 @@ class ARFPlot(HistogramPlot):
                 raise PlotErr('notpha', data.name)
             if data.units == "wavelength":
                 self.xlabel = 'Wavelength (Angstrom)'
-                self.xlo = data._hc / self.xlo
-                self.xhi = data._hc / self.xhi
+                self.xlo = hc / self.xlo
+                self.xhi = hc / self.xhi
 
 
 class BkgDataPlot(DataPHAPlot):
@@ -538,8 +539,8 @@ class OrderPlot(ModelHistogram):
                 xlo = data.apply_filter(elo, data._min)
                 xhi = data.apply_filter(ehi, data._max)
                 if data.units == 'wavelength':
-                    xlo = data._hc / xlo
-                    xhi = data._hc / xhi
+                    xlo = hc / xlo
+                    xhi = hc / xhi
             else:
                 xhi = xlo + 1.
 

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -48,6 +48,7 @@ from sherpa.astro.instrument import ARF1D, ARFModelNoPHA, ARFModelPHA, \
     PSFModel
 from sherpa.fit import Fit
 from sherpa.astro.data import DataPHA, DataRMF
+from sherpa.astro import hc
 from sherpa.models.basic import Box1D, Const1D, Polynom1D, PowLaw1D
 from sherpa.utils.err import DataErr
 from sherpa.utils.testing import requires_xspec, requires_data, requires_fits
@@ -1042,7 +1043,7 @@ def test_rspmodelpha_delta_call_wave():
     # Angstroms, so the bin width to multiply by is
     # Angstroms, not keV.
     #
-    dl = (DataPHA._hc / elo) - (DataPHA._hc / ehi)
+    dl = (hc / elo) - (hc / ehi)
     expected = constant * specresp * dl
 
     out = wrapped([4, 5])

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -30,6 +30,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.astro.plot import SourcePlot, \
     DataPHAPlot, ModelPHAHistogram, EnergyFluxHistogram, PhotonFluxHistogram
 from sherpa.astro import plot as aplot
+from sherpa.astro import hc
 from sherpa.data import Data1D
 from sherpa.models.basic import Const1D, Gauss1D, Polynom1D
 from sherpa import stats
@@ -134,7 +135,7 @@ def check_sourceplot_wavelength(sp, factor=0):
     # Use the code from DataPHA to convert from keV to Angstroms.
     #
     ebins = np.arange(0.1, 10.1, 0.1)
-    lbins = DataPHA._hc / ebins
+    lbins = hc / ebins
     assert sp.xlo == pytest.approx(lbins[:-1])
     assert sp.xhi == pytest.approx(lbins[1:])
 

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -35,6 +35,7 @@ from sherpa.utils.testing import requires_data, requires_fits, \
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, \
     IdentifierErr, IOErr, ModelErr
 import sherpa.astro.utils
+from sherpa.astro import hc, charge_e
 
 
 def fail(*arg):
@@ -137,8 +138,6 @@ def test_calc_flux_pha_bin_edges(clean_astro_ui):
     pflux = ui.calc_photon_flux(2.6, 7.8)
     eflux = ui.calc_energy_flux(2.6, 7.8)
 
-    enscale = sherpa.astro.utils._charge_e
-
     # Left in as notes:
     #
     # This are the true values. Given that the edge bins (should be)
@@ -163,7 +162,7 @@ def test_calc_flux_pha_bin_edges(clean_astro_ui):
     scale = np.asarray([0.0, 0.4, 1.0, 1.0, 1.0, 1.0, 0.8, 0, 0.0, 0.0])
     expected_pflux = (ymdl * scale).sum()
 
-    emid = enscale * (elo + ehi) / 2
+    emid = charge_e * (elo + ehi) / 2
     expected_eflux = (emid * ymdl * scale).sum()
 
     assert pflux == pytest.approx(expected_pflux)
@@ -208,15 +207,13 @@ def test_calc_flux_pha_density_bin_edges(clean_astro_ui):
     pdens = ui.calc_photon_flux(2.6)
     edens = ui.calc_energy_flux(2.6)
 
-    enscale = sherpa.astro.utils._charge_e
-
     # Evaluate the model over the bin 2-3 keV; since the grid
     # has a width of 1 keV we do not need to divide by the bin
     # width when calculating the density.
     #
     ymdl = pl([2], [3])
     expected_pdens = ymdl.sum()
-    expected_edens = enscale * 2.5 * expected_pdens
+    expected_edens = charge_e * 2.5 * expected_pdens
 
     # Prior to fixing #619, Sherpa returns 0 for both densities
     #
@@ -323,7 +320,7 @@ def test_calc_flux_pha(id, lo, hi, make_data_path, clean_astro_ui):
     assert eflux == pytest.approx(eflux_exp, rel=1e-4)
 
 
-# The lo/hi range which match in the different settings; using _hc
+# The lo/hi range which match in the different settings; using hc
 # to convert from keV to Angstroms is a bit low-level.
 #
 # The energy-to-channel conversion was done by filtering in energy
@@ -335,7 +332,7 @@ def test_calc_flux_pha(id, lo, hi, make_data_path, clean_astro_ui):
                          [(None, None, 'wave', None, None),
                           (None, None, 'channel', None, None),
                           (0.5, 7.0, 'wave',
-                           ui.DataPHA._hc / 7.0, ui.DataPHA._hc / 0.5),
+                           hc / 7.0, hc / 0.5),
                           fail(0.5, 7.0, 'channel', 35, 480)  # issue 619 see also 308
                          ])
 def test_calc_flux_pha_analysis(elo, ehi, setting, lo, hi, make_data_path, clean_astro_ui):

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -27,6 +27,7 @@ from sherpa.utils.err import IOErr, DataErr
 from ._utils import arf_fold, do_group, expand_grouped_mask, \
     filter_resp, is_in, resp_init, rmf_fold, shrink_effarea
 from ._pileup import apply_pileup
+from sherpa.astro import hc, charge_e
 
 
 __all__ = ['arf_fold', 'rmf_fold', 'do_group', 'apply_pileup',
@@ -42,12 +43,6 @@ __all__ = ['arf_fold', 'rmf_fold', 'do_group', 'apply_pileup',
 warning = logging.getLogger(__name__).warning
 
 
-# Useful constants
-#
-_hc = 12.39841874  # nist.gov in [keV-Angstrom]
-_charge_e = 1.60217653e-09  # elementary charge [ergs] 1 keV, nist.gov
-
-
 def reshape_2d_arrays(x0, x1):
     new_x0, new_x1 = numpy.meshgrid(x0, x1)
     return new_x0.ravel(), new_x1.ravel()
@@ -56,12 +51,12 @@ def reshape_2d_arrays(x0, x1):
 def get_xspec_position(y, x, xhi=None):
     if xhi is not None:
         if x[0] > x[-1] and xhi[0] > xhi[-1]:
-            lo = _hc / xhi
-            hi = _hc / x
+            lo = hc / xhi
+            hi = hc / x
             x, xhi = lo, hi
     else:
         if x[0] > x[-1]:
-            x = _hc / x
+            x = hc / x
     return get_position(y, x, xhi)
 
 
@@ -324,7 +319,7 @@ def _flux(data, lo, hi, src, eflux=False, srcflux=False):
         for axis in axislist:
             grid = axis
             if convert:
-                grid = data._hc / grid
+                grid = hc / grid
             energ.append(grid)
 
         if dim == 2:
@@ -367,7 +362,7 @@ def _flux(data, lo, hi, src, eflux=False, srcflux=False):
 
     flux = (scale * y).sum()
     if eflux:
-        flux *= _charge_e
+        flux *= charge_e
 
     return flux
 


### PR DESCRIPTION
# Summary
hc (as in "Planck constant * speed of light") is a physical constant that does not depend on the DataPHA and thus it should not be defined as a class attribute. 

(Is a summary really needed for this change?)

# Details
hc was actually defined in more than one place (and it's still separate in one test file) and in particular there is no need for it to be an hidden (`_hc`) attribute to the DataPHA class. I need this change for other work to avoid circular imports (DataPHA is imported into instrument.py purely to access `DataPHA._hc` and I want to remove that import), but I'm pulling it out as a separate PR because it's ready already and I believe this is a good change in any case.