### PR TITLE
Fix  "unable to parse region string: None" errors (issue #1214)

### DIFF
--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1189,8 +1189,7 @@ def test_pickle_image_filter_none(make_test_image):
 
     This test assumes we have region support, but we do not
     currently have any test builds without it so do not
-    bother skipping (as many tests would need to be fixed
-    if we add a no-region build, which we probably should).
+    bother skipping.
 
     """
 
@@ -1212,8 +1211,7 @@ def test_pickle_image_filter(ignore, region, expected, make_test_image):
 
     This test assumes we have region support, but we do not
     currently have any test builds without it so do not
-    bother skipping (as many tests would need to be fixed
-    if we add a no-region build, which we probably should).
+    bother skipping.
 
     """
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1184,7 +1184,6 @@ def test_xmmrgs_notice(make_data_path):
     assert dat.get_filter(format='%.2f') == '19.01:19.20'
 
 
-@pytest.mark.xfail
 def test_pickle_image_filter_none(make_test_image):
     """Check we can pickle/unpickle without a region filter.
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10591,7 +10591,7 @@ class Session(sherpa.ui.utils.Session):
 
         return super().get_pvalue_plot(null_model=null_model, alt_model=alt_model,
                                        conv_model=conv_model, id=id, otherids=otherids,
-                                       num=num, bins=25, numcores=numcores,
+                                       num=num, bins=bins, numcores=numcores,
                                        recalc=recalc)
 
     get_pvalue_plot.__doc__ = sherpa.ui.utils.Session.get_pvalue_plot.__doc__

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -731,15 +731,15 @@ class PSFModel(Model):
                 psf_pixel_size = self.kernel.sky.cdelt
             except AttributeError:
                 # If the kernel does not have a pixel size, issue a warning and keep going
-                warnings.warn("PSF Image does not have a pixel size. Sherpa will assume the pixel size is the same"
-                              "as the data")
+                warnings.warn("PSF Image does not have a pixel size. Sherpa will assume "
+                              "the pixel size is the same as the data")
                 return self.SAME_RESOLUTION
 
             try:
                 data_pixel_size = data.sky.cdelt
             except AttributeError:
-                warnings.warn("Data Image does not have a pixel size. Sherpa will assume the pixel size is the same"
-                              "as the PSF")
+                warnings.warn("Data Image does not have a pixel size. Sherpa will assume "
+                              "the pixel size is the same as the PSF")
                 return self.SAME_RESOLUTION
 
             if numpy.allclose(psf_pixel_size, data_pixel_size):

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -35,7 +35,6 @@ from sherpa.astro import ui
 from sherpa.models.basic import Gauss2D
 
 
-@pytest.mark.xfail
 @requires_xspec
 @requires_fits
 @requires_data
@@ -341,7 +340,6 @@ def check_imgdata_convolved():
     assert tmp.y.shape == (6, )
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_plot_pvalue_imgpsf_model_unconvolved(clean_astro_ui, hide_logging, setup_imgdata_model, caplog):
@@ -358,7 +356,6 @@ def test_plot_pvalue_imgpsf_model_unconvolved(clean_astro_ui, hide_logging, setu
     check_imgdata_unconvolved(caplog)
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_plot_pvalue_imgpsf_model_convolved(clean_astro_ui, hide_logging, setup_imgdata_model):
@@ -372,7 +369,6 @@ def test_plot_pvalue_imgpsf_model_convolved(clean_astro_ui, hide_logging, setup_
     check_imgdata_convolved()
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_plot_pvalue_imgpsf_file_unconvolved(clean_astro_ui, hide_logging, setup_imgdata_file, caplog):

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -250,7 +250,7 @@ def setup_imgdata_file(tmp_path, recwarn):
 
     # NOTE: there's a typo (missing space) in this warning
     wmsg = 'PSF Image does not have a pixel size. Sherpa ' + \
-        'will assume the pixel size is the sameas the data'
+        'will assume the pixel size is the same as the data'
     assert str(w.message) == wmsg
 
 

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -248,7 +248,6 @@ def setup_imgdata_file(tmp_path, recwarn):
     w = recwarn.pop()
     assert issubclass(w.category, UserWarning)
 
-    # NOTE: there's a typo (missing space) in this warning
     wmsg = 'PSF Image does not have a pixel size. Sherpa ' + \
         'will assume the pixel size is the same as the data'
     assert str(w.message) == wmsg

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -381,7 +381,6 @@ def test_plot_pvalue_imgpsf_file_unconvolved(clean_astro_ui, hide_logging, setup
     check_imgdata_unconvolved(caplog)
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_plot_pvalue_imgpsf_file_convolved(clean_astro_ui, hide_logging, setup_imgdata_file):

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -17,7 +17,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import logging
+"""This is labelled ui but really tests astro/ui
+
+"""
 
 import pytest
 
@@ -26,24 +28,12 @@ from sherpa.utils.testing import requires_data, \
 
 from sherpa.astro import ui
 
-logger = logging.getLogger("sherpa")
-
-
-@pytest.fixture
-def hide_log_output():
-
-    olvl = logger.getEffectiveLevel()
-    logger.setLevel(logging.ERROR)
-
-    yield
-
-    logger.setLevel(olvl)
-
 
 @requires_xspec
 @requires_fits
 @requires_data
-def test_plot_pvalue(make_data_path, clean_astro_ui, hide_log_output):
+def test_plot_pvalue(make_data_path, clean_astro_ui, hide_logging):
+    """Check plot_pvalue with PHA data."""
 
     fname = make_data_path("qso.pi")
     ui.load_pha(fname)
@@ -54,8 +44,7 @@ def test_plot_pvalue(make_data_path, clean_astro_ui, hide_log_output):
     ui.group_counts(10)
     ui.notice(0.3, 8)
 
-    ui.set_model("xsphabs.abs1*xspowerlaw.p1")
-    ui.set_model("abs1*(p1+gauss1d.g1)")
+    ui.set_model("xsphabs.abs1*(xspowerlaw.p1 +gauss1d.g1)")
 
     # move the fit close to the best fit to save a small amount
     # of time.
@@ -69,6 +58,10 @@ def test_plot_pvalue(make_data_path, clean_astro_ui, hide_log_output):
     g1.fwhm = 0.1
     ui.freeze(g1.fwhm)
 
+    # Could we reduce the number of bins to save evaluation time?
+    # We do want a non-default num value when checking the shapes
+    # of the output attributes.
+    #
     ui.fit()
     ui.plot_pvalue(p1, p1 + g1, num=100)
 
@@ -77,3 +70,12 @@ def test_plot_pvalue(make_data_path, clean_astro_ui, hide_log_output):
     assert tmp.null == pytest.approx(210.34566845619273)
     assert tmp.alt == pytest.approx(207.66618095925094)
     assert tmp.lr == pytest.approx(2.679487496941789)
+
+    # Have we returned the correct info?
+    #
+    # Is it worth checking the stored data (aka how randomised is this
+    # output)?
+    #
+    assert tmp.samples.shape == (100, 2)
+    assert tmp.stats.shape == (100, 2)
+    assert tmp.ratios.shape == (100, )

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -29,6 +29,7 @@ from sherpa.utils.testing import requires_data, \
 from sherpa.astro import ui
 
 
+@pytest.mark.xfail
 @requires_xspec
 @requires_fits
 @requires_data
@@ -63,7 +64,7 @@ def test_plot_pvalue(make_data_path, clean_astro_ui, hide_logging):
     # of the output attributes.
     #
     ui.fit()
-    ui.plot_pvalue(p1, p1 + g1, num=100)
+    ui.plot_pvalue(p1, p1 + g1, num=100, bins=20)
 
     tmp = ui.get_pvalue_results()
 
@@ -79,3 +80,20 @@ def test_plot_pvalue(make_data_path, clean_astro_ui, hide_logging):
     assert tmp.samples.shape == (100, 2)
     assert tmp.stats.shape == (100, 2)
     assert tmp.ratios.shape == (100, )
+
+    # Check the plot
+    #
+    tmp = ui.get_pvalue_plot()
+
+    assert tmp.lr == pytest.approx(2.679487496941789)
+
+    assert tmp.xlabel == 'Likelihood Ratio'
+    assert tmp.ylabel == 'Frequency'
+    assert tmp.title == 'Likelihood Ratio Distribution'
+
+    # It would be nice to check the values here
+    #
+    assert tmp.ratios.shape == (100, )
+    assert tmp.xlo.shape == (21, )
+    assert tmp.xhi.shape == (21, )
+    assert tmp.y.shape == (21, )

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -21,12 +21,18 @@
 
 """
 
+import logging
+
+import numpy as np
+
 import pytest
 
+from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, \
     requires_xspec, requires_fits
 
 from sherpa.astro import ui
+from sherpa.models.basic import Gauss2D
 
 
 @pytest.mark.xfail
@@ -97,3 +103,292 @@ def test_plot_pvalue(make_data_path, clean_astro_ui, hide_logging):
     assert tmp.xlo.shape == (21, )
     assert tmp.xhi.shape == (21, )
     assert tmp.y.shape == (21, )
+
+
+@pytest.fixture
+def setup_imgdata_model():
+    """Use a model for the PSF"""
+
+    # Fake an image
+    #
+    x1, x0 = np.mgrid[0:8, 0:10]
+    ymod = 10 + 100 / ((x0 - 5.5)**2 + (x1 - 3.5)**2)
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = ymod.flatten()
+
+    y = y.astype(int)  # convert to integers
+
+    ui.load_arrays(1, x0, x1, y, (8, 10), ui.DataIMG)
+
+    pmodel = ui.create_model_component('gauss2d', 'pmodel')
+    pmodel.xpos = 0
+    pmodel.ypos = 0
+    pmodel.fwhm = 3
+
+    ui.load_psf('psf', pmodel)
+    psf.size = [10, 10]  # not sure if this is useful but leave in
+    psf.center = [5, 4]
+    ui.set_psf(psf)
+
+    setup_imgdata_source()
+
+
+def setup_imgdata_source():
+    """Set the model and fit setup"""
+    ui.set_source(ui.gauss2d.g1 + ui.const2d.c1)
+
+    c1.c0 = 10
+    g1.fwhm = 4
+    g1.xpos = 4
+    g1.ypos = 3
+    g1.ampl = 100
+
+    ui.set_stat('cstat')
+    ui.set_method("simplex")
+
+    # Fit and check we are in the expected place (so this is a
+    # pre-condition for the tests).
+    #
+    ui.fit()
+    assert ui.calc_stat() == pytest.approx(362.9264257040166)
+
+
+def fake_psf_image(outfile):
+    """Create a PSF image
+
+    This is based on the output of image_psf() saved to a file
+    for the test_plot_pvalue_imgpsf_convolved case. As this is
+    a very-small file and it could change (to make the test more
+    meaningful) we do not add the data to the repository but
+    create it directly.
+
+    """
+
+    hdr = ['SIMPLE  =                    T /',
+           'BITPIX  =                  -64 / Bits per pixel',
+           'NAXIS   =                    2 /',
+           'NAXIS1  =                   10 /',
+           'NAXIS2  =                    8 /']
+
+    x1, x0 = np.mgrid[0:8, 0:10]
+    dx0 = (x0 - 5).flatten()
+    dx1 = (x1 - 4).flatten()
+
+    mdl = Gauss2D()
+    mdl.fwhm = 3
+    y = mdl(dx0, dx1)
+    y = y / y.max()
+
+    # Create the FITS structure
+    #
+    with open(outfile, "wb") as fh:
+        for h in hdr:
+            fh.write(f'{h:80s}'.encode('ascii'))
+
+        n = 2880 - (len(hdr) + 1) * 80
+
+        # assume we don't have enough lines to pass 1 block!
+        assert n > 0
+
+        fmt = f'{{:{n}s}}'
+        fh.write(fmt.format(' ').encode('ascii'))
+
+        fh.write('{:80s}'.format('END').encode('ascii'))
+
+        # FITS is big-endian
+        yb = y.astype('>f8').tobytes()
+        fh.write(yb)
+
+        n = 2880 - len(yb)
+        assert n > 0
+
+        fh.write(b'\0' * n)
+
+
+@pytest.fixture
+def setup_imgdata_file(tmp_path, recwarn):
+    """Use a model for the PSF"""
+
+    # Fake an image
+    #
+    x1, x0 = np.mgrid[0:8, 0:10]
+    ymod = 10 + 100 / ((x0 - 5.5)**2 + (x1 - 3.5)**2)
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = ymod.flatten()
+
+    y = y.astype(int)  # convert to integers
+
+    ui.load_arrays(1, x0, x1, y, (8, 10), ui.DataIMG)
+
+    # Sherpa can confuse astropy if you send in pathlib objects so
+    # convert to the raw filesystem path.
+    #
+    fname = tmp_path / "psf.fits"
+    infile = str(fname)
+    fake_psf_image(infile)
+
+    ui.load_psf('psf', infile)
+    psf.size = [10, 8]
+    psf.center = [5, 4]
+
+    # Just check where the warning comes from (pytest.warns didn't
+    # seem to remove the warning so it still triggered the general
+    # "check no warning" fixture, so use recwarn like this).
+    #
+    assert len(recwarn) == 0
+    ui.set_psf(psf)
+    assert len(recwarn) == 1
+
+    setup_imgdata_source()
+
+    assert len(recwarn) == 1
+    w = recwarn.pop()
+    assert issubclass(w.category, UserWarning)
+
+    # NOTE: there's a typo (missing space) in this warning
+    wmsg = 'PSF Image does not have a pixel size. Sherpa ' + \
+        'will assume the pixel size is the sameas the data'
+    assert str(w.message) == wmsg
+
+
+def check_imgdata_unconvolved(caplog):
+    """What is the behavior when we do not add the PSF to plot_pvalue?
+
+    Note we add a check of the screen output here.
+    """
+
+    # include a check of the screen output
+    #
+    with caplog.at_level('INFO', logger='sherpa'):
+        with SherpaVerbosity('INFO'):
+            ui.plot_pvalue(c1, c1 + g1, num=40, bins=5)
+
+    assert len(caplog.records) == 1
+
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == 'sherpa.ui.utils'
+    assert lvl == logging.INFO
+
+    # Do not use equality tests for the numeric values in case
+    # there are numpy-version differences in the number of
+    # significant figures.
+    #
+    toks = msg.split('\n')
+    assert len(toks) == 5
+    assert toks[0] == 'Likelihood Ratio Test'
+    assert toks[1].startswith('null statistic   =  2391.2696')
+    assert toks[2].startswith('alt statistic    =  353.82')
+    assert toks[3].startswith('likelihood ratio =  2037.446')
+    assert toks[4] == 'p-value          <  0.025'
+
+    tmp = ui.get_pvalue_results()
+
+    assert tmp.null == pytest.approx(2391.2696310023503)
+    assert tmp.alt == pytest.approx(353.8235336370698)
+    assert tmp.lr == pytest.approx(2037.4460973652804)
+
+    assert tmp.samples.shape == (40, 1)
+    assert tmp.stats.shape == (40, 2)
+    assert tmp.ratios.shape == (40, )
+
+    tmp = ui.get_pvalue_plot(2037.4460973652804)
+
+    assert tmp.lr == pytest.approx(2037.4460973652804)
+
+    assert tmp.xlabel == 'Likelihood Ratio'
+    assert tmp.ylabel == 'Frequency'
+    assert tmp.title == 'Likelihood Ratio Distribution'
+
+    assert tmp.ratios.shape == (40, )
+    assert tmp.xlo.shape == (6, )
+    assert tmp.xhi.shape == (6, )
+    assert tmp.y.shape == (6, )
+
+
+def check_imgdata_convolved():
+    """What is the behavior when we add the PSF to plot_pvalue?"""
+
+    r1 = ui.get_psf()
+    ui.plot_pvalue(c1, c1 + g1, conv_model=r1, num=40, bins=5)
+
+    tmp = ui.get_pvalue_results()
+
+    # these values are different to test_plot_pvalue_imgpsf_unconvolved
+    #
+    assert tmp.null == pytest.approx(2391.26963100235)
+    assert tmp.alt == pytest.approx(563.3992697080881)
+    assert tmp.lr == pytest.approx(1827.8703612942618)
+
+    assert tmp.samples.shape == (40, 1)
+    assert tmp.stats.shape == (40, 2)
+    assert tmp.ratios.shape == (40, )
+
+    tmp = ui.get_pvalue_plot()
+
+    assert tmp.lr == pytest.approx(1827.8703612942618)
+
+    assert tmp.xlabel == 'Likelihood Ratio'
+    assert tmp.ylabel == 'Frequency'
+    assert tmp.title == 'Likelihood Ratio Distribution'
+
+    assert tmp.ratios.shape == (40, )
+    assert tmp.xlo.shape == (6, )
+    assert tmp.xhi.shape == (6, )
+    assert tmp.y.shape == (6, )
+
+
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+def test_plot_pvalue_imgpsf_model_unconvolved(clean_astro_ui, hide_logging, setup_imgdata_model, caplog):
+    """Test of issue #1214 but with no explicit convolution
+
+    This is an extra check added while working on 1214:
+    this does not add an explicit convolution model.
+
+    I've taken the liberty to add an explicit check of
+    the screen output with this routine which we don't
+    do in the convolved case.
+    """
+
+    check_imgdata_unconvolved(caplog)
+
+
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+def test_plot_pvalue_imgpsf_model_convolved(clean_astro_ui, hide_logging, setup_imgdata_model):
+    """Test of issue #1214
+
+    It is not obvious if this is a meaningful test. It also does not
+    trigger #1214.
+
+    """
+
+    check_imgdata_convolved()
+
+
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+def test_plot_pvalue_imgpsf_file_unconvolved(clean_astro_ui, hide_logging, setup_imgdata_file, caplog):
+    """Added as part of #1214 but just to exercise the system.
+
+    As with the imgpsf_model version we check the screen
+    output, which should be the same.
+    """
+
+    check_imgdata_unconvolved(caplog)
+
+
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+def test_plot_pvalue_imgpsf_file_convolved(clean_astro_ui, hide_logging, setup_imgdata_file):
+    """Test of issue #1214. This does trigger the problem."""
+
+    check_imgdata_convolved()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8338,20 +8338,6 @@ class Session(NoNewAttributesAfterInit):
     # Simulation functions
     #
 
-    def _run_pvalue(self, null_model, alt_model, conv_model=None,
-                    id=1, otherids=(), num=500, bins=25, numcores=None):
-        ids, fit = self._get_fit(id, otherids)
-
-        pvalue = sherpa.sim.LikelihoodRatioTest.run
-        results = pvalue(fit, null_model, alt_model, conv_model,
-                         niter=num,
-                         stat=self._current_stat,
-                         method=self._current_method,
-                         numcores=numcores)
-
-        info(results.format())
-        self._pvalue_results = results
-
     def get_pvalue_results(self):
         """Return the data calculated by the last plot_pvalue call.
 
@@ -8517,7 +8503,7 @@ class Session(NoNewAttributesAfterInit):
 
         lrplot = self.get_pvalue_plot(null_model=null_model, alt_model=alt_model,
                                       conv_model=conv_model, id=id, otherids=otherids,
-                                      num=num, bins=25, numcores=numcores,
+                                      num=num, bins=bins, numcores=numcores,
                                       recalc=not replot)
         self._plot(lrplot, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
@@ -8596,11 +8582,21 @@ class Session(NoNewAttributesAfterInit):
         if alt_model is None:
             raise TypeError("alternative model cannot be None")
 
-        self._run_pvalue(null_model, alt_model, conv_model,
-                         id, otherids, num, bins, numcores)
-        results = self._pvalue_results
-        lrplot.prepare(results.ratios, bins,
-                       num, results.lr, results.ppp)
+        ids, fit = self._get_fit(id, otherids)
+
+        pvalue = sherpa.sim.LikelihoodRatioTest.run
+        results = pvalue(fit, null_model, alt_model,
+                         conv_mdl=conv_model,
+                         stat=self._current_stat,
+                         method=self._current_method,
+                         niter=num,
+                         numcores=numcores)
+
+        info(results.format())
+        self._pvalue_results = results
+
+        lrplot.prepare(ratios=results.ratios, bins=bins,
+                       niter=num, lr=results.lr, ppp=results.ppp)
         return lrplot
 
     #


### PR DESCRIPTION
# Summary

In certain circumstances (such as plot_pvalue with an explicit 2D PSF convolution operator read from a file) the code would fail with the error `unable to parse region string: None` (issue #1214). This PR fixes this problem and several minor related issues.

# Details

This PR originally contained some region changes (which was where I started looking for a fix) but they've been pulled out into #1246

Issue #1214 was caused by the fixes added in #968, which made `sherpa.astro.utils._region.Region("None")` an error - since `"None"` is not a valid region string. In fact, prior to #968 you could send in any invalid region string and get back an "empty" region filter, but the sordid tale of #1214 is concerned with just the `"None"` argument...

Why do we care about the string "None"? Well. the sherpa.astro.data.DataIMG class has specialized state handling code in `__setstate__` and `__getstate__` to deal with pickling objects: one of the things we care about is that we have not provided pickling support for `Region` objects, so we need to handle this case during pickling (by turning a region object to a string or converting a string back to a region object). Unfortunately, this picklnig for the `_region` field ended up converting None to the string "None", and then this was being used later to re-create the region, based on the previously-undocumented support for Region('None'). We now

a) do not convert `None` to `'None'` in `__getstate__`
b) in `__setstate__` we now do not "always" try to create a Region object - i.e. we only try when `_region` is not `None`. 

In diagnosing this behavior I started with `plot_pvalue`, as this is how the bug was found. I added some more `plot_pvalue`-related tests and identified a couple of related issues (e.g. in #906 I introduced an error where the `bins` argument was being ignored for `plot_pvalue` and there was a typo in some warning messages).