### PR TITLE
Restrict the values used in PHA notice/filter calls

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3706,7 +3706,15 @@ class DataPHA(Data1D):
         # enforce limits if channels are being used because it's
         # not clear if channels can technically be negative.
         #
-        if self.units != 'channel':
+        # For channels we just require the numbers are integers.
+        #
+        if self.units == 'channel':
+            if lo is not None and not float(lo).is_integer():
+                raise DataErr('bad', 'lo argument', 'must be an integer channel value')
+            if hi is not None and not float(hi).is_integer():
+                raise DataErr('bad', 'hi argument', 'must be an integer channel value')
+
+        else:
             if lo is not None and lo < 0:
                 raise DataErr('bad', 'lo argument', 'must be >= 0')
             if hi is not None and hi < 0:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3427,7 +3427,7 @@ class DataPHA(Data1D):
                 elo, ehi = self._get_ebins(response_id=response_id)
             except DataErr:
                 # What should we do here? This indicates that all bins
-                # have been marked as bad.
+                # have been marked as bad (and grouping is present).
                 #
                 return numpy.asarray([])
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1923,6 +1923,9 @@ class DataPHA(Data1D):
             elo = self.apply_grouping(elo, self._min)
             ehi = self.apply_grouping(ehi, self._max)
 
+            if len(elo) == 0:
+                raise DataErr('notmask')
+
         # apply_grouping applies a quality filter to the output
         # but if we get here then there is no equivalent. This
         # is likely confusing, at best, but we don't have good
@@ -2116,12 +2119,6 @@ class DataPHA(Data1D):
 
     def _energy_to_channel(self, val):
         elo, ehi = self._get_ebins()
-
-        # special case handling no noticed data (e.g. ignore_bad
-        # removes all bins); assume if elo is empty then so is ehi.
-        #
-        if len(elo) == 0:
-            raise DataErr('notmask')
 
         val = numpy.asarray(val)
         res = []
@@ -3416,7 +3413,6 @@ class DataPHA(Data1D):
         return self._fix_y_units(err, filter, response_id)
 
     def get_xerr(self, filter=False, response_id=None):
-        elo, ehi = self._get_ebins(response_id=response_id)
         filter = bool_cast(filter)
         if filter:
             # If we apply a filter, make sure that
@@ -3425,6 +3421,15 @@ class DataPHA(Data1D):
             elo, ehi = self._get_ebins(response_id, group=False)
             elo = self.apply_filter(elo, self._min)
             ehi = self.apply_filter(ehi, self._max)
+
+        else:
+            try:
+                elo, ehi = self._get_ebins(response_id=response_id)
+            except DataErr:
+                # What should we do here? This indicates that all bins
+                # have been marked as bad.
+                #
+                return numpy.asarray([])
 
         return ehi - elo
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3690,6 +3690,23 @@ class DataPHA(Data1D):
                 # match the error seen from other data classes here
                 raise DataErr('typecheck', f'{label} bound')
 
+        # Validate input
+        #
+        if lo is not None and hi is not None and lo > hi:
+            raise DataErr('bad', 'hi argument', 'must be >= lo')
+
+        # Ensure the limits are physically meaningful, that is
+        # energy and wavelengths are >= 0. Technically it should be
+        # > but using 0 is a nice value for a minimum. We do not
+        # enforce limits if channels are being used because it's
+        # not clear if channels can technically be negative.
+        #
+        if self.units != 'channel':
+            if lo is not None and lo < 0:
+                raise DataErr('bad', 'lo argument', 'must be >= 0')
+            if hi is not None and hi < 0:
+                raise DataErr('bad', 'hi argument', 'must be >= 0')
+
         # If any background IDs are actually given, then impose
         # the filter on those backgrounds *only*, and return.  Do
         # *not* impose filter on data itself.  (Revision possibly

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1524,10 +1524,10 @@ def test_notice_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_da
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, '0.1248:12.4100'),
+                         [(0, 2000, '0.1248:12.4100'),
                           (0.7, 2000, '0.6716:12.4100'),
-                          (-5, 4.2, '0.1248:4.1391'),
-                          (-20, -5, '0.1248:12.4100'),
+                          (0, 4.2, '0.1248:4.1391'),
+                          (0, 1e-10, '0.1248:12.4100'),
                           (2000, 3000, '0.1248:12.4100')])
 def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1545,10 +1545,10 @@ def test_notice_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, '0.0080:14.9431'),
+                         [(0, 2000, '0.0080:14.9431'),
                           (0.7, 2000, '0.6935:14.9431'),
-                          (-5, 4.2, '0.0080:4.1975'),
-                          (-20, -5, '0.0080:14.9431'),
+                          (0, 4.2, '0.0080:4.1975'),
+                          (0, 1e-10, '0.0080:14.9431'),
                           (2000, 3000, '0.0080:14.9431')])
 def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1566,10 +1566,10 @@ def test_notice_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 8000, '0.9991:99.3224'),
+                         [(0, 8000, '0.9991:99.3224'),
                           (20, 8000, '20.4628:99.3224'),
-                          (-5, 15, '0.9991:14.7688'),
-                          (-20, -5, '0.9991:99.3224'),
+                          (0, 15, '0.9991:14.7688'),
+                          (0, 1e-10, '0.9991:99.3224'),
                           (8000, 9000, '99.3224')])
 def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1587,10 +1587,10 @@ def test_notice_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 8000, '0.8297:1544.0123'),
+                         [(0, 8000, '0.8297:1544.0123'),
                           (20, 8000, '19.9813:1544.0123'),
-                          (-5, 15, '0.8297:15.0302'),
-                          (-20, -5, '0.8297:1544.0123'),
+                          (0, 15, '0.8297:15.0302'),
+                          (0, 1e-10, '0.8297:1544.0123'),
                           (8000, 9000, '1544.0123')])
 def test_notice_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1650,10 +1650,10 @@ def test_ignore_channel_grouping_outofbounds_ungrouped(lo, hi, expected, make_da
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, ''),
+                         [(0, 2000, ''),
                           (0.8, 2000, '0.1248:0.7665'),
-                          (-5, 3.5, '3.6792:12.4100'),
-                          (-20, -5, '0.1248:12.4100'),
+                          (0, 3.5, '3.6792:12.4100'),
+                          (0, 1e-10, '0.1248:12.4100'),
                           (2000, 3000, '0.1248:12.4100')])
 def test_ignore_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1671,10 +1671,10 @@ def test_ignore_energy_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, ''),
+                         [(0, 2000, ''),
                           (0.8, 2000, '0.0080:0.7811'),
-                          (-5, 3.5, '3.5113:14.9431'),
-                          (-20, -5, '0.0080:14.9431'),
+                          (0, 3.5, '3.5113:14.9431'),
+                          (0, 1e-10, '0.0080:14.9431'),
                           (2000, 3000, '0.0080:14.9431')])
 def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1692,10 +1692,10 @@ def test_ignore_energy_grouping_outofbounds_ungrouped(lo, hi, expected, make_dat
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, ''),
+                         [(0, 2000, ''),
                           (20, 2000, '0.9991:18.4610'),
-                          (-5, 15, '15.4401:99.3224'),
-                          (-20, -5, '0.9991:99.3224'),
+                          (0, 15, '15.4401:99.3224'),
+                          (0, 1e-10, '0.9991:99.3224'),
                           (2000, 3000, '0.9991:44.6951')])
 def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1713,10 +1713,10 @@ def test_ignore_wave_grouping_outofbounds(lo, hi, expected, make_data_path):
 @requires_data
 @requires_fits
 @pytest.mark.parametrize("lo,hi,expected",
-                         [(-5, 2000, ''),
+                         [(0, 2000, ''),
                           (20, 2000, '0.8297:19.5220'),
-                          (-5, 15, '15.3010:1544.0123'),
-                          (-20, -5, '0.8297:1544.0123'),
+                          (0, 15, '15.3010:1544.0123'),
+                          (0, 1e-10, '0.8297:1544.0123'),
                           (2000, 3000, '0.8297:566.1378')])
 def test_ignore_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_path):
     """Check what happens with silly results"""
@@ -1729,6 +1729,43 @@ def test_ignore_wave_grouping_outofbounds_ungrouped(lo, hi, expected, make_data_
 
     pha.ignore(lo, hi)
     assert pha.get_filter(format='%.4f') == expected
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("units", ["energy", "wave"])
+@pytest.mark.parametrize("notice", [True, False])
+@pytest.mark.parametrize("lo,hi",
+                         [(-5, -2), (-5, 2), (-5, None), (0, -2), (None, -2)])
+def test_pha_validates_limits(units, notice, lo, hi, make_data_path):
+    """Check the limits are validated."""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    pha.units = units
+    func = pha.notice if notice else pha.ignore
+
+    with pytest.raises(DataErr) as de:
+        func(lo, hi)
+
+    assert str(de.value).startswith('unknown ')
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("notice", [True, False])
+def test_pha_validates_range(notice, make_data_path):
+    """Ensure lo <= hi check is made"""
+
+    from sherpa.astro.io import read_pha
+
+    pha = read_pha(make_data_path('3c273.pi'))
+    func = pha.notice if notice else pha.ignore
+    with pytest.raises(DataErr) as de:
+        func(3, 2)
+
+    assert str(de.value) == "unknown hi argument: 'must be >= lo'"
 
 
 @requires_data

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2539,10 +2539,9 @@ def test_pha_check_limit(ignore, lo, hi, evals):
                           (7, 7, (6, 1, 3)),
                           (8, 8, (7, 1, 2)),
                           (9, 9, (8, 1, 1)),
-                          # (10, 10, (9, 1, 0)),
-                          (10, 10, None),
+                          (10, 10, None),  # (9, 1, 0))
                           # check last upper limit
-                          (10, 11, None),
+                          (10, 11, None)   # (9, 1, 0))
                          ])
 def test_pha_check_limit_channel(ignore, lo, hi, evals):
     """What happens when we hit values at bin edges [channel]?

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -372,7 +372,7 @@ def test_288_a_energy():
     pha.ignore(3, 4)
 
     # I use approx because it gives a nice answer, even though
-    # I want eqiuality not approximation in this test. Fortunately
+    # I want equality not approximation in this test. Fortunately
     # with bools the use of approx is okay (it can tell the
     # difference between 0 and 1, aka False and True).
     #

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -244,7 +244,7 @@ def test_pha_get_xerr_all_bad_channel_group():
     """get_xerr handles all bad values [channel]
 
     The behavior with grouping is different, presumably because
-    we assume we have groping when we have a quality array.
+    we assume we have grouping when we have a quality array.
     """
 
     pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
@@ -286,7 +286,7 @@ def test_pha_get_xerr_all_bad_energy_group():
     """get_xerr handles all bad values [energy]
 
     The behavior with grouping is different, presumably because
-    we assume we have groping when we have a quality array.
+    we assume we have grouping when we have a quality array.
     """
 
     pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
@@ -561,7 +561,7 @@ def test_416_c():
     pha.set_analysis('energy')
 
     # When using channels this used notice(3.5, 6.5)
-    # but using energy space we need to use a differnt
+    # but using energy space we need to use a different
     # range to match the ones the original channel filter
     # used.
     #

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -411,7 +411,8 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     # bin.
     #
     # Unfortunately, using a range of 0.3-8.0 gives 771 bins
-    # in XSPEC - channels 30 to 800 - but 772 bins in Sherpa.
+    # in XSPEC - channels 30 to 800 - but 772 bins in Sherpa,
+    # channels 30 to 801.
     #
     # Note that the channel numbering starts at 0:
     # % dmlist target_sr.pha header,clean,raw | grep TLMIN
@@ -439,28 +440,23 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     #        800                  8.0         8.0100002289
     #        801         8.0100002289         8.0200004578
     #
-    # If I use ignore(None, 0.3); ignore(8.0, None) instead
-    # then the result is 771 bins. This is because the e_min/max
-    # of the RMF has channel widths of 0.01 keV, starting at 0,
-    # so both 0.3 and 8.0 fall on a bin boundary. So, it's either
-    # a difference in < or <= (or > vs >=), or a rounding issue
-    # due to floating-point conversion leading to one bin boundary
-    # being slightly different in Sherpa vs XSPEC).
+    # If I use ignore(None, 0.3); ignore(8.0, None) instead then the
+    # result is 771 bins (channels 31 to 800). This is because the
+    # e_min/max of the RMF has channel widths of 0.01 keV, starting at
+    # 0, so both 0.3 and 8.0 fall on a bin boundary. So, it's either a
+    # difference in < or <= (or > vs >=), or a rounding issue due to
+    # floating-point conversion leading to one bin boundary being
+    # slightly different in Sherpa vs XSPEC).
     #
     # When using ui.notice(0.3, 8.0); ui.get_indep(filter=True)
     # returns 772 channels, 30 to 801.
     #
     # Using ui.notice(0.3, 7.995) selects channels 30 to 800. So
     # this range is used. Alternatively, channel 801 could have been
-    # excluded explicitly.
+    # excluded explicitly. Note that notice(0.299, 7.995) selects
+    # the same range as 0.3-7.995.
     #
-    # With changes to PHA filtering we now have to change the
-    # filter range again to include the 0.29-0.30 bin.
-    #
-    # ui.notice(0.3, 8.0)
-    # ui.notice(0.3, 7.995)
-    # ui.notice(0.299, 8.0)
-    ui.notice(0.299, 7.995)  # TODO why has this changed?
+    ui.notice(0.3, 7.995)
 
     # Check the selected range
     pha = ui.get_data()

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -454,8 +454,13 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     # this range is used. Alternatively, channel 801 could have been
     # excluded explicitly.
     #
+    # With changes to PHA filtering we now have to change the
+    # filter range again to include the 0.29-0.30 bin.
+    #
     # ui.notice(0.3, 8.0)
-    ui.notice(0.3, 7.995)
+    # ui.notice(0.3, 7.995)
+    # ui.notice(0.299, 8.0)
+    ui.notice(0.299, 7.995)  # TODO why has this changed?
 
     # Check the selected range
     pha = ui.get_data()

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1119,10 +1119,11 @@ class Data1D(Data):
         # for derived intergrated classes, this will return values in center of
         # bin.
         x = self.get_x(filter=True)
-        mask = numpy.ones(len(x), dtype=bool)
         if numpy.iterable(self.mask):
             mask = self.mask
-        return create_expr(x, mask, format, delim)
+        else:
+            mask = numpy.ones(len(x), dtype=bool)
+        return create_expr(x, mask=mask, format=format, delim=delim)
 
     def get_filter_expr(self):
         return self.get_filter(delim='-') + ' ' + self.get_xlabel()

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -46,6 +46,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from sherpa.astro.data import DataPHA
+from sherpa.astro.instrument import create_delta_rmf
 from sherpa.data import Data1D, Data1DInt, Data2D, DataSimulFit
 from sherpa.models.model import SimulFitModel
 from sherpa.models.basic import Const1D, Polynom1D
@@ -252,8 +253,8 @@ def setup_single_pha(stat, sys, background=True,
                      areascal="none"):
     """Return a single data set and model.
 
-    This is aimed at wstat calculation, and so the DataPHA object has
-    no attached response. The data set is grouped.
+    This is aimed at wstat calculation. The data set is grouped
+    which is a bit against the ethos of WSTAT (fit all the channels).
 
     Parameters
     ----------
@@ -298,6 +299,9 @@ def setup_single_pha(stat, sys, background=True,
     channels = np.arange(1, 6, dtype=np.int16)
     counts = np.asarray([10, 13, 9, 17, 21], dtype=np.int16)
 
+    rlo = channels - 0.5
+    rhi = channels + 0.5
+
     if stat:
         staterror = np.asarray([3.0, 4.0, 3.0, 4.0, 5.0])
     else:
@@ -323,6 +327,10 @@ def setup_single_pha(stat, sys, background=True,
                    syserror=syserror, grouping=grouping,
                    quality=quality, exposure=exposure,
                    backscal=backscal, areascal=ascal)
+
+    rmf = create_delta_rmf(rlo, rhi, e_min=rlo, e_max=rhi)
+    data.set_rmf(rmf)
+    data.units = 'energy'
 
     if background:
         bgcounts = np.asarray([2, 1, 0, 2, 2], dtype=np.int16)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -97,6 +97,7 @@ import pytest
 from sherpa.fit import Fit, StatInfoResults
 from sherpa.data import Data1D, DataSimulFit
 from sherpa.astro.data import DataPHA
+from sherpa.astro.instrument import create_delta_rmf
 from sherpa.models.model import SimulFitModel
 from sherpa.models.basic import Const1D, Gauss1D, Polynom1D, StepLo1D
 from sherpa.utils.err import DataErr, EstErr, FitErr, StatErr
@@ -229,7 +230,8 @@ def setup_pha_single(scalar, usestat, usesys, flo, fhi,
     """Set up a single PHA dataset.
 
     A sherpa.data.DataPHA instance is used, with an associated
-    background data set.
+    background data set. A RMF is added so that we can filter
+    the data with non-integer values.
 
     Parameters
     ----------
@@ -270,6 +272,14 @@ def setup_pha_single(scalar, usestat, usesys, flo, fhi,
 
     src = DataPHA('tst', channels, src_counts,
                   exposure=100.0, backscal=0.01)
+
+    # Add a RMF so that we can filter with non-interger values
+    #
+    rlo = channels - 0.5
+    rhi = channels + 0.5
+    rmf = create_delta_rmf(rlo, rhi, e_min=rlo, e_max=rhi)
+    src.set_rmf(rmf)
+    src.units = 'energy'
 
     if scalar:
         backscal = 0.03
@@ -1173,18 +1183,18 @@ wstat_single_array_mid_stat = 13.468744214842486
     # with flo/fhi options
     #
     # Start with some edge cases
-    (True, False, False, -10, 10, wstat_single_scalar_stat),
+    (True, False, False, 0, 10, wstat_single_scalar_stat),
     (True, False, False, 1, 5, wstat_single_scalar_stat),
     #
     # Now some more-general choices
     (True, False, False, 2, None, wstat_single_scalar_lo_stat),
-    (True, False, False, 1.2, None, wstat_single_scalar_lo_stat),
+    (True, False, False, 1.7, None, wstat_single_scalar_lo_stat),
     (True, True, True, 2, None, wstat_single_scalar_lo_stat),
     (True, False, False, None, 4.1, wstat_single_scalar_hi_stat),
     (True, True, True, None, 4.1, wstat_single_scalar_hi_stat),
-    (True, False, False, 1.2, 4.1, wstat_single_scalar_mid_stat),
+    (True, False, False, 1.7, 4.1, wstat_single_scalar_mid_stat),
     (True, False, False, 2, 4.1, wstat_single_scalar_mid_stat),
-    (True, True, True, 1.2, 4.1, wstat_single_scalar_mid_stat),
+    (True, True, True, 1.7, 4.1, wstat_single_scalar_mid_stat),
 
     # switch to an array for the background backscal
     (False, False, False, None, None, wstat_single_array_stat),
@@ -1192,14 +1202,14 @@ wstat_single_array_mid_stat = 13.468744214842486
     (False, False, True, None, None, wstat_single_array_stat),
     (False, True, True, None, None, wstat_single_array_stat),
 
-    (False, False, False, -1, 6, wstat_single_array_stat),
+    (False, False, False, 0, 6, wstat_single_array_stat),
     (False, False, False, 1, 5, wstat_single_array_stat),
 
-    (False, True, False, 1.2, None, wstat_single_array_lo_stat),
+    (False, True, False, 1.7, None, wstat_single_array_lo_stat),
     (False, False, True, 2, None, wstat_single_array_lo_stat),
 
     (False, False, False, None, 4.1, wstat_single_array_hi_stat),
-    (False, False, False, 1.2, 4.1, wstat_single_array_mid_stat),
+    (False, False, False, 1.7, 4.1, wstat_single_array_mid_stat),
     (False, False, False, 2, 4.1, wstat_single_array_mid_stat),
     (False, False, False, 2, 4, wstat_single_array_mid_stat)
 ])
@@ -1236,12 +1246,12 @@ qval_array_mid = 0.00118932173205
     (True, False, True, None, None, 5, wstat_single_scalar_stat, qval_scalar),
     (True, True, True, None, None, 5, wstat_single_scalar_stat, qval_scalar),
 
-    (True, False, False, -10, 10, 5, wstat_single_scalar_stat, qval_scalar),
+    (True, False, False, 0, 10, 5, wstat_single_scalar_stat, qval_scalar),
     (True, False, False, 1, 5, 5, wstat_single_scalar_stat, qval_scalar),
 
     (True, False, False, 2, None, 4, wstat_single_scalar_lo_stat,
      qval_scalar_lo),
-    (True, False, False, 1.2, None, 4, wstat_single_scalar_lo_stat,
+    (True, False, False, 1.7, None, 4, wstat_single_scalar_lo_stat,
      qval_scalar_lo),
     (True, True, True, 2, None, 4, wstat_single_scalar_lo_stat,
      qval_scalar_lo),
@@ -1251,11 +1261,11 @@ qval_array_mid = 0.00118932173205
     (True, True, True, None, 4.1, 4, wstat_single_scalar_hi_stat,
      qval_scalar_hi),
 
-    (True, False, False, 1.2, 4.1, 3, wstat_single_scalar_mid_stat,
+    (True, False, False, 1.7, 4.1, 3, wstat_single_scalar_mid_stat,
      qval_scalar_mid),
     (True, False, False, 2, 4.1, 3, wstat_single_scalar_mid_stat,
      qval_scalar_mid),
-    (True, True, True, 1.2, 4.1, 3, wstat_single_scalar_mid_stat,
+    (True, True, True, 1.7, 4.1, 3, wstat_single_scalar_mid_stat,
      qval_scalar_mid),
 
     (False, False, False, None, None, 5, wstat_single_array_stat, qval_array),
@@ -1263,10 +1273,10 @@ qval_array_mid = 0.00118932173205
     (False, False, True, None, None, 5, wstat_single_array_stat, qval_array),
     (False, True, True, None, None, 5, wstat_single_array_stat, qval_array),
 
-    (False, False, False, -1, 6, 5, wstat_single_array_stat, qval_array),
+    (False, False, False, 0, 6, 5, wstat_single_array_stat, qval_array),
     (False, False, False, 1, 5, 5, wstat_single_array_stat, qval_array),
 
-    (False, True, False, 1.2, None, 4, wstat_single_array_lo_stat,
+    (False, True, False, 1.7, None, 4, wstat_single_array_lo_stat,
      qval_array_lo),
     (False, False, True, 2, None, 4, wstat_single_array_lo_stat,
      qval_array_lo),
@@ -1274,7 +1284,7 @@ qval_array_mid = 0.00118932173205
     (False, False, False, None, 4.1, 4, wstat_single_array_hi_stat,
      qval_array_hi),
 
-    (False, False, False, 1.2, 4.1, 3, wstat_single_array_mid_stat,
+    (False, False, False, 1.7, 4.1, 3, wstat_single_array_mid_stat,
      qval_array_mid),
     (False, False, False, 2, 4.1, 3, wstat_single_array_mid_stat,
      qval_array_mid),
@@ -1318,26 +1328,26 @@ def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
     (True, True, False, None, None),
     (True, False, True, None, None),
     (True, True, True, None, None),
-    (True, False, False, -10, 10),
+    (True, False, False, 0, 10),
     (True, False, False, 1, 5),
     (True, False, False, 2, None),
-    (True, False, False, 1.2, None),
+    (True, False, False, 1.7, None),
     (True, True, True, 2, None),
     (True, False, False, None, 4.1),
     (True, True, True, None, 4.1),
-    (True, False, False, 1.2, 4.1),
+    (True, False, False, 1.7, 4.1),
     (True, False, False, 2, 4.1),
-    (True, True, True, 1.2, 4.1),
+    (True, True, True, 1.7, 4.1),
     (False, False, False, None, None),
     (False, True, False, None, None),
     (False, False, True, None, None),
     (False, True, True, None, None),
-    (False, False, False, -1, 6),
+    (False, False, False, 0, 6),
     (False, False, False, 1, 5),
-    (False, True, False, 1.2, None),
+    (False, True, False, 1.7, None),
     (False, False, True, 2, None),
     (False, False, False, None, 4.1),
-    (False, False, False, 1.2, 4.1),
+    (False, False, False, 1.7, 4.1),
     (False, False, False, 2, 4.1),
     (False, False, False, 2, 4)
 ])
@@ -1982,7 +1992,7 @@ def test_fit_single_pha(stat, scalar, usestat, usesys, filtflag, finalstat):
 
     numpoints = 5
     if filtflag:
-        fit.data.ignore(3.8, 4.5)
+        fit.data.ignore(3.8, 4.4)
         numpoints -= 1
 
     fr = fit.fit()

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -2696,6 +2696,21 @@ def test_plot_fit_xxx_pylab(ptype, clean_ui):
     fig = plt.gcf()
     axes = fig.axes
 
+    # This test occasionally fails because len(axes) == 3
+    # but it's not obvious why - so let's print some
+    # info in the hope it's informative
+    print(plt.get_current_fig_manager())
+    print(fig)
+    print(axes)
+    for ax in axes:
+        print(ax.get_xlabel())
+        print(ax.get_ylabel())
+        print(ax.get_title())
+        print(ax.lines)
+        print(ax.get_xlim())
+        print(ax.get_ylim())
+        print('---')
+
     assert len(axes) == 2
     assert axes[0].xaxis.get_label().get_text() == ''
 


### PR DESCRIPTION
# Summary

Ensure that the low and high limits for notice and ignore calls for DataPHA objects are sensible (hi >= lo and that for energy or wavelength filters they are >= 0). When filtering DataPHA objects in channel units the lo and hi arguments must be integers otherwise an error is raised.

# Details

In working towards #1129 I realized that the code is a little cleaner if we reject invalid lo/hi values, so for a PHA dataset we now raise a DataErr for `notice` and `ignore` calls when both `lo` and `hi` are set:

 - hi < lo
 - lo or hi values < 0 when filtering in energy or wavelength space
 - non-integer values for channel filters (issue #1212)

**To think about** We could add similar restrictions for other data classes (at least that hi should be >= lo) and I don't know whether to add that here or not.

**To think about** I have used the `DataErr` "bad" error as there isn't really a direct match in DataErr. I could have invented a new error entry for this but I am not sure it's worth it.

Technically we could error out if the `hi` value <= 0 (and ditto for the `lo` value) for energy or wavelength filtering, but using 0 as the low value is a usability "fix" (it's a lot easier to say 0 than have to worry about what the minimum supported energy or wavelength is), and keeping the same check for `hi` is "okay". Using 0 for `lo` is really the same as using `None`, but it's less characters to type.

The non-integer channel error is the **largest usability change** and as discussed in #1212 we could still allow it but either using int(x) [round down for positive values] or pick the nearest integer. If we wanted to go this way (which would be easy to add here) I would vote for int(x) and not nearest integer since if we think of channel 2 really being 2 <= x < 3 then 2.9 should go to 2.

Most of the changes are actually tests for future changes to the filtering code (notice/ignore handling) but I wanted them in before I made those changes. Some of the tests - such as those added in #288 and #416 - have had to be adjusted because they used non-integer channel values. In these cases I've generally  tried to create two copies of the test: a) a version using integer channel values (which probably don't actually probe the original case being tested, and b) a version with a response added so we can keep the non-integer notice/ignore calls. Note that there isn't a way to change a non-integer channel filter to an energy filter and always keep the same lo/hi values and so some subtle changes to the tests have had to be made. A number of other tests have had to be changed because I wrote them to check the behavior when you give a negative energy/wavelength range to a notice/ignore call and so there the negative had to be replaced by a number like 0.

This PR is the second in a sequence: #1208, #1215, #1216, #1219 (hopefully this is all).

# Examples

## energy filters

Before this PR

```python
>>> from sherpa.astro.ui import *
>>> load_pha('3c273.pi')
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi
>>> set_analysis('energy')
>>> notice(-5, 2)
>>> get_filter()
'0.124829999695:1.985600054264'
>>> notice()
>>> notice(-5, -5)
>>> get_filter()
'0.124829999695'
>>> notice()
>>> notice(20, 10)
>>> get_filter()
'12.410000324249'
```

Notice that the -5,-5 and 20,10 filters end up creating odd filter expressions (these are because of problems to be fixed in a later PR in this series but by error-ing out we don't have to worry about it).

With this PR everything fails...

```python
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find xpaget on your PATH'
>>> load_pha('3c273.pi')
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi
>>> set_analysis('energy')
>>> notice(-5, 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in notice
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/ui/utils.py", line 6759, in notice
    sherpa.ui.utils.Session.notice(self, lo, hi, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/ui/utils.py", line 4739, in notice
    d.notice(lo, hi, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/data.py", line 3718, in notice
    raise DataErr('bad', 'lo argument', 'must be >= 0')
sherpa.utils.err.DataErr: unknown lo argument: 'must be >= 0'
>>> notice(-5, -5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in notice
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/ui/utils.py", line 6759, in notice
    sherpa.ui.utils.Session.notice(self, lo, hi, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/ui/utils.py", line 4739, in notice
    d.notice(lo, hi, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/data.py", line 3718, in notice
    raise DataErr('bad', 'lo argument', 'must be >= 0')
sherpa.utils.err.DataErr: unknown lo argument: 'must be >= 0'
>>> notice(20, 10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in notice
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/ui/utils.py", line 6759, in notice
    sherpa.ui.utils.Session.notice(self, lo, hi, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/ui/utils.py", line 4739, in notice
    d.notice(lo, hi, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/data.py", line 3700, in notice
    raise DataErr('bad', 'hi argument', 'must be >= lo')
sherpa.utils.err.DataErr: unknown hi argument: 'must be >= lo'
```

## channel filters

Before this PR

```python
>>> import numpy as np
>>> from sherpa.astro.data import DataPHA
>>> d = DataPHA('x', np.asarray([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5])
>>> d.notice(2.4, 4)
>>> d.get_filter()
'3:4'
>>> d.notice()
>>> d.notice(2, 3.5)
>>> d.get_filter()
'2:3'
```

Note that it's not immediately obvious what 2.5-4 and 2-3.5 are selecting: it's not nearest neighbor and it's not int(val) - so by error-ing out we ignore this headache! {it's actually using the Data1D rules but that's not directly relevant here but would be in future PRs in this series}.

After this PR both `notice` calls are an error

```python
>>> import numpy as np
>>> d = DataPHA('x', np.asarray([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5])
>>> d.notice(2.4, 4)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/data.py", line 3712, in notice
    raise DataErr('bad', 'lo argument', 'must be an integer channel value')
sherpa.utils.err.DataErr: unknown lo argument: 'must be an integer channel value'
>>> d.notice(2, 3.5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/data.py", line 3714, in notice
    raise DataErr('bad', 'hi argument', 'must be an integer channel value')
sherpa.utils.err.DataErr: unknown hi argument: 'must be an integer channel value'
```
