### PR TITLE
Stop odd interaction between plot_model and PHA filters (Fix #1024)

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3973,14 +3973,13 @@ def test_pha_model_plot_filter_range_manual_1024(clean_astro_ui):
     assert f == '0.775000000000:1.210000000000'
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 @requires_plotting
 def test_pha_model_plot_filter_range_1024(make_data_path, clean_astro_ui):
     """Check if issue #1024 is fixed.
 
-    Unlike test_pha_model_plot_fitler_range_manual_1024
+    Unlike test_pha_model_plot_filter_range_manual_1024
     this test does show issue #1024.
     """
 
@@ -4017,7 +4016,7 @@ def test_pha_model_plot_filter_range_1024_true(mask, make_data_path, clean_astro
 @requires_plotting
 @pytest.mark.parametrize("mask,expected",
                          [(False, 'No noticed bins'),
-                          pytest.param(np.zeros(46, dtype=bool), '', marks=pytest.mark.xfail)])
+                          (np.zeros(46, dtype=bool), '')])
 def test_pha_model_plot_filter_range_1024_false(mask, expected, make_data_path, clean_astro_ui):
     """Special-case handling of mask: all masked out.
     """


### PR DESCRIPTION
# Summary

plot_model(), if done before calling notice or ignore, could lead to strange filters (e.g. filter not getting applied). This has been fixed. Fixes #1024 

# Details

The sherpa.astro.plot.ModelHistogram class is used by `plot_model` when plotting PHA data. The logic it used to temporarily ungroup the data just for the plot looks okay but invalidates an invariant used by the filter code, which triggers the behavior seen in #1024. I have re-written the code to be *really* explict, which fixes the problem (i.e. we only bother doing the filter re-creation - needed because we don't have #1249 or something similar - when it is needed, rather than whenever the data is grouped).

There is one small change in behavior if you have filtered out all points using ignore calls with explicit ranges since prior to this case the plot would be created by plot_model, after miraculously removing all filters (i.e. an example of #1024), whereas we now error out. If you had called ignore() - i.e. with no arguments - then you get an error (before and after). This is partly related to #1220

# Notes

This PR conflicts with #1216/#1219 (in that the tests will need to be updated to reflect the changes made in #1219 I would guess). As this is an easy review we could do this first and I can update the other PRs.

This has been pulled out of #1161 as it's not clear what I'm going to do with that PR.