### PR TITLE
Fix three parameter names for XSPEC models

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -7205,6 +7205,10 @@ class XSzkerrbb(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. versionchanged:: 4.14.0
+       The fcol parameter was incorrectly labelled as hd: both names
+       can be used to access this parameter.
+
     Attributes
     ----------
     eta
@@ -7264,7 +7268,9 @@ class XSzkerrbb(XSAdditiveModel):
         self.Mbh = Parameter(name, 'Mbh', 1., 0., 100., 0.0, hugeval, 'M_sun')
         self.Mdd = Parameter(name, 'Mdd', 1., 0., 1000., 0.0, hugeval, 'M0yr')
         self.z = Parameter(name, 'z', 0.01, 0., 10., 0.0, 10, frozen=True)
-        self.fcol = Parameter(name, 'hd', 1.7, 1., 10., 0.0, hugeval, frozen=True)
+        self.fcol = Parameter(name, 'fcol', 1.7, 1., 10., 0.0, hugeval, frozen=True,
+                              # Parameter was mis-labelled until 4.14.0
+                              aliases=['hd'])
         self.rflag = Parameter(name, 'rflag', 1., -100., 100., -hugeval, hugeval, alwaysfrozen=True)
         self.lflag = Parameter(name, 'lflag', 0., -100., 100., -hugeval, hugeval, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
@@ -12886,6 +12892,10 @@ class XSvashift(XSConvolutionKernel):
 
     The model is described at [1]_.
 
+    .. versionchanged:: 4.14.0
+       The Velocity parameter was incorrectly labelled as Redshift:
+       both names can be used to access this parameter.
+
     .. versionadded:: 4.12.2
 
     Attributes
@@ -12914,10 +12924,12 @@ class XSvashift(XSConvolutionKernel):
     __function__ = "C_vashift"
 
     def __init__(self, name='xsvashift'):
-        self.Redshift = Parameter(name, 'Velocity', 0.0,
+        self.Velocity = Parameter(name, 'Velocity', 0.0,
                                   min=-1e4, max=1e4,
                                   hard_min=-1e4, hard_max=1e4,
-                                  units='km/s', frozen=True)
+                                  units='km/s', frozen=True,
+                                  # Parameter was mis-labelled until 4.14.0
+                                  aliases=['Redshift'])
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
@@ -12926,6 +12938,10 @@ class XSvmshift(XSConvolutionKernel):
     """The XSPEC vmshift convolution model: velocity shift a multiplicative model.
 
     The model is described at [1]_.
+
+    .. versionchanged:: 4.14.0
+       The Velocity parameter was incorrectly labelled as Redshift:
+       both names can be used to access this parameter.
 
     .. versionadded:: 4.12.2
 
@@ -12955,10 +12971,12 @@ class XSvmshift(XSConvolutionKernel):
     __function__ = "C_vmshift"
 
     def __init__(self, name='xsvmshift'):
-        self.Redshift = Parameter(name, 'Velocity', 0.0,
+        self.Velocity = Parameter(name, 'Velocity', 0.0,
                                   min=-1e4, max=1e4,
                                   hard_min=-1e4, hard_max=1e4,
-                                  units='km/s', frozen=True)
+                                  units='km/s', frozen=True,
+                                  # Parameter was mis-labelled until 4.14.0
+                                  aliases=['Redshift'])
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -861,6 +861,37 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
 
     version_enabled = True
 
+    def __init__(self, name, pars):
+
+        # Validate the parameters argument to check that the
+        # names are unique (name insensitive) and members of
+        # the class (i.e. there are attributes with this name).
+        #
+        # This could be done at a higher level of the class structure
+        # but given the support for composite models it can't be
+        # done at the Model layer. It probably makes sense to do this
+        # at the ArithmeticModel layer but this is the place where we
+        # make the most changes and we know these constraints are
+        # correct here so do so here.
+        #
+        # These are development errors so use asserts rather than
+        # raising an error.
+        #
+        seen = set()
+        for par in pars:
+            pname = par.name.lower()
+
+            # unique names
+            assert pname not in seen, (par.name, name)
+            seen.add(pname)
+
+            # there's actually an attribute with this name
+            attr = getattr(self, par.name)
+            assert attr.name == par.name, (par.name, name)
+
+        super().__init__(name, pars)
+
+
     @modelCacher1d
     def calc(self, *args, **kwargs):
         """Calculate the model given the parameters and grid.

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -564,7 +564,8 @@ class Model(NoNewAttributesAfterInit):
         NoNewAttributesAfterInit.__getattribute__(self, name)
 
     def __setattr__(self, name, val):
-        par = getattr(self, name.lower(), None)
+        lname = name.lower()
+        par = getattr(self, lname, None)
         if (par is not None) and isinstance(par, Parameter):
             # When setting an attribute that is a Parameter, set the parameter's
             # value instead.
@@ -572,8 +573,16 @@ class Model(NoNewAttributesAfterInit):
         else:
             NoNewAttributesAfterInit.__setattr__(self, name, val)
             if isinstance(val, Parameter):
+                vname = val.name.lower()
+
+                # Check the parameter names match - as this is a
+                # 'development' error then just make this an assert.
+                # Ideally it should be exact but support lower case
+                # comparison only
+                assert lname == vname, (name, val.name, self.name)
+
                 # Update parameter index
-                self._par_index[val.name.lower()] = val
+                self._par_index[vname] = val
                 if val.aliases:
                     # Update index of aliases, if necessary
                     for alias in val.aliases:


### PR DESCRIPTION
# Summary

Fix three XSPEC models which had some internal confusion over parameter names: `XSzkerrbb` should have uses `fcol` but had instead used `hd`, and `XSzashift` and `XSzmshift` used `Redshift` instead of `Velocity`. The old names have been kept as aliases.

# Details

In working on #1223 I added some checks to ensure we don't create XSPEC parameters with a different name to the attribute setting, which showed three cases where we had done this. We now use the correct name and leave the old name as an alias so old code will still work.

To make sure this doesn't happen we have included assertions that will fail if someone tries to create a model incorrectly. These are not mapped to Python errors as this is very low-level code and I believe using an assert is enough. There is a discussion to be had about where some of the checks should be made - at the moment this is done in the base XSPEC model class as we have historically changed XSPEC model parameters, or added new XSPEC models, **much more** than other models, and moving this code to an earlier class would require more thinking about than I want to do here. We could remove the `Internal improvements ...` commit and just avoid this.
