### PR TITLE
FIX: #1235 change XSPEC chatter to 10 from 0

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -50,6 +50,10 @@ are now taken from the user's XSPEC configuration file - either
 for these settings. The default value for the photo-ionization table
 in this case is now ``vern`` rather than ``bcmc``.
 
+The default chatter setting - used by models to inform users of
+issues - was set to 0 (which hid the messages) until Sherpa 4.14.0,
+when it was changed to 10 (to match XSPEC).
+
 Supported models
 ----------------
 
@@ -167,7 +171,7 @@ def get_xschatter():
     --------
 
     >>> get_xschatter()
-    0
+    10
     """
 
     return _xspec.get_xschatter()
@@ -335,13 +339,18 @@ def set_xschatter(level):
     what information gets printed to the screen. It is equivalent to
     the X-Spec ``chatter`` command [1]_.
 
+    .. versionchanged:: 4.14.0
+       The default chatter setting has been bumped from 0 to 10 to
+       match XSPEC. Users will see extra screen output the first
+       time some XSPEC models are evaluated.
+
     Parameters
     ----------
     level : int
        The higher the value of ``level``, the more screen output will
-       be created by X-Spec routines. A value of ``0`` hides
-       most information while ``25`` will generate a lot of
-       debug output.
+       be created by X-Spec routines. A value of ``0`` hides most
+       information while ``25`` will generate a lot of debug
+       output. The starting value is ``10``.
 
     See Also
     --------
@@ -349,10 +358,6 @@ def set_xschatter(level):
 
     Notes
     -----
-    The default chatter setting used by Sherpa is ``0``, which is lower
-    than - so, creates less screen output - the default value used by
-    X-Spec (``10``).
-
     There is no way to change the X-Spec "log chatter" setting.
 
     References
@@ -365,9 +370,11 @@ def set_xschatter(level):
     Examples
     --------
 
-    Set the chatter level to the default used by X-Spec:
+    Set the chatter level to hide most, if not all, output from X-Spec
+    models:
 
-    >>> set_xschatter(10)
+    >>> set_xschatter(0)
+
     """
 
     _xspec.set_xschatter(level)

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,5 +1,5 @@
-//  Copyright (C) 2007, 2015-2018, 2019, 2020
-//      Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015-2018, 2019, 2020, 2021
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -429,8 +429,13 @@ int _sherpa_init_xspec_library()
     fout.clear();
     fout.close();
 
-    // Try to minimize model chatter for normal operation.
-    FPCHAT( 0 );
+    // We used to set the chatter to 0 but this misses useful info
+    // (like XSPEC can't find the data files) that would be reported
+    // by XSPEC, so use the default XSPEC setting. It does not appear
+    // that this value is read in from ~/.xspec/Xspec.init so set
+    // it here so we have repeatable behavior.
+    //
+    FPCHAT( 10 );
 
     // Set cosmology initial values to XSPEC initial values
     csmph0( 70.0 );


### PR DESCRIPTION
# Summary

Change the default X-Spec chatter level from 0 to 10. This may result in screen output the first time an XSPEC model is evaluated (e.g. from a plot_model or fit call). There have been a number of cases where APEC models appeared to be creating no output because of missing data files (due to old ~/.xspec/Xspec.init settings) which would have been more obvious with this change. To get back to the previous behavior users can call `set_xschatter(0)`.

# Details

The chatter level is explicitly set to 10 rather than 0 (it appears
to be the default value but let's be explicit in case things change).
I had wondered whether it would be read from the ~/.xspec/Xspec.init
file but it doesn't appear so.