### PR TITLE
datastack: Improve show_stack and add _repr_html_ for stack

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -367,7 +367,7 @@ def html_pha(pha):
                           ('HDUCLAS2', 'Data stored'),
                           ('HDUCLAS3', 'Data format'),
                           ('HDUCLAS4', 'PHA format'),
-                          ('XFLT0001', 'Stokes (polarimetry)')])
+                          ('XFLT0001', 'XEPC filter 0001')])
 
     if meta is not None:
         ls.append(formatting.html_section(meta, summary='Metadata'))

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -366,7 +366,8 @@ def html_pha(pha):
                           ('CHANTYPE', 'The channel type'),
                           ('HDUCLAS2', 'Data stored'),
                           ('HDUCLAS3', 'Data format'),
-                          ('HDUCLAS4', 'PHA format')])
+                          ('HDUCLAS4', 'PHA format'),
+                          ('XFLT0001', 'Stokes (polarimetry)')])
 
     if meta is not None:
         ls.append(formatting.html_section(meta, summary='Metadata'))

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -138,7 +138,7 @@ class DataStack():
         header : list of strings
             Column names
         data : list of lists
-            Eahc list is a row, corresponding to one dataset
+            Each list is a row, corresponding to one dataset
 
         '''
         tab = []

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -21,6 +21,7 @@ import numpy
 from sherpa.utils.logging import config_logger
 from sherpa.utils.err import IOErr
 from sherpa.utils.formatting import html_table, html_from_sections
+from sherpa.utils import send_to_pager
 from sherpa.astro import ui
 from .utils import load_error_msg, load_wrapper, model_wrapper, \
     simple_wrapper, fit_wrapper, plot_wrapper
@@ -173,18 +174,30 @@ class DataStack():
                           summary=f'datastack with {data.shape[0]} datasets')
         return html_from_sections(self, htab)
 
-    # QUS: should this use the logger instead of print?
-    def show_stack(self):
+    def show_stack(self, outfile=None, clobber=False):
         """Display basic information about the contents of the data stack.
 
         A brief summary of each data set in the stack is printed to the
         standard output channel. The information displayed depends on the
         type of each data set.
+
+        Parameters
+        ----------
+        outfile : str, optional
+           If not given the results are displayed to the screen,
+           otherwise it is taken to be the name of the file to
+           write the results to.
+        clobber : bool, optional
+           If `outfile` is not ``None``, then this flag controls
+           whether an existing file can be overwritten (``True``)
+           or if it raises an exception (``False``, the default
+           setting).
         """
         header, data = self._summary_for_display()
-        print('|'.join(header))
+        txt = '|'.join(header) + '\n'
         for row in data:
-            print('|'.join(row))
+            txt += '|'.join(row) + '\n'
+        send_to_pager(txt, outfile, clobber)
 
     # QUS: should this return a copy of the list?
     def get_stack_ids(self):

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -739,7 +739,7 @@ def test_show_empty_datastack(capsys):
     assert len(lines) == 2
     assert 'empty datastack' in lines[0]
     assert lines[1].strip() == ''
-     # Now, the check the html representation
+    # Now, the check the html representation
     html = mystack._repr_html_()
     assert 'datastack with 0 datasets' in html
 

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -739,7 +739,7 @@ def test_show_empty_datastack(capsys):
     assert len(lines) == 2
     assert 'empty datastack' in lines[0]
     assert lines[1].strip() == ''
-     # Now, the check the html represention
+     # Now, the check the html representation
     html = mystack._repr_html_()
     assert 'datastack with 0 datasets' in html
 


### PR DESCRIPTION
# Summary
Improve datastack display (via `show_stack` and in the notebook) for datastacks.

# Details
The previous code listed only the OBSID and MJD_OBS and the name of the datstack. This works well when using a datstack for a time series of spectra. However, for other use cases where all spectra in the datstack from from the observation (and sometimes even form the same PHA II file) that display is useless. In particular for grating data (where HEG and MEG positive and negative orders all have the same OBSID and MJD_OBS)  or polarimetry data (IXPE) all displayed values are identical - not very useful.
Now, the table is constructed from a longer list of header keywords, but only keywords that are present and actually differ between rows are displayed; the list of keywords used can be changed as a module-level variable if needed.
I also added a html represenation for notebook display.

# Notes
The previous implementation went to great length to unify treatment for files that have MJD_OBS or MJD-OBS set. CIAO changed that header keywords a few years ago. I don't think that complexity is warranted any longer. I just treat the columns separately. In practice, cases where people mix files from a 3 year old CIAO version with a current CIAO version in the same datastack are going to be rare and columns with non-existent keywords are not displayed, so users will see either MJD-OBD or MJD_OBS but not both.

# Example
old:
![Screen Shot 2021-06-20 at 6 51 43 AM](https://user-images.githubusercontent.com/498688/122671646-b318a080-d195-11eb-95e5-c24ad23b1ec9.png)

new:
![Screen Shot 2021-06-20 at 6 52 04 AM](https://user-images.githubusercontent.com/498688/122671652-b9a71800-d195-11eb-9248-ece97d3fe36e.png)
