### PR TITLE
Simplify switching the astro.io backend

### DIFF
--- a/docs/overview/astro_io.rst
+++ b/docs/overview/astro_io.rst
@@ -6,8 +6,16 @@ The sherpa.astro.io module
 
 .. automodule:: sherpa.astro.io
 
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: api
+
+      backend
+
+
    .. rubric:: Functions
-               
+
    .. autosummary::
       :toctree: api
 

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -33,7 +33,7 @@ __all__ = ('get_table_data', 'get_image_data', 'get_arf_data', 'get_rmf_data',
 lgr = logging.getLogger(__name__)
 
 warning = lgr.warning
-warning("""Cannot import usable FITS I/O backend.
+warning("""Cannot import usable I/O backend.
     If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
     If you are using Standalone Sherpa, please install astropy.""")
 

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -1,0 +1,54 @@
+#
+#  Copyright (C) 2021
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+'''A dummy backend for I/O.
+
+This backend provides no functionality and raises an error if any of its
+functions are used. It is just here to ensure that `sherpa.astro.io` can be
+imported, even if no FITS reader is installed.
+'''
+import logging
+
+__all__ = ('get_table_data', 'get_image_data', 'get_arf_data', 'get_rmf_data',
+           'get_pha_data', 'set_table_data', 'set_image_data', 'set_pha_data',
+           'get_column_data', 'get_ascii_data')
+
+
+lgr = logging.getLogger(__name__)
+
+warning = lgr.warning
+warning("""Cannot import usable FITS I/O backend.
+    If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
+    If you are using Standalone Sherpa, please install astropy.""")
+
+
+def get_table_data(*args, **kwargs):
+    """A do-nothing operation"""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+get_image_data = get_table_data
+get_arf_data = get_table_data
+get_rmf_data = get_table_data
+get_pha_data = get_table_data
+set_table_data = get_table_data
+set_image_data = get_table_data
+set_pha_data = get_table_data
+get_column_data = get_table_data
+get_ascii_data = get_table_data

--- a/sherpa/astro/io/tests/test_backend_switch.py
+++ b/sherpa/astro/io/tests/test_backend_switch.py
@@ -1,0 +1,52 @@
+#
+#  Copyright (C) 2021
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+import pytest
+
+from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.astro import io
+from sherpa.astro import ui
+
+
+@requires_fits
+@requires_data
+def test_backend_switch(make_data_path):
+    '''Test that we can switch backends.
+
+    Of course, switching only makes sense if there is more than one backend
+    to try, so this is listed as "requires_fits".
+    '''
+    pha = make_data_path("3c273.pi")
+    ui.clean()
+    ui.load_pha(pha)
+    assert ui.get_data().name.endswith('3c273.pi')
+
+    orig_backend = io.backend
+
+    import sherpa.astro.io.dummy_backend
+    io.backend = sherpa.astro.io.dummy_backend
+
+    with pytest.raises(NotImplementedError,
+                       match="No usable I/O backend was imported."):
+         ui.load_pha(pha)
+
+    io.backend = orig_backend
+    infile = make_data_path("9774.pi")
+    ui.load_pha(infile)
+    assert ui.get_data().name.endswith('9774.pi')

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -651,21 +651,21 @@ def check_output(out, colnames, rows):
 
     """
 
-    from sherpa.astro.io import backend
+    from sherpa.astro import io
 
     lines = out.split('\n')
     assert len(lines) > 2
 
     cols = ' '.join(colnames)
-    if backend.__name__ == 'sherpa.astro.io.crates_backend':
+    if io.backend.__name__ == 'sherpa.astro.io.crates_backend':
         assert lines[0] == "#TEXT/SIMPLE"
         assert lines[1] == f"# {cols}"
         lines = lines[2:]
-    elif backend.__name__ == 'sherpa.astro.io.pyfits_backend':
+    elif io.backend.__name__ == 'sherpa.astro.io.pyfits_backend':
         assert lines[0] == f"#{cols}"
         lines = lines[1:]
     else:
-        raise RuntimeError(f"UNKNOWN I/O BACKEND: {backend.__name__}")
+        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")
 
     assert lines[-1] == ""
     lines = lines[:-1]
@@ -766,7 +766,7 @@ def test_save_data_data1dint_fits(tmp_path):
 def test_save_data_data2d(tmp_path):
     """Does save_data work for Data2D?"""
 
-    from sherpa.astro.io import backend
+    from sherpa.astro import io
 
     y, x = np.mgrid[20:22, 10:13]
     x = x.flatten()
@@ -782,7 +782,7 @@ def test_save_data_data2d(tmp_path):
 
     # the output depends on the backend, and neither seems ideal
     #
-    if backend.__name__ == 'sherpa.astro.io.crates_backend':
+    if io.backend.__name__ == 'sherpa.astro.io.crates_backend':
         expected = ["#TEXT/SIMPLE", "# X0 X1 Y SHAPE"]
         s = [2, 3, 0, 0, 0, 0]
         for xi, yi, zi, si in zip(x, y, z, s):
@@ -790,10 +790,10 @@ def test_save_data_data2d(tmp_path):
 
         expected = "\n".join(expected) + "\n"
 
-    elif backend.__name__ == 'sherpa.astro.io.pyfits_backend':
+    elif io.backend.__name__ == 'sherpa.astro.io.pyfits_backend':
         expected = "\n".join([str(zz) for zz in z]) + "\n"
     else:
-        raise RuntimeError(f"UNKNOWN I/O BACKEND: {backend.__name__}")
+        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")
 
     assert cts == expected
 
@@ -830,8 +830,8 @@ def test_save_data_dataimg(tmp_path):
     """Does save_data work for DataIMG? ASCII"""
 
     # Can not write out an ASCII image with crates
-    from sherpa.astro.io import backend
-    if backend.__name__ == 'sherpa.astro.io.crates_backend':
+    from sherpa.astro import io
+    if io.backend.__name__ == 'sherpa.astro.io.crates_backend':
         pytest.skip('ASCII not supported for images with pycrates')
 
     y, x = np.mgrid[0:2, 0:3]
@@ -1267,8 +1267,8 @@ def test_save_resid_dataimg(tmp_path):
     """Residual, DataIMG, ASCII"""
 
     # Can not write out an ASCII image with crates
-    from sherpa.astro.io import backend
-    if backend.__name__ == 'sherpa.astro.io.crates_backend':
+    from sherpa.astro import io
+    if io.backend.__name__ == 'sherpa.astro.io.crates_backend':
         pytest.skip('ASCII not supported for images with pycrates')
 
     y, x = np.mgrid[10:12, 20:23]

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -821,7 +821,7 @@ class Session(sherpa.ui.utils.Session):
         dataset = None
         try:
             dataset = sherpa.astro.io.read_arrays(*args)
-        except AttributeError:
+        except NotImplementedError:
             # if the astro backend is not set, fall back on io module version.
             dataset = sherpa.io.read_arrays(*args)
         return dataset

--- a/sherpa/sherpa-standalone.rc
+++ b/sherpa/sherpa-standalone.rc
@@ -1,10 +1,10 @@
-# SHERPA_VERSION 4.12.2
+# SHERPA_VERSION 4.14.1
 [options]
 # Plotting packages available- pylab
 plot_pkg   : pylab
 
-# IO packages available- pyfits, crates
-io_pkg     : pyfits
+# IO packages (space separated list) in the order they will be tried
+io_pkg     : crates pyfits dummy
 
 [statistics]
 # If true, use truncation value in Cash, C-stat
@@ -33,7 +33,7 @@ level      : 10000
 # smaller than the threshold size, all the elements are printed out.
 # (This setting makes no change to the actual array, but merely
 # governs how the array is represented when a copy of the array is
-# converted to a string.)  
+# converted to a string.)
 #
 # The default threshold size is 1000.  Here, the threshold size is
 # changed to a much larger value as Sherpa often deals with large
@@ -49,10 +49,10 @@ numcores : None
 [multiprocessing]
 # Define the method by which the multiprocessing package starts
 # parallel processes. Sherpa requires the "fork" method in order to
-# utilize multiprocessing to improve performance and pass all tests. 
-# However, on MacOSX there are known issues with using "fork" that 
-# prompted a change in the multiprocessing default to be "spawn" on 
+# utilize multiprocessing to improve performance and pass all tests.
+# However, on MacOSX there are known issues with using "fork" that
+# prompted a change in the multiprocessing default to be "spawn" on
 # MacOSX. Expert users may consider changing this value to either
-# "spawn" or "default", where the latter will use the 
+# "spawn" or "default", where the latter will use the
 # platform-specific start method of the multiprocessing package.
 multiprocessing_start_method: fork

--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -1,10 +1,10 @@
-# SHERPA_VERSION 4.12.2
+# SHERPA_VERSION 4.14.1
 [options]
 # Plotting packages available- pylab
 plot_pkg   : pylab
 
-# IO packages available- pyfits, crates
-io_pkg     : crates
+# IO packages (space separated list) in the order they will be tried
+io_pkg     : crates pyfits dummy
 
 [statistics]
 # If true, use truncation value in Cash, C-stat
@@ -33,7 +33,7 @@ level      : 0
 # smaller than the threshold size, all the elements are printed out.
 # (This setting makes no change to the actual array, but merely
 # governs how the array is represented when a copy of the array is
-# converted to a string.)  
+# converted to a string.)
 #
 # The default threshold size is 1000.  Here, the threshold size is
 # changed to a much larger value as Sherpa often deals with large
@@ -49,10 +49,10 @@ numcores : None
 [multiprocessing]
 # Define the method by which the multiprocessing package starts
 # parallel processes. Sherpa requires the "fork" method in order to
-# utilize multiprocessing to improve performance and pass all tests. 
-# However, on MacOSX there are known issues with using "fork" that 
-# prompted a change in the multiprocessing default to be "spawn" on 
+# utilize multiprocessing to improve performance and pass all tests.
+# However, on MacOSX there are known issues with using "fork" that
+# prompted a change in the multiprocessing default to be "spawn" on
 # MacOSX. Expert users may consider changing this value to either
-# "spawn" or "default", where the latter will use the 
+# "spawn" or "default", where the latter will use the
 # platform-specific start method of the multiprocessing package.
 multiprocessing_start_method: fork


### PR DESCRIPTION
# Summary

Add dummy_module, docs, and test case for switching the `sherpa.astro.io` backend. io backend are now tried in a default order (crates, pyfits, dummy), so this effects users who have both crates and astropy installed in a CIAO installation and manually selected the pyfits backend in their `sherpa.rc` - they will now get crates as I/O backend.

# Details
Switching this has always been possible, but this PR makes it simplerby (a) adding a dummy_backend (similar to what we already have for plotting) to ensure that sherpa.astro.io can always be imported even if no fits reader  is present, and (b) adding docs and tests on how to switch.
 