### PR TITLE
to get sherpa to run Apple M1 (arm)

### DIFF
--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -32,6 +32,7 @@ import string
 import sys
 from configparser import ConfigParser, NoSectionError
 import pydoc
+import platform
 
 import numpy
 import numpy.random
@@ -1303,10 +1304,8 @@ def print_fields(names, vals, converters=None):
         converters = {numpy.bool_: 'Bool',
                       numpy.bytes_: 'Bytes0',
                       numpy.complex128: 'Complex128',
-                      numpy.complex256: 'Complex256',
                       numpy.complex64: 'Complex64',
                       numpy.datetime64: 'Datetime64',
-                      numpy.float128: 'Float128',
                       numpy.float16: 'Float16',
                       numpy.float32: 'Float32',
                       numpy.float64: 'Float64',
@@ -1323,6 +1322,10 @@ def print_fields(names, vals, converters=None):
                       numpy.uint8: 'UInt8',
                       numpy.void: 'Void0'
                       }
+        if platform.processor() != 'arm' or platform.machine() != 'arm64':
+            converters[numpy.complex256] = 'Complex256'
+            converters[numpy.float128] = 'Float128'
+
 
     width = max(len(n) for n in names)
     fmt = '%%-%ds = %%s' % width

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1322,10 +1322,14 @@ def print_fields(names, vals, converters=None):
                       numpy.uint8: 'UInt8',
                       numpy.void: 'Void0'
                       }
-        if platform.processor() != 'arm' or platform.machine() != 'arm64':
+        try:
             converters[numpy.complex256] = 'Complex256'
+        except AttributeError:
+            pass
+        try:
             converters[numpy.float128] = 'Float128'
-
+        except AttributeError:
+            pass
 
     width = max(len(n) for n in names)
     fmt = '%%-%ds = %%s' % width

--- a/sherpa/utils/src/cephes/const.c
+++ b/sherpa/utils/src/cephes/const.c
@@ -91,8 +91,6 @@ double TWOOPI =  6.36619772367581343075535E-1; /* 2/pi */
 #ifdef INFINITIES
 #ifndef INFINITY
 double INFINITY = 1.0/0.0;
-#else
-double INFINITY =  1.79769313486231570815E308;    /* 2**1024*(1-MACHEP) */
 #endif
 #endif
 #ifdef NANS

--- a/sherpa/utils/src/cephes/const.c
+++ b/sherpa/utils/src/cephes/const.c
@@ -89,14 +89,16 @@ double LOGSQ2 =  3.46573590279972654709E-1;    /* log(2)/2 */
 double THPIO4 =  2.35619449019234492885;       /* 3*pi/4 */
 double TWOOPI =  6.36619772367581343075535E-1; /* 2/pi */
 #ifdef INFINITIES
-double INFINITY = strtod("INF");  /* 99e999; */
+#ifndef INFINITY
+double INFINITY = 1.0/0.0;
 #else
 double INFINITY =  1.79769313486231570815E308;    /* 2**1024*(1-MACHEP) */
 #endif
+#endif
 #ifdef NANS
-double NAN = strtod("NAN");
-#else
-double NAN = 0.0;
+#ifndef NAN
+double NAN = 1.0/0.0 - 1.0/0.0;
+#endif
 #endif
 #ifdef MINUSZERO
 double NEGZERO = -0.0;

--- a/sherpa/utils/src/cephes/gamma.c
+++ b/sherpa/utils/src/cephes/gamma.c
@@ -179,10 +179,13 @@ static unsigned short Q[] = {
 0x0000,0x0000,0x0000,0x3ff0
 };
 #define MAXGAM 171.624376956302725
+/*
 static unsigned short LPI[4] = {
 0xa1bd,0x48e7,0x50d0,0x3ff2,
 };
 #define LOGPI *(double *)LPI
+*/
+#define LOGPI 1.14472988584940017414
 #endif 
 
 #ifdef MIEEE
@@ -247,10 +250,13 @@ static unsigned short STIR[20] = {
 0x5986,0x5555,0x5555,0x3fb5,
 };
 #define MAXSTIR 143.01608
+/*
 static unsigned short SQT[4] = {
 0x2706,0x1ff6,0x0d93,0x4004,
 };
 #define SQTPI *(double *)SQT
+*/
+#define SQTPI 2.50662827463100050242E0
 #endif
 #if MIEEE
 static unsigned short STIR[20] = {
@@ -520,10 +526,13 @@ static unsigned short C[] = {
 0xe14a,0x6a11,0xce4b,0xc13e
 };
 /* log( sqrt( 2*pi ) ) */
+/*
 static unsigned short LS2P[] = {
 0xbeb5,0xc864,0x67f1,0x3fed
 };
 #define LS2PI *(double *)LS2P
+*/
+#define LS2PI 0.91893853320467274178
 #define MAXLGM 2.556348e305
 #endif
 

--- a/sherpa/utils/src/cephes/ndtri.c
+++ b/sherpa/utils/src/cephes/ndtri.c
@@ -66,8 +66,11 @@ static unsigned short s2p[] = {0040440,0066230,0177661,0034055};
 #endif
 
 #ifdef IBMPC
+/*
 static unsigned short s2p[] = {0x2706,0x1ff6,0x0d93,0x4004};
 #define s2pi *(double *)s2p
+*/
+#define s2pi 2.50662827463100050242E0
 #endif
 
 #ifdef MIEEE


### PR DESCRIPTION
# Note

This PR enables sherpa to run on Apple M1, without XSpec.

```
=============================== warnings summary ===============================
../../../../proj/port_ots/macOS-BigSur-ARM/Python-3.9.4.macOS-BigSur-ARM/lib/python3.9/site-packages/_pytest/cacheprovider.py:428
  /proj/port_ots/macOS-BigSur-ARM/Python-3.9.4.macOS-BigSur-ARM/lib/python3.9/site-packages/_pytest/cacheprovider.py:428: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/nodeids
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../../proj/port_ots/macOS-BigSur-ARM/Python-3.9.4.macOS-BigSur-ARM/lib/python3.9/site-packages/_pytest/stepwise.py:49
  /proj/port_ots/macOS-BigSur-ARM/Python-3.9.4.macOS-BigSur-ARM/lib/python3.9/site-packages/_pytest/stepwise.py:49: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/stepwise
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===== 3705 passed, 924 skipped, 71 xfailed, 2 warnings in 99.23s (0:01:39) =====
```
