### PR TITLE
XSPEC test cleanup

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -790,14 +790,33 @@ def test_xspec_tablemodel_requires_bin_edges(make_data_path, clean_astro_ui):
     This used to be supported in Sherpa 4.13 and before.
     """
 
-    import sherpa.astro.xspec as xs
+    from sherpa.astro import xspec
 
-    ui.load_xstable_model('mdl', make_data_path('xspec-tablemodel-RCS.mod'))
-    mdl = ui.get_model_component('mdl')
+    path = make_data_path('xspec-tablemodel-RCS.mod')
+    tbl = xspec.read_xstable_model('bar', path)
 
     emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
     with pytest.warns(FutureWarning, match=emsg):
-        mdl([0.1, 0.2, 0.3, 0.4])
+        tbl([0.1, 0.2, 0.3, 0.4])
+
+
+@requires_fits
+@requires_data
+@requires_xspec
+def test_xspec_tablemodel_requires_bin_edges_low_level(make_data_path, clean_astro_ui):
+    """Check we can not call a table model with a single grid (calc).
+
+    This used to be supported in Sherpa 4.13 and before.
+    """
+
+    from sherpa.astro import xspec
+
+    path = make_data_path('xspec-tablemodel-RCS.mod')
+    tbl = xspec.read_xstable_model('bar', path)
+
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
+        tbl.calc([p.val for p in tbl.pars], [0.1, 0.2, 0.3, 0.4])
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1054,7 +1054,7 @@ def test_xstbl_link_parameter_evaluation(make_data_path):
     # a link and run the model
     assert tbl.tau.val == pytest.approx(2)
     y2 = tbl(glo, ghi)
-    assert (y2[:-1] > 0).all()
+    assert (y2 > 0).all()
 
     # Test the fix for #742
     lmdl.c0 = 20


### PR DESCRIPTION
# Summary

Very minor improvement to the XSPEC test suite.

# Details

This adds a test for the XSPEC table model to handle the #1112 changes (where we now require XSPEC models to be evaluated with low and high grid values, not a single grid) for when we call the calc method.

It also updates a test that (probably) wasn't updated in #1112 but could have been. The test is now technically more correct (as it tests all the data rather than all-but-the-last-element) but doesn't really make a noticeable difference.

These are both minor changes but I've pulled them out of #830 as that has been sitting around for a long time.