### PR TITLE
Update GitLab Conda recipe to numpy 1.19

### DIFF
--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -18,14 +18,13 @@ requirements:
 
  host:
   - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.7.*') }}
-  - numpy 1.19.* # [py>=39]
-  - numpy 1.18.* # [py<39]
+  - numpy 1.19.*
   - setuptools
   - six
 
  run:
   - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.7.*') }}
-  - numpy
+  - {{ pin_compatible('numpy') }}
   - setuptools
   - pytest
   - six


### PR DESCRIPTION
This is an additional update to the recent in #1192. The default Conda channel does not currently offer numpy 1.18.* for Python 3.9. Additionally this adds back in the numpy run pin:

- Old method: >the current version (would be >1.19.* with the original method)
- Current method: unpinned
- New method: Will now pull in >=the current version built with <the next major release (currently: >=1.19.*,<2.0.0). This just means that we don't have to update it in two places each time.