### PR TITLE
Attempt to unify set_arf/rmf and load_arf/rmf

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_multi_response.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_multi_response.py
@@ -157,8 +157,9 @@ def make_rmf2():
     return rmf1, rmf2, dset
 
 
+@pytest.mark.parametrize("set_arf", [ui.set_arf, ui.load_arf])
 @pytest.mark.parametrize("id", [None, 1, "three"])
-def test_set_multi_arfs(id, clean_astro_ui):
+def test_set_multi_arfs(id, set_arf, clean_astro_ui):
 
     arf1, arf2, dset = make_arf2()
 
@@ -166,10 +167,10 @@ def test_set_multi_arfs(id, clean_astro_ui):
     d = ui.get_data(id=id)
     assert d.response_ids == []
 
-    ui.set_arf(id=id, arf=arf1, resp_id=1)
+    set_arf(id, arf1, 1)
     assert d.response_ids == [1]
 
-    ui.set_arf(id=id, arf=arf2, resp_id=2)
+    set_arf(id, arf2, 2)
     assert d.response_ids == [1, 2]
 
 
@@ -189,8 +190,9 @@ def test_set_multi_arfs_reorder(id, clean_astro_ui):
     assert d.response_ids == [2, 1]
 
 
+@pytest.mark.parametrize("set_rmf", [ui.set_rmf, ui.load_rmf])
 @pytest.mark.parametrize("id", [None, 1, "three"])
-def test_set_multi_rmfs(id, clean_astro_ui):
+def test_set_multi_rmfs(id, set_rmf, clean_astro_ui):
 
     rmf1, rmf2, dset = make_rmf2()
 
@@ -198,10 +200,10 @@ def test_set_multi_rmfs(id, clean_astro_ui):
     d = ui.get_data(id=id)
     assert d.response_ids == []
 
-    ui.set_rmf(id=id, rmf=rmf1, resp_id=1)
+    set_rmf(id, rmf1, 1)
     assert d.response_ids == [1]
 
-    ui.set_rmf(id=id, rmf=rmf2, resp_id=2)
+    set_rmf(id, rmf2, 2)
     assert d.response_ids == [1, 2]
 
 
@@ -267,13 +269,14 @@ def check_eval_multi_arf():
     assert mplot.y[600] == pytest.approx(ymid)
 
 
-def test_eval_multi_arf(clean_astro_ui):
+@pytest.mark.parametrize("set_arf", [ui.set_arf, ui.load_arf])
+def test_eval_multi_arf(set_arf, clean_astro_ui):
     """See also test_eval_multi_arf_reorder"""
 
     arf1, arf2, dset = make_arf2()
     ui.set_data(1, dset)
-    ui.set_arf(id=1, arf=arf1, resp_id=1)
-    ui.set_arf(id=1, arf=arf2, resp_id=2)
+    set_arf(1, arf1, 1)
+    set_arf(1, arf2, 2)
 
     check_eval_multi_arf()
 
@@ -344,13 +347,14 @@ def check_eval_multi_rmf():
     assert mplot.y[968:988] == pytest.approx(is_high)
 
 
-def test_eval_multi_rmf(clean_astro_ui):
+@pytest.mark.parametrize("set_rmf", [ui.set_rmf, ui.load_rmf])
+def test_eval_multi_rmf(set_rmf, clean_astro_ui):
     """See also test_eval_multi_rmf_reorder"""
 
     rmf1, rmf2, dset = make_rmf2()
     ui.set_data(1, dset)
-    ui.set_rmf(id=1, rmf=rmf1, resp_id=1)
-    ui.set_rmf(id=1, rmf=rmf2, resp_id=2)
+    set_rmf(1, rmf1, 1)
+    set_rmf(1, rmf2, 2)
 
     check_eval_multi_rmf()
 

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -27,7 +27,8 @@ import numpy as np
 import pytest
 
 from sherpa.astro import ui
-from sherpa.utils.err import DataErr,IOErr
+from sherpa.utils.err import DataErr, IOErr
+from sherpa.utils.testing import requires_fits
 
 
 @pytest.mark.parametrize("id", [None, 1, "faked"])
@@ -49,6 +50,7 @@ def test_fake_pha_no_rmf(id, clean_astro_ui):
     assert str(exc.value) == emsg
 
 
+@requires_fits
 @pytest.mark.parametrize("id", [None, 1, "faked"])
 def test_fake_pha_missing_rmf(id, clean_astro_ui, tmp_path):
     """Check we error out if RMF is not valid."""
@@ -65,6 +67,7 @@ def test_fake_pha_missing_rmf(id, clean_astro_ui, tmp_path):
     assert str(exc.value) == f"file '{rmf}' not found"
 
 
+@requires_fits
 @pytest.mark.parametrize("id", [None, 1, "faked"])
 def test_fake_pha_missing_arf(id, clean_astro_ui, tmp_path):
     """Check we error out if ARF is not valid."""

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8762,18 +8762,11 @@ class Session(sherpa.ui.utils.Session):
 
         if rmf is None:
             raise DataErr('normffake', id)
+        else:
+            rmf = self.unpack_rmf(rmf)
 
-        if type(rmf) in (str, numpy.string_):
-            if os.path.isfile(rmf):
-                rmf = self.unpack_rmf(rmf)
-            else:
-                raise IOErr("filenotfound", rmf)
-
-        if arf is not None and type(arf) in (str, numpy.string_):
-            if os.path.isfile(arf):
-                arf = self.unpack_arf(arf)
-            else:
-                raise IOErr("filenotfound", arf)
+        if arf is not None:
+            arf = self.unpack_arf(arf)
 
         d.exposure = exposure
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -5480,11 +5480,13 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        arg
+        arg :
            Identify the ARF: a file name, or a data structure
            representing the data to use, as used by the I/O backend in
            use by Sherpa: a ``TABLECrate`` for crates, as used by CIAO,
            or a list of AstroPy HDU objects.
+           If ``arg`` is already a `sherpa.astro.instrument.ARF1D` instance
+           it is returned unchanged.
 
         Returns
         -------
@@ -5525,7 +5527,13 @@ class Session(sherpa.ui.utils.Session):
         >>> arf = unpack_arf(hdus)
 
         """
-        return sherpa.astro.instrument.ARF1D(sherpa.astro.io.read_arf(arg))
+        if isinstance(arg, sherpa.astro.instrument.ARF1D):
+            return arg
+        elif isinstance(arg, sherpa.astro.data.DataARF):
+            return sherpa.astro.instrument.ARF1D(arg)
+        else:
+            arg = sherpa.astro.instrument.ARF1D(sherpa.astro.io.read_arf(arg))
+        return arg
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
@@ -5545,7 +5553,8 @@ class Session(sherpa.ui.utils.Session):
            Identify the ARF: a file name, or a data structure
            representing the data to use, as used by the I/O backend in
            use by Sherpa: a ``TABLECrate`` for crates, as used by CIAO,
-           or a list of AstroPy HDU objects.
+           or a list of AstroPy HDU objects or a
+           `sherpa.astro.instrument.ARF1D` instance.
         resp_id : int or str, optional
            The identifier for the ARF within this data set, if there
            are multiple responses.
@@ -5676,7 +5685,8 @@ class Session(sherpa.ui.utils.Session):
            Identify the ARF: a file name, or a data structure
            representing the data to use, as used by the I/O backend in
            use by Sherpa: a ``TABLECrate`` for crates, as used by CIAO,
-           or a list of AstroPy HDU objects.
+           or a list of AstroPy HDU objects or a
+           `sherpa.astro.instrument.ARF1D` instance.
 
         See Also
         --------
@@ -5737,8 +5747,8 @@ class Session(sherpa.ui.utils.Session):
         id : int or str, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        filenames : iterable of str
-           An array of file names.
+        filenames : iterable
+           An array of file names or `sherpa.astro.instrument.ARF1D` instances.
         resp_ids : iterable of int or str
            The identifiers for the ARF within this data set.
            The length should match the filenames argument.
@@ -5958,6 +5968,8 @@ class Session(sherpa.ui.utils.Session):
            representing the data to use, as used by the I/O backend in
            use by Sherpa: a ``RMFCrateDataset`` for crates, as used by
            CIAO, or a list of AstroPy HDU objects.
+           If arg is already a `sherpa.astro.instrument.RMF1D` instance,
+           it will be returned unchanged.
 
         Returns
         -------
@@ -5998,7 +6010,13 @@ class Session(sherpa.ui.utils.Session):
         >>> rmf = unpack_rmf(hdus)
 
         """
-        return sherpa.astro.instrument.RMF1D(sherpa.astro.io.read_rmf(arg))
+        if isinstance(arg, sherpa.astro.instrument.RMF1D):
+            return arg
+        elif isinstance(arg, sherpa.astro.data.DataRMF):
+            return sherpa.astro.instrument.RMF1D(arg)
+        else:
+            arg = sherpa.astro.instrument.RMF1D(sherpa.astro.io.read_rmf(arg))
+        return arg
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
@@ -6018,7 +6036,8 @@ class Session(sherpa.ui.utils.Session):
            Identify the RMF: a file name, or a data structure
            representing the data to use, as used by the I/O
            backend in use by Sherpa: a ``RMFCrateDataset`` for
-           crates, as used by CIAO, or an AstroPy ``HDUList`` object.
+           crates, as used by CIAO, or an AstroPy ``HDUList`` object or
+           a `sherpa.astro.instrument.RMF1D` instance.
         resp_id : int or str, optional
            The identifier for the RMF within this data set, if there
            are multiple responses.
@@ -6144,7 +6163,8 @@ class Session(sherpa.ui.utils.Session):
            Identify the RMF: a file name, or a data structure
            representing the data to use, as used by the I/O
            backend in use by Sherpa: a ``RMFCrateDataset`` for
-           crates, as used by CIAO, or an AstroPy ``HDUList`` object.
+           crates, as used by CIAO, or an AstroPy ``HDUList`` object or a
+           `sherpa.astro.instrument.RMF1D` instance.
 
         See Also
         --------
@@ -6205,8 +6225,8 @@ class Session(sherpa.ui.utils.Session):
         id : int or str, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        filenames : iterable of str
-           An array of file names.
+        filenames : iterable
+           An array of file names or `sherpa.astro.instrument.RMF1D` instances.
         resp_ids : iterable of int or str
            The identifiers for the RMF within this data set.
            The length should match the filenames argument.
@@ -8642,10 +8662,10 @@ class Session(sherpa.ui.utils.Session):
            exists then it is assumed to contain a PHA data set and the
            counts will be over-written.
         arf : filename or ARF object
-           The name of the ARF, or an ARF data object (e.g.  as
+           The name of the ARF, or an ARF data object (e.g. as
            returned by `get_arf` or `unpack_arf`).
         rmf : filename or RMF object
-           The name of the RMF, or an RMF data object (e.g.  as
+           The name of the RMF, or an RMF data object (e.g. as
            returned by `get_arf` or `unpack_arf`).
         exposure : number
            The exposure time, in seconds.


### PR DESCRIPTION
I am proposing to make `load_arf/rm`f work not just with filenames, but also with the ARF/RMF objects that I get from `get_arf/rmf`. If that is done, `set_arf/rmf` would essentially not be needed any more and could be removed. (Note that I'm not trying to remove them in this PR because they are a legacy interface I don't want to break, but they can stay around as a alias to `load_arf/rmf`).

My motivation for this change is:
- When I read "load_arf" I something think of "load into dataset" not necessarily "load from file".
- If these functions were more similar, then `set_multi_arfs/rmfs` could accept both filename and ARF/RMF objects. 
- If these functions were more similar, then `fake_pha` would work not only with filename, but also with ARF/RMF objects. That way, if I run a number of simulations, I only have to read the ARF/RMF file once and can keep it in memory. 

Unfortunately,
- I don't quite understand the differentce between ARF1D and DataARF and when to use the one or the other.
- The argument names of `load_arf/rmf` and `set_arf/rmf` are almost but not quite identical. In one case, the important argument is called `arg`, the other `arf` or `rmf`. That's not a real problem, it's just annoying for paramerizing tests.