### PR TITLE
Bump minimum supported XSPEC version to 12.9.1

### DIFF
--- a/.github/scripts/setup_xspec_ds9.sh
+++ b/.github/scripts/setup_xspec_ds9.sh
@@ -82,7 +82,7 @@ echo "* configuring XSPEC"
 sed -i.orig "s/#with-xspec=True/with-xspec=True/g" setup.cfg
 sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${xspec_library_path}|g" setup.cfg
 sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xspec_include_path}|g" setup.cfg
-sed -i.orig "s|#xspec_version = 12.9.0|xspec_version = ${xspec_version_string}|g" setup.cfg
+sed -i.orig "s|#xspec_version = 12.9.1|xspec_version = ${xspec_version_string}|g" setup.cfg
 
 #Xspec ~12.10.1n now requires fftw. This disables the fftw build from extern
 sed -i.orig "s|#fftw=local|fftw=local|g" setup.cfg

--- a/.github/scripts/setup_xspec_ds9.sh
+++ b/.github/scripts/setup_xspec_ds9.sh
@@ -82,7 +82,7 @@ echo "* configuring XSPEC"
 sed -i.orig "s/#with-xspec=True/with-xspec=True/g" setup.cfg
 sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${xspec_library_path}|g" setup.cfg
 sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xspec_include_path}|g" setup.cfg
-sed -i.orig "s|#xspec_version = 12.9.1|xspec_version = ${xspec_version_string}|g" setup.cfg
+sed -i.orig "s|#xspec_version = .*|xspec_version = ${xspec_version_string}|g" setup.cfg
 
 #Xspec ~12.10.1n now requires fftw. This disables the fftw build from extern
 sed -i.orig "s|#fftw=local|fftw=local|g" setup.cfg

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -256,7 +256,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.11.1 down to 12.9.0. It may build against
+:term:`XSPEC` versions 12.11.1 down to 12.9.1. It may build against
 newer versions, but if it does it will not provide access
 to any new models in the release. The following steps are needed
 to update to a newer version, and assume that you have the new version
@@ -277,7 +277,7 @@ them).
    When adding support for XSPEC 12.11.1, the code in the ``run``
    method was changed to include the triple ``(12, 11, 1)``::
 
-       for major, minor, patch in [(12, 9, 0), (12, 9, 1),
+       for major, minor, patch in [(12, 9, 1),
                                    (12, 10, 0), (12, 10, 1),
                                    (12, 11, 0), (12, 11, 1)]:
            version = '{}.{}.{}'.format(major, minor, patch)

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -145,4 +145,4 @@ Glossary
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
        Sherpa can be built to use XSPEC versions 12.11.1, 12.11.0, 12.10.1 (patch level `a`
-       or later), 12.10.0, 12.9.1, or 12.9.0.
+       or later), 12.10.0, or 12.9.1.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -51,7 +51,7 @@ The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
 functions from the :term:`XSPEC`.
 The supported versions of XSPEC are 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later),
-12.10.0, 12.9.1, and 12.9.0.
+12.10.0, and 12.9.1.
 
 Interactive display and manipulation of two-dimensional images
 is available if the :term:`DS9` image viewer and the :term:`XPA`
@@ -215,12 +215,12 @@ XSPEC
 
 Sherpa can be built to use the Astronomy models provided by
 :term:`XSPEC` versions 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
-12.9.1, and 12.9.0. To enable XSPEC support, several changes must be
+and 12.9.1. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
 
     with-xspec = False
-    xspec_version = 12.9.0
+    xspec_version = 12.9.1
     xspec_lib_dirs = None
     xspec_include_dirs = None
     xspec_libraries = XSFunctions XSModel XSUtil XS
@@ -294,7 +294,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
 
-5. If the full XSPEC 12.9.x system has been built then use::
+5. If the full XSPEC 12.9.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.9.1
@@ -303,8 +303,6 @@ match the contents of the XSPEC installation.
        xspec_libraries = XSFunctions XSModel XSUtil XS
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
-
-   changing ``12.9.1`` to ``12.9.0`` as appropriate.
 
 6. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2014-2017, 2018, 2020
-#       Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014-2017, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -34,7 +34,7 @@ class xspec_config(Command):
     description = "Configure XSPEC Models external module (optional) "
     user_options = [
                     ('with-xspec', None, "Whether sherpa must build the XSPEC module (default False)"),
-                    ('xspec-version', None, "the XSPEC version (default 12.9.0)"),
+                    ('xspec-version', None, "the XSPEC version (default 12.9.1)"),
                     ('xspec-lib-dirs', None, "Where the xspec libraries are located, if with-xspec is True"),
                     ('xspec-libraries', None, "Name of the libraries that should be linked for xspec"),
                     ('cfitsio-lib-dirs', None, "Where the cfitsio libraries are located, if with-xspec is True"),
@@ -49,7 +49,7 @@ class xspec_config(Command):
 
     def initialize_options(self):
         self.with_xspec = False
-        self.xspec_version = '12.9.0'
+        self.xspec_version = '12.9.1'
         self.xspec_include_dirs = ''
         self.xspec_lib_dirs = ''
         self.xspec_libraries = 'XSFunctions XSModel XSUtil XS'
@@ -99,13 +99,13 @@ class xspec_config(Command):
                 self.announce("Found XSPEC version: {}".format(xspec_raw_version), 2)
                 xspec_version = LooseVersion(xspec_raw_version)
 
-                if xspec_version < LooseVersion("12.9.0"):
-                    self.warn("XSPEC Version is less than 12.9.0, which is the minimal supported version for Sherpa")
+                if xspec_version < LooseVersion("12.9.1"):
+                    self.warn("XSPEC Version is less than 12.9.1, which is the minimal supported version for Sherpa")
 
                 # I am not sure what the naming of the XSPEC components are,
                 # but let's stick with major, minor, and patch.
                 #
-                for major, minor, patch in [(12, 9, 0), (12, 9, 1),
+                for major, minor, patch in [(12, 9, 1),
                                             (12, 10, 0), (12, 10, 1),
                                             (12, 11, 0), (12, 11, 1)]:
                     version = '{}.{}.{}'.format(major, minor, patch)

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,8 +72,7 @@ source-dir = docs
 # If with-xspec is True, make sure to point Sherpa to right
 # XSPEC-related libraries and to indicate the XSPEC version.
 # As of XSPEC 12.10.0, determining the version os XSPEC at build
-# time is too complex and unreliable. If you have XSPEC 12.9.0
-# you can leave the version option commented out.
+# time is too complex and unreliable.
 #
 # The xspec_include_dirs and xspec_lib_dirs items should be set
 # to $HEADAS/include and $HEADAS/lib respectively (expand out the
@@ -96,7 +95,7 @@ source-dir = docs
 #
 # The gfortran_lib_dirs should be set if needed.
 #
-#xspec_version = 12.9.0
+#xspec_version = 12.9.1
 #xspec_lib_dirs = None
 #xspec_include_dirs = None
 #xspec_libraries = XSFunctions XSModel XSUtil XS

--- a/sherpa/astro/ui/__init__.py
+++ b/sherpa/astro/ui/__init__.py
@@ -40,7 +40,7 @@ _session._add_model_types(sherpa.astro.models)
 _session._add_model_types(sherpa.astro.optical)
 _session._add_model_types(sherpa.models.template)
 
-# To add PSFModel to list -- doesn't inherit from ArithmeticModel
+# To add PSFModel to list -- doesn't inherit from Arit`<hmeticModel
 _session._add_model_types(sherpa.instrument, baselist=(sherpa.models.Model,))
 
 # Get RMFModel, ARFModel in list of models
@@ -52,13 +52,15 @@ if hasattr(sherpa.astro, 'xspec'):
                                sherpa.astro.xspec.XSMultiplicativeModel,
                                sherpa.astro.xspec.XSConvolutionKernel))
 
-    from sherpa.astro.xspec import get_xsabund, get_xscosmo, get_xsxsect, \
-        set_xsabund, set_xscosmo, set_xsxsect, set_xsxset, get_xsxset, \
-        get_xschatter, set_xschatter
-    __all__.extend(('get_xsabund', 'get_xschatter', 'get_xscosmo',
-                    'get_xsxsect', 'set_xsabund', 'set_xschatter',
-                    'set_xscosmo', 'set_xsxsect', 'set_xsxset',
-                    'get_xsxset'))
+    from sherpa.astro.xspec import get_xsabund, get_xsabundances, \
+        get_xsatomdb, get_xselements, get_xscosmo, get_xsxsect, \
+        set_xsabund, set_xsatomdb, set_xscosmo, set_xsxsect, set_xsxset, \
+        get_xsxset, get_xschatter, set_xschatter
+    __all__.extend(('get_xsabund', 'get_xsabundances', 'get_xsatomdb',
+                    'get_xselements', 'get_xschatter', 'get_xscosmo',
+                    'get_xsxsect', 'set_xsabund', 'set_xsatomdb',
+                    'set_xschatter', 'set_xscosmo', 'set_xsxsect',
+                    'set_xsxset', 'get_xsxset'))
 
 __all__.extend(_session._export_names(globals()))
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
+Sherpa supports versions 12.11.1, 12.11.0, 12.10.1, 12.10.0, and 12.9.1
 of XSPEC [1]_, and can be built against the model library or the full
 application.  There is no guarantee of support for older or newer
 versions of XSPEC.
@@ -1592,7 +1592,7 @@ class XSapec(XSAdditiveModel):
     .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelApec.html
 
     """
-    __function__ = "C_apec" if equal_or_greater_than("12.9.1") else "xsaped"
+    __function__ = "C_apec"
 
     def __init__(self, name='apec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -1683,7 +1683,7 @@ class XSbapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_bapec" if equal_or_greater_than("12.9.1") else "xsbape"
+    __function__ = "C_bapec"
 
     def __init__(self, name='bapec'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -2166,7 +2166,7 @@ class XSbvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_bvapec" if equal_or_greater_than("12.9.1") else "xsbvpe"
+    __function__ = "C_bvapec"
 
     def __init__(self, name='bvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -3629,7 +3629,7 @@ class XSgaussian(XSAdditiveModel):
 
     """
 
-    __function__ = "C_gaussianLine" if equal_or_greater_than("12.9.1") else "xsgaul"
+    __function__ = "C_gaussianLine"
 
     def __init__(self, name='gaussian'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -4291,7 +4291,7 @@ class XSlorentz(XSAdditiveModel):
 
     """
 
-    __function__ = "C_lorentzianLine" if equal_or_greater_than("12.9.1") else "xslorz"
+    __function__ = "C_lorentzianLine"
 
     def __init__(self, name='lorentz'):
         self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, hugeval, 'keV')
@@ -4336,7 +4336,7 @@ class XSmeka(XSAdditiveModel):
 
     """
 
-    __function__ = "C_meka" if equal_or_greater_than("12.9.1") else "xsmeka"
+    __function__ = "C_meka"
 
     def __init__(self, name='meka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -4383,7 +4383,7 @@ class XSmekal(XSAdditiveModel):
 
     """
 
-    __function__ = "C_mekal" if equal_or_greater_than("12.9.1") else "xsmekl"
+    __function__ = "C_mekal"
 
     def __init__(self, name='mekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -5518,7 +5518,7 @@ class XSraymond(XSAdditiveModel):
 
     """
 
-    __function__ = "C_raysmith" if equal_or_greater_than("12.9.1") else "xsrays"
+    __function__ = "C_raysmith"
 
     def __init__(self, name='raymond'):
         self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.0, hugeval, 'keV')
@@ -5924,7 +5924,7 @@ class XSvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vapec" if equal_or_greater_than("12.9.1") else "xsvape"
+    __function__ = "C_vapec"
 
     def __init__(self, name='vapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -6223,7 +6223,7 @@ class XSvmeka(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vmeka" if equal_or_greater_than("12.9.1") else "xsvmek"
+    __function__ = "C_vmeka"
 
     def __init__(self, name='vmeka'):
         self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 0.0, hugeval, 'keV')
@@ -6282,7 +6282,7 @@ class XSvmekal(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vmekal" if equal_or_greater_than("12.9.1") else "xsvmkl"
+    __function__ = "C_vmekal"
 
     def __init__(self, name='vmekal'):
         self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -6825,7 +6825,7 @@ class XSvraymond(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vraysmith" if equal_or_greater_than("12.9.1") else "xsvrys"
+    __function__ = "C_vraysmith"
 
     def __init__(self, name='vraymond'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0, hugeval, 'keV')
@@ -9555,7 +9555,7 @@ class XSbvvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_bvvapec" if equal_or_greater_than("12.9.1") else "xsbvvp"
+    __function__ = "C_bvvapec"
 
     def __init__(self, name='bvvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -9711,7 +9711,7 @@ class XSvvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vvapec" if equal_or_greater_than("12.9.1") else "xsvvap"
+    __function__ = "C_vvapec"
 
     def __init__(self, name='vvapec'):
         self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0, hugeval, 'keV')
@@ -10511,7 +10511,6 @@ class XSzbabs(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.nHeI, self.nHeII, self.z))
 
 
-@version_at_least("12.9.1")
 class XSbtapec(XSAdditiveModel):
     """The XSPEC btapec model: velocity broadened APEC emission spectrum with separate continuum and line temperatures.
 
@@ -10543,10 +10542,6 @@ class XSbtapec(XSAdditiveModel):
     --------
     XSbapec, XSbvtapec, XSbvvtapec
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -10567,7 +10562,6 @@ class XSbtapec(XSAdditiveModel):
                                  (self.kT, self.kTi, self.Abundanc, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSbvtapec(XSAdditiveModel):
     """The XSPEC bvtapec model: velocity broadened APEC emission spectrum with separate continuum and line temperatures.
 
@@ -10596,10 +10590,6 @@ class XSbvtapec(XSAdditiveModel):
     See Also
     --------
     XSbapec, XSbtapec, XSbvvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -10635,7 +10625,6 @@ class XSbvtapec(XSAdditiveModel):
                                   self.Fe, self.Ni, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSbvvtapec(XSAdditiveModel):
     """The XSPEC bvvtapec model: velocity broadened APEC emission spectrum with separate continuum and line temperatures.
 
@@ -10663,10 +10652,6 @@ class XSbvvtapec(XSAdditiveModel):
     See Also
     --------
     XSbapec, XSbtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -10717,7 +10702,6 @@ class XSbvvtapec(XSAdditiveModel):
                                  (self.kT, self.kTi, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.9.1")
 class XStapec(XSAdditiveModel):
     """The XSPEC tapec model: APEC emission spectrum with separate continuum and line temperatures.
 
@@ -10748,10 +10732,6 @@ class XStapec(XSAdditiveModel):
     --------
     XSbtapec, XSvtapec, XSvvtapec
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -10771,7 +10751,6 @@ class XStapec(XSAdditiveModel):
                                  (self.kT, self.kTi, self.Abundanc, self.Redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSvtapec(XSAdditiveModel):
     """The XSPEC vtapec model: APEC emission spectrum with separate continuum and line temperatures.
 
@@ -10799,10 +10778,6 @@ class XSvtapec(XSAdditiveModel):
     See Also
     --------
     XSbvtapec, XStapec, XSvvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -10837,7 +10812,6 @@ class XSvtapec(XSAdditiveModel):
                                   self.Fe, self.Ni, self.Redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSvvtapec(XSAdditiveModel):
     """The XSPEC vvtapec model: APEC emission spectrum with separate continuum and line temperatures.
 
@@ -10864,10 +10838,6 @@ class XSvvtapec(XSAdditiveModel):
     See Also
     --------
     XSbvvtapec, XStapec, XSvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -10917,7 +10887,6 @@ class XSvvtapec(XSAdditiveModel):
                                  (self.kT, self.kTi, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XScarbatm(XSAdditiveModel):
     """The XSPEC carbatm model: Nonmagnetic carbon atmosphere of a neutron star.
 
@@ -10941,10 +10910,6 @@ class XScarbatm(XSAdditiveModel):
     --------
     XShatm
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -10964,7 +10929,6 @@ class XScarbatm(XSAdditiveModel):
                                  (self.T, self.NSmass, self.NSrad, self.norm))
 
 
-@version_at_least("12.9.1")
 class XShatm(XSAdditiveModel):
     """The XSPEC hatm model: Nonmagnetic hydrogen atmosphere of a neutron star.
 
@@ -10987,10 +10951,6 @@ class XShatm(XSAdditiveModel):
     See Also
     --------
     XScarbatm
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11108,7 +11068,6 @@ class XSjet(XSAdditiveModel):
                                   self.s2, self.z, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSismabs(XSMultiplicativeModel):
     """The XSPEC ismabs model: A high resolution ISM absorption model with variable columns for individual ions.
 
@@ -11131,8 +11090,6 @@ class XSismabs(XSMultiplicativeModel):
     for Silicon and Sulfur include an underscore character after the
     element name to avoid conflict: that is Si_I and S_I refer to
     the XSPEC SiI and SI parameters respectively.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11385,7 +11342,6 @@ class XSolivineabs(XSMultiplicativeModel):
                                        (self.moliv, self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSslimbh(XSAdditiveModel):
     """The XSPEC slimbh model: Stationary slim accretion disk.
 
@@ -11422,10 +11378,6 @@ class XSslimbh(XSAdditiveModel):
         The normalization of the model: see [1]_ for an explanation
         of the units.
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11459,7 +11411,6 @@ class XSslimbh(XSAdditiveModel):
                                   self.lflag, self.vflag, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSsnapec(XSAdditiveModel):
     """The XSPEC snapec model: galaxy cluster spectrum using SN yields.
 
@@ -11489,10 +11440,6 @@ class XSsnapec(XSAdditiveModel):
     --------
     XSapec
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11520,7 +11467,6 @@ class XSsnapec(XSAdditiveModel):
                                   self.redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSTBfeo(XSMultiplicativeModel):
     """The XSPEC TBfeo model: ISM grain absorption.
 
@@ -11546,8 +11492,6 @@ class XSTBfeo(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11568,7 +11512,6 @@ class XSTBfeo(XSMultiplicativeModel):
                                         self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSTBgas(XSMultiplicativeModel):
     """The XSPEC TBgas model: ISM grain absorption.
 
@@ -11590,8 +11533,6 @@ class XSTBgas(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11609,7 +11550,6 @@ class XSTBgas(XSMultiplicativeModel):
                                        (self.nH, self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSTBpcf(XSMultiplicativeModel):
     """The XSPEC TBpcf model: ISM grain absorption.
 
@@ -11633,8 +11573,6 @@ class XSTBpcf(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11653,7 +11591,6 @@ class XSTBpcf(XSMultiplicativeModel):
                                        (self.nH, self.pcf, self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSTBrel(XSMultiplicativeModel):
     """The XSPEC TBrel model: ISM grain absorption.
 
@@ -11690,8 +11627,6 @@ class XSTBrel(XSMultiplicativeModel):
     -----
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11778,7 +11713,6 @@ class XSTBrel(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, pars)
 
 
-@version_at_least("12.9.1")
 class XSvoigt(XSAdditiveModel):
     """The XSPEC voigt model: Voigt line profile.
 
@@ -11799,10 +11733,6 @@ class XSvoigt(XSAdditiveModel):
     --------
     XSgauss, XSlorentz
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11822,7 +11752,6 @@ class XSvoigt(XSAdditiveModel):
                                   self.norm))
 
 
-@version_at_least("12.9.1")
 class XSxscat(XSMultiplicativeModel):
     """The XSPEC xscat model: dust scattering.
 
@@ -11840,10 +11769,6 @@ class XSxscat(XSMultiplicativeModel):
         The radius of the circular extraction region, in arcsec.
     DustModel
         The dust model used: see [1]_ for more information.
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11940,7 +11865,6 @@ class XScflux(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.9.1")
 class XSclumin(XSConvolutionKernel):
     """The XSPEC clumin convolution model: calculate luminosity
 
@@ -11971,8 +11895,6 @@ class XSclumin(XSConvolutionKernel):
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
     emission component (or components) at 1.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -12661,7 +12583,6 @@ class XSreflect(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.9.1")
 class XSrfxconv(XSConvolutionKernel):
     """The XSPEC rfxconv convolution model: angle-dependent reflection from an ionized disk
 
@@ -12698,8 +12619,6 @@ class XSrfxconv(XSConvolutionKernel):
     the ``set_xsxset`` function to set the value of the RFXCONV_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -12880,7 +12799,6 @@ class XSthcomp(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.9.1")
 class XSvashift(XSConvolutionKernel):
     """The XSPEC vashift convolution model: velocity shift an additive model.
 
@@ -12902,8 +12820,6 @@ class XSvashift(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -12921,7 +12837,6 @@ class XSvashift(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
-@version_at_least("12.9.1")
 class XSvmshift(XSConvolutionKernel):
     """The XSPEC vmshift convolution model: velocity shift a multiplicative model.
 
@@ -12943,8 +12858,6 @@ class XSvmshift(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -12962,7 +12875,6 @@ class XSvmshift(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
-@version_at_least("12.9.1")
 class XSxilconv(XSConvolutionKernel):
     """The XSPEC xilconv convolution model: angle-dependent reflection from an ionized disk
 
@@ -13001,8 +12913,6 @@ class XSxilconv(XSConvolutionKernel):
     the ``set_xsxset`` function to set the value of the XILCONV_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,5 +1,5 @@
-//  Copyright (C) 2007, 2015-2018, 2019, 2020
-//      Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015-2018, 2019, 2020, 2021
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -122,19 +122,10 @@ void qsosed_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void agnslim_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 
-#ifndef XSPEC_12_9_1
-void xsaped_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsbape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
 void xsblbd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbbrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbmc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsbrms_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-
-#ifndef XSPEC_12_9_1
-void xsbvpe_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
 
 #ifndef XSPEC_12_10_0
 void c6mekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -161,10 +152,6 @@ void xsdiskpn_(float* ear, int* ne, float* param, int* ifl, float* photar, float
 void xsxpdec_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void ezdiskbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
-#ifndef XSPEC_12_9_1
-void xsgaul_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
 void grad_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
 #ifdef XSPEC_12_10_0
@@ -181,12 +168,6 @@ void spin_(float* ear, int* ne, float* param, int* ifl, float* photar, float* ph
 void kyrline_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 #endif
 
-#ifndef XSPEC_12_9_1
-void xslorz_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsmeka_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
 void nsa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsagrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void nsatmos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -199,10 +180,6 @@ void xspegp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void xsp1tr_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsposm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
-#ifndef XSPEC_12_9_1
-void xsrays_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
 void xredge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xsrefsch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void srcut_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -212,20 +189,7 @@ void ssa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* pho
 #endif
 void xsstep_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
-#ifndef XSPEC_12_9_1
-void xsvape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
 void xsbrmv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-
-#ifndef XSPEC_12_9_1
-void xsvmek_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
-#ifndef XSPEC_12_9_1
-void xsvrys_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
 
 void xszbod_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszbrm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -281,11 +245,6 @@ void xszabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void xszwnb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
 
-#ifndef XSPEC_12_9_1
-void xsbvvp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsvvap_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-#endif
-
 void zigm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
 #ifndef XSPEC_12_10_1
@@ -310,11 +269,9 @@ void xsphei_(float* ear, int* ne, float* param, int* ifl, float* photar, float* 
 void xslyman_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 void xszbabs(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
 
-#ifdef XSPEC_12_9_1
 void ismabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 // Note: have dropped the leading 'c_' for this model
 void slimbbmodel(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-#endif
 
 #ifdef XSPEC_12_11_0
 void ismdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
@@ -986,13 +943,8 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( agnslim, 15 ),
 #endif
 
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_apec, 4 ),
   XSPECMODELFCT_C_NORM( C_bapec, 5 ),
-#else
-  XSPECMODELFCT_NORM( xsaped, 4 ),
-  XSPECMODELFCT_NORM( xsbape, 5 ),
-#endif
   XSPECMODELFCT_NORM( xsblbd, 2 ),
   XSPECMODELFCT_NORM( xsbbrd, 2 ),
   XSPECMODELFCT_C_NORM( C_xsbexrav, 10 ),
@@ -1005,11 +957,7 @@ static PyMethodDef XSpecMethods[] = {
 #ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_brnei, 7 ),
 #endif
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_bvapec, 17 ),
-#else
-  XSPECMODELFCT_NORM( xsbvpe, 17 ),
-#endif
 #ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_bvrnei, 19 ),
   XSPECMODELFCT_C_NORM( C_c6mekl, 11 ),
@@ -1046,11 +994,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_equil, 4 ),
   XSPECMODELFCT_NORM( xsxpdec, 2 ),
   XSPECMODELFCT_NORM( ezdiskbb, 2 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_gaussianLine, 3 ),
-#else
-  XSPECMODELFCT_NORM( xsgaul, 3 ),
-#endif
   XSPECMODELFCT_C_NORM( C_gnei, 6 ),
   XSPECMODELFCT_NORM( grad, 7 ),
 #ifdef XSPEC_12_10_0
@@ -1084,15 +1028,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_xslaor, 6 ),
 #endif
   XSPECMODELFCT_C_NORM( C_laor2, 8 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_lorentzianLine, 3 ),
   XSPECMODELFCT_C_NORM( C_meka, 5 ),
   XSPECMODELFCT_C_NORM( C_mekal, 6 ),
-#else
-  XSPECMODELFCT_NORM( xslorz, 3 ),
-  XSPECMODELFCT_NORM( xsmeka, 5 ),
-  XSPECMODELFCT_NORM( xsmekl, 6 ),
-#endif
   XSPECMODELFCT_C_NORM( C_xsmkcf, 6 ),
   XSPECMODELFCT_C_NORM( C_nei, 5 ),
   XSPECMODELFCT_C_NORM( C_nlapec, 4 ),
@@ -1114,11 +1052,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_powerLaw, 2 ),
   XSPECMODELFCT_NORM( xsposm, 1 ),
   XSPECMODELFCT_C_NORM( C_pshock, 6 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM(C_raysmith, 4 ),
-#else
-  XSPECMODELFCT_NORM( xsrays, 4 ),
-#endif
   XSPECMODELFCT_NORM( xredge, 3 ),
   XSPECMODELFCT_NORM( xsrefsch, 14 ),
 
@@ -1130,11 +1064,7 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT_NORM( xsstep, 3 ),
 
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vapec, 16 ),
-#else
-  XSPECMODELFCT_NORM( xsvape, 16 ),
-#endif
   XSPECMODELFCT_NORM( xsbrmv, 3 ),
 
 #ifdef XSPEC_12_10_1
@@ -1143,22 +1073,13 @@ static PyMethodDef XSpecMethods[] = {
 
   XSPECMODELFCT_C_NORM( C_vequil, 15 ),
   XSPECMODELFCT_C_NORM( C_vgnei, 18 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vmeka, 18 ),
   XSPECMODELFCT_C_NORM( C_vmekal, 19 ),
-#else
-  XSPECMODELFCT_NORM( xsvmek, 18 ),
-  XSPECMODELFCT_NORM( xsvmkl, 19 ),
-#endif
   XSPECMODELFCT_C_NORM( C_xsvmcf, 19 ),
   XSPECMODELFCT_C_NORM( C_vnei, 17 ),
   XSPECMODELFCT_C_NORM( C_vnpshock, 19 ),
   XSPECMODELFCT_C_NORM( C_vpshock, 18 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vraysmith, 15 ),
-#else
-  XSPECMODELFCT_NORM( xsvrys, 15 ),
-#endif
   XSPECMODELFCT_C_NORM( C_vsedov, 18 ),
   XSPECMODELFCT_NORM( xszbod, 3 ),
 
@@ -1250,13 +1171,8 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_xseqpair, 21 ),
   XSPECMODELFCT_C_NORM( C_xseqth, 21 ),
   XSPECMODELFCT_C_NORM( C_xscompth, 21 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_bvvapec, 34 ),
   XSPECMODELFCT_C_NORM( C_vvapec, 33 ),
-#else
-  XSPECMODELFCT_NORM( xsbvvp, 34 ),
-  XSPECMODELFCT_NORM( xsvvap, 33 ),
-#endif
 #ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_bvvrnei, 36 ),
 #endif
@@ -1360,8 +1276,6 @@ static PyMethodDef XSpecMethods[] = {
 
   // Models from 12.9.1
   //
-  //
-  #ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM(C_btapec, 6),
   XSPECMODELFCT_C_NORM(C_bvtapec, 18),
   XSPECMODELFCT_C_NORM(C_bvvtapec, 35),
@@ -1387,7 +1301,6 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_vashift, 1),
   XSPECMODELFCT_CON(C_vmshift, 1),
   XSPECMODELFCT_CON(C_xilconv, 6),
-  #endif
 
 #ifdef XSPEC_12_10_0
   XSPECMODELFCT_NORM(jet, 16),

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -99,13 +99,6 @@ def get_xspec_models():
               'XSTableModel', 'XSConvolutionModel', 'XSConvolutionKernel']:
         remove_item(model_names, n)
 
-    # The sirf model - in 12.8.2 and up to 12.9.0d at least - includes
-    # a read outside of an array. This has been seen to cause occasional
-    # errors in the Sherpa test case, so it is removed from the test
-    # for now. This problem has been reported to the XSPEC developers,
-    # so it will hopefully be fixed in one of ther 12.9.0 patches.
-    remove_item(model_names, 'XSsirf')
-
     models = [getattr(xs, model_name) for model_name in model_names]
     models = list(filter(lambda mod: mod.version_enabled, models))
 


### PR DESCRIPTION
# Summary

Bump the minimum supported XSPEC version from 12.9.0 to 12.9.1 and add extra functionality to the XSPEC module. The set_xsabund can now be sent an array of abundances and new routines are: get_xselements, get_xsabundancies, get_xsatomdb, and set_xsatomdb.

# Details

Ideally I'd like to jump straight to 12.12.0 as then we could add more functionality, but that is a more-significant change (see #1225).

As well as the functions mentioned in the summary, which are accessible to sherpa.astro.xspec and sherpa.astro.ui users, there are several new routines only accessible to sherpa.astro.xspec._xspec users - these are included for experimental work, and are:

- get_xspath_abundance/set_xspath_abundance/get_xsabundance_file/set_xsabundance_file

It's not clear if this is worthwhile functionality.

- get_xsxsflt_number, get_xsxflt_has_key, get_xsxflt_key/set_xsxflt_key

To support the smaug additive model or the projc mixing model (and possibly other models) we need access to the XFLT "database". This is used to send data from the header of each spectrum to the models, but we need to work out how to deal with "spectrum numbers" in Sherpa, including how to pass them through to the model evaluation. So this is the first step.

Two of the advantages of this are

- a number of models were >= 12.9.1 only so we can now make these always available
- we can drop some of the CPP code (to remove the 12.9.0/1 changes)

# Examples

So, for this build which was built against HEASOFT 6.26.1 / XSPEC 12.10.1

```python
>>> from sherpa.astro import xspec
>>> xspec.get_xsversion()
'12.10.1s'
```

We can now get a dictionary of all the supported elements (keys are name, values are the atomic number) - this is mainly just for show but is helpful for explanations:

```python
>>> xspec.get_xselements()
{'H': 1, 'He': 2, 'Li': 3, 'Be': 4, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 'F': 9, 'Ne': 10, 'Na': 11, 'Mg': 12, 'Al': 13, 'Si': 14, 'P': 15, 'S': 16, 'Cl': 17, 'Ar': 18, 'K': 19, 'Ca': 20, 'Sc': 21, 'Ti': 22, 'V': 23, 'Cr': 24, 'Mn': 25, 'Fe': 26, 'Co': 27, 'Ni': 28, 'Cu': 29, 'Zn': 30}
>>> xspec.get_xselements()['Fe']
26
```

The `get_xsabund` comman returns either the nae of the table or the abundance of a particular element. The `get_xsabundances` just takes the latter approach but returns a dictionary of all the elements:

```python
>>> xspec.get_xsabundances()
{'H': 1.0, 'He': 0.09769999980926514, 'Li': 1.4500000158901294e-11, 'Be': 1.409999981355492e-11, 'B': 3.979999940728618e-10, 'C': 0.00036299999919719994, 'N': 0.00011200000153621659, 'O':
0.0008510000188834965, 'F': 3.630000122711863e-08, 'Ne': 0.0001230000052601099, 'Na': 2.1400001060101204e-06, 'Mg': 3.7999998312443495e-05, 'Al': 2.9499999527615728e-06, 'Si': 3.550000110408291e-05, 'P': 2.8200000201650255e-07, 'S': 1.6199999663513154e-05, 'Cl': 3.160000119351025e-07, 'Ar': 3.6300000374467345e-06, 'K': 1.3199999671087426e-07, 'Ca': 2.2900001113157487e-06, 'Sc': 1.259999993230565e-09, 'Ti': 9.770000275466373e-08, 'V': 9.99999993922529e-09, 'Cr': 4.679999960899295e-07, 'Mn': 2.4499999540239514e-07, 'Fe': 4.6799999836366624e-05, 'Co': 8.319999977857151e-08, 'Ni': 1.7800000478018774e-06, 'Cu': 1.619999956403717e-08, 'Zn': 3.979999974035309e-08}
```

If you want to change all the abundances you can write them to a file, or just send them straight to `set_xsabud`:

```python
>>> from sherpa.astro import xspec
>>> rvals = [1] + [i * 0.1 for i in range(1, 30)]
>>> rvals
[1, 0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6000000000000001, 0.7000000000000001, 0.8, 0.9, 1.0, 1.1, 1.2000000000000002, 1.3, 1.4000000000000001, 1.5, 1.6, 1.7000000000000002, 1.8, 1.9000000000000001, 2.0, 2.1, 2.2, 2.3000000000000003, 2.4000000000000004, 2.5, 2.6, 2.7, 2.8000000000000003, 2.9000000000000004]
>>> xspec.set_xsabund(rvals)
 Solar Abundance Vector set to file:  User defined abundance vector / no description specified
>>> xspec.get_xsabund('H')
1.0
>>> xspec.get_xsabund('He')
0.10000000149011612
>>> xspec.get_xsabund('Cr')
2.299999952316284
``` 

## BUG

This is #1240 and not directly related to this PR although we do make use of one of the problem routines, so it kind-od still is an issue here....

There's something odd about this since if I follow it up it doesn't seem to pick up the new values so I need to look at this - note the abundances have not been updated:

```python
>>> rvals = [1] + [i * 0.01 for i in range(1, 30)]
>>> rvals
[1, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29]
>>> xspec.set_xsabund(rvals)
 Solar Abundance Vector set to file:  User defined abundance vector / no description specified
>>> xspec.get_xsabund('H')
1.0
>>> xspec.get_xsabund('He')
0.10000000149011612
>>> xspec.get_xsabund('Cr')
2.299999952316284
```

My guess is that there's some internal changes (that `RFLABD` does but other routines do not do and the docs do not document).


We can also get the ATOMDB version (which can be helpful to diagnose problems as discussed in #1235):

```python
>>> xspec.get_xsatomdb()
'3.0.9'
```

You can use `set_xsatomdb` to change the setting but I haven't really checked this.