### PR TITLE
Fix c minim

### DIFF
--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2016, 2017, 2018, 2020
+#  Copyright (C) 2014, 2016, 2017, 2018, 2020, 2021
 #       Smithsonian Astrophysical Observatory
 #
 #
@@ -240,6 +240,17 @@ astro_utils = Extension('sherpa.astro.utils._utils',
               depends=(get_deps(['extension', 'utils', 'astro/utils'])+
                        ['sherpa/utils/src/gsl/fcmp.h']))
 
+####
+# FORTRAN EXTENSIONS
+####
+minim =  Extension('sherpa.optmethods._minim',
+              ['sherpa/optmethods/src/_minim.pyf',
+               'sherpa/optmethods/src/minim.f',
+               'sherpa/optmethods/src/syminv.f'],
+		# extra_link_args=['-static-libgfortran'],
+                    )
+
+fortran_exts = [minim]
 
 static_ext_modules = [
                    estmethods,
@@ -252,4 +263,5 @@ static_ext_modules = [
                    astro_modelfcts,
                    pileup,
                    astro_utils,
+                   minim,
                 ]

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -136,7 +136,9 @@ set_method_opt("ftol", 1.19209289551e-07)
 set_method_opt("initsimplex", 0)
 set_method_opt("iquad", 1)
 set_method_opt("maxfev", 5000)
+set_method_opt("reflect", True)
 set_method_opt("step", None)
+set_method_opt("useminimC", True)
 set_method_opt("verbose", 1)
 
 
@@ -727,7 +729,9 @@ set_method_opt("ftol", 1.19209289551e-07)
 set_method_opt("initsimplex", 0)
 set_method_opt("iquad", 1)
 set_method_opt("maxfev", None)
+set_method_opt("reflect", True)
 set_method_opt("step", None)
+set_method_opt("useminimC", True)
 set_method_opt("verbose", 0)
 
 

--- a/sherpa/include/sherpa/syminv.hh
+++ b/sherpa/include/sherpa/syminv.hh
@@ -2,363 +2,227 @@
 #define syminv_hh
 
 #include <cmath>
+#include <vector>
 
 namespace appliedstats {
 
-  template< typename Real >
-  void chola( std::vector<Real>& a, int n, std::vector<Real>& u, int& nullty,
-	      int& ifault, Real& rmax, std::vector<Real>& r ) {
-    //
-    //      subroutine chola(a, n, u, nullty, ifault, rmax, r)
-    //c
-    //c     algorithm as6, applied statistics, vol.17, 1968, with
-    //c     modifications by a.j.miller
-    //c
-    //c     arguments:-
-    //c     a()     = input, a +ve definite matrix stored in lower-triangular
-    //c               form.
-    //c     n       = input, the order of a
-    //c     u()     = output, a lower triangular matrix such that u*u' = a.
-    //c               a & u may occupy the same locations.
-    //c     nullty  = output, the rank deficiency of a.
-    //c     ifault  = output, error indicator
-    //c                     = 1 if n < 1
-    //c                     = 2 if a is not +ve semi-definite
-    //c                     = 0 otherwise
-    //c     rmax    = output, an estimate of the relative accuracy of the
-    //c               diagonal elements of u.
-    //c     r()     = output, array containing bounds on the relative accuracy
-    //c               of each diagonal element of u.
-    //c
-    //c     latest revision - 18 october 1985
-    //c
-    //c************************************************************************
-    //c
-    //      integer*4 ifault,n,nullty
-    //      real*8 a(*),u(*),r(n),rmax
-    //c
-    //c     eta should be set equal to the smallest +ve value such that
-    //c     1.0 + eta is calculated as being greater than 1.0 in the accuracy
-    //c     being used.
-    //c
-    //      integer*4 i,icol,irow,j,k,l,m
-    //      real*8 eta,five,rsq,w,zero
-    //      data eta/1.d-16/, zero/0.d0/, five/5.d0/
-    const Real eta = std::numeric_limits< Real >::epsilon();
-    const Real zero = 0.0;
-    const Real five = 5.0;
+  template< typename real >
+  void CHOLA(std::vector<real>& A, int N, std::vector<real>& U,
+             int& NULLTY, int& IFAULT, real& RMAX, std::vector<real>& R) {
+    //C
+    //C     ALGORITHM AS6, APPLIED STATISTICS, VOL.17, 1968, WITH
+    //C     MODIFICATIONS BY A.J.MILLER
+    //C
+    //C     ARGUMENTS:-
+    //C     A()     = INPUT, A +VE DEFINITE MATRIX STORED IN LOWER-TRIANGULAR
+    //C               FORM.
+    //C     N       = INPUT, THE ORDER OF A
+    //C     U()     = OUTPUT, A LOWER TRIANGULAR MATRIX SUCH THAT U*U' = A.
+    //C               A & U MAY OCCUPY THE SAME LOCATIONS.
+    //C     NULLTY  = OUTPUT, THE RANK DEFICIENCY OF A.
+    //C     IFAULT  = OUTPUT, ERROR INDICATOR
+    //C                     = 1 IF N < 1
+    //C                     = 2 IF A IS NOT +VE SEMI-DEFINITE
+    //C                     = 0 OTHERWISE
+    //C     RMAX    = OUTPUT, AN ESTIMATE OF THE RELATIVE ACCURACY OF THE
+    //C               DIAGONAL ELEMENTS OF U.
+    //C     R()     = OUTPUT, ARRAY CONTAINING BOUNDS ON THE RELATIVE ACCURACY
+    //C               OF EACH DIAGONAL ELEMENT OF U.
+    //C
+    //C     LATEST REVISION - 18 October 1985
+    //C
+    //C*************************************************************************
+    //C
+    // implicit double(a - h, o - z)
+    //DIMENSION A(*), U(*), R(N)
+    //C
+    //C     ETA SHOULD BE SET EQUAL TO THE SMALLEST +VE VALUE SUCH THAT
+    //C     1.0 + ETA IS CALCULATED AS BEING GREATER THAN 1.0 IN THE ACCURACY
+    //C     BEING USED.
+    //C
+    // DATA ETA/1.D - 16/, ZERO/0.D0/, FIVE/5.D0/;
+    //C
+    const real ETA = std::numeric_limits<real>::epsilon();
+    const real ZERO = 0.0;
+    const real FIVE = 5.0;
+    real RSQ = 0.0;
+    real W = 0.0;
+    int I=0, J, K;
 
-    int i__ = 0;
-    Real rsq = 0.;
-    Real w = 0.;
-
-    //c
-    //      ifault=1
-    //      if(n.le.0) go to 100
-    ifault = 1;
-    if ( n <= 0 )
-      goto L100;
-
-    //      ifault=2
-    //      nullty=0
-    //      rmax=eta
-    //      r(1)=eta
-    //      j=1
-    //      k=0
-    ifault = 2;
-    nullty = 0;
-    rmax = eta;
-    r[0] = eta;
-    int j, k;
-    j = 1;
-    k = 0;
-
-
-    //c
-    //c     factorize column by column, icol = column no.
-    //c
-    //      do 80 icol=1,n
-    //        l=0
-    for ( int icol = 1; icol <= n; ++icol) {
-      int l = 0;
-
-      //c
-      //c     irow = row number within column icol
-      //c
-      //        do 40 irow=1,icol
-      //          k=k+1
-      //          w=a(k)
-      //          if(irow.eq.icol) rsq=(w*eta)**2
-      //          m=j
-      for ( int irow = 1; irow <= icol; ++irow) {
-	++k;
-	w = a[k - 1];
-	if (irow == icol)
-	  rsq = pow( w * eta, 2.0 );
-	int m = j;
-
-
-	//          do 10 i=1,irow
-	//            l=l+1
-	//            if(i.eq.irow) go to 20
-	//            w=w-u(l)*u(m)
-	//            if(irow.eq.icol) rsq=rsq+(u(l)**2*r(i))**2
-	//            m=m+1
-	//   10     continue
-	for (i__ = 1; i__ <= irow; ++i__) {
-	  ++l;
-	  if (i__ == irow)
-	    goto L20;
-	  w -= u[l - 1] * u[m - 1];
-	  if (irow == icol)
-	    rsq += pow( u[l - 1]*u[l - 1] * r[i__ - 1], 2.0 );
-	  ++m;
-	  /* L10: */
-	}
-
-	
-	//   20     if(irow.eq.icol) go to 50
-	//          if(u(l).eq.zero) go to 30
-      L20:
-	if (irow == icol)
-	  goto L50;
-	if (u[l - 1] == zero)
-	  goto L30;
-
-	
-	//          u(k)=w/u(l)
-	//          go to 40
-	//   30     u(k)=zero
-	//          if(abs(w).gt.abs(rmax*a(k))) go to 100
-	//   40   continue
-	u[k - 1] = w / u[l - 1];
-	goto L40;
-      L30:
-	u[k - 1] = zero;
-	if ( fabs( w ) > fabs( rmax * a[k - 1] ) )
-	  goto L100;
-      L40:
-	;
-      }                            // for ( int irow = 0; irow < icol; ++irow )
-
-
-    //c
-    //c     end of row, estimate relative accuracy of diagonal element.
-    //c
-    //   50   rsq=sqrt(rsq)
-    //        if(abs(w).le.five*rsq) go to 60
-    //        if(w.lt.zero) go to 100
-    //        u(k)=sqrt(w)
-    //        r(i)=rsq/w
-    //        if(r(i).gt.rmax) rmax=r(i)
-    //        go to 70
-    L50:
-      rsq = sqrt(rsq);
-      if (fabs(w) <= five * rsq)
-	goto L60;
-      if (w < zero)
-	goto L100;
-      u[k - 1] = sqrt(w);
-      r[i__ - 1] = rsq / w;
-      if (r[i__ - 1] > rmax)
-	rmax = r[i__ - 1];
-      goto L70;
-
-      //   60   u(k)=zero
-      //        nullty=nullty+1
-    L60:
-      u[k - 1] = zero;
-      ++nullty;
-    L70:
-      j += icol;
-      /* L80: */
+    IFAULT = 1;
+    if (N <= 0) goto g100;
+    IFAULT = 2;
+    NULLTY = 0;
+    RMAX = ETA;
+    R[0] = ETA;
+    J = 1;
+    K = 0;
+    //C
+    //C     FACTORIZE COLUMN BY COLUMN, ICOL = COLUMN NO.
+    //C
+    for(int ICOL=1; ICOL<=N; ICOL++) {
+      int L = 0;
+      //C
+      //C     IROW = ROW NUMBER WITHIN COLUMN ICOL
+      //C
+      for(int IROW=1; IROW<=ICOL; IROW++) {
+        K = K + 1;
+        W = A[K-1];
+        if (IROW == ICOL)
+          // RSQ = (W*ETA)**2;
+          RSQ = pow(W*ETA, 2);
+        int M = J;
+        for(I=1; I<=IROW; I++) {
+          L = L + 1;
+          if (I == IROW) goto g20;
+          W = W - U[L-1]*U[M-1];
+          if (IROW == ICOL)
+            // RSQ = RSQ + (U[L]**2*R[I])**2;
+            RSQ += pow(U[L-1]*U[L-1]*R[I-1], 2.0);
+          M = M + 1;
+        }
+      g20:
+        if (IROW == ICOL) goto g50;
+        if (U[L-1] == ZERO) goto g30;
+        U[K-1] = W/U[L-1];
+        goto g40;
+      g30:
+        U[K-1] = ZERO;
+        if (fabs(W) > fabs(RMAX*A[K-1])) goto g100;
+      g40:
+        ;
+      }
+      //C
+      //C     END OF ROW, ESTIMATE RELATIVE ACCURACY OF DIAGONAL ELEMENT.
+      //C
+    g50:
+      RSQ = sqrt(RSQ);
+      if (fabs(W) <= FIVE*RSQ) goto g60;
+      if (W < ZERO) goto g100;
+      U[K-1] = sqrt(W);
+      R[I-1] = RSQ/W;
+      if (R[I-1] > RMAX) RMAX = R[I-1];
+      goto g70;
+    g60:
+      U[K-1] = ZERO;
+      NULLTY = NULLTY + 1;
+    g70:
+      J = J + ICOL;
     }
-    ifault = 0;
-
-  L100:
+    IFAULT = 0;
+    //C
+  g100:
     return;
-  } /* chola */
+  }
+  //c
+  //c http://lib.stat.cmu.edu/apstat/47
+  //c
 
 
-  template< typename Real >
-  void syminv(std::vector<Real>& a, int n, std::vector<Real>& c, 
-	      std::vector<Real>& w, int& nullty, int& ifault, Real& rmax) {
-    //
-    //      subroutine syminv(a,n,c,w,nullty,ifault,rmax)
-    //c
-    //c     algorithm as7, applied statistics, vol.17, 1968.
-    //c
-    //c     arguments:-
-    //c     a()     = input, the symmetric matrix to be inverted, stored in
-    //c               lower triangular form
-    //c     n       = input, order of the matrix
-    //c     c()     = output, the inverse of a (a generalized inverse if c is
-    //c               singular), also stored in lower triangular.
-    //c               c and a may occupy the same locations.
-    //c     w()     = workspace, dimension at least n.
-    //c     nullty  = output, the rank deficiency of a.
-    //c     ifault  = output, error indicator
-    //c                     = 1 if n < 1
-    //c                     = 2 if a is not +ve semi-definite
-    //c                     = 0 otherwise
-    //c     rmax    = output, approximate bound on the accuracy of the diagonal
-    //c               elements of c.  e.g. if rmax = 1.e-04 then the diagonal
-    //c               elements of c will be accurate to about 4 dec. digits.
-    //c
-    //c     latest revision - 18 october 1985
-    //c
-    //c************************************************************************
-    //c
-    //      integer*4 ifault,n,nullty
-    //      real*8 a(*),c(*),rmax,w(n)
-    //
-    //      integer*4 i,icol,irow,j,jcol,k,l,mdiag,ndiag,nn,nrow
-    //      real*8 one,x,zero
-    //      data zero/0.d0/, one/1.d0/
-    //c
-    const Real zero = 0.;
-    const Real one = 1.;
-
-    //      integer*4 i,icol,irow,j,jcol,k,l,mdiag,ndiag,nn,nrow
-    //      real*8 one,x,zero
-    //      data zero/0.d0/, one/1.d0/
-    //c
-    int j, k, l;
-    Real x;
-    int nn, icol, jcol, irow, nrow, mdiag, ndiag;
-
-    nrow = n;
-    ifault = 1;
-    if (nrow <= 0) {
-      goto L100;
+  template< typename real >
+  void SYMINV(std::vector<real>& A, int N, std::vector<real>& C,
+              std::vector<real>& W, int& NULLTY, int& IFAULT, real& RMAX) {
+    //C
+    //C     ALGORITHM AS7, APPLIED STATISTICS, VOL.17, 1968.
+    //C
+    //C     ARGUMENTS:-
+    //C     A()     = INPUT, THE SYMMETRIC MATRIX TO BE INVERTED, STORED IN
+    //C               LOWER TRIANGULAR FORM
+    //C     N       = INPUT, ORDER OF THE MATRIX
+    //C     C()     = OUTPUT, THE INVERSE OF A (A GENERALIZED INVERSE IF C IS
+    //C               SINGULAR), ALSO STORED IN LOWER TRIANGULAR.
+    //C               C AND A MAY OCCUPY THE SAME LOCATIONS.
+    //C     W()     = WORKSPACE, DIMENSION AT LEAST N.
+    //C     NULLTY  = OUTPUT, THE RANK DEFICIENCY OF A.
+    //C     IFAULT  = OUTPUT, ERROR INDICATOR
+    //C                     = 1 IF N < 1
+    //C                     = 2 IF A IS NOT +VE SEMI-DEFINITE
+    //C                     = 0 OTHERWISE
+    //C     RMAX    = OUTPUT, APPROXIMATE BOUND ON THE ACCURACY OF THE DIAGONAL
+    //C               ELEMENTS OF C.  E.G. IF RMAX = 1.E-04 THEN THE DIAGONAL
+    //C               ELEMENTS OF C WILL BE ACCURATE TO ABOUT 4 DEC. DIGITS.
+    //C
+    //C     LATEST REVISION - 18 October 1985
+    //C
+    //C*************************************************************************
+    //C
+    // implicit double(a - h, o - z)
+    //DIMENSION A(*), C(*), W(N)
+    // DATA ZERO/0.D0/, ONE/1.D0/;
+    //C
+    const real ZERO = 0.0;
+    const real ONE = 1.0;
+    int I, J, K, L;
+    real X;
+    int NN, ICOL, JCOL, IROW, NROW, MDIAG, NDIAG;
+    NROW = N;
+    IFAULT = 1;
+    if (NROW <= 0) goto g100;
+    IFAULT = 0;
+    //C
+    //C     CHOLESKY FACTORIZATION OF A, RESULT IN C
+    //C
+    CHOLA(A, NROW, C, NULLTY, IFAULT, RMAX, W);
+    if (IFAULT != 0) goto g100;
+    //C
+    //C     INVERT C & FORM THE PRODUCT (CINV)'*CINV, WHERE CINV IS THE INVERSE
+    //C     OF C, ROW BY ROW STARTING WITH THE LAST ROW.
+    //C     IROW = THE ROW NUMBER, NDIAG = LOCATION OF LAST ELEMENT IN THE ROW.
+    //C
+    NN = NROW*(NROW + 1)/2;
+    IROW = NROW;
+    NDIAG = NN;
+  g10:
+    if (C[NDIAG-1] == ZERO) goto g60;
+    L = NDIAG;
+    for(I=IROW; I<=NROW; I++) {
+      W[I-1] = C[L-1];
+      L = L + I;
     }
-    ifault = 0;
-
+    ICOL = NROW;
+    JCOL = NN;
+    MDIAG = NN;
+  g30:
+    L = JCOL;
+    X = ZERO;
+    if (ICOL == IROW) X = ONE/W[IROW-1];
+    K = NROW;
+  g40:
+    if (K == IROW) goto g50;
+    X = X - W[K-1]*C[L-1];
+    K = K - 1;
+    L = L - 1;
+    if (L > MDIAG) L = L - K + 1;
+    goto g40;
+  g50:
+    C[L-1] = X/W[IROW-1];
+    if (ICOL == IROW) goto g80;
+    MDIAG = MDIAG - ICOL;
+    ICOL = ICOL - 1;
+    JCOL = JCOL - 1;
+    goto g30;
     //c
-    //c     cholesky factorization of a, result in c
+    //c     Special case, zero diagonal element.
     //c
-    //      call chola(a,nrow,c,nullty,ifault,rmax,w)
-    //      if(ifault.ne.0) go to 100
-    chola(a, nrow, c, nullty, ifault, rmax, w);
-    if ( ifault != 0 )
-      goto L100;
-
-    //c
-    //c     invert c & form the product (cinv)'*cinv, where cinv is the inverse
-    //c     of c, row by row starting with the last row.
-    //c     irow = the row number, ndiag = location of last element in the row.
-    //c
-    //      nn=nrow*(nrow+1)/2
-    //      irow=nrow
-    //      ndiag=nn
-    nn = nrow * (nrow + 1) / 2;
-    irow = nrow;
-    ndiag = nn;
-    
-    //   10 if(c(ndiag).eq.zero) go to 60
-    //      l=ndiag
-    //      do 20 i=irow,nrow
-    //        w(i)=c(l)
-    //        l=l+i
-  L10:
-    if (c[ndiag - 1] == zero) {
-      goto L60;
-    }
-    l = ndiag;
-    for ( int i__ = irow; i__ <= nrow; ++i__) {
-      w[i__ - 1] = c[l - 1];
-      l += i__;
-      /* L20: */
-    }
-
-    //   20 continue
-    //      icol=nrow
-    //      jcol=nn
-    //      mdiag=nn
-    icol = nrow;
-    jcol = nn;
-    mdiag = nn;
-
-    //   30 l=jcol
-    //      x=zero
-    //      if(icol.eq.irow) x=one/w(irow)
-    //      k=nrow
-  L30:
-    l = jcol;
-    x = zero;
-    if ( icol == irow )
-      x = one / w[irow - 1];
-    k = nrow;
-
-    //   40 if(k.eq.irow) go to 50
-    //      x=x-w(k)*c(l)
-    //      k=k-1
-    //      l=l-1
-    //      if(l.gt.mdiag) l=l-k+1
-    //      go to 40
-  L40:
-    if ( k == irow )
-      goto L50;
-    x -= w[k - 1] * c[l - 1];
-    --k;
-    --l;
-    if (l > mdiag) {
-      l = l - k + 1;
-    }
-    goto L40;
-
-    //   50 c(l)=x/w(irow)
-    //      if(icol.eq.irow) go to 80
-    //      mdiag=mdiag-icol
-    //      icol=icol-1
-    //      jcol=jcol-1
-    //      go to 30
-    
-  L50:
-    c[l - 1] = x / w[irow - 1];
-    if (icol == irow) {
-      goto L80;
-    }
-    mdiag -= icol;
-    --icol;
-    --jcol;
-    goto L30;
-
-
-    //c
-    //c     special case, zero diagonal element.
-    //c
-    //   60 l=ndiag
-    //      do 70 j=irow,nrow
-    //        c(l)=zero
-    //        l=l+j
-    //   70 continue
-  L60:
-    l = ndiag;
-    for (j = irow; j <= nrow; ++j) {
-      c[l - 1] = zero;
-      l += j;
-      /* L70: */
+  g60:
+    L = NDIAG;
+    for(J=IROW; J<=NROW; J++) {
+      C[L-1] = ZERO;
+      L = L + J;
     }
     //c
-    //c      end of row.
+    //c      End of row.
     //c
-
-    //   80 ndiag=ndiag-irow
-    //      irow=irow-1
-    //      if(irow.ne.0) go to 10
-    //  100 return
-    //      end
-  L80:
-    ndiag -= irow;
-    --irow;
-    if (irow != 0) {
-      goto L10;
-    }
-  L100:
+  g80:
+    NDIAG = NDIAG - IROW;
+    IROW = IROW - 1;
+    if (IROW != 0) goto g10;
+  g100:
     return;
-
-  }                                                                   // syminv
+  }
+  //c
+  //c http://lib.stat.cmu.edu/apstat/47
+  //c
 
 }                                                     // namespace appliedstats
 #endif

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2019, 2020
-#      Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,19 +18,70 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""Optimizing functions.
 
-import numpy
+These functions take a callback, the current set of parameters, the
+minimum and maximum parameter ranges, along with optional arguments,
+and return a tuple containing
+
+    status, parameters, statistic, message, dict
+
+where ``status`` is a boolean indicating whether the optimisation
+succeeded or not, parameters is the list of parameter values at the
+best-fit location, the statistic value at this location, a string
+message - when ``status`` is ``False`` this will give information on the
+failure - and a dictionary which depends on the optimiser.
+
+The callback should return the current statistic value and an array
+of the statistic value per bin.
+
+Notes
+-----
+
+Each optimizer has certain classes of problem where it is more, or
+less, successful. For instance, the `neldermead` function should
+only be used with chi-square based statistics.
+
+Examples
+--------
+
+Fit a constant model to the array of values in ``y``, using a
+least-square statistic:
+
+>>> y = np.asarray([3, 2, 7])
+>>> def cb(pars):
+...     'Least-squares statistic value from fitting a constant model to y'
+...     dy = y - pars[0]
+...     dy *= dy
+...     return (dy.sum(), dy)
+...
+
+This can be evaluated using the `neldermead` optimiser, starting at a
+model value of 1 and bounded to the range 0 to 10000:
+
+>>> res = neldermead(cb, [1], [0], [1e4])
+>>> print(res)
+(True, array([4.]), 14.0, 'Optimization terminated successfully', {'info': True, 'nfev': 98})
+>>> print(f"Best-fit value: {res[1][0]}")
+Best-fit value: 4.0
+
+"""
+
 import random
-import sys
+import numpy
 
 from . import _saoopt
+from . import _minim
+
 from sherpa.optmethods.ncoresde import ncoresDifEvo
 from sherpa.optmethods.ncoresnm import ncoresNelderMead
 
 from sherpa.utils import parallel_map, func_counter
 from sherpa.utils._utils import sao_fcmp
 
-import numpy as np
+__all__ = ('difevo', 'difevo_lm', 'difevo_nm', 'grid_search', 'lmdif',
+           'minim', 'montecarlo', 'neldermead')
+
 
 #
 # Use FLT_EPSILON as default tolerance
@@ -42,9 +93,8 @@ EPSILON = numpy.float_(numpy.finfo(numpy.float32).eps)
 # has exceeded parameter boundaries.  All the optimizers expect double
 # precision arguments, so we use numpy.float_ instead of SherpaFloat.
 #
-# As of numpy 0.9.5, 'max' is a 0-D array, which seems like a bug.
-#
-FUNC_MAX = numpy.float_(numpy.finfo(numpy.float_).max)
+FUNC_MAX = numpy.finfo(numpy.float_).max
+
 
 def _check_args(x0, xmin, xmax):
     x = numpy.array(x0, numpy.float_)  # Make a copy
@@ -58,7 +108,8 @@ def _check_args(x0, xmin, xmax):
 
     return x, xmin, xmax
 
-def _get_saofit_msg( maxfev, ierr ):
+
+def _get_saofit_msg(maxfev, ierr):
     key = {
         0: (True, 'successful termination'),
         1: (False, 'improper input parameters'),
@@ -67,7 +118,8 @@ def _get_saofit_msg( maxfev, ierr ):
             ('number of function evaluations has exceeded maxfev=%d' %
              maxfev))
         }
-    return key.get( ierr, (False, 'unknown status flag (%d)' % ierr))
+    return key.get(ierr, (False, 'unknown status flag (%d)' % ierr))
+
 
 def _move_within_limits(x, xmin, xmax):
     below = numpy.flatnonzero(x < xmin)
@@ -78,17 +130,16 @@ def _move_within_limits(x, xmin, xmax):
     if above.size > 0:
         x[above] = xmax[above]
 
-def _my_is_nan( x ):
+
+def _my_is_nan(x):
     fubar = list(filter(lambda xx: xx != xx or xx is numpy.nan or numpy.isnan(xx) and numpy.isfinite(xx), x))
-    if len( fubar ) > 0:
-        return True
-    else:
-        return False
+    return len(fubar) > 0
 
-def _narrow_limits( myrange, xxx, debug ):
 
-    def double_check_limits( myx, myxmin, myxmax ):
-        for my_l,my_x,my_h in zip( myxmin, myx, myxmax ):
+def _narrow_limits(myrange, xxx, debug):
+
+    def double_check_limits(myx, myxmin, myxmax):
+        for my_l, my_x, my_h in zip(myxmin, myx, myxmax):
             if my_x < my_l:
                 print('x = ', my_x, ' is < lower limit = ', my_l)
             if my_x > my_h:
@@ -124,44 +175,48 @@ def _narrow_limits( myrange, xxx, debug ):
             print()
         return myxmax
 
-    x = xxx[ 0 ]
-    xmin = xxx[ 1 ]
-    xmax = xxx[ 2 ]
+    x = xxx[0]
+    xmin = xxx[1]
+    xmax = xxx[2]
 
-    if False != debug:
+    if debug:
         print('narrow_limits: xmin=%s' % xmin)
         print('narrow_limits: x=%s' % x)
         print('narrow_limits: xmax=%s' % xmax)
-    myxmin = raise_min_limit( myrange, xmin, x, debug=False )
-    myxmax = lower_max_limit( myrange, x, xmax, debug=False )
+    myxmin = raise_min_limit(myrange, xmin, x, debug=False)
+    myxmax = lower_max_limit(myrange, x, xmax, debug=False)
 
-    if False != debug:
+    if debug:
         print('range = %d' % myrange)
         print('narrow_limits: myxmin=%s' % myxmin)
         print('narrow_limits: x=%s' % x)
         print('narrow_limits: myxmax=%s\n' % myxmax)
 
-    double_check_limits( x, myxmin, myxmax )
+    double_check_limits(x, myxmin, myxmax)
 
     return myxmin, myxmax
 
-def _par_at_boundary( low, val, high, tol ):
-    for par_min, par_val, par_max in zip( low, val, high ):
-        if sao_fcmp( par_val, par_min, tol ) == 0:
+
+def _par_at_boundary(low, val, high, tol):
+    for par_min, par_val, par_max in zip(low, val, high):
+        if sao_fcmp(par_val, par_min, tol) == 0:
             return True
-        if sao_fcmp( par_val, par_max, tol ) == 0:
+        if sao_fcmp(par_val, par_max, tol) == 0:
             return True
     return False
+
 
 def _outside_limits(x, xmin, xmax):
     return (numpy.any(x < xmin) or numpy.any(x > xmax))
 
-def _same_par(a,b):
+
+def _same_par(a, b):
     b = numpy.array(b, numpy.float_)
-    same = numpy.flatnonzero( a < b )
+    same = numpy.flatnonzero(a < b)
     if same.size == 0:
         return 1
     return 0
+
 
 def _set_limits(x, xmin, xmax):
     below = numpy.nonzero(x < xmin)
@@ -175,8 +230,6 @@ def _set_limits(x, xmin, xmax):
     return 0
 
 
-__all__ = ('difevo', 'difevo_lm', 'difevo_nm', 'grid_search', 'lmdif', 'minim', 'montecarlo', 'neldermead')
-
 def difevo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
            seed=2005815, population_size=None, xprob=0.9,
            weighting_factor=0.8):
@@ -184,12 +237,12 @@ def difevo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max( 0.1, xprob )
-    xprob = min( xprob, 1.0 )
+    xprob = max(0.1, xprob)
+    xprob = min(xprob, 1.0)
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max( 0.1, weighting_factor )
-    weighting_factor = min( weighting_factor, 1.0 )
+    weighting_factor = max(0.1, weighting_factor)
+    weighting_factor = min(weighting_factor, 1.0)
 
     if population_size is None:
         population_size = 16 * x.size
@@ -197,20 +250,21 @@ def difevo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     if maxfev is None:
         maxfev = 1024 * x.size
 
-    de = _saoopt.difevo( verbose, maxfev, seed, population_size, ftol, xprob,
-                         weighting_factor, xmin, xmax, x, fcn )
-    fval = de[ 1 ]
-    nfev = de[ 2 ]
-    ierr = de[ 3 ]
+    de = _saoopt.difevo(verbose, maxfev, seed, population_size, ftol, xprob,
+                        weighting_factor, xmin, xmax, x, fcn)
+    fval = de[1]
+    nfev = de[2]
+    ierr = de[3]
 
     if verbose:
-        print('difevo: f%s=%e in %d nfev' % ( x, fval, nfev ))
+        print('difevo: f%s=%e in %d nfev' % (x, fval, nfev))
 
-    status, msg = _get_saofit_msg( maxfev, ierr )
+    status, msg = _get_saofit_msg(maxfev, ierr)
     rv = (status, x, fval)
     rv += (msg, {'info': ierr, 'nfev': nfev})
 
     return rv
+
 
 def difevo_lm(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
               seed=2005815, population_size=None, xprob=0.9,
@@ -219,12 +273,12 @@ def difevo_lm(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max( 0.1, xprob )
-    xprob = min( xprob, 1.0 )
+    xprob = max(0.1, xprob)
+    xprob = min(xprob, 1.0)
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max( 0.1, weighting_factor )
-    weighting_factor = min( weighting_factor, 1.0 )
+    weighting_factor = max(0.1, weighting_factor)
+    weighting_factor = min(weighting_factor, 1.0)
 
     if population_size is None:
         population_size = 16 * x.size
@@ -232,150 +286,198 @@ def difevo_lm(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     if maxfev is None:
         maxfev = 1024 * x.size
 
-    de = _saoopt.lm_difevo( verbose, maxfev, seed, population_size, ftol,
-                            xprob, weighting_factor, xmin, xmax,
-                            x, fcn, numpy.asanyarray(fcn(x)).size )
-    fval = de[ 1 ]
-    nfev = de[ 2 ]
-    ierr = de[ 3 ]
+    de = _saoopt.lm_difevo(verbose, maxfev, seed, population_size, ftol,
+                           xprob, weighting_factor, xmin, xmax,
+                           x, fcn, numpy.asanyarray(fcn(x)).size)
+    fval = de[1]
+    nfev = de[2]
+    ierr = de[3]
 
-    status, msg = _get_saofit_msg( maxfev, ierr )
+    status, msg = _get_saofit_msg(maxfev, ierr)
     rv = (status, x, fval)
     rv += (msg, {'info': ierr, 'nfev': nfev})
 
     return rv
 
-def difevo_nm(fcn, x0, xmin, xmax, ftol, maxfev, verbose, seed, population_size, xprob,
-              weighting_factor):
 
-    def stat_cb0( pars ):
-        return fcn( pars )[ 0 ]
+def difevo_nm(fcn, x0, xmin, xmax, ftol, maxfev, verbose, seed,
+              population_size, xprob, weighting_factor):
+
+    def stat_cb0(pars):
+        return fcn(pars)[0]
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max( 0.1, xprob )
-    xprob = min( xprob, 1.0 )
+    xprob = max(0.1, xprob)
+    xprob = min(xprob, 1.0)
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max( 0.1, weighting_factor )
-    weighting_factor = min( weighting_factor, 1.0 )
+    weighting_factor = max(0.1, weighting_factor)
+    weighting_factor = min(weighting_factor, 1.0)
 
     if population_size is None:
-        population_size = max( population_size, 16 * x.size )
+        population_size = max(population_size, 16 * x.size)
 
     if maxfev is None:
         maxfev = 1024 * population_size
 
-    de = _saoopt.nm_difevo( verbose, maxfev, seed, population_size,
-                            ftol, xprob, weighting_factor, xmin, xmax,
-                            x, stat_cb0 )
-    fval = de[ 1 ]
-    nfev = de[ 2 ]
-    ierr = de[ 3 ]
+    de = _saoopt.nm_difevo(verbose, maxfev, seed, population_size,
+                           ftol, xprob, weighting_factor, xmin, xmax,
+                           x, stat_cb0)
+    fval = de[1]
+    nfev = de[2]
+    ierr = de[3]
 
     if verbose:
-        print('difevo_nm: f%s=%e in %d nfev' % ( x, fval, nfev ))
+        print('difevo_nm: f%s=%e in %d nfev' % (x, fval, nfev))
 
-    status, msg = _get_saofit_msg( maxfev, ierr )
+    status, msg = _get_saofit_msg(maxfev, ierr)
     rv = (status, x, fval)
     rv += (msg, {'info': ierr, 'nfev': nfev})
 
     return rv
 
-def grid_search( fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
-                 maxfev=None, ftol=EPSILON, method=None, verbose=0 ):
+
+def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
+                maxfev=None, ftol=EPSILON, method=None, verbose=0):
+    """Grid Search optimization method.
+
+    This method evaluates the fit statistic for each point in the
+    parameter space grid; the best match is the grid point with the
+    lowest value of the fit statistic. It is intended for use with
+    template models as it is very inefficient for general models.
+
+    Parameters
+    ----------
+    fcn : function reference
+       Returns the current statistic and per-bin statistic value when
+       given the model parameters.
+    x0, xmin, xmax : sequence of number
+       The starting point, minimum, and maximum values for each
+       parameter.
+    num : int
+       The size of the grid for each parameter when `sequence` is
+       `None`, so `npar^num` fits will be evaluated, where `npar` is
+       the number of free parameters. The grid spacing is uniform.
+    sequence : sequence of numbers or `None`
+       The list through which to evaluate. Leave as `None` to use
+       a uniform grid spacing as determined by the `num` attribute.
+    numcores : int or `None`
+       The number of CPU cores to use. The default is `1` and a
+       value of `None` will use all the cores on the machine.
+    maxfev : int or `None`
+       The `maxfev` attribute if `method` is not `None`.
+    ftol : number
+       The `ftol` attribute if `method` is not `None`.
+    method : str or `None`
+       The optimization method to use to refine the best-fit
+       location found using the grid search. If `None` then
+       this step is not run.
+    verbose: int
+       The amount of information to print during the fit. The default
+       is `0`, which means no output.
+
+    Returns
+    -------
+    retval : tuple
+       A boolean indicating whether the optimization succeeded, the
+       best-fit parameter values, the best-fit statistic value, a
+       string message indicating the status, and a dictionary
+       returning information from the optimizer.
+
+    """
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
-    npar = len( x )
+    npar = len(x)
 
-    def func( pars ):
-        aaa = fcn( pars )[ 0 ]
+    def func(pars):
+        aaa = fcn(pars)[0]
         if verbose:
-            print('f%s=%g' % ( pars, aaa ))
+            print('f%s=%g' % (pars, aaa))
         return aaa
 
-    def make_sequence( ranges, N ):
-        list_ranges = list( ranges )
-        for ii in range( npar ):
-            list_ranges[ ii ] = tuple( list_ranges[ ii ] ) + ( complex( N ), )
-            list_ranges[ ii ] = slice( *list_ranges[ ii ] )
-        grid = numpy.mgrid[ list_ranges ]
-        mynfev = pow( N, npar )
-        grid = list(map( numpy.ravel, grid ))
+    def make_sequence(ranges, N):
+        list_ranges = list(ranges)
+        for ii in range(npar):
+            list_ranges[ii] = tuple(list_ranges[ii]) + (complex(N),)
+            list_ranges[ii] = slice(*list_ranges[ii])
+
+        grid = numpy.mgrid[list_ranges]
+        mynfev = pow(N, npar)
+        grid = list(map(numpy.ravel, grid))
         sequence = []
-        for index in range( mynfev ):
+        for index in range(mynfev):
             tmp = []
-            for xx in range( npar ):
-                tmp.append( grid[ xx ][ index ] )
-            sequence.append( tmp )
+            for xx in range(npar):
+                tmp.append(grid[xx][index])
+            sequence.append(tmp)
         return sequence
 
-    def eval_stat_func( xxx ):
-        return numpy.append( func( xxx ), xxx )
+    def eval_stat_func(xxx):
+        return numpy.append(func(xxx), xxx)
 
     if sequence is None:
         ranges = []
-        for index in range( npar ):
-            ranges.append( [ xmin[ index ], xmax[ index ] ] )
-        sequence = make_sequence( ranges, num )
+        for index in range(npar):
+            ranges.append([xmin[index], xmax[index]])
+        sequence = make_sequence(ranges, num)
     else:
-        if not numpy.iterable( sequence ):
-            raise TypeError( "sequence option must be iterable" )
+        if not numpy.iterable(sequence):
+            raise TypeError("sequence option must be iterable")
         else:
             for seq in sequence:
-                if npar != len( seq ):
-                    msg = "%s must be of length %d" % ( seq, npar )
-                    raise TypeError( msg )
+                if npar != len(seq):
+                    msg = "%s must be of length %d" % (seq, npar)
+                    raise TypeError(msg)
 
-
-    answer = eval_stat_func( x )
-    sequence_results = list(parallel_map( eval_stat_func, sequence, numcores ))
-    for xresult in sequence_results[ 1: ]:
-        if xresult[ 0 ] < answer[ 0 ]:
+    answer = eval_stat_func(x)
+    sequence_results = list(parallel_map(eval_stat_func, sequence, numcores))
+    for xresult in sequence_results[1:]:
+        if xresult[0] < answer[0]:
             answer = xresult
 
-    fval = answer[ 0 ]
-    x = answer[ 1: ]
-    nfev = len( sequence_results ) + 1
+    fval = answer[0]
+    x = answer[1:]
+    nfev = len(sequence_results) + 1
     ierr = 0
-    status, msg = _get_saofit_msg( ierr, ierr )
-    rv = ( status, x, fval )
-    rv += (msg, {'info': ierr, 'nfev': nfev })
+    status, msg = _get_saofit_msg(ierr, ierr)
+    rv = (status, x, fval)
+    rv += (msg, {'info': ierr, 'nfev': nfev})
 
-    if ( 'NelderMead' == method or 'neldermead' == method or \
-         'Neldermead' == method or 'nelderMead' == method ):
-        #re.search( '^[Nn]elder[Mm]ead', method ):
-        nm_result = neldermead( fcn, x, xmin, xmax, ftol=ftol, maxfev=maxfev,
-                                verbose=verbose )
+    # TODO: should we just use case-insensitive comparison?
+    if method in ['NelderMead', 'neldermead', 'Neldermead', 'nelderMead']:
+        # re.search( '^[Nn]elder[Mm]ead', method ):
+        nm_result = neldermead(fcn, x, xmin, xmax, ftol=ftol, maxfev=maxfev,
+                               verbose=verbose)
         tmp_nm_result = list(nm_result)
         tmp_nm_result_4 = tmp_nm_result[4]
         tmp_nm_result_4['nfev'] += nfev
-        rv = tuple( tmp_nm_result )
+        rv = tuple(tmp_nm_result)
 
-    if ( 'LevMar' == method or 'levmar' == method or \
-         'Levmar' == method or 'levMar' == method ):
-        #re.search( '^[Ll]ev[Mm]ar', method ):
-        levmar_result = lmdif( fcn, x, xmin, xmax, ftol=ftol, xtol=ftol,
-                               gtol=ftol, maxfev=maxfev, verbose=verbose )
+    if method in ['LevMar', 'levmar', 'Levmar', 'levMar']:
+        # re.search( '^[Ll]ev[Mm]ar', method ):
+        levmar_result = lmdif(fcn, x, xmin, xmax, ftol=ftol, xtol=ftol,
+                              gtol=ftol, maxfev=maxfev, verbose=verbose)
         tmp_levmar_result = list(levmar_result)
         tmp_levmar_result_4 = tmp_levmar_result[4]
         tmp_levmar_result_4['nfev'] += nfev
-        rv = tuple( tmp_levmar_result )
-
+        rv = tuple(tmp_levmar_result)
 
     return rv
 
 
 #
-# Nelder Mead
+# C-version of minim
 #
-def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
-          nloop=1, iquad=1, simp=None, verbose=-1):
+def minimC(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
+           nloop=1, iquad=1, simp=None, verbose=-1, reflect=True):
 
-    def stat_cb0( pars ):
-        return fcn( pars )[ 0 ]
+    # TODO: rework so do not have two stat_cb0 functions which
+    #       are both used
+    def stat_cb0(pars):
+        return fcn(pars)[0]
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
@@ -388,14 +490,16 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
         maxfev = 512 * len(x)
 
     orig_fcn = stat_cb0
+
     def stat_cb0(x_new):
         if _my_is_nan(x_new) or _outside_limits(x_new, xmin, xmax):
             return FUNC_MAX
         return orig_fcn(x_new)
 
     init = 0
-    x, fval, neval, ifault = _saoopt.minim(verbose, maxfev, init, iquad, simp,
-                                           ftol, step, xmin, xmax, x, stat_cb0)
+    x, fval, neval, ifault = _saoopt.minim(reflect, verbose, maxfev, init, \
+                                           iquad, simp, ftol, step, \
+                                           xmin, xmax, x, stat_cb0)
 
     key = {
         0: (True, 'successful termination'),
@@ -417,6 +521,71 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
 def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
                seed=74815, population_size=None, xprob=0.9,
                weighting_factor=0.8, numcores=1):
+    """Monte Carlo optimization method.
+
+    This is an implementation of the differential-evolution algorithm
+    from Storn and Price (1997) [1]_. A population of fixed size -
+    which contains n-dimensional vectors, where n is the number of
+    free parameters - is randomly initialized.  At each iteration, a
+    new n-dimensional vector is generated by combining vectors from
+    the pool of population, the resulting trial vector is selected if
+    it lowers the objective function.
+
+    Parameters
+    ----------
+    fcn : function reference
+       Returns the current statistic and per-bin statistic value when
+       given the model parameters.
+    x0, xmin, xmax : sequence of number
+       The starting point, minimum, and maximum values for each
+       parameter.
+    ftol : number
+       The function tolerance to terminate the search for the minimum;
+       the default is sqrt(DBL_EPSILON) ~ 1.19209289551e-07, where
+       DBL_EPSILON is the smallest number x such that `1.0 != 1.0 +
+       x`.
+    maxfev : int or `None`
+       The maximum number of function evaluations; the default value
+       of `None` means to use `8192 * n`, where `n` is the number of
+       free parameters.
+    verbose: int
+       The amount of information to print during the fit. The default
+       is `0`, which means no output.
+    seed : int
+       The seed for the random number generator.
+    population_size : int or `None`
+       The population of potential solutions is allowed to evolve to
+       search for the minimum of the fit statistics. The trial
+       solution is randomly chosen from a combination from the current
+       population, and it is only accepted if it lowers the
+       statistics.  A value of `None` means to use a value `16 * n`,
+       where `n` is the number of free parameters.
+    xprob : num
+       The crossover probability should be within the range [0.5,1.0];
+       default value is 0.9. A high value for the crossover
+       probability should result in a faster convergence rate;
+       conversely, a lower value should make the differential
+       evolution method more robust.
+    weighting_factor: num
+       The weighting factor should be within the range [0.5, 1.0];
+       default is 0.8. Differential evolution is more sensitive to the
+       weighting_factor then the xprob parameter. A lower value for
+       the weighting_factor, coupled with an increase in the
+       population_size, gives a more robust search at the cost of
+       efficiency.
+    numcores : int
+       The number of CPU cores to use. The default is `1`.
+
+    References
+    ----------
+
+    .. [1] Storn, R. and Price, K. "Differential Evolution: A Simple
+           and Efficient Adaptive Scheme for Global Optimization over
+           Continuous Spaces." J. Global Optimization 11, 341-359,
+           1997.
+           http://www.icsi.berkeley.edu/~storn/code.html
+
+    """
 
     def stat_cb0(pars):
         return fcn(pars)[0]
@@ -431,9 +600,10 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     weighting_factor = max(0.1, weighting_factor)
     weighting_factor = min(weighting_factor, 1.0)
 
-    random.seed(seed )
+    random.seed(seed)
     if seed is None:
-        seed = random.randint(0, 2147483648) # pow(2,31) == 2147483648L
+        # pow(2,31) == 2147483648L
+        seed = random.randint(0, 2147483648)
     if population_size is None:
         population_size = 12 * x.size
 
@@ -441,7 +611,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         maxfev = 8192 * population_size
 
     def myopt(myfcn, xxx, ftol, maxfev, seed, pop, xprob,
-               weight, factor=4.0, debug=False):
+              weight, factor=4.0, debug=False):
 
         x = xxx[0]
         xmin = xxx[1]
@@ -462,7 +632,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
             mystep = list(map(lambda fubar: 1.2 * fubar, x))
         if 1 == numcores:
             result = neldermead(myfcn, x, xmin, xmax, maxfev=mymaxfev,
-                                ftol=ftol,finalsimplex=9, step=mystep)
+                                ftol=ftol, finalsimplex=9, step=mystep)
             x = numpy.asarray(result[1], numpy.float_)
             nfval = result[2]
             nfev = result[4].get('nfev')
@@ -470,16 +640,17 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
             ncores_nm = ncoresNelderMead()
             nfev, nfval, x = \
                 ncores_nm(stat_cb0, x, xmin, xmax, ftol, mymaxfev, numcores)
-        if verbose or debug != False:
+
+        if verbose or debug:
             print('f_nm%s=%.14e in %d nfev' % (x, nfval, nfev))
         ############################# NelderMead #############################
 
         ############################## nmDifEvo #############################
-        xmin, xmax = _narrow_limits(4 * factor, [x,xmin,xmax], debug=False)
+        xmin, xmax = _narrow_limits(4 * factor, [x, xmin, xmax], debug=False)
         mymaxfev = min(maxfev_per_iter, maxfev - nfev)
         if 1 == numcores:
             result = difevo_nm(myfcn, x, xmin, xmax, ftol, mymaxfev, verbose,
-                                seed, pop, xprob, weight)
+                               seed, pop, xprob, weight)
             nfev += result[4].get('nfev')
             x = numpy.asarray(result[1], numpy.float_)
             nfval = result[2]
@@ -492,33 +663,33 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
             nfev += tmp_nfev
             if tmp_fmin < nfval:
                 nfval = tmp_fmin
-                x     = tmp_par
-        if verbose or debug != False:
+                x = tmp_par
+
+        if verbose or debug:
             print('f_de_nm%s=%.14e in %d nfev' % (x, nfval, nfev))
         ############################## nmDifEvo #############################
 
         ofval = FUNC_MAX
         while nfev < maxfev:
 
-            xmin, xmax = _narrow_limits(factor, [x,xmin,xmax], debug=False)
+            xmin, xmax = _narrow_limits(factor, [x, xmin, xmax], debug=False)
 
             ############################ nmDifEvo #############################
             y = random_start(xmin, xmax)
             mymaxfev = min(maxfev_per_iter, maxfev - nfev)
-            if 1 == numcores:
+            if numcores == 1:
                 result = difevo_nm(myfcn, y, xmin, xmax, ftol, mymaxfev,
                                    verbose, seed, pop, xprob, weight)
                 nfev += result[4].get('nfev')
                 if result[2] < nfval:
                     nfval = result[2]
                     x = numpy.asarray(result[1], numpy.float_)
-                if verbose or debug != False:
-                    print('f_de_nm%s=%.14e in %d nfev' % \
+                if verbose or debug:
+                    print('f_de_nm%s=%.14e in %d nfev' %
                           (x, result[2], result[4].get('nfev')))
             ############################ nmDifEvo #############################
 
-
-            if debug != False:
+            if debug:
                 print('ofval=%.14e\tnfval=%.14e\n' % (ofval, nfval))
 
             if sao_fcmp(ofval, nfval, ftol) <= 0:
@@ -529,9 +700,9 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         return x, nfval, nfev
 
     x, fval, nfev = myopt(fcn, [x, xmin, xmax], numpy.sqrt(ftol), maxfev,
-                           seed, population_size, xprob, weighting_factor,
-                           factor=2.0, debug=False)
-    
+                          seed, population_size, xprob, weighting_factor,
+                          factor=2.0, debug=False)
+
     if nfev < maxfev:
         if all(x == 0.0):
             mystep = list(map(lambda fubar: 1.2 + fubar, x))
@@ -548,7 +719,8 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         else:
             ncores_nm = ncoresNelderMead()
             tmp_nfev, tmp_fmin, tmp_par = \
-                ncores_nm(stat_cb0, x, xmin, xmax, ftol, maxfev - nfev, numcores)
+                ncores_nm(stat_cb0, x, xmin, xmax, ftol, maxfev - nfev,
+                          numcores)
             nfev += tmp_nfev
             # There is a bug here somewhere using broyden_tridiagonal
             if tmp_fmin < fval:
@@ -559,128 +731,331 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         ierr = 3
     status, msg = _get_saofit_msg(maxfev, ierr)
 
-    rv = (status, x, fval,msg, {'info': status, 'nfev': nfev})
+    rv = (status, x, fval, msg, {'info': status, 'nfev': nfev})
     return rv
 
 
 #
 # Nelder Mead
 #
-def neldermead( fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
-                initsimplex=0, finalsimplex=9, step=None, iquad=1,
-                verbose=0 ):
+def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
+               initsimplex=0, finalsimplex=9, step=None, iquad=1,
+               verbose=0, useminimC=True,reflect=True):
+    """Nelder-Mead Simplex optimization method.
+
+    The Nelder-Mead Simplex algorithm, devised by J.A. Nelder and
+    R. Mead [1]_, is a direct search method of optimization for
+    finding a local minimum of an objective function of several
+    variables. The implementation of the Nelder-Mead Simplex algorithm is
+    a variation of the algorithm outlined in [2]_ and [3]_. As noted,
+    terminating the simplex is not a simple task:
+
+    "For any non-derivative method, the issue of termination is
+    problematical as well as highly sensitive to problem scaling.
+    Since gradient information is unavailable, it is provably
+    impossible to verify closeness to optimality simply by sampling f
+    at a finite number of points.  Most implementations of direct
+    search methods terminate based on two criteria intended to reflect
+    the progress of the algorithm: either the function values at the
+    vertices are close, or the simplex has become very small."
+
+    "Either form of termination-close function values or a small
+    simplex-can be misleading for badly scaled functions."
+
+    Parameters
+    ----------
+    fcn : function reference
+       Returns the current statistic and per-bin statistic value when
+       given the model parameters.
+    x0, xmin, xmax : sequence of number
+       The starting point, minimum, and maximum values for each
+       parameter.
+    ftol : number
+       The function tolerance to terminate the search for the minimum;
+       the default is sqrt(DBL_EPSILON) ~ 1.19209289551e-07, where
+       DBL_EPSILON is the smallest number x such that `1.0 != 1.0 +
+       x`.
+    maxfev : int or `None`
+       The maximum number of function evaluations; the default value
+       of `None` means to use `1024 * n`, where `n` is the number of
+       free parameters.
+    initsimplex : int
+       Dictates how the non-degenerate initial simplex is to be
+       constructed.  Default is `0`; see the "cases for initsimplex"
+       section below for details.
+    finalsimplex : int
+       At each iteration, a combination of one of the following
+       stopping criteria is tested to see if the simplex has converged
+       or not.  Full details are in the "cases for finalsimplex"
+       section below.
+    step : array of number or `None`
+       A list of length `n` (number of free parameters) to initialize
+       the simplex; see the `initsimplex` for details. The default of
+       `None` means to use a step of 0.4 for each free parameter.
+    iquad : int
+       A boolean flag which indicates whether a fit to a quadratic
+       surface is done.  If iquad is set to `1` (the default) then a
+       fit to a quadratic surface is done; if iquad is set to `0` then
+       the quadratic surface fit is not done.  If the fit to the
+       quadratic surface is not positive semi-definitive, then the
+       search terminated prematurely.  The code to fit the quadratic
+       surface was written by D. E. Shaw, CSIRO, Division of
+       Mathematics & Statistics, with amendments by
+       R. W. M. Wedderburn, Rothamsted Experimental Station, and Alan
+       Miller, CSIRO, Division of Mathematics & Statistics.  See also
+       [1]_.
+    verbose: int
+       The amount of information to print during the fit. The default
+       is `0`, which means no output.
+
+    Notes
+    -----
+
+    The `initsimplex` option determines how the non-degenerate initial
+    simplex is to be constructed:
+
+    - when `initsimplex` is `0`:
+
+      Then x_(user_supplied) is one of the vertices of the simplex.
+      The other `n` vertices are::
+
+        for ( int i = 0; i &lt; n; ++i ) {
+          for ( int j = 0; j &lt; n; ++j )
+            x[ i + 1 ][ j ] = x_[ j ];
+            x[ i + 1 ][ i ] = x_[ i ] + step[ i ];
+        }
+
+      where step[i] is the ith element of the option step.
+
+    - if `initsimplex` is `1`:
+
+      Then x_(user_supplied) is one of the vertices of the simplex.
+      The other `n` vertices are::
+
+                    { x_[j] + pn,   if i - 1 != j
+                    {
+        x[i][j]  =  {
+                    {
+                    { x_[j] + qn,   otherwise
+
+      for 1 <= i <= n, 0 <= j < n and::
+
+        pn = ( sqrt( n + 1 ) - 1 + n ) / ( n * sqrt(2) )
+        qn = ( sqrt( n + 1 ) - 1 ) / ( n * sqrt(2) )
+
+    The `finalsimplex` option determines whether the simplex has
+    converged:
+
+    - case a (if the max length of the simplex is small enough)::
+
+        max( | x_i - x_0 | ) <= ftol max( 1, | x_0 | )
+        1 <= i <= n
+
+    - case b (if the standard deviation the simplex is < `ftol`)::
+
+         n           -   2
+        ===   ( f  - f )
+        \        i                    2
+        /     -----------     <=  ftol
+        ====   sqrt( n )
+        i = 0
+
+    - case c (if the function values are close enough)::
+
+        f_0  < f_(n-1)     within ftol
+
+    The combination of the above stopping criteria are:
+
+    - case 0: same as case a
+
+    - case 1: case a, case b and case c have to be met
+
+    - case 2: case a and either case b or case c have to be met.
+
+    The `finalsimplex` value controls which of these criteria need to
+    hold:
+
+    - if `finalsimplex=0` then convergence is assumed if case 1 is met.
+
+    - if `finalsimplex=1` then convergence is assumed if case 2 is met.
+
+    - if `finalsimplex=2` then convergence is assumed if case 0 is met
+      at two consecutive iterations.
+
+    - if `finalsimplex=3` then convergence is assumed if case 0 then
+      case 1 are met on two consecutive iterations.
+
+    - if `finalsimplex=4` then convergence is assumed if case 0 then
+      case 1 then case 0 are met on three consecutive iterations.
+
+    - if `finalsimplex=5` then convergence is assumed if case 0 then
+      case 1 then case 0 are met on three consecutive iterations.
+
+    - if `finalsimplex=6` then convergence is assumed if case 1 then
+      case 1 then case 0 are met on three consecutive iterations.
+
+    - if `finalsimplex=7` then convergence is assumed if case 2 then
+      case 1 then case 0 are met on three consecutive iterations.
+
+    - if `finalsimplex=8` then convergence is assumed if case 0 then
+      case 2 then case 0 are met on three consecutive iterations.
+
+    - if `finalsimplex=9` then convergence is assumed if case 0 then
+      case 1 then case 1 are met on three consecutive iterations.
+
+    - if `finalsimplex=10` then convergence is assumed if case 0 then
+      case 2 then case 1 are met on three consecutive iterations.
+
+    - if `finalsimplex=11` then convergence is assumed if case 1 is
+      met on three consecutive iterations.
+
+    - if `finalsimplex=12` then convergence is assumed if case 1 then
+      case 2 then case 1 are met on three consecutive iterations.
+
+    - if `finalsimplex=13` then convergence is assumed if case 2 then
+      case 1 then case 1 are met on three consecutive iterations.
+
+    - otherwise convergence is assumed if case 2 is met on three
+      consecutive iterations.
+
+    References
+    ----------
+
+    .. [1] "A simplex method for function minimization", J.A. Nelder
+           and R. Mead (Computer Journal, 1965, vol 7, pp 308-313)
+           https://doi.org/10.1093%2Fcomjnl%2F7.4.308
+
+    .. [2] "Convergence Properties of the Nelder-Mead Simplex
+           Algorithm in Low Dimensions", Jeffrey C. Lagarias, James
+           A. Reeds, Margaret H. Wright, Paul E. Wright , SIAM Journal
+           on Optimization, Vol. 9, No. 1 (1998), pages 112-147.
+           http://citeseer.ist.psu.edu/3996.html
+
+    .. [3] "Direct Search Methods: Once Scorned, Now Respectable"
+           Wright, M. H. (1996) in Numerical Analysis 1995
+           (Proceedings of the 1995 Dundee Biennial Conference in
+           Numerical Analysis, D.F. Griffiths and G.A. Watson, eds.),
+           191-208, Addison Wesley Longman, Harlow, United Kingdom.
+           http://citeseer.ist.psu.edu/155516.html
+
+    """
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     order = 'F' if numpy.isfortran(x) else 'C'
-    if step is None or ( numpy.iterable(step) and len(step) != len(x) ):
-        step = 1.2*numpy.ones(x.shape, numpy.float_, order)
+    if step is None or (numpy.iterable(step) and len(step) != len(x)):
+        step = 1.2 * numpy.ones(x.shape, numpy.float_, order)
     elif numpy.isscalar(step):
-        step = step*numpy.ones(x.shape, numpy.float_, order)
+        step = step * numpy.ones(x.shape, numpy.float_, order)
 
-    def stat_cb0( pars ):
-        return fcn( pars )[ 0 ]
+    def stat_cb0(pars):
+        return fcn(pars)[0]
 
     #
     # A safeguard just in case the initial simplex is outside the bounds
     #
     orig_fcn = stat_cb0
+
     def stat_cb0(x_new):
         if _my_is_nan(x_new) or _outside_limits(x_new, xmin, xmax):
             return FUNC_MAX
         return orig_fcn(x_new)
 
-    debug = False             # for internal use only
+    # for internal use only
+    debug = False
 
-    if numpy.isscalar(finalsimplex) and 0 == numpy.iterable(finalsimplex):
-        finalsimplex = int( finalsimplex )
+    if numpy.isscalar(finalsimplex) and numpy.iterable(finalsimplex) == 0:
+        finalsimplex = int(finalsimplex)
         if 0 == finalsimplex:
-            finalsimplex = [ 1 ]
+            finalsimplex = [1]
         elif 1 == finalsimplex:
-            finalsimplex = [ 2 ]
+            finalsimplex = [2]
         elif 2 == finalsimplex:
-            finalsimplex = [ 0, 0 ]
+            finalsimplex = [0, 0]
         elif 3 == finalsimplex:
-            finalsimplex = [ 0, 1 ]
+            finalsimplex = [0, 1]
         elif 4 == finalsimplex:
-            finalsimplex = [ 0, 1, 0 ]
+            finalsimplex = [0, 1, 0]
         elif 5 == finalsimplex:
-            finalsimplex = [ 0, 2, 0 ]
+            finalsimplex = [0, 2, 0]
         elif 6 == finalsimplex:
-            finalsimplex = [ 1, 1, 0 ]
+            finalsimplex = [1, 1, 0]
         elif 7 == finalsimplex:
-            finalsimplex = [ 2, 1, 0 ]
+            finalsimplex = [2, 1, 0]
         elif 8 == finalsimplex:
-            finalsimplex = [ 1, 2, 0 ]
+            finalsimplex = [1, 2, 0]
         elif 9 == finalsimplex:
-            finalsimplex = [ 0, 1, 1 ]
+            finalsimplex = [0, 1, 1]
         elif 10 == finalsimplex:
-            finalsimplex = [ 0, 2, 1 ]
+            finalsimplex = [0, 2, 1]
         elif 11 == finalsimplex:
-            finalsimplex = [ 1, 1, 1 ]
+            finalsimplex = [1, 1, 1]
         elif 12 == finalsimplex:
-            finalsimplex = [ 1, 2, 1 ]
+            finalsimplex = [1, 2, 1]
         elif 13 == finalsimplex:
-            finalsimplex = [ 2, 1, 1 ]
+            finalsimplex = [2, 1, 1]
         else:
-            finalsimplex = [ 2, 2, 2 ]
-    elif ( False == numpy.isscalar(finalsimplex) and
-           1 == numpy.iterable(finalsimplex) ):
+            finalsimplex = [2, 2, 2]
+    elif (not numpy.isscalar(finalsimplex) and
+          numpy.iterable(finalsimplex) == 1):
         pass
     else:
-        finalsimplex = [ 2, 2, 2 ]
+        finalsimplex = [2, 2, 2]
 
     finalsimplex = numpy.asarray(finalsimplex, numpy.int_)
 
     if maxfev is None:
-        maxfev = 1024 * len( x )
+        maxfev = 1024 * len(x)
 
     if debug:
-        print('opfcts.py neldermead() finalsimplex=%s\tisscalar=%s\titerable=%d' % (finalsimplex,numpy.isscalar(finalsimplex), numpy.iterable(finalsimplex)))
+        print('opfcts.py neldermead() finalsimplex=%s\tisscalar=%s\titerable=%d' % (finalsimplex, numpy.isscalar(finalsimplex), numpy.iterable(finalsimplex)))
 
-    def simplex( verbose, maxfev, init, final, tol, step, xmin, xmax, x,
-                 myfcn, debug, ofval=FUNC_MAX ):
+    def simplex(verbose, maxfev, init, final, tol, step, xmin, xmax, x,
+                myfcn, debug, ofval=FUNC_MAX):
 
         tmpfinal = final[:]
-        if len( final ) >= 3:
-            tmpfinal = final[0:-1] # get rid of the last entry in the list
+        if len(final) >= 3:
+            # get rid of the last entry in the list
+            tmpfinal = final[0:-1]
 
-        xx,ff,nf,er = _saoopt.neldermead( verbose, maxfev, init, tmpfinal, tol,
-                                          step, xmin, xmax, x, myfcn )
+        xx, ff, nf, er = _saoopt.neldermead(verbose, maxfev, init, tmpfinal,
+                                            tol, step, xmin, xmax, x, myfcn)
 
         if debug:
-            print('finalsimplex=%s, nfev=%d:\tf%s=%.20e' % (tmpfinal,nf,xx,ff))
+            print('finalsimplex=%s, nfev=%d:\tf%s=%.20e' % (tmpfinal, nf, xx, ff))
 
-        if len( final ) >= 3 and ff < 0.995 * ofval and nf < maxfev:
+        if len(final) >= 3 and ff < 0.995 * ofval and nf < maxfev:
             myfinal = [final[-1]]
-            x,fval,nfev,err = simplex( verbose, maxfev-nf, init, myfinal, tol,
-                                       step, xmin, xmax, x, myfcn, debug,
-                                       ofval=ff )
-            return x,fval,nfev+nf,err
+            x, fval, nfev, err = simplex(verbose, maxfev-nf, init, myfinal, tol,
+                                         step, xmin, xmax, x, myfcn, debug,
+                                         ofval=ff)
+            return x, fval, nfev + nf, err
         else:
-            return xx,ff,nf,er
+            return xx, ff, nf, er
 
-    x, fval, nfev, ier = simplex( verbose, maxfev, initsimplex, finalsimplex,
-                                  ftol, step, xmin, xmax, x, stat_cb0, debug )
+    x, fval, nfev, ier = simplex(verbose, maxfev, initsimplex, finalsimplex,
+                                 ftol, step, xmin, xmax, x, stat_cb0, debug)
     if debug:
-        print('f%s=%e in %d nfev' % ( x, fval, nfev ))
+        print('f%s=%e in %d nfev' % (x, fval, nfev))
 
-    info=1
-    covarerr=None
-    if len( finalsimplex ) >= 3 and 0 != iquad:
-        nelmea = minim( fcn, x, xmin, xmax, ftol=10.0*ftol, maxfev=maxfev-nfev-12, iquad=1 )
-        nelmea_x = numpy.asarray( nelmea[1], numpy.float_ )
-        nelmea_nfev = nelmea[4].get( 'nfev' )
-        info = nelmea[4].get( 'info' )
-        covarerr = nelmea[4].get( 'covarerr' )
+    info = 1
+    covarerr = None
+    if len(finalsimplex) >= 3 and 0 != iquad:
+        nelmea = minim(fcn, x, xmin, xmax, ftol=10.0*ftol,
+                       maxfev=maxfev - nfev - 12, iquad=1, useminimC=useminimC,
+                       reflect=reflect)
+        nelmea_x = numpy.asarray(nelmea[1], numpy.float_)
+        nelmea_nfev = nelmea[4].get('nfev')
+        info = nelmea[4].get('info')
+        covarerr = nelmea[4].get('covarerr')
         nfev += nelmea_nfev
-        minim_fval = nelmea[ 2 ]
+        minim_fval = nelmea[2]
         if minim_fval < fval:
             x = nelmea_x
             fval = minim_fval
         if debug:
-            print('minim: f%s=%e %d nfev, info=%d' % (x,fval,nelmea_nfev,info))
-    
+            print('minim: f%s=%e %d nfev, info=%d' % (x, fval, nelmea_nfev, info))
+
     if nfev >= maxfev:
         ier = 3
     key = {
@@ -690,27 +1065,160 @@ def neldermead( fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
         3: (False,
             'number of function evaluations has exceeded %d' % maxfev)
         }
-    status, msg = key.get( ier,
-                           (False, 'unknown status flag (%d)' % ier) )
+    status, msg = key.get(ier,
+                          (False, 'unknown status flag (%d)' % ier))
 
     rv = (status, x, fval)
     print_covar_err = False
-    if print_covar_err and None != covarerr:
+    if print_covar_err and covarerr is not None:
         rv += (msg, {'covarerr': covarerr, 'info': status, 'nfev': nfev})
     else:
         rv += (msg, {'info': status, 'nfev': nfev})
     return rv
 
 
+#
+# Fortran-versrion of minim
+#
+def minimF(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
+           nloop=1, iquad=1, simp=None, verbose=-1):
+
+    # TODO: rework so do not have two stat_cb0 functions which
+    #       are both used
+    def stat_cb0(pars):
+        return fcn(pars)[0]
+
+    x, xmin, xmax = _check_args(x0, xmin, xmax)
+
+    if step is None:
+        order = 'F' if numpy.isfortran(x) else 'C'
+        step = 0.4*numpy.ones(x.shape, numpy.float_, order)
+    if simp is None:
+        simp = 1.0e-2 * ftol
+    if maxfev is None:
+        maxfev = 512 * len(x)
+
+    orig_fcn = stat_cb0
+    def stat_cb0(x_new):
+        if _outside_limits(x_new, xmin, xmax) or _my_is_nan(x_new):
+            return FUNC_MAX
+        return orig_fcn(x_new)
+
+    fval, var, ifault, neval = _minim.minim(x, step, maxfev, verbose, ftol,
+                                            nloop, iquad, simp, stat_cb0,
+                                            xmin, xmax)
+    key = {
+        0: (True, 'successful termination'),
+        1: (False,
+            'number of function evaluations has exceeded maxfev=%d' % maxfev),
+        2: (False, 'information matrix is not +ve semi-definite'),
+        3: (False, 'number of parameters is less than 1'),
+        4: (False, 'nloop=%d is less than 1' % nloop)
+        }
+    status, msg = key.get(ifault, (False, 'unknown status flag (%d)' % ifault))
+
+    rv = (status, x, fval)
+    print_covar_err = False
+    if print_covar_err and 0 == ifault and numpy.any( var > 0.0 ):
+        var = map( lambda x: x * numpy.sqrt(2.0), var )
+        rv += (msg, {'covarerr': numpy.sqrt(var), 'info': ifault,
+                     'nfev': neval})
+    else:
+        rv += (msg, {'info': ifault, 'nfev': neval})
+    return rv
+
+#
+# minim
+#
+def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
+          step=None, nloop=1, iquad=1, simp=None, verbose=-1, useminimC=True,
+          reflect=True):
+
+    if useminimC:
+        return minimC(fcn, x0, xmin, xmax, ftol=ftol, maxfev=maxfev,
+                      step=step, nloop=nloop, iquad=iquad, verbose=verbose,
+                      reflect=reflect)
+    else:
+        return minimF(fcn, x0, xmin, xmax, ftol=ftol, maxfev=maxfev,
+                      step=step, nloop=nloop, iquad=iquad, verbose=verbose)
+
 def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
           maxfev=None, epsfcn=EPSILON, factor=100.0, numcores=1, verbose=0):
+    """Levenberg-Marquardt optimization method.
+
+    The Levenberg-Marquardt method is an interface to the MINPACK
+    subroutine lmdif to find the local minimum of nonlinear least
+    squares functions of several variables by a modification of the
+    Levenberg-Marquardt algorithm [1]_.
+
+    Parameters
+    ----------
+    fcn : function reference
+       Returns the current statistic and per-bin statistic value when
+       given the model parameters.
+    x0, xmin, xmax : sequence of number
+       The starting point, minimum, and maximum values for each
+       parameter.
+    ftol : number
+       The function tolerance to terminate the search for the minimum;
+       the default is FLT_EPSILON ~ 1.19209289551e-07, where
+       FLT_EPSILON is the smallest number x such that `1.0 != 1.0 +
+       x`. The conditions are satisfied when both the actual and
+       predicted relative reductions in the sum of squares are, at
+       most, ftol.
+    xtol : number
+       The relative error desired in the approximate solution; default
+       is FLT_EPSILON ~ 1.19209289551e-07, where FLT_EPSILON
+       is the smallest number x such that `1.0 != 1.0 + x`. The
+       conditions are satisfied when the relative error between two
+       consecutive iterates is, at most, `xtol`.
+    gtol : number
+       The orthogonality desired between the function vector and the
+       columns of the jacobian; default is FLT_EPSILON ~
+       1.19209289551e-07, where FLT_EPSILON is the smallest number x
+       such that `1.0 != 1.0 + x`. The conditions are satisfied when
+       the cosine of the angle between fvec and any column of the
+       jacobian is, at most, `gtol` in absolute value.
+    maxfev : int or `None`
+       The maximum number of function evaluations; the default value
+       of `None` means to use `1024 * n`, where `n` is the number of
+       free parameters.
+    epsfcn : number
+       This is used in determining a suitable step length for the
+       forward-difference approximation; default is FLT_EPSILON
+       ~ 1.19209289551e-07, where FLT_EPSILON is the smallest number
+       x such that `1.0 != 1.0 + x`. This approximation assumes that
+       the relative errors in the functions are of the order of
+       `epsfcn`. If `epsfcn` is less than the machine precision, it is
+       assumed that the relative errors in the functions are of the
+       order of the machine precision.
+    factor : int
+       Used in determining the initial step bound; default is 100. The
+       initial step bound is set to the product of `factor` and the
+       euclidean norm of diag*x if nonzero, or else to factor itself.
+       In most cases, `factor` should be from the interval (.1,100.).
+    numcores : int
+       The number of CPU cores to use. The default is `1`.
+    verbose: int
+       The amount of information to print during the fit. The default
+       is `0`, which means no output.
+
+    References
+    ----------
+
+    .. [1] J.J. More, "The Levenberg Marquardt algorithm:
+           implementation and theory," in Lecture Notes in Mathematics
+           630: Numerical Analysis, G.A. Watson (Ed.),
+           Springer-Verlag: Berlin, 1978, pp.105-116.
+
+    """
 
     class fdJac:
-        
+
         def __init__(self, func, fvec, pars):
             self.func = func
             self.fvec = fvec
-            epsmch = numpy.float_(numpy.finfo(numpy.float).eps)
+            epsmch = numpy.finfo(float).eps
             self.eps = numpy.sqrt(max(epsmch, epsfcn))
             self.h = self.calc_h(pars)
             self.pars = numpy.copy(pars)
@@ -741,7 +1249,6 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
                 params.append(tmp_pars)
             return tuple(params)
 
-        
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     if maxfev is None:
@@ -749,15 +1256,18 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
 
     def stat_cb0(pars):
         return fcn(pars)[0]
+
     def stat_cb1(pars):
         return fcn(pars)[1]
+
     def fcn_parallel(pars, fvec):
         fd_jac = fdJac(stat_cb1, fvec, pars)
         params = fd_jac.calc_params()
         fjac = parallel_map(fd_jac, params, numcores)
         return numpy.concatenate(fjac)
+
     num_parallel_map, fcn_parallel_counter = func_counter(fcn_parallel)
-    
+
     # TO DO: reduce 1 model eval by passing the resulting 'fvec' to cpp_lmdif
     m = numpy.asanyarray(stat_cb1(x)).size
 
@@ -781,8 +1291,8 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
 
         if _par_at_boundary(xmin, x, xmax, xtol):
             nm_result = neldermead(fcn, x, xmin, xmax, ftol=numpy.sqrt(ftol),
-                                    maxfev=maxfev-nfev, finalsimplex=2, iquad=0,
-                                    verbose=0)
+                                   maxfev=maxfev-nfev, finalsimplex=2, iquad=0,
+                                   verbose=0)
             nfev += nm_result[4]['nfev']
             x = nm_result[1]
             fval = nm_result[2]

--- a/sherpa/optmethods/src/Simplex.hh
+++ b/sherpa/optmethods/src/Simplex.hh
@@ -276,7 +276,11 @@ public:
 
 private:
 
+#if (__STDC_VERSION__ < 201112L)
   std::auto_ptr< sherpa::Simplex > simplex;
+#else
+  std::unique_ptr< sherpa::Simplex > simplex;
+#endif
 
 };
 

--- a/sherpa/optmethods/src/_minim.pyf
+++ b/sherpa/optmethods/src/_minim.pyf
@@ -1,0 +1,54 @@
+!    -*- f90 -*-
+! Note: the context of this file is case sensitive.
+
+python module minim__user__routines 
+    interface minim_user_interface
+       subroutine functn(p,nop,func)
+         real*8 dimension(nop),intent(in) :: p
+         integer*4 depend(p),intent(hide) :: nop=len(p)
+         real*8 intent(out) :: func
+       end subroutine functn
+    end interface minim_user_interface
+end python module minim__user__routines
+python module _minim
+    interface
+        subroutine minim(p,step,nop,func,max,iprint,stopcr,nloop,iquad,simp,var,functn,ifault,neval,lb,ub,g,h,pbar,pstar,pstst,aval,bmat,pmin,vc,temp)
+            use minim__user__routines
+            real*8 dimension(nop),intent(inout) :: p
+            real*8 dimension(nop),intent(in) :: step
+            integer*4 depend(p),intent(hide) :: nop=len(p)
+            real*8 intent(out) :: func
+            integer*4 intent(in) :: max
+            integer*4 intent(in) :: iprint
+            real*8 intent(in) :: stopcr
+            integer*4 intent(in) :: nloop
+            integer*4 intent(in) :: iquad
+            real*8 intent(in) :: simp
+            real*8 dimension(nop),intent(out) :: var
+            external functn
+            integer*4 intent(out) :: ifault
+            integer*4 intent(out) :: neval
+            real*8 dimension(nop),intent(in) :: lb
+            real*8 dimension(nop),intent(in) :: ub
+            real*8 dimension(nop+1,nop),intent(hide) :: g
+            real*8 dimension(nop+1),intent(hide) :: h
+            real*8 dimension(nop),intent(hide) :: pbar
+            real*8 dimension(nop),intent(hide) :: pstar
+            real*8 dimension(nop),intent(hide) :: pstst
+            real*8 dimension(nop),intent(hide) :: aval
+            real*8 dimension(nop*(nop+1)/2),intent(hide) :: bmat
+            real*8 dimension(nop),intent(hide) :: pmin
+            real*8 dimension(nop*(nop+1)/2),intent(hide) :: vc
+            real*8 dimension(nop),intent(hide) :: temp
+        end subroutine minim
+        subroutine syminv(a,n,c,w,nullty,ifault,rmax)
+          real*8 dimension(n*(n+1)/2),intent(in) :: a
+          integer*4 intent(in) :: n
+          real*8 dimension(n*(n+1)/2),intent(out) :: c
+          real*8 dimension(n),intent(hide) :: w
+          integer*4 intent(hide) :: nullty
+          integer*4 intent(out) :: ifault
+          real*8 intent(out) :: rmax
+        end subroutine syminv
+    end interface 
+end python module _minim

--- a/sherpa/optmethods/src/_saoopt.cc
+++ b/sherpa/optmethods/src/_saoopt.cc
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <memory>
 
 #include "DifEvo.hh"
 #include "minim.hh"
@@ -833,10 +834,11 @@ static PyObject* py_minim( PyObject* self, PyObject* args,
   PyObject* py_function=NULL;
   DoubleArray par, step, lb, ub;
   IntArray finalsimplex;
-  int verbose, maxnfev, nfev, iquad, ierr, initsimplex;
+  int reflect, verbose, maxnfev, nfev, iquad, ierr, initsimplex;
   double fval, ftol, simp;
 
-  if ( !PyArg_ParseTuple( args, (char*) "iiiiddO&O&O&O&O",
+  if ( !PyArg_ParseTuple( args, (char*) "iiiiiddO&O&O&O&O",
+                          &reflect,
 			  &verbose,
 			  &maxnfev,
 			  &initsimplex,
@@ -877,14 +879,23 @@ static PyObject* py_minim( PyObject* self, PyObject* args,
     std::vector<double> myub( &ub[0], &ub[0] + npar );
     std::vector<double> mypar( &par[0], &par[0] + npar );
     std::vector<double> mystep( &step[0], &step[0] + step.get_size( ) );
-
-    const sherpa::Bounds<double> bounds(mylb, myub);
-    sherpa::Minim<Func, PyObject*, double> minim(callback_func, py_function );
-
     std::vector<double> vc(npar*(npar+1)/2);
+    const sherpa::Bounds<double> bounds(mylb, myub);
 
-    minim.minim( mypar, mystep, npar, fval, maxnfev, verbose, ftol, iquad,
-                 simp, vc, ierr, nfev, bounds);
+    sherpa::Minim<Func, PyObject*, double>* nm = NULL;
+    if (reflect)
+      nm = new sherpa::Minim<Func, PyObject*, double>( callback_func, py_function );
+    else
+      nm = new sherpa::MinimNoReflect<Func, PyObject*, double>( callback_func, py_function );
+
+#if (__STDC_VERSION__ < 201112L)
+    std::auto_ptr< sherpa::Minim<Func, PyObject*, double> > minim(nm);
+#else
+    std::unique_ptr< sherpa::Minim<Func, PyObject*, double> > minim(nm);
+#endif
+
+    minim->minim( mypar, mystep, npar, fval, maxnfev, verbose, ftol, iquad,
+                  simp, vc, ierr, nfev, bounds);
     for ( int ii = 0; ii < npar; ++ii )
       par[ ii ] = mypar[ ii ];
 

--- a/sherpa/optmethods/src/minim.cc
+++ b/sherpa/optmethods/src/minim.cc
@@ -1,7 +1,7 @@
 #ifdef testMinim
 
 //
-//  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -20,42 +20,15 @@
 //
 
 #include <cstring>
+#include <memory>
 
 #include "minim.hh"
 #include "tests/tstopt.hh"
 
-void tst_minim( ) {
-
-  const int npar=2;
-  std::vector<int> finalsimplex(npar);
-  std::vector<double> x(npar), vc(npar*(npar+1)/2, 0.0);
-  std::vector<double> lb(npar, -10.0), ub(npar, 10.0), step(npar, 1.0);
-  x[0] = -1.0;
-  x[1] = 1.2;
-
-  int maxfev=1024, iprint=0, neval=0, initsimplex=1;
-  double func=0.0, tol=1.0e-6;
-
-  const sherpa::Bounds<double> bounds(lb, ub);
-  sherpa::Minim<Fct, const sherpa::Bounds<double>&, double>
-    minim( tstoptfct::Rosenbrock, bounds );
-  minim( iprint, maxfev, tol, npar, initsimplex, finalsimplex, lb, ub,
-         step, x, neval, func );
-
-  // std::cout << "ifault = " << ifault << ", neval = " << neval << '\n';
-  // std::cout << "f(" << x[0];
-  // for ( int ii = 1; ii < npar; ++ii )
-  //   std::cout << ", " << x[ii];
-  // std::cout << ") = " << func << "\nvc = ";;
-  // for ( int ii = 0; ii < npar*(npar+1)/2; ++ii )
-  //   std::cout << vc[ii] << '\t';
-  // std::cout << '\n';
-
-}
 
 void tstminim( Init init, Fct fct, int npar, std::vector<double>& par,
 	    std::vector<double>& lo, std::vector<double>& hi,
-	    double tol, const char* fct_name, int npop, int maxfev,
+	    double tol, const char* fct_name, int reflect, int maxfev,
 	    double c1, double c2 ) {
 
   try {
@@ -81,14 +54,25 @@ void tstminim( Init init, Fct fct, int npar, std::vector<double>& par,
     for ( int jj = 0; jj < npar; ++jj )
       mypar[ jj ] = par[ jj ];
     sherpa::Bounds<double> bounds(lo, hi);
-    sherpa::Minim< Fct, const sherpa::Bounds<double>&, double > nm( fct,
-                                                                    bounds );
+
+    sherpa::Minim<Fct, const sherpa::Bounds<double>&, double>* nm = NULL;
+    
+    if (reflect)
+      nm = new sherpa::Minim<Fct, const sherpa::Bounds<double>&, double>( fct, bounds);
+    else
+      nm = new sherpa::MinimNoReflect<Fct, const sherpa::Bounds<double>&, double>( fct, bounds );
+
+#if (__STDC_VERSION__ < 201112L)
+    std::auto_ptr< sherpa::Minim<Fct, const sherpa::Bounds<double>&, double> > mynm(nm);
+#else
+    std::unique_ptr< sherpa::Minim<Fct, const sherpa::Bounds<double>&, double> > mynm(nm);
+#endif
 
     int verbose=0, maxnfev=npar*npar*maxfev, nfev=0;
     double fmin;
     int initsimplex=1;
-    nm( verbose, maxnfev, tol, npar, initsimplex, finalsimplex, lo, hi,
-        step, mypar, nfev, fmin );
+    mynm->operator()( verbose, maxnfev, tol, npar, initsimplex, finalsimplex, lo, hi,
+      step, mypar, nfev, fmin );
 
     strcpy( header, "Minim_" );
     print_pars( header, fct_name, nfev, fmin, answer, npar, mypar );
@@ -105,11 +89,9 @@ void tstminim( Init init, Fct fct, int npar, std::vector<double>& par,
 
 int main( int argc, char* argv[] ) {
 
-  tst_minim();
-
   try {
 
-    int c, uncopt = 1, globalopt = 1;
+    int c, uncopt = 1, globalopt = 1, reflect = 1;
     while ( --argc > 0 && (*++argv)[ 0 ] == '-' )
       while ( (c = *++argv[ 0 ]) )
 	switch( c ) {
@@ -119,6 +101,9 @@ int main( int argc, char* argv[] ) {
 	case 'g':
 	  globalopt = 0;
 	  break;
+        case 'r':
+          reflect = 0;
+          break;
 	default:
 	  fprintf( stderr, "%s: illegal option '%c'\n", argv[ 0 ], c );
 	  fprintf( stderr, "Usage %s [ -g ] [ -u ] [ npar ]\n", argv[ 0 ] );
@@ -143,13 +128,13 @@ int main( int argc, char* argv[] ) {
       "optimization method did not converge\n#\n";
     std::cout << "name\tnfev\tanswer\tstat\tpar\nS\tN\tN\tN\tN\n";
 
-    int npop=0, maxfev=1024;
+    int maxfev=1024;
     double c1=0.0, c2=0.0;
     if ( uncopt )
-      tst_unc_opt<tstFct, double>( npar, tol, tstminim, npop, maxfev, c1, c2 );
+      tst_unc_opt<tstFct, double>( npar, tol, tstminim, reflect, maxfev, c1, c2 );
 
     if ( globalopt )
-      tst_global( npar, tol, tstminim, npop, maxfev, c1, c2 );
+      tst_global( npar, tol, tstminim, reflect, maxfev, c1, c2 );
 
     return EXIT_SUCCESS;
 
@@ -167,86 +152,83 @@ int main( int argc, char* argv[] ) {
 /*
 g++ -o minim -DtestMinim -DNDEBUG -Wall -ansi -pedantic -O3 -I../../include -I.. minim.cc
 
-(sherpa) [dtn@devel12 src]$ valgrind minim
-==32284== Memcheck, a memory error detector
-==32284== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
-==32284== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
-==32284== Command: minim
-==32284== 
-#
-#:npar = 6
-#:tol=1e-08
-# A negative value for the nfev signifies that the optimization method did not converge
-#
-name	nfev	answer	stat	par
-S	N	N	N	N
-Minim_Rosenbrock	-961	0	1.29567	0.184248,0.0284826,1.63673,2.68041,0.529682,0.278636
-Minim_FreudensteinRoth	-574	0	146.953	11.4128,-0.896805,11.4128,-0.896805,11.4128,-0.896805
-Minim_PowellBadlyScaled	1003	0	1.63198e-06	1.50587e-05,6.64168,8.25696e-06,12.1085,1.30173e-05,7.68102
-Minim_BrownBadlyScaled	2151	0	7.60681e-20	1e+06,1.99991e-06,1e+06,2.0001e-06,1e+06,2e-06
-Minim_Beale	399	0	2.70425e-16	3,0.5,3,0.5,3,0.5
-Minim_JennrichSampson	861	373.086	373.087	0.257825,0.257825,0.257825,0.257825,0.257825,0.257825
-Minim_HelicalValley	145	0	1.12431e-16	1,4.47078e-09,6.95162e-09
-Minim_Bard	154	0.00821487	0.00821488	0.0824106,1.13304,2.34369
-Minim_Gaussian	112	1.12793e-08	1.12793e-08	0.398956,1.00002,-4.65898e-10
-Minim_Meyer	3081	87.9458	87.9459	0.00560964,6181.35,345.224
-Minim_GulfResearchDevelopment	308	0	7.68697e-05	19.4537,-6.56898,1.03413
-Minim_Box3d	214	0	8.7639e-16	1,10,1
-Minim_PowellSingular	243	0	1.16082e-08	-0.00181298,0.000181175,0.00351953,0.00353512
-Minim_Wood	316	0	2.6502e-15	1,1,1,1
-Minim_KowalikOsborne	255	0.000307505	0.000307506	0.192807,0.19129,0.123059,0.136066
-Minim_BrownDennis	332	85822.2	85822.2	-11.5944,13.2036,-0.403439,0.236779
-Minim_Osborne1	519	5.46489e-05	5.49625e-05	0.376183,2.03372,-1.56315,0.0130563,0.0217551
-Minim_Biggs	162	0	4.61328e-10	1.60027,10.0005,1.00001,4.99958,3.99978,2.99958
-Minim_Osborne2	-3415	0.0401377	0.0772305	1.22656,0.322674,0.568139,0.537683,0.532828,1.67286,1.32382,4.26204,2.426,4.58298,5.66337
-Minim_Watson	576	0.00228767	0.00228767	-0.0157251,1.01243,-0.232992,1.26043,-1.51373,0.992996
-Minim_PenaltyI	-274	9.37629e-06	4.50241e-05	-0.198834,-0.221917,0.390035,-0.0954568
-Minim_PenaltyII	-153	9.37629e-06	9.98143e-06	0.200004,0.400644,0.422337,-0.0415098
-Minim_VariablyDimensioned	376	0	1.61504e-24	1,1,1,1,1,1
-Minim_Trigonometric	600	0	5.22623e-14	0.0121122,0.0117014,0.0113404,-0.122016,-0.0940155,0.0104681
-Minim_BrownAlmostLinear	-362	1	1.19581e-14	1,1,1,1,1,1
-Minim_DiscreteBoundary	281	0	1.75795e-18	-0.0898882,-0.167863,-0.15361,-0.132462,-0.102058,-0.0592968
-Minim_DiscreteIntegral	283	0	7.94022e-19	-0.0654635,-0.118166,-0.154627,-0.169992,-0.15727,-0.106031
-Minim_BroydenTridiagonal	346	0	3.40409e-17	-0.576058,-0.69593,-0.680249,-0.642988,-0.556421,-0.366025
-Minim_BroydenBanded	449	0	3.44158e-16	-0.428303,-0.476596,-0.519653,-0.558073,-0.593437,-0.593437
-Minim_LinearFullRank	326	0	1.77494e-30	-1,-1,-1,-1,-1,-1
-Minim_LinearFullRank1	247	1.15385	1.15385	2.97377,2.2046,2.13584,0.15931,0.59993,-2.8661
-Minim_LinearFullRank0cols0rows	244	2.66667	2.66667	2.14801,1.95638,0.261166,0.8645,-1.56419,2.61241
-Minim_Chebyquad	641	0	8.64238e-06	0.04472,0.205762,0.230925,0.424449,0.491337,0.591077,0.761322,0.804917,0.956254
-Minim_McCormick	93	-1.9132	-1.91322	-0.547198,-1.5472
-Minim_BoxBetts	94	0	8.5606e-16	1,10,1
-Minim_Paviani	1497	-45.778	-45.6242	9.32565,9.39821,9.34252,9.46265,9.35731,9.36868,9.28165,9.299,9.40574,9.21271
-Minim_GoldsteinPrice	92	3	3	7.848e-14,-1
-Minim_Shekel5	-171	-10.1532	-5.10077	7.99958,7.99964,7.99958,7.99964
-Minim_Shekel7	-179	-10.4029	-5.12882	7.99951,7.99962,7.9995,7.99961
-Minim_Shekel10	-189	-10.5364	-5.17565	7.99948,7.99945,7.99946,7.99944
-Minim_Levy4	-803	-21.502	9.85125	2.64769,1.99586,0.670413,6.99797
-Minim_Levy5	-317	-11.504	38.8617	3.96386,3.99615,3.99623,3.99624,3.99945
-Minim_Levy6	-306	-11.504	47.8504	3.96386,3.99615,3.99623,3.99623,3.99624,3.99945
-Minim_Levy7	-383	-11.504	56.8392	3.96386,3.99615,3.99623,3.99623,3.99623,3.99624,3.99945
-Minim_Griewank	-79	0	4.91141	100.481,-97.6456
-Minim_SixHumpCamel	91	-1.03	-1.03163	0.089842,-0.712656
-Minim_Branin	97	0.397889	0.397887	9.42478,2.475
-Minim_Shubert	-96	-24.06	-14.6909	8.82716,5.79179
-Minim_Hansen	113	-176.54	-176.542	4.97648,4.85806
-Minim_Cola	-866	12.8154	256.203	1.94861,-0.57903,0.373911,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108,0.673911,-0.0382,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108,0.0739108
-Minim_Ackley	-85	0	19.3325	16.9988,16.9988
-Minim_Bohachevsky1	122	0	0	-1.20688e-13,-4.84744e-14
-Minim_Bohachevsky2	122	0	0	4.72187e-13,-1.38867e-13
-Minim_Bohachevsky3	119	0	0	-7.20017e-14,5.35598e-14
-Minim_Easom	-4096	-1	-0	25.55,25.55
-Minim_Rastrigin	-97	0	7.95966	1.98991,1.98991
-Minim_Michalewicz2	77	-1.8013	-1.8013	2.20291,1.5708
-Minim_Michalewicz5	-323	-4.68766	-4.3749	2.20291,1.5708,2.21933,1.92306,0.996677
-Minim_Michalewicz10	-938	-9.66015	-7.54148	2.20303,1.57081,1.28501,1.39237,1.72048,1.57081,2.22106,1.5867,1.65572,1.5708
-Minim_McKinnon	-4098	-0.25	-2.376e+11	-100,-100
-==32284== 
-==32284== HEAP SUMMARY:
-==32284==     in use at exit: 0 bytes in 0 blocks
-==32284==   total heap usage: 93,753 allocs, 93,753 frees, 113,818,312 bytes allocated
-==32284== 
-==32284== All heap blocks were freed -- no leaks are possible
-==32284== 
-==32284== For counts of detected and suppressed errors, rerun with: -v
-==32284== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+(sherpa-4.14-dev) [dtn@devel12 src]$ time minim -r > noreflect
+
+real0m0.160s
+user0m0.158s
+sys0m0.002s
+(sherpa-4.14-dev) [dtn@devel12 src]$ time valgrind minim > reflect
+==6304== Memcheck, a memory error detector
+==6304== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==6304== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
+==6304== Command: minim
+==6304== 
+==6304== 
+==6304== HEAP SUMMARY:
+==6304==     in use at exit: 0 bytes in 0 blocks
+==6304==   total heap usage: 93,345 allocs, 93,345 frees, 113,812,184 bytes allocated
+==6304== 
+==6304== All heap blocks were freed -- no leaks are possible
+==6304== 
+==6304== For counts of detected and suppressed errors, rerun with: -v
+==6304== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+
+real0m1.876s
+user0m1.820s
+sys0m0.049s
+
+(sherpa-4.14-dev) [dtn@devel12 src]$ time valgrind minim -r > noreflect
+==6316== Memcheck, a memory error detector
+==6316== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==6316== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
+==6316== Command: minim -r
+==6316== 
+==6316== 
+==6316== HEAP SUMMARY:
+==6316==     in use at exit: 0 bytes in 0 blocks
+==6316==   total heap usage: 23,929 allocs, 23,929 frees, 3,681,464 bytes allocated
+==6316== 
+==6316== All heap blocks were freed -- no leaks are possible
+==6316== 
+==6316== For counts of detected and suppressed errors, rerun with: -v
+==6316== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+
+real0m3.821s
+user0m3.781s
+sys0m0.040s
+
+(sherpa-4.14-dev) [dtn@devel12 src]$ diff reflect noreflect 
+11c11
+< Minim_BrownBadlyScaled	2151	0	7.60681e-20	1e+06,1.99991e-06,1e+06,2.0001e-06,1e+06,2e-06
+---
+> Minim_BrownBadlyScaled	4547	0	1.10634e-17	1e+06,1.99977e-06,1e+06,1.99819e-06,1e+06,2e-06
+41,44c41,44
+< Minim_McCormick	93	-1.9132	-1.91322	-0.547198,-1.5472
+< Minim_BoxBetts	94	0	8.5606e-16	1,10,1
+< Minim_Paviani	1497	-45.778	-45.6242	9.32565,9.39821,9.34252,9.46265,9.35731,9.36868,9.28165,9.299,9.40574,9.21271
+< Minim_GoldsteinPrice	92	3	3	7.848e-14,-1
+---
+> Minim_McCormick	4098	-1.9132	-nan	-nan,-nan
+> Minim_BoxBetts	114	0	1.43046e-16	1,10,1
+> Minim_Paviani	-102402	-45.778	-2.75503	5.78989,7.49795,5.06157,7.23616,4.91172,5.56942,7.55769,6.10409,6.90818,7.98112
+> Minim_GoldsteinPrice	-132	3	84	1.8,0.2
+49,51c49,51
+< Minim_Levy5	-317	-11.504	38.8617	3.96386,3.99615,3.99623,3.99624,3.99945
+< Minim_Levy6	-306	-11.504	47.8504	3.96386,3.99615,3.99623,3.99623,3.99624,3.99945
+< Minim_Levy7	-383	-11.504	56.8392	3.96386,3.99615,3.99623,3.99623,3.99623,3.99624,3.99945
+---
+> Minim_Levy5	-263	-11.504	38.8617	3.96386,3.99615,3.99623,3.99624,3.99945
+> Minim_Levy6	-345	-11.504	47.8504	3.96386,3.99615,3.99623,3.99623,3.99624,3.99945
+> Minim_Levy7	-391	-11.504	56.8392	3.96386,3.99615,3.99623,3.99623,3.99623,3.99624,3.99945
+53,54c53,54
+< Minim_SixHumpCamel	91	-1.03	-1.03163	0.089842,-0.712656
+< Minim_Branin	97	0.397889	0.397887	9.42478,2.475
+---
+> Minim_SixHumpCamel	93	-1.03	-1.03163	0.089842,-0.712656
+> Minim_Branin	81	0.397889	0.397887	9.42478,2.475
+67c67
+< Minim_McKinnon	-4098	-0.25	-2.376e+11	-100,-100
+---
+> Minim_McKinnon	-4099	-0.25	-inf	-1.46426e+76,-1.06339e+77
+
 */

--- a/sherpa/optmethods/src/minim.f
+++ b/sherpa/optmethods/src/minim.f
@@ -1,0 +1,880 @@
+c
+c----------------------------------------------------------------------
+c
+      SUBROUTINE MINIM(P,STEP,NOP,FUNC,MAX,IPRINT,STOPCR,NLOOP,IQUAD,
+c     --dtn
+c$$$     1  SIMP,VAR,FUNCTN,IFAULT)
+     1     SIMP,VAR,FUNCTN,IFAULT,
+     2     neval,lb,ub,g,h,pbar,pstar,pstst,aval,bmat,pmin,vc,temp)
+      implicit none
+      integer*4 nop,max,iprint,nloop,iquad,ifault
+      real*8 p(nop),step(nop),func,stopcr,simp,var(nop)
+      real*8 g(nop+1,nop),h(nop+1),pbar(nop),pstar(nop),
+     1  pstst(nop),aval(nop),bmat(nop*(nop+1)/2),pmin(nop),
+     1  vc(nop*(nop+1)/2),temp(nop),lb(nop),ub(nop)
+      external functn
+c     --dtn
+C
+C     A PROGRAM FOR FUNCTION MINIMIZATION USING THE SIMPLEX METHOD.
+C     The minimum found will often be a local, not a global, minimum.
+C
+C     FOR DETAILS, SEE NELDER & MEAD, THE COMPUTER JOURNAL, JANUARY 1965
+C
+C     PROGRAMMED BY D.E.SHAW,
+C     CSIRO, DIVISION OF MATHEMATICS & STATISTICS
+C     P.O. BOX 218, LINDFIELD, N.S.W. 2070
+C
+C     WITH AMENDMENTS BY R.W.M.WEDDERBURN
+C     ROTHAMSTED EXPERIMENTAL STATION
+C     HARPENDEN, HERTFORDSHIRE, ENGLAND
+C
+C     Further amended by Alan Miller,
+C     CSIRO, Division of Mathematics & Statistics
+C     Private Bag 10, CLAYTON, VIC. 3168
+C
+C     ARGUMENTS:-
+C     P()     = INPUT, STARTING VALUES OF PARAMETERS
+C               OUTPUT, FINAL VALUES OF PARAMETERS
+C     STEP()  = INPUT, INITIAL STEP SIZES
+C     NOP     = INPUT, NO. OF PARAMETERS, INCL. ANY TO BE HELD FIXED
+C     FUNC    = OUTPUT, THE FUNCTION VALUE CORRESPONDING TO THE FINAL
+C               PARAMETER VALUES
+C     MAX     = INPUT, THE MAXIMUM NO. OF FUNCTION EVALUATIONS ALLOWED
+C     IPRINT  = INPUT, PRINT CONTROL PARAMETER
+C                     < 0 NO PRINTING
+C                     = 0 PRINTING OF PARAMETER VALUES AND THE FUNCTION
+C                         VALUE AFTER INITIAL EVIDENCE OF CONVERGENCE.
+C                     > 0 AS FOR IPRINT = 0 PLUS PROGRESS REPORTS AFTER
+C                         EVERY IPRINT EVALUATIONS, PLUS PRINTING FOR THE
+C                         INITIAL SIMPLEX.
+C     STOPCR  = INPUT, STOPPING CRITERION
+C     NLOOP   = INPUT, THE STOPPING RULE IS APPLIED AFTER EVERY NLOOP
+C               FUNCTION EVALUATIONS.
+C     IQUAD   = INPUT, = 1 IF THE FITTING OF A QUADRATIC SURFACE IS REQUIRED
+C                      = 0 IF NOT
+C     SIMP    = INPUT, CRITERION FOR EXPANDING THE SIMPLEX TO OVERCOME
+C               ROUNDING ERRORS BEFORE FITTING THE QUADRATIC SURFACE.
+C     VAR()   = OUTPUT, CONTAINS THE DIAGONAL ELEMENTS OF THE INVERSE OF
+C               THE INFORMATION MATRIX.
+C     FUNCTN  = INPUT, NAME OF THE USER'S SUBROUTINE - ARGUMENTS (P,FUNC)
+C               WHICH RETURNS THE FUNCTION VALUE FOR A GIVEN SET OF
+C               PARAMETER VALUES IN ARRAY P.
+C****   FUNCTN MUST BE DECLARED EXTERNAL IN THE CALLING PROGRAM.
+C       IFAULT  = OUTPUT, = 0 FOR SUCCESSFUL TERMINATION
+C                         = 1 IF MAXIMUM NO. OF FUNCTION EVALUATIONS EXCEEDED
+C                         = 2 IF INFORMATION MATRIX IS NOT +VE SEMI-DEFINITE
+C                         = 3 IF NOP < 1
+C                         = 4 IF NLOOP < 1
+C
+C       Advice on usage:
+C       If the function minimized can be expected to be smooth in the vicinity
+C       of the minimum, users are strongly urged to use the quadratic-surface
+C       fitting option.   This is the only satisfactory way of testing that the
+C       minimum has been found.   The value of SIMP should be set to at least
+C       1000 times the rounding error in calculating the fitted function.
+C       e.g. in double precision on a micro- or mini-computer with about 16
+C       decimal digit representation of floating-point numbers, the rounding
+C       errors in calculating the objective function may be of the order of
+C       1.E-12 say in a particular case.   A suitable value for SIMP would then
+C       be 1.E-08.   However, if numerical integration is required in the
+C       calculation of the objective function, it may only be accurate to say
+C       1.E-05 and an appropriate value for SIMP would be about 0.1.
+C       If the fitted quadratic surface is not +ve definite (and the function
+C       should be smooth in the vicinity of the minimum), it probably means
+C       that the search terminated prematurely and you have not found the
+C       minimum.
+C
+C       N.B. P, STEP AND VAR (IF IQUAD = 1) MUST HAVE DIMENSION AT LEAST NOP
+C            IN THE CALLING PROGRAM.
+C       THE DIMENSIONS BELOW ARE FOR A MAXIMUM OF 20 PARAMETERS.
+C      The dimension of BMAT should be at least NOP*(NOP+1)/2.
+C
+C****      N.B. This version is in DOUBLE PRECISION throughout
+C
+C       LATEST REVISION - 11 August 1991
+C
+C*****************************************************************************
+C
+c     --dtn
+c$$$
+c$$$      implicit double precision (a-h, o-z)
+c$$$      external FUNCTN
+c$$$      DIMENSION P(NOP),STEP(NOP),VAR(NOP)
+c$$$      DIMENSION G(21,20),H(21),PBAR(20),PSTAR(20),PSTST(20),AVAL(20),
+c$$$     1  BMAT(210),PMIN(20),VC(210),TEMP(20)
+c$$$      DATA ZERO/0.D0/, ONE/1.D0/, TWO/2.D0/, THREE/3.D0/, HALF/0.5D0/
+c     --dtn
+C
+C     A = REFLECTION COEFFICIENT, B = CONTRACTION COEFFICIENT, AND
+C     C = EXPANSION COEFFICIENT.
+C
+c     --dtn
+      integer*4 i,i1,i2,iflag,imax,imin,j,j1,irow,k,l,ijk,ii,jj,ij
+      integer*4 loop,nap,neval,np1,nullty,irank
+      real*8 fnp1,fnap,hmax,hmean,hmin,hstar,hstd,hstst,savemn,test
+      real*8 a0,rmax,ymin
+      integer*4 lout
+      real*8 a,b,c
+      real*8 zero,half,one,two,three
+      data zero/0.d0/, half/0.5d0/, one/1.d0/, two/2.d0/, three/3.d0/
+c     --dtn
+      DATA A,B,C/1.D0, 0.5D0, 2.D0/
+C
+C     SET LOUT = LOGICAL UNIT NO. FOR OUTPUT
+C
+      DATA LOUT/6/
+C
+C     IF PROGRESS REPORTS HAVE BEEN REQUESTED, PRINT HEADING
+C
+c$$$      IF(IPRINT.GT.0) WRITE(LOUT,1000) IPRINT
+c$$$ 1000 FORMAT(' PROGRESS REPORT EVERY',I4,' FUNCTION EVALUATIONS'/,
+c$$$     1  ' EVAL.  FUNC.',15X,'PARAMETER VALUES')
+C
+C     CHECK INPUT ARGUMENTS
+C
+      IFAULT=0
+      IF(NOP.LE.0) IFAULT=3
+      IF(NLOOP.LE.0) IFAULT=4
+      IF(IFAULT.NE.0) RETURN
+C
+C     SET NAP = NO. OF PARAMETERS TO BE VARIED, I.E. WITH STEP.NE.0
+C
+      NAP=0
+      LOOP=0
+      IFLAG=0
+      DO 10 I=1,NOP
+        IF(STEP(I).NE.ZERO) NAP=NAP+1
+   10 CONTINUE
+C
+C     IF NAP = 0 EVALUATE FUNCTION AT THE STARTING POINT AND RETURN
+C
+      IF(NAP.GT.0) GO TO 30
+c     --dtn
+c$$$      CALL FUNCTN(P,FUNC)
+      CALL FUNCTN(P,NOP,FUNC)
+c     --dtn
+      RETURN
+C
+C     SET UP THE INITIAL SIMPLEX
+C
+   30 DO 40 I=1,NOP
+   40 G(1,I)=P(I)
+      IROW=2
+      DO 60 I=1,NOP
+        IF(STEP(I).EQ.ZERO) GO TO 60
+        DO 50 J=1,NOP
+   50   G(IROW,J)=P(J)
+        G(IROW,I)=P(I)+STEP(I)
+c     --dtn
+        g(irow,i) = dmax1(lb(i),dmin1(g(irow,i),ub(i)))
+c     --dtn
+        IROW=IROW+1
+   60 CONTINUE
+      NP1=NAP+1
+      NEVAL=0
+      DO 90 I=1,NP1
+        DO 70 J=1,NOP
+   70   P(J)=G(I,J)
+c     --dtn
+c$$$        CALL FUNCTN(P,H(I))
+        CALL FUNCTN(P,nop,H(I))
+c     --dtn
+        NEVAL=NEVAL+1
+c$$$        IF(IPRINT.LE.0) GO TO 90
+c$$$        WRITE(LOUT,1010) NEVAL,H(I),(P(J),J=1,NOP)
+c$$$ 1010   FORMAT(/I4, 2X, G12.5, 2X, 5G12.5, 3(/20X, 5G12.5))
+   90 CONTINUE
+C
+C     START OF MAIN CYCLE.
+C
+C     FIND MAX. & MIN. VALUES FOR CURRENT SIMPLEX (HMAX & HMIN).
+C
+  100 LOOP=LOOP+1
+      IMAX=1
+      IMIN=1
+      HMAX=H(1)
+      HMIN=H(1)
+      DO 120 I=2,NP1
+        IF(H(I).LE.HMAX) GO TO 110
+        IMAX=I
+        HMAX=H(I)
+        GO TO 120
+  110   IF(H(I).GE.HMIN) GO TO 120
+        IMIN=I
+        HMIN=H(I)
+  120 CONTINUE
+C
+C     FIND THE CENTROID OF THE VERTICES OTHER THAN P(IMAX)
+C
+      DO 130 I=1,NOP
+  130 PBAR(I)=ZERO
+      DO 150 I=1,NP1
+        IF(I.EQ.IMAX) GO TO 150
+        DO 140 J=1,NOP
+  140   PBAR(J)=PBAR(J)+G(I,J)
+  150 CONTINUE
+      DO 160 J=1,NOP
+      FNAP = NAP
+  160 PBAR(J)=PBAR(J)/FNAP
+C
+C     REFLECT MAXIMUM THROUGH PBAR TO PSTAR,
+C     HSTAR = FUNCTION VALUE AT PSTAR.
+C
+      DO 170 I=1,NOP
+  170 PSTAR(I)=A*(PBAR(I)-G(IMAX,I))+PBAR(I)
+c     --dtn
+c$$$      CALL FUNCTN(PSTAR,HSTAR)
+      CALL FUNCTN(PSTAR,nop,HSTAR)
+c     --dtn
+      NEVAL=NEVAL+1
+c$$$      IF(IPRINT.LE.0) GO TO 180
+c$$$      IF(MOD(NEVAL,IPRINT).EQ.0) WRITE(LOUT,1010) NEVAL,HSTAR,
+c$$$     1  (PSTAR(J),J=1,NOP)
+C
+C     IF HSTAR < HMIN, REFLECT PBAR THROUGH PSTAR,
+C     HSTST = FUNCTION VALUE AT PSTST.
+C
+  180 IF(HSTAR.GE.HMIN) GO TO 220
+      DO 190 I=1,NOP
+  190 PSTST(I)=C*(PSTAR(I)-PBAR(I))+PBAR(I)
+c     --dtn
+c$$$      CALL FUNCTN(PSTST,HSTST)
+      CALL FUNCTN(PSTST,nop,HSTST)
+c     --dtn
+      NEVAL=NEVAL+1
+c$$$      IF(IPRINT.LE.0) GO TO 200
+c$$$      IF(MOD(NEVAL,IPRINT).EQ.0) WRITE(LOUT,1010) NEVAL,HSTST,
+c$$$     1  (PSTST(J),J=1,NOP)
+C
+C     IF HSTST < HMIN REPLACE CURRENT MAXIMUM POINT BY PSTST AND
+C     HMAX BY HSTST, THEN TEST FOR CONVERGENCE.
+C
+  200 IF(HSTST.GE.HMIN) GO TO 320
+      DO 210 I=1,NOP
+        IF(STEP(I).NE.ZERO) G(IMAX,I)=PSTST(I)
+  210 CONTINUE
+      H(IMAX)=HSTST
+      GO TO 340
+C
+C     HSTAR IS NOT < HMIN.
+C     TEST WHETHER IT IS < FUNCTION VALUE AT SOME POINT OTHER THAN
+C     P(IMAX).   IF IT IS REPLACE P(IMAX) BY PSTAR & HMAX BY HSTAR.
+C
+  220 DO 230 I=1,NP1
+        IF(I.EQ.IMAX) GO TO 230
+        IF(HSTAR.LT.H(I)) GO TO 320
+  230 CONTINUE
+C
+C     HSTAR > ALL FUNCTION VALUES EXCEPT POSSIBLY HMAX.
+C     IF HSTAR <= HMAX, REPLACE P(IMAX) BY PSTAR & HMAX BY HSTAR.
+C
+      IF(HSTAR.GT.HMAX) GO TO 260
+      DO 250 I=1,NOP
+        IF(STEP(I).NE.ZERO) G(IMAX,I)=PSTAR(I)
+  250 CONTINUE
+      HMAX=HSTAR
+      H(IMAX)=HSTAR
+C
+C     CONTRACTED STEP TO THE POINT PSTST,
+C     HSTST = FUNCTION VALUE AT PSTST.
+C
+  260 DO 270 I=1,NOP
+  270 PSTST(I)=B*G(IMAX,I) + (1.d0-B)*PBAR(I)
+c     --dtn
+c$$$      CALL FUNCTN(PSTST,HSTST)
+      CALL FUNCTN(PSTST,nop,HSTST)
+c     --dtn
+      NEVAL=NEVAL+1
+c$$$      IF(IPRINT.LE.0) GO TO 280
+c$$$      IF(MOD(NEVAL,IPRINT).EQ.0) WRITE(LOUT,1010) NEVAL,HSTST,
+c$$$     1  (PSTST(J),J=1,NOP)
+C
+C     IF HSTST < HMAX REPLACE P(IMAX) BY PSTST & HMAX BY HSTST.
+C
+  280 IF(HSTST.GT.HMAX) GO TO 300
+      DO 290 I=1,NOP
+        IF(STEP(I).NE.ZERO) G(IMAX,I)=PSTST(I)
+  290 CONTINUE
+      H(IMAX)=HSTST
+      GO TO 340
+C
+C     HSTST > HMAX.
+C     SHRINK THE SIMPLEX BY REPLACING EACH POINT, OTHER THAN THE CURRENT
+C     MINIMUM, BY A POINT MID-WAY BETWEEN ITS CURRENT POSITION AND THE
+C     MINIMUM.
+C
+  300 DO 315 I=1,NP1
+        IF(I.EQ.IMIN) GO TO 315
+        DO 310 J=1,NOP
+          IF(STEP(J).NE.ZERO) G(I,J)=(G(I,J)+G(IMIN,J))*HALF
+          P(J)=G(I,J)
+  310   CONTINUE
+c     --dtn
+c$$$        CALL FUNCTN(P,H(I))
+        CALL FUNCTN(P,nop,H(I))
+c     --dtn
+        NEVAL=NEVAL+1
+c$$$        IF(IPRINT.LE.0) GO TO 315
+c$$$        IF(MOD(NEVAL,IPRINT).EQ.0) WRITE(LOUT,1010) NEVAL,H(I),
+c$$$     1              (P(J),J=1,NOP)
+  315 CONTINUE
+      GO TO 340
+C
+C     REPLACE MAXIMUM POINT BY PSTAR & H(IMAX) BY HSTAR.
+C
+  320 DO 330 I=1,NOP
+        IF(STEP(I).NE.ZERO) G(IMAX,I)=PSTAR(I)
+  330 CONTINUE
+      H(IMAX)=HSTAR
+C
+C     IF LOOP = NLOOP TEST FOR CONVERGENCE, OTHERWISE REPEAT MAIN CYCLE.
+C
+  340 IF(LOOP.LT.NLOOP) GO TO 100
+C
+C     CALCULATE MEAN & STANDARD DEVIATION OF FUNCTION VALUES FOR THE
+C     CURRENT SIMPLEX.
+C
+      HSTD=ZERO
+      HMEAN=ZERO
+      DO 350 I=1,NP1
+  350 HMEAN=HMEAN+H(I)
+      FNP1 = NP1
+      HMEAN=HMEAN/FNP1
+      DO 360 I=1,NP1
+  360 HSTD=HSTD+(H(I)-HMEAN)**2
+      HSTD=SQRT(HSTD/FLOAT(NP1))
+C
+C     IF THE RMS > STOPCR, SET IFLAG & LOOP TO ZERO AND GO TO THE
+C     START OF THE MAIN CYCLE AGAIN.
+C
+      IF(HSTD.LE.STOPCR.OR.NEVAL.GT.MAX) GO TO 410
+      IFLAG=0
+      LOOP=0
+      GO TO 100
+C
+C     FIND THE CENTROID OF THE CURRENT SIMPLEX AND THE FUNCTION VALUE THERE.
+C
+  410 DO 380 I=1,NOP
+        IF(STEP(I).EQ.ZERO) GO TO 380
+        P(I)=ZERO
+        DO 370 J=1,NP1
+  370   P(I)=P(I)+G(J,I)
+        FNP1 = NP1
+        P(I)=P(I)/FNP1
+  380 CONTINUE
+c     --dtn
+c$$$      CALL FUNCTN(P,FUNC)
+      CALL FUNCTN(P,nop,FUNC)
+c     --dtn
+      NEVAL=NEVAL+1
+c$$$      IF(IPRINT.LE.0) GO TO 390
+c$$$      IF(MOD(NEVAL,IPRINT).EQ.0) WRITE(LOUT,1010) NEVAL,FUNC,
+c$$$     1  (P(J),J=1,NOP)
+C
+C     TEST WHETHER THE NO. OF FUNCTION VALUES ALLOWED, MAX, HAS BEEN
+C     OVERRUN; IF SO, EXIT WITH IFAULT = 1.
+C
+  390 IF(NEVAL.LE.MAX) GO TO 420
+      IFAULT=1
+      IF(IPRINT.LT.0) RETURN
+c$$$      WRITE(LOUT,1020) MAX
+c$$$ 1020 FORMAT(' NO. OF FUNCTION EVALUATIONS EXCEEDS',I5)
+c$$$      WRITE(LOUT,1030) HSTD
+c$$$ 1030 FORMAT(' RMS OF FUNCTION VALUES OF LAST SIMPLEX =',G14.6)
+c$$$      WRITE(LOUT,1040)(P(I),I=1,NOP)
+c$$$ 1040 FORMAT(' CENTROID OF LAST SIMPLEX =',4(/1X,6G13.5))
+c$$$      WRITE(LOUT,1050) FUNC
+c$$$ 1050 FORMAT(' FUNCTION VALUE AT CENTROID =',G14.6)
+      RETURN
+C
+C     CONVERGENCE CRITERION SATISFIED.
+C     IF IFLAG = 0, SET IFLAG & SAVE HMEAN.
+C     IF IFLAG = 1 & CHANGE IN HMEAN <= STOPCR THEN SEARCH IS COMPLETE.
+C
+ 420  continue
+c$$$  420 IF(IPRINT.LT.0) GO TO 430
+c$$$      WRITE(LOUT,1060)
+c$$$ 1060 FORMAT(/' EVIDENCE OF CONVERGENCE')
+c$$$      WRITE(LOUT,1040)(P(I),I=1,NOP)
+c$$$      WRITE(LOUT,1050) FUNC
+  430 IF(IFLAG.GT.0) GO TO 450
+      IFLAG=1
+  440 SAVEMN=HMEAN
+      LOOP=0
+      GO TO 100
+  450 IF(ABS(SAVEMN-HMEAN).GE.STOPCR) GO TO 440
+      IF(IPRINT.LT.0) GO TO 460
+c$$$      WRITE(LOUT,1070) NEVAL
+c$$$ 1070 FORMAT(//' MINIMUM FOUND AFTER',I5,' FUNCTION EVALUATIONS')
+c$$$      WRITE(LOUT,1080)(P(I),I=1,NOP)
+c$$$ 1080 FORMAT(' MINIMUM AT',4(/1X,6G13.6))
+c$$$      WRITE(LOUT,1090) FUNC
+c$$$ 1090 FORMAT(' FUNCTION VALUE AT MINIMUM =',G14.6)
+  460 IF(IQUAD.LE.0) RETURN
+C-------------------------------------------------------------------
+C
+C     QUADRATIC SURFACE FITTING
+C
+c$$$      IF(IPRINT.GE.0) WRITE(LOUT,1110)
+c$$$ 1110 FORMAT(/' QUADRATIC SURFACE FITTING ABOUT SUPPOSED MINIMUM'/)
+C
+C     EXPAND THE FINAL SIMPLEX, IF NECESSARY, TO OVERCOME ROUNDING
+C     ERRORS.
+C
+c     --dtn
+c$$$      NEVAL=0
+c     --dtn
+      DO 490 I=1,NP1
+  470   TEST=ABS(H(I)-FUNC)
+        IF(TEST.GE.SIMP) GO TO 490
+        DO 480 J=1,NOP
+          IF(STEP(J).NE.ZERO) G(I,J)=(G(I,J)-P(J))+G(I,J)
+          PSTST(J)=G(I,J)
+  480   CONTINUE
+c     --dtn
+c$$$        CALL FUNCTN(PSTST,H(I))
+        NEVAL=NEVAL+1
+        CALL FUNCTN(PSTST,nop,H(I))
+        if ( neval .ge. max ) then
+           return
+        endif
+c     --dtn
+        GO TO 470
+  490 CONTINUE
+C
+C     FUNCTION VALUES ARE CALCULATED AT AN ADDITIONAL NAP POINTS.
+C
+      DO 510 I=1,NAP
+        I1=I+1
+        DO 500 J=1,NOP
+  500   PSTAR(J)=(G(1,J)+G(I1,J))*HALF
+c     --dtn
+c$$$        CALL FUNCTN(PSTAR,AVAL(I))
+        NEVAL=NEVAL+1
+        CALL FUNCTN(PSTAR,nop,AVAL(I))
+        if ( neval .ge. max ) then
+           return
+        endif
+c     --dtn
+  510 CONTINUE
+C
+C     THE MATRIX OF ESTIMATED SECOND DERIVATIVES IS CALCULATED AND ITS
+C     LOWER TRIANGLE STORED IN BMAT.
+C
+      A0=H(1)
+      DO 540 I=1,NAP
+        I1=I-1
+        I2=I+1
+        IF(I1.LT.1) GO TO 540
+        DO 530 J=1,I1
+          J1=J+1
+          DO 520 K=1,NOP
+  520     PSTST(K)=(G(I2,K)+G(J1,K))*HALF
+c     --dtn
+c$$$          CALL FUNCTN(PSTST,HSTST)
+          NEVAL=NEVAL+1
+          CALL FUNCTN(PSTST,nop,HSTST)
+        if ( neval .ge. max ) then
+           return
+        endif
+c     --dtn
+          L=I*(I-1)/2+J
+          BMAT(L)=TWO*(HSTST+A0-AVAL(I)-AVAL(J))
+  530   CONTINUE
+  540 CONTINUE
+      L=0
+      DO 550 I=1,NAP
+        I1=I+1
+        L=L+I
+        BMAT(L)=TWO*(H(I1)+A0-TWO*AVAL(I))
+  550 CONTINUE
+C
+C     THE VECTOR OF ESTIMATED FIRST DERIVATIVES IS CALCULATED AND
+C     STORED IN AVAL.
+C
+      DO 560 I=1,NAP
+        I1=I+1
+        AVAL(I)=TWO*AVAL(I)-(H(I1)+THREE*A0)*HALF
+  560 CONTINUE
+C
+C     THE MATRIX Q OF NELDER & MEAD IS CALCULATED AND STORED IN G.
+C
+      DO 570 I=1,NOP
+  570 PMIN(I)=G(1,I)
+      DO 580 I=1,NAP
+        I1=I+1
+        DO 580 J=1,NOP
+        G(I1,J)=G(I1,J)-G(1,J)
+  580 CONTINUE
+      DO 590 I=1,NAP
+        I1=I+1
+        DO 590 J=1,NOP
+          G(I,J)=G(I1,J)
+  590 CONTINUE
+C
+C     INVERT BMAT
+C
+      CALL SYMINV(BMAT,NAP,BMAT,TEMP,NULLTY,IFAULT,RMAX)
+      IF(IFAULT.NE.0) GO TO 600
+      IRANK=NAP-NULLTY
+      GO TO 610
+ 600  continue
+c$$$  600 IF(IPRINT.GE.0) WRITE(LOUT,1120)
+c$$$ 1120 FORMAT(/' MATRIX OF ESTIMATED SECOND DERIVATIVES NOT +VE DEFN.'/
+c$$$     1  ' MINIMUM PROBABLY NOT FOUND'/)
+      IFAULT=2
+      RETURN
+C
+C     BMAT*A/2 IS CALCULATED AND STORED IN H.
+C
+  610 DO 650 I=1,NAP
+        H(I)=ZERO
+        DO 640 J=1,NAP
+          IF(J.GT.I) GO TO 620
+          L=I*(I-1)/2+J
+          GO TO 630
+  620     L=J*(J-1)/2+I
+  630     H(I)=H(I)+BMAT(L)*AVAL(J)
+  640   CONTINUE
+  650 CONTINUE
+C
+C     FIND THE POSITION, PMIN, & VALUE, YMIN, OF THE MINIMUM OF THE
+C     QUADRATIC.
+C
+      YMIN=ZERO
+      DO 660 I=1,NAP
+  660 YMIN=YMIN+H(I)*AVAL(I)
+      YMIN=A0-YMIN
+      DO 670 I=1,NOP
+        PSTST(I)=ZERO
+        DO 670 J=1,NAP
+  670 PSTST(I)=PSTST(I)+H(J)*G(J,I)
+      DO 680 I=1,NOP
+  680 PMIN(I)=PMIN(I)-PSTST(I)
+      IF(IPRINT.LT.0) GO TO 682
+c$$$      WRITE(LOUT,1130) YMIN,(PMIN(I),I=1,NOP)
+c$$$ 1130 FORMAT(' MINIMUM OF QUADRATIC SURFACE =',G14.6,' AT',
+c$$$     1  4(/1X,6G13.5))
+c$$$      WRITE(LOUT,1150)
+c$$$ 1150 FORMAT(' IF THIS DIFFERS BY MUCH FROM THE MINIMUM ESTIMATED',
+c$$$     1  1X,'FROM THE MINIMIZATION,'/
+c$$$     2  ' THE MINIMUM MAY BE FALSE &/OR THE INFORMATION MATRIX MAY BE',
+c$$$     3  1X,'INACCURATE'/)
+c
+c     Calculate true function value at the minimum of the quadratic.
+c
+  682 neval = neval + 1
+c     --dtn
+c$$$      call functn(pmin, hstar)
+      call functn(pmin,nop, hstar)
+        if ( neval .ge. max ) then
+           return
+        endif
+c     --dtn
+c
+c     If HSTAR < FUNC, replace search minimum with quadratic minimum.
+c
+      if (hstar .ge. func) go to 690
+      func = hstar
+      do 684 i = 1, nop
+  684 p(i) = pmin(i)
+c     --dtn
+c$$$      write(lout, 1140) func
+c     --dtn
+ 1140 format(' True func. value at minimum of quadratic = ', g14.6/)
+C
+C     Q*BMAT*Q'/2 IS CALCULATED & ITS LOWER TRIANGLE STORED IN VC
+C
+  690 DO 760 I=1,NOP
+        DO 730 J=1,NAP
+          H(J)=ZERO
+          DO 720 K=1,NAP
+            IF(K.GT.J) GO TO 700
+            L=J*(J-1)/2+K
+            GO TO 710
+  700       L=K*(K-1)/2+J
+  710       H(J)=H(J)+BMAT(L)*G(K,I)*HALF
+  720     CONTINUE
+  730   CONTINUE
+        DO 750 J=I,NOP
+          L=J*(J-1)/2+I
+          VC(L)=ZERO
+          DO 740 K=1,NAP
+  740     VC(L)=VC(L)+H(K)*G(K,J)
+  750   CONTINUE
+  760 CONTINUE
+C
+C     THE DIAGONAL ELEMENTS OF VC ARE COPIED INTO VAR.
+C
+      J=0
+      DO 770 I=1,NOP
+        J=J+I
+        VAR(I)=VC(J)
+  770    CONTINUE
+      IF(IPRINT.LT.0) RETURN
+c$$$      WRITE(LOUT,1160) IRANK
+c$$$ 1160 FORMAT(' RANK OF INFORMATION MATRIX =',I3/
+c$$$     1  ' GENERALIZED INVERSE OF INFORMATION MATRIX:-')
+      IJK=1
+      GO TO 880
+  790 CONTINUE
+c$$$      WRITE(LOUT,1170)
+c$$$ 1170 FORMAT(/' IF THE FUNCTION MINIMIZED WAS -LOG(LIKELIHOOD),'/
+c$$$     1  ' THIS IS THE COVARIANCE MATRIX OF THE PARAMETERS'/
+c$$$     2  ' IF THE FUNCTION WAS A SUM OF SQUARES OF RESIDUALS'/
+c$$$     3  ' THIS MATRIX MUST BE MULTIPLIED BY TWICE THE ESTIMATED',
+c$$$c     --dtn
+c$$$c     4  1X'RESIDUAL VARIANCE'/' TO OBTAIN THE COVARIANCE MATRIX.'/)
+c$$$     4  1X,'RESIDUAL VARIANCE'/' TO OBTAIN THE COVARIANCE MATRIX.'/)
+c$$$c     --dtn
+      CALL SYMINV(VC,NAP,BMAT,TEMP,NULLTY,IFAULT,RMAX)
+C
+C     BMAT NOW CONTAINS THE INFORMATION MATRIX
+C
+c$$$      WRITE(LOUT,1190)
+c$$$ 1190 FORMAT(' INFORMATION MATRIX:-'/)
+      IJK=3
+      GO TO 880
+c
+c     Calculate correlations of parameter estimates, put into VC.
+c
+  800 IJK=2
+      II=0
+      IJ=0
+      DO 840 I=1,NOP
+        II=II+I
+        IF(VC(II).GT.ZERO) THEN
+          VC(II)=ONE/SQRT(VC(II))
+        ELSE 
+          VC(II)=ZERO
+	END IF
+        JJ=0
+        DO 830 J=1,I-1
+          JJ=JJ+J
+          IJ=IJ+1
+          VC(IJ)=VC(IJ)*VC(II)*VC(JJ)
+  830   CONTINUE
+        IJ=IJ+1
+  840 CONTINUE
+c$$$      WRITE(LOUT,1200)
+c$$$ 1200 FORMAT(/' CORRELATION MATRIX:-')
+      II=0
+      DO 850 I=1,NOP
+        II=II+I
+        IF(VC(II).NE.ZERO) VC(II)=ONE
+  850 CONTINUE
+      GO TO 880
+ 860  continue
+c$$$  860 WRITE(LOUT,1210) NEVAL
+c$$$ 1210 FORMAT(/' A FURTHER',I4,' FUNCTION EVALUATIONS HAVE BEEN USED'/)
+      RETURN
+c
+c     Pseudo-subroutine to print VC if IJK = 1 or 2, or
+c     BMAT if IJK = 3.
+c
+  880 L=1
+  890 IF(L.GT.NOP) GO TO (790,860,800),IJK
+      II=L*(L-1)/2
+      DO 910 I=L,NOP
+        I1=II+L
+        II=II+I
+        I2=MIN(II,I1+5)
+        IF(IJK.EQ.3) GO TO 900
+c$$$        WRITE(LOUT,1230)(VC(J),J=I1,I2)
+        GO TO 910
+ 900  continue
+c$$$  900   WRITE(LOUT,1230)(BMAT(J),J=I1,I2)
+  910 CONTINUE
+c$$$ 1230 FORMAT(1X,6G13.5)
+c$$$      WRITE(LOUT,1240)
+c$$$ 1240 FORMAT(/)
+      L=L+6
+      GO TO 890
+      END
+c$$$
+c$$$
+c$$$
+c$$$
+c$$$      SUBROUTINE SYMINV(A,N,C,W,NULLTY,IFAULT,RMAX)
+c$$$C
+c$$$C     ALGORITHM AS7, APPLIED STATISTICS, VOL.17, 1968.
+c$$$C
+c$$$C     ARGUMENTS:-
+c$$$C     A()     = INPUT, THE SYMMETRIC MATRIX TO BE INVERTED, STORED IN
+c$$$C               LOWER TRIANGULAR FORM
+c$$$C     N       = INPUT, ORDER OF THE MATRIX
+c$$$C     C()     = OUTPUT, THE INVERSE OF A (A GENERALIZED INVERSE IF C IS
+c$$$C               SINGULAR), ALSO STORED IN LOWER TRIANGULAR.
+c$$$C               C AND A MAY OCCUPY THE SAME LOCATIONS.
+c$$$C     W()     = WORKSPACE, DIMENSION AT LEAST N.
+c$$$C     NULLTY  = OUTPUT, THE RANK DEFICIENCY OF A.
+c$$$C     IFAULT  = OUTPUT, ERROR INDICATOR
+c$$$C                     = 1 IF N < 1
+c$$$C                     = 2 IF A IS NOT +VE SEMI-DEFINITE
+c$$$C                     = 0 OTHERWISE
+c$$$C     RMAX    = OUTPUT, APPROXIMATE BOUND ON THE ACCURACY OF THE DIAGONAL
+c$$$C               ELEMENTS OF C.  E.G. IF RMAX = 1.E-04 THEN THE DIAGONAL
+c$$$C               ELEMENTS OF C WILL BE ACCURATE TO ABOUT 4 DEC. DIGITS.
+c$$$C
+c$$$C     LATEST REVISION - 18 October 1985
+c$$$C
+c$$$C*************************************************************************
+c$$$C
+c$$$      implicit double precision (a-h, o-z)
+c$$$      DIMENSION A(*),C(*),W(N)
+c$$$      DATA ZERO/0.D0/, ONE/1.D0/
+c$$$C
+c$$$      NROW=N
+c$$$      IFAULT=1
+c$$$      IF(NROW.LE.0) GO TO 100
+c$$$      IFAULT=0
+c$$$C
+c$$$C     CHOLESKY FACTORIZATION OF A, RESULT IN C
+c$$$C
+c$$$      CALL CHOLA(A,NROW,C,NULLTY,IFAULT,RMAX,W)
+c$$$      IF(IFAULT.NE.0) GO TO 100
+c$$$C
+c$$$C     INVERT C & FORM THE PRODUCT (CINV)'*CINV, WHERE CINV IS THE INVERSE
+c$$$C     OF C, ROW BY ROW STARTING WITH THE LAST ROW.
+c$$$C     IROW = THE ROW NUMBER, NDIAG = LOCATION OF LAST ELEMENT IN THE ROW.
+c$$$C
+c$$$      NN=NROW*(NROW+1)/2
+c$$$      IROW=NROW
+c$$$      NDIAG=NN
+c$$$   10 IF(C(NDIAG).EQ.ZERO) GO TO 60
+c$$$      L=NDIAG
+c$$$      DO 20 I=IROW,NROW
+c$$$        W(I)=C(L)
+c$$$        L=L+I
+c$$$   20 CONTINUE
+c$$$      ICOL=NROW
+c$$$      JCOL=NN
+c$$$      MDIAG=NN
+c$$$   30 L=JCOL
+c$$$      X=ZERO
+c$$$      IF(ICOL.EQ.IROW) X=ONE/W(IROW)
+c$$$      K=NROW
+c$$$   40 IF(K.EQ.IROW) GO TO 50
+c$$$      X=X-W(K)*C(L)
+c$$$      K=K-1
+c$$$      L=L-1
+c$$$      IF(L.GT.MDIAG) L=L-K+1
+c$$$      GO TO 40
+c$$$   50 C(L)=X/W(IROW)
+c$$$      IF(ICOL.EQ.IROW) GO TO 80
+c$$$      MDIAG=MDIAG-ICOL
+c$$$      ICOL=ICOL-1
+c$$$      JCOL=JCOL-1
+c$$$      GO TO 30
+c$$$c
+c$$$c     Special case, zero diagonal element.
+c$$$c
+c$$$   60 L=NDIAG
+c$$$      DO 70 J=IROW,NROW
+c$$$        C(L)=ZERO
+c$$$        L=L+J
+c$$$   70 CONTINUE
+c$$$c
+c$$$c      End of row.
+c$$$c
+c$$$   80 NDIAG=NDIAG-IROW
+c$$$      IROW=IROW-1
+c$$$      IF(IROW.NE.0) GO TO 10
+c$$$  100 RETURN
+c$$$      END
+c$$$
+c$$$
+c$$$
+c$$$
+c$$$
+c$$$      SUBROUTINE CHOLA(A, N, U, NULLTY, IFAULT, RMAX, R)
+c$$$C
+c$$$C     ALGORITHM AS6, APPLIED STATISTICS, VOL.17, 1968, WITH
+c$$$C     MODIFICATIONS BY A.J.MILLER
+c$$$C
+c$$$C     ARGUMENTS:-
+c$$$C     A()     = INPUT, A +VE DEFINITE MATRIX STORED IN LOWER-TRIANGULAR
+c$$$C               FORM.
+c$$$C     N       = INPUT, THE ORDER OF A
+c$$$C     U()     = OUTPUT, A LOWER TRIANGULAR MATRIX SUCH THAT U*U' = A.
+c$$$C               A & U MAY OCCUPY THE SAME LOCATIONS.
+c$$$C     NULLTY  = OUTPUT, THE RANK DEFICIENCY OF A.
+c$$$C     IFAULT  = OUTPUT, ERROR INDICATOR
+c$$$C                     = 1 IF N < 1
+c$$$C                     = 2 IF A IS NOT +VE SEMI-DEFINITE
+c$$$C                     = 0 OTHERWISE
+c$$$C     RMAX    = OUTPUT, AN ESTIMATE OF THE RELATIVE ACCURACY OF THE
+c$$$C               DIAGONAL ELEMENTS OF U.
+c$$$C     R()     = OUTPUT, ARRAY CONTAINING BOUNDS ON THE RELATIVE ACCURACY
+c$$$C               OF EACH DIAGONAL ELEMENT OF U.
+c$$$C
+c$$$C     LATEST REVISION - 18 October 1985
+c$$$C
+c$$$C*************************************************************************
+c$$$C
+c$$$      implicit double precision (a-h, o-z)
+c$$$      DIMENSION A(*),U(*),R(N)
+c$$$C
+c$$$C     ETA SHOULD BE SET EQUAL TO THE SMALLEST +VE VALUE SUCH THAT
+c$$$C     1.0 + ETA IS CALCULATED AS BEING GREATER THAN 1.0 IN THE ACCURACY
+c$$$C     BEING USED.
+c$$$C
+c$$$      DATA ETA/1.D-16/, ZERO/0.D0/, FIVE/5.D0/
+c$$$C
+c$$$      IFAULT=1
+c$$$      IF(N.LE.0) GO TO 100
+c$$$      IFAULT=2
+c$$$      NULLTY=0
+c$$$      RMAX=ETA
+c$$$      R(1)=ETA
+c$$$      J=1
+c$$$      K=0
+c$$$C
+c$$$C     FACTORIZE COLUMN BY COLUMN, ICOL = COLUMN NO.
+c$$$C
+c$$$      DO 80 ICOL=1,N
+c$$$        L=0
+c$$$C
+c$$$C     IROW = ROW NUMBER WITHIN COLUMN ICOL
+c$$$C
+c$$$        DO 40 IROW=1,ICOL
+c$$$          K=K+1
+c$$$          W=A(K)
+c$$$          IF(IROW.EQ.ICOL) RSQ=(W*ETA)**2
+c$$$          M=J
+c$$$          DO 10 I=1,IROW
+c$$$            L=L+1
+c$$$            IF(I.EQ.IROW) GO TO 20
+c$$$            W=W-U(L)*U(M)
+c$$$            IF(IROW.EQ.ICOL) RSQ=RSQ+(U(L)**2*R(I))**2
+c$$$            M=M+1
+c$$$   10     CONTINUE
+c$$$   20     IF(IROW.EQ.ICOL) GO TO 50
+c$$$          IF(U(L).EQ.ZERO) GO TO 30
+c$$$          U(K)=W/U(L)
+c$$$          GO TO 40
+c$$$   30     U(K)=ZERO
+c$$$          IF(ABS(W).GT.ABS(RMAX*A(K))) GO TO 100
+c$$$   40   CONTINUE
+c$$$C
+c$$$C     END OF ROW, ESTIMATE RELATIVE ACCURACY OF DIAGONAL ELEMENT.
+c$$$C
+c$$$   50   RSQ=SQRT(RSQ)
+c$$$        IF(ABS(W).LE.FIVE*RSQ) GO TO 60
+c$$$        IF(W.LT.ZERO) GO TO 100
+c$$$        U(K)=SQRT(W)
+c$$$        R(I)=RSQ/W
+c$$$        IF(R(I).GT.RMAX) RMAX=R(I)
+c$$$        GO TO 70
+c$$$   60   U(K)=ZERO
+c$$$        NULLTY=NULLTY+1
+c$$$   70   J=J+ICOL
+c$$$   80 CONTINUE
+c$$$      IFAULT=0
+c$$$C
+c$$$  100 RETURN
+c$$$      END
+c$$$
+c
+c http://lib.stat.cmu.edu/apstat/47
+c

--- a/sherpa/optmethods/src/minim.hh
+++ b/sherpa/optmethods/src/minim.hh
@@ -5,6 +5,7 @@
 
 #include "Opt.hh"
 #include "sherpa/myArray.hh"
+#include "sherpa/syminv.hh"
 
 namespace sherpa {
 
@@ -38,10 +39,16 @@ namespace sherpa {
       return;
     }
 
-  private:
+  protected:
 
     Func usr_func;
     Data usr_data;
+
+    virtual void check_limits( sherpa::Array2d<real>& G, int I, int IROW,
+                               const std::vector<real>& lb,
+                               const std::vector<real>& ub ) {
+      return;
+    }
 
     //
     // minim has over expanded beyond a free parameter's boundary, need
@@ -67,7 +74,7 @@ namespace sherpa {
 
     }
 
-    void eval_usr_func( int npar, std::vector<real>& par, real& fval,
+    virtual void eval_usr_func( int npar, std::vector<real>& par, real& fval,
                         const sherpa::Bounds<real>& limits ) {
       reflect_about_boundary( npar, par, limits );
       int ierr = EXIT_SUCCESS;
@@ -76,116 +83,6 @@ namespace sherpa {
 	throw sherpa::OptErr( sherpa::OptErr::UsrFunc );
     }
 
-    void CHOLA(std::vector<real>& A, int N, std::vector<real>& U,
-               int& NULLTY, int& IFAULT, real& RMAX, std::vector<real>& R) {
-      //C
-      //C     ALGORITHM AS6, APPLIED STATISTICS, VOL.17, 1968, WITH
-      //C     MODIFICATIONS BY A.J.MILLER
-      //C
-      //C     ARGUMENTS:-
-      //C     A()     = INPUT, A +VE DEFINITE MATRIX STORED IN LOWER-TRIANGULAR
-      //C               FORM.
-      //C     N       = INPUT, THE ORDER OF A
-      //C     U()     = OUTPUT, A LOWER TRIANGULAR MATRIX SUCH THAT U*U' = A.
-      //C               A & U MAY OCCUPY THE SAME LOCATIONS.
-      //C     NULLTY  = OUTPUT, THE RANK DEFICIENCY OF A.
-      //C     IFAULT  = OUTPUT, ERROR INDICATOR
-      //C                     = 1 IF N < 1
-      //C                     = 2 IF A IS NOT +VE SEMI-DEFINITE
-      //C                     = 0 OTHERWISE
-      //C     RMAX    = OUTPUT, AN ESTIMATE OF THE RELATIVE ACCURACY OF THE
-      //C               DIAGONAL ELEMENTS OF U.
-      //C     R()     = OUTPUT, ARRAY CONTAINING BOUNDS ON THE RELATIVE ACCURACY
-      //C               OF EACH DIAGONAL ELEMENT OF U.
-      //C
-      //C     LATEST REVISION - 18 October 1985
-      //C
-      //C*************************************************************************
-      //C
-      // implicit double(a - h, o - z)
-      //DIMENSION A(*), U(*), R(N)
-      //C
-      //C     ETA SHOULD BE SET EQUAL TO THE SMALLEST +VE VALUE SUCH THAT
-      //C     1.0 + ETA IS CALCULATED AS BEING GREATER THAN 1.0 IN THE ACCURACY
-      //C     BEING USED.
-      //C
-      // DATA ETA/1.D - 16/, ZERO/0.D0/, FIVE/5.D0/;
-      //C
-      const real ETA = std::numeric_limits<real>::epsilon();
-      const real ZERO = 0.0;
-      const real FIVE = 5.0;
-      real RSQ = 0.0;
-      real W = 0.0;
-      int I=0, J, K;
-
-      IFAULT = 1;
-      if (N <= 0) goto g100;
-      IFAULT = 2;
-      NULLTY = 0;
-      RMAX = ETA;
-      R[0] = ETA;
-      J = 1;
-      K = 0;
-      //C
-      //C     FACTORIZE COLUMN BY COLUMN, ICOL = COLUMN NO.
-      //C
-      for(int ICOL=1; ICOL<=N; ICOL++) {
-        int L = 0;
-        //C
-        //C     IROW = ROW NUMBER WITHIN COLUMN ICOL
-        //C
-        for(int IROW=1; IROW<=ICOL; IROW++) {
-          K = K + 1;
-          W = A[K-1];
-          if (IROW == ICOL)
-            // RSQ = (W*ETA)**2;
-            RSQ = pow(W*ETA, 2);
-          int M = J;
-          for(I=1; I<=IROW; I++) {
-            L = L + 1;
-            if (I == IROW) goto g20;
-            W = W - U[L-1]*U[M-1];
-            if (IROW == ICOL)
-              // RSQ = RSQ + (U[L]**2*R[I])**2;
-              RSQ += pow(U[L-1]*U[L-1]*R[I-1], 2.0);
-            M = M + 1;
-          }
-        g20:
-          if (IROW == ICOL) goto g50;
-          if (U[L-1] == ZERO) goto g30;
-          U[K-1] = W/U[L-1];
-          goto g40;
-        g30:
-          U[K-1] = ZERO;
-          if (fabs(W) > fabs(RMAX*A[K-1])) goto g100;
-        g40:
-          ;
-        }
-        //C
-        //C     END OF ROW, ESTIMATE RELATIVE ACCURACY OF DIAGONAL ELEMENT.
-        //C
-      g50:
-        RSQ = sqrt(RSQ);
-        if (fabs(W) <= FIVE*RSQ) goto g60;
-        if (W < ZERO) goto g100;
-        U[K-1] = sqrt(W);
-        R[I-1] = RSQ/W;
-        if (R[I-1] > RMAX) RMAX = R[I-1];
-        goto g70;
-      g60:
-        U[K-1] = ZERO;
-        NULLTY = NULLTY + 1;
-      g70:
-        J = J + ICOL;
-      }
-      IFAULT = 0;
-      //C
-    g100:
-      return;
-    }
-    //c
-    //c http://lib.stat.cmu.edu/apstat/47
-    //c
 
     void MINIM( std::vector<real>& P, const std::vector<real>& STEP,
                 int NOP, real& FUNC, int MAXNFEV, int IPRINT, real STOPCR,
@@ -285,6 +182,8 @@ namespace sherpa {
       int LOOP, NAP, NP1, NULLTY, IRANK;
       real FNP1, FNAP, HMAX, HMEAN, HMIN, HSTAR, HSTD, HSTST, SAVEMN=0, TEST;
       real A0, RMAX, YMIN;
+      const std::vector<real>& lb = LIMITS.get_lb();
+      const std::vector<real>& ub = LIMITS.get_ub();
 
       const int NLOOP = 1;
       const real ZERO = 0.;
@@ -300,7 +199,7 @@ namespace sherpa {
       //C     IF PROGRESS REPORTS HAVE BEEN REQUESTED, PRINT HEADING
       //C
       if ( IPRINT > 0 )
-        std::cout << "PROGRESS REPORT EVERY " << IPRINT << " FUNCTION EVALUATIONS";
+        std::cout << "PROGRESS REPORT EVERY " << IPRINT << " FUNCTION EVALUATIONS\n";
       //C
       //C     CHECK INPUT ARGUMENTS
       //C
@@ -338,7 +237,7 @@ namespace sherpa {
           }
           G[IROW-1][I-1] = P[I-1] + STEP[I-1];
           //c     --dtn
-          //c        g(irow,i) = dmax1(lb(i),dmin1(g(irow,i),ub(i)))
+          check_limits(G, I, IROW, lb, ub);
           //c     --dtn
           IROW = IROW + 1;
         }
@@ -700,7 +599,7 @@ namespace sherpa {
       //C
       //C     INVERT BMAT
       //C
-      SYMINV(BMAT, NAP, BMAT, TEMP, NULLTY, IFAULT, RMAX);
+      appliedstats::SYMINV(BMAT, NAP, BMAT, TEMP, NULLTY, IFAULT, RMAX);
       if (IFAULT != 0) goto g600;
       IRANK = NAP - NULLTY;
       goto g610;
@@ -823,7 +722,7 @@ namespace sherpa {
           "IF THE FUNCTION WAS A SUM OF SQUARES OF RESIDUALS\n"
           "THIS MATRIX MUST BE MULTIPLIED BY TWICE THE ESTIMATED "
           "RESIDUAL VARIANCE\nTO OBTAIN THE COVARIANCE MATRIX.\n";
-      SYMINV(VC, NAP, BMAT, TEMP, NULLTY, IFAULT, RMAX);
+      appliedstats::SYMINV(VC, NAP, BMAT, TEMP, NULLTY, IFAULT, RMAX);
       //C
       //C     BMAT NOW CONTAINS THE INFORMATION MATRIX
       //C
@@ -903,107 +802,6 @@ namespace sherpa {
       goto g890;
     }
 
-    void SYMINV(std::vector<real>& A, int N, std::vector<real>& C,
-                std::vector<real>& W, int& NULLTY, int& IFAULT, real& RMAX) {
-      //C
-      //C     ALGORITHM AS7, APPLIED STATISTICS, VOL.17, 1968.
-      //C
-      //C     ARGUMENTS:-
-      //C     A()     = INPUT, THE SYMMETRIC MATRIX TO BE INVERTED, STORED IN
-      //C               LOWER TRIANGULAR FORM
-      //C     N       = INPUT, ORDER OF THE MATRIX
-      //C     C()     = OUTPUT, THE INVERSE OF A (A GENERALIZED INVERSE IF C IS
-      //C               SINGULAR), ALSO STORED IN LOWER TRIANGULAR.
-      //C               C AND A MAY OCCUPY THE SAME LOCATIONS.
-      //C     W()     = WORKSPACE, DIMENSION AT LEAST N.
-      //C     NULLTY  = OUTPUT, THE RANK DEFICIENCY OF A.
-      //C     IFAULT  = OUTPUT, ERROR INDICATOR
-      //C                     = 1 IF N < 1
-      //C                     = 2 IF A IS NOT +VE SEMI-DEFINITE
-      //C                     = 0 OTHERWISE
-      //C     RMAX    = OUTPUT, APPROXIMATE BOUND ON THE ACCURACY OF THE DIAGONAL
-      //C               ELEMENTS OF C.  E.G. IF RMAX = 1.E-04 THEN THE DIAGONAL
-      //C               ELEMENTS OF C WILL BE ACCURATE TO ABOUT 4 DEC. DIGITS.
-      //C
-      //C     LATEST REVISION - 18 October 1985
-      //C
-      //C*************************************************************************
-      //C
-      // implicit double(a - h, o - z)
-      //DIMENSION A(*), C(*), W(N)
-      // DATA ZERO/0.D0/, ONE/1.D0/;
-      //C
-      const real ZERO = 0.0;
-      const real ONE = 1.0;
-      int I, J, K, L;
-      real X;
-      int NN, ICOL, JCOL, IROW, NROW, MDIAG, NDIAG;
-      NROW = N;
-      IFAULT = 1;
-      if (NROW <= 0) goto g100;
-      IFAULT = 0;
-      //C
-      //C     CHOLESKY FACTORIZATION OF A, RESULT IN C
-      //C
-      CHOLA(A, NROW, C, NULLTY, IFAULT, RMAX, W);
-      if (IFAULT != 0) goto g100;
-      //C
-      //C     INVERT C & FORM THE PRODUCT (CINV)'*CINV, WHERE CINV IS THE INVERSE
-      //C     OF C, ROW BY ROW STARTING WITH THE LAST ROW.
-      //C     IROW = THE ROW NUMBER, NDIAG = LOCATION OF LAST ELEMENT IN THE ROW.
-      //C
-      NN = NROW*(NROW + 1)/2;
-      IROW = NROW;
-      NDIAG = NN;
-    g10:
-      if (C[NDIAG-1] == ZERO) goto g60;
-      L = NDIAG;
-      for(I=IROW; I<=NROW; I++) {
-        W[I-1] = C[L-1];
-        L = L + I;
-      }
-      ICOL = NROW;
-      JCOL = NN;
-      MDIAG = NN;
-    g30:
-      L = JCOL;
-      X = ZERO;
-      if (ICOL == IROW) X = ONE/W[IROW-1];
-      K = NROW;
-    g40:
-      if (K == IROW) goto g50;
-      X = X - W[K-1]*C[L-1];
-      K = K - 1;
-      L = L - 1;
-      if (L > MDIAG) L = L - K + 1;
-      goto g40;
-    g50:
-      C[L-1] = X/W[IROW-1];
-      if (ICOL == IROW) goto g80;
-      MDIAG = MDIAG - ICOL;
-      ICOL = ICOL - 1;
-      JCOL = JCOL - 1;
-      goto g30;
-      //c
-      //c     Special case, zero diagonal element.
-      //c
-    g60:
-      L = NDIAG;
-      for(J=IROW; J<=NROW; J++) {
-        C[L-1] = ZERO;
-        L = L + J;
-      }
-      //c
-      //c      End of row.
-      //c
-    g80:
-      NDIAG = NDIAG - IROW;
-      IROW = IROW - 1;
-      if (IROW != 0) goto g10;
-    g100:
-      return;
-    };
-
     void print_par( int nop, const std::vector<real>& p, const real& fval ) {
       std::cout << "f(" << p[0];
       for ( int jj = 1; jj < nop; ++jj )
@@ -1017,7 +815,32 @@ namespace sherpa {
       print_par( nop, p, fval );
     }
 
+  }; // class Minim
 
-  };
+  template<typename Func, typename Data, typename real>
+  class MinimNoReflect : public Minim< Func, Data, real > {
+
+  public:
+
+    MinimNoReflect( Func func, Data xdata ) : Minim<Func, Data, real>( func, xdata ) { }
+
+  protected:
+
+    virtual void check_limits( sherpa::Array2d<real>& G, int I, int IROW,
+                               const std::vector<real>& lb,
+                               const std::vector<real>& ub ) {
+      G[IROW-1][I-1] = std::max(lb[I-1], std::min(G[IROW-1][I-1], ub[I-1]));
+      return;
+    }
+
+    virtual void eval_usr_func( int npar, std::vector<real>& par, real& fval,
+                                const sherpa::Bounds<real>& limits ) {
+      int ierr = EXIT_SUCCESS;
+      this->usr_func( npar, &par[0], fval, ierr, Minim<Func, Data, real>::usr_data );
+      if ( EXIT_SUCCESS != ierr )
+	throw sherpa::OptErr( sherpa::OptErr::UsrFunc );
+    }
+
+  }; // class MinimNoReflect
 
 }

--- a/sherpa/optmethods/src/syminv.f
+++ b/sherpa/optmethods/src/syminv.f
@@ -1,0 +1,189 @@
+      subroutine syminv(a,n,c,w,nullty,ifault,rmax)
+c
+c     algorithm as7, applied statistics, vol.17, 1968.
+c
+c     arguments:-
+c     a()     = input, the symmetric matrix to be inverted, stored in
+c               lower triangular form
+c     n       = input, order of the matrix
+c     c()     = output, the inverse of a (a generalized inverse if c is
+c               singular), also stored in lower triangular.
+c               c and a may occupy the same locations.
+c     w()     = workspace, dimension at least n.
+c     nullty  = output, the rank deficiency of a.
+c     ifault  = output, error indicator
+c                     = 1 if n < 1
+c                     = 2 if a is not +ve semi-definite
+c                     = 0 otherwise
+c     rmax    = output, approximate bound on the accuracy of the diagonal
+c               elements of c.  e.g. if rmax = 1.e-04 then the diagonal
+c               elements of c will be accurate to about 4 dec. digits.
+c
+c     latest revision - 18 october 1985
+c
+c*************************************************************************
+c
+      integer*4 ifault,n,nullty
+      real*8 a(*),c(*),rmax,w(n)
+
+      integer*4 i,icol,irow,j,jcol,k,l,mdiag,ndiag,nn,nrow
+      real*8 one,x,zero
+      data zero/0.d0/, one/1.d0/
+c
+      nrow=n
+      ifault=1
+      if(nrow.le.0) go to 100
+      ifault=0
+c
+c     cholesky factorization of a, result in c
+c
+      call chola(a,nrow,c,nullty,ifault,rmax,w)
+      if(ifault.ne.0) go to 100
+c
+c     invert c & form the product (cinv)'*cinv, where cinv is the inverse
+c     of c, row by row starting with the last row.
+c     irow = the row number, ndiag = location of last element in the row.
+c
+      nn=nrow*(nrow+1)/2
+      irow=nrow
+      ndiag=nn
+   10 if(c(ndiag).eq.zero) go to 60
+      l=ndiag
+      do 20 i=irow,nrow
+        w(i)=c(l)
+        l=l+i
+   20 continue
+      icol=nrow
+      jcol=nn
+      mdiag=nn
+   30 l=jcol
+      x=zero
+      if(icol.eq.irow) x=one/w(irow)
+      k=nrow
+   40 if(k.eq.irow) go to 50
+      x=x-w(k)*c(l)
+      k=k-1
+      l=l-1
+      if(l.gt.mdiag) l=l-k+1
+      go to 40
+   50 c(l)=x/w(irow)
+      if(icol.eq.irow) go to 80
+      mdiag=mdiag-icol
+      icol=icol-1
+      jcol=jcol-1
+      go to 30
+c
+c     special case, zero diagonal element.
+c
+   60 l=ndiag
+      do 70 j=irow,nrow
+        c(l)=zero
+        l=l+j
+   70 continue
+c
+c      end of row.
+c
+   80 ndiag=ndiag-irow
+      irow=irow-1
+      if(irow.ne.0) go to 10
+  100 return
+      end
+
+
+
+
+
+      subroutine chola(a, n, u, nullty, ifault, rmax, r)
+c
+c     algorithm as6, applied statistics, vol.17, 1968, with
+c     modifications by a.j.miller
+c
+c     arguments:-
+c     a()     = input, a +ve definite matrix stored in lower-triangular
+c               form.
+c     n       = input, the order of a
+c     u()     = output, a lower triangular matrix such that u*u' = a.
+c               a & u may occupy the same locations.
+c     nullty  = output, the rank deficiency of a.
+c     ifault  = output, error indicator
+c                     = 1 if n < 1
+c                     = 2 if a is not +ve semi-definite
+c                     = 0 otherwise
+c     rmax    = output, an estimate of the relative accuracy of the
+c               diagonal elements of u.
+c     r()     = output, array containing bounds on the relative accuracy
+c               of each diagonal element of u.
+c
+c     latest revision - 18 october 1985
+c
+c*************************************************************************
+c
+      integer*4 ifault,n,nullty
+      real*8 a(*),u(*),r(n),rmax
+c
+c     eta should be set equal to the smallest +ve value such that
+c     1.0 + eta is calculated as being greater than 1.0 in the accuracy
+c     being used.
+c
+      integer*4 i,icol,irow,j,k,l,m
+      real*8 eta,five,rsq,w,zero
+      data eta/1.d-16/, zero/0.d0/, five/5.d0/
+
+      i=0
+      rsq=0.0d0
+      w=0.0d0
+c
+      ifault=1
+      if(n.le.0) go to 100
+      ifault=2
+      nullty=0
+      rmax=eta
+      r(1)=eta
+      j=1
+      k=0
+c
+c     factorize column by column, icol = column no.
+c
+      do 80 icol=1,n
+        l=0
+c
+c     irow = row number within column icol
+c
+        do 40 irow=1,icol
+          k=k+1
+          w=a(k)
+          if(irow.eq.icol) rsq=(w*eta)**2
+          m=j
+          do 10 i=1,irow
+            l=l+1
+            if(i.eq.irow) go to 20
+            w=w-u(l)*u(m)
+            if(irow.eq.icol) rsq=rsq+(u(l)**2*r(i))**2
+            m=m+1
+   10     continue
+   20     if(irow.eq.icol) go to 50
+          if(u(l).eq.zero) go to 30
+          u(k)=w/u(l)
+          go to 40
+   30     u(k)=zero
+          if(abs(w).gt.abs(rmax*a(k))) go to 100
+   40   continue
+c
+c     end of row, estimate relative accuracy of diagonal element.
+c
+   50   rsq=sqrt(rsq)
+        if(abs(w).le.five*rsq) go to 60
+        if(w.lt.zero) go to 100
+        u(k)=sqrt(w)
+        r(i)=rsq/w
+        if(r(i).gt.rmax) rmax=r(i)
+        go to 70
+   60   u(k)=zero
+        nullty=nullty+1
+   70   j=j+icol
+   80 continue
+      ifault=0
+c
+  100 return
+      end
+

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020, 2021
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -47,6 +47,15 @@ def tst_opt(opt, fct, npar, reltol=1.0e-3, abstol=1.0e-3):
         assert xtra.get('num_parallel_map') != 0
 
 ###############################################################################
+
+def test_minim_no_reflect(reltol=1.0e-3, abstol=1.0e-3):
+    fct = _tstoptfct.Colville
+    wrong_fval = 174.28569111739617
+    x0, xmin, xmax, fmin = init( fct.__name__, 4)
+    status, x, fval, msg, xtra = minim(fct, x0, xmin, xmax, reflect=False)
+    assert fval == pytest.approx(wrong_fval, rel=reltol, abs=abstol)
+    assert fmin != wrong_fval
+
 @pytest.mark.parametrize("opt", [lmdif, minim, montecarlo, neldermead])
 def test_rosenbrock(opt, npar=4):
     tst_opt(opt, _tstoptfct.rosenbrock, npar)


### PR DESCRIPTION
# Note

This PR restores the Fortran version of minim and changes how the parameter boundary violations in the C/C++ version of minim are done (from reflecting about the limits to stopping at the limits).

It turns out the translation of the C/C++ version of minim was done correctly, after all it has been used for quite a while now; However, in the process of translating to the C/C++ version the violation of the parameter boundary limits were changed to reflection about the limits. As an aside, there was a discussion about making the option of how neldermead handles the boundary conditions available for future releases since the fitted results depend on how the boundary conditions are handled.

# User's guide:

To use the Fortran version of minim, the user should set the neldermead option useminimC from the default value of True to False. The L3 variability pipeline should use this option if the Fortran version is to be used.

To use the C/C++ version of minim, the user has two options:

To get identical results as the Fortran version of minim, change the neldermead default value of reflect from True to False. The L3 variability pipeline should use this option if the C/C++ version is to be used.
To use neldermead as the ciao412, then do not change the options useminimC nor reflect. The rest of the L3 scripts, ie non-variabilty pipelines, should use this option.