### PR TITLE
XSPEC 12.12.0 support

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -256,7 +256,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.11.1 down to 12.9.0. It may build against
+:term:`XSPEC` versions 12.12.0 down to 12.9.0. It may build against
 newer versions, but if it does it will not provide access to any new
 models in the release. The following sections of the `XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.11.1, 12.11.0, 12.10.1 (patch level `a`
-       or later), 12.10.0, 12.9.1, or 12.9.0.
+       Sherpa can be built to use XSPEC versions 12.12.0, 12.11.1, 12.11.0,
+       12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, or 12.9.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -50,8 +50,8 @@ if installed:
 The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
 functions from the :term:`XSPEC`.
-The supported versions of XSPEC are 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later),
-12.10.0, 12.9.1, and 12.9.0.
+The supported versions of XSPEC are 12.12.0, 12.11.1, 12.11.0,
+12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, and 12.9.0.
 
 Interactive display and manipulation of two-dimensional images
 is available if the :term:`DS9` image viewer and the :term:`XPA`
@@ -214,7 +214,7 @@ XSPEC
    to support changes made in XSPEC 12.10.0.
 
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC` versions 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
+:term:`XSPEC` versions 12.12.0, 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
 12.9.1, and 12.9.0. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
@@ -242,10 +242,23 @@ the XSPEC model library or the full XSPEC system has been installed.
 
 In the examples below, the ``$HEADAS`` value **must be replaced**
 by the actual path to the HEADAS installation, and the versions of
-the libraries - such as ``CCfits_2.5`` - may need to be changed to
+the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.11.1 system has been built then use::
+1. If the full XSPEC 12.12.0 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.12.0
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.29
+       ccfits_libraries = CCfits_2.6
+       wcslib_libraries = wcs-7.3.1
+
+   where the version numbers were taken from version 6.29 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.11.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.1
@@ -255,10 +268,9 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.19.1
 
-   where the version numbers were taken from version 6.28 of HEASOFT and
-   may need updating with a newer release.
+   where the version numbers were taken from version 6.28 of HEASOFT.
 
-2. If the full XSPEC 12.11.0 system has been built then use::
+3. If the full XSPEC 12.11.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.0
@@ -268,10 +280,9 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.19.1
 
-   where the version numbers were taken from version 6.27 of HEASOFT and
-   may need updating with a newer release.
+   where the version numbers were taken from version 6.27 of HEASOFT.
 
-3. If the full XSPEC 12.10.1 system has been built then use::
+4. If the full XSPEC 12.10.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.1
@@ -281,10 +292,9 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.19.1
 
-   where the version numbers were taken from version 6.26.1 of HEASOFT and
-   may need updating with a newer release.
+   where the version numbers were taken from version 6.26.1 of HEASOFT.
 
-4. If the full XSPEC 12.10.0 system has been built then use::
+5. If the full XSPEC 12.10.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.0
@@ -294,7 +304,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
 
-5. If the full XSPEC 12.9.x system has been built then use::
+6. If the full XSPEC 12.9.x system has been built then use::
 
        with-xspec = True
        xspec_version = 12.9.1
@@ -306,7 +316,7 @@ match the contents of the XSPEC installation.
 
    changing ``12.9.1`` to ``12.9.0`` as appropriate.
 
-6. If the model-only build of XSPEC has been installed, then
+7. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may
    not need version numbers and locations, depending on how the
    ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
@@ -334,14 +344,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.11.1
-
-.. warning::
-
-   The ``--enable-xs-models-only`` flag with XSPEC 12.10.0 is known
-   to cause problems for Sherpa. It is **strongly recommended** that
-   either that the full XSPEC distribution is built, or that the
-   XSPEC installation from CIAO 4.11 is used.
+    12.12.0
 
 Other options
 ^^^^^^^^^^^^^

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -16,6 +16,8 @@ are described in :doc:`astro_xspec`.
    .. autosummary::
       :toctree: api
 
+      XSBaseParameter
+      XSParameter
       XSModel
       XSAdditiveModel
       XSMultiplicativeModel
@@ -49,5 +51,5 @@ are described in :doc:`astro_xspec`.
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSModel XSAdditiveModel XSMultiplicativeModel XSConvolutionKernel XSConvolutionModel XSTableModel
+.. inheritance-diagram:: XSBaseParameter XSParameter XSModel XSAdditiveModel XSMultiplicativeModel XSConvolutionKernel XSConvolutionModel XSTableModel
    :parts: 1

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2014-2017, 2018, 2020
-#       Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014-2017, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,9 +17,6 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
-import sys
-import os
 
 from distutils.version import LooseVersion
 from distutils.cmd import Command
@@ -107,16 +104,19 @@ class xspec_config(Command):
                 #
                 for major, minor, patch in [(12, 9, 0), (12, 9, 1),
                                             (12, 10, 0), (12, 10, 1),
-                                            (12, 11, 0), (12, 11, 1)]:
+                                            (12, 11, 0), (12, 11, 1),
+                                            (12, 12, 0)]:
                     version = '{}.{}.{}'.format(major, minor, patch)
                     macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
                     if xspec_version >= LooseVersion(version):
                         macros += [(macro, None)]
 
-                # Since there are patches (e.g. 12.10.0c), look for the
-                # "next highest version.
-                if xspec_version >= LooseVersion("12.11.2"):
-                    self.warn("XSPEC Version is greater than 12.11.1, which is the latest supported version for Sherpa")
+                # Since there are patches (e.g. 12.10.0c), look for
+                # the "next highest" version (i.e. increase the
+                # "patch" value by 1).
+                #
+                if xspec_version >= LooseVersion("12.12.1"):
+                    self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
 
             extension = build_ext('xspec', ld, inc, l, define_macros=macros)
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9682,12 +9682,12 @@ class Session(sherpa.ui.utils.Session):
     def load_xstable_model(self, modelname, filename, etable=False):
         """Load a XSPEC table model.
 
-        Create an additive (``atable``, [1]_), multiplicative
-        (``mtable``, [2]_), or exponential (``etable``, [3]_) XSPEC
+        Create an additive ('atable', [1]_), multiplicative
+        ('mtable', [2]_), or exponential ('etable', [3]_) XSPEC
         table model component. These models may have multiple model
         parameters.
 
-        .. versionchanged:: 4.13.2
+        .. versionchanged:: 4.14.0
            The etable argument has been added to allow exponential table
            models to be used.
 
@@ -9745,7 +9745,7 @@ class Session(sherpa.ui.utils.Session):
         >>> set_source(xsphabs.gal * xtbl)
         >>> print(xtbl)
 
-        Load in an XSPEC etable model
+        Load in an XSPEC etable model:
 
         >>> load_xstable_model('etbl', 'etable.mod', etable=True)
 

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -352,7 +352,7 @@ kT      keV     1.    0.008   0.008   64.0      64.0      .01
     assert 'class XSapec(XSAdditiveModel):' in python
     assert '    _calc = _models.C_apec' in python
     assert "    def __init__(self, name='apec'):" in python
-    assert "        self.kT = Parameter(name, 'kT', 1.0, min=0.008, max=64.0, hard_min=0.008, hard_max=64.0, units='keV')" in python
+    assert "        self.kT = XSParameter(name, 'kT', 1.0, min=0.008, max=64.0, hard_min=0.008, hard_max=64.0, units='keV')" in python
     assert "        self.norm = Parameter(name, 'norm', 1.0, min=0.0, max=1e+24, hard_min=0.0, hard_max=1e+24)" in python
     assert '        XSAdditiveModel.__init__(self, name, (self.kT,self.norm))' in python
 
@@ -379,7 +379,7 @@ nH      cm^-3   1.0   1.e-6  1.e-5  1.e19  1.e20   -0.01
     assert 'class XSabcd(XSMultiplicativeModel):' in python
     assert '    _calc = _models.foos' in python
     assert "    def __init__(self, name='abcd'):" in python
-    assert "        self.nH = Parameter(name, 'nH', 1.0, min=1e-05, max=1e+19, hard_min=1e-06, hard_max=1e+20, frozen=True, units='cm^-3')" in python
+    assert "        self.nH = XSParameter(name, 'nH', 1.0, min=1e-05, max=1e+19, hard_min=1e-06, hard_max=1e+20, frozen=True, units='cm^-3')" in python
     assert '        XSMultiplicativeModel.__init__(self, name, (self.nH,))' in python
 
     assert '  void foos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);' in compiled
@@ -405,7 +405,7 @@ order    " "  -1.   -3.    -3.      -1.       -1.       -1
     assert 'class XSrgsxsrc(XSConvolutionKernel):' in python
     assert '    _calc = _models.rgsxsrc' in python
     assert "    def __init__(self, name='rgsxsrc'):" in python
-    assert "        self.order = Parameter(name, 'order', -1.0, min=-3.0, max=-1.0, hard_min=-3.0, hard_max=-1.0, frozen=True)" in python
+    assert "        self.order = XSParameter(name, 'order', -1.0, min=-3.0, max=-1.0, hard_min=-3.0, hard_max=-1.0, frozen=True)" in python
     assert '        XSConvolutionKernel.__init__(self, name, (self.order,))' in python
 
     assert '  void rgsxsrc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);' in compiled

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -258,7 +258,7 @@ class ParameterDefinition():
         return f"{self.name} = {self.default}"
 
     def param_string(self):
-        out = f"Parameter(name, '{self.name}', {self.default}"
+        out = f"XSParameter(name, '{self.name}', {self.default}"
 
         for (pval, pname) in [(self.softmin, "min"),
                               (self.softmax, "max"),
@@ -351,7 +351,21 @@ class BasicParameterDefinition(ParameterDefinition):
         return out
 
     def param_string(self):
-        out = f"Parameter(name, '{self.name}', {self.default}, "
+
+        # We need to decide between
+        #   XSParameter
+        #   XSBaseParameter
+        #   Parameter
+        #
+        # For this case we don't need to bother with XSBaseParameter
+        # and Parameter is only for the norm parameter.
+        #
+        if self.name == 'norm':
+            out = "Parameter"
+        else:
+            out = "XSParameter"
+
+        out += f"(name, '{self.name}', {self.default}, "
         out += f"min={self.softmin}, max={self.softmax}, "
         out += f"hard_min={self.hardmin}, hard_max={self.hardmax}"
         if self.frozen:

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -12201,7 +12201,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     Attributes
     ----------
-    nH
+    Nh
         The column density, in units of 10^22 cm^2.
     log_xi
         The log of xi: see [1]_ for more details.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -42,13 +42,13 @@ are set to H_0=70, q_0=0.0, and lambda_0=0.73 (they can be changed with
 
 The other settings - for example for the abundance and cross-section
 tables - follow the standard rules for XSPEC. For XSPEC versions prior
-to 12.10.1, this means that the abundance table uses the ``angr``
-setting and the cross sections the ``bcmc`` setting (see `set_xsabund`
+to 12.10.1, this means that the abundance table uses the 'angr'
+setting and the cross sections the 'bcmc' setting (see `set_xsabund`
 and `set_xsxsect` for full details). As of XSPEC 12.10.1, the values
 are now taken from the user's XSPEC configuration file - either
 ``~/.xspec/Xspec.init`` or ``$HEADAS/../spectral/manager/Xspec.init`` -
 for these settings. The default value for the photo-ionization table
-in this case is now ``vern`` rather than ``bcmc``.
+in this case is now 'vern' rather than 'bcmc'.
 
 The default chatter setting - used by models to inform users of
 issues - was set to 0 (which hid the messages) until Sherpa 4.14.0,
@@ -136,7 +136,7 @@ def get_xsabund(element=None):
     Returns
     -------
     val : str or float
-       When ``element`` is ``None``, the abundance table name is
+       When `element` is `None`, the abundance table name is
        returned (see `set_xsabund`); the string 'file' is used
        when the abundances were read from a file. A numeric value
        is returned when an element name is given. This value is the
@@ -573,7 +573,7 @@ def set_xsxset(name, value):
     `set_xschatter` if it is not clear if a setting is being used.
 
     The model settings are stored so that they can be included in the
-    output of `sherpa.astro.ui.utils.save_all`.
+    output of `sherpa.astro.ui.save_all`.
 
     References
     ----------
@@ -771,7 +771,7 @@ def read_xstable_model(modelname, filename, etable=False):
     XSPEC additive (atable, [1]_), multiplicative (mtable, [2]_), and
     exponential (etable, [3]_) table models are supported.
 
-    .. versionchanged:: 4.13.2
+    .. versionchanged:: 4.14.0
        The etable argument has been added to allow exponential table
        models to be used.
 
@@ -867,19 +867,24 @@ class XSBaseParameter(Parameter):
     """An XSPEC parameter.
 
     XSPEC has soft and hard parameter limits, which are the ones sent
-    in as the ``min``, ``max``, ``hard_min``, and ``hard_max``
-    parameters.  However, Sherpa's soft limits are more-like the XSPEC
-    hard limits, and it is possible in XSPEC to change a model's hard
-    limits. This class therefore:
+    in as the `min`, `max`, `hard_min`, and `hard_max` parameters.
+    However, Sherpa's soft limits are more-like the XSPEC hard limits,
+    and it is possible in XSPEC to change a model's hard limits. This
+    class therefore:
 
-    - stores the input ``min`` and ``max`` values as the
-      _xspec_soft_min and _xspec_soft_max parameters
+    - stores the input `min` and `max` values as the
+      _xspec_soft_min and _xspec_soft_max attributes and the
+      `hard_min` and `hard_max` values as _xspec_hard_min and
+      _xspec_hard_max attributes;
 
-    - sets the underlying ``min`` and ``max`` values to the XSPEC hard
-      limits
+    - sets the underlying `min` and `max` values to the XSPEC hard
+      limits;
 
-    - sets the underlying ``hard_min`` and ``hard_max`` values to the
-      XSPEC hard limits
+    - and sets the underlying `hard_min` and `hard_max` values to
+      the XSPEC hard limits.
+
+    Note that you can not change the hard limits; for that see
+    `XSParameter`.
 
     See Also
     --------
@@ -998,8 +1003,8 @@ class XSParameter(XSBaseParameter):
 
     hard_min = property(Parameter._get_hard_min, _set_hard_min,
                         doc='The hard minimum of the parameter.\n\n' +
-                        'Unlike normal parameters the ``hard_min`` value can be changed (and\n' +
-                        'will also change the correspondnig ``min`` value at the same time).\n' +
+                        'Unlike normal parameters the `hard_min` value can be changed (and\n' +
+                        'will also change the corresponding `min` value at the same time).\n' +
                         'This is needed to support the small-number of XSPEC models that\n' +
                         'use a value outside the default hard range as a way to control the\n' +
                         'model. Unfortunately some models can crash when using values like\n' +
@@ -1033,8 +1038,8 @@ class XSParameter(XSBaseParameter):
 
     hard_max = property(Parameter._get_hard_max, _set_hard_max,
                         doc='The hard maximum of the parameter.\n\n' +
-                        'Unlike normal parameters the ``hard_max`` value can be changed (and\n' +
-                        'will also change the correspondnig ``max`` value at the same time).\n' +
+                        'Unlike normal parameters the `hard_max` value can be changed (and\n' +
+                        'will also change the corresponding `max` value at the same time).\n' +
                         'This is needed to support the small-number of XSPEC models that\n' +
                         'use a value outside the default hard range as a way to control the\n' +
                         'model. Unfortunately some models can crash when using values like\n' +
@@ -1068,7 +1073,7 @@ class XSParameter(XSBaseParameter):
             The new default parameter limits.
         hard_min, hard_max : numer or None, optional
             Changing the hard limits will also change the matching
-            soft limit (``min`` or ``max``).
+            soft limit (`min` or `max`).
 
         """
 
@@ -1103,7 +1108,7 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
     Notes
     -----
     The XSPEC models are evaluated on a one-dimensional, integrated,
-    contiguous grid. When the ``calc`` method is called with both
+    contiguous grid. When the `calc` method is called with both
     low and high bin values, the arrays are converted into a single
     array matching the XSPEC calling convention - that is elo_0,
     elo_1, ..., elo_n for n bins (so the last value is the upper edge
@@ -1113,7 +1118,7 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
     added to account for non-contiguous input values.
 
     If used on an unbinned dataset, so only one array is sent to
-    ``calc``, then the input values are taken to match the XSPEC
+    `calc`, then the input values are taken to match the XSPEC
     calling convention - i.e. a contiguous grid where the last element
     represents the upper edge of the last bin. This means that for
     an input grid of ``n`` points, the returned array will contain
@@ -1203,9 +1208,9 @@ class XSTableModel(XSModel):
     XSPEC supports loading in user-supplied data files for use
     as a table model [1]_. This class provides a low-level
     way to access this functionality. A simpler interface is provided
-    by ``read_xstable_model`` and ``sherpa.astro.ui.load_xstable_model``.
+    by `read_xstable_model` and `sherpa.astro.ui.load_xstable_model`.
 
-    .. versionchanged:: 4.13.2
+    .. versionchanged:: 4.14.0
        The etable argument has been added to allow exponential table
        models to be used.
 
@@ -1234,18 +1239,18 @@ class XSTableModel(XSModel):
         The first ``nint`` parameters are marked as thawed by default,
         the remaining default to frozen.
     addmodel : bool
-        Is this an additive model (``True``) or multiplicative model
-        (``False``)? It should be set to the value of the "ADDMODEL"
+        Is this an additive model (`True`) or multiplicative model
+        (`False`)? It should be set to the value of the "ADDMODEL"
         keyword of the primary header of the input file. When False
         the etable keyword is used to distinguish between mtable and
         etable models.
     addredshift : bool
-        If ``True`` then a redshift parameter is added to the parameters.
+        If `True` then a redshift parameter is added to the parameters.
         It should be set to the value of the "REDSHIFT" keyword of the
         primary header of the input file.
     etable : bool
         When addmodel is False this defines whether the file is a
-        mtable model (False, the default) or an etable model (True).
+        mtable model (`False`, the default) or an etable model (`True`).
 
     References
     ----------
@@ -1537,17 +1542,17 @@ class XSConvolutionModel(CompositeModel, XSModel):
 
     Parameters
     ----------
-    model : sherpa.models.model.ArithmeticModel instance
+    model : `sherpa.models.model.ArithmeticModel`
         The model whose results, when evaluated, are passed to
         the convolution model.
-    wrapper : sherpa.astro.xspec.XSConvolutionKernel instance
+    wrapper : `sherpa.astro.xspec.XSConvolutionKernel`
         The XSPEC convolution model.
 
     Examples
     --------
 
     The following evaluates two models (creating the y1 and y2
-    arrays), where y1 applies the `XScfux` convolution model to the
+    arrays), where y1 applies the `XScflux` convolution model to the
     combined absorption times powerlaw model, and y2 applies the
     convolution model to only the power-law model, and then multiples
     this by the absorption model. In the following mdl1 and mdl2

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1930,7 +1930,7 @@ class XSapec(XSAdditiveModel):
 
     See Also
     --------
-    XSbapec, XSbvapec, XSbvvapec, XSnlapec, XSsnapec, XSvapec, XSvvapec
+    XSbapec, XSbvapec, XSbvvapec, XSnlapec, XSsnapec, XSvapec, XSvvapec, XSwdem
 
     References
     ----------
@@ -4934,7 +4934,7 @@ class XSgrbcomp(XSAdditiveModel):
 
     See Also
     --------
-    XSgrbm
+    XSgrbjet, XSgrbm
 
     Notes
     -----
@@ -4963,6 +4963,86 @@ class XSgrbcomp(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kTs, self.gamma, self.kTe, self.tau, self.beta, self.fbflag, self.log_A, self.z, self.a_boost, self.norm))
 
 
+@version_at_least("12.12.0")
+class XSgrbjet(XSAdditiveModel):
+    """The XSPEC grbjet model: Two-phase Comptonization model of soft thermal seed photons for GRB prompt emission
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    thobs
+        The observing viewing angle in degrees.
+    thjet
+        The jet half-opening angle in degrees.
+    gamma
+        The jet gamma Lorentz factor.
+    r12
+        The jet radius in 10^12 cm.
+    p1
+        The low-energy index of the coming frame broken powerlaw
+        spectrum.
+    p2
+        The high-energy index of the coming frame broken powerlaw
+        spectrum.
+    E0
+        The break energy in keV.
+    delta
+        The smoothness of the transition between the two powerlaws.
+    index_pl
+        The energy index of the comoving-frame cutoff powerlaw
+        spectrum.
+    ecut
+        The cut-off energy in keV.
+    ktbb
+        The comoving frame blackbody temperature in keV.
+    model
+        The comoving frame emissivity law: 1 is broken powerlaw,
+        2 is cutoff powerlaw, and 3 is blackbody.
+    redshift
+        The source redshift.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSgrbcomp, XSgrbm
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.12.0 or later.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGrbjet.html
+
+    """
+
+    __function__ = "xsgrbjet"
+
+    def __init__(self, name='grbjet'):
+        self.thobs = XSParameter(name, 'thobs', 5.0, min=0.0, max=30.0, hard_min=0.0, hard_max=30.0, frozen=True)
+        self.thjet = XSParameter(name, 'thjet', 10.0, min=2.0, max=20.0, hard_min=2.0, hard_max=20.0, frozen=True)
+        self.gamma = XSParameter(name, 'gamma', 200.0, min=1.0, max=500.0, hard_min=1.0, hard_max=500.0)
+        self.r12 = XSParameter(name, 'r12', 1.0, min=0.1, max=100.0, hard_min=0.1, hard_max=100.0, frozen=True)
+        self.p1 = XSParameter(name, 'p1', 0.0, min=-2.0, max=1.0, hard_min=-2.0, hard_max=1.0)
+        self.p2 = XSParameter(name, 'p2', 1.5, min=1.1, max=10.0, hard_min=1.1, hard_max=10.0)
+        self.E0 = XSParameter(name, 'E0', 1.0, min=0.1, max=1000.0, hard_min=0.1, hard_max=1000.0, units='keV')
+        self.delta = XSParameter(name, 'delta', 0.2, min=0.01, max=1.5, hard_min=0.01, hard_max=1.5, frozen=True)
+        self.index_pl = XSParameter(name, 'index_pl', 0.8, min=0.0, max=1.5, hard_min=0.0, hard_max=1.5, frozen=True)
+        self.ecut = XSParameter(name, 'ecut', 20.0, min=0.1, max=1000.0, hard_min=0.1, hard_max=1000.0, frozen=True, units='keV')
+        self.ktbb = XSParameter(name, 'ktbb', 1.0, min=0.1, max=1000.0, hard_min=0.1, hard_max=1000.0, frozen=True, units='keV')
+        self.model = XSParameter(name, 'model', 1, alwaysfrozen=True)
+        self.redshift = XSParameter(name, 'redshift', 2.0, min=0.01, max=10.0, hard_min=0.001, hard_max=10.0, frozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, min=0.0, max=1e+24, hard_min=0.0, hard_max=1e+24)
+        XSAdditiveModel.__init__(self, name, (self.thobs, self.thjet, self.gamma, self.r12,
+                                              self.p1, self.p2, self.E0, self.delta,
+                                              self.index_pl, self.ecut, self.ktbb,
+                                              self.model, self.redshift, self.norm))
+
+
 class XSgrbm(XSAdditiveModel):
     """The XSPEC grbm model: gamma-ray burst continuum.
 
@@ -4987,7 +5067,7 @@ class XSgrbm(XSAdditiveModel):
 
     See Also
     --------
-    XSgrbcomp
+    XSgrbcomp, XSgrbjet
 
     References
     ----------
@@ -9286,6 +9366,233 @@ class XSvvtapec(XSAdditiveModel):
                                  (self.kT, self.kTi, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.norm))
 
 
+@version_at_least("12.12.0")
+class XSvvwdem(XSAdditiveModel):
+    """The XSPEC vvwdem model: plasma emission, multi-temperature with power-law distribution of emission measure.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Tmax
+        The maximum temperature for power-law emission measure
+        distribution.
+    beta
+        The ratio of minimum to maxmum temperature.
+    inv_slope
+        The inverse of the slope (labelled p in the XSPEC documentation).
+    nH
+        Fixed at 1 for most applications.
+    H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+        The abundance of the element in solar units.
+    Redshift
+        The redshift of the plasma.
+    switch
+        What model to use: 0 calculates with MEKAL, 1 interpolates
+        with MEKAL, and 2 interpoates with APEC.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSvwdem, XSwdem
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.12.0 or later.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWdem.html
+
+    """
+    __function__ = "C_vvwDem"
+
+    def __init__(self, name='vvwdem'):
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, min=0.01, max=10.0, hard_min=0.01, hard_max=20.0, units='keV')
+        self.beta = XSParameter(name, 'beta', 0.1, min=0.01, max=1.0, hard_min=0.01, hard_max=1.0)
+        # can not use p for the name as it conflicts with P
+        self.inv_slope = XSParameter(name, 'inv_slope', 0.25, min=-1.0, max=10.0, hard_min=-1.0, hard_max=10.0)
+        self.nH = XSParameter(name, 'nH', 1.0, min=1e-05, max=1e+19, hard_min=1e-06, hard_max=1e+20, frozen=True, units='cm^-3')
+        self.H = XSParameter(name, 'H', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0, hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.switch = XSParameter(name, 'switch', 2, alwaysfrozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, min=0.0, max=1e+24, hard_min=0.0, hard_max=1e+24)
+        XSAdditiveModel.__init__(self, name, (self.Tmax, self.beta, self.inv_slope, self.nH,
+                                              self.H, self.He, self.Li, self.Be, self.B,
+                                              self.C, self.N, self.O, self.F, self.Ne,
+                                              self.Na, self.Mg, self.Al, self.Si, self.P,
+                                              self.S, self.Cl, self.Ar, self.K, self.Ca,
+                                              self.Sc, self.Ti, self.V, self.Cr, self.Mn,
+                                              self.Fe, self.Co, self.Ni, self.Cu, self.Zn,
+                                              self.redshift, self.switch, self.norm))
+
+
+@version_at_least("12.12.0")
+class XSvwdem(XSAdditiveModel):
+    """The XSPEC vwdem model: plasma emission, multi-temperature with power-law distribution of emission measure.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Tmax
+        The maximum temperature for power-law emission measure
+        distribution.
+    beta
+        The ratio of minimum to maxmum temperature.
+    inv_slope
+        The inverse of the slope (labelled p in the XSPEC documentation).
+    nH
+        Fixed at 1 for most applications.
+    He, C, N, O, Ne, Na, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element in solar units.
+    Redshift
+        The redshift of the plasma.
+    switch
+        What model to use: 0 calculates with MEKAL, 1 interpolates
+        with MEKAL, and 2 interpoates with APEC.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSvvwdem, XSwdem
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.12.0 or later.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWdem.html
+
+    """
+    __function__ = "C_vwDem"
+
+    def __init__(self, name='vwdem'):
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, min=0.01, max=10.0, hard_min=0.01, hard_max=20.0, units='keV')
+        self.beta = XSParameter(name, 'beta', 0.1, min=0.01, max=1.0, hard_min=0.01, hard_max=1.0)
+        # can not use p for the name as it conflicts with P for the XSvvwdem model
+        self.inv_slope = XSParameter(name, 'inv_slope', 0.25, min=-1.0, max=10.0, hard_min=-1.0, hard_max=10.0)
+        self.nH = XSParameter(name, 'nH', 1.0, min=1e-05, max=1e+19, hard_min=1e-06, hard_max=1e+20, frozen=True, units='cm^-3')
+        self.He = XSParameter(name, 'He', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0, hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.switch = XSParameter(name, 'switch', 2, alwaysfrozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, min=0.0, max=1e+24, hard_min=0.0, hard_max=1e+24)
+        XSAdditiveModel.__init__(self, name, (self.Tmax, self.beta, self.inv_slope, self.nH,
+                                              self.He, self.C, self.N, self.O, self.Ne,
+                                              self.Na, self.Mg, self.Al, self.Si, self.S,
+                                              self.Ar, self.Ca, self.Fe, self.Ni,
+                                              self.redshift, self.switch, self.norm))
+
+
+@version_at_least("12.12.0")
+class XSwdem(XSAdditiveModel):
+    """The XSPEC wdem model: plasma emission, multi-temperature with power-law distribution of emission measure.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    Tmax
+        The maximum temperature for power-law emission measure
+        distribution.
+    beta
+        The ratio of minimum to maxmum temperature.
+    inv_slope
+        The inverse of the slope (labelled p in the XSPEC documentation).
+    nH
+        Fixed at 1 for most applications.
+    abundanc
+        The abundance relative to solar.
+    Redshift
+        The redshift of the plasma.
+    switch
+        What model to use: 0 calculates with MEKAL, 1 interpolates
+        with MEKAL, and 2 interpoates with APEC.
+    norm
+        The normalization of the model: see [1]_ for an explanation
+        of the units.
+
+    See Also
+    --------
+    XSapec, XSmekal, XSvwdem, XSvvdem
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.12.0 or later.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelWdem.html
+
+    """
+    __function__ = "C_wDem"
+
+    def __init__(self, name='wdem'):
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, min=0.01, max=10.0, hard_min=0.01, hard_max=20.0, units='keV')
+        self.beta = XSParameter(name, 'beta', 0.1, min=0.01, max=1.0, hard_min=0.01, hard_max=1.0)
+        # can not use p for the name as it conflicts with P for the XSvvwdem model
+        self.inv_slope = XSParameter(name, 'inv_slope', 0.25, min=-1.0, max=10.0, hard_min=-1.0, hard_max=10.0)
+        self.nH = XSParameter(name, 'nH', 1.0, min=1e-05, max=1e+19, hard_min=1e-06, hard_max=1e+20, frozen=True, units='cm^-3')
+        self.abundanc = XSParameter(name, 'abundanc', 1.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0, hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.switch = XSParameter(name, 'switch', 2, alwaysfrozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, min=0.0, max=1e+24, hard_min=0.0, hard_max=1e+24)
+        XSAdditiveModel.__init__(self, name, (self.Tmax, self.beta, self.inv_slope, self.nH,
+                                              self.abundanc, self.redshift, self.switch,
+                                              self.norm))
+
+
 class XSzagauss(XSAdditiveModel):
     """The XSPEC zagauss model: gaussian line profile in wavelength space.
 
@@ -10618,7 +10925,7 @@ class XSpwab(XSMultiplicativeModel):
 
     See Also
     --------
-    XSpcfabs, XSwabs
+    XSpcfabs, XSwabs, XSzxipab
 
     References
     ----------
@@ -11835,6 +12142,50 @@ class XSzphabs(XSMultiplicativeModel):
         self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
         self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.redshift))
+
+
+@version_at_least("12.12.0")
+class XSzxipab(XSMultiplicativeModel):
+    """The XSPEC zxipab model: power-law distribution of ionized absorbers.
+
+    The model is described at [1]_.
+
+    Attributes
+    ----------
+    nHmin
+        The minimum equivalent hydrogen column (in units of
+        10^22 atoms/cm^2).
+    nHmax
+        The maximum equivalent hydrogen column (in units of
+        10^22 atoms/cm^2).
+    beta
+        The power law index for the covering fraction.
+
+    See Also
+    --------
+    XSpwab
+
+    Notes
+    -----
+    This model is only available when used with XSPEC 12.12.0 or later.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelZxipab.html
+
+    """
+
+    __function__ = "zxipab"
+
+    def __init__(self, name='zxipab'):
+        self.nHmin = XSParameter(name, 'nHmin', 0.01, min=1e-07, max=1000.0, hard_min=1e-07, hard_max=1000000.0, units='10^22')
+        self.nHmax = XSParameter(name, 'nHmax', 10.0, min=1e-07, max=1000.0, hard_min=1e-07, hard_max=1000000.0, units='10^22')
+        self.beta = XSParameter(name, 'beta', 0.0, min=-10.0, max=10.0, hard_min=-10.0, hard_max=10.0)
+        self.log_xi = XSParameter(name, 'log_xi', 3.0, min=-3.0, max=6.0, hard_min=-3.0, hard_max=6.0)
+        self.redshift = XSParameter(name, 'redshift', 0.0, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
+        XSMultiplicativeModel.__init__(self, name, (self.nHmin, self.nHmax, self.beta,
+                                                    self.log_xi, self.redshift))
 
 
 class XSzxipcf(XSMultiplicativeModel):

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -295,6 +295,8 @@ def set_xsabund(abundance):
      - 'wilm', from [7]_, except for elements not listed which
        are given zero abundance
      - 'lodd', from [8]_
+     - 'lpgp', from [9]_ (photospheric, requires XSPEC 12.12.0 or later)
+     - 'lpgs', from [9]_ (proto-solar, requires XSPEC 12.12.0 or later)
 
     The values for these tables are given at [1]_.
 
@@ -336,6 +338,10 @@ def set_xsabund(abundance):
 
     .. [8] Lodders, K (2003, ApJ 591, 1220)
            https://adsabs.harvard.edu/abs/2003ApJ...591.1220L
+
+    .. [9] Lodders K., Palme H., Gail H.P., Landolt-Börnstein,
+           New Series, vol VI/4B, pp 560–630 (2009)
+           https://ui.adsabs.harvard.edu/abs/2009LanB...4B..712L/abstract
 
     Examples
     --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
+Sherpa supports versions 12.12.0, 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
 of XSPEC [1]_, and can be built against the model library or the full
 application.  There is no guarantee of support for older or newer
 versions of XSPEC.

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -360,6 +360,14 @@ void kyconv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void thcompf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 
+// XSPEC 12.12.0 changes
+#ifdef XSPEC_12_12_0
+// Note: have dropped the leading 'c_' for this model to follow xsgrbcomp
+void xsgrbjet(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+
+void zxipab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+#endif
+
 }
 
 // This routine could be called when the module is being initialized,
@@ -368,7 +376,11 @@ void thcompf_(float* ear, int* ne, float* param, int* ifl, float* photar, float*
 // that they call _sherpa_init_xspec_library before calling any
 // XSPEC routine.
 //
-// Sun's C++ compiler complains if this is declared static
+// Sun's C++ compiler complains if this is declared static.
+//
+// TODO: should we expose this so that anyone who wants to use a user-model
+//       can access it?
+//
 int _sherpa_init_xspec_library()
 {
 
@@ -1409,6 +1421,15 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(olivineabs, 2),
   XSPECMODELFCT_C(C_logconst, 1),
   XSPECMODELFCT_C(C_log10con, 1),
+#endif
+
+#ifdef XSPEC_12_12_0
+  XSPECMODELFCT_C_NORM( xsgrbjet, 14 ),  // follow xsgrbcomp and drop the leading c_
+  XSPECMODELFCT_C_NORM( C_vvwDem, 37 ),
+  XSPECMODELFCT_C_NORM( C_vwDem, 21 ),
+  XSPECMODELFCT_C_NORM( C_wDem, 8 ),
+
+  XSPECMODELFCT(zxipab, 5),
 #endif
 
   { NULL, NULL, 0, NULL }

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -100,16 +100,22 @@ int _sherpa_init_xspec_library();
 // gammap
 // gammq
 //
-#include "xsFortran.h"
-
-// TODO: is this defined in an XSPEC header file?
-#define ABUND_SIZE (30) // number of elements in Solar Abundance table
-
-// C_<model> are declared here; the other models are defined in
+// TODO:: switch to C++ FuntionUtility interface rather than use xsFortran.h
+//
+// funcWrappers: C_<model> are declared here; the other models are defined in
 // functionMap.h but that requires using the XSPEC build location
 // rather than install location.
 //
+#ifdef XSPEC_12_12_0
+#include "XSFunctions/Utilities/xsFortran.h"
+#include "XSFunctions/funcWrappers.h"
+#else
+#include "xsFortran.h"
 #include "funcWrappers.h"
+#endif
+
+// TODO: is this defined in an XSPEC header file?
+#define ABUND_SIZE (30) // number of elements in Solar Abundance table
 
 extern "C" {
 


### PR DESCRIPTION
# Summary

Support the new additive and multiplicative models in XSPEC 12.12.0 - XSgrbjet, XSwdem, XSvwdem, XSvvwdem are additive and XSzxipab is multiplicative - and note the additional abundance tables that are available when running with XSPEC 12.12.0 (`lpgp` and `lpgs`).

# Details

The initial commit fixes up #1260 (the commit-log erroneously claims #1261) for changes from #1259 (as they were merged contemporaneously). This is technically not needed for XSPEC 12.12.0 but these changes were useful to validate the changes I had made (e.g. that the model parameters matched the `model.dat` file).

Commit "Initial XSPEC 12.12.0 support" makes the necessary changes so we can build against XSPEC 12.12.0 (the build has changed so that the location of the include files has moved [but this is a useful change on XSPECs part]).

Commit "Add the XSPEC 12.12.0 models (low level only)" adds the new models in this release to the compiled code, but they can't be used from Sherpa as the model classes haven't been added. These changes are, thanks to #1260, pretty mechanical with `scripts/add_xspec_model.py`.

Commit "Add the XSPEC 12.12.0 models (usable from Sherpa)" adds the model classes so these new models can be used. This is also a partly-mechanical process with `scripts/add_xspec_model.py`, but it needs more work to add necessary code to support conditional compilation and expanding the documentation. The `scripts/check_xspec_update.py` script has been used to check that the result matches the HEASARC 6.29 model.dat file.

The other changes are in the documentation, partly driven by #1268 to improve the linking in the readthedocs documentation (mechanical things like changing a double backtick to a single back tick or ' and fixing up some links).

# Notes

I have an ongoing support ticket with HEASARC as there's some odd behavior with the grbjet model. The tests skip this model because of this (the model can occasionally return all zeros). As it's a new model it won't break anyone's code if they can't use this model reliably (it is an XSPEC issue).

I also reported an issue with the log(xi) parameter name for the zxipab model and I expect it to be renamed to log_xi in a patch (as the other parameters named this are). We can not use log(xi) as the parameter name so we are using log_xi in anticipation of this change. Similarly there is a conflict with the p and P parameters of XSvvwdem so I have renamed "p" to "inv_slope" for all three *wdem models for consistency. I've also been in contact with Keith about this.