### PR TITLE
More numpy 1.20 warning fixes

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -221,6 +221,7 @@ def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
     return dstype(name, *cols)
 
 
+# TODO: should this be exported?
 def read_ascii(filename, ncols=2, colkeys=None, dstype=Data1D, **kwargs):
     """Create a dataset from an ASCII tabular file.
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -202,8 +202,151 @@ def test_get_syserror_missing(bid):
     assert str(exc.value) == "data set '1' does not specify systematic errors"
 
 
+@pytest.mark.xfail
+@requires_fits
+@pytest.mark.parametrize("ascii,reader",
+                         [(True, ui.unpack_ascii), (False, ui.unpack_table)])
 @pytest.mark.parametrize("bid", [None, 1])
-def test_save_filter_ignored(bid):
+def test_save_filter_pha(ascii, reader, bid, tmp_path, clean_astro_ui):
+    """Does save_filter work? [PHA]
+
+    Does background copy the source filter by default?  No, hence we
+    get different filters.
+
+    """
+
+    x = np.arange(1, 11, dtype=np.int16)
+    ui.load_arrays(1, x, x, ui.DataPHA)
+    bkg = ui.DataPHA('bkg', x, x)
+    ui.set_bkg(bkg)
+
+    ui.notice(2, 4)
+    ui.notice(6, 8)
+
+    outfile = tmp_path / "filter.dat"
+    ui.save_filter(str(outfile), bkg_id=bid, ascii=ascii)
+
+    expected = [0, 1, 1, 1, 0, 1, 1, 1, 0, 0]
+
+    d = reader(str(outfile), colkeys=['X', 'FILTER'])
+    assert isinstance(d, ui.Data1D)
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(expected)
+    assert d.staterror is None
+    assert d.syserror is None
+
+
+@requires_fits
+@pytest.mark.parametrize("ascii,reader",
+                         [(True, ui.unpack_ascii), (False, ui.unpack_table)])
+@pytest.mark.parametrize("bid,expected",
+                         [(None, [1, -1, 1, 1, 1, -1, -1, 1, 1, -1]),
+                          (1, [1] * 10)])
+def test_save_grouping_pha(ascii, reader, bid, expected, tmp_path, clean_astro_ui):
+    """Does save_grouping work? [PHA]"""
+
+    x = np.arange(1, 11, dtype=np.int16)
+    ui.load_arrays(1, x, x, ui.DataPHA)
+    bkg = ui.DataPHA('bkg', x, x)
+    ui.set_bkg(bkg)
+
+    ui.set_grouping([1, -1, 1, 1, 1, -1, -1, 1, 1, -1])
+    ui.set_grouping([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], bkg_id=1)
+
+    outfile = tmp_path / "grouping.dat"
+    ui.save_grouping(str(outfile), bkg_id=bid, ascii=ascii)
+
+    d = reader(str(outfile), colkeys=['CHANNEL', 'GROUPS'])
+    assert isinstance(d, ui.Data1D)
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(expected)
+    assert d.staterror is None
+    assert d.syserror is None
+
+
+@requires_fits
+@pytest.mark.parametrize("ascii,reader",
+                         [(True, ui.unpack_ascii), (False, ui.unpack_table)])
+@pytest.mark.parametrize("bid,expected",
+                         [(None, [0] * 10),
+                          (1, [5, 0, 0, 0, 0, 0, 0, 0, 0, 2])])
+def test_save_quality_pha(ascii, reader, bid, expected, tmp_path, clean_astro_ui):
+    """Does save_quality work? [PHA]"""
+
+    x = np.arange(1, 11, dtype=np.int16)
+    ui.load_arrays(1, x, x, ui.DataPHA)
+    bkg = ui.DataPHA('bkg', x, x)
+    ui.set_bkg(bkg)
+
+    ui.set_quality([0] * 10)
+    ui.set_quality([5, 0, 0, 0, 0, 0, 0, 0, 0, 2], bkg_id=1)
+
+    outfile = tmp_path / "quality.dat"
+    ui.save_quality(str(outfile), bkg_id=bid, ascii=ascii)
+
+    d = reader(str(outfile), colkeys=['CHANNEL', 'QUALITY'])
+    assert isinstance(d, ui.Data1D)
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(expected)
+    assert d.staterror is None
+    assert d.syserror is None
+
+
+@requires_fits
+@pytest.mark.parametrize("ascii,reader",
+                         [(True, ui.unpack_ascii), (False, ui.unpack_table)])
+def test_save_table_data1d(ascii, reader, tmp_path, clean_astro_ui):
+    """Does save_table work? [Data1D]"""
+
+    x = np.asarray([1, 2, 5])
+    y = np.asarray([2, -3, 5])
+    ui.load_arrays(1, x, y)
+
+    outfile = tmp_path / "table.dat"
+    ui.save_table(str(outfile), ascii=ascii)
+
+    d = reader(str(outfile))
+    assert isinstance(d, ui.Data1D)
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(y)
+    assert d.staterror is None
+    assert d.syserror is None
+
+
+@pytest.mark.xfail  # see issue #47
+@requires_fits
+@pytest.mark.parametrize("ascii,reader",
+                         [(True, ui.unpack_ascii), (False, ui.unpack_table)])
+@pytest.mark.parametrize("bid,expected",
+                         [(None, [0] * 10),
+                          (1, [5, 0, 0, 0, 0, 0, 0, 0, 0, 2])])
+def test_save_table_pha(ascii, reader, bid, expected, tmp_path, clean_astro_ui):
+    """Does save_table work? [PHA]"""
+
+    x = np.arange(1, 11, dtype=np.int16)
+    ui.load_arrays(1, x, x, ui.DataPHA)
+    bkg = ui.DataPHA('bkg', x, x)
+    ui.set_bkg(bkg)
+
+    ui.set_quality([0] * 10)
+    ui.set_quality([5, 0, 0, 0, 0, 0, 0, 0, 0, 2], bkg_id=1)
+
+    outfile = tmp_path / "table.dat"
+    ui.save_table(str(outfile), bkg_id=bid, ascii=ascii)
+
+    # How do we check the save_table output? At the moment the
+    # code is broken so it's not obvious what it's meant to
+    # be.
+    d = reader(str(outfile))
+    assert isinstance(d, ui.Data1D)
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(x)
+    assert d.staterror is None
+    assert d.syserror is None
+
+
+@pytest.mark.parametrize("bid", [None, 1])
+def test_save_filter_ignored(bid, tmp_path):
     """Does save_filter error out if everything is masked?
 
     We should be able to write out the filter in this case,
@@ -216,9 +359,9 @@ def test_save_filter_ignored(bid):
 
     ui.ignore(None, None)
 
+    outfile = tmp_path / "temp-file-that-should-not-be-created"
     with pytest.raises(DataErr) as exc:
-        ui.save_filter("temp-file-that-should-not-be-created",
-                       bkg_id=bid)
+        ui.save_filter(str(outfile), bkg_id=bid)
 
     assert str(exc.value) == "mask excludes all data"
 
@@ -230,6 +373,12 @@ def test_save_filter_ignored(bid):
                            "data set '1' does not specify grouping flags"),
                           (ui.save_quality,  DataErr,
                            "data set '1' does not specify quality flags"),
+                          (ui.save_staterror,  StatErr,
+                           "If you select chi2 as the statistic, all datasets must provide a staterror column"),
+                          (ui.save_syserror,  DataErr,
+                           "data set '1' does not specify systematic errors"),
+                          (ui.save_error,  StatErr,
+                           "If you select chi2 as the statistic, all datasets must provide a staterror column"),
                           (ui.save_source,  IdentifierErr,
                            "source 1 has not been set, consider using set_source() or set_model()"),
                           (ui.save_model,  IdentifierErr,
@@ -238,7 +387,7 @@ def test_save_filter_ignored(bid):
                            "model 1 has not been set"),
                           (ui.save_delchi,  IdentifierErr,
                            "model 1 has not been set")])
-def test_save_xxx_nodata(func, etype, emsg):
+def test_save_xxx_nodata(func, etype, emsg, tmp_path):
     """Does save_xxx error out if there's no data to save? DataPHA
     """
 
@@ -246,14 +395,18 @@ def test_save_xxx_nodata(func, etype, emsg):
     bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
     ui.set_bkg(bkg)
 
+    # Without this we can't check save_staterror or save_error
+    ui.set_stat('chi2')
+
+    outfile = tmp_path / "temp-file-that-should-not-be-created"
     with pytest.raises(etype) as exc:
-        func("temp-file-that-should-not-be-created")
+        func(str(outfile))
 
     assert str(exc.value) == emsg
 
 
 @requires_fits
-def test_save_image_nodata():
+def test_save_image_nodata(tmp_path):
     """Does save_image error out if there's no data to save? DataPHA
 
     Unlike the other calls, this requires a FITS library
@@ -263,28 +416,35 @@ def test_save_image_nodata():
     bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
     ui.set_bkg(bkg)
 
+    outfile = tmp_path / "temp-file-that-should-not-be-created"
     with pytest.raises(IOErr) as exc:
-        ui.save_image("temp-file-that-should-not-be-created")
+        ui.save_image(str(outfile))
 
     assert str(exc.value) == "data set '' does not contain an image"
 
 
 @pytest.mark.parametrize("func,etype,emsg",
                          [(ui.save_filter, DataErr,
-                           "data set '1' has no filter"),
+                          "data set '1' has no filter"),
                           (ui.save_grouping, DataErr,
                            "data set '1' does not specify grouping flags"),
                           (ui.save_quality,  DataErr,
                            "data set '1' does not specify quality flags"),
                           (ui.save_source,  ModelErr,
                            "background model 1 for data set 1 has not been set"),
+                          (ui.save_staterror,  StatErr,
+                           "If you select chi2 as the statistic, all datasets must provide a staterror column"),
+                          (ui.save_syserror,  DataErr,
+                           "data set '1' does not specify systematic errors"),
+                          (ui.save_error,  StatErr,
+                           "If you select chi2 as the statistic, all datasets must provide a staterror column"),
                           (ui.save_model,  ModelErr,
                            "background model 1 for data set 1 has not been set"),
                           (ui.save_resid,  ModelErr,
                            "background model 1 for data set 1 has not been set"),
                           (ui.save_delchi,  ModelErr,
                            "background model 1 for data set 1 has not been set")])
-def test_save_xxx_bkg_nodata(func, etype, emsg):
+def test_save_xxx_bkg_nodata(func, etype, emsg, tmp_path):
     """Does save_xxx error out if there's no data to save? DataPHA + bkg
 
     Note that save_image does not support a bkg_id parameter so is
@@ -295,8 +455,12 @@ def test_save_xxx_bkg_nodata(func, etype, emsg):
     bkg = ui.DataPHA('bkg', np.asarray([1, 2, 3]), [1, 1, 0])
     ui.set_bkg(bkg)
 
+    # Without this we can't check save_staterror or save_error
+    ui.set_stat('chi2')
+
+    outfile = tmp_path / "temp-file-that-should-not-be-created"
     with pytest.raises(etype) as exc:
-        func("temp-file-that-should-not-be-created", bkg_id=1)
+        func(str(outfile), bkg_id=1)
 
     assert str(exc.value) == emsg
 
@@ -316,20 +480,21 @@ def test_save_xxx_bkg_nodata(func, etype, emsg):
                            "model 1 has not been set"),
                           (ui.save_delchi,  IdentifierErr,
                            "model 1 has not been set")])
-def test_save_xxx_data1d_nodata(func, etype, emsg):
+def test_save_xxx_data1d_nodata(func, etype, emsg, tmp_path):
     """Does save_xxx error out if there's no data to save? Data1D
     """
 
     ui.load_arrays(1, [1, 2, 3], [5, 4, 3], ui.Data1D)
 
+    outfile = tmp_path / "temp-file-that-should-not-be-created"
     with pytest.raises(etype) as exc:
-        func("temp-file-that-should-not-be-created")
+        func(str(outfile))
 
     assert str(exc.value) == emsg
 
 
 @requires_fits
-def test_save_image_data1d_nodata():
+def test_save_image_data1d_nodata(tmp_path):
     """Does save_image error out if there's no data to save? Data1D
 
     Unlike the other cases we need a FITS backend.
@@ -337,8 +502,9 @@ def test_save_image_data1d_nodata():
 
     ui.load_arrays(1, [1, 2, 3], [5, 4, 3], ui.Data1D)
 
+    outfile = tmp_path / "temp-file-that-should-not-be-created"
     with pytest.raises(IOErr) as exc:
-        ui.save_image("temp-file-that-should-not-be-created")
+        ui.save_image(str(outfile))
 
     assert str(exc.value) == "data set '' does not contain an image"
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -202,7 +202,6 @@ def test_get_syserror_missing(bid):
     assert str(exc.value) == "data set '1' does not specify systematic errors"
 
 
-@pytest.mark.xfail
 @requires_fits
 @pytest.mark.parametrize("ascii,reader",
                          [(True, ui.unpack_ascii), (False, ui.unpack_table)])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4352,24 +4352,32 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
         _check_type(filename, string_types, 'filename', 'a string')
-        d = self.get_data(id)
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
 
+        if bkg_id is not None:
+            d = self.get_bkg(id, bkg_id)
+        else:
+            d = self.get_data(id)
+
         # Leave this check as d.mask is False since d.mask need not be a boolean
+        # and we want different errors if mask is True or False (and leave as
+        # the iterable check to catch 'd.mask is True or any other value that
+        # could cause the following code to fall over).
+        #
         if d.mask is False:
             raise DataErr('notmask')
         if not numpy.iterable(d.mask):
             raise DataErr('nomask', id)
 
-        x = d.get_indep(filter=False)[0]
-        mask = numpy.asarray(d.mask, int)
         if isinstance(d, sherpa.astro.data.DataPHA):
             x = d._get_ebins(group=True)[0]
+        else:
+            x = d.get_indep(filter=False)[0]
 
-        self.save_arrays(filename, [x, mask], ['X', 'FILTER'],
-                         ascii, clobber)
+        mask = numpy.asarray(d.mask, int)
+
+        self.save_arrays(filename, [x, mask], fields=['X', 'FILTER'],
+                         ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
     def save_staterror(self, id, filename=None, bkg_id=None, ascii=True,
@@ -4454,12 +4462,14 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
 
-        x = d.get_indep(filter=False)[0]
         if isinstance(d, sherpa.astro.data.DataPHA):
             x = d._get_ebins(group=True)[0]
+        else:
+            x = d.get_indep(filter=False)[0]
+
         err = self.get_staterror(id, filter=False, bkg_id=bkg_id)
-        self.save_arrays(filename, [x, err], ['X', 'STAT_ERR'],
-                         ascii, clobber)
+        self.save_arrays(filename, [x, err], fields=['X', 'STAT_ERR'],
+                         ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
     def save_syserror(self, id, filename=None, bkg_id=None, ascii=True,
@@ -4542,12 +4552,14 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
 
-        x = d.get_indep(filter=False)[0]
         if isinstance(d, sherpa.astro.data.DataPHA):
             x = d._get_ebins(group=True)[0]
+        else:
+            x = d.get_indep(filter=False)[0]
+
         err = self.get_syserror(id, filter=False, bkg_id=bkg_id)
-        self.save_arrays(filename, [x, err], ['X', 'SYS_ERR'],
-                         ascii, clobber)
+        self.save_arrays(filename, [x, err], fields=['X', 'SYS_ERR'],
+                         ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
     def save_error(self, id, filename=None, bkg_id=None, ascii=True,
@@ -4637,12 +4649,14 @@ class Session(sherpa.ui.utils.Session):
             d = self.get_bkg(id, bkg_id)
         id = self._fix_id(id)
 
-        x = d.get_indep(filter=False)[0]
         if isinstance(d, sherpa.astro.data.DataPHA):
             x = d._get_ebins(group=True)[0]
+        else:
+            x = d.get_indep(filter=False)[0]
+
         err = self.get_error(id, filter=False, bkg_id=bkg_id)
-        self.save_arrays(filename, [x, err], ['X', 'ERR'],
-                         ascii, clobber)
+        self.save_arrays(filename, [x, err], fields=['X', 'ERR'],
+                         ascii=ascii, clobber=clobber)
 
     def save_pha(self, id, filename=None, bkg_id=None, ascii=False,
                  clobber=False):
@@ -4794,9 +4808,10 @@ class Session(sherpa.ui.utils.Session):
             id, filename = filename, id
         _check_type(filename, string_types, 'filename', 'a string')
         id = self._fix_id(id)
-        d = self._get_pha_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
+        else:
+            d = self._get_pha_data(id)
 
         if d.grouping is None or not numpy.iterable(d.grouping):
             raise DataErr('nogrouping', id)
@@ -4878,9 +4893,10 @@ class Session(sherpa.ui.utils.Session):
             id, filename = filename, id
         _check_type(filename, string_types, 'filename', 'a string')
         id = self._fix_id(id)
-        d = self._get_pha_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
+        else:
+            d = self._get_pha_data(id)
 
         if d.quality is None or not numpy.iterable(d.quality):
             raise DataErr('noquality', id)
@@ -5022,6 +5038,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
+        id = self._fix_id(id)
         _check_type(filename, string_types, 'filename', 'a string')
 
         sherpa.astro.io.write_table(filename, self.get_data(id),
@@ -5103,9 +5120,10 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
         _check_type(filename, string_types, 'filename', 'a string')
-        d = self.get_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
+        else:
+            d = self.get_data(id)
 
         try:
             sherpa.astro.io.write_pha(filename, d, ascii=ascii,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4364,7 +4364,7 @@ class Session(sherpa.ui.utils.Session):
             raise DataErr('nomask', id)
 
         x = d.get_indep(filter=False)[0]
-        mask = numpy.asarray(d.mask, numpy.int)
+        mask = numpy.asarray(d.mask, int)
         if isinstance(d, sherpa.astro.data.DataPHA):
             x = d._get_ebins(group=True)[0]
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4361,7 +4361,7 @@ class Session(sherpa.ui.utils.Session):
 
         # Leave this check as d.mask is False since d.mask need not be a boolean
         # and we want different errors if mask is True or False (and leave as
-        # the iterable check to catch 'd.mask is True or any other value that
+        # the iterable check to catch 'd.mask' is True or any other value that
         # could cause the following code to fall over).
         #
         if d.mask is False:

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -102,7 +102,6 @@ def test_filter_no_data_is_an_error(func, lo, hi, clean_ui):
     assert str(ie.value) == 'No data sets found'
 
 
-@pytest.mark.xfail
 def test_save_filter_data1d(tmp_path, clean_ui):
     """Check save_filter [Data1D]"""
 

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -25,6 +25,8 @@ Note that this test is almost duplicated in
 sherpa/astro/ui/tests/test_astro_ui_unit.py
 """
 
+import numpy as np
+
 import pytest
 
 from sherpa import ui
@@ -98,3 +100,26 @@ def test_filter_no_data_is_an_error(func, lo, hi, clean_ui):
         func(lo, hi)
 
     assert str(ie.value) == 'No data sets found'
+
+
+@pytest.mark.xfail
+def test_save_filter_data1d(tmp_path, clean_ui):
+    """Check save_filter [Data1D]"""
+
+    x = np.arange(1, 11, dtype=np.int16)
+    ui.load_arrays(1, x, x)
+
+    ui.notice(2, 4)
+    ui.notice(6, 8)
+
+    outfile = tmp_path / "filter.dat"
+    ui.save_filter(str(outfile))
+
+    expected = [0, 1, 1, 1, 0, 1, 1, 1, 0, 0]
+
+    d = ui.unpack_data(str(outfile), colkeys=['X', 'FILTER'])
+    assert isinstance(d, ui.Data1D)
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(expected)
+    assert d.staterror is None
+    assert d.syserror is None

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4391,7 +4391,7 @@ class Session(NoNewAttributesAfterInit):
         if not numpy.iterable(d.mask):
             raise sherpa.utils.err.DataErr('nomask', id)
         x = d.get_indep(filter=False)[0]
-        mask = numpy.asarray(d.mask, numpy.int)
+        mask = numpy.asarray(d.mask, int)
         self.save_arrays(filename, [x, mask], ['X', 'FILTER'],
                          clobber, sep, comment, linebreak, format)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4392,8 +4392,9 @@ class Session(NoNewAttributesAfterInit):
             raise sherpa.utils.err.DataErr('nomask', id)
         x = d.get_indep(filter=False)[0]
         mask = numpy.asarray(d.mask, int)
-        self.save_arrays(filename, [x, mask], ['X', 'FILTER'],
-                         clobber, sep, comment, linebreak, format)
+        self.save_arrays(filename, [x, mask], fields=['X', 'FILTER'],
+                         clobber=clobber, sep=sep, comment=comment,
+                         linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
     def save_staterror(self, id, filename=None, clobber=False, sep=' ',
@@ -4470,8 +4471,9 @@ class Session(NoNewAttributesAfterInit):
         _check_type(filename, string_types, 'filename', 'a string')
         x = self.get_data(id).get_indep(filter=False)[0]
         err = self.get_staterror(id, filter=False)
-        self.save_arrays(filename, [x, err], ['X', 'STAT_ERR'],
-                         clobber, sep, comment, linebreak, format)
+        self.save_arrays(filename, [x, err], fields=['X', 'STAT_ERR'],
+                         clobber=clobber, sep=sep, comment=comment,
+                         linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
     def save_syserror(self, id, filename=None, clobber=False, sep=' ',
@@ -4546,8 +4548,9 @@ class Session(NoNewAttributesAfterInit):
         _check_type(filename, string_types, 'filename', 'a string')
         x = self.get_data(id).get_indep(filter=False)[0]
         err = self.get_syserror(id, filter=False)
-        self.save_arrays(filename, [x, err], ['X', 'SYS_ERR'],
-                         clobber, sep, comment, linebreak, format)
+        self.save_arrays(filename, [x, err], fields=['X', 'SYS_ERR'],
+                         clobber=clobber, sep=sep, comment=comment,
+                         linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
     def save_error(self, id, filename=None, clobber=False, sep=' ',
@@ -4629,8 +4632,9 @@ class Session(NoNewAttributesAfterInit):
         _check_type(filename, string_types, 'filename', 'a string')
         x = self.get_data(id).get_indep(filter=False)[0]
         err = self.get_error(id, filter=False)
-        self.save_arrays(filename, [x, err], ['X', 'ERR'],
-                         clobber, sep, comment, linebreak, format)
+        self.save_arrays(filename, [x, err], fields=['X', 'ERR'],
+                         clobber=clobber, sep=sep, comment=comment,
+                         linebreak=linebreak, format=format)
 
     def _notice_expr(self, expr=None, **kwargs):
         ids = self.list_data_ids()


### PR DESCRIPTION
# Summary

Avoid warnings from NumPy 1.20 about using the deprecated np.int symbol.

# Details

PR #1138 was supposed to fix the NumPy warnings but mu grep-fu must have been lacking. I've added tests to `save_filter` (and related functions) which show the issue (i.e. a reason why I missed them in #1138 is because we had no test that executed these lines)

I also add a test of #47 (currently marked as xfail) so we'll know when that fails (I wanted to make sure that we had tests for the clean-up code changes I made).

I've marked this as a blocker issue as I would want to have numpy 1.20 issues fixed before we release.