### PR TITLE
Remove Python 3.6 and add Python 3.9

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -27,9 +27,18 @@ jobs:
           - name: Linux Minimum Setup 
             os: ubuntu-latest
             python-version: 3.8
-            numpy-version: 1.17
+            numpy-version: 1.18
             install-type: develop 
             test-data: none
+
+          - name: Linux Full Build (Python 3.9)
+            os: ubuntu-latest
+            python-version: 3.9
+            install-type: develop
+            fits: astropy
+            test-data: submodule
+            matplotlib-version: 3
+            xspec-version: 12.11.1
 
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest 
@@ -43,26 +52,16 @@ jobs:
           - name: Linux Full Build (Python 3.7)
             os: ubuntu-latest
             python-version: 3.7
-            numpy-version: 1.15
+            numpy-version: 1.19
             install-type: install
             fits: astropy
             test-data: submodule 
             matplotlib-version: 3
             xspec-version: 12.10.1s
 
-          - name: Linux Full Build (Python 3.6)
-            os: ubuntu-latest
-            python-version: 3.6
-            numpy-version: 1.11
-            install-type: install
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 2
-            xspec-version: 12.10.1s
-
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.6 
+            python-version: 3.9 
             install-type: install
             test-data: package
             matplotlib-version: 2
@@ -70,6 +69,7 @@ jobs:
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
             python-version: 3.7
+            numpy-version: 1.18
             install-type: develop 
             fits: astropy
             test-data: none

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   sherpa_channel: sherpa
-  xspec_channel: "xspec/label/dev"
+  xspec_channel: "xspec/label/test"
   miniconda_loc: ${{ github.workspace }}/miniconda
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.9SDK/MacOSX10.9.sdk
 

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -64,7 +64,7 @@ jobs:
             python-version: 3.9 
             install-type: install
             test-data: package
-            matplotlib-version: 2
+            matplotlib-version: 3
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   sherpa_channel: sherpa
-  xspec_channel: "xspec/channel/test"
+  xspec_channel: "xspec/label/dev"
   miniconda_loc: ${{ github.workspace }}/miniconda
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.9SDK/MacOSX10.9.sdk
 
@@ -111,7 +111,6 @@ jobs:
     - name: Build Sherpa
       env:
         PYTHON_LDFLAGS: " "
-        _CONDA_PYTHON_SYSCONFIGDATA_NAME: "${{ runner.os == 'linux' && '_sysconfigdata_x86_64_conda_cos6_linux_gnu' || '_sysconfigdata_x86_64_apple_darwin13_4_0' }}" 
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
@@ -122,7 +121,6 @@ jobs:
         TEST: ${{ matrix.test-data }}
         XSPECVER: ${{ matrix.xspec-version }}
         FITS: ${{ matrix.fits }}
-        _CONDA_PYTHON_SYSCONFIGDATA_NAME: "${{ runner.os == 'linux' && '_sysconfigdata_x86_64_conda_cos6_linux_gnu' || '_sysconfigdata_x86_64_apple_darwin13_4_0' }}" 
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -12,13 +12,13 @@ jobs:
           - name: Linux Minimum Setup 
             os: ubuntu-latest
             python-version: 3.8
-            numpy-pkg: 'numpy>=1.17,<1.18'
+            numpy-pkg: 'numpy>=1.18,<1.19'
             install-type: develop 
             test-data: none
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.6 
+            python-version: 3.9
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,11 +28,6 @@ stages:
   tags:
       - sherpa-macos-build
 
-macos-python3.6-conda-build:
-  <<: *template_macos_conda_build
-  variables:
-      SHERPA_PYTHON_VERSION: "3.6.*"
-
 macos-python3.7-conda-build:
   <<: *template_macos_conda_build
   variables:
@@ -43,10 +38,10 @@ macos-python3.8-conda-build:
   variables:
       SHERPA_PYTHON_VERSION: "3.8.*"
 
-linux-python3.6-conda-build:
-  <<: *template_linux_conda_build
+macos-python3.9-conda-build:
+  <<: *template_macos_conda_build
   variables:
-    SHERPA_PYTHON_VERSION: '3.6.*'
+      SHERPA_PYTHON_VERSION: "3.9.*"
 
 linux-python3.7-conda-build:
   <<: *template_linux_conda_build
@@ -58,18 +53,23 @@ linux-python3.8-conda-build:
   variables:
     SHERPA_PYTHON_VERSION: '3.8.*'
 
+linux-python3.9-conda-build:
+  <<: *template_linux_conda_build
+  variables:
+    SHERPA_PYTHON_VERSION: '3.9.*'
+
 conda:
   stage: deploy
   tags:
       - sherpa
   image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
   dependencies:
-      - linux-python3.6-conda-build
       - linux-python3.7-conda-build
       - linux-python3.8-conda-build
-      - macos-python3.6-conda-build
+      - linux-python3.9-conda-build
       - macos-python3.7-conda-build
       - macos-python3.8-conda-build
+      - macos-python3.9-conda-build
   script:
       - echo $CONDA_UPLOAD_TOKEN
       - anaconda -t $CONDA_UPLOAD_TOKEN upload -u sherpa -c dev packages/linux-64/sherpa* --force
@@ -89,11 +89,6 @@ conda:
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
       - export PATH=~/miniconda/bin:$PATH
       - conda update -qq -y --all
-      - conda create -n test36 --yes -q -c sherpa/label/dev python=3.6 astropy sherpa matplotlib # How to make sure it's the correct version?
-      - source activate test36
-      - pip install /main.zip
-      - sherpa_smoke -f astropy
-      - sherpa_test
       - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test37
       - pip install /main.zip
@@ -101,6 +96,11 @@ conda:
       - sherpa_test
       - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test38
+      - pip install /main.zip
+      - sherpa_smoke -f astropy
+      - sherpa_test
+      - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - source activate test39
       - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
@@ -113,11 +113,6 @@ conda:
     - cd /tmp
     - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip
     - conda update -qq -y --all
-    - conda create -n test36 --yes -q -c sherpa/label/dev python=3.6 astropy sherpa matplotlib # How to make sure it's the correct version?
-    - conda activate test36
-    - pip install main.zip
-    - sherpa_smoke -f astropy
-    - sherpa_test
     - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test37
     - pip install main.zip
@@ -125,6 +120,11 @@ conda:
     - sherpa_test
     - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test38
+    - pip install main.zip
+    - sherpa_smoke -f astropy
+    - sherpa_test
+    - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa matplotlib # How to make sure it's the correct version?
+    - conda activate test39
     - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -17,14 +17,15 @@ requirements:
   - flex
 
  host:
-  - python {{ environ.get('SHERPA_PYTHON_VERSION', '2.7.*') }}
-  - numpy 1.11.*
+  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.7.*') }}
+  - numpy 1.19.* # [py>=39]
+  - numpy 1.18.* # [py<39]
   - setuptools
   - six
 
  run:
-  - python {{ environ.get('SHERPA_PYTHON_VERSION', '2.7.*') }}
-  - numpy >1.11
+  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.7.*') }}
+  - numpy
   - setuptools
   - pytest
   - six


### PR DESCRIPTION
This update includes:

- Xspec re-builds to support readline 8.1 (needed to support Python 3.9)
- Removal of the recent workaround added in PR#[1187](https://github.com/sherpa/sherpa/pull/1187). This is now fixed with the xspec readline updates above (allows us to grab more recent micro versions of Python from Conda without the issue).
- The GitHub Actions pip and Conda tests and the Conda builds have been updated to support NEP-29 for July 26th (Python 3.7+ and numpy 1.18+). 
- Though the Conda build meta.yaml was a little out of date. It had a python 2.7 fallback that has now been switched to 3.7. The minimum numpy support for the Sherpa Conda builds have been bumped to 1.18.* for Python 3.7/3.8 and 1.19.* for Python 3.9 (to avoid conflict).

