### PR TITLE
Remove compiler warnings

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -138,7 +138,7 @@ The prerequisites for building from source are:
 
 * Python versions: 3.6, 3.7, 3.8
 * Python packages: ``setuptools``, ``numpy``
-* System: ``gcc``, ``g++``, ``make``, ``flex``,
+* System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these
   tools; please report problems to the
   `Sherpa issue tracker <https://github.com/sherpa/sherpa/issues/>`_).
@@ -368,6 +368,9 @@ or that provided by
 `Virtualenv <https://virtualenv.pypa.io/en/stable/>`_,
 be used when building and installing Sherpa.
 
+The ``CC`` and ``CXX`` environment variables can be set to the C and
+C++ compilers to use if not found by ``setup.py``.
+
 .. warning::
 
    When building Sherpa on macOS within a conda environment, the following
@@ -380,7 +383,7 @@ be used when building and installing Sherpa.
 
 .. note::
 
-   Additionally, if you are building with Clang version 12, you will
+   If you are building with Clang version 12, you will
    encounter build issues in the region area related to an implicit
    declaration. If so, pre-pending the following to your pip install
    or python setup.py install line should resolve the build issues::
@@ -391,7 +394,6 @@ be used when building and installing Sherpa.
    you specifically install a gcc from a different source, you are
    likely to run into this problem, even if you believe that your
    compiler is invoked with `gcc`.)
-
 
 A standard installation
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/sherpa/include/sherpa/MersenneTwister.h
+++ b/sherpa/include/sherpa/MersenneTwister.h
@@ -173,9 +173,9 @@ inline void MTRand::initialize( const uint32 aseed )
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
   // In previous versions, most significant bits (MSBs) of the seed affect
   // only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-  register uint32 *s = state;
-  register uint32 *r = state;
-  register int i = 1;
+  uint32 *s = state;
+  uint32 *r = state;
+  int i = 1;
   *s++ = aseed & 0xffffffffUL;
   for( ; i < N; ++i )
     {
@@ -189,8 +189,8 @@ inline void MTRand::reload()
   // Generate N new values in state
   // Made clearer and faster by Matthew Bellew (matthew.bellew@home.com)
   static const int MmN = int(M) - int(N);  // in case enums are unsigned
-  register uint32 *p = state;
-  register int i;
+  uint32 *p = state;
+  int i;
   for( i = N - M; i--; ++p )
     *p = twist( p[M], p[0], p[1] );
   for( i = M; --i; ++p )
@@ -216,9 +216,9 @@ inline void MTRand::seed( uint32 *const bigSeed, const uint32 seedLength )
   // in each element are discarded.
   // Just call seed() if you want to get array from /dev/urandom
   initialize(19650218UL);
-  register int i = 1;
-  register uint32 j = 0;
-  register int k = ( N > seedLength ? N : seedLength );
+  int i = 1;
+  uint32 j = 0;
+  int k = ( N > seedLength ? N : seedLength );
   for( ; k; --k )
     {
       state[i] =
@@ -252,9 +252,9 @@ inline void MTRand::seed()
   if( urandom )
     {
       uint32 bigSeed[N];
-      register uint32 *s = bigSeed;
-      register int i = N;
-      register bool success = true;
+      uint32 *s = bigSeed;
+      int i = N;
+      bool success = true;
       while( success && i-- )
 	success = fread( s++, sizeof(uint32), 1, urandom );
       fclose(urandom);
@@ -276,9 +276,9 @@ inline MTRand::MTRand()
 
 inline MTRand::MTRand( const MTRand& o )
 {
-  register const uint32 *t = o.state;
-  register uint32 *s = state;
-  register int i = N;
+  const uint32 *t = o.state;
+  uint32 *s = state;
+  int i = N;
   for( ; i--; *s++ = *t++ ) {}
   left = o.left;
   pNext = &state[N-left];
@@ -292,7 +292,7 @@ inline MTRand::uint32 MTRand::randInt()
   if( left == 0 ) reload();
   --left;
 	
-  register uint32 s1;
+  uint32 s1;
   s1 = *pNext++;
   s1 ^= (s1 >> 11);
   s1 ^= (s1 <<  7) & 0x9d2c5680UL;
@@ -366,18 +366,18 @@ inline double MTRand::operator()()
 
 inline void MTRand::save( uint32* saveArray ) const
 {
-  register const uint32 *s = state;
-  register uint32 *sa = saveArray;
-  register int i = N;
+  const uint32 *s = state;
+  uint32 *sa = saveArray;
+  int i = N;
   for( ; i--; *sa++ = *s++ ) {}
   *sa = left;
 }
 
 inline void MTRand::load( uint32 *const loadArray )
 {
-  register uint32 *s = state;
-  register uint32 *la = loadArray;
-  register int i = N;
+  uint32 *s = state;
+  uint32 *la = loadArray;
+  int i = N;
   for( ; i--; *s++ = *la++ ) {}
   left = *la;
   pNext = &state[N-left];
@@ -385,16 +385,16 @@ inline void MTRand::load( uint32 *const loadArray )
 
 inline std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
 {
-  register const MTRand::uint32 *s = mtrand.state;
-  register int i = mtrand.N;
+  const MTRand::uint32 *s = mtrand.state;
+  int i = mtrand.N;
   for( ; i--; os << *s++ << "\t" ) {}
   return os << mtrand.left;
 }
 
 inline std::istream& operator>>( std::istream& is, MTRand& mtrand )
 {
-  register MTRand::uint32 *s = mtrand.state;
-  register int i = mtrand.N;
+  MTRand::uint32 *s = mtrand.state;
+  int i = mtrand.N;
   for( ; i--; is >> *s++ ) {}
   is >> mtrand.left;
   mtrand.pNext = &mtrand.state[mtrand.N-mtrand.left];
@@ -404,9 +404,9 @@ inline std::istream& operator>>( std::istream& is, MTRand& mtrand )
 inline MTRand& MTRand::operator=( const MTRand& o )
 {
   if( this == &o ) return (*this);
-  register const uint32 *t = o.state;
-  register uint32 *s = state;
-  register int i = N;
+  const uint32 *t = o.state;
+  uint32 *s = state;
+  int i = N;
   for( ; i--; *s++ = *t++ ) {}
   left = o.left;
   pNext = &state[N-left];

--- a/sherpa/include/sherpa/astro/models.hh
+++ b/sherpa/include/sherpa/astro/models.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2020  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2020, 2021  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -334,10 +334,10 @@ namespace sherpa { namespace astro { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType EoverkTlo = elo/t;
-    register DataType EoverkThi = ehi/t;
-    register DataType ylo = 0.0;
-    register DataType yhi = 0.0;
+    DataType EoverkTlo = elo/t;
+    DataType EoverkThi = ehi/t;
+    DataType ylo = 0.0;
+    DataType yhi = 0.0;
 
     if(integrate && EoverkThi <= 1.0e-4) {
       ylo = elo*t;
@@ -376,10 +376,10 @@ namespace sherpa { namespace astro { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType hcoverlamkTlo = H_KEV*C_ANG/wlo/t;
-    register DataType hcoverlamkThi = H_KEV*C_ANG/whi/t;
-    register DataType ylo = 0.0;
-    register DataType yhi = 0.0;
+    DataType hcoverlamkTlo = H_KEV*C_ANG/wlo/t;
+    DataType hcoverlamkThi = H_KEV*C_ANG/whi/t;
+    DataType ylo = 0.0;
+    DataType yhi = 0.0;
 
     if(integrate && hcoverlamkTlo <= 1.0e-4) {
       ylo = t/POW(wlo,3.0)/H_KEV/C_ANG;
@@ -406,7 +406,7 @@ namespace sherpa { namespace astro { namespace models {
   inline int bbody_point( const ConstArrayType& p, DataType x, DataType& val )
   {
 
-    register int bbunit = (int)((floor)(p[0]+0.5));
+    int bbunit = (int)((floor)(p[0]+0.5));
     DataType wave;
     DataType energy;
 
@@ -468,7 +468,7 @@ namespace sherpa { namespace astro { namespace models {
 	val = p[4]*POW((x/p[3]),-p[0]);
 	return EXIT_SUCCESS;
       } else {
-	register DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
+	DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
 	val = a*POW(x/p[3],-p[1]);
 	return EXIT_SUCCESS;
       }
@@ -494,9 +494,9 @@ namespace sherpa { namespace astro { namespace models {
 	  val = p[4]*p[3]*(LOG(xhi)-LOG(xlo));
 	  return EXIT_SUCCESS;
 	} else {
-	  register DataType p1 = POW(xlo,1.0-p[0]);
-	  register DataType p2 = POW(xhi,1.0-p[0]);
-	  register DataType a1 = p[4]/POW(p[3],-p[0])/(1.0-p[0]);
+	  DataType p1 = POW(xlo,1.0-p[0]);
+	  DataType p2 = POW(xhi,1.0-p[0]);
+	  DataType a1 = p[4]/POW(p[3],-p[0])/(1.0-p[0]);
 	  val = a1*(p2-p1);
 	  return EXIT_SUCCESS;
 	}
@@ -506,20 +506,20 @@ namespace sherpa { namespace astro { namespace models {
 	  return EXIT_FAILURE;
 	}
 	if ( p[1] == 1.0 ) {
-	  register DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
+	  DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
 	  val = a*p[3]*(LOG(xhi)-LOG(xlo));
 	  return EXIT_SUCCESS;
 	} else {
-	  register DataType p1 = POW(xlo,1.0-p[1]);
-	  register DataType p2 = POW(xhi,1.0-p[1]);
-	  register DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
-	  register DataType a2 = a/POW(p[3],-p[1])/(1.0-p[1]);
+	  DataType p1 = POW(xlo,1.0-p[1]);
+	  DataType p2 = POW(xhi,1.0-p[1]);
+	  DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
+	  DataType a2 = a/POW(p[3],-p[1])/(1.0-p[1]);
 	  val = a2*(p2-p1);
 	  return EXIT_SUCCESS;
 	}
       } else {
-	register DataType out1 = 0.0;
-	register DataType out2 = 0.0;
+	DataType out1 = 0.0;
+	DataType out2 = 0.0;
 	if ( p[0] == 1.0 ) {
 	  if ( p[2] <= 0.0 || xlo <= 0.0 ) {
 	    // val = NAN;
@@ -527,9 +527,9 @@ namespace sherpa { namespace astro { namespace models {
 	  }
 	  out1 = p[4]*p[3]*(LOG(p[2])-LOG(xlo));
 	} else {
-	  register DataType p1 = POW(xlo,1.0-p[0]);
-	  register DataType p2 = POW(p[2],1.0-p[0]);
-	  register DataType a1 = p[4]/POW(p[3],-p[0])/(1.0-p[0]);
+	  DataType p1 = POW(xlo,1.0-p[0]);
+	  DataType p2 = POW(p[2],1.0-p[0]);
+	  DataType a1 = p[4]/POW(p[3],-p[0])/(1.0-p[0]);
 	  out1 = a1*(p2-p1);
 	}
 	if ( 0.0 == p[3] ) {
@@ -537,13 +537,13 @@ namespace sherpa { namespace astro { namespace models {
 	  return EXIT_FAILURE;
 	}
 	if ( p[1] == 1.0 ) {
-	  register DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
+	  DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
 	  out2 = a*p[3]*(LOG(xhi)-LOG(p[2]));
 	} else {
-	  register DataType p1 = POW(p[2],1.0-p[1]);
-	  register DataType p2 = POW(xhi,1.0-p[1]);
-	  register DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
-	  register DataType a2 = a/POW(p[3],-p[1])/(1.0-p[1]);
+	  DataType p1 = POW(p[2],1.0-p[1]);
+	  DataType p2 = POW(xhi,1.0-p[1]);
+	  DataType a = p[4]*POW((p[2]/p[3]),p[1])*POW((p[2]/p[3]),-p[0]);
+	  DataType a2 = a/POW(p[3],-p[1])/(1.0-p[1]);
 	  out2 = a2*(p2-p1);
 	}
 	val = (out1 + out2);
@@ -562,19 +562,19 @@ namespace sherpa { namespace astro { namespace models {
   inline int dered_point( const ConstArrayType& p, DataType x, DataType& val )
   {
 
-    register DataType ebv = p[1]/58.0;
-    register DataType fa;
-    register DataType fb;
-    register DataType a = 0.0;
-    register DataType b = 0.0;
-    register DataType xarg;
+    DataType ebv = p[1]/58.0;
+    DataType fa;
+    DataType fb;
+    DataType a = 0.0;
+    DataType b = 0.0;
+    DataType xarg;
     // Here's where things get ugly.  Values of a and b are functions
     // of wavelength xtmp in units of inverse microns.  I put the
     // formulae from Cardelli, J. A., Clayton, G. C., \& Mathis,
     // J. S. 1989, ApJ, 345, 245 into Fortran for the hell of it.
     // determine a and b for wavelength x (in inverse microns) between
     // 0.3um-1 and 10um-1 (33333 to 1000 Angstroms)
-    register DataType xtemp = 1.e+4/x;
+    DataType xtemp = 1.e+4/x;
     if ( xtemp <= 5.9 || xtemp > 8.0 ) {
       fa = 0.0; fb = 0.0;
     } else {
@@ -601,9 +601,9 @@ namespace sherpa { namespace astro { namespace models {
     }
     // UV   (3.3 < xtemp < 8) (3030 > lambda > 1250)
     if ( xtemp > 3.3 && xtemp <= 8.0 ) {
-      register DataType adenom = POW(xtemp-4.67,2.0) + 0.341;
+      DataType adenom = POW(xtemp-4.67,2.0) + 0.341;
       a = 1.752 - (0.316*xtemp) - (0.104/adenom) + fa;
-      register DataType bdenom = POW(xtemp-4.62,2.0) + 0.263;
+      DataType bdenom = POW(xtemp-4.62,2.0) + 0.263;
       b = -3.090 + (1.825*xtemp) + (1.206/bdenom) + fb;
     }
     // determine a and b for wavelength xtemp (in inverse microns)
@@ -619,7 +619,7 @@ namespace sherpa { namespace astro { namespace models {
     //    and derive the absolute extinction at any wavelength
     //    (Alambda) via
     //                Alambda = E(B-V) * [a*Rv + b]
-    register DataType alambda = ebv*((a*p[0])+b);
+    DataType alambda = ebv*((a*p[0])+b);
     //   Then relate to fluxes via    I(lambda) = I(o)e^-tau(lambda)
     //   and   Alambda = 1.086 * tau(lambda)
     //   FINAL OUTPUT
@@ -633,7 +633,7 @@ namespace sherpa { namespace astro { namespace models {
   inline int edge_point( const ConstArrayType& p, DataType x, DataType& val )
   {
 
-    register int u = (int)((floor)(p[0] + 0.5));
+    int u = (int)((floor)(p[0] + 0.5));
     if( u == 0 && x < p[1] ) {
       val = 1.0;
       return EXIT_SUCCESS;
@@ -749,9 +749,9 @@ namespace sherpa { namespace astro { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType prefix = 2.0*C_KM*p[0]/(PI*p[2]*p[1]);
-    register DataType inside = POW(C_KM,2.0)/(POW(p[2],2.0)*POW(p[1],2.0));
-    register DataType z = 1.0 - POW((x-p[1]),2.0)*inside;
+    DataType prefix = 2.0*C_KM*p[0]/(PI*p[2]*p[1]);
+    DataType inside = POW(C_KM,2.0)/(POW(p[2],2.0)*POW(p[1],2.0));
+    DataType z = 1.0 - POW((x-p[1]),2.0)*inside;
     if( z < 0.0 ) {
       // val = NAN;
       return EXIT_FAILURE;
@@ -768,20 +768,20 @@ namespace sherpa { namespace astro { namespace models {
 				   DataType xlo, DataType xhi, DataType& val )
   {
 
-    register DataType prefix = 2.0*C_KM*p[0]/(PI*p[2]*p[1]);
-    register DataType inside = POW(C_KM,2.0)/(POW(p[2],2.0)*POW(p[1],2.0));
+    DataType prefix = 2.0*C_KM*p[0]/(PI*p[2]*p[1]);
+    DataType inside = POW(C_KM,2.0)/(POW(p[2],2.0)*POW(p[1],2.0));
 
     if( inside < 0 ) {
       //val = NAN;
       return EXIT_FAILURE;
     }
 
-    register DataType sub0 = xlo - p[1];
-    register DataType sub1 = xhi - p[1];
-    register DataType frac0 = 1 - inside*sub0*sub0;
-    register DataType frac1 = 1 - inside*sub1*sub1;
-    register DataType theta0 = SQRT(inside)*sub0;
-    register DataType theta1 = SQRT(inside)*sub1;
+    DataType sub0 = xlo - p[1];
+    DataType sub1 = xhi - p[1];
+    DataType frac0 = 1 - inside*sub0*sub0;
+    DataType frac1 = 1 - inside*sub1*sub1;
+    DataType theta0 = SQRT(inside)*sub0;
+    DataType theta1 = SQRT(inside)*sub1;
 
     if( (frac0 < 0) || (frac1 < 0) ) {
       //val = NAN;
@@ -798,8 +798,8 @@ namespace sherpa { namespace astro { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType val0 = SQRT(frac0) * sub0 + ASIN(theta0)/SQRT(inside);
-    register DataType val1 = SQRT(frac1) * sub1 + ASIN(theta1)/SQRT(inside);
+    DataType val0 = SQRT(frac0) * sub0 + ASIN(theta0)/SQRT(inside);
+    DataType val1 = SQRT(frac1) * sub1 + ASIN(theta1)/SQRT(inside);
     val = 0.5*prefix*(val1 - val0);
     return EXIT_SUCCESS;
 
@@ -868,8 +868,8 @@ namespace sherpa { namespace astro { namespace models {
 				   DataType xlo, DataType xhi, DataType& val )
   {
 
-    register DataType angle1 = 0.0;
-    register DataType angle2 = 0.0;
+    DataType angle1 = 0.0;
+    DataType angle2 = 0.0;
     if ( xhi - p[1] != 0.0 ) {
       angle2 = atan2( p[0] / 2.0, xhi - p[1] );
     } else {
@@ -897,8 +897,8 @@ namespace sherpa { namespace astro { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     else {
-      register DataType gammaratio = EXP(LGAMMA(p[2]-0.5)-LGAMMA(p[2]));
-      register DataType norm = p[3]/(p[1]*SQRT_PI*gammaratio);
+      DataType gammaratio = EXP(LGAMMA(p[2]-0.5)-LGAMMA(p[2]));
+      DataType norm = p[3]/(p[1]*SQRT_PI*gammaratio);
       val = norm*POW((1.0+(x-p[0])*(x-p[0])/p[1]/p[1]),-p[2]);
       return EXIT_SUCCESS;
     }
@@ -928,8 +928,8 @@ namespace sherpa { namespace astro { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     else {
-      register DataType xthis = xlo/p[1];
-      register DataType xnext = xhi/p[1];
+      DataType xthis = xlo/p[1];
+      DataType xnext = xhi/p[1];
       val = p[2]*POW(xthis, p[0])*EXP(-xthis)*(xnext - xthis);
       return EXIT_SUCCESS;
     }
@@ -945,7 +945,7 @@ namespace sherpa { namespace astro { namespace models {
 			   DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r;
+    DataType r;
 
     if( EXIT_SUCCESS != sherpa::utils::radius2(p, x0, x1, r)) {
       return EXIT_FAILURE;
@@ -967,7 +967,7 @@ namespace sherpa { namespace astro { namespace models {
 			  DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r;
+    DataType r;
 
     if( EXIT_SUCCESS != sherpa::utils::radius(p,x0,x1,r)) {
       return EXIT_FAILURE;
@@ -989,7 +989,7 @@ namespace sherpa { namespace astro { namespace models {
 		       DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r;
+    DataType r;
 
     if( EXIT_SUCCESS != sherpa::utils::radius2(p, x0, x1, r)) {
       return EXIT_FAILURE;
@@ -1010,7 +1010,7 @@ namespace sherpa { namespace astro { namespace models {
 			      DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r;
+    DataType r;
 
     if( EXIT_SUCCESS != sherpa::utils::radius2(p,x0,x1, r)) {
       return EXIT_FAILURE;
@@ -1030,7 +1030,7 @@ namespace sherpa { namespace astro { namespace models {
 			   DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r;
+    DataType r;
 
     if( EXIT_SUCCESS != sherpa::utils::radius(p,x0,x1,r)) {
       return EXIT_FAILURE;

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2021  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -105,7 +105,7 @@ namespace sherpa { namespace astro { namespace utils {
     // num_chans vectors, as we can have multiple groups associated
     // with energy bin ii.
 
-    register IndexType ii;
+    IndexType ii;
 
     // The position in the response array is yet different; if there
     // are two channel groups associated with energy bin ii, and the
@@ -117,22 +117,22 @@ namespace sherpa { namespace astro { namespace utils {
     //  - Increment group_counter by two;
     //  - And increment response_counter by twenty (five + fifteen)
 
-    //register IndexType resp_counter = 0;
+    //IndexType resp_counter = 0;
 
     // How many groups are in the current energy bin?
-    register IndexType current_num_groups = 0;
+    IndexType current_num_groups = 0;
 
     // How many channels are in the current group?
-    register IndexType current_num_chans = 0;
+    IndexType current_num_chans = 0;
 
     // What is the current channel of the output (counts) array?
-    //register IndexType current_chan = 0;
+    //IndexType current_chan = 0;
 
-    register FloatType source_bin_ii;
-    register const ConstFloatType *resp_tmp = resp;
-    register const ConstIntType *first_chan_tmp = first_chan;
-    register const ConstIntType *num_chans_tmp = num_chans;
-    register FloatType *counts_tmp = counts;
+    FloatType source_bin_ii;
+    const ConstFloatType *resp_tmp = resp;
+    const ConstIntType *first_chan_tmp = first_chan;
+    const ConstIntType *num_chans_tmp = num_chans;
+    FloatType *counts_tmp = counts;
 
     for ( ii = 0; ii < len_source; ii++ ) {
       
@@ -238,15 +238,15 @@ namespace sherpa { namespace astro { namespace utils {
 		   vector<FloatType>& rsp,
 		   BoolType *mask) {
 
-    register IndexType response_counter = 0, group_counter = 0;
-    register IntType current_num_chans = 0, current_chan = 0,
+    IndexType response_counter = 0, group_counter = 0;
+    IntType current_num_chans = 0, current_chan = 0,
       current_num_groups = 0, lo = 0, hi = 0;
     
     for( IndexType ii = 0; ii < len_num_groups; ++ii ) {
       
       current_num_groups = n_grp[ ii ];
      
-      register IntType ngrp = 0;
+      IntType ngrp = 0;
  
       while( current_num_groups > 0 ) {
 	

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2015, 2017, 2020  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2015, 2017, 2020, 2021  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -192,7 +192,7 @@ static bool create_grid(const sherpa::Array<CType, ArrayType> &xlo,
             << " and cell " << (i+1)
             << " (" << (*x1)[i+1] << " to " << (*x2)[i+1] << ")";
         PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-        return NULL;
+        return false;
         ***/
       }
     }
@@ -245,7 +245,7 @@ static bool create_grid(const sherpa::Array<CType, ArrayType> &xlo,
         std::ostringstream err;
         err << "Wavelength must be > 0, sent " << ear[i];
         PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-        return NULL;
+        return false;
       }
       ear[i] = hc / ear[i];
     }
@@ -268,7 +268,7 @@ static bool create_grid(const sherpa::Array<CType, ArrayType> &xlo,
       err << "Grid is not monotonic: " << ear[i] << " to " <<
         ear[i+1];
       PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-      return NULL;
+      return false;
     }
   }
   ***/
@@ -363,7 +363,7 @@ static bool create_contiguous_grid(const sherpa::Array<CType, ArrayType> &xlo,
         std::ostringstream err;
         err << "Wavelength must be > 0, sent " << ear[i];
         PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-        return NULL;
+        return false;
       }
       ear[i] = hc / ear[i];
     }
@@ -386,7 +386,7 @@ static bool create_contiguous_grid(const sherpa::Array<CType, ArrayType> &xlo,
       err << "Grid is not monotonic: " << ear[i] << " to " <<
         ear[i+1];
       PyErr_SetString( PyExc_ValueError, err.str().c_str() );
-      return NULL;
+      return false;
     }
   }
   ***/

--- a/sherpa/include/sherpa/models.hh
+++ b/sherpa/include/sherpa/models.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2020  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2020, 2021  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -101,7 +101,7 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType tmp = TWOPI*(x-p[1])/p[0];
+    DataType tmp = TWOPI*(x-p[1])/p[0];
     val = p[2]*COS(tmp);
     return EXIT_SUCCESS;
 
@@ -117,8 +117,8 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType tmp1 = TWOPI*(xlo-p[1])/p[0];
-    register DataType tmp2 = TWOPI*(xhi-p[1])/p[0];
+    DataType tmp1 = TWOPI*(xlo-p[1])/p[0];
+    DataType tmp2 = TWOPI*(xhi-p[1])/p[0];
     val = p[2]*p[0]*(SIN(tmp2)-SIN(tmp1))/TWOPI;
     return EXIT_SUCCESS;
 
@@ -192,7 +192,7 @@ namespace sherpa { namespace models {
   template <typename DataType, typename ConstArrayType>
   inline DataType _erf_sub1( const ConstArrayType& p, DataType x )
   {
-    register DataType arg = ( x - p[1] ) / p[2];
+    DataType arg = ( x - p[1] ) / p[2];
     return arg * ERF( arg ) + EXP( -arg*arg )
       / constants::sqrt_pi< DataType >();
   }
@@ -201,7 +201,7 @@ namespace sherpa { namespace models {
   template <typename DataType, typename ConstArrayType>
   inline DataType _erf_sub2( const ConstArrayType& p, DataType x )
   {
-    register DataType arg = ( x - p[1] ) / p[2];
+    DataType arg = ( x - p[1] ) / p[2];
     if ( x < p[1] )  arg *= -1.0;
     return arg;
   }
@@ -271,7 +271,7 @@ namespace sherpa { namespace models {
   template <typename DataType, typename ConstArrayType>
   inline DataType _erfc_sub1( const ConstArrayType& p, DataType x )
   {
-    register DataType arg = ( x - p[1] ) / p[2];
+    DataType arg = ( x - p[1] ) / p[2];
     return arg * ERFC( arg ) - EXP( -arg*arg )
       / constants::sqrt_pi< DataType >();
   }
@@ -328,8 +328,8 @@ namespace sherpa { namespace models {
   {
 
     if ( p[1] != 0.0 ) {
-      register DataType y2 = p[1]*(xhi-p[0]);
-      register DataType y1 = p[1]*(xlo-p[0]);
+      DataType y2 = p[1]*(xhi-p[0]);
+      DataType y1 = p[1]*(xlo-p[0]);
       val = (p[2]/p[1])*(EXP(y2)-EXP(y1));
       return EXIT_SUCCESS;
     } else {
@@ -357,8 +357,8 @@ namespace sherpa { namespace models {
   {
 
     if ( p[1] != 0.0 ) {
-      register DataType y2 = LOGTEN*p[1]*(xhi-p[0]);
-      register DataType y1 = LOGTEN*p[1]*(xlo-p[0]);
+      DataType y2 = LOGTEN*p[1]*(xhi-p[0]);
+      DataType y1 = LOGTEN*p[1]*(xlo-p[0]);
       val = (p[2]/p[1]/LOGTEN)*(EXP(y2)-EXP(y1));
       return EXIT_SUCCESS;
     } else {
@@ -403,8 +403,8 @@ namespace sherpa { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType z2 = SQRT_GFACTOR * ( xhi - p[1] ) / p[0];
-    register DataType z1 = SQRT_GFACTOR * ( xlo - p[1] ) / p[0];
+    DataType z2 = SQRT_GFACTOR * ( xhi - p[1] ) / p[0];
+    DataType z1 = SQRT_GFACTOR * ( xlo - p[1] ) / p[0];
 
     val =
       p[2] * p[0] * SQRT_PI * ( ERF(z2) - ERF(z1) ) / ( 2. * SQRT_GFACTOR );
@@ -438,8 +438,8 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType y1 = p[1]*(xlo-p[0]);
-    register DataType y2 = p[1]*(xhi-p[0]);
+    DataType y1 = p[1]*(xlo-p[0]);
+    DataType y2 = p[1]*(xhi-p[0]);
 
     if ( y1 > 0.0 && y2 > 0.0 ) {
       val = p[2]*(y2*LOG(y2)-y1*LOG(y1)-y2+y1)/p[1];
@@ -477,8 +477,8 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType y1 = p[1]*(xlo-p[0]);
-    register DataType y2 = p[1]*(xhi-p[0]);
+    DataType y1 = p[1]*(xlo-p[0]);
+    DataType y2 = p[1]*(xhi-p[0]);
 
     if ( y1 > 0.0 && y2 > 0.0 ) {
       val = p[2]*(y2*LOG(y2)-y1*LOG(y1)-y2+y1)/p[1]/LOG(10.0);
@@ -503,7 +503,7 @@ namespace sherpa { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType norm = SQRT(PI/GFACTOR)*p[0];
+    DataType norm = SQRT(PI/GFACTOR)*p[0];
     val = (p[2]/norm)*EXP(-GFACTOR*(x-p[1])*(x-p[1])/p[0]/p[0]);
     return EXIT_SUCCESS;
 
@@ -519,8 +519,8 @@ namespace sherpa { namespace models {
       // val = NAN
       return EXIT_FAILURE;
     else {
-      register DataType z2 = SQRT_GFACTOR*((xhi-p[1])/p[0]);
-      register DataType z1 = SQRT_GFACTOR*((xlo-p[1])/p[0]);
+      DataType z2 = SQRT_GFACTOR*((xhi-p[1])/p[0]);
+      DataType z1 = SQRT_GFACTOR*((xlo-p[1])/p[0]);
       val = (p[2]*(ERF(z2)-ERF(z1))/2.0);
       return EXIT_SUCCESS;
     }
@@ -533,8 +533,8 @@ namespace sherpa { namespace models {
 			    DataType& val )
   {
 
-    register DataType p_zero_fact;
-    register DataType x_fact;
+    DataType p_zero_fact;
+    DataType x_fact;
 
     if( EXIT_SUCCESS != lfactorial(p[0], p_zero_fact)) {
       return EXIT_FAILURE;
@@ -560,8 +560,8 @@ namespace sherpa { namespace models {
   inline int poly1d_point( const ConstArrayType& p, DataType x, DataType& val )
   {
 
-    register DataType xtemp = x - p[9];
-    register DataType retval = p[8];
+    DataType xtemp = x - p[9];
+    DataType retval = p[8];
     int ii;
     for ( ii = 7; ii >= 0; ii--) {
       retval = retval*xtemp + p[ii];
@@ -577,12 +577,12 @@ namespace sherpa { namespace models {
 				DataType xlo, DataType xhi, DataType& val )
   {
 
-    register DataType xtemp1 = xlo - p[9];
-    register DataType xtemp2 = xhi - p[9];
-    register DataType retval = 0.0;
+    DataType xtemp1 = xlo - p[9];
+    DataType xtemp2 = xhi - p[9];
+    DataType retval = 0.0;
     int ii;
     for( ii = 0; ii <= 8; ii++) {
-      register DataType pexp = (DataType)(ii+1);
+      DataType pexp = (DataType)(ii+1);
       retval += p[ii]*(POW(xtemp2,pexp)-POW(xtemp1,pexp))/pexp;
     }
     val = retval;
@@ -634,8 +634,8 @@ namespace sherpa { namespace models {
 	val = p[2] * p[1] * ( LOG(xhi) - LOG(xlo) );
 	return EXIT_SUCCESS;
       } else {
-	register DataType p1 = POW( xlo, 1.0-p[0] ) / (1.0-p[0]);
-	register DataType p2 = POW( xhi, 1.0-p[0] ) / (1.0-p[0]);
+	DataType p1 = POW( xlo, 1.0-p[0] ) / (1.0-p[0]);
+	DataType p2 = POW( xhi, 1.0-p[0] ) / (1.0-p[0]);
 	val = p[2] / POW( p[1], -p[0] ) * ( p2 - p1 );
 	return EXIT_SUCCESS;
       }
@@ -659,7 +659,7 @@ namespace sherpa { namespace models {
 
     if ( p[0] != 0 ) {
 
-      register DataType frac = (x / p[0]);
+      DataType frac = (x / p[0]);
 
       if ( frac > 0.0 ) {
 	val = p[3] * POW( frac, - p[1] - p[2] * LOG10( frac ) );
@@ -681,7 +681,7 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType tmp = TWOPI*(x-p[1])/p[0];
+    DataType tmp = TWOPI*(x-p[1])/p[0];
     val = p[2]*SIN(tmp);
     return EXIT_SUCCESS;
 
@@ -697,8 +697,8 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType tmp1 = TWOPI*(xlo-p[1])/p[0];
-    register DataType tmp2 = TWOPI*(xhi-p[1])/p[0];
+    DataType tmp1 = TWOPI*(xlo-p[1])/p[0];
+    DataType tmp2 = TWOPI*(xhi-p[1])/p[0];
     val = -1.0*p[2]*p[0]*(COS(tmp2)-COS(tmp1))/TWOPI;
     return EXIT_SUCCESS;
 
@@ -732,8 +732,8 @@ namespace sherpa { namespace models {
       return EXIT_FAILURE;
     }
 
-    register DataType tmp1 = POW(xlo-p[0], 1.50);
-    register DataType tmp2 = POW(xhi-p[0], 1.50);
+    DataType tmp1 = POW(xlo-p[0], 1.50);
+    DataType tmp2 = POW(xhi-p[0], 1.50);
     val = 2.0*p[1]*(tmp2-tmp1)/3.0;
     return EXIT_SUCCESS;
 
@@ -824,7 +824,7 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType tmp = TWOPI*(x-p[1])/p[0];
+    DataType tmp = TWOPI*(x-p[1])/p[0];
     val = p[2]*TAN(tmp);
     return EXIT_SUCCESS;
 
@@ -840,8 +840,8 @@ namespace sherpa { namespace models {
       // val = NAN;
       return EXIT_FAILURE;
     }
-    register DataType tmp1 = TWOPI*(xlo-p[1])/p[0];
-    register DataType tmp2 = TWOPI*(xhi-p[1])/p[0];
+    DataType tmp1 = TWOPI*(xlo-p[1])/p[0];
+    DataType tmp2 = TWOPI*(xhi-p[1])/p[0];
     val = -1.0*p[2]*p[0]*(LOG(COS(tmp2))-LOG(COS(tmp1)))/TWOPI;
     return EXIT_SUCCESS;
 
@@ -875,8 +875,8 @@ namespace sherpa { namespace models {
       val = 0.0;
       return EXIT_SUCCESS;
     } else {
-      register DataType x0frac = (std::min(x0hi,p[1])-std::max(x0lo,p[0]))/(x0hi-x0lo);
-      register DataType x1frac = (std::min(x1hi,p[3])-std::max(x1lo,p[2]))/(x1hi-x1lo);
+      DataType x0frac = (std::min(x0hi,p[1])-std::max(x0lo,p[0]))/(x0hi-x0lo);
+      DataType x1frac = (std::min(x1hi,p[3])-std::max(x1lo,p[2]))/(x1hi-x1lo);
       val = p[4]*x0frac*x1frac;
       return EXIT_SUCCESS;
     }
@@ -945,7 +945,7 @@ namespace sherpa { namespace models {
 			    DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r = 0.0;
+    DataType r = 0.0;
 
     if( EXIT_SUCCESS != sherpa::utils::radius2(p, x0, x1, r)) {
       return EXIT_FAILURE;
@@ -963,7 +963,7 @@ namespace sherpa { namespace models {
   inline int sigmagauss2d_point( const ConstArrayType& p,
 				 DataType x0, DataType x1, DataType& val ) {
 
-    register DataType r = 0.0;
+    DataType r = 0.0;
 
     if ( 0 == p[0] || 0 == p[1] )
       return EXIT_FAILURE;
@@ -1041,7 +1041,7 @@ namespace sherpa { namespace models {
 			     DataType x0, DataType x1, DataType& val )
   {
 
-    register DataType r = 0.0;
+    DataType r = 0.0;
 
     if( EXIT_SUCCESS != sherpa::utils::radius2(p, x0, x1, r)) {
       return EXIT_FAILURE;
@@ -1049,7 +1049,7 @@ namespace sherpa { namespace models {
     if( p[0] == 0.0 )
       return EXIT_FAILURE;
     else {
-      register DataType norm = (PI/GFACTOR)*p[0]*p[0]*SQRT(1.0 - (p[3]*p[3]));
+      DataType norm = (PI/GFACTOR)*p[0]*p[0]*SQRT(1.0 - (p[3]*p[3]));
       val = (p[5]/norm)*EXP(-r/(p[0]*p[0])*GFACTOR);
       return EXIT_SUCCESS;
     }
@@ -1062,9 +1062,9 @@ namespace sherpa { namespace models {
 			   DataType x0, DataType x1, DataType& val )
   {
 
-    register int ix;
-    register int iy;
-    register DataType retval = 0.0;
+    int ix;
+    int iy;
+    DataType retval = 0.0;
     for ( ix = 0 ; ix < 3 ; ix++ ) {
       for ( iy = 0 ; iy < 3 ; iy++ ) {
 	retval += POW(x0,(DataType)ix)*POW(x1,(DataType)iy)*p[3*ix+iy];
@@ -1082,11 +1082,11 @@ namespace sherpa { namespace models {
 				DataType x1lo, DataType x1hi, DataType& val )
   {
 
-    register int ix;
-    register int iy;
-    register DataType retval = 0.0;
-    register DataType u[3];
-    register DataType v[3];
+    int ix;
+    int iy;
+    DataType retval = 0.0;
+    DataType u[3];
+    DataType v[3];
     u[0] = x0hi - x0lo;
     u[1] = (POW(x0hi,2.0)/2.0) - (POW(x0lo,2.0)/2.0);
     u[2] = (POW(x0hi,3.0)/3.0) - (POW(x0lo,3.0)/3.0);

--- a/sherpa/include/sherpa/utils.hh
+++ b/sherpa/include/sherpa/utils.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2008  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2008, 2021  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -236,9 +236,9 @@ namespace sherpa { namespace utils {
 		      DataType x0, DataType x1, DataType& val )
   {
   
-    register DataType deltaX = x0 - p[1];
-    register DataType deltaY = x1 - p[2];
-    register DataType p_four = p[4];
+    DataType deltaX = x0 - p[1];
+    DataType deltaY = x1 - p[2];
+    DataType p_four = p[4];
     if( p[3] != 0 ) {
       while( p_four >= 2*PI ) {
 	p_four -= 2*PI;
@@ -246,14 +246,14 @@ namespace sherpa { namespace utils {
       while( p_four < 0.0 ) {
 	p_four += 2*PI;
       }
-      register DataType cosTheta = COS(p_four);
-      register DataType sinTheta = SIN(p_four);
-      register DataType newX = deltaX * cosTheta + deltaY * sinTheta;
-      register DataType newY = deltaY * cosTheta - deltaX * sinTheta;
+      DataType cosTheta = COS(p_four);
+      DataType sinTheta = SIN(p_four);
+      DataType newX = deltaX * cosTheta + deltaY * sinTheta;
+      DataType newY = deltaY * cosTheta - deltaX * sinTheta;
       if( p[3] == 1 )
 	return EXIT_FAILURE;
       else {
-	register DataType ellip2 = (1. - p[3]) * (1. - p[3]);
+	DataType ellip2 = (1. - p[3]) * (1. - p[3]);
 	val = (newX * newX * ellip2 + newY * newY) / ellip2;
 	return EXIT_SUCCESS;
       }
@@ -273,9 +273,9 @@ namespace sherpa { namespace utils {
   {
     DataType sigmaa = p[0];
     DataType sigmab = p[1];
-    register DataType deltaX = x0 - p[2];
-    register DataType deltaY = x1 - p[3];
-    register DataType theta = p[4];
+    DataType deltaX = x0 - p[2];
+    DataType deltaY = x1 - p[3];
+    DataType theta = p[4];
 
     if ( 0 == sigmaa || 0 == sigmab ) {
       val = 0.0;
@@ -288,10 +288,10 @@ namespace sherpa { namespace utils {
     while( theta < 0.0 ) {
       theta += 2*PI;
     }
-    register DataType cosTheta = COS(theta);
-    register DataType sinTheta = SIN(theta);
-    register DataType newX = deltaX * cosTheta + deltaY * sinTheta;
-    register DataType newY = deltaY * cosTheta - deltaX * sinTheta;
+    DataType cosTheta = COS(theta);
+    DataType sinTheta = SIN(theta);
+    DataType newX = deltaX * cosTheta + deltaY * sinTheta;
+    DataType newY = deltaY * cosTheta - deltaX * sinTheta;
     DataType a = newX / sigmaa;
     DataType b = newY / sigmab;
     val = a*a + b*b;
@@ -316,9 +316,9 @@ namespace sherpa { namespace utils {
 
   // {
   
-  //   register DataType deltaX = x0 - p[1];
-  //   register DataType deltaY = x1 - p[2];
-  //   register DataType p_four = p[4];
+  //   DataType deltaX = x0 - p[1];
+  //   DataType deltaY = x1 - p[2];
+  //   DataType p_four = p[4];
   //   if( p[3] != 0 ) {
   //     while( p_four >= 2*PI ) {
   // 	p_four -= 2*PI;
@@ -326,10 +326,10 @@ namespace sherpa { namespace utils {
   //     while( p_four < 0.0 ) {
   // 	p_four += 2*PI;
   //     }
-  //     register DataType cosTheta = COS(p_four);
-  //     register DataType sinTheta = SIN(p_four);
-  //     register DataType newX = deltaX * cosTheta + deltaY * sinTheta;
-  //     register DataType newY = deltaY * cosTheta - deltaX * sinTheta;
+  //     DataType cosTheta = COS(p_four);
+  //     DataType sinTheta = SIN(p_four);
+  //     DataType newX = deltaX * cosTheta + deltaY * sinTheta;
+  //     DataType newY = deltaY * cosTheta - deltaX * sinTheta;
   //     if( p[3] == 1 )
   // 	return EXIT_FAILURE;
   //     else {

--- a/sherpa/include/sherpa/utils.hh
+++ b/sherpa/include/sherpa/utils.hh
@@ -519,7 +519,7 @@ namespace sherpa { namespace utils {
       return my_max;
 
     // avoid underflow
-    if ( 0.0 == num || denom > 1 && num < denom * my_min )
+    if ( 0.0 == num || (denom > 1 && num < denom * my_min) )
       return T(0);
     
     return num / denom;


### PR DESCRIPTION
# Summary

Avoid compiler warnings from clang, fixing #1232 and several other warnings.

# Details

I added a very-small note about setting CC/CXX to set the compiler and noted you can build with clang/clang++ as well as gcc/g++ to the RTD documentation.

The first commit is the most contentious, as it removes the `register` keywords. I believe that compilers nowadays ignore this setting (or don't give it much regard, see https://www.drdobbs.com/keywords-that-arent-or-comments-by-anoth/184403859 for one "rant") so I don't expect it will slow down code. It is also verboten as of C++17 as you get the following warning.

```
warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
```