### PR TITLE
Support AstroPy 4.3 for tests

### DIFF
--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -150,8 +150,12 @@ def fake_rmf(outfile):
     def hdr(key, value):
         if isinstance(value, str):
             value = "'{}'".format(value)
-        elif isinstance(value, bool):
-            value = 'T' if value else 'F'
+        else:
+            if isinstance(value, bool):
+                value = 'T' if value else 'F'
+
+            # add spacing to make FVERIFY happy
+            value = f"{str(value):>20s}"
 
         out = "{:8s}= {}".format(key, value)
         return out.ljust(80)


### PR DESCRIPTION
# Summary

The AstroPy FITS reader is less tolerant of invalid FITS files in AstroPy 4.3 which trips one of our tests. The test has been updated with a FITS file that doesn't trigger the error case. There is no functional change in this commmit.

# Details

Fixes #1226 

The FITS checking meant that a test that created a test FITS file (which was dome rather than adding one to the sheropa-test-data directory) was no-longer valid for AstroPy, so tweak the output to appease both AstroPy 4.3 and fverify (at least for the header lines, it still claims the fill character is wrong but this is less important).

I've tested this out as part of #1223 but pulled it out into its own PR.