### PR TITLE
Image region filters are now specified correctly (Fix #1245)

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4209,7 +4209,10 @@ class DataIMG(Data2D):
         #
         if self._region is None:
             if ignore:
-                reg.invert()
+                # add an explicit "whole field" constructor to avoid
+                # possible issues with stringification of multiple
+                # ignores.
+                reg = Region('field()').subtract(reg)
 
             self._region = reg
         elif ignore:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4212,8 +4212,10 @@ class DataIMG(Data2D):
                 reg.invert()
 
             self._region = reg
+        elif ignore:
+            self._region = self._region.subtract(reg)
         else:
-            self._region = self._region.combine(reg, ignore)
+            self._region = self._region.union(reg)
 
     def get_bounding_mask(self):
         mask = self.mask

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -798,26 +798,6 @@ def check_ignore_ignore(d):
     assert d.get_filter() == expected
 
 
-def check_ignore_ignore2(d):
-    """Check removing the shapes works as expected."""
-
-    shape1 = 'ellipse(4260,3840,3,2,0)'
-    d.notice2d(shape1, ignore=True)
-
-    mask1 = ~Region(shape1).mask(d.x0, d.x1).astype(bool)
-    assert d.mask == pytest.approx(mask1)
-
-    shape2 = 'rect(4258,3830,4264,3841)'
-    d.notice2d(shape2, ignore=True)
-
-    mask2 = ~Region(shape2).mask(d.x0, d.x1).astype(bool)
-    assert d.mask == pytest.approx(mask1 & mask2)
-
-    shape2 = shape2.replace('rect', 'rectangle')
-    expected = '!' + shape1.capitalize() + '&!' + shape2.capitalize()
-    assert d.get_filter() == expected
-
-
 def test_img_get_filter_included_excluded(make_test_image):
     """Simple get_filter check on an image.
 

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2009, 2016, 2020  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2016, 2020, 2021
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -178,6 +179,9 @@ static PyMethodDef pyRegion_methods[] = {
 };
 
 
+// Unfortunately we can not use C99-style designated initializers here
+// so we need to keep all the "null" values.
+//
 static PyTypeObject pyRegion_Type = {
   // Note that there is no semicolon after the PyObject_HEAD_INIT macro;
   // one is included in the macro definition.
@@ -319,8 +323,10 @@ PyInit__region(void)
     return NULL;
 
   Py_INCREF(&pyRegion_Type);
-
-  PyModule_AddObject(m, (char*)"Region", (PyObject *)&pyRegion_Type);
+  if (PyModule_AddObject(m, (char*)"Region", (PyObject *)&pyRegion_Type) < 0) {
+    Py_DECREF(&pyRegion_Type);
+    Py_DECREF(m);
+  }
   return m;
 
 }

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -246,7 +246,7 @@ static PyObject* region_union( PyRegion* self, PyObject* args, PyObject *kwargs 
   regRegion *r1 = self->region;
   regRegion *r2 = reg2->region;
 
-  regRegion *combined = regCombineRegion( r1, r2 );
+  regRegion *combined = regUnionRegion( r1, r2 );
   if ( NULL == combined ) {
     PyErr_SetString( PyExc_TypeError,
 		     (char*)"unable to union the regions" );
@@ -282,7 +282,7 @@ static PyObject* region_subtract( PyRegion* self, PyObject* args, PyObject *kwar
   regRegion *r1 = self->region;
   regRegion *r2 = regInvert( reg2->region );
 
-  regRegion *combined = regCombineRegion( r1, r2 );
+  regRegion *combined = regIntersectRegion( r1, r2 );
   regFree( r2 );
 
   if ( NULL == combined ) {

--- a/sherpa/astro/utils/tests/test_region_unit.py
+++ b/sherpa/astro/utils/tests/test_region_unit.py
@@ -322,6 +322,56 @@ def test_region_invert_empty():
     assert r.mask(x, y) == pytest.approx([0, 0, 0])
 
 
+def check_region_invert_compare(reg):
+    """Check that [field()]-rect(..) is filtering correctly."""
+
+    y, x = np.mgrid[99:108, 100:106]
+    x = x.flatten()
+    y = y.flatten()
+
+    m = reg.mask(x, y)
+
+    # For boxes it's <= for the upper limit, not <
+    expected = (x >= 100) & (x <= 104) & (y >= 100) & (y <= 106)
+    expected = ~expected
+    assert np.all(m == expected.flatten())
+
+    # just check we are actually doing a filter...
+    assert expected.size == 54
+    assert expected.sum() == 19
+
+
+def test_region_invert_compare_invert():
+    """-r and field()-r should ideally filter the same way
+    but they are potentially different.
+    """
+
+    shape = "rect(100, 100, 104, 106)"
+    r = Region(shape)
+    r.invert()
+    check_region_invert_compare(r)
+
+
+def test_region_invert_compare_steps():
+    """-r and field()-r should ideally filter the same way
+    but they are potentially different.
+    """
+
+    shape = "rect(100, 100, 104, 106)"
+    r = Region("field()").combine(Region(shape), exclude=True)
+    check_region_invert_compare(r)
+
+
+def test_region_invert_compare_inone():
+    """-r and field()-r should ideally filter the same way
+    but they are potentially different.
+    """
+
+    shape = "rect(100, 100, 104, 106)"
+    r = Region(f"field()-{shape}")
+    check_region_invert_compare(r)
+
+
 COMPLEX_REGION = ["circle(50,50,30)",
                   "ellipse(40,75,30,20,320)",
                   "-rotbox(30,30,10,5,45)"]


### PR DESCRIPTION
TODO: the RTD documentation could be improved to add an image case to https://sherpa.readthedocs.io/en/latest/data/index.html#astronomy-data and something to match https://sherpa.readthedocs.io/en/latest/developer/index.html#pha-filtering - however I claiim that is not required for this PR, just a nice to have, and shouldn't stop anyone from reviewing it.

# Summary

Update the image filter code so that the region description matches what the filter actually is: rather than use `&` to combine regions we now use `|` as it is a logical or rather than logical and. This is mainly going to affect users who 

- have used the output of `get_filter()` as input to `calc_data_sum2d`
- have very-complex spatial filters
- are restoring Sherpa sessions created by `save` or `save_all`.

Fixes #1245.

# Details

Note that the changes here are all in very-low-level code: users (even those using the object layer and not the ui layer) are not going to directly interact with Region objects - therefore I feel okay making relatively large API changes as anyone who is affected by these changes is probably doing something they shouldn't be! This can be thought of as the logical conclusion of #968 - I had thought I'd got it right then but obviously not. I am not an expert in the region library so I don't know how the filters seemed to be doing the right thing while the string representation was wrong (creating & rather than |). If I had added tests that had tried to re-create a filter from the region `__str__` method then perhaps I'd have found this when developing #968 (and I want to point out that these problems were not added in #968, they existed in the code before that PR its just that using this code quickly lead to a segfault so you couldn't really appreciate this error) .

I was going to clean up the region code initializer as it can be a lot-more readable (following advice from the Python documentation), but then realized that needs C99 style designated initalizers which we don't have in C++. The initalization code is now more-resistant to errors (but in reality it's not clear how useful this is as if it fails then something is seriously wrong anyway). These changes are suggested by https://docs.python.org/3/c-api/index.html and references therein.

After a few commits that either adds tests or cleans up the test code, we get to the first important change: remove support for the empty region. This is something that may have been present before #968 but I did add tests for this functinoality in #968. However, we don't actually use this capability (the ability to create an "empty" region, which is not well defined) so I removed it. Note that this only changes the low-level region test code (where I had added explicit tests of this behavior, including some with notes like "it's not obvious what this should do but let's just check we get back a known response"), which shows we don't use empty regions in Sherpa.

The next change is similar in that it changes low-level routines (but that are used by Sherpa, but only in one place in sherpa.astro.data.DataIMG). The region library had a combine method for combining two regions, with a flag to say whether it should be a subtraction or not. I have removed the combine method and replaced it with union (for adding together two regions) and subtract (for subtracting the second region from the first). As well as being (I feel) a bit more obvious when in use, it does improve the code slightly (as the two methods are simpler) at the expense of a little-bit of replicated code.

The final change is to correct these two methods so that they use the correct method for combining the regions: for union we use `regUnionRegion` and subtract we use `regIntersectRegion` whereas they both used to use `regCombineRegion` (which is what was used before #968). My guess is that this code was never updated when the region library gained these routines (since the use of `regCombineRegion` was present in the first git commit). I chose `regUnionRegion` and `regIntersectRegion` based on work Kenny did in generating the SDS prototype code for what became the region.CXCRegion Python class in CIAO. I have left in support for the invert method even though we don't use it in sherpa.astro.data.DataIMG "just in case". It is in this commit that I cange how we handle the `notice2d(); ignore2d(shape);` case - rather than inverting the region we subtract it from the catch-all "Field()" case as that fixes some odd region outputs we were seeing in the tests. 

# Notes

In general the test changes are in the `test_region_unit.py` file, which is the low-level tests for the Region class. This is important to test but it is not user facing. The number of test changes required for the "user-level" code is much smaller (but that may just suggest we don't have enough tests of the image filtering functionality).

Sherpa's use of the region library is much "smaller" than the CIAO region module (in particular region.CXCRegion), as all we really need are union, subtract, and possibly invert. We could think about adding support for intersection and possibly even area calculations, but that is not really relevant for this PR.

#1247 adds tests that are likely to change with this code so we'd want that merged first.

# Examples

## Example from 1245

Following the example in #1245 we now have

```python
>>> from sherpa.astro.ui import *
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> load_image('img.fits')
>>> get_filter()
''
>>> notice2d("Circle(50,50,30)")
>>> calc_data_sum2d("circle(50,50,30)")
1424.1255
>>> get_filter()
'Circle(50,50,30)'
>>> image_data()   # matches the result from #1245
```

```python
>>> notice2d()
>>> get_filter()
''
>>> notice2d("Ellipse(40,75,30,20,320)")
>>> get_filter()
'Ellipse(40,75,30,20,320)'
>>> calc_data_sum2d("Ellipse(40,75,30,20,320)")
946.3522
>>> image_data()   # matches the result from #1245
```

We have the first difference here in the `get_filter` `output` - it uses `|` rather than `&` to combine the regions  (and it should be `|` or `+` as this is OR - see https://cxc.harvard.edu/ciao/ahelp/dmregions.html - as `&` is AND which isn't technically correct, even though the actual filter as shown by `image_data` hasn't apparently changed):

```python
>>> notice2d()
>>> get_filter()
''
>>> notice2d("Circle(50,50,30)")
>>> get_filter()
'Circle(50,50,30)'
>>> notice2d("Ellipse(40,75,30,20,320)")
>>> get_filter()
'Circle(50,50,30)|Ellipse(40,75,30,20,320)'
>>> image_data()   # matches the result from #1245
```

We can see the difference of `&` vs `|` in the `calc_data_sum2d` output:

```python
>>> calc_data_sum2d('Circle(50,50,30)&Ellipse(40,75,30,20,320)')
489.9276
>>> calc_data_sum2d('Circle(50,50,30)|Ellipse(40,75,30,20,320)')
1880.55
```

The second version, using `|`, makes more sense for what we are trying to do (this is just repeating the text from #1245 here...)

```python
>>> notice2d()
>>> notice2d("Circle(50,50,30)&Ellipse(40,75,30,20,320)")
>>> get_filter()
'Circle(50,50,30)&Ellipse(40,75,30,20,320)'
>>> image_data()   # matches the result from #1245
```

```python
>>> notice2d()
>>> notice2d("Circle(50,50,30)|Ellipse(40,75,30,20,320)")
>>> get_filter()
'Circle(50,50,30)|Ellipse(40,75,30,20,320)'
>>> image_data()   # matches the result from #1245
```

In the following I noted in #1245 that the image_data was correct but the filter expression was wrong - you can know see it is "correct" - we have `circle1-rotbox` combined with `circle2` (the region library has been smart enough to recognize that `rotbox` doesn't overlap `circle2` so it can simplify `circle1-rotbox | circle2-rotbox` to the filter below:

```python
>>> notice2d()
>>> notice2d("Circle(50,50,30)")
>>> notice2d("Ellipse(40,75,30,20,320)")
>>> ignore2d("RotBox(30,30,10,5,45)")
>>> get_filter()
'Circle(50,50,30)&!RotBox(30,30,10,5,45)|Ellipse(40,75,30,20,320)'
>>> image_data()   # matches the result from #1245
```

One thing we now have is that applying the filter from get_filter to an unfiltered image will now correctly create the filter, when previously it didn't because it was using & rather than |. 

## Just negating things

One interesting piece I had to do is handle a case of "first filter is a subtraction" a little differently - we now expilctly add a `Field()` filter because without it strange things could happen (we could have used a bounding box around the image rather than `Field()` which would have some advantages but also difficulties). So we now have:

```python
>>> image_data()
>>> notice2d()
>>> ignore2d("circle(50,50,30)")
>>> get_filter()
'Field()&!Circle(50,50,30)'
>>> image_data()    # sorry, forgot to grab a screenshot
>>> ignore2d("Ellipse(40,75,30,20,320)")
>>> get_filter()
'Field()&!Circle(50,50,30)&!Ellipse(40,75,30,20,320)'
>>> image_data()
```

![sherpa](https://user-images.githubusercontent.com/224638/129117868-027afeb8-6079-4963-9f2f-bf87c0f45ffa.png)

```python
>>> ignore2d("RotBox(30,30,10,5,45)")
>>> get_filter()
'Field()&!Circle(50,50,30)&!Ellipse(40,75,30,20,320)&!RotBox(30,30,10,5,45)'
>>> image_data()
```

![sherpa](https://user-images.githubusercontent.com/224638/129117953-69584099-ff09-4be7-964a-e15ae2410382.png)

(note that it does exclude a few more pixels than the previous version).

Before this PR the result was the same, but without the Field statements:

```python
>>> from sherpa.astro.ui import *
>>> load_image('img.fits')
>>> get_filter()
''
>>> ignore2d("circle(50,50,30)")
>>> get_filter()
'!Circle(50,50,30)'
>>> image_data()
>>> ignore2d("Ellipse(40,75,30,20,320)")
>>> get_filter()
'!Circle(50,50,30)&!Ellipse(40,75,30,20,320)'
>>> image_data()
>>> ignore2d("RotBox(30,30,10,5,45)")
>>> get_filter()
'!Circle(50,50,30)&!Ellipse(40,75,30,20,320)&!RotBox(30,30,10,5,45)'
>>> image_data()
```

However, with the changes to how `union` and `subtract` work for the Region object (note: this is all internal stuff that users, even those using the object layer, would use) if we didn't add the field() statement the filter expressions after we removed the second region would have been `""`, which is just wrong (although the image_data output would have been correct)

## an example reading regions from files

https://gist.github.com/DougBurke/a14a78a11d5d9fed2a32c402d05b263e shows a notebook run with the main branc (`test_old.ipynb`) and this PR (`test_new.ipynb`) which shows that the filter returned by `get_filter` can not reliably be used before this PR but can with this one. The filters created by the `notice2d` calls select the same pixels in this case (which is reasonably complex), it's just that if you try to re-create the filter you get a problem.