### PR TITLE
Fix plotting of model components for PHA data (fix #1020)

### DIFF
--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -1441,3 +1441,57 @@ def calc_grp_chan_matrix(fname):
     except sherpa.utils.err.IOErr as ioerr:
         print(ioerr)
         raise ioerr
+
+
+def has_pha_response(model):
+    """Does the model contain a PHA response?
+
+    Parameters
+    ----------
+    model : Model instance
+        The model expression to check.
+
+    Returns
+    -------
+    flag : bool
+        True if there is a PHA response included anywhere in the
+        expression.
+
+    Examples
+    --------
+
+    >>> rsp = Response1D(pha)
+    >>> m1 = Gauss1D()
+    >>> m2 = PowLaw1D()
+    >>> has_pha_response(m1)
+    False
+    >>> has_pha_response(rsp(m1))
+    True
+    >>> has_pha_response(m1 + m2)
+    False
+    >>> has_pha_response(rsp(m1 + m2))
+    True
+    >>> has_pha_response(m1 + rsp(m2))
+    True
+
+    """
+
+    # The following check should probably include ResponseNestedModel
+    # but it's not obvious if this is currently used.
+    #
+    def wanted(c):
+        return isinstance(c, (RSPModel, ARFModel, RMFModel))
+
+    if wanted(model):
+        return True
+
+    # This check relies on a composite class like the RSPModel is
+    # included in the __iter__ method (see CompositeModel._get_parts)
+    # otherwise the following would have had to be a recursive call
+    # to has_pha_instance.
+    #
+    for cpt in model:
+        if wanted(cpt):
+            return True
+
+    return False

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1266,9 +1266,6 @@ def check_pha1_model_component_plot(mplot, mdl):
 def test_pha1_get_model_component_plot_add_response(clean_astro_ui, basic_pha1):
     """Do we automatically add in the response? See issue #1020
 
-    At the moment we do not. Ideally we'd get the y values used
-    by test_pha1_get_model_component_plot_with_response.
-
     Note that this test does not need requires_plotting since
     we don't use anything that requires the plot backend.
     """

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1047,6 +1047,22 @@ def basic_pha1(make_data_path):
 
 
 @pytest.fixture
+def basic_pha1_bg(make_data_path):
+    """Create a basic PHA-1 data set/setup for the background.
+
+    This is currently only used to get a dataset with no response.
+    """
+
+    ui.set_default_id('tst')
+    ui.load_pha(make_data_path('3c273_bg.pi'))
+    ui.notice(33, 676)
+    ui.set_source(ui.powlaw1d.pl)
+    pl = ui.get_model_component('pl')
+    pl.gamma = 1.93
+    pl.ampl = 1.74e-4
+
+
+@pytest.fixture
 def basic_img(make_data_path):
     """Create a basic image data set/setup"""
 
@@ -1175,6 +1191,170 @@ def test_pha1_bkg_plot(plotfunc, clean_astro_ui, basic_pha1, hide_logging):
                                       ui.plot_source_component])
 def test_pha1_plot_component(clean_astro_ui, basic_pha1, plotfunc):
     plotfunc("pl")
+
+
+def test_data1_get_model_component_plot(clean_astro_ui):
+    """There is no response concept for non-PHA data.
+
+    See test_pha1_get_model_component_plot_add_response
+    for the PHA explanation.
+    """
+
+    x = np.asarray([1, 2, 3])
+    ui.load_arrays(1, x, x)
+    ui.set_source(ui.polynom1d.mdl)
+    mdl.c0 = -3
+    mdl.c1 = 2
+
+    # Apparently we have sherpa.astro.plot.ComponentModelPlot
+    # and sherpa.plot.ComponentModelPlot.
+    #
+    mplot = ui.get_model_component_plot('mdl')
+    assert isinstance(mplot, sherpa.plot.ComponentModelPlot)
+    assert mplot.title == 'Model component: polynom1d.mdl'
+
+    # Unlike the PHA case it's easy to evaluate the model
+    # for this test.
+    assert mplot.x == pytest.approx([1, 2, 3])
+    assert mplot.y == pytest.approx([-1, 1, 3])
+
+
+def check_pha1_model_component_plot(mplot, mdl):
+    """The checks for get_model_component_plot with PHA data
+
+    This is for when the response is included.
+    """
+
+    assert isinstance(mplot, ComponentModelPlot)
+
+    # The plot title includes the exposure time whose output could change
+    # so do not use an equality check but something a bit-more forgiving
+    # (could use a regexp but not worth it).
+    #
+    assert mplot.title.startswith('Model component: apply_rmf(apply_arf((38564.60')
+    assert mplot.title.endswith(' * powlaw1d.pl)))')
+
+    # This may change if we change the filtering/grouping code
+    # Note that the model is evaluated on the un-grouped data.
+    #
+    assert len(mplot.xlo) == 644
+    assert mplot.xlo[0] == pytest.approx(0.467200)
+    assert mplot.xlo[-1] == pytest.approx(9.85500)
+    assert mplot.xhi[0] == pytest.approx(0.481800)
+    assert mplot.xhi[-1] == pytest.approx(9.869600)
+
+    # The model is evaluated over the full channel range so we need to
+    # restrict to the noticed channel range (of 33 to 676 inclusive).
+    # I am 'cheating' with the argument to mdl() here since it is currently
+    # ignored as long as it's specified.
+    #
+    yexp = mdl([1])
+    assert len(yexp) == 1024
+    yexp = yexp[32:676]
+
+    dy = mplot.xhi - mplot.xlo
+    texp = 38564.608926889
+    assert mplot.y == pytest.approx(yexp / dy / texp)
+
+    # manual check of one the y values
+    #
+    assert mplot.y[0] == pytest.approx(0.00501761)
+
+
+@requires_fits
+@requires_data
+def test_pha1_get_model_component_plot_add_response(clean_astro_ui, basic_pha1):
+    """Do we automatically add in the response? See issue #1020
+
+    At the moment we do not. Ideally we'd get the y values used
+    by test_pha1_get_model_component_plot_with_response.
+
+    Note that this test does not need requires_plotting since
+    we don't use anything that requires the plot backend.
+    """
+
+    # It's important to also test the "specify a string not
+    # a model object" feature of the get_xxx_plot call here.
+    # The explicit call in xxxx_with_response below does
+    # not use a string.
+    #
+    mplot = ui.get_model_component_plot('pl')
+
+    # Note that these tests are similar to check_pha1_model_component_plot
+    assert isinstance(mplot, ComponentModelPlot)
+    assert mplot.title == 'Model component: powlaw1d.pl'
+
+    # This may change if we change the filtering/grouping code
+    # Note that the model is evaluated on the un-grouped data.
+    #
+    assert len(mplot.xlo) == 644
+    assert mplot.xlo[0] == pytest.approx(0.467200)
+    assert mplot.xlo[-1] == pytest.approx(9.85500)
+    assert mplot.xhi[0] == pytest.approx(0.481800)
+    assert mplot.xhi[-1] == pytest.approx(9.869600)
+
+    # The y values are currently pl(channels) / bin width / time
+    # for the selected channel range.
+    #
+    chans = np.arange(33, 677)
+    yexp = pl(chans)
+    dy = mplot.xhi - mplot.xlo
+    texp = 38564.608926889
+    assert mplot.y == pytest.approx(yexp / dy / texp)
+
+
+@requires_fits
+@requires_data
+def test_pha1_get_model_component_plot_with_response(clean_astro_ui, basic_pha1):
+    """What happens if we explicitly include the response?
+
+    Note that this test does not need requires_plotting since
+    we don't use anything that requires the plot backend.
+    """
+
+    rsp = ui.get_response()
+    mdl = rsp(pl)
+    mplot = ui.get_model_component_plot(mdl)
+    check_pha1_model_component_plot(mplot, mdl)
+
+
+@requires_fits
+@requires_data
+def test_pha1_get_model_component_plot_no_response(clean_astro_ui, basic_pha1_bg):
+    """What happens if we have no response?"""
+
+    # safety check the file remains response "free".
+    pha = ui.get_data('tst')
+    assert pha.units == 'channel'
+    assert pha.get_response() == (None, None)
+    with pytest.raises(DataErr) as exc:
+        ui.get_response()
+
+    assert str(exc.value).startswith('No instrument response found for dataset')
+    assert str(exc.value).endswith('3c273_bg.pi')
+
+    # use the background dataset as it's response "free"
+    mplot = ui.get_model_component_plot('pl')
+    print(mplot)
+
+    assert isinstance(mplot, ComponentModelPlot)
+    assert mplot.title == 'Model component: powlaw1d.pl'
+
+    xlo = np.arange(33, 677)
+    assert mplot.xlo == pytest.approx(xlo)
+    assert mplot.xhi == pytest.approx(xlo + 1)
+
+    # The y values are currently pl(channels) / bin width / time
+    # for the selected channel range. Fortunately the bin width is 1.
+    #
+    chans = np.arange(33, 677)
+    yexp = pl(chans)
+    texp = 38564.608926889
+    assert mplot.y == pytest.approx(yexp / texp)
+
+    # manual check of one the y values
+    #
+    assert np.log10(mplot.y[0]) == pytest.approx(-11.276372)
 
 
 @requires_plotting

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1261,6 +1261,11 @@ def check_pha1_model_component_plot(mplot, mdl):
     assert mplot.y[0] == pytest.approx(0.00501761)
 
 
+# NOTE: the following model_component tests are just different
+# enough in how you send in the data that it's not easy to parametrize
+# them, so we have a bunch of similar routines rather than a single
+# parametrized test.
+
 @requires_fits
 @requires_data
 def test_pha1_get_model_component_plot_add_response(clean_astro_ui, basic_pha1):
@@ -1333,6 +1338,101 @@ def test_pha1_get_model_component_plot_no_response(clean_astro_ui, basic_pha1_bg
     # manual check of one the y values
     #
     assert np.log10(mplot.y[0]) == pytest.approx(-11.276372)
+
+
+def check_pha1_plot_model_component_plot():
+    """Check the model component plot.
+
+    This is much-more limited than the test_pha1_get_model_component_plot_xxx
+    variants, as all we do is check the y axis range makes sense
+    (as it wouldn't have with #1020 unfixed).
+
+    Any test calling this requires @requires_plotting
+    """
+    from matplotlib import pyplot as plt
+
+    # Just check the Y range to be close to the expected range - this
+    # could vary a bit across matplotlib versions
+    #
+    # The range is expected to be ~1e-5 to 1e-2
+    ylim = plt.ylim()
+    assert ylim[0] > 1e-6
+    assert ylim[1] > 1e-2
+    assert ylim[1] < 2e-2
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_model_component_add_response(clean_astro_ui, basic_pha1):
+    """Do we automatically add in the response? See issue #1020.
+    """
+    ui.plot_model_component('pl', ylog=True)
+    check_pha1_plot_model_component_plot()
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_with_model_component_add_response(clean_astro_ui, basic_pha1):
+    """Do we automatically add in the response? See issue #1020.
+    """
+    ui.plot('model_component', 'pl', ylog=True)
+    check_pha1_plot_model_component_plot()
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_model_component_with_response(clean_astro_ui, basic_pha1):
+    """Plot is okay if we include the response
+    """
+    rsp = ui.get_response()
+    ui.plot_model_component(rsp(pl), ylog=True)
+    check_pha1_plot_model_component_plot()
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_with_model_component_with_response(clean_astro_ui, basic_pha1):
+    """Plot is okay if we include the response
+    """
+    rsp = ui.get_response()
+    ui.plot('model_component', rsp(pl), ylog=True)
+    check_pha1_plot_model_component_plot()
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_model_component_no_response(clean_astro_ui, basic_pha1_bg):
+    """PHA file but no response
+    """
+    from matplotlib import pyplot as plt
+
+    ui.plot_model_component('pl', ylog=True)
+
+    # The range is expected to be ~1e-14 to ~7e-12 which is very different
+    # from the 'with response' values
+    ylim = plt.ylim()
+    assert ylim[1] < 1e-11
+
+
+@requires_plotting
+@requires_fits
+@requires_data
+def test_pha1_plot_with_model_component_no_response(clean_astro_ui, basic_pha1_bg):
+    """PHA file but no response
+    """
+    from matplotlib import pyplot as plt
+
+    ui.plot('model_component', pl, ylog=True)
+
+    # The range is expected to be ~1e-14 to ~7e-12 which is very different
+    # from the 'with response' values
+    ylim = plt.ylim()
+    assert ylim[1] < 1e-11
 
 
 @requires_plotting

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1279,28 +1279,9 @@ def test_pha1_get_model_component_plot_add_response(clean_astro_ui, basic_pha1):
     # not use a string.
     #
     mplot = ui.get_model_component_plot('pl')
-
-    # Note that these tests are similar to check_pha1_model_component_plot
-    assert isinstance(mplot, ComponentModelPlot)
-    assert mplot.title == 'Model component: powlaw1d.pl'
-
-    # This may change if we change the filtering/grouping code
-    # Note that the model is evaluated on the un-grouped data.
-    #
-    assert len(mplot.xlo) == 644
-    assert mplot.xlo[0] == pytest.approx(0.467200)
-    assert mplot.xlo[-1] == pytest.approx(9.85500)
-    assert mplot.xhi[0] == pytest.approx(0.481800)
-    assert mplot.xhi[-1] == pytest.approx(9.869600)
-
-    # The y values are currently pl(channels) / bin width / time
-    # for the selected channel range.
-    #
-    chans = np.arange(33, 677)
-    yexp = pl(chans)
-    dy = mplot.xhi - mplot.xlo
-    texp = 38564.608926889
-    assert mplot.y == pytest.approx(yexp / dy / texp)
+    rsp = ui.get_response()
+    mdl = rsp(pl)
+    check_pha1_model_component_plot(mplot, mdl)
 
 
 @requires_fits

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10434,9 +10434,8 @@ class Session(sherpa.ui.utils.Session):
     def get_model_component_plot(self, id, model=None, recalc=True):
         """Return the data used to create the model-component plot.
 
-        .. versionchanged :: 4.13.2
-           For PHA data, the response model is now automatically added
-           by the routine unless the model contains a response.
+        For PHA data, the response model is automatically added by the
+        routine unless the model contains a response.
 
         Parameters
         ----------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10486,7 +10486,7 @@ class Session(sherpa.ui.utils.Session):
         >>> fmodel = xsphabs.gal * (powlaw1d.pl + gauss1d.gline)
         >>> set_source('jet', fmodel)
         >>> fit('jet')
-        >>> fplot = get_model('jet')
+        >>> fplot = get_model_plot('jet')
         >>> plot1 = get_model_component_plot('jet', pl*gal)
         >>> plot2 = get_model_component_plot('jet', gline*gal)
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10435,9 +10435,7 @@ class Session(sherpa.ui.utils.Session):
     def get_model_component_plot(self, id, model=None, recalc=True):
         if model is None:
             id, model = model, id
-        self._check_model(model)
-        if isinstance(model, string_types):
-            model = self._eval_model_expression(model)
+        model = self._check_model(model)
 
         try:
             d = self.get_data(id)
@@ -10460,9 +10458,7 @@ class Session(sherpa.ui.utils.Session):
     def get_source_component_plot(self, id, model=None, recalc=True):
         if model is None:
             id, model = model, id
-        self._check_model(model)
-        if isinstance(model, string_types):
-            model = self._eval_model_expression(model)
+        model = self._check_model(model)
 
         try:
             d = self.get_data(id)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -872,6 +872,10 @@ class CompositeModel(Model):
             assert (p is not self), (("'%s' object holds a reference to " +
                                       "itself") % type(self).__name__)
 
+            # Including itself seems a bit strange if it's a CompositeModel
+            # but is used by sherpa.astro.instrument.has_pha_instance (and
+            # possibly elsewhere).
+            #
             parts.append(p)
             if isinstance(p, CompositeModel):
                 parts.extend(p._get_parts())

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12627,10 +12627,8 @@ class Session(NoNewAttributesAfterInit):
         This function evaluates and plots a component of the model
         expression for a data set, including any instrument response.
         Use `plot_source_component` to display without any response.
-
-        .. versionchanged :: 4.13.2
-           For PHA data, the response model is now automatically added
-           by the routine unless the model contains a response.
+        For PHA data, the response model is automatically added by the
+        routine unless the model contains a response.
 
         Parameters
         ----------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10900,9 +10900,7 @@ class Session(NoNewAttributesAfterInit):
         """
         if model is None:
             id, model = model, id
-        self._check_model(model)
-        if isinstance(model, string_types):
-            model = self._eval_model_expression(model)
+        model = self._check_model(model)
 
         try:
             d = self.get_data(id)
@@ -10981,9 +10979,7 @@ class Session(NoNewAttributesAfterInit):
         """
         if model is None:
             id, model = model, id
-        self._check_model(model)
-        if isinstance(model, string_types):
-            model = self._eval_model_expression(model)
+        model = self._check_model(model)
 
         try:
             d = self.get_data(id)
@@ -15610,9 +15606,7 @@ class Session(NoNewAttributesAfterInit):
         """
         if model is None:
             id, model = model, id
-        self._check_model(model)
-        if isinstance(model, string_types):
-            model = self._eval_model_expression(model)
+        model = self._check_model(model)
 
         # Ensure the convolution models get applied
         is_source = self._get_model_status(id)[1]
@@ -15677,9 +15671,7 @@ class Session(NoNewAttributesAfterInit):
         """
         if model is None:
             id, model = model, id
-        self._check_model(model)
-        if isinstance(model, string_types):
-            model = self._eval_model_expression(model)
+        model = self._check_model(model)
 
         imageobj = self._image_types['source_component']
         data = self.get_data(id)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10892,7 +10892,7 @@ class Session(NoNewAttributesAfterInit):
         >>> fmodel = xsphabs.gal * (powlaw1d.pl + gauss1d.gline)
         >>> set_source('jet', fmodel)
         >>> fit('jet')
-        >>> fplot = get_model('jet')
+        >>> fplot = get_model_plot('jet')
         >>> plot1 = get_model_component_plot('jet', pl*gal)
         >>> plot2 = get_model_component_plot('jet', gline*gal)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10840,7 +10840,6 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    # sherpa.astro.utils version copies this docstring
     def get_model_component_plot(self, id, model=None, recalc=True):
         """Return the data used to create the model-component plot.
 
@@ -12621,8 +12620,6 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    # DOC-NOTE: also in sherpa.astro.utils, for now copies this text
-    #           but does the astro version support a bkg_id parameter?
     def plot_model_component(self, id, model=None, replot=False,
                              overplot=False, clearwindow=True, **kwargs):
         """Plot a component of the model for a data set.
@@ -12630,6 +12627,10 @@ class Session(NoNewAttributesAfterInit):
         This function evaluates and plots a component of the model
         expression for a data set, including any instrument response.
         Use `plot_source_component` to display without any response.
+
+        .. versionchanged :: 4.13.2
+           For PHA data, the response model is now automatically added
+           by the routine unless the model contains a response.
 
         Parameters
         ----------
@@ -12688,6 +12689,14 @@ class Session(NoNewAttributesAfterInit):
         >>> plot_fit('jet')
         >>> plot_model_component('jet', pl, overplot=True)
         >>> plot_model_component('core', pl, overplot=True)
+
+        For PHA data sets the response is automatically added, but it
+        can also be explicitly included, which will create the same
+        plot:
+
+        >>> plot_model_component(pl)
+        >>> rsp = get_response()
+        >>> plot_model_component(rsp(pl))
 
         """
 


### PR DESCRIPTION
# Summary

The use of plot_model_component and get_model_component will now automatically add the response for PHA data sets, if there is one. Model expressions which contain a response will not be changed. Fixes #1020.

# Details

This is a re-work of the code I wrote in #1022 

1. just deals with the `plot_model` case, not the new functionality of the `plot_model_components` part of #1022, which was the most problematic
2. drops the `add_response` keyword and now makes a best-case estimate of whether a model contains a response, using the sherpa.astro.instrument.has_pha_response function (which is similar to a routine @hamogu suggested in #1022 but taking advantage of the `__iter__` support we have)

What we lose is the ability of a user to plot a model component without a response (e.g. say you have fitted a phenomenological model for the particle background which ignores all responses). Users who do this would have to be told how to create the data to plot themselves.

One "trick" in this is that the documentation for `sherpa.ui.utils.plot_model_component` has been updated when technically it should be `sherpa.astro.ui.utils.plot_model_component`. Given that the astro version is our primary user base I think this is okay (the text is not wrong for the sherpa.ui layer, it is just you don't have DataPHA data here). I actually hope to add an astro-secific plot_model_components routine (to add support for the `bkg_id` parameter) in which case we can move the text to the "correct" place. I note that our existng sherpa.ui documentation occasionally documents DataPHA-related documentation (e.g. `plot_model`), for similar reasons (not wanting to copy a function just to tweak the docstring).

# Note

In CIAO 4.13 the output of `plot_model_component(src)` would be numerically wrong but have the nice title:

    'Model component: xsapec.src'

Now we get the correct data, but the title is a tad-more ungainly (see `Example 3` below):

    'Model component: apply_rmf(apply_arf((38564.608926889 * xsapec.src)))'

There are tricks we could add to try and fix this, but I don't think it's worth it and it would probably only be a heuristic, so could fail at some point.

# Examples

The three examples really just plot the same data, but it may be useful to see the differences explicitly.

## Example 1

With the following script I create plots from CIAO 4.13 (labelled `before`) and this PR (`after`):

```
from matplotlib import pyplot as plt
from sherpa.astro.ui import *
load_pha('3c273.pi')
notice(0.5, 7)
set_source(xsphabs.gal * xsapec.src)
gal.nh = 0.05
gal.nh.freeze()
src.kt = 3.96
src.norm = 5.233e-4

plot_model(alpha=0.5, ylog=True)
plot_model_component(src, alpha=0.5, overplot=True)
plt.savefig('fig.png')
print("Created: fig.png")
```

### before

![before](https://user-images.githubusercontent.com/224638/121417247-ae532180-c937-11eb-8975-de34cf15827b.png)

### after

![after](https://user-images.githubusercontent.com/224638/121417283-b743f300-c937-11eb-8f11-d52f4624880f.png)

The blue line shows the `plot_model` output - i.e. `xsphabs * xsapec` - and the yellow line just the `xsapec` component. You can see #1020 in the `before` plot - the yellow line is way below the blue line and is completely wrong. In the `after` case we can see that `plot_model_component(src)` creates a plot very-similar to `plot_model()`, as it should, since the absorption is small in this case.

## Example 2

For the plot

```
plot_fit(ylog=True)
plot_model_component(src, alpha=0.5, overplot=True)
```

### before

![before2](https://user-images.githubusercontent.com/224638/121421385-1c014c80-c93c-11eb-9076-ad8de115d0c6.png)

### after

![after2](https://user-images.githubusercontent.com/224638/121421431-26bbe180-c93c-11eb-8c5f-ef52a0731e37.png)

## Example 3

For the plot

```
plot_model_component(src)
```

### before

![before3](https://user-images.githubusercontent.com/224638/121421519-3c310b80-c93c-11eb-9ab0-8e3fa82e6020.png)

### after

![after3](https://user-images.githubusercontent.com/224638/121421542-4521dd00-c93c-11eb-9978-18e1c7d496dc.png)
