### PR TITLE
Conda GCC 9.3.0 update issue

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -114,9 +114,10 @@ jobs:
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
-        if [ ${{ runner.os }} == "linux" ] ; then
+        if [ ${runner.os } == "linux" ] ; then
             #To be removed when we can get to the latest Python builds
             export _CONDA_PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata_x86_64_conda_cos6_linux_gnu"
+            echo " _CONDA_PYTHON_SYSCONFIGDATA_NAME=$ _CONDA_PYTHON_SYSCONFIGDATA_NAME"
         fi
         python setup.py ${{ matrix.install-type }}
 

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -110,23 +110,19 @@ jobs:
 
     - name: Build Sherpa
       env:
-        PYTHON_LDFLAGS: " " 
-        _CONDA_PYTHON_SYSCONFIGDATA_NAME: "_sysconfigdata_x86_64_conda_cos6_linux_gnu"
+        PYTHON_LDFLAGS: " "
+        _CONDA_PYTHON_SYSCONFIGDATA_NAME: "${{ runner.os == 'linux' && '_sysconfigdata_x86_64_conda_cos6_linux_gnu' || '_sysconfigdata_x86_64_apple_darwin13_4_0' }}" 
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
-        if [ `uname -s` == "linux" ] ; then
-            #To be removed when we can get to the latest Python builds
-            export _CONDA_PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata_x86_64_conda_cos6_linux_gnu"
-            echo " _CONDA_PYTHON_SYSCONFIGDATA_NAME=$_CONDA_PYTHON_SYSCONFIGDATA_NAME"
-        fi
         python setup.py ${{ matrix.install-type }}
 
     - name: Tests
       env:
         TEST: ${{ matrix.test-data }}
         XSPECVER: ${{ matrix.xspec-version }}
-        FITS: ${{ matrix.fits }} 
+        FITS: ${{ matrix.fits }}
+        _CONDA_PYTHON_SYSCONFIGDATA_NAME: "${{ runner.os == 'linux' && '_sysconfigdata_x86_64_conda_cos6_linux_gnu' || '_sysconfigdata_x86_64_apple_darwin13_4_0' }}" 
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
-        if [ ${runner.os } == "linux" ] ; then
+        if [ `uname -s` == "linux" ] ; then
             #To be removed when we can get to the latest Python builds
             export _CONDA_PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata_x86_64_conda_cos6_linux_gnu"
             echo " _CONDA_PYTHON_SYSCONFIGDATA_NAME=$ _CONDA_PYTHON_SYSCONFIGDATA_NAME"

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -111,13 +111,14 @@ jobs:
     - name: Build Sherpa
       env:
         PYTHON_LDFLAGS: " " 
+        _CONDA_PYTHON_SYSCONFIGDATA_NAME: "_sysconfigdata_x86_64_conda_cos6_linux_gnu"
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
         if [ `uname -s` == "linux" ] ; then
             #To be removed when we can get to the latest Python builds
             export _CONDA_PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata_x86_64_conda_cos6_linux_gnu"
-            echo " _CONDA_PYTHON_SYSCONFIGDATA_NAME=$ _CONDA_PYTHON_SYSCONFIGDATA_NAME"
+            echo " _CONDA_PYTHON_SYSCONFIGDATA_NAME=$_CONDA_PYTHON_SYSCONFIGDATA_NAME"
         fi
         python setup.py ${{ matrix.install-type }}
 

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -114,6 +114,10 @@ jobs:
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
+        if [ ${{ runner.os }} == "linux" ] ; then
+            #To be removed when we can get to the latest Python builds
+            export _CONDA_PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata_x86_64_conda_cos6_linux_gnu"
+        fi
         python setup.py ${{ matrix.install-type }}
 
     - name: Tests


### PR DESCRIPTION
**What happened?**
Basically, gcc/gxx 9.3.0 has been released for defaults (amongst other package updates). There was a coordinated removal of the "cos6" portion from some environment variables/files/directories on Conda's part. This involved updating an environment variable in the gcc activation script that sets the Python sysconfigdata file name. However, the sysconfig file of that name does not exist in Python packages we are currently using. We need to be able the latest builds for each version of Python to pick up the fix without issues. On the Sherpa side, Python _appears_ to be held back by xspec. 

**Fix/Workaround**
We are able to workaround the issue with the automated tests temporarily by setting the environment variable for build appropriately for builds. This is NOT a permanent fix, but just enough to get us going while we work on a permanent fix (getting the builds to pick up the latest python builds). 