### PR TITLE
Improve handling of the integrate flag for models

### DIFF
--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -329,7 +329,7 @@ pl.ampl.units   = ""
 pl.ampl.frozen  = False
 
 create_model_component("xsphabs", "gal")
-gal.integrate = True
+gal.integrate = False
 
 gal.nH.default_val = 1.0
 gal.nH.default_min = 0.0
@@ -460,7 +460,7 @@ gpl.ampl.units   = ""
 gpl.ampl.frozen  = False
 
 create_model_component("xsphabs", "ggal")
-ggal.integrate = True
+ggal.integrate = False
 
 ggal.nH.default_val = 2.0
 ggal.nH.default_min = 0.0
@@ -582,7 +582,7 @@ gpl.ampl.units   = ""
 gpl.ampl.frozen  = False
 
 create_model_component("xsphabs", "ggal")
-ggal.integrate = True
+ggal.integrate = False
 
 ggal.nH.default_val = 2.0
 ggal.nH.default_min = 0.0

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1117,9 +1117,19 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
     represents the upper edge of the last bin. This means that for
     an input grid of ``n`` points, the returned array will contain
     ``n`` values, but the last element will be zero.
+
+    The ``integrate`` setting is fixed for XSPEC models: it is set to
+    ``True`` for Additive models and ``False`` for Multiplicative
+    models. Convolution models are expected to be used with "additive"
+    models (or a mixture of multiplicative and additive models) and
+    so they are set to ``True``. The integrate setting is not used
+    to determine how to evaluate the models, but it is used by the
+    RegriddableModel1D class to determine how to rebin the data.
+
     """
 
     version_enabled = True
+    _integrate = True
 
     def __init__(self, name, pars):
 
@@ -1151,6 +1161,24 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
 
         super().__init__(name, pars)
 
+    @property
+    def integrate(self):
+        """The integrate setting.
+
+        It can not be changed for XSPEC models.
+        """
+        return self._integrate
+
+    @integrate.setter
+    def integrate(self, newval):
+        # We could raise an error if the setting is changed, but there
+        # are save files created before we made the integrate
+        # un-changeable that would fail for no good reason. So we just
+        # ignore any request to change the setting. It is possible for
+        # the user to change _integrate but that is undefined
+        # behavior.
+        #
+        pass
 
     @modelCacher1d
     def calc(self, p, *args, **kwargs):
@@ -1307,6 +1335,9 @@ class XSTableModel(XSModel):
                                   hugeval)
             pars.append(self.norm)
 
+        # The integrate setting is the same as the addmodel parameter.
+        #
+        self._integrate = addmodel
         XSModel.__init__(self, name, pars)
 
     def fold(*args, **kwargs):
@@ -1367,7 +1398,7 @@ class XSMultiplicativeModel(XSModel):
 
     """
 
-    pass
+    _integrate = False
 
 
 class XSConvolutionKernel(XSModel):
@@ -1446,8 +1477,7 @@ class XSConvolutionKernel(XSModel):
     """
 
     def __repr__(self):
-        return "<{} kernel instance '{}'>".format(type(self).__name__,
-                                                  self.name)
+        return f"<{type(self).__name__} kernel instance '{self.name}'>"
 
     def __call__(self, model):
         return XSConvolutionModel(model, self)
@@ -1585,9 +1615,7 @@ class XSConvolutionModel(CompositeModel, XSModel):
     def __init__(self, model, wrapper):
         self.model = self.wrapobj(model)
         self.wrapper = wrapper
-        CompositeModel.__init__(self,
-                                "{}({})".format(self.wrapper.name,
-                                                self.model.name),
+        CompositeModel.__init__(self, f"{self.wrapper.name}({self.model.name})",
                                 (self.wrapper, self.model))
 
     # for now this is not cached

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1201,6 +1201,14 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
             warnings.warn(emsg, FutureWarning)
             # raise TypeError(emsg)
 
+        # The XSPEC code does not recognize the integrate flag.
+        # In fact, should we remove all keywords here?
+        #
+        try:
+            del kwargs["integrate"]
+        except KeyError:
+            pass
+
         # Ensure output is finite (Keith Arnaud mentioned that XSPEC
         # does this as a check). This is done at this level (Python)
         # rather than in the C++ interface since:

--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -1,0 +1,637 @@
+#
+#  Copyright (C) 2020, 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Check we can regrid XSPEC models.
+
+Basic testing is based on the XSPEC wabs and powerlaw models, since
+they are "simple" and unlikely to change significantly. They are
+mutiplicative and additive models respectively.
+
+These tests do not exercise the whole set of regrid options, since
+it is expected that these should just work (from other tests). This
+is to check sepcialized behavior with the XSPEC models.
+
+"""
+
+import numpy as np
+import pytest
+
+from sherpa.models.basic import Const1D, Gauss1D
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_xspec
+
+
+# To make sure we track current behavior, we check that routines fail
+# in the expected way rather than just marking them as xfail.  This
+# way, when support is finally unlocked, we should find out from the
+# tests (rather that just going from xfail to xpass which is easy to
+# miss). It also lets us check why a test fails (in case the failure
+# mode changes due to other parts of Sherpa).
+#
+IntegrateError = "'integrate' is an invalid keyword argument for this function"
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_name(mname, xsmodel):
+    """What is the name of the regrid component"""
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    mdl = xsmodel(mname, "base")
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    assert mdl.name == 'base'
+    assert regrid.name == 'regrid1d(base)'
+
+
+@requires_xspec
+def test_regrid_name_combined():
+    """What is the name of the regrid component"""
+
+    from sherpa.astro import xspec
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    c1 = xspec.XSwabs()
+    c2 = xspec.XSpowerlaw()
+    mdl = c1 * c2
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    assert mdl.name == '(wabs * powerlaw)'
+    assert regrid.name == 'regrid1d((wabs * powerlaw))'
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_does_not_require_bins(mname, xsmodel):
+    """The regrid method does not require lo,hi bins but running it does"""
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    mdl = xsmodel(mname, "base")
+    regrid = mdl.regrid(ebase)
+
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
+        with pytest.raises(TypeError) as exc:
+            regrid([0.4, 0.5, 0.6])
+
+    # assert str(exc.value) == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+    # assert str(exc.value).endswith('() takes no keyword arguments')
+    assert str(exc.value) == IntegrateError
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+def test_regrid_table_requires_bins(make_data_path):
+    """Does the regrid method require lo,hi bins for XSPEC tables?"""
+
+    from sherpa.astro import xspec
+
+    path = make_data_path('testpcfabs.mod')
+    tbl = xspec.read_xstable_model('bar', path)
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    regrid = tbl.regrid(ebase)
+
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
+        y = regrid([0.52, 0.57, 0.62])
+
+    # Answer calculated with XSPEC 12.12.1
+    assert y == pytest.approx([0.50037217, 0.50017911, 0.50086778])
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_identity(mname, xsmodel):
+    """Check regrid returns the same data when grids are equal"""
+
+    elo = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85]
+    ehi = [0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    mdl = xsmodel(mname, "base")
+    regrid = mdl.regrid(elo, ehi)
+
+    # scale y values to make them closer to unity
+    y1 = 100 * mdl(elo, ehi)
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = 100 * regrid(elo, ehi)
+
+    # assert y2 == pytest.approx(y1)
+
+
+@requires_xspec
+def test_regrid_identity_combined():
+    """Check regrid returns the same data when grids are equal"""
+
+    from sherpa.astro import xspec
+
+    elo = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85]
+    ehi = [0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    c1 = xspec.XSwabs()
+    c2 = xspec.XSpowerlaw()
+    c1.nh = 0.05
+    c2.norm = 100
+
+    # The mdl.regrid call fails with a TypeError:
+    # 'integrate' is an invalid keyword argument for this function
+    #
+    mdl = c1 * c2
+    regrid = mdl.regrid(elo, ehi)
+
+    # scale y values to make them closer to unity
+    y1 = mdl(elo, ehi)
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(elo, ehi)
+
+    # assert y2 == pytest.approx(y1)
+
+
+@requires_xspec
+def test_additive():
+    """Simple test of an additive model"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(1.1, 1.5, 0.01)
+    egrid = np.arange(1.1, 1.5, 0.05)
+
+    mdl = xspec.XSpowerlaw('add')
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # will change regrid too
+    mdl.norm = 100
+
+    y1 = mdl(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(y1)
+
+
+# ideally we would test all three cases
+#   no overlap
+#   overlaps low
+#   overlaps high
+#
+overlap_none = np.arange(10, 15, 0.1)
+overlap_low = np.arange(0.8, 1.3, 0.05)
+overlap_high = np.arange(1.2, 1.8, 0.05)
+
+ans_none = np.zeros(overlap_none.size - 1)
+ans_low = np.asarray([0, 0, 0, 0, 0, 0,
+                      4.44517626, 4.25596144, 4.08219945])
+ans_high = np.asarray([4.08219945, 3.92207132, 3.7740328, 3.63676442,
+                       3.50913198, 2.72125635,  # this is a partial bin
+                       0, 0, 0, 0, 0, 0])
+
+
+@requires_xspec
+@pytest.mark.parametrize("egrid,yexp",
+                         [(overlap_none, ans_none),
+                          (overlap_low, ans_low),
+                          (overlap_high, ans_high)
+                         ])
+def test_additive_overlap(egrid, yexp):
+    """Simple test of an additive model.
+
+    There is only partial overlap of the two grids.
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(1.1, 1.5, 0.01)
+
+    mdl = xspec.XSpowerlaw()
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # will change regrid too
+    mdl.norm = 100
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(yexp)
+
+
+# To make it easy to compare the multiplicative tests we want
+# the center of the bins to match. To do this I am just shifting
+# the bins, so for an output of
+#
+#   0.1-0.2   entered at 0.15
+#   0.2-0.3              0.25
+#   0.3-0.4              0.35 ...
+#
+# we use a "regrid" that looks like
+#   0.125-0.175  this is centered at 0.15
+#   0.175-0.225
+#   0.225-0.275  this is centered at 0.25
+#   0.275-0.325
+#
+
+@requires_xspec
+def test_multiplicative():
+    """Simple test of a multiplicative model"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    mdl = xspec.XSwabs('mul')
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    mdl.nh = 0.05
+
+    y1 = mdl(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(y1, rel=0.04)
+
+
+# The expected values have been calculated based on akima interpolation
+# of the grided values, and differ from evaluating mdl on egrid (for
+# those bins which overlap the ebase range).
+#
+overlap2_low = np.arange(0.4, 0.9, 0.1)
+overlap2_high = np.arange(0.7, 1.3, 0.1)
+
+ans2_low = np.asarray([0, 0.641675, 0.7399567, 0.7984249])
+ans2_high = np.asarray([0.7984249, 0.84757835, 0.8698429, 0, 0, 0])
+
+
+@requires_xspec
+@pytest.mark.parametrize("egrid,yexp",
+                         [(overlap_none, ans_none),
+                          (overlap2_low, ans2_low),
+                          (overlap2_high, ans2_high)
+                         ])
+def test_multiplicative_overlap(egrid, yexp):
+    """Simple test of a multiplicative model
+
+    There is only partial overlap of the two grids.
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+
+    mdl = xspec.XSwabs()
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # will change regrid too
+    mdl.nh = 0.05
+
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(yexp)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name1,par1,val1,name2,par2,val2",
+                         [('wabs', 'nh', 0.05,
+                           'powerlaw', 'norm', 100),
+                          ('powerlaw', 'norm', 100,
+                           'wabs', 'nh', 0.05)])
+def test_combined(name1, par1, val1, name2, par2, val2, xsmodel):
+    """Simple test of an additive model * multiplicative model
+
+    We want to check it works for both a * b and
+    b * a (there is logic in the BinaryOp model
+    that favors the left-hand model, so we want to check
+    it is handled correctly here).
+    """
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    com1 = xsmodel(name1, "com1")
+    com2 = xsmodel(name2, "com2")
+    setattr(com1, par1, val1)
+    setattr(com2, par2, val2)
+
+    mdl = com1 * com2
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    y1 = mdl(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(y1, rel=0.04)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name,par,val",
+                         [('wabs', 'nh', 0.05),
+                          ('powerlaw', 'norm', 100)])
+def test_combined_arithmetic_left(name, par, val, xsmodel):
+    """Simple test of an additive model * multiplicative model"""
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    com = xsmodel(name, "com")
+    setattr(com, par, val)
+
+    mdl = 4 * com
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    yexp = 4 * com(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y1 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y1 == pytest.approx(yexp, rel=0.04)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name,par,val",
+                         [('wabs', 'nh', 0.05),
+                          ('powerlaw', 'norm', 100)])
+def test_combined_arithmetic_right(name, par, val, xsmodel):
+    """Simple test of an additive model * multiplicative model"""
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    com = xsmodel(name, "com")
+    setattr(com, par, val)
+
+    mdl = com * 4
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    yexp = 4 * com(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y1 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y1 == pytest.approx(yexp, rel=0.04)
+
+
+@requires_xspec
+def test_multi_combined_additive():
+    """Can we handle a "deep" binop tree?
+
+    What happens with (2 * mul) / (3 + mul)? Does it get
+    treated as additive?
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    m1 = xspec.XSgaussian('m1')
+    m2 = xspec.XSgaussian('m2')
+
+    mdl = (2 * m1) / (3 + m2)
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    expected = mdl(elo, ehi)
+    with pytest.raises(TypeError, match=IntegrateError):
+        got = regrid(elo, ehi)
+
+    # assert got == pytest.approx(expected)
+
+
+@requires_xspec
+def test_multi_combined_multiplicative():
+    """Can we handle a "deep" binop tree?
+
+    What happens with (2 * mul) / (3 + mul)? Does it get
+    treated as multiplicative?
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    m1 = xspec.XSconstant('m1')
+    m2 = xspec.XSconstant('m2')
+
+    mdl = (2 * m1) / (3 + m2)
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    expected = mdl(elo, ehi)
+    with pytest.raises(TypeError, match=IntegrateError):
+        got = regrid(elo, ehi)
+
+    # assert got == pytest.approx(expected)
+
+
+@requires_xspec
+@pytest.mark.parametrize('sherpa_first', [True, False])
+def test_sherpa_mul_xspec_add(sherpa_first):
+    """Check sherpa (multiplicative) * xspec (additive)"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    msherpa = Const1D('m1')
+    msherpa.c0 = 2
+    msherpa.integrate = False
+
+    mxspec = xspec.XSpowerlaw('m2')
+    mxspec.phoindex = 1.8
+
+    if sherpa_first:
+        comb = msherpa * mxspec
+    else:
+        comb = mxspec * msherpa
+
+    rcomb = comb.regrid(ebase[:-1], ebase[1:])
+
+    # Check the results make sense, but do not check the absolute values
+    yexp = 2 * mxspec(eg1, eg2)
+
+    # Note the tolerance is different to test_sherpa_add_xspec_mul
+    assert comb(eg1, eg2) == pytest.approx(yexp)
+    with pytest.raises(TypeError, match=IntegrateError):
+        assert rcomb(eg1, eg2) == pytest.approx(yexp, rel=0.006)
+
+
+@requires_xspec
+@pytest.mark.parametrize('sherpa_first', [True, False])
+def test_sherpa_add_xspec_mul(sherpa_first):
+    """Check sherpa (additive) * xspec (multiplicative)"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    msherpa = Gauss1D('m1')
+    msherpa.pos = 1.02
+    msherpa.fwhm = 0.4
+    msherpa.integrate = True
+
+    mxspec = xspec.XSconstant('m2')
+    mxspec.factor = 2
+
+    if sherpa_first:
+        comb = msherpa * mxspec
+    else:
+        comb = mxspec * msherpa
+
+    rcomb = comb.regrid(ebase[:-1], ebase[1:])
+
+    # Check the results make sense, but do not check the absolute values
+    yexp = 2 * msherpa(eg1, eg2)
+
+    # Note the tolerance is different to test_sherpa_mul_xspec_add
+    assert comb(eg1, eg2) == pytest.approx(yexp)
+    with pytest.raises(TypeError, match=IntegrateError):
+        assert rcomb(eg1, eg2) == pytest.approx(yexp, rel=0.07)
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+@pytest.mark.parametrize('name,iflag,tol',
+                         [('xspec-tablemodel-RCS.mod', True, 1e-6),
+                          pytest.param('testpcfabs.mod', False, 1e-3, marks=pytest.mark.xfail)])  # XFAIL: iflag is wrong and values do not match
+def test_regrid_table(name, iflag, tol, make_data_path):
+    """Can we regrid a table model?
+
+    We test out both additive and multiplicative models.
+    """
+
+    from sherpa.astro import xspec as xs
+
+    infile = make_data_path(name)
+    tbl = xs.read_xstable_model('mod', infile)
+
+    assert tbl.ndim == 1
+    assert tbl.integrate == iflag
+
+    egrid = np.arange(0.5, 1.5, 0.1)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    exp = tbl(eg1, eg2)
+    assert (exp > 0).all()
+
+    ebase = np.arange(0.45, 1.55, 0.05)
+    rtbl = tbl.regrid(ebase[:-1], ebase[1:])
+    y = rtbl(eg1, eg2)
+
+    assert y == pytest.approx(exp, rel=tol)
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_convolution_requires_bins(mname, xsmodel):
+    """Does the regrid method require lo,hi bins?
+
+    This just checks the current behavior, which is about what is
+    allowed and what warnings are created, not the returned values.
+
+    """
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    conv = xsmodel("cflux")
+    mdl = xsmodel(mname, "base")
+    cmdl = conv(mdl)
+
+    rmdl = cmdl.regrid(ebase)
+    with pytest.warns(FutureWarning) as record:
+        rmdl([0.57, 0.62, 0.66, 0.72])
+
+    assert len(record) == 3
+    assert record[0].message.args[0] == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+    assert record[1].message.args[0] == 'calc() requires pars,rhs,lo,hi arguments, sent 3 arguments'
+    assert record[2].message.args[0] == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+
+
+@requires_xspec
+@pytest.mark.parametrize('model,tol',
+                         [('powerlaw', 1e-3),
+                          ('wabs', 0.72)])  # was tol=0.31 at one point
+def test_regrid_convolution_single(model, tol, xsmodel):
+    """regriding an additive model or multiplicative.
+    """
+
+    ebase = np.arange(0.4, 10, 0.1)
+    egrid = np.arange(0.5, 10, 0.2)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    conv = xsmodel("cflux")
+    conv.emin = 1
+    conv.emax = 9
+
+    mdl = xsmodel(model)
+    cmdl = conv(mdl)
+
+    rmdl = cmdl.regrid(ebase[:-1], ebase[1:])
+
+    exp = cmdl(eg1, eg2)
+    assert (exp > 0).all()
+
+    y = rmdl(eg1, eg2)
+    assert y == pytest.approx(exp, rel=tol)
+
+
+@requires_xspec
+@pytest.mark.parametrize('name1,name2',
+                         [('wabs', 'powerlaw'),
+                          ('powerlaw', 'wabs')])
+def test_regrid_convolution_combined(name1, name2, xsmodel):
+    """regriding convolved(mdl1 * mdl2)
+
+    The tolerance is very large
+    """
+
+    ebase = np.arange(0.4, 10, 0.1)
+    egrid = np.arange(0.5, 10, 0.2)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    conv = xsmodel("cflux")
+    conv.emin = 1
+    conv.emax = 9
+
+    mdl1 = xsmodel(name1)
+    mdl2 = xsmodel(name2)
+    cmdl = conv(mdl1 * mdl2)
+
+    rmdl = cmdl.regrid(ebase[:-1], ebase[1:])
+
+    exp = cmdl(eg1, eg2)
+    assert (exp > 0).all()
+
+    y = rmdl(eg1, eg2)
+    assert y == pytest.approx(exp, rel=0.35)

--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -367,8 +367,16 @@ def test_combined_arithmetic_left(name, par, val, xsmodel):
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
     yexp = 4 * com(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
-        y1 = regrid(egrid[:-1], egrid[1:])
+
+    # WHY HAS THIS CHANGED?
+    if name == 'wabs':
+        with pytest.warns(FutureWarning, match=" requires pars,lo,hi arguments, sent 2 arguments"):
+            with pytest.raises(TypeError, match=IntegrateError):
+                y1 = regrid(egrid[:-1], egrid[1:])
+
+    else:
+        with pytest.raises(TypeError, match=IntegrateError):
+            y1 = regrid(egrid[:-1], egrid[1:])
 
     # assert y1 == pytest.approx(yexp, rel=0.04)
 
@@ -390,8 +398,16 @@ def test_combined_arithmetic_right(name, par, val, xsmodel):
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
     yexp = 4 * com(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
-        y1 = regrid(egrid[:-1], egrid[1:])
+
+    # WHY HAS THIS CHANGED?
+    if name == 'wabs':
+        with pytest.warns(FutureWarning, match=" requires pars,lo,hi arguments, sent 2 arguments"):
+            with pytest.raises(TypeError, match=IntegrateError):
+                y1 = regrid(egrid[:-1], egrid[1:])
+
+    else:
+        with pytest.raises(TypeError, match=IntegrateError):
+            y1 = regrid(egrid[:-1], egrid[1:])
 
     # assert y1 == pytest.approx(yexp, rel=0.04)
 
@@ -446,8 +462,9 @@ def test_multi_combined_multiplicative():
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
     expected = mdl(elo, ehi)
-    with pytest.raises(TypeError, match=IntegrateError):
-        got = regrid(elo, ehi)
+    with pytest.warns(FutureWarning, match=" requires pars,lo,hi arguments, sent 2 arguments"):
+        with pytest.raises(TypeError, match=IntegrateError):
+            got = regrid(elo, ehi)
 
     # assert got == pytest.approx(expected)
 

--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -135,8 +135,16 @@ def test_regrid_identity(mname, xsmodel):
 
     # scale y values to make them closer to unity
     y1 = 100 * mdl(elo, ehi)
-    with pytest.raises(TypeError, match=IntegrateError):
-        y2 = 100 * regrid(elo, ehi)
+
+    # WHY HAS THIS CHANGED?
+    if mname == "wabs":
+        with pytest.warns(FutureWarning, match=" requires pars,lo,hi arguments, sent 2 arguments"):
+            with pytest.raises(TypeError, match=IntegrateError):
+                y2 = 100 * regrid(elo, ehi)
+
+    else:
+        with pytest.raises(TypeError, match=IntegrateError):
+            y2 = 100 * regrid(elo, ehi)
 
     # assert y2 == pytest.approx(y1)
 
@@ -265,8 +273,9 @@ def test_multiplicative():
     mdl.nh = 0.05
 
     y1 = mdl(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
-        y2 = regrid(egrid[:-1], egrid[1:])
+    with pytest.warns(FutureWarning, match=" requires pars,lo,hi arguments, sent 2 arguments"):
+        with pytest.raises(TypeError, match=IntegrateError):
+            y2 = regrid(egrid[:-1], egrid[1:])
 
     # assert y2 == pytest.approx(y1, rel=0.04)
 
@@ -285,8 +294,8 @@ ans2_high = np.asarray([0.7984249, 0.84757835, 0.8698429, 0, 0, 0])
 @requires_xspec
 @pytest.mark.parametrize("egrid,yexp",
                          [(overlap_none, ans_none),
-                          (overlap2_low, ans2_low),
-                          (overlap2_high, ans2_high)
+                          pytest.param(overlap2_low, ans2_low, marks=pytest.mark.xfail),  # XFAIL: raises TypeError
+                          pytest.param(overlap2_high, ans2_high, marks=pytest.mark.xfail)
                          ])
 def test_multiplicative_overlap(egrid, yexp):
     """Simple test of a multiplicative model
@@ -303,11 +312,9 @@ def test_multiplicative_overlap(egrid, yexp):
 
     # will change regrid too
     mdl.nh = 0.05
+    y2 = regrid(egrid[:-1], egrid[1:])
 
-    with pytest.raises(TypeError, match=IntegrateError):
-        y2 = regrid(egrid[:-1], egrid[1:])
-
-    # assert y2 == pytest.approx(yexp)
+    assert y2 == pytest.approx(yexp)
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -24,7 +24,6 @@
 import copy
 import logging
 import os
-from tempfile import NamedTemporaryFile, gettempdir
 
 import pytest
 
@@ -369,7 +368,7 @@ def test_abund_change_string():
 
 
 @requires_xspec
-def test_abund_change_file():
+def test_abund_change_file(tmp_path):
     """Can we change the abundance setting: file
 
     This test hard-codes the number of elements expected in the
@@ -380,15 +379,16 @@ def test_abund_change_file():
 
     elems = {n: i * 0.1 for i, n in enumerate(ELEMENT_NAMES)}
 
-    tfh = NamedTemporaryFile(mode='w', suffix='.xspec')
+    out = ""
     for n in ELEMENT_NAMES:
-        tfh.write("{}\n".format(elems[n]))
+        out += f"{elems[n]}\n"
 
-    tfh.flush()
+    tempfile = tmp_path / "abundances.xspec"
+    tempfile.write_text(out)
 
     oval = xspec.get_xsabund()
     try:
-        xspec.set_xsabund(tfh.name)
+        xspec.set_xsabund(str(tempfile))
 
         abund = xspec.get_xsabund()
         out = {n: xspec.get_xsabund(n)
@@ -477,7 +477,7 @@ def test_cosmo_change():
 
 
 @requires_xspec
-def test_path_manager_change():
+def test_path_manager_change(tmp_path):
     """Can we change the manager-path setting?
     """
 
@@ -486,7 +486,7 @@ def test_path_manager_change():
     validate_xspec_setting(xspec.get_xspath_manager,
                            xspec.set_xspath_manager,
                            '/dev/null',
-                           gettempdir())
+                           str(tmp_path))
 
 
 # Note that the XSPEC state is used in test_xspec.py, but only
@@ -722,15 +722,13 @@ def test_read_xstable_model(make_data_path):
 
 @requires_xspec
 @pytest.mark.parametrize("clsname", ["powerlaw", "wabs"])
-def test_xspec_model_requires_bins(clsname):
+def test_xspec_model_requires_bins(clsname, xsmodel):
     """Ensure you can not call with a single grid for the energies.
 
     You used to be able to do this (in Sherpa 4.13 and earlier).
     """
 
-    from sherpa.astro import xspec
-
-    mdl = getattr(xspec, 'XS{}'.format(clsname))()
+    mdl = xsmodel(clsname)
 
     emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
     with pytest.warns(FutureWarning, match=emsg):
@@ -739,15 +737,13 @@ def test_xspec_model_requires_bins(clsname):
 
 @requires_xspec
 @pytest.mark.parametrize("clsname", ["powerlaw", "wabs"])
-def test_xspec_model_requires_bins_low_level(clsname):
+def test_xspec_model_requires_bins_low_level(clsname, xsmodel):
     """Ensure you can not call with a single grid for the energies (calc).
 
     You used to be able to do this (in Sherpa 4.13 and earlier).
     """
 
-    from sherpa.astro import xspec
-
-    mdl = getattr(xspec, 'XS{}'.format(clsname))()
+    mdl = xsmodel(clsname)
 
     emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
     with pytest.warns(FutureWarning, match=emsg):
@@ -756,15 +752,13 @@ def test_xspec_model_requires_bins_low_level(clsname):
 
 @requires_xspec
 @pytest.mark.parametrize("clsname", ["powerlaw", "wabs"])
-def test_xspec_model_requires_bins_very_low_level(clsname):
+def test_xspec_model_requires_bins_very_low_level(clsname, xsmodel):
     """Check we can use a single grid for direct access (_calc).
 
     This is the flip side to test-xspec_model_requires_bins_low_level
     """
 
-    from sherpa.astro import xspec
-
-    mdl = getattr(xspec, 'XS{}'.format(clsname))()
+    mdl = xsmodel(clsname)
 
     # pick a range which does not evaluate to 0 for wabs
     egrid = np.arange(0.5, 1.0, 0.1)
@@ -1069,7 +1063,7 @@ def test_xstbl_link_parameter_evaluation(make_data_path):
 
 @requires_xspec
 @pytest.mark.parametrize("clsname", ["powerlaw", "wabs"])
-def test_integrate_setting(clsname):
+def test_integrate_setting(clsname, xsmodel):
     """Can we change the integrate setting?
 
     It's not obvious what the integrate setting is meant to do for
@@ -1077,13 +1071,11 @@ def test_integrate_setting(clsname):
 
     """
 
-    from sherpa.astro import xspec
-
     egrid = np.arange(0.1, 1.0, 0.1)
     elo = egrid[:-1]
     ehi = egrid[1:]
 
-    mdl = getattr(xspec, 'XS{}'.format(clsname))()
+    mdl = xsmodel(clsname)
     assert mdl.integrate
 
     y1 = mdl(elo, ehi)
@@ -1108,7 +1100,7 @@ def test_integrate_setting(clsname):
 
 @requires_xspec
 @pytest.mark.parametrize("clsname", ["powerlaw", "wabs"])
-def test_integrate_setting_con(clsname):
+def test_integrate_setting_con(clsname, xsmodel):
     """Can we change the integrate setting of convolution models.
 
     This is test_integrate_setting after wrapping the model by a
@@ -1121,16 +1113,14 @@ def test_integrate_setting_con(clsname):
 
     """
 
-    from sherpa.astro import xspec
-
     egrid = np.arange(0.1, 1.0, 0.1)
     elo = egrid[:-1]
     ehi = egrid[1:]
 
-    conv = xspec.XScflux()
+    conv = xsmodel("cflux")
     assert conv.integrate
 
-    omdl = getattr(xspec, 'XS{}'.format(clsname))()
+    omdl = xsmodel(clsname)
     assert omdl.integrate
 
     # Convolution models do not have an integrate setting
@@ -1180,7 +1170,7 @@ def test_xsparameter_within_limit(val):
 @requires_xspec
 @pytest.mark.parametrize("val", [1, 8])
 def test_xsparameter_at_limit(val):
-    """What happens if we pass outside soft but within hard range?
+    """What happens if we pass outside soft but at hard limit?
 
     """
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -661,6 +661,7 @@ def cleanup_ds9_backend():
     from sherpa.image import backend
     backend.close()
 
+
 @pytest.fixture(autouse=True)
 def add_sherpa_test_data_dir(doctest_namespace):
     '''Define `data_dir` for doctests
@@ -685,3 +686,27 @@ def add_sherpa_test_data_dir(doctest_namespace):
         path += '/'
 
     doctest_namespace["data_dir"] = path
+
+
+@pytest.fixture
+def xsmodel():
+    """fixture that returns an XS<name> model instance.
+
+    The test needs to be marked @requires_xspec when using this
+    fixture.
+
+    """
+
+    try:
+        from sherpa.astro import xspec
+    except ImportError:
+        raise RuntimeError("Test needs the requires_xspec decorator")
+
+    def func(name, mname=None):
+        cls = getattr(xspec, f"XS{name}")
+        if mname is None:
+            return cls()
+
+        return cls(mname)
+
+    return func

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1048,6 +1048,9 @@ class SimulFitModel(CompositeModel):
 class ArithmeticConstantModel(Model):
     """Represent a constant value, or values.
 
+    .. versionchanged:: 4.16.0
+       Models now have an `integrate` value, set to False.
+
     Parameters
     ----------
     val : number or sequence
@@ -1061,6 +1064,14 @@ class ArithmeticConstantModel(Model):
     val : number
 
     """
+
+    @property
+    def integrate(self):
+        """The model is not integrated across the independent axis.
+
+        It can not be changed for ArithmeticConstant models.
+        """
+        return False
 
     def __init__(self, val, name=None):
         val = SherpaFloat(val)
@@ -1502,7 +1513,10 @@ class FilterModel(CompositeModel, ArithmeticModel):
     def calc(self, p, *args, **kwargs):
         return self.model.calc(p, *args, **kwargs)[self.filter]
 
-
+# TODO: should this gain an integrate setting? It depends on the
+# function, so there's no way for the code to set it to a sensible
+# value.
+#
 class ArithmeticFunctionModel(Model):
     """Represent a callable function.
 

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,6 +22,7 @@
 
 from functools import reduce
 import operator
+import re
 
 import numpy as np
 
@@ -28,7 +30,8 @@ import pytest
 
 from sherpa.astro.ui.utils import Session
 from sherpa.models import basic
-from sherpa.models.model import ArithmeticConstantModel, BinaryOpModel, UnaryOpModel
+from sherpa.models.model import ArithmeticConstantModel, \
+    ArithmeticFunctionModel, BinaryOpModel, UnaryOpModel
 from sherpa.utils.err import ModelErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
 
@@ -201,10 +204,9 @@ def test_combine_models_1d_2d():
     m1 = basic.Box1D()
     m2 = basic.Box2D()
 
-    with pytest.raises(ModelErr) as exc:
+    with pytest.raises(ModelErr,
+                       match=re.escape("Models do not match: 1D (box1d) and 2D (box2d)")):
         m1 + m2
-
-    assert str(exc.value) == 'Models do not match: 1D (box1d) and 2D (box2d)'
 
 
 @pytest.mark.parametrize("val", [2, [1, 3, 4]])
@@ -223,10 +225,9 @@ def test_arithmeticconstantmodel(val):
 def test_arithmeticconstantmodel_dimerr():
 
     x = np.ones(6).reshape(2, 3)
-    with pytest.raises(ModelErr) as exc:
+    with pytest.raises(ModelErr,
+                       match="The constant must be a scalar or 1D, not 2D"):
         ArithmeticConstantModel(x)
-
-    assert str(exc.value) == 'The constant must be a scalar or 1D, not 2D'
 
 
 @requires_xspec
@@ -281,3 +282,131 @@ def test_load_table_model(make_data_path):
     s.load_table_model('tbl', make_data_path('double.dat'))
     tbl = s.get_model_component('tbl')
     assert tbl.ndim is None
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_unop_integrate(flag):
+    """Is the integrate flag carried over"""
+
+    mdl = basic.Const1D()
+    mdl.integrate = flag
+
+    umdl = -mdl
+    with pytest.raises(AttributeError):
+        assert umdl.integrate == flag
+
+
+def test_aconstant_integrate():
+    """Do we have an integrate setting?
+
+    test_unop_integrate_unset and others use an
+    ArithmeticConstantModel (implicitly) because at the time of
+    writing it doesn't have an integrate setting. Make this a
+    regression test (it is not a priori a problem if it does change
+    behavior, we just want to know we have a test).
+
+    """
+
+    mdl = ArithmeticConstantModel(3.2)
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+def test_unop_integrate_unset():
+    """Is the integrate flag not set for an unary op model"""
+
+    # UnaryOpModel converts the constant to an
+    # ArithmeticConstantModel.
+    #
+    mdl = UnaryOpModel(4, np.negative, "-")
+
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_binop_integrate_same(flag):
+    """Is the integrate flag carried over when the same"""
+
+    mdl1 = basic.Const1D()
+    mdl1.integrate = flag
+
+    mdl2 = basic.Const1D()
+    mdl2.integrate = flag
+
+    mdl = mdl1 + mdl2
+    with pytest.raises(AttributeError):
+        assert mdl.integrate == flag
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_binop_integrate_different(flag):
+    """Is the integrate flag not carried over when different"""
+
+    mdl1 = basic.Const1D()
+    mdl1.integrate = flag
+
+    mdl2 = basic.Const1D()
+    mdl2.integrate = not flag
+
+    mdl = mdl1 + mdl2
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+def test_binop_integrate_unset():
+    """Is the integrate flag not set for a binary op model"""
+
+    # The ArithmeticConstantModel, which the binary-op model casts
+    # the constant terms, has no integrate setting.
+    #
+    mdl = BinaryOpModel(4, 4, np.add, '+')
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+@pytest.mark.parametrize("m1,m2", [(1, basic.Const1D()),
+                                   (basic.Const1D(), 1),
+                                   (1, basic.Scale1D()),
+                                   (basic.Scale1D(), 1)])
+def test_binop_arithmeticmodel_integrate(m1, m2):
+    """Do we have an integrate setting?
+
+    This is a regression test.
+    """
+
+    mdl = m1 + m2
+    assert not hasattr(mdl, "integrate")
+
+
+AMODEL = ArithmeticFunctionModel(np.sin)
+
+
+@pytest.mark.parametrize("m1,m2", [(AMODEL, basic.Const1D()),
+                                   (basic.Const1D(), AMODEL),
+                                   (AMODEL, basic.Scale1D()),
+                                   (basic.Scale1D(), AMODEL)])
+def test_binop_arithmeticfunction_integrate(m1, m2):
+    """What's the integrate setting when ArithmeticFunctionModel is present?
+
+    This is a regression test.
+    """
+
+    mdl = m1 + m2
+    assert not hasattr(mdl, "integrate")
+
+
+@pytest.mark.parametrize("m1,m2", [(AMODEL, 2),
+                                   (2, AMODEL)])
+def test_binop_arithmeticfunction_works(m1, m2):
+    """Check we can evaluate a function model in a binop"""
+
+    grid = np.asarray([-0.2, -0.1, 0.1, 0.3])
+
+    # There's no support for creating these models easily.
+    #
+    mdl = BinaryOpModel(m1, m2, np.multiply, '*')
+    y = mdl(grid)
+
+    expected = 2 * np.sin(grid)
+    assert y == pytest.approx(expected)

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -292,8 +292,7 @@ def test_unop_integrate(flag):
     mdl.integrate = flag
 
     umdl = -mdl
-    with pytest.raises(AttributeError):
-        assert umdl.integrate == flag
+    assert umdl.integrate == flag
 
 
 def test_aconstant_integrate():
@@ -313,15 +312,14 @@ def test_aconstant_integrate():
 
 
 def test_unop_integrate_unset():
-    """Is the integrate flag not set for an unary op model"""
+    """Is the integrate flag set for an unary op model"""
 
     # UnaryOpModel converts the constant to an
     # ArithmeticConstantModel.
     #
     mdl = UnaryOpModel(4, np.negative, "-")
 
-    with pytest.raises(AttributeError):
-        mdl.integrate
+    assert not mdl.integrate
 
 
 @pytest.mark.parametrize("flag", [True, False])
@@ -335,13 +333,12 @@ def test_binop_integrate_same(flag):
     mdl2.integrate = flag
 
     mdl = mdl1 + mdl2
-    with pytest.raises(AttributeError):
-        assert mdl.integrate == flag
+    assert mdl.integrate == flag
 
 
 @pytest.mark.parametrize("flag", [True, False])
 def test_binop_integrate_different(flag):
-    """Is the integrate flag not carried over when different"""
+    """Is the integrate flag carried over when different"""
 
     mdl1 = basic.Const1D()
     mdl1.integrate = flag
@@ -350,50 +347,48 @@ def test_binop_integrate_different(flag):
     mdl2.integrate = not flag
 
     mdl = mdl1 + mdl2
-    with pytest.raises(AttributeError):
-        mdl.integrate
+    assert mdl.integrate  # NOTE: this is always True
 
 
 def test_binop_integrate_unset():
-    """Is the integrate flag not set for a binary op model"""
+    """Is the integrate flag set for a binary op model"""
 
     # The ArithmeticConstantModel, which the binary-op model casts
     # the constant terms, has integrate=False
     #
     mdl = BinaryOpModel(4, 4, np.add, '+')
-    with pytest.raises(AttributeError):
-        mdl.integrate
+    assert not mdl.integrate
 
 
-@pytest.mark.parametrize("m1,m2", [(1, basic.Const1D()),
-                                   (basic.Const1D(), 1),
-                                   (1, basic.Scale1D()),
-                                   (basic.Scale1D(), 1)])
-def test_binop_arithmeticmodel_integrate(m1, m2):
+@pytest.mark.parametrize("m1,m2,iflag", [(1, basic.Const1D(), True),
+                                         (basic.Const1D(), 1, True),
+                                         (1, basic.Scale1D(), False),
+                                         (basic.Scale1D(), 1, False)])
+def test_binop_arithmeticmodel_integrate(m1, m2, iflag):
     """Do we have an integrate setting?
 
     This is a regression test.
     """
 
     mdl = m1 + m2
-    assert not hasattr(mdl, "integrate")
+    assert mdl.integrate is iflag
 
 
 AMODEL = ArithmeticFunctionModel(np.sin)
 
 
-@pytest.mark.parametrize("m1,m2", [(AMODEL, basic.Const1D()),
-                                   (basic.Const1D(), AMODEL),
-                                   (AMODEL, basic.Scale1D()),
-                                   (basic.Scale1D(), AMODEL)])
-def test_binop_arithmeticfunction_integrate(m1, m2):
+@pytest.mark.parametrize("m1,m2,iflag", [(AMODEL, basic.Const1D(), True),
+                                         (basic.Const1D(), AMODEL, True),
+                                         (AMODEL, basic.Scale1D(), False),
+                                         (basic.Scale1D(), AMODEL, False)])
+def test_binop_arithmeticfunction_integrate(m1, m2, iflag):
     """What's the integrate setting when ArithmeticFunctionModel is present?
 
     This is a regression test.
     """
 
     mdl = m1 + m2
-    assert not hasattr(mdl, "integrate")
+    assert mdl.integrate is iflag
 
 
 @pytest.mark.parametrize("m1,m2", [(AMODEL, 2),

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -299,17 +299,17 @@ def test_unop_integrate(flag):
 def test_aconstant_integrate():
     """Do we have an integrate setting?
 
-    test_unop_integrate_unset and others use an
-    ArithmeticConstantModel (implicitly) because at the time of
-    writing it doesn't have an integrate setting. Make this a
-    regression test (it is not a priori a problem if it does change
-    behavior, we just want to know we have a test).
-
+    This is a regression test
     """
 
     mdl = ArithmeticConstantModel(3.2)
+    assert mdl.integrate is False
+
+    # Check we can't change it
     with pytest.raises(AttributeError):
-        mdl.integrate
+        mdl.integrate = True
+
+    assert mdl.integrate is False
 
 
 def test_unop_integrate_unset():
@@ -358,7 +358,7 @@ def test_binop_integrate_unset():
     """Is the integrate flag not set for a binary op model"""
 
     # The ArithmeticConstantModel, which the binary-op model casts
-    # the constant terms, has no integrate setting.
+    # the constant terms, has integrate=False
     #
     mdl = BinaryOpModel(4, 4, np.add, '+')
     with pytest.raises(AttributeError):

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -1196,23 +1196,23 @@ def test_evaluationspace1d_zeros_like_integrated():
     assert EvaluationSpace1D([3, 2, -1], [2, 1, -3]).zeros_like() == pytest.approx([0, 0, 0])
 
 
-@pytest.mark.parametrize("flag,mdl",
-                         [(False, Box1D() * Const1D() * Gauss1D()),
-                          (False, Box1D() * Const1D() * (1 + Gauss1D())),
-                          (False, 1 / (1 + Const1D())),
-                          (False, 1 / (Box1D() * Gauss1D())),
-                          (False, 1 / (1 + Box1D() * Gauss1D())),
-                          (False, ((Box1D() + Const1D()) / (Box1D() + Gauss1D()))),
-                          (False, (Const1D() / (Box1D() + Gauss1D()) + Box1D())),
-                          (False, (1 / (1 - (-Const1D())))),
-                          (False, ((-Box1D()) / ((-Const1D()) - (-Gauss1D())))),
-                          (True, Box1D() * Gauss1D()),
-                          (True, Box1D() / (Const1D() + Gauss1D())),
-                          (True, Const1D() / (1 + Box1D() * Gauss1D())),
-                          (True, (Box1D() + Const1D() / (Box1D() + Gauss1D())))
+@pytest.mark.parametrize("mdl",
+                         [(Box1D() * Const1D() * Gauss1D()),
+                          (Box1D() * Const1D() * (1 + Gauss1D())),
+                          (1 / (1 + Const1D())),
+                          (1 / (Box1D() * Gauss1D())),
+                          (1 / (1 + Box1D() * Gauss1D())),
+                          (((Box1D() + Const1D()) / (Box1D() + Gauss1D()))),
+                          ((Const1D() / (Box1D() + Gauss1D()) + Box1D())),
+                          pytest.param(1 / (1 - (-Const1D())), marks=pytest.mark.xfail),  # XFAIL: no regrid method found
+                          pytest.param((-Box1D()) / ((-Const1D()) - (-Gauss1D())), marks=pytest.mark.xfail),  # XFAIL: no regrid method found
+                          (Box1D() * Gauss1D()),
+                          (Box1D() / (Const1D() + Gauss1D())),
+                          (Const1D() / (1 + Box1D() * Gauss1D())),
+                          ((Box1D() + Const1D() / (Box1D() + Gauss1D())))
                           ])
 @pytest.mark.parametrize("args", [([1, 2, 3], ), ([1, 2, 4], [2, 3, 5])])
-def test_recursion_1802(flag, mdl, args):
+def test_recursion_1802(mdl, args):
     """Can we create moderately-complex models to regrid?
 
     Test cases from #1802. It is unlikely that the axis choice (point
@@ -1220,18 +1220,10 @@ def test_recursion_1802(flag, mdl, args):
 
     """
 
-    # This test could be marked XFAIL but I want to make it obvious
-    # once it gets fixed.
-    #
-    if flag:
-        rmdl = mdl.regrid(*args)
-        # basic check to see if we have got a regrid model
-        assert isinstance(rmdl, RegridWrappedModel)
-        assert rmdl.name == f"regrid1d({mdl.name})"
-        return
-
-    with pytest.raises(RecursionError):
-        mdl.regrid(*args)
+    rmdl = mdl.regrid(*args)
+    # basic check to see if we have got a regrid model
+    assert isinstance(rmdl, RegridWrappedModel)
+    assert rmdl.name == f"regrid1d({mdl.name})"
 
 
 def test_unop_regrid():

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -25,8 +25,9 @@ from numpy.testing import assert_allclose
 
 import pytest
 
-from sherpa.models.model import Model, ArithmeticModel, CompositeModel, \
-    ArithmeticFunctionModel, RegridWrappedModel
+from sherpa.models.model import Model, ArithmeticModel, BinaryOpModel, \
+    CompositeModel, ArithmeticConstantModel, ArithmeticFunctionModel, \
+    RegridWrappedModel, UnaryOpModel
 from sherpa.models.basic import Box1D, Const1D, Gauss1D, \
     PowLaw1D, StepLo1D
 from sherpa.models.parameter import Parameter
@@ -147,7 +148,7 @@ def test_regrid1d_wrapping_name():
     #       incorrect. There is "prior art" here with PSF, ARF,
     #       and RMF models to look at.
     #
-    expected_name = 'regrid1d({})'.format(imodel_name)
+    expected_name = f'regrid1d({imodel_name})'
     assert mdl.name == expected_name
 
 
@@ -172,7 +173,7 @@ def test_regrid1d_wrapping_str():
     rmdl = ModelDomainRegridder1D(name='test')
     mdl = rmdl.apply_to(internal_model)
 
-    expected_name = 'test({})'.format(imodel_name)
+    expected_name = f'test({imodel_name})'
 
     # need to strip off the first line and replace it with
     # the new model name
@@ -389,7 +390,7 @@ def test_regrid1d_passes_through_the_grid():
 
     rmdl.grid = grid_expected
     store = imdl._calc_store
-    len(store) == 0
+    assert len(store) == 0
 
     y = mdl(grid_requested)
     assert len(y) == len(grid_requested)
@@ -827,15 +828,13 @@ class ReNormalizerModel1DInt(CompositeModel, ArithmeticModel):
     def wrapobj(obj):
         if isinstance(obj, ArithmeticModel):
             return obj
-        else:
-            return ArithmeticFunctionModel(obj)
+
+        return ArithmeticFunctionModel(obj)
 
     def __init__(self, model, wrapper):
         self.model = self.wrapobj(model)
         self.wrapper = wrapper
-        CompositeModel.__init__(self,
-                                "{}({})".format(self.wrapper.name,
-                                                self.model.name),
+        CompositeModel.__init__(self, f"{self.wrapper.name}({self.model.name})",
                                 (self.wrapper, self.model))
 
     def calc(self, p, *args, **kwargs):
@@ -1259,3 +1258,189 @@ def test_unop_binop_combo():
     #
     expected = mdl2(egrid) - mdl1(egrid)
     assert got == pytest.approx(expected)
+
+
+def test_regrid_binop_arithmeticconstantmodel():
+    """If you have managed to create binop(constants) then regridded, does it work"""
+
+    grid = np.linspace(20, 30, 21)
+    orig = BinaryOpModel(4, 6, np.add, '+')
+
+    with pytest.raises(ModelErr) as exc:
+        orig.regrid(grid)
+
+    assert str(exc.value) == 'Neither component supports regrid method'
+
+
+def test_box1d_point():
+    """This model is used in several tests so check it out"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = cpt
+    exp = np.asarray([0, 0, 1, 1, 1, 1, 1])
+
+    xgrid = np.arange(105, 195, 13)
+    assert mdl(xgrid) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase)
+    assert rmdl(xgrid) == pytest.approx(exp)
+
+
+def test_constant_box1d_point():
+    """Check 3 + mdl"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = 3 + cpt
+
+    exp = 3 + np.asarray([0, 0, 1, 1, 1, 1, 1])
+
+    xgrid = np.arange(105, 195, 13)
+    assert mdl(xgrid) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase)
+    assert rmdl(xgrid) == pytest.approx(exp)
+
+
+def test_box1d_bin():
+    """This model is used in several tests so check it out"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = cpt
+    exp = np.asarray([0, 1, 13, 13, 13, 13])
+
+    # Ideally this would be exp, but it's not quite
+    exp2 = np.asarray([0, 1, 13, 13, 13, 12.7])
+
+    xgrid = np.arange(105, 195, 13)
+    xg1 = xgrid[:-1]
+    xg2 = xgrid[1:]
+    assert mdl(xg1, xg2) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase[:-1], xbase[1:])
+    assert rmdl(xg1, xg2) == pytest.approx(exp2)
+
+
+def test_constant_box1d_bin():
+    """Check 3 + mdl"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = 3 + cpt
+
+    # What is the correct value here? That is, what do
+    # we expect the "integrated" version of the constant
+    # to be? It should just be 3 (i.e. it doesn't care about
+    # the bin width), but once we start rebinning things it
+    # gets complicated.
+    #
+    exp = 3 + np.asarray([0, 1, 13, 13, 13, 13])
+
+    # Just report the current value
+    exp2 = 3.9 + np.asarray([0, 1, 13, 13, 13, 12.7])
+
+    xgrid = np.arange(105, 195, 13)
+    xg1 = xgrid[:-1]
+    xg2 = xgrid[1:]
+    assert mdl(xg1, xg2) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase[:-1], xbase[1:])
+    assert rmdl(xg1, xg2) == pytest.approx(exp2)
+
+
+@pytest.mark.parametrize("integrate", [True, False])
+def test_deep_binop_points(integrate):
+    """Can we handle a "deep" binop tree?
+
+    (2 * model) / (3 + model)
+
+    We evaluate it on a set of points, not a grid,
+    so the integration setting doesn't matter.
+    """
+
+    yexp = np.asarray([0, 2/3, 0.5, 0.5, 0.5, 0, 0])
+
+    xbase = np.arange(100, 200, 10)
+    xgrid = np.arange(105, 195, 13)
+
+    m1 = Box1D('m1')
+    m2 = Box1D('m2')
+    m1.xlow = 110
+    m1.xhi = 160
+    m2.xlow = 130
+    m2.xhi = 189
+
+    m1.integrate = integrate
+    m2.integrate = integrate
+
+    mdl = (2 * m1) / (3 + m2)
+    regrid = mdl.regrid(xbase)
+
+    ym = mdl(xgrid)
+    assert ym == pytest.approx(yexp)
+
+    yr = regrid(xgrid)
+    assert yr == pytest.approx(ym)
+
+
+@pytest.mark.parametrize("integrate,yexp,yexp2",
+                         [(True,
+                           [16/3, 26/4, 26/16, 26/16, 6/16, 0, 0],
+                           [40/7.5, 8.15384615, 2, 2, 0.46153846, 0, 0]
+                         ),
+                          pytest.param(False,
+                           [0, 2/3, 0.5, 0.5, 0.5, 0, 0],
+                           [4/7.5, 0.85, 0.65, 0.65, 0.65, 0, 0],
+                                       marks=pytest.mark.xfail  # XFAIL: values very different to yexp2, error in code or in the expectation?
+                          )])
+def test_deep_binop_bins(integrate, yexp, yexp2):
+    """Can we handle a "deep" binop tree?
+
+    (2 * model) / (3 + model)
+
+    We evaluate it on bins (lo,hi) so the integration
+    setting does matter here.
+
+    We have to give separate "expected" results for the
+    un-regridded and regridded models as they are not close
+    enough to use the same values.
+    """
+
+    yexp = np.asarray(yexp)
+    yexp2 = np.asarray(yexp2)
+
+    xbase = np.arange(100, 200 + 10, 10)
+    xgrid = np.arange(105, 195 + 13, 13)
+
+    m1 = Box1D('m1')
+    m2 = Box1D('m2')
+    m1.xlow = 110
+    m1.xhi = 160
+    m2.xlow = 130
+    m2.xhi = 189
+
+    m1.integrate = integrate
+    m2.integrate = integrate
+
+    mdl = (2 * m1) / (3 + m2)
+    regrid = mdl.regrid(xbase[:-1], xbase[1:])
+
+    ym = mdl(xgrid[:-1], xgrid[1:])
+    assert ym == pytest.approx(yexp)
+
+    yr = regrid(xgrid[:-1], xgrid[1:])
+    assert yr == pytest.approx(yexp2)


### PR DESCRIPTION
I'm coming back to review this and so the text below is not guaranteed to match up with the code behavior.

# Summary

Improve the handling of the integrate setting for models: it is now passed on for composite models, such as an expression like "mdl1 * (mdl2 - mdl3)", and XSPEC models no longer allow users to change the setting (any attempt will be ignored, which will allow scripts created by save_all using an older version of Sherpa to still work).

# Details

This is a rework of the last part of #947 and then merging in work done in #830. This is closely related to the regrid work but has been broken out of that (see #830, which depends on this PR). This PR depends on

- #1803

The ideas are that

- adding more tests to cover some of the issues we have uncovered
- allow the integrate to be passed "up" the model classes, so that composite models can have an integrate setting [1]
- special case the XSPEC models since we know that should send the data "integrated" arrays - that is low and high edges - **but** we also know there's a difference for additive and multiplicative models that maps well to `integrate=True` and `integrate=False` respectively when regridding data [2], [3]

[1] technically it makes to copy the integrate flag for something like an unary op model, but it's less clear what happens for binary op models where you may be combing models with `integrate=True` and `integrate=False`. We could set `integrate` to `None` in this case (or even record all the integrate settings in some way) but I am not sure it would help downstream users. I think the current code will fall over to a `True` setting for this case (see the paragraph starting "One interesting outcome" below).

[2] XSPEC models now have a fixed `integrate` setting, and attempting to change it does nothing. That is, you can say "mdl.integrate = False` for an additive model, but the field will stay set to `True`. I originally made this be an error, **but** that would break any use of `save_all` which contains a multiplicative XSPEC model, for no actual user benefit. So now we just do nothing. We could use the warning logger, or a warnings FutureWarning to create a message, but I am not sure many people actually change this setting, so all we'd then do would be make users of `save_all` see even more screen messages they would then learn to ignore.

[3] XSPEC convolution models are a special case - I believe the way that XSPEC works, you aren't able to apply a convolution model to anything but an additive model (that is, a model expression that "ends" with an additive component), which would imply XSPEC convolution models should be marked as `integrate=True`, so this is what we do

One interesting outcome of the current code, and something we could try to clean up, is that models tend now to default to `integrate=True` (thanks to `ArithmeticModel`) and that this can lead to things like "unary op model is sent something with no `integrate` setting, so we try not to set the `integrate` flag, but it magically gains it from the `ArithmeticModel` hierarchy".

It is hard to update the documentation to highlight this change, as there's no single `ui` routine (for example) we can document. Something to think about.

This code is going to conflict with all the existing XSPEC changes we have (e.g. #1396 https://github.com/sherpa/sherpa/pull/1609 https://github.com/sherpa/sherpa/pull/1615 https://github.com/sherpa/sherpa/pull/1630)

# Question

How useful is the `integrate` setting? In some ways I'd like to get rid of it, but that would be quite a large change for little obvious user benefit.

We could use the integrate setting to validate model expressions, in a similar manner to the way we do with model dimensionaluity, but

 - the dimensional check can be made when the model expression is being created, whereas the integrate setting would need to be checked whenever the composite model is evaluated
 - for XSPEC models we can come up with something (like you can multiply but not add multiplicative components) but is this true for the general case (and coming up with rules is more onerous than I'd like for a simple check)

# Trying to change the integrate setting

In #947 I had made code like

    mdl = XSapec()
    mdl.integrate = False

raise an error, because the integrate setting of this model (an additive model) is True. In this version it just ignores the user setting, so the following would hold after the above:

    assert mdl.integrate

Normally I'd be all for raising an error here, but it would make any script saved by `save_all` that contains an XSPEC multiplicative model to fail when evaluated because before this change the file would include a line `mdl.integrate = True` for these models  (because prior to this PR the multiplicative models did have integrate set to True), which would mean annoying changes for users that doesn't actually improve anything.  Hence the change to the setter just ignoring the user value.

# Example

## Generic

In CIAO 4.15 we have

```
sherpa-4.15.0> mdl1 = 2 + const1d.foo1

sherpa-4.15.0> mdl2 = 2 + scale1d.bar1

sherpa-4.15.0> foo1.integrate
True

sherpa-4.15.0> bar1.integrate
False

sherpa-4.15.0> mdl1.integrate
AttributeError: 'BinaryOpModel' object has no attribute 'integrate'

sherpa-4.15.0> mdl2.integrate
AttributeError: 'BinaryOpModel' object has no attribute 'integrate'

sherpa-4.15.0> tmp = -bar1

sherpa-4.15.0> tmp.integrate
AttributeError: 'UnaryOpModel' object has no attribute 'integrate'
```

With this PR we get

```
>>> from sherpa.astro.ui import *
>>> mdl1 = 2 + const1d.foo1
>>> mdl2 = 2 + scale1d.bar1
>>> (foo1.integrate, bar1.integrate)
(True, False)
>>> (mdl1.integrate, mdl2.integrate)
(True, True)
>>> tmp = -bar1
>>> tmp.integrate
False
```

Now, should `2 + bar1` have an integrate setting of `True`? Ideally not.

I note that when combining "actual" models we get the `integrate` setting combined as you might expect:

```
>>> foo1.integrate, bar1.integrate
(True, False)
>>> (foo1 + bar1).integrate
True
>>> (foo1 + foo1).integrate
True
>>> (bar1 + bar1).integrate
False
>>> (bar1 + foo1).integrate
True
```

[as a reminder, in CIAO 4.15 composite models do not have an `integrate` setting:

```
sherpa-4.15.0> (foo1 + bar1).integrate
AttributeError: 'BinaryOpModel' object has no attribute 'integrate'
```
]

## XSPEC

In CIAO 4.15 we have

```\sherpa-4.15.0> mdl = xsphabs.gal * xsapec.src

sherpa-4.15.0> (gal.integrate, src.integrate)
(True, True)

sherpa-4.15.0> mdl.integrate
AttributeError: 'BinaryOpModel' object has no attribute 'integrate'

sherpa-4.15.0> src.integrate = False

sherpa-4.15.0> (gal.integrate, src.integrate)
(True, False)
```

We now get

```
>>> mdl = xsphabs.gal * xsapec.src
>>> (gal.integrate, src.integrate)
(False, True)
>>> mdl.integrate
True
>>> (gal + gal).integrate     # NOTE: combing two False create a combined model with integrate=False
False
>>> src.integrate = False
>>> (gal.integrate, src.integrate)
(False, True)
>>> mdl.integrate
True
```