### PR TITLE
Improve OGIP headers in PHA files

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1589,11 +1589,11 @@ must be an integer.""")
         self.backscal = backscal
         self.areascal = areascal
         if header is None:
-            self.header = {'HDUCLASS': "OGIP", 'HDUCLAS1': "SPECTRUM",
-                           'HDUCLAS2': "TOTAL", 'HDUCLAS3': "TYPE:I",
-                           'HDUCLAS4': "COUNT", 'HDUVERS': "1.2.1",
-                           'TELESCOP': "UNKNOWN", 'INTRUME': "UNKNOWN",
-                           "FILTER": "UNKNOWN", "POISSERR": True}
+            self.header = {"HDUCLASS": "OGIP", "HDUCLAS1": "SPECTRUM",
+                           "HDUCLAS2": "TOTAL", "HDUCLAS3": "TYPE:I",
+                           "HDUCLAS4": "COUNT", "HDUVERS": "1.2.1",
+                           "TELESCOP": "none", "INSTRUME": "none",
+                           "FILTER": "none", "POISSERR": True}
 
         else:
             self.header = header
@@ -1611,7 +1611,7 @@ must be an integer.""")
         self._backgrounds = {}
         self._rate = True
         self._plot_fac = 0
-        self.units = 'channel'
+        self.units = "channel"
         self.quality_filter = None
         Data1D.__init__(self, name, channel, counts, staterror, syserror)
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -778,7 +778,10 @@ def _pack_pha(dataset):
     _set_keyword(header, "ANCRFILE", arf)
     _set_keyword(header, "BACKFILE", bkg)
 
-    # TODO: perhaps we shuold error out if channel or counts is not set?
+    # The channel ordering for the ouput file is determined by the
+    # order the keys are added to the data dict.
+    #
+    # TODO: perhaps we should error out if channel or counts is not set?
     #
     data = {}
     data["channel"] = getattr(dataset, "channel", None)
@@ -892,7 +895,7 @@ def _pack_pha(dataset):
     except KeyError:
         pass
 
-    return data, list(data.keys()), header
+    return data, header
 
 
 def write_arrays(filename, args, fields=None, ascii=True, clobber=False):
@@ -990,7 +993,8 @@ def write_pha(filename, dataset, ascii=True, clobber=False):
     read_pha
 
     """
-    data, col_names, hdr = _pack_pha(dataset)
+    data, hdr = _pack_pha(dataset)
+    col_names = list(data.keys())
     backend.set_pha_data(filename, data, col_names, hdr, ascii=ascii,
                          clobber=clobber)
 
@@ -1073,7 +1077,8 @@ def pack_pha(dataset):
     pack_image, pack_table
 
     """
-    data, col_names, hdr = _pack_pha(dataset)
+    data, hdr = _pack_pha(dataset)
+    col_names = list(data.keys())
     return backend.set_pha_data('', data, col_names, hdr, packup=True)
 
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -761,6 +761,10 @@ def _pack_pha(dataset):
     _set("HDUVERS", "1.2.1")
     _set("HDUDOC", "Arnaud et al. 1992a Legacy 2  p 65")
 
+    # Rely on the DataPHA class to have set up TELESCOP/INSTRUME/FILTER
+    # based on any associated background or response. If the user has
+    # changed them then so be it.
+    #
     _set("TELESCOP", "none")
     _set("INSTRUME", "none")
     _set("FILTER", "none")

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2021
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -671,7 +671,7 @@ def _set_keyword(header, label, value):
 
 
 def _pack_pha(dataset):
-    """Extract FITS  column and header information.
+    """Extract FITS column and header information.
 
     Notes
     -----
@@ -692,7 +692,7 @@ def _pack_pha(dataset):
         HDUCLAS1 - should contain the string "SPECTRUM" to indicate this is a spectrum.
         HDUVERS - the version number of the format (this document describes version 1.2.1)
         POISSERR - whether Poissonian errors are appropriate to the data (see below).
-        CHANTYPE - whether the channels used in the file have been corrected in anyway (see below).
+        CHANTYPE - whether the channels used in the file have been corrected in any way (see below).
         DETCHANS - the total number of detector channels available.
 
     We also add in the following, defaulting to the first value - we
@@ -783,7 +783,7 @@ def _pack_pha(dataset):
     _set_keyword(header, "ANCRFILE", arf)
     _set_keyword(header, "BACKFILE", bkg)
 
-    # The channel ordering for the ouput file is determined by the
+    # The column ordering for the ouput file is determined by the
     # order the keys are added to the data dict.
     #
     # TODO: perhaps we should error out if channel or counts is not set?

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -25,9 +25,9 @@ import numpy as np
 
 import pytest
 
-from sherpa.data import Data1D, Data2DInt
 from sherpa.astro import io
 from sherpa.astro import ui
+from sherpa.data import Data1D, Data2DInt
 from sherpa.models.basic import Box1D, Const1D
 from sherpa.utils.err import IOErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group, \

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -1,0 +1,146 @@
+#
+#  Copyright (C) 2021
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.data import DataIMG
+from sherpa.astro import io
+from sherpa.utils.testing import requires_data, requires_fits
+
+
+def backend_is(name):
+    """Are we using the given backend?"""
+    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+
+
+@requires_fits
+@requires_data
+def test_image_write_basic(make_data_path, tmp_path):
+    """Check we can write out an image file as a FITS file
+    and keep useful data.
+    """
+
+    def check_header(obj):
+        # check header for a selected set of keywords
+        hdr = obj.header
+
+        # selected OGIP keywords
+        if not backend_is("crates"):
+            assert hdr["HDUNAME"] == "EVENTS_IMAGE"
+
+        assert hdr["HDUCLASS"] == "OGIP"
+        assert hdr["HDUCLAS1"] == "EVENTS"
+        assert hdr["HDUCLAS2"] == "ACCEPTED"
+        assert "HDUCLAS3" not in hdr
+        assert hdr["HDUVERS"] == "1.0.0"
+
+        # a few header keywords to check they are handled,
+        # including data types (string, float, integer,
+        # logical).
+        #
+        assert hdr["OBJECT"] == "CSC"
+        assert hdr["INSTRUME"] == "ACIS"
+        assert hdr["GRATING"] == "NONE"
+        assert hdr["DETNAM"] == "ACIS-0"
+        assert hdr["RAND_SKY"] == pytest.approx(0.5)
+        assert hdr["RAND_PI"] == pytest.approx(1.0)
+        assert hdr["DATE-OBS"] == "2006-11-25T09:25:17"
+        assert isinstance(hdr["CLOCKAPP"], (bool, np.bool_))
+        assert hdr["CLOCKAPP"]
+        assert hdr["TIMEZERO"] == 0
+
+        assert "EQUINOX" not in hdr
+
+    def check_data(obj):
+        """Basic checks of the data"""
+
+        assert obj.shape == (377, 169)
+        assert obj.staterror is None
+        assert obj.syserror is None
+
+        assert isinstance(obj.sky, io.wcs.WCS)
+        assert isinstance(obj.eqpos, io.wcs.WCS)
+
+        assert obj.sky.name == "physical"
+        assert obj.sky.type == "LINEAR"
+        assert obj.sky.crval == pytest.approx([3061.8101, 4332.6299])
+        assert obj.sky.crpix == pytest.approx([0.5, 0.5])
+        assert obj.sky.cdelt == pytest.approx([1.0, 1.0])
+
+        assert obj.eqpos.name == "world"
+        assert obj.eqpos.type == "WCS"
+        assert obj.eqpos.crval == pytest.approx([149.8853, 2.60795])
+        assert obj.eqpos.crpix == pytest.approx([4096.5, 4096.5])
+        cd = 0.492 / 3600
+        assert obj.eqpos.cdelt == pytest.approx([-cd, cd])
+        assert obj.eqpos.crota == pytest.approx(0)
+        assert obj.eqpos.epoch == pytest.approx(2000.0)
+        assert obj.eqpos.equinox == pytest.approx(2000.0)
+
+        assert obj.coord == "logical"
+
+        assert obj.x0.shape == (63713, )
+        assert obj.x1.shape == (63713, )
+        assert obj.y.shape == (63713, )
+
+        yexp, xexp = np.mgrid[1:378, 1:170]
+        xexp = xexp.flatten()
+        yexp = yexp.flatten()
+
+        assert obj.x0 == pytest.approx(xexp)
+        assert obj.x1 == pytest.approx(yexp)
+
+        vals = obj.y.reshape((377, 169))
+        expected = np.asarray([0, 1, 0, 0, 0, 0, 1, 0, 0, 2])
+        assert vals[184:194, 83] == pytest.approx(expected)
+
+        # What do we expect for the data types? It is backend-specific
+        #
+        assert obj.x0.dtype == np.dtype("float64")
+        assert obj.x1.dtype == np.dtype("float64")
+        if backend_is("crates"):
+            assert obj.y.dtype == np.dtype("float64")
+
+        elif backend_is("pyfits"):
+            assert obj.y.dtype == np.dtype(">i2")
+
+        else:
+            pytest.fail("Unrecognized IO backend")
+
+    infile = make_data_path("acisf07999_000N001_r0035_regevt3_srcimg.fits")
+    indata = io.read_image(infile)
+    assert isinstance(indata, DataIMG)
+    assert indata.name.endswith("/acisf07999_000N001_r0035_regevt3_srcimg.fits")
+    check_header(indata)
+    check_data(indata)
+
+    # check we can write it out - be explicit with all options
+    #
+    outfile = tmp_path / "test.img"
+    outfile = str(outfile)  # our IO routines don't recognize paths
+    io.write_image(outfile, indata, ascii=False, clobber=False)
+
+    outdata = io.read_image(outfile)
+    assert isinstance(outdata, DataIMG)
+    assert outdata.name.endswith("/test.img")
+    check_header(outdata)
+    check_data(outdata)

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021
+#  Copyright (C) 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -353,7 +353,7 @@ def test_pha_write_xmm_grating(make_data_path, tmp_path):
     """Check we can handle an XMM grating.
 
     This has an AREASCAL column and WCS attached to the CHANNEL
-    colun. We don't guarantee the WCS info will be retained or
+    column. We don't guarantee the WCS info will be retained or
     propagated.
 
     """

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,0 +1,878 @@
+#
+#  Copyright (C) 2020, 2021
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Check that we can write out and read in PHA files.
+
+Check that the PHA files match OGIP standards where appropriate and
+that we can do things like read in the file we've just created.
+
+The Sherpa I/O routines are deliberately not general purpose, so in
+order to check the output files we use the backend-specific
+functionality.  There may be a way to abstract this somewhat, but wait
+until we have enough tests that make it worthwhile.
+
+"""
+
+import logging
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.data import DataPHA
+from sherpa.astro import io
+from sherpa.utils.logging import SherpaVerbosity
+from sherpa.utils.testing import requires_data, requires_fits
+
+
+def backend_is(name):
+    """Are we using the specified backend?"""
+    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+
+
+def check_hduname(hdr, expected):
+    """crates removes the HDUNAME setting but pyfits keeps it"""
+
+    if backend_is("crates"):
+        assert "HDUNAME" not in hdr
+    else:
+        assert hdr["HDUNAME"] == expected
+
+
+@requires_fits
+@requires_data
+def test_pha_write_basic(make_data_path, tmp_path):
+    """Check we can write out a PHA file as a FITS file.
+
+    This uses an existing PHA file rather than creating one manually.
+
+    """
+
+    def check_header(obj):
+        # check header for a selected set of keywords
+        hdr = obj.header
+
+        # selected OGIP keywords
+        check_hduname(hdr, "SPECTRUM")
+
+        assert hdr["HDUCLASS"] == "OGIP"
+        assert hdr["HDUCLAS1"] == "SPECTRUM"
+        assert hdr["HDUCLAS2"] == "TOTAL"
+        assert hdr["HDUCLAS3"] == "TYPE:I"
+        assert hdr["HDUCLAS4"] == "COUNT"
+        assert hdr["HDUVERS"] == "1.1.0"
+        assert hdr["HDUVERS1"] == "1.1.0"
+
+        # a few header keywords to check they are handled,
+        # including data types (string, float, integer,
+        # logical).
+        #
+        assert hdr["OBJECT"] == "3C 273"
+        assert hdr["INSTRUME"] == "ACIS"
+        assert hdr["GRATING"] == "HETG"
+        assert hdr["DETNAM"] == "ACIS-56789"
+        assert hdr["RA_NOM"] == pytest.approx(187.28186566)
+        assert hdr["DEC_NOM"] == pytest.approx(2.05610034)
+        assert hdr["SIM_X"] == pytest.approx(-0.68282252)
+        assert hdr["DATE-OBS"] == "2000-01-10T06:47:15"
+        assert isinstance(hdr["CLOCKAPP"], (bool, np.bool_))
+        assert hdr["CLOCKAPP"]
+        assert hdr["TIMEZERO"] == 0
+        assert hdr["DETCHANS"] == 1024
+
+    def check_data(obj):
+        """Basic checks of the data"""
+
+        assert obj.staterror is None
+        assert obj.syserror is None
+        assert obj.bin_lo is None
+        assert obj.bin_hi is None
+
+        assert obj.exposure == pytest.approx(38564.608926889)
+        assert np.log10(obj.backscal) == pytest.approx(-5.597491618115439)
+        assert obj.areascal == pytest.approx(1.0)
+        for f in ["grouped", "subtracted", "rate"]:
+            assert isinstance(getattr(obj, f), bool)
+
+        assert obj.grouped
+        assert not obj.subtracted
+        assert obj.rate
+
+        assert obj.plot_fac == 0
+
+        assert obj.channel.dtype == np.dtype("float64")
+        assert obj.counts.dtype == np.dtype("float64")
+
+        assert obj.channel == pytest.approx(np.arange(1, 1025))
+        assert len(obj.counts) == 1024
+        assert obj.counts[0:11] == pytest.approx(np.zeros(11))
+        cvals = [1, 3, 2, 3, 7, 1, 6, 4, 4, 0]
+        assert obj.counts[12:22] == pytest.approx(cvals)
+
+        assert len(obj.grouping) == 1024
+        assert len(obj.quality) == 1024
+
+        if backend_is("crates"):
+            assert obj.grouping.dtype == np.dtype("int16")
+            assert obj.quality.dtype == np.dtype("int16")
+
+        elif backend_is("pyfits"):
+            assert obj.grouping.dtype == np.dtype(">i2")
+            assert obj.quality.dtype == np.dtype(">i2")
+
+        else:
+            pytest.fail("Unrecognized IO backend")
+
+        assert obj.quality == pytest.approx(np.zeros(1024))
+
+        one, = np.where(obj.grouping == 1)
+        expected = [0,  17,  21,  32,  39,  44,  48,  51,  54,  56,  59,  61,  65,
+                    68,  71,  75,  78,  82,  88,  96, 101, 110, 116, 124, 130, 133,
+                    139, 143, 150, 156, 164, 177, 186, 196, 211, 232, 244, 260, 276,
+                    291, 323, 344, 368, 404, 450, 676]
+        assert one == pytest.approx(expected)
+        assert obj.grouping.sum() == -932
+        assert set(obj.grouping) == {-1, 1}
+
+    infile = make_data_path("3c273.pi")
+    indata = io.read_pha(infile)
+    assert isinstance(indata, DataPHA)
+    assert indata.name.endswith("/3c273.pi")
+    check_header(indata)
+    check_data(indata)
+
+    # The responses and background should be read in
+    #
+    assert indata.response_ids == pytest.approx([1])
+    assert indata.background_ids == pytest.approx([1])
+
+    assert indata.get_arf().name.endswith("/3c273.arf")
+    assert indata.get_rmf().name.endswith("/3c273.rmf")
+    assert indata.get_background().name.endswith("/3c273_bg.pi")
+
+    # check we can write it out - be explicit with all options
+    #
+    outfile = tmp_path / "test.pha"
+    outfile = str(outfile)  # our IO routines don't recognize paths
+    io.write_pha(outfile, indata, ascii=False, clobber=False)
+
+    outdata = io.read_pha(outfile)
+    assert isinstance(outdata, DataPHA)
+    assert outdata.name.endswith("/test.pha")
+    check_header(outdata)
+    check_data(outdata)
+
+    # The responses and background should NOT be read in
+    # (we are in a different directory to infile so we can't
+    # find these files).
+    #
+    assert outdata.response_ids == []
+    assert outdata.background_ids == []
+
+    assert outdata.get_arf() is None
+    assert outdata.get_rmf() is None
+    assert outdata.get_background() is None
+
+
+def check_write_pha_fits_basic_roundtrip_crates(path):
+    import pycrates
+    ds = pycrates.CrateDataset(str(path), mode="r")
+
+    assert ds.get_ncrates() == 2
+    cr = ds.get_crate(2)
+
+    assert cr.name == "SPECTRUM"
+    assert cr.get_colnames() == ["CHANNEL", "COUNTS"]
+
+    c0 = cr.get_column(0)
+    assert c0.name == "CHANNEL"
+    assert c0.values.dtype == np.int16
+    assert c0.get_tlmin() == -32768
+    assert c0.get_tlmax() == 32767
+
+    c1 = cr.get_column(1)
+    assert c1.name == "COUNTS"
+    assert c1.values.dtype == np.int16
+    assert c1.get_tlmin() == -32768
+    assert c1.get_tlmax() == 32767
+
+    assert cr.get_key_value("HDUCLASS") == "OGIP"
+    assert cr.get_key_value("HDUCLAS1") == "SPECTRUM"
+    assert cr.get_key_value("HDUCLAS2") == "TOTAL"
+    assert cr.get_key_value("HDUCLAS3") == "TYPE:I"
+    assert cr.get_key_value("HDUCLAS4") == "COUNT"
+    assert cr.get_key_value("HDUVERS") == "1.2.1"
+    assert cr.get_key_value("TELESCOP") == "UNKNOWN"
+    assert cr.get_key_value("INTRUME") == "UNKNOWN"  # TYPO - should be INSTRUME
+    assert cr.get_key_value("FILTER") == "UNKNOWN"
+    assert cr.get_key_value("POISSERR")
+
+    # keywords we should have but currently don't
+    for key in ["EXPOSURE", "BACKFILE", "BACKSCAL", "CORRFILE",
+                "CORRSCAL", "RESPFILE", "ANCRFILE", "AREASCAL",
+                "CHANTYPE", "DETCHANS"]:
+        assert cr.get_key_value(key) is None
+
+
+def check_write_pha_fits_basic_roundtrip_pyfits(path):
+    from astropy.io import fits
+    hdus = fits.open(str(path))
+    try:
+        assert len(hdus) == 2
+        hdu = hdus[1]
+        assert hdu.name == "SPECTRUM"
+        assert hdu.level == 1
+        assert hdu.ver == 1
+        assert len(hdu.columns) == 2
+
+        assert hdu.columns[0].name == "CHANNEL"
+        assert hdu.columns[0].format == "INT16"
+        assert hdu.columns[1].name == "COUNTS"
+        assert hdu.columns[1].format == "INT16"
+
+        assert hdu.header["HDUCLASS"] == "OGIP"
+        assert hdu.header["HDUCLAS1"] == "SPECTRUM"
+        assert hdu.header["HDUCLAS2"] == "TOTAL"
+        assert hdu.header["HDUCLAS3"] == "TYPE:I"
+        assert hdu.header["HDUCLAS4"] == "COUNT"
+        assert hdu.header["HDUVERS"] == "1.2.1"
+        assert hdu.header["TELESCOP"] == "UNKNOWN"
+        assert hdu.header["INTRUME"] == "UNKNOWN"  # TYPO - should be INSTRUME
+        assert hdu.header["FILTER"] == "UNKNOWN"
+
+        assert hdu.header["POISSERR"]
+
+        # check some keywords we don't expect
+        #
+        assert "TLMIN1" not in hdu.header
+        assert "TLMAX1" not in hdu.header
+        assert "TLMIN2" not in hdu.header
+        assert "TLMAX2" not in hdu.header
+
+        # keywords we should have but currently don't
+        for key in ["EXPOSURE", "BACKFILE", "BACKSCAL", "CORRFILE",
+                    "CORRSCAL", "RESPFILE", "ANCRFILE", "AREASCAL",
+                    "CHANTYPE", "DETCHANS"]:
+            assert key not in hdu.header
+
+    finally:
+        hdus.close()
+
+
+@requires_fits
+def test_write_pha_fits_basic_roundtrip(tmp_path):
+    """A very-basic PHA output
+
+    No ancillary information and no header.
+    """
+
+    chans = np.arange(1, 5, dtype=np.int16)
+    counts = np.asarray([1, 0, 3, 2], dtype=np.int16)
+    pha = DataPHA("testy", chans, counts)
+
+    outfile = tmp_path / "out.pi"
+    io.write_pha(str(outfile), pha, ascii=False, clobber=False)
+    pha = None
+
+    inpha = io.read_pha(str(outfile))
+    assert isinstance(inpha, DataPHA)
+    assert inpha.channel == pytest.approx(chans)
+    assert inpha.counts == pytest.approx(counts)
+    for field in ["staterror", "syserror", "bin_lo", "bin_hi",
+                  "grouping", "quality", "exposure", "backscal",
+                  "areascal"]:
+        assert getattr(inpha, field) is None
+
+    assert not inpha.grouped
+    assert not inpha.subtracted
+    assert inpha.units == "channel"
+    assert inpha.rate
+    assert inpha.plot_fac == 0
+    assert inpha.response_ids == []
+    assert inpha.background_ids == []
+
+    if backend_is("crates"):
+        check_write_pha_fits_basic_roundtrip_crates(outfile)
+
+    elif backend_is("pyfits"):
+        check_write_pha_fits_basic_roundtrip_pyfits(outfile)
+
+    else:
+        # Technically this could be dummy_backend but it would have
+        # failed earlier.
+        #
+        raise RuntimeError(f"Unknown io backend: {io.backend}")
+
+
+def check_write_pha_fits_with_extras_roundtrip_crates(path, etime, bscal):
+    import pycrates
+    ds = pycrates.CrateDataset(str(path), mode="r")
+
+    assert ds.get_ncrates() == 2
+    cr = ds.get_crate(2)
+
+    assert cr.name == "SPECTRUM"
+    assert cr.get_colnames() == ["CHANNEL", "COUNTS", "GROUPING", "QUALITY", "AREASCAL"]
+
+    c0 = cr.get_column(0)
+    assert c0.name == "CHANNEL"
+    assert c0.values.dtype == np.float64
+    assert c0.get_tlmin() < 1e308
+    assert c0.get_tlmax() > 1e308
+
+    c1 = cr.get_column(1)
+    assert c1.name == "COUNTS"
+    assert c1.values.dtype == np.float32
+    assert c1.get_tlmin() == pytest.approx(-3.4028235e+38)
+    assert c1.get_tlmax() == pytest.approx(3.4028235e+38)
+
+    c2 = cr.get_column(2)
+    assert c2.name == "GROUPING"
+    assert c2.values.dtype == np.float32
+    assert c2.get_tlmin() == pytest.approx(-3.4028235e+38)
+    assert c2.get_tlmax() == pytest.approx(3.4028235e+38)
+
+    c3 = cr.get_column(3)
+    assert c3.name == "QUALITY"
+    assert c3.values.dtype == np.float64
+    assert c3.get_tlmin() < 1e308
+    assert c3.get_tlmax() > 1e308
+
+    c4 = cr.get_column(4)
+    assert c4.name == "AREASCAL"
+    assert c4.values.dtype == np.float64
+    assert c4.get_tlmin() < 1e308
+    assert c4.get_tlmax() > 1e308
+
+    # Keywords we should have but do not
+    for key in ["HDUCLASS", "HDUCLAS1", "HDUCLAS2", "HDUCLAS3", "HDUCLAS4",
+                "HDUVERS", "POISSERR"]:
+        assert cr.get_key_value(key) is None
+
+    assert cr.get_key_value("TELESCOP") == "CHANDRA"
+    assert cr.get_key_value("INTRUME") == "ACIS"
+    assert cr.get_key_value("FILTER") == "NONE"
+
+    assert cr.get_key_value("EXPOSURE") == pytest.approx(etime)
+    assert cr.get_key_value("BACKSCAL") == pytest.approx(bscal)
+    assert cr.get_key_value("CORRFILE") == "None"
+    assert cr.get_key_value("ANCRFILE") == "made-up-ancrfile.fits"
+
+    assert cr.get_key_value("CHANTYPE") == "PI"
+    assert cr.get_key_value("DETCHANS") == 10
+
+    # keywords we should have but currently don't
+    for key in ["BACKFILE", "CORRSCAL", "RESPFILE", "AREASCAL"]:
+        assert cr.get_key_value(key) is None
+
+
+def check_write_pha_fits_with_extras_roundtrip_pyfits(path, etime, bscal):
+    from astropy.io import fits
+    hdus = fits.open(str(path))
+    try:
+        assert len(hdus) == 2
+        hdu = hdus[1]
+        assert hdu.name == "SPECTRUM"
+        assert hdu.level == 1
+        assert hdu.ver == 1
+        assert len(hdu.columns) == 5
+
+        assert hdu.columns[0].name == "CHANNEL"
+        assert hdu.columns[0].format == "D"
+        assert hdu.columns[1].name == "COUNTS"
+        assert hdu.columns[1].format == "D"
+        assert hdu.columns[2].name == "GROUPING"
+        assert hdu.columns[2].format == "D"
+        assert hdu.columns[3].name == "QUALITY"
+        assert hdu.columns[3].format == "D"
+        assert hdu.columns[4].name == "AREASCAL"
+        assert hdu.columns[4].format == "D"
+
+        # Keywords we should have but do not
+        for key in ["HDUCLASS", "HDUCLAS1", "HDUCLAS2", "HDUCLAS3", "HDUCLAS4",
+                    "HDUVERS", "POISSERR"]:
+            assert key not in hdu.header
+
+        assert hdu.header["TELESCOP"] == "CHANDRA"
+        assert hdu.header["INSTRUME"] == "ACIS"
+        assert hdu.header["FILTER"] == "NONE"
+
+        assert hdu.header["EXPOSURE"] == pytest.approx(etime)
+        assert hdu.header["BACKSCAL"] == pytest.approx(bscal)
+        assert hdu.header["CORRFILE"] == "None"
+        assert hdu.header["ANCRFILE"] == "made-up-ancrfile.fits"
+
+        assert hdu.header["CHANTYPE"] == "PI"
+        assert hdu.header["DETCHANS"] == 10
+
+        assert hdu.header["TLMIN1"] == 1
+        assert hdu.header["TLMAX1"] == 10
+
+        # keywords we should have but currently don't
+        for key in ["BACKFILE", "CORRSCAL", "RESPFILE", "AREASCAL"]:
+            assert key not in hdu.header
+
+    finally:
+        hdus.close()
+
+
+@requires_fits
+def test_write_pha_fits_with_extras_roundtrip(tmp_path, caplog):
+    """PHA-I with grouping/quality/errors/header
+
+    This covers issue #488 - that is, should the output use the correct
+    data type for columns? At present the code does not.
+
+    """
+
+    chans = np.arange(1, 5, dtype=np.int32)
+    counts = np.asarray([1, 0, 3, 2], dtype=np.int32)
+    grouping = np.asarray([1, -1, 1, 1], dtype=np.int16)
+    quality = np.asarray([0, 0, 0, 2], dtype=np.int16)
+    etime = 1023.4
+    bscal = 0.05
+    ascal = np.asarray([1, 1, 0.9, 0.9])
+
+    hdr = {"TELESCOP": "CHANDRA", "INSTRUME": "ACIS", "FILTER": "NONE",
+           "CHANTYPE": "PI",
+           "DETCHANS": 10,  # This intentionally does not match the data
+           "OBJECT": "Made up source",
+           "CORRFILE": "None",
+           # This will cause a warning when reading in the file
+           "ANCRFILE": "made-up-ancrfile.fits",
+           # "structural keywords" which match DETCHANS
+           "TLMIN1": 1, "TLMAX1": 10}
+
+    pha = DataPHA("testy",
+                  chans.astype(np.float64),
+                  counts.astype(np.float32),
+                  grouping=grouping.astype(np.float32),
+                  quality=quality.astype(np.float64),
+                  exposure=etime,
+                  backscal=bscal,
+                  areascal=ascal,
+                  header=hdr)
+
+    outfile = tmp_path / "out.pi"
+    io.write_pha(str(outfile), pha, ascii=False, clobber=False)
+    pha = None
+
+    assert len(caplog.record_tuples) == 0
+
+    # We can't read in the PHA file with crates
+    if backend_is("crates"):
+        pytest.skip("Can not read in this PHA file with crates")
+
+    with SherpaVerbosity("INFO"):
+        inpha = io.read_pha(str(outfile))
+
+    assert len(caplog.record_tuples) == 1
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == "sherpa.astro.io"
+    assert lvl == logging.WARNING
+
+    # message depends on the backend
+    if backend_is("crates"):
+        assert msg.startswith("File ")
+        assert msg.endswith("/made-up-ancrfile.fits does not exist.")
+    elif backend_is("pyfits"):
+        assert msg.startswith("file '")
+        assert msg.endswith("/made-up-ancrfile.fits' not found")
+
+    assert isinstance(inpha, DataPHA)
+    assert inpha.channel == pytest.approx(chans)
+    assert inpha.counts == pytest.approx(counts)
+    assert inpha.grouping == pytest.approx(grouping)
+    assert inpha.quality == pytest.approx(quality)
+    assert inpha.exposure == pytest.approx(etime)
+    assert inpha.backscal == pytest.approx(bscal)
+    assert inpha.areascal == pytest.approx(ascal)
+    for field in ["staterror", "syserror", "bin_lo", "bin_hi"]:
+        assert getattr(inpha, field) is None
+
+    assert inpha.grouped
+    assert not inpha.subtracted
+    assert inpha.units == "channel"
+    assert inpha.rate
+    assert inpha.plot_fac == 0
+    assert inpha.response_ids == []
+    assert inpha.background_ids == []
+
+    if backend_is("crates"):
+        check_write_pha_fits_with_extras_roundtrip_crates(outfile, etime, bscal)
+
+    elif backend_is("pyfits"):
+        check_write_pha_fits_with_extras_roundtrip_pyfits(outfile, etime, bscal)
+
+    else:
+        raise RuntimeError(f"Unknown io backend: {io.backend}")
+
+
+@requires_fits
+@requires_data
+def test_chandra_phaII_roundtrip(make_data_path, tmp_path):
+    """Can we read in/write out/read in a PHA-II dataset.
+
+    There is no abiility to write out a PHA-II file,
+    only PHA-I.
+    """
+
+    def check_header(pha):
+        hdr = pha.header
+        assert hdr["TG_M"] == 2
+        assert hdr["TG_PART"] == 1
+
+        check_hduname(hdr, "SPECTRUM")
+
+        assert hdr["HDUCLASS"] == "OGIP"
+        assert hdr["HDUCLAS1"] == "SPECTRUM"
+        assert hdr["HDUCLAS2"] == "TOTAL"
+        assert hdr["HDUCLAS3"] == "COUNT"
+        assert hdr["HDUCLAS4"] == "TYPE:II"
+        assert hdr["HDUVERS"] == "1.0.0"
+        assert hdr["HDUVERS1"] == "1.0.0"
+        assert "HDUVERS2" not in hdr
+
+        assert hdr["ORIGIN"] == "ASC"
+        assert hdr["CREATOR"] == "tgextract - Version CIAO 4.8"
+
+        assert hdr["OBJECT"] == "3C 120"
+        assert hdr["MISSION"] == "AXAF"
+        assert hdr["TELESCOP"] == "CHANDRA"
+        assert hdr["INSTRUME"] == "ACIS"
+        assert hdr["GRATING"] == "HETG"
+        assert hdr["DETNAM"] == "ACIS-56789"
+
+        assert hdr["DETCHANS"] == 8192
+        assert hdr["CHANTYPE"] == "PI"
+        assert "TOTCTS" not in hdr
+
+        assert not hdr["POISSERR"]
+        assert not "SYS_ERR" in hdr
+
+        assert hdr["QUALITY"] == 0
+        assert hdr["GROUPING"] == 0
+
+        assert hdr["CORRFILE"] == "none"
+        assert hdr["CORRSCAL"] == pytest.approx(1.0)
+
+        for key in ["ANCRFILE", "BACKFILE", "RESPFILE"]:
+            assert key not in hdr
+
+    def check_data(pha, bkg=False, roundtrip=False):
+        assert len(pha.channel) == 8192
+        assert len(pha.counts) == 8192
+        assert pha.staterror is None
+        assert pha.syserror is None
+        assert len(pha.channel) == 8192
+        assert len(pha.channel) == 8192
+        assert pha.grouping is None
+        assert pha.quality is None
+        assert pha.exposure == pytest.approx(77716.294300039)
+        if bkg:
+            assert pha.backscal == pytest.approx(4.0188284)
+            assert pha.areascal is None
+        else:
+            assert pha.backscal == pytest.approx(1.0)
+            assert pha.areascal == pytest.approx(1.0)
+
+        assert pha.rate
+        assert pha.response_ids == []
+        expected = [] if bkg or roundtrip else [1, 2]
+        assert pha.background_ids == expected
+
+    infile = make_data_path("3c120_pha2.gz")
+    phas = io.read_pha(infile)
+    assert len(phas) == 12
+
+    # pick the fifth element and a few quick checks
+    pha = phas[4]
+    assert isinstance(pha, DataPHA)
+    assert pha.name.endswith("/3c120_pha2.gz")
+    check_header(pha)
+    check_data(pha)
+
+    bkg1 = pha.get_background(1)
+    bkg2 = pha.get_background(2)
+    check_header(bkg1)
+    check_header(bkg1)
+    check_data(bkg1, bkg=True)
+    check_data(bkg2, bkg=True)
+
+    outfile = tmp_path / "test.pha"
+    io.write_pha(str(outfile), pha, ascii=False, clobber=False)
+
+    outpha = io.read_pha(str(outfile))
+    assert isinstance(outpha, DataPHA)
+    assert outpha.name.endswith("/test.pha")
+    check_header(outpha)
+    check_data(outpha, roundtrip=True)
+
+
+def check_csc_pha_roundtrip_crates(path):
+    import pycrates
+    ds = pycrates.CrateDataset(str(path), mode="r")
+
+    assert ds.get_ncrates() == 2
+    cr = ds.get_crate(2)
+
+    assert cr.name == "SPECTRUM"
+    assert cr.get_colnames() == ["CHANNEL", "COUNTS"]
+
+    c0 = cr.get_column(0)
+    assert c0.name == "CHANNEL"
+    assert c0.values.dtype == np.float64
+    assert c0.get_tlmin() < -1e308
+    assert c0.get_tlmax() > 1e308
+
+    c1 = cr.get_column(1)
+    assert c1.name == "COUNTS"
+    assert c1.values.dtype == np.float64
+    assert c1.get_tlmin() < -1e308
+    assert c1.get_tlmax() > 1e308
+
+    assert cr.get_key_value("HDUCLASS") == "OGIP"
+    assert cr.get_key_value("HDUCLAS1") == "SPECTRUM"
+    assert cr.get_key_value("HDUCLAS2") == "TOTAL"
+    assert cr.get_key_value("HDUCLAS3") == "COUNT"
+    assert cr.get_key_value("HDUCLAS4") is None
+    assert cr.get_key_value("HDUVERS") == "1.1.0"
+    assert cr.get_key_value("HDUVERS1") == "1.1.0"
+
+    assert cr.get_key_value("POISSERR")
+
+    assert cr.get_key_value("TELESCOP") == "CHANDRA"
+    assert cr.get_key_value("INSTRUME") == "ACIS"
+    assert cr.get_key_value("FILTER") is None
+
+    assert cr.get_key_value("EXPOSURE") == pytest.approx(37664.157219191)
+    assert cr.get_key_value("BACKSCAL") == pytest.approx(2.2426552620567e-06)
+    assert cr.get_key_value("CORRFILE") == "none"
+    assert cr.get_key_value("ANCRFILE") == "acisf01575_001N001_r0085_arf3.fits"
+    assert cr.get_key_value("BACKFILE") == "acisf01575_001N001_r0085_pha3.fits"
+    assert cr.get_key_value("RESPFILE") == "acisf01575_001N001_r0085_rmf3.fits"
+
+    assert cr.get_key_value("CHANTYPE") == "PI"
+    assert cr.get_key_value("DETCHANS") == 1024
+
+    assert cr.get_key_value("CORRSCAL") == 0
+    assert cr.get_key_value("SYS_ERR") == 0
+
+    assert cr.get_key_value("AREASCAL") == pytest.approx(1.0)
+    assert cr.get_key_value("QUALITY") == 0
+    assert cr.get_key_value("GROUPING") == 0
+
+
+def check_csc_pha_roundtrip_pyfits(path):
+    from astropy.io import fits
+    hdus = fits.open(str(path))
+    try:
+        assert len(hdus) == 2
+        hdu = hdus[1]
+        assert hdu.name == "SPECTRUM"
+        assert hdu.level == 1
+        assert hdu.ver == 1
+        assert len(hdu.columns) == 2
+
+        assert hdu.columns[0].name == "CHANNEL"
+        assert hdu.columns[0].format == "D"
+        assert hdu.columns[1].name == "COUNTS"
+        assert hdu.columns[1].format == "D"
+
+        assert hdu.header["HDUCLASS"] == "OGIP"
+        assert hdu.header["HDUCLAS1"] == "SPECTRUM"
+        assert hdu.header["HDUCLAS2"] == "TOTAL"
+        assert hdu.header["HDUCLAS3"] == "COUNT"
+        assert "HDUCLAS4" not in hdu.header
+        assert hdu.header["HDUVERS"] == "1.1.0"
+        assert hdu.header["HDUVERS1"] == "1.1.0"
+
+        assert hdu.header["POISSERR"]
+
+        assert hdu.header["TELESCOP"] == "CHANDRA"
+        assert hdu.header["INSTRUME"] == "ACIS"
+        assert "FILTER" not in hdu.header
+
+        assert hdu.header["EXPOSURE"] == pytest.approx(37664.157219191)
+        assert hdu.header["BACKSCAL"] == pytest.approx(2.2426552620567e-06)
+        assert hdu.header["CORRFILE"] == "none"
+        assert hdu.header["ANCRFILE"] == "acisf01575_001N001_r0085_arf3.fits"
+        assert hdu.header["BACKFILE"] == "acisf01575_001N001_r0085_pha3.fits"
+        assert hdu.header["RESPFILE"] == "acisf01575_001N001_r0085_rmf3.fits"
+
+        assert hdu.header["CHANTYPE"] == "PI"
+        assert hdu.header["DETCHANS"] == 1024
+
+        assert hdu.header["CORRSCAL"] == 0
+        assert hdu.header["SYS_ERR"] == 0
+
+        assert hdu.header["AREASCAL"] == pytest.approx(1.0)
+        assert hdu.header["QUALITY"] == 0
+        assert hdu.header["GROUPING"] == 0
+
+        assert hdu.header["TLMIN1"] == 1
+        assert hdu.header["TLMAX1"] == 1024
+
+    finally:
+        hdus.close()
+
+
+@requires_fits
+@requires_data
+def test_csc_pha_roundtrip(make_data_path, tmp_path):
+    """Can we read in/write out/read in a CSC file.
+
+    These files contain both source and background spectra.
+    """
+
+    def check_header(obj, background=False):
+        # check header for a selected set of keywords
+        hdr = obj.header
+
+        # selected OGIP keywords
+        expected = "SPECTRUM" + ("2" if background else "1")
+        check_hduname(hdr, expected)
+
+        assert hdr["HDUCLASS"] == "OGIP"
+        assert hdr["HDUCLAS1"] == "SPECTRUM"
+        assert hdr["HDUCLAS2"] == "BKG" if background else "TOTAL"
+        assert hdr["HDUCLAS3"] == "COUNT"
+        assert hdr["HDUVERS"] == "1.1.0"
+        assert hdr["HDUVERS1"] == "1.1.0"
+
+        assert hdr["ORIGIN"] == "ASC"
+        assert hdr["CREATOR"] == "dmextract - Version CAT 2.7"
+        assert hdr["REGIONID"] == "0085"
+
+        assert hdr["OBJECT"] == "CSC"
+        assert hdr["MISSION"] == "AXAF"
+        assert hdr["TELESCOP"] == "CHANDRA"
+        assert hdr["INSTRUME"] == "ACIS"
+        assert hdr["GRATING"] == "NONE"
+        assert hdr["DETNAM"] == "ACIS-67"
+
+        assert hdr["DETCHANS"] == 1024
+        assert hdr["CHANTYPE"] == "PI"
+        assert hdr["TOTCTS"] == 303 if background else 855
+
+        assert hdr["POISSERR"]
+        assert hdr["SYS_ERR"] == pytest.approx(0)
+        assert hdr["QUALITY"] == 0
+        assert hdr["GROUPING"] == 0
+
+        assert hdr["CORRFILE"] == "none"
+        assert hdr["CORRSCAL"] == pytest.approx(0)
+
+        for key in ["ANCRFILE", "BACKFILE", "RESPFILE"]:
+            assert key not in hdr
+
+    def check_data(obj, background=False):
+        """Basic checks of the data"""
+
+        lbscal = -4.269110831682076 if background else -5.649237480448729
+
+        assert obj.staterror is None
+        assert obj.syserror is None
+        assert obj.bin_lo is None
+        assert obj.bin_hi is None
+
+        assert obj.exposure == pytest.approx(37664.157219191)
+        assert np.log10(obj.backscal) == pytest.approx(lbscal)
+        assert obj.areascal == pytest.approx(1.0)
+        for f in ["grouped", "subtracted", "rate"]:
+            assert isinstance(getattr(obj, f), bool)
+
+        assert not obj.grouped
+        assert not obj.subtracted
+        assert obj.rate
+
+        assert obj.plot_fac == 0
+
+        assert obj.channel.dtype == np.dtype("float64")
+        assert obj.counts.dtype == np.dtype("float64")
+
+        assert obj.channel == pytest.approx(np.arange(1, 1025))
+        assert len(obj.counts) == 1024
+        assert obj.counts[0:11] == pytest.approx(np.zeros(11))
+        assert obj.counts.sum() == 303 if background else 855
+        assert obj.counts.max() == 59 if background else 15
+        assert np.argmax(obj.counts) == 1023 if background else 60
+
+        assert obj.grouping is None
+        assert obj.quality is None
+
+    infile = make_data_path("acisf01575_001N001_r0085_pha3.fits.gz")
+    inpha = io.read_pha(infile)
+    assert isinstance(inpha, DataPHA)
+    assert inpha.name.endswith("/acisf01575_001N001_r0085_pha3.fits.gz")
+    check_header(inpha)
+    assert "HDUCLAS4" not in inpha.header
+    check_data(inpha)
+
+    # We do read in a response
+    assert inpha.get_arf().name.endswith("/acisf01575_001N001_r0085_arf3.fits")
+    assert inpha.get_rmf().name.endswith("/acisf01575_001N001_r0085_rmf3.fits")
+
+    # Did we read in the background?
+    assert inpha.background_ids == [1]
+    inbkg = inpha.get_background()
+    assert isinstance(inbkg, DataPHA)
+    # Note that the name is slightly different to inpha
+    assert inbkg.name.endswith("/acisf01575_001N001_r0085_pha3.fits")
+    check_header(inbkg, background=True)
+    assert "HDUCLAS4" not in inbkg.header
+    check_data(inbkg, background=True)
+
+    # We do read in a response
+    assert inbkg.get_arf().name.endswith("/acisf01575_001N001_r0085_arf3.fits")
+    assert inbkg.get_rmf().name.endswith("/acisf01575_001N001_r0085_rmf3.fits")
+
+    # but not a background
+    assert inbkg.get_background() is None
+
+    outfile = tmp_path / "test.pha"
+    io.write_pha(str(outfile), inpha, ascii=False, clobber=False)
+
+    outpha = io.read_pha(str(outfile))
+    assert isinstance(outpha, DataPHA)
+    assert outpha.name.endswith("/test.pha")
+    check_header(outpha)
+    assert "HDUCLAS4" not in outpha.header
+    check_data(outpha)
+
+    # The responses and background should NOT be read in
+    # (we are in a different directory to infile so we can't
+    # find these files).
+    #
+    assert outpha.response_ids == []
+    assert outpha.background_ids == []
+
+    assert outpha.get_arf() is None
+    assert outpha.get_rmf() is None
+    assert outpha.get_background() is None
+
+    if backend_is("crates"):
+        check_csc_pha_roundtrip_crates(outfile)
+
+    elif backend_is("pyfits"):
+        check_csc_pha_roundtrip_pyfits(outfile)
+
+    else:
+        raise RuntimeError(f"Unknown io backend: {io.backend}")

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -570,13 +570,15 @@ def check_write_pha_fits_basic_roundtrip_crates(path):
     assert cr.get_key_value("QUALITY") == 0
     assert cr.get_key_value("GROUPING") == 0
 
+    assert cr.get_key_value("AREASCAL") == pytest.approx(1.0)
+    assert cr.get_key_value("BACKSCAL") == pytest.approx(1.0)
     assert cr.get_key_value("CORRSCAL") == 0
 
     for key in ["BACKFILE", "CORRFILE", "RESPFILE", "ANCRFILE"]:
         assert cr.get_key_value(key) == "none"
 
     # keywords we should have but currently don't
-    for key in ["EXPOSURE", "BACKSCAL", "AREASCAL"]:
+    for key in ["EXPOSURE"]:
         assert cr.get_key_value(key) is None
 
 
@@ -615,7 +617,10 @@ def check_write_pha_fits_basic_roundtrip_pyfits(path):
         assert hdu.header['QUALITY'] == 0
         assert hdu.header['GROUPING'] == 0
 
+        assert hdu.header["AREASCAL"] == pytest.approx(1.0)
+        assert hdu.header["BACKSCAL"] == pytest.approx(1.0)
         assert hdu.header["CORRSCAL"] == 0
+
         for key in ["BACKFILE", "CORRFILE", "RESPFILE", "ANCRFILE"]:
             assert hdu.header[key] == "none"
 
@@ -628,7 +633,7 @@ def check_write_pha_fits_basic_roundtrip_pyfits(path):
         assert "TLMAX2" not in hdu.header
 
         # keywords we should have but currently don't
-        for key in ["EXPOSURE", "BACKSCAL", "AREASCAL"]:
+        for key in ["EXPOSURE"]:
             assert key not in hdu.header
 
     finally:
@@ -655,9 +660,11 @@ def test_write_pha_fits_basic_roundtrip(tmp_path):
     assert inpha.channel == pytest.approx(chans)
     assert inpha.counts == pytest.approx(counts)
     for field in ["staterror", "syserror", "bin_lo", "bin_hi",
-                  "grouping", "quality", "exposure", "backscal",
-                  "areascal"]:
+                  "grouping", "quality", "exposure"]:
         assert getattr(inpha, field) is None
+
+    assert inpha.backscal == pytest.approx(1.0)
+    assert inpha.areascal == pytest.approx(1.0)
 
     assert not inpha.grouped
     assert not inpha.subtracted
@@ -723,8 +730,6 @@ def check_write_pha_fits_with_extras_roundtrip_crates(path, etime, bscal):
     assert cr.get_key_value("HDUCLASS") == "OGIP"
     assert cr.get_key_value("HDUCLAS1") == "SPECTRUM"
     assert cr.get_key_value("HDUCLAS2") == "TOTAL"
-    # assert cr.get_key_value("HDUCLAS3") == "TYPE:I"
-    # assert cr.get_key_value("HDUCLAS4") == "COUNT"
     assert cr.get_key_value("HDUCLAS3") == "COUNT"
     assert cr.get_key_value("HDUCLAS4") == "TYPE:I"
     assert cr.get_key_value("HDUVERS") == "1.2.1"
@@ -781,8 +786,6 @@ def check_write_pha_fits_with_extras_roundtrip_pyfits(path, etime, bscal):
         assert hdu.header["HDUCLASS"] == "OGIP"
         assert hdu.header["HDUCLAS1"] == "SPECTRUM"
         assert hdu.header["HDUCLAS2"] == "TOTAL"
-        # assert hdu.header["HDUCLAS3"] == "TYPE:I"
-        # assert hdu.header["HDUCLAS4"] == "COUNT"
         assert hdu.header["HDUCLAS3"] == "COUNT"  # WRONG I think
         assert hdu.header["HDUCLAS4"] == "TYPE:I"  # WRONG I think
         assert hdu.header["HDUVERS"] == "1.2.1"  # should this be 1.1.0?

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -1,0 +1,185 @@
+#
+#  Copyright (C) 2021
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Check that we can read in PHA response files.
+
+We don't have "write" routines for these.
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro import io
+from sherpa.astro.data import DataARF, DataRMF
+from sherpa.utils.testing import requires_data, requires_fits
+
+
+def backend_is(name):
+    """Are we using the specified backend?"""
+    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+
+
+def check_hduname(hdr, expected):
+    """crates removes the HDUNAME setting but pyfits keeps it"""
+
+    if backend_is("crates"):
+        assert "HDUNAME" not in hdr
+    else:
+        assert hdr["HDUNAME"] == expected
+
+
+@requires_data
+@requires_fits
+def test_read_arf(make_data_path):
+    """Read in a Chandra grating ARF"""
+
+    infile = make_data_path("3c120_meg_1.arf.gz")
+    arf = io.read_arf(infile)
+    assert isinstance(arf, DataARF)
+    assert arf.name.endswith("/3c120_meg_1.arf.gz")
+    assert arf.exposure == pytest.approx(77715.64389196)
+    assert np.log10(arf.ethresh) == pytest.approx(-10)
+
+    hdr = arf.header
+    check_hduname(hdr, "SPECRESP")
+
+    assert hdr["CONTENT"] == "SPECRESP"
+    assert hdr["HDUCLASS"] == "OGIP"
+    assert hdr["HDUCLAS1"] == "RESPONSE"
+    assert hdr["HDUCLAS2"] == "SPECRESP"
+    assert hdr["HDUVERS"] == "1.1.0"
+    assert hdr["HDUVERS1"] == "1.0.0"
+    assert hdr["HDUVERS2"] == "1.1.0"
+    assert hdr["ARFVERSN"] == "1992a"
+
+    assert hdr["MISSION"] == "AXAF"
+    assert hdr["TELESCOP"] == "CHANDRA"
+    assert hdr["INSTRUME"] == "ACIS"
+    assert hdr["GRATING"] == "HETG"
+    assert hdr["FILTER"] == ""
+
+    assert hdr["OBJECT"] == "3C 120"
+    assert hdr["RESPFILE"] == "grid(meg_1.rmf)"
+
+    assert hdr["OBS_ID"] == "16221"
+    assert hdr["OBI_NUM"] == 0
+    assert hdr["CTI_CORR"]
+    assert hdr["DTCOR"] == pytest.approx(0.98318749385508,)
+
+    for field in ["energ_lo", "energ_hi", "specresp", "bin_lo", "bin_hi"]:
+        attr = getattr(arf, field)
+        assert len(attr) == 8192
+        assert attr.dtype == np.float64
+
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(0.29548186064)
+    assert arf.energ_hi[-1] == pytest.approx(12.398418427)
+
+    assert arf.specresp.sum() == pytest.approx(67517.7296)
+    assert np.argmax(arf.specresp) == 7041
+
+    assert (arf.bin_lo[:-1] == arf.bin_hi[1:]).all()
+    assert arf.bin_lo[-1] == pytest.approx(1.0)
+    assert arf.bin_hi[0] == pytest.approx(41.959999084)
+
+
+@requires_data
+@requires_fits
+def test_read_rmf(make_data_path):
+    """Read in an ASCA RMF with slightly different structure to Chandra
+
+    This has F_CHAN[2]/N_CHAN[2] rather than scalar values.
+    """
+
+    infile = make_data_path("s0_mar24.rmf")
+    rmf = io.read_rmf(infile)
+    print(rmf)
+    assert isinstance(rmf, DataRMF)
+    assert rmf.name.endswith("/s0_mar24.rmf")
+    assert rmf.detchans == 512
+    assert rmf.offset == 0
+    assert np.log10(rmf.ethresh) == pytest.approx(-10)
+
+    hdr = rmf.header
+    assert "HDUNAME" not in hdr
+
+    assert hdr["HDUCLASS"] == "OGIP"
+    assert hdr["HDUCLAS1"] == "RESPONSE"
+    assert hdr["HDUCLAS2"] == "RSP_MATRIX"
+    assert hdr["HDUCLAS3"] == "DETECTOR"
+    assert hdr["HDUVERS1"] == "1.0.0"
+    assert hdr["HDUVERS2"] == "1.1.0"
+    assert hdr["RMFVERSN"] == "1992a"
+
+    assert hdr["TELESCOP"] == "ASCA"
+    assert hdr["INSTRUME"] == "SIS0"
+    assert hdr["FILTER"] == "NONE"
+
+    assert hdr["CHANTYPE"] == "PI"
+    assert np.log10(hdr["LO_THRES"]) == pytest.approx(-7)
+
+    assert len(rmf.energ_lo) == 1180
+    assert len(rmf.energ_hi) == 1180
+    assert len(rmf.n_grp) == 1180
+
+    assert len(rmf.f_chan) == 1189
+    assert len(rmf.n_chan) == 1189
+
+    assert len(rmf.matrix) == 260775
+
+    assert len(rmf.e_min) == 512
+    assert len(rmf.e_max) == 512
+
+    assert rmf.n_grp.dtype == np.uint64
+
+    for field in ["f_chan", "n_chan"]:
+        attr = getattr(rmf, field)
+        if backend_is("crates"):
+            assert attr.dtype == np.uint32
+        elif backend_is("pyfits"):
+            assert attr.dtype == np.uint64
+        else:
+            raise RuntimeError(f"unsupported I/O backend: {io.backend}")
+
+    for field in ["energ_lo", "energ_hi", "matrix", "e_min", "e_max"]:
+        attr = getattr(rmf, field)
+        assert attr.dtype == np.float64
+
+    assert (rmf.energ_lo[1:] == rmf.energ_hi[:-1]).all()
+    assert rmf.energ_lo[0] == pytest.approx(0.20000000298)
+    assert rmf.energ_hi[-1] == pytest.approx(12)
+
+    assert rmf.n_grp.sum() == 1189
+    assert np.argmax(rmf.n_grp) == 12
+
+    # It is not obvious how the RMF is flattened here, so treat this
+    # as a regression test rather than "from first principles"
+    #
+    assert rmf.f_chan.sum() == 16711
+    assert rmf.n_chan.sum() == 260775
+
+    assert rmf.matrix.sum() == pytest.approx(544.8837793875416)
+
+    # e_min/max come from the EBOUNDS block
+    #
+    assert (rmf.e_min[1:] == rmf.e_max[:-1]).all()
+    assert rmf.e_min[0] == pytest.approx(0.01329296827316)
+    assert rmf.e_max[-1] == pytest.approx(14.678317070)

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -107,7 +107,7 @@ def test_pha(header, override_plot_backend):
                      header=header)
     r = d._repr_html_()
     if header is None:
-        nmeta = 5
+        nmeta = 6
     elif header == {}:
         nmeta = 0
     else:

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2017, 2018, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -40,27 +41,13 @@ import pytest
 from sherpa.utils.testing import requires_data, requires_fits
 from sherpa.utils.err import IOErr
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
-
-# Should each test import io instead of this? Also, do we have a
-# better way of determining what the backend is?
-#
-try:
-    from sherpa.astro import io
-    if io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        backend = "pyfits"
-    elif io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        backend = "crates"
-    else:
-        # Should not happen, but do not want to error out here.
-        # Leave io as whatever was loaded, which will likely cause
-        # the tests to fail.
-        backend = None
-
-except ImportError:
-    io = None
-    backend = None
-
+from sherpa.astro import io
 from sherpa.astro import ui
+
+
+def backend_is(name):
+    """Are we using the specified backend?"""
+    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
 
 
 # PHA and ARF are stored uncompressed while RMF is gzip-compressed.
@@ -135,14 +122,14 @@ def test_read_pha(make_data_path):
 def test_read_pha_fails_arf(make_data_path):
     """Just check in we can't read in an ARF as a PHA file."""
 
-    if backend == 'pyfits':
+    if backend_is("pyfits"):
         emsg = " does not appear to be a PHA spectrum"
         etype = IOErr
-    elif backend == 'crates':
-        emsg = 'File must be a PHA file.'
+    elif backend_is("crates"):
+        emsg = "File must be a PHA file."
         etype = TypeError
     else:
-        assert False, "Internal error: unknown backend {}".format(backend)
+        assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(ARFFILE)
     with pytest.raises(etype) as excinfo:
@@ -156,14 +143,14 @@ def test_read_pha_fails_arf(make_data_path):
 def test_read_pha_fails_rmf(make_data_path):
     """Just check in we can't read in a RMF as a PHA file."""
 
-    if backend == 'pyfits':
+    if backend_is("pyfits"):
         emsg = " does not appear to be a PHA spectrum"
         etype = IOErr
-    elif backend == 'crates':
-        emsg = 'File must be a PHA file.'
+    elif backend_is("crates"):
+        emsg = "File must be a PHA file."
         etype = TypeError
     else:
-        assert False, "Internal error: unknown backend {}".format(backend)
+        assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(RMFFILE)
     with pytest.raises(etype) as excinfo:
@@ -179,8 +166,8 @@ def validate_replacement_warning(ws, rtype, label):
     w = ws[0]
     assert w.category == UserWarning
 
-    emsg = "The minimum ENERG_LO in the {} '{}' ".format(rtype, label) + \
-           "was 0 and has been replaced by {}".format(EMIN)
+    emsg = f"The minimum ENERG_LO in the {rtype} '{label}' " + \
+           f"was 0 and has been replaced by {EMIN}"
     assert str(w.message) == emsg
 
 
@@ -228,12 +215,12 @@ def test_read_arf(make_data_path):
 def test_read_arf_fails_pha(make_data_path):
     """Just check in we can't read in a PHA file as an ARF."""
 
-    if backend == 'pyfits':
-        emsg = ' does not appear to be an ARF'
-    elif backend == 'crates':
+    if backend_is("pyfits"):
+        emsg = " does not appear to be an ARF"
+    elif backend_is("crates"):
         emsg = "Required column 'ENERG_LO' not found in "
     else:
-        assert False, "Internal error: unknown backend {}".format(backend)
+        assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(PHAFILE)
     with pytest.raises(IOErr) as excinfo:
@@ -247,12 +234,12 @@ def test_read_arf_fails_pha(make_data_path):
 def test_read_arf_fails_rmf(make_data_path):
     """Just check in we can't read in a RNF as an ARF."""
 
-    if backend == 'pyfits':
-        emsg = ' does not appear to be an ARF'
-    elif backend == 'crates':
+    if backend_is("pyfits"):
+        emsg = " does not appear to be an ARF"
+    elif backend_is("crates"):
         emsg = "Required column 'SPECRESP' not found in "
     else:
-        assert False, "Internal error: unknown backend {}".format(backend)
+        assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(RMFFILE)
     with pytest.raises(IOErr) as excinfo:
@@ -324,14 +311,14 @@ def test_read_rmf(make_data_path):
 def test_read_rmf_fails_pha(make_data_path):
     """Just check in we can't read in a PHA file as a RMF."""
 
-    if backend == 'pyfits':
-        emsg = ' does not appear to be an RMF'
+    if backend_is("pyfits"):
+        emsg = " does not appear to be an RMF"
         etype = IOErr
-    elif backend == 'crates':
-        emsg = ' does not contain a Response Matrix.'
+    elif backend_is("crates"):
+        emsg = " does not contain a Response Matrix."
         etype = TypeError
     else:
-        assert False, "Internal error: unknown backend {}".format(backend)
+        assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(PHAFILE)
     with pytest.raises(etype) as excinfo:
@@ -345,14 +332,14 @@ def test_read_rmf_fails_pha(make_data_path):
 def test_read_rmf_fails_arf(make_data_path):
     """Just check in we can't read in a ARF as a RMF."""
 
-    if backend == 'pyfits':
+    if backend_is("pyfits"):
         emsg = " does not have a 'DETCHANS' keyword"
         etype = IOErr
-    elif backend == 'crates':
-        emsg = ' does not contain a Response Matrix.'
+    elif backend_is("crates"):
+        emsg = " does not contain a Response Matrix."
         etype = TypeError
     else:
-        assert False, "Internal error: unknown backend {}".format(backend)
+        assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(ARFFILE)
     with pytest.raises(etype) as excinfo:
@@ -492,3 +479,71 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     assert stat_cstat.dof == 769
     assert_allclose(stat_cstat.statval, 568.52,
                     rtol=0, atol=0.005)
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("mode", [["arf"], ["rmf"], ["arf", "rmf"]])
+def test_1209_response(mode, make_data_path):
+    """Do we pick up the header keywords from the response?
+
+    This is related to issue #1209
+    """
+
+    # We could set up channels and counts, but let's not.
+    #
+    d = DataPHA("dummy", None, None)
+    assert d.header["TELESCOP"] == "none"
+    assert d.header["INSTRUME"] == "none"
+    assert d.header["FILTER"] == "none"
+
+    # We do not care about the warning messages here from
+    # ENERG_LO replacement.
+    #
+    if "arf" in mode:
+        infile = make_data_path(ARFFILE)
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("ignore")
+            arf = io.read_arf(infile)
+
+        d.set_arf(arf)
+
+    if "rmf" in mode:
+        infile = make_data_path(RMFFILE)
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("ignore")
+            rmf = io.read_rmf(infile)
+
+        d.set_rmf(rmf)
+
+    # The PHA file contains a FILTER keyword but the responses do not.
+    #
+    assert d.header["TELESCOP"] == "SWIFT"
+    assert d.header["INSTRUME"] == "XRT"
+    assert d.header["FILTER"] == "none"
+
+
+@requires_fits
+@requires_data
+def test_1209_background(make_data_path):
+    """Do we pick up the header keywords from the background?
+
+    This is related to issue #1209
+    """
+
+    # We could set up channels and counts, but let's not.
+    #
+    d = DataPHA("dummy", None, None)
+    assert d.header["TELESCOP"] == "none"
+    assert d.header["INSTRUME"] == "none"
+    assert d.header["FILTER"] == "none"
+
+    infile = make_data_path(PHAFILE)
+    bkg = io.read_pha(infile)
+    d.set_background(bkg)
+
+    # The PHA file contains a FILTER keyword but the responses do not.
+    #
+    assert d.header["TELESCOP"] == "SWIFT"
+    assert d.header["INSTRUME"] == "XRT"
+    assert d.header["FILTER"] == "NONE"

--- a/sherpa/astro/tests/test_fake_pha.py
+++ b/sherpa/astro/tests/test_fake_pha.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,7 +30,10 @@ import pytest
 from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.astro.data import DataPHA
 from sherpa.astro.fake import fake_pha
+from sherpa.astro import io
 from sherpa.models import Const1D
+from sherpa.utils.testing import requires_data, requires_fits
+
 
 channels = np.arange(1, 4, dtype=np.int16)
 counts = np.ones(3, dtype=np.int16)
@@ -55,17 +59,17 @@ def test_fake_pha_basic(has_bkg, is_source, reset_seed):
     not be used in the simulation with default settings
     """
     np.random.seed(4276)
-    data = DataPHA('any', channels, counts, exposure=1000.)
+    data = DataPHA("any", channels, counts, exposure=1000.)
 
     if has_bkg:
-        bkg = DataPHA('bkg', channels, bcounts,
+        bkg = DataPHA("bkg", channels, bcounts,
                       exposure=2000, backscal=0.4)
-        data.set_background(bkg, id='unused-bkg')
+        data.set_background(bkg, id="unused-bkg")
 
     data.set_arf(arf)
     data.set_rmf(rmf)
 
-    mdl = Const1D('mdl')
+    mdl = Const1D("mdl")
     mdl.c0 = 2
 
     fake_pha(data, mdl, is_source=is_source, add_bkgs=False)
@@ -73,14 +77,14 @@ def test_fake_pha_basic(has_bkg, is_source, reset_seed):
     assert data.exposure == pytest.approx(1000.0)
     assert (data.channel == channels).all()
 
-    assert data.name == 'any'
-    assert data.get_arf().name == 'user-arf'
-    assert data.get_rmf().name == 'delta-rmf'
+    assert data.name == "any"
+    assert data.get_arf().name == "user-arf"
+    assert data.get_rmf().name == "delta-rmf"
 
     if has_bkg:
-        assert data.background_ids == ['unused-bkg']
-        bkg = data.get_background('unused-bkg')
-        assert bkg.name == 'bkg'
+        assert data.background_ids == ["unused-bkg"]
+        bkg = data.get_background("unused-bkg")
+        assert bkg.name == "bkg"
         assert bkg.counts == pytest.approx(bcounts)
         assert bkg.exposure == pytest.approx(2000)
 
@@ -124,17 +128,17 @@ def test_fake_pha_basic(has_bkg, is_source, reset_seed):
 
 
 def test_fake_pha_background_pha(reset_seed):
-    '''Sample from background pha'''
+    """Sample from background pha"""
     np.random.seed(1234)
 
-    data = DataPHA('any', channels, counts, exposure=1000.)
-    bkg = DataPHA('bkg', channels, bcounts, exposure=2000, backscal=2.5)
-    data.set_background(bkg, id='used-bkg')
+    data = DataPHA("any", channels, counts, exposure=1000.)
+    bkg = DataPHA("bkg", channels, bcounts, exposure=2000, backscal=2.5)
+    data.set_background(bkg, id="used-bkg")
 
     data.set_arf(arf)
     data.set_rmf(rmf)
 
-    mdl = Const1D('mdl')
+    mdl = Const1D("mdl")
     mdl.c0 = 0
     # Just make sure that the model does not contribute
     fake_pha(data, mdl, is_source=True, add_bkgs=False)
@@ -150,7 +154,7 @@ def test_fake_pha_background_pha(reset_seed):
     # and essentially 0 counts. So, we should find 1/11 of the counts
     # we found in the last run.
     for i in range(5):
-        bkg = DataPHA('bkg', channels, np.ones(3, dtype=np.int16),
+        bkg = DataPHA("bkg", channels, np.ones(3, dtype=np.int16),
                       exposure=1000, backscal=2.5)
         data.set_background(bkg, id=i)
 
@@ -163,11 +167,11 @@ def test_fake_pha_background_pha(reset_seed):
 def test_fake_pha_bkg_model():
     """Test background model
     """
-    data = DataPHA('any', channels, counts, exposure=1000.)
+    data = DataPHA("any", channels, counts, exposure=1000.)
 
-    bkg = DataPHA('bkg', channels, bcounts,
+    bkg = DataPHA("bkg", channels, bcounts,
                   exposure=2000, backscal=1.)
-    data.set_background(bkg, id='used-bkg')
+    data.set_background(bkg, id="used-bkg")
 
     data.set_arf(arf)
     data.set_rmf(rmf)
@@ -175,26 +179,26 @@ def test_fake_pha_bkg_model():
     bkg.set_arf(arf)
     bkg.set_rmf(rmf)
 
-    mdl = Const1D('mdl')
+    mdl = Const1D("mdl")
     mdl.c0 = 0
 
-    bmdl = Const1D('bmdl')
+    bmdl = Const1D("bmdl")
     bmdl.c0 = 2
 
     fake_pha(data, mdl, is_source=True, add_bkgs=True,
-             bkg_models={'used-bkg': bmdl})
+             bkg_models={"used-bkg": bmdl})
 
     assert data.exposure == pytest.approx(1000.0)
     assert (data.channel == channels).all()
 
-    assert data.name == 'any'
-    assert data.get_arf().name == 'user-arf'
-    assert data.get_rmf().name == 'delta-rmf'
+    assert data.name == "any"
+    assert data.get_arf().name == "user-arf"
+    assert data.get_rmf().name == "delta-rmf"
 
     # The background itself is unchanged
-    assert data.background_ids == ['used-bkg']
-    bkg = data.get_background('used-bkg')
-    assert bkg.name == 'bkg'
+    assert data.background_ids == ["used-bkg"]
+    bkg = data.get_background("used-bkg")
+    assert bkg.name == "bkg"
     assert bkg.counts == pytest.approx(bcounts)
     assert bkg.exposure == pytest.approx(2000)
 
@@ -223,7 +227,133 @@ def test_fake_pha_bkg_model():
     data.set_arf(arf, 2)
     data.set_rmf(rmf, 2)
     fake_pha(data, mdl, is_source=True, add_bkgs=True,
-             bkg_models={'used-bkg': bmdl})
+             bkg_models={"used-bkg": bmdl})
     assert data.counts.sum() > 500
     assert data.counts.sum() < 1500
     assert data.counts[1] > 1.5 * data.counts[0]
+
+
+@requires_fits
+def test_fake_pha_has_valid_ogip_keywords_all_fake(tmp_path, reset_seed):
+    """See #1209
+
+    When everything is faked, what happens?
+    """
+
+    np.random.seed(5)
+
+    data = DataPHA("any", channels, counts, exposure=1000.)
+
+    bkg = DataPHA("bkg", channels, bcounts,
+                  exposure=2000, backscal=1.)
+    data.set_background(bkg, id="used-bkg")
+
+    data.set_arf(arf)
+    data.set_rmf(rmf)
+
+    bkg.set_arf(arf)
+    bkg.set_rmf(rmf)
+
+    mdl = Const1D("mdl")
+    mdl.c0 = 0
+
+    bmdl = Const1D("bmdl")
+    bmdl.c0 = 2
+
+    fake_pha(data, mdl, is_source=True, add_bkgs=True,
+             bkg_models={"used-bkg": bmdl})
+
+    outfile = tmp_path / "sim.pha"
+    io.write_pha(str(outfile), data, ascii=False)
+
+    inpha = io.read_pha(str(outfile))
+    assert inpha.channel == pytest.approx(channels)
+
+    # it is not required that we check counts (that is, we can drop this
+    # if it turns out not to be repeatable across platforms), but for
+    # now keep the check.
+    #
+    assert inpha.counts == pytest.approx([188, 399, 416])
+
+    for field in ["staterror", "syserror", "bin_lo", "bin_hi",
+                  "grouping", "quality"]:
+        assert getattr(inpha, field) is None
+
+    assert inpha.exposure == pytest.approx(1000.0)
+    assert inpha.backscal == pytest.approx(1.0)
+    assert inpha.areascal == pytest.approx(1.0)
+    assert not inpha.grouped
+    assert not inpha.subtracted
+    assert inpha.response_ids == []
+    assert inpha.background_ids == []
+
+    hdr = inpha.header
+    assert hdr["TELESCOP"] == "none"
+    assert hdr["INSTRUME"] == "none"
+    assert hdr["FILTER"] == "none"
+
+    for key in ["EXPOSURE", "AREASCAL", "BACKSCAL",
+                "ANCRFILE", "BACKFILE", "RESPFILE"]:
+        assert key not in hdr
+
+
+@requires_fits
+@requires_data
+def test_fake_pha_has_valid_ogip_keywords_from_real(make_data_path, tmp_path, reset_seed):
+    """See #1209
+
+    In this version we use a "real" PHA file as the base.
+
+    See sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+
+        test_fake_pha_issue_1209
+
+    which is closer to the reported case in #1209
+    """
+
+    np.random.seed(5)
+
+    infile = make_data_path("acisf01575_001N001_r0085_pha3.fits.gz")
+    data = io.read_pha(infile)
+
+    mdl = Const1D("mdl")
+    mdl.c0 = 0
+
+    bmdl = Const1D("bmdl")
+    bmdl.c0 = 2
+
+    fake_pha(data, mdl, is_source=True, add_bkgs=True,
+             bkg_models={"used-bkg": bmdl})
+
+    outfile = tmp_path / "sim.pha"
+    io.write_pha(str(outfile), data, ascii=False)
+
+    inpha = io.read_pha(str(outfile))
+    assert inpha.channel == pytest.approx(np.arange(1, 1025))
+
+    # it is not required that we check counts (that is, we can drop this
+    # if it turns out not to be repeatable across platforms), but for
+    # now keep the check.
+    #
+    assert inpha.counts.sum() == 19
+
+    for field in ["staterror", "syserror", "bin_lo", "bin_hi",
+                  "grouping", "quality"]:
+        assert getattr(inpha, field) is None
+
+    assert inpha.exposure == pytest.approx(37664.157219191)
+    assert inpha.backscal == pytest.approx(2.2426552620567e-06)
+    assert inpha.areascal == pytest.approx(1.0)
+    assert not inpha.grouped
+    assert not inpha.subtracted
+    assert inpha.response_ids == []
+    assert inpha.background_ids == []
+
+    hdr = inpha.header
+    assert hdr["TELESCOP"] == "CHANDRA"
+    assert hdr["INSTRUME"] == "ACIS"
+    assert hdr["FILTER"] == "none"
+
+    for key in ["EXPOSURE", "AREASCAL", "BACKSCAL",
+                "ANCRFILE", "BACKFILE", "RESPFILE"]:
+        assert key not in hdr

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -527,8 +527,8 @@ def test_fake_pha_issue_1209(make_data_path, clean_astro_ui, tmp_path):
 
     # check the header
     hdr = d3.header
-    assert hdr["TELESCOP"] == "none"
-    assert hdr["INSTRUME"] == "none"
+    assert hdr["TELESCOP"] == "CHANDRA"
+    assert hdr["INSTRUME"] == "ACIS"
     assert hdr["FILTER"] == "none"
 
     # check some other values related to #1209 and #488 (OGIP)


### PR DESCRIPTION
# Summary

Improve the FITS headers created when writing out a PHA file (to better match OGIP standards). Fixes #488 and #1209

# Details

This has been rebased to match the latest code. This does not fix all possible problems, as there are a number of changes that likely require some deep thinking about the DataPHA class.

We start with adding a test that ensures the FITS headers are written out for an image which was changed in #1155 but we didn't have a test to notice this. It also shows some future work #1206.

Then tests of PHA writing/reading are added, leading up to the point where we check the created FITS header and see it doesn't match OGIP standards (many keywords are missing), so add them. The tests are rather low level as we need direct I/O routines - so crates and astropy - rather than those provided by Sherpa.

Note that we add a test that shows that in the `main` branch we can create a PHA file that crates can't read back in. This is fixed in this PR.

Finally I add code to improve the PHA output when compared to the OGIP standards - that is 

- https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
- https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007a/ogip_92_007a.html

This addresses #488 - in that we now write out the "standard" columns as int or float values where appropriate. I believe that the `DataPHA` class should be updated so that it encodes these constraints directly (e.g. makes sure the grouping data is of the correct type) but that is a substantially-larger change than this, and there are likely still to be times when the I/O layer has to do some conversion.

This partially addresses #203 but is not a "sufficient" fix for it.

The final few commits are related to issue #1209 - can we ensure that the PHA file we write out (whether for fake_pha or any other case) can be read in by XSPEC. The OGIP changes here address some of this. The remaining change is to ensure that the files have "sensible" TELESCOP/INSTRUME/FILTER keywords. In this case we copy over the value from the response (ARF or RMF) or the background file when they are added to a DataPHA` file that we are creating (rather than have read in). The logic for this is in the DataPHA set_response (used by set_arf/set_rmf) and set_background methods. The user can change this "after the fact", but if they decide to do this then they have a reason to do so so we let them.
 
I have tested this out on a build with crates but unfortunately you can't tell here (well, not unless we resolve #1069).

There have been some changes to the tests to account for improvements that are now possible because the I/O backend is "hot swappable" thanks to #1185 (e.g. we can now always load sherpa.astro.io rather than have it gated behind a @requires_fits decorator).

# Things still to do

There are a number of issues which I don't address here, as I believe they need work at the `DataPHA` interface layer and are for future work. These include

- how do we determine the channel type (`PI` vs `PHA`)
- handling of RATE files (that is, the PHA contains a rate and not a count). We do have some files that contain rates but they are hacked-up chandra observations and we need a real RATE file (as the headers of the hacked versions are not correct). See #1367 as we do actually have such a file.
- how do we handle cases where the PHA dataset contains OGIP keywords that should be changed to match the data: at the moment we tend not to over-write an existing keyword but is that the right thing to do? I can come up with arguments both ways. One example is that our existing chandra datasets often have HDUCLAS3/4 set to "TYPE:I"/"COUNTS" when they should be the other way around.