### PR TITLE
XSPEC parameter changes - you can change the hard limits of most XSPEC parameters

### DIFF
--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -331,10 +331,10 @@ gal.integrate = True
 
 gal.nH.default_val = 1.0
 gal.nH.default_min = 0.0
-gal.nH.default_max = 100000.0
+gal.nH.default_max = 1000000.0
 gal.nH.val     = 1.0
 gal.nH.min     = 0.0
-gal.nH.max     = 100000.0
+gal.nH.max     = 1000000.0
 gal.nH.units   = "10^22 atoms / cm^2"
 gal.nH.frozen  = False
 
@@ -462,10 +462,10 @@ ggal.integrate = True
 
 ggal.nH.default_val = 2.0
 ggal.nH.default_min = 0.0
-ggal.nH.default_max = 100000.0
+ggal.nH.default_max = 1000000.0
 ggal.nH.val     = 2.0
 ggal.nH.min     = 0.0
-ggal.nH.max     = 100000.0
+ggal.nH.max     = 1000000.0
 ggal.nH.units   = "10^22 atoms / cm^2"
 ggal.nH.frozen  = True
 
@@ -584,10 +584,10 @@ ggal.integrate = True
 
 ggal.nH.default_val = 2.0
 ggal.nH.default_min = 0.0
-ggal.nH.default_max = 100000.0
+ggal.nH.default_max = 1000000.0
 ggal.nH.val     = 2.0
 ggal.nH.min     = 0.0
-ggal.nH.max     = 100000.0
+ggal.nH.max     = 1000000.0
 ggal.nH.units   = "10^22 atoms / cm^2"
 ggal.nH.frozen  = True
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1026,6 +1026,120 @@ set_source(1, (gauss2d.gmdl + scale2d.bmdl))
 
 """
 
+# Set an XSPEC parameter beyond the default hard limits: min
+_canonical_xspec_hard_limit_min = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("epsfcn", 1)
+set_method_opt("factor", 1)
+set_method_opt("ftol", 1)
+set_method_opt("gtol", 1)
+set_method_opt("maxfev", 1)
+set_method_opt("numcores", 1)
+set_method_opt("verbose", 1)
+set_method_opt("xtol", 1)
+
+
+######### Set Model Components and Parameters
+
+create_model_component("xspowerlaw", "mdl")
+mdl.integrate = True
+
+mdl.PhoIndex.hard_min    = -5.0
+mdl.PhoIndex.default_val = -5.0
+mdl.PhoIndex.default_min = -3.0
+mdl.PhoIndex.default_max = 10.0
+mdl.PhoIndex.val     = -5.0
+mdl.PhoIndex.min     = -5.0
+mdl.PhoIndex.max     = 10.0
+mdl.PhoIndex.units   = ""
+mdl.PhoIndex.frozen  = True
+
+mdl.norm.default_val = 1.0
+mdl.norm.default_min = 0.0
+mdl.norm.default_max = 9.9999999999999998e+23
+mdl.norm.val     = 1.0
+mdl.norm.min     = 0.0
+mdl.norm.max     = 100.0
+mdl.norm.units   = ""
+mdl.norm.frozen  = False
+
+
+
+######### Set Source, Pileup and Background Models
+
+"""
+
+# Set an XSPEC parameter beyond the default hard limits: max
+_canonical_xspec_hard_limit_max = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("epsfcn", 1)
+set_method_opt("factor", 1)
+set_method_opt("ftol", 1)
+set_method_opt("gtol", 1)
+set_method_opt("maxfev", 1)
+set_method_opt("numcores", 1)
+set_method_opt("verbose", 1)
+set_method_opt("xtol", 1)
+
+
+######### Set Model Components and Parameters
+
+create_model_component("xspowerlaw", "mdl")
+mdl.integrate = True
+
+mdl.PhoIndex.hard_max    = 15.0
+mdl.PhoIndex.default_val = 15.0
+mdl.PhoIndex.default_min = -3.0
+mdl.PhoIndex.default_max = 10.0
+mdl.PhoIndex.val     = 15.0
+mdl.PhoIndex.min     = -3.0
+mdl.PhoIndex.max     = 15.0
+mdl.PhoIndex.units   = ""
+mdl.PhoIndex.frozen  = True
+
+mdl.norm.default_val = 1.0
+mdl.norm.default_min = 0.0
+mdl.norm.default_max = 9.9999999999999998e+23
+mdl.norm.val     = 1.0
+mdl.norm.min     = 0.0
+mdl.norm.max     = 100.0
+mdl.norm.units   = ""
+mdl.norm.frozen  = False
+
+
+
+######### Set Source, Pileup and Background Models
+
+"""
+
 if has_xspec:
     _canonical_extra = """
 ######### XSPEC Module Settings
@@ -1044,6 +1158,8 @@ set_xsxsect("bcmc")
     _canonical_usermodel += _canonical_extra
     _canonical_img_no_filter_no_model += _canonical_extra
     _canonical_img_filter_model += _canonical_extra
+    _canonical_xspec_hard_limit_min += _canonical_extra
+    _canonical_xspec_hard_limit_max += _canonical_extra
 
     del _canonical_extra
 
@@ -1570,3 +1686,85 @@ def test_restore_img_filter_model(make_data_path, clean_astro_ui):
     # It should be this, but isn't for some reason
     # assert cnew == pytest.approx(corig)
     assert cnew == pytest.approx(1828.198211697685)
+
+
+@requires_xspec
+def test_canonical_xspec_hard_limit_min():
+    "Can we save an XSPEC model with the hard limit extended: min"
+
+    # Reset the optimiser parameters to make them easy to check,
+    # even if they are un-usable.
+    #
+    for key in ui.get_method_opt().keys():
+        ui.set_method_opt(key, 1)
+
+    ui.create_model_component('xspowerlaw', 'mdl')
+    mdl.phoindex.set(val=-5, hard_min=-5, frozen=True)
+    mdl.norm.max = 100
+
+    compare(_canonical_xspec_hard_limit_min)
+
+
+@requires_xspec
+def test_canonical_xspec_hard_limit_max():
+    "Can we save an XSPEC model with the hard limit extended: max"
+
+    # Reset the optimiser parameters to make them easy to check,
+    # even if they are un-usable.
+    #
+    for key in ui.get_method_opt().keys():
+        ui.set_method_opt(key, 1)
+
+    ui.create_model_component('xspowerlaw', 'mdl')
+    mdl.phoindex.set(val=15, hard_max=15, frozen=True)
+    mdl.norm.max = 100
+
+    compare(_canonical_xspec_hard_limit_max)
+
+
+@requires_xspec
+def test_restore_xspec_hard_limit_min():
+    "Can the reload a XSPEC model with changed hard limits: min"
+
+    # TODO: Why do we need to capture the return value when we
+    # did not need to in test_canonical_xspec_hard_limit_min?
+    #
+    mdl = ui.create_model_component('xspowerlaw', 'mdl')
+    mdl.phoindex.set(val=-5, hard_min=-5, frozen=True)
+    mdl.norm.max = 100
+    mdl = None
+
+    restore()
+
+    mdl = ui.get_model_component('mdl')
+    assert mdl.name == 'xspowerlaw.mdl'
+    assert mdl.PhoIndex.val == pytest.approx(-5)
+    assert mdl.PhoIndex.min == pytest.approx(-5)
+    assert mdl.PhoIndex.hard_min == pytest.approx(-5)
+    assert mdl.PhoIndex.frozen
+
+    assert mdl.norm.max == pytest.approx(100)
+
+
+@requires_xspec
+def test_restore_xspec_hard_limit_max():
+    "Can the reload a XSPEC model with changed hard limits: max"
+
+    # TODO: Why do we need to capture the return value when we
+    # did not need to in test_canonical_xspec_hard_limit_min?
+    #
+    mdl = ui.create_model_component('xspowerlaw', 'mdl')
+    mdl.phoindex.set(val=15, hard_max=15)
+    mdl.norm.max = 100
+    mdl = None
+
+    restore()
+
+    mdl = ui.get_model_component('mdl')
+    assert mdl.name == 'xspowerlaw.mdl'
+    assert mdl.PhoIndex.val == pytest.approx(15)
+    assert mdl.PhoIndex.max == pytest.approx(15)
+    assert mdl.PhoIndex.hard_max == pytest.approx(15)
+    assert not mdl.PhoIndex.frozen
+
+    assert mdl.norm.max == pytest.approx(100)

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -24,7 +24,7 @@ from tempfile import NamedTemporaryFile
 import unittest
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 
 from sherpa.astro import ui
 from sherpa.utils.testing import has_package_from_list
@@ -198,7 +198,7 @@ class SmokeTest(unittest.TestCase):
         model = ui.get_model_component("p")
         expected = [-1.2940997851602858, 0.5969328003146177]
         observed = [model.PhoIndex.val, model.norm.val]
-        assert_almost_equal(observed, expected)
+        assert_allclose(observed, expected, rtol=1e-6)
 
     def test_failure(self):
         """

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1221,9 +1221,9 @@ class XSTableModel(XSModel):
                 parname = parnames[ii]
 
             parname = parname.strip().lower().translate(tbl)
-            par = Parameter(name, parname, initvals[ii],
-                            mins[ii], maxes[ii],
-                            hardmins[ii], hardmaxes[ii], frozen=isfrozen)
+            par = XSBaseParameter(name, parname, initvals[ii],
+                                  mins[ii], maxes[ii],
+                                  hardmins[ii], hardmaxes[ii], frozen=isfrozen)
             self.__dict__[parname] = par
             pars.append(par)
             nint -= 1
@@ -1233,8 +1233,8 @@ class XSTableModel(XSModel):
         self.etable = etable
 
         if addredshift:
-            self.redshift = Parameter(name, 'redshift', 0., 0., 5.,
-                                      0.0, hugeval, frozen=True)
+            self.redshift = XSBaseParameter(name, 'redshift', 0., 0., 5.,
+                                            0.0, 5, frozen=True)
             pars.append(self.redshift)
 
         if addmodel:
@@ -1600,8 +1600,8 @@ class XSagauss(XSAdditiveModel):
     __function__ = "C_agauss"
 
     def __init__(self, name='agauss'):
-        self.LineE = Parameter(name, 'LineE', 10.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
-        self.Sigma = Parameter(name, 'Sigma', 1.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
+        self.LineE = XSParameter(name, 'LineE', 10.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
+        self.Sigma = XSParameter(name, 'Sigma', 1.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.norm))
 
@@ -1680,39 +1680,39 @@ class XSagnsed(XSAdditiveModel):
     __function__ = "agnsed"
 
     def __init__(self, name='agnsed'):
-        self.mass = Parameter(name, 'mass', 1e7, 1.0, 1e10, 1.0, 1e10,
-                              'solar', frozen=True)
-        self.dist = Parameter(name, 'dist', 100, 0.01, 1e9, 0.01, 1e9,
-                              'Mpc', frozen=True)
-        self.logmdot = Parameter(name, 'logmdot', -1, -10, 2, -10, 2)
-        self.astar = Parameter(name, 'astar', 0.0, -1, 0.998, -1, 0.998,
-                               frozen=True)
-        self.cosi = Parameter(name, 'cosi', 0.5, 0.05, 1.0, 0.05, 1.0,
-                              frozen=True)
+        self.mass = XSParameter(name, 'mass', 1e7, 1.0, 1e10, 1.0, 1e10,
+                                'solar', frozen=True)
+        self.dist = XSParameter(name, 'dist', 100, 0.01, 1e9, 0.01, 1e9,
+                                'Mpc', frozen=True)
+        self.logmdot = XSParameter(name, 'logmdot', -1, -10, 2, -10, 2)
+        self.astar = XSParameter(name, 'astar', 0.0, -1, 0.998, -1, 0.998,
+                                 frozen=True)
+        self.cosi = XSParameter(name, 'cosi', 0.5, 0.05, 1.0, 0.05, 1.0,
+                                frozen=True)
         # TODO: allow negative values
-        self.kTe_hot = Parameter(name, 'kTe_hot', 100.0, 10, 300, 10, 300,
-                                 'keV(_pl)', frozen=True)
-        self.kTe_warm = Parameter(name, 'kTe_warm', 0.2, 0.1, 0.5, 0.1, 0.5,
-                                  'keV(_sc)')
-        self.Gamma_hot = Parameter(name, 'Gamma_hot', 1.7, 1.3, 3, 1.3, 3,
-                                   '(_calc)')
-        self.Gamma_warm = Parameter(name, 'Gamma_warm', 2.7, 2, 5, 2, 10,
-                                    '(_disk)')
+        self.kTe_hot = XSParameter(name, 'kTe_hot', 100.0, 10, 300, 10, 300,
+                                   'keV(_pl)', frozen=True)
+        self.kTe_warm = XSParameter(name, 'kTe_warm', 0.2, 0.1, 0.5, 0.1, 0.5,
+                                    'keV(_sc)')
+        self.Gamma_hot = XSParameter(name, 'Gamma_hot', 1.7, 1.3, 3, 1.3, 3,
+                                     '(_calc)')
+        self.Gamma_warm = XSParameter(name, 'Gamma_warm', 2.7, 2, 5, 2, 10,
+                                      '(_disk)')
 
-        self.R_hot = Parameter(name, 'R_hot', 10, 6, 500, 6, 500, 'Rg')
-        self.R_warm = Parameter(name, 'R_warm', 20, 6, 500, 6, 500, 'Rg')
+        self.R_hot = XSParameter(name, 'R_hot', 10, 6, 500, 6, 500, 'Rg')
+        self.R_warm = XSParameter(name, 'R_warm', 20, 6, 500, 6, 500, 'Rg')
 
-        self.logrout = Parameter(name, 'logrout', -1, -3, 7, -3, 7,
-                                 '(_selfg)', frozen=True)
+        self.logrout = XSParameter(name, 'logrout', -1, -3, 7, -3, 7,
+                                   '(_selfg)', frozen=True)
 
-        self.Htmax = Parameter(name, 'Htmax', 10, 6, 10, 6, 10,
-                               'Rg', frozen=True)
+        self.Htmax = XSParameter(name, 'Htmax', 10, 6, 10, 6, 10,
+                                 'Rg', frozen=True)
 
-        self.reprocess = Parameter(name, 'reprocess', 1, 0, 1, 0, 1,
-                                   '0off/1on', alwaysfrozen=True)
+        self.reprocess = XSParameter(name, 'reprocess', 1, 0, 1, 0, 1,
+                                     '0off/1on', alwaysfrozen=True)
 
-        self.redshift = Parameter(name, 'redshift', 0, 0, 1, 0, 1,
-                                  frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0, 0, 1, 0, 1,
+                                    frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.mass, self.dist, self.logmdot, self.astar, self.cosi,
@@ -1796,34 +1796,34 @@ class XSagnslim(XSAdditiveModel):
     __function__ = "agnslim"
 
     def __init__(self, name='agnslim'):
-        self.mass = Parameter(name, 'mass', 1e7, 1.0, 1e10, 1.0, 1e10,
-                              'solar', frozen=True)
-        self.dist = Parameter(name, 'dist', 100, 0.01, 1e9, 0.01, 1e9,
-                              'Mpc', frozen=True)
-        self.logmdot = Parameter(name, 'logmdot', 1, -10, 3, -10, 3)
-        self.astar = Parameter(name, 'astar', 0.0, 0, 0.998, 0, 0.998,
-                               frozen=True)
-        self.cosi = Parameter(name, 'cosi', 0.5, 0.05, 1.0, 0.05, 1.0,
-                              frozen=True)
-        self.kTe_hot = Parameter(name, 'kTe_hot', 100.0, 10, 300, 10, 300,
-                                 'keV(-pl)', frozen=True)
-        self.kTe_warm = Parameter(name, 'kTe_warm', 0.2, 0.1, 0.5, 0.1, 0.5,
-                                  'keV(-sc)')
-        self.Gamma_hot = Parameter(name, 'Gamma_hot', 2.4, 1.3, 3, 1.3, 3)
-        self.Gamma_warm = Parameter(name, 'Gamma_warm', 3.0, 2, 5, 2, 10,
-                                    '(-disk)')
+        self.mass = XSParameter(name, 'mass', 1e7, 1.0, 1e10, 1.0, 1e10,
+                                'solar', frozen=True)
+        self.dist = XSParameter(name, 'dist', 100, 0.01, 1e9, 0.01, 1e9,
+                                'Mpc', frozen=True)
+        self.logmdot = XSParameter(name, 'logmdot', 1, -10, 3, -10, 3)
+        self.astar = XSParameter(name, 'astar', 0.0, 0, 0.998, 0, 0.998,
+                                 frozen=True)
+        self.cosi = XSParameter(name, 'cosi', 0.5, 0.05, 1.0, 0.05, 1.0,
+                                frozen=True)
+        self.kTe_hot = XSParameter(name, 'kTe_hot', 100.0, 10, 300, 10, 300,
+                                   'keV(-pl)', frozen=True)
+        self.kTe_warm = XSParameter(name, 'kTe_warm', 0.2, 0.1, 0.5, 0.1, 0.5,
+                                    'keV(-sc)')
+        self.Gamma_hot = XSParameter(name, 'Gamma_hot', 2.4, 1.3, 3, 1.3, 3)
+        self.Gamma_warm = XSParameter(name, 'Gamma_warm', 3.0, 2, 5, 2, 10,
+                                      '(-disk)')
 
-        self.R_hot = Parameter(name, 'R_hot', 10, 2, 500, 2, 500, units='Rg')
-        self.R_warm = Parameter(name, 'R_warm', 20, 2, 500, 2, 500, units='Rg')
+        self.R_hot = XSParameter(name, 'R_hot', 10, 2, 500, 2, 500, units='Rg')
+        self.R_warm = XSParameter(name, 'R_warm', 20, 2, 500, 2, 500, units='Rg')
 
-        self.logrout = Parameter(name, 'logrout', -1, -3, 7, -3, 7,
-                                 '(-selfg)', frozen=True)
+        self.logrout = XSParameter(name, 'logrout', -1, -3, 7, -3, 7,
+                                   '(-selfg)', frozen=True)
 
-        self.rin = Parameter(name, 'rin', -1, -1, 100, -1, 100,
-                                   frozen=True)  # TODO: make alwaysfrozen?
+        self.rin = XSParameter(name, 'rin', -1, -1, 100, -1, 100,
+                               frozen=True)  # TODO: make alwaysfrozen?
 
-        self.redshift = Parameter(name, 'redshift', 0, 0, 5, 0, 5,
-                                  frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0, 0, 5, 0, 5,
+                                    frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.mass, self.dist, self.logmdot, self.astar, self.cosi,
@@ -1871,9 +1871,9 @@ class XSapec(XSAdditiveModel):
     __function__ = "C_apec" if equal_or_greater_than("12.9.1") else "xsaped"
 
     def __init__(self, name='apec'):
-        self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64.0, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64.0, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.redshift, self.norm))
 
@@ -1917,10 +1917,10 @@ class XSbapec(XSAdditiveModel):
     __function__ = "C_bapec" if equal_or_greater_than("12.9.1") else "xsbape"
 
     def __init__(self, name='bapec'):
-        self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1e6, units='km/s', frozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1e6, units='km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Redshift, self.Velocity, self.norm))
 
@@ -1971,11 +1971,11 @@ class XSbtapec(XSAdditiveModel):
     __function__ = "C_btapec"
 
     def __init__(self, name='btapec'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
-        self.kTi = Parameter(name, 'kTi', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0.0, 5.0, 0.0, 5.0, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10, frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6, 'km/s', frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
+        self.kTi = XSParameter(name, 'kTi', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0.0, 5.0, 0.0, 5.0, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10, frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6, 'km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.kTi, self.Abundanc, self.Redshift, self.Velocity, self.norm))
@@ -2008,7 +2008,7 @@ class XSbbody(XSAdditiveModel):
     __function__ = "xsblbd"
 
     def __init__(self, name='bbody'):
-        self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
+        self.kT = XSParameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.norm))
 
@@ -2040,7 +2040,7 @@ class XSbbodyrad(XSAdditiveModel):
     __function__ = "xsbbrd"
 
     def __init__(self, name='bbodyrad'):
-        self.kT = Parameter(name, 'kT', 3., 1e-3, 100, 1e-4, 200, units='keV')
+        self.kT = XSParameter(name, 'kT', 3., 1e-3, 100, 1e-4, 200, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.norm))
 
@@ -2100,15 +2100,15 @@ class XSbexrav(XSAdditiveModel):
     __function__ = "C_xsbexrav"
 
     def __init__(self, name='bexrav'):
-        self.Gamma1 = Parameter(name, 'Gamma1', 2., -9., 9., -10, 10)
-        self.breakE = Parameter(name, 'breakE', 10., 0.1, 1000., 0.1, 1000, units='keV')
-        self.Gamma2 = Parameter(name, 'Gamma2', 2., -9., 9., -10, 10)
-        self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
-        self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 10., 0.0, 10)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.abund = Parameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Gamma1 = XSParameter(name, 'Gamma1', 2., -9., 9., -10, 10)
+        self.breakE = XSParameter(name, 'breakE', 10., 0.1, 1000., 0.1, 1000, units='keV')
+        self.Gamma2 = XSParameter(name, 'Gamma2', 2., -9., 9., -10, 10)
+        self.foldE = XSParameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
+        self.rel_refl = XSParameter(name, 'rel_refl', 0., 0., 10., 0.0, 10)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Gamma1, self.breakE, self.Gamma2, self.foldE, self.rel_refl, self.cosIncl, self.abund, self.Fe_abund, self.redshift, self.norm))
 
@@ -2175,17 +2175,17 @@ class XSbexriv(XSAdditiveModel):
     __function__ = "C_xsbexriv"
 
     def __init__(self, name='bexriv'):
-        self.Gamma1 = Parameter(name, 'Gamma1', 2., -9., 9., -10, 10)
-        self.breakE = Parameter(name, 'breakE', 10., 0.1, 1000., 0.1, 1000, units='keV')
-        self.Gamma2 = Parameter(name, 'Gamma2', 2., -9., 9., -10, 10)
-        self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 1, 1e6, units='keV')
-        self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e6, 0.0, 1e6)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.abund = Parameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.T_disk = Parameter(name, 'T_disk', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 1., 0., 1.e3, 0.0, 5e3, units='erg cm/s')
+        self.Gamma1 = XSParameter(name, 'Gamma1', 2., -9., 9., -10, 10)
+        self.breakE = XSParameter(name, 'breakE', 10., 0.1, 1000., 0.1, 1000, units='keV')
+        self.Gamma2 = XSParameter(name, 'Gamma2', 2., -9., 9., -10, 10)
+        self.foldE = XSParameter(name, 'foldE', 100., 1., 1.e6, 1, 1e6, units='keV')
+        self.rel_refl = XSParameter(name, 'rel_refl', 0., 0., 1.e6, 0.0, 1e6)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.T_disk = XSParameter(name, 'T_disk', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 1., 0., 1.e3, 0.0, 5e3, units='erg cm/s')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Gamma1, self.breakE, self.Gamma2, self.foldE, self.rel_refl, self.redshift, self.abund, self.Fe_abund, self.cosIncl, self.T_disk, self.xi, self.norm))
 
@@ -2227,9 +2227,9 @@ class XSbknpower(XSAdditiveModel):
     __function__ = "C_brokenPowerLaw"
 
     def __init__(self, name='bknpower'):
-        self.PhoIndx1 = Parameter(name, 'PhoIndx1', 1., -2., 9., -3, 10)
-        self.BreakE = Parameter(name, 'BreakE', 5., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
-        self.PhoIndx2 = Parameter(name, 'PhoIndx2', 2., -2., 9., -3, 10)
+        self.PhoIndx1 = XSParameter(name, 'PhoIndx1', 1., -2., 9., -3, 10)
+        self.BreakE = XSParameter(name, 'BreakE', 5., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
+        self.PhoIndx2 = XSParameter(name, 'PhoIndx2', 2., -2., 9., -3, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.PhoIndx1, self.BreakE, self.PhoIndx2, self.norm)
@@ -2279,11 +2279,11 @@ class XSbkn2pow(XSAdditiveModel):
     __function__ = "C_broken2PowerLaw"
 
     def __init__(self, name='bkn2pow'):
-        self.PhoIndx1 = Parameter(name, 'PhoIndx1', 1., -2., 9., -3, 10)
-        self.BreakE1 = Parameter(name, 'BreakE1', 5., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
-        self.PhoIndx2 = Parameter(name, 'PhoIndx2', 2., -2., 9., -3, 10)
-        self.BreakE2 = Parameter(name, 'BreakE2', 10., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
-        self.PhoIndx3 = Parameter(name, 'PhoIndx3', 3., -2., 9., -3, 10)
+        self.PhoIndx1 = XSParameter(name, 'PhoIndx1', 1., -2., 9., -3, 10)
+        self.BreakE1 = XSParameter(name, 'BreakE1', 5., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
+        self.PhoIndx2 = XSParameter(name, 'PhoIndx2', 2., -2., 9., -3, 10)
+        self.BreakE2 = XSParameter(name, 'BreakE2', 10., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
+        self.PhoIndx3 = XSParameter(name, 'PhoIndx3', 3., -2., 9., -3, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndx1, self.BreakE1, self.PhoIndx2, self.BreakE2, self.PhoIndx3, self.norm))
 
@@ -2327,9 +2327,9 @@ class XSbmc(XSAdditiveModel):
     __function__ = "xsbmc"
 
     def __init__(self, name='bmc'):
-        self.kT = Parameter(name, 'kT', 1., 1.e-2, 100., 1e-4, 200, units='keV')
-        self.alpha = Parameter(name, 'alpha', 1., 1.e-2, 4.0, 1e-4, 6)
-        self.log_A = Parameter(name, 'log_A', 0.0, -6.0, 6.0, -8, 8, aliases=["logA"])
+        self.kT = XSParameter(name, 'kT', 1., 1.e-2, 100., 1e-4, 200, units='keV')
+        self.alpha = XSParameter(name, 'alpha', 1., 1.e-2, 4.0, 1e-4, 6)
+        self.log_A = XSParameter(name, 'log_A', 0.0, -6.0, 6.0, -8, 8, aliases=["logA"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.alpha, self.log_A, self.norm))
 
@@ -2361,7 +2361,7 @@ class XSbremss(XSAdditiveModel):
     __function__ = "xsbrms"
 
     def __init__(self, name='bremss'):
-        self.kT = Parameter(name, 'kT', 7.0, 1.e-4, 100., 1e-4, 200, units='keV')
+        self.kT = XSParameter(name, 'kT', 7.0, 1.e-4, 100., 1e-4, 200, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.norm))
 
@@ -2411,13 +2411,13 @@ class XSbrnei(XSAdditiveModel):
     __function__ = "C_brnei"
 
     def __init__(self, name='brnei'):
-        self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_init = Parameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.Redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6,
-                                  units='km/s', frozen=True)
+        self.kT = XSParameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.Redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6,
+                                    units='km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.Abundanc, self.Tau, self.Redshift, self.Velocity, self.norm))
 
@@ -2456,22 +2456,22 @@ class XSbvapec(XSAdditiveModel):
     __function__ = "C_bvapec" if equal_or_greater_than("12.9.1") else "xsbvpe"
 
     def __init__(self, name='bvapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1e6, units='km/s', frozen=True)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1e6, units='km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self.Velocity, self.norm))
 
@@ -2520,24 +2520,24 @@ class XSbvrnei(XSAdditiveModel):
     __function__ = "C_bvrnei"
 
     def __init__(self, name='bvrnei'):
-        self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_init = Parameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1., 0.0, 1.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 10000., frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10., frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1.e6, 'km/s', frozen=True)
+        self.kT = XSParameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1., 0.0, 1.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 10000., frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10., frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1.e6, 'km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.Redshift, self.Velocity, self.norm))
 
@@ -2586,23 +2586,23 @@ class XSbvtapec(XSAdditiveModel):
     __function__ = "C_bvtapec"
 
     def __init__(self, name='bvtapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.kTi = Parameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
-        self.Velocity = Parameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6, units='km/s')
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.kTi = XSParameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
+        self.Velocity = XSParameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6, units='km/s')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.kTi, self.He, self.C, self.N, self.O,
@@ -2645,39 +2645,39 @@ class XSbvvapec(XSAdditiveModel):
     __function__ = "C_bvvapec" if equal_or_greater_than("12.9.1") else "xsbvvp"
 
     def __init__(self, name='bvvapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1e6, units='km/s', frozen=True)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1e6, units='km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.Velocity, self.norm))
 
@@ -2727,43 +2727,43 @@ class XSbvvrnei(XSAdditiveModel):
     __function__ = "C_bvvrnei"
 
     def __init__(self, name='bvvrnei'):
-        self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_init = Parameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT = XSParameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
         maxval = 1000.0
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, maxval, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10., frozen=True)
-        self.Velocity = Parameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1.e6,
-                                  units='km/s', frozen=True)
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, maxval, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10., frozen=True)
+        self.Velocity = XSParameter(name, 'Velocity', 0., 0., 1.e6, 0.0, 1.e6,
+                                    units='km/s', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.Redshift, self.Velocity, self.norm))
 
@@ -2811,40 +2811,40 @@ class XSbvvtapec(XSAdditiveModel):
     __function__ = "C_bvvtapec"
 
     def __init__(self, name='bvvtapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.kTi = Parameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
-        self.Velocity = Parameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6, units='km/s')
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.kTi = XSParameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
+        self.Velocity = XSParameter(name, 'Velocity', 0.0, 0.0, 1.0e6, 0.0, 1.0e6, units='km/s')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.kTi, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.Velocity, self.norm))
@@ -2887,16 +2887,16 @@ class XSc6mekl(XSAdditiveModel):
     __function__ = _f77_or_c_12100("c6mekl")
 
     def __init__(self, name='c6mekl'):
-        self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
-        self.CPcoef2 = Parameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
-        self.CPcoef3 = Parameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
-        self.CPcoef4 = Parameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
-        self.CPcoef5 = Parameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
-        self.CPcoef6 = Parameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, alwaysfrozen=True)
+        self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
+        self.CPcoef2 = XSParameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
+        self.CPcoef3 = XSParameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
+        self.CPcoef4 = XSParameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
+        self.CPcoef5 = XSParameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
+        self.CPcoef6 = XSParameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.abundanc = XSParameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
@@ -2942,16 +2942,16 @@ class XSc6pmekl(XSAdditiveModel):
     __function__ = _f77_or_c_12100("c6pmekl")
 
     def __init__(self, name='c6pmekl'):
-        self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
-        self.CPcoef2 = Parameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
-        self.CPcoef3 = Parameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
-        self.CPcoef4 = Parameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
-        self.CPcoef5 = Parameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
-        self.CPcoef6 = Parameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, alwaysfrozen=True)
+        self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
+        self.CPcoef2 = XSParameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
+        self.CPcoef3 = XSParameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
+        self.CPcoef4 = XSParameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
+        self.CPcoef5 = XSParameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
+        self.CPcoef6 = XSParameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.abundanc = XSParameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
@@ -2997,29 +2997,29 @@ class XSc6pvmkl(XSAdditiveModel):
     __function__ = _f77_or_c_12100("c6pvmkl")
 
     def __init__(self, name='c6pvmkl'):
-        self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
-        self.CPcoef2 = Parameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
-        self.CPcoef3 = Parameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
-        self.CPcoef4 = Parameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
-        self.CPcoef5 = Parameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
-        self.CPcoef6 = Parameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Na = Parameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, alwaysfrozen=True)
+        self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
+        self.CPcoef2 = XSParameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
+        self.CPcoef3 = XSParameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
+        self.CPcoef4 = XSParameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
+        self.CPcoef5 = XSParameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
+        self.CPcoef6 = XSParameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
@@ -3065,29 +3065,29 @@ class XSc6vmekl(XSAdditiveModel):
     __function__ = _f77_or_c_12100("c6vmekl")
 
     def __init__(self, name='c6vmekl'):
-        self.CPcoef1 = Parameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
-        self.CPcoef2 = Parameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
-        self.CPcoef3 = Parameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
-        self.CPcoef4 = Parameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
-        self.CPcoef5 = Parameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
-        self.CPcoef6 = Parameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Na = Parameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, alwaysfrozen=True)
+        self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
+        self.CPcoef2 = XSParameter(name, 'CPcoef2', 0.5, -1, 1, -1, 1)
+        self.CPcoef3 = XSParameter(name, 'CPcoef3', 0.5, -1, 1, -1, 1)
+        self.CPcoef4 = XSParameter(name, 'CPcoef4', 0.5, -1, 1, -1, 1)
+        self.CPcoef5 = XSParameter(name, 'CPcoef5', 0.5, -1, 1, -1, 1)
+        self.CPcoef6 = XSParameter(name, 'CPcoef6', 0.5, -1, 1, -1, 1)
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.CPcoef1, self.CPcoef2, self.CPcoef3, self.CPcoef4, self.CPcoef5,
@@ -3134,10 +3134,10 @@ class XScarbatm(XSAdditiveModel):
     __function__ = "C_carbatm"
 
     def __init__(self, name='carbatm'):
-        self.T = Parameter(name, 'T', 2.0, 1.0, 4.0, 1.0, 4.0, units='MK')
-        self.NSmass = Parameter(name, 'NSmass', 1.4, 0.6, 2.8, 0.6, 2.8,
-                                units='Msun')
-        self.NSrad = Parameter(name, 'NSrad', 10.0, 6.0, 23.0, 6.0, 23.0, units='km')
+        self.T = XSParameter(name, 'T', 2.0, 1.0, 4.0, 1.0, 4.0, units='MK')
+        self.NSmass = XSParameter(name, 'NSmass', 1.4, 0.6, 2.8, 0.6, 2.8,
+                                  units='Msun')
+        self.NSrad = XSParameter(name, 'NSrad', 10.0, 6.0, 23.0, 6.0, 23.0, units='km')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.T, self.NSmass, self.NSrad, self.norm))
@@ -3182,12 +3182,12 @@ class XScemekl(XSAdditiveModel):
     __function__ = "cemekl"
 
     def __init__(self, name='cemekl'):
-        self.alpha = Parameter(name, 'alpha', 1.0, 0.01, 10, 0.01, 20, frozen=True)
-        self.Tmax = Parameter(name, 'Tmax', 1.0, 0.01, 1.e2, 0.01, 1e2, units='keV')
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self.alpha = XSParameter(name, 'alpha', 1.0, 0.01, 10, 0.01, 20, frozen=True)
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, 0.01, 1.e2, 0.01, 1e2, units='keV')
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.abundanc = XSParameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.abundanc, self.redshift,
@@ -3233,25 +3233,25 @@ class XScevmkl(XSAdditiveModel):
     __function__ = "C_cemVMekal"
 
     def __init__(self, name='cevmkl'):
-        self.alpha = Parameter(name, 'alpha', 1.0, 0.01, 10, 0.01, 20, frozen=True)
-        self.Tmax = Parameter(name, 'Tmax', 1.0, 0.01, 1.e2, 0.01, 1e2, units='keV')
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Na = Parameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self.alpha = XSParameter(name, 'alpha', 1.0, 0.01, 10, 0.01, 20, frozen=True)
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, 0.01, 1.e2, 0.01, 1e2, units='keV')
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.Tmax, self.nH, self.He, self.C, self.N, self.O, self.Ne,
@@ -3294,11 +3294,11 @@ class XScflow(XSAdditiveModel):
     __function__ = "C_xscflw"
 
     def __init__(self, name='cflow'):
-        self.slope = Parameter(name, 'slope', 0., -5., 5., -5, 5)
-        self.lowT = Parameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0.0, 5., 0.0, 5)
-        self.redshift = Parameter(name, 'redshift', .1, 1.e-10, 10., 1e-10, 10, frozen=True)
+        self.slope = XSParameter(name, 'slope', 0., -5., 5., -5, 5)
+        self.lowT = XSParameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.highT = XSParameter(name, 'highT', 4., 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0.0, 5., 0.0, 5)
+        self.redshift = XSParameter(name, 'redshift', .1, 1.e-10, 10., 1e-10, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.slope, self.lowT, self.highT, self.Abundanc, self.redshift, self.norm))
 
@@ -3334,9 +3334,9 @@ class XScompbb(XSAdditiveModel):
     __function__ = "compbb"
 
     def __init__(self, name='compbb'):
-        self.kT = Parameter(name, 'kT', 1.0, 1.e-2, 100., 1e-4, 200, units='keV')
-        self.kTe = Parameter(name, 'kTe', 50, 1., 200., 1.0, 200, units='keV', frozen=True)
-        self.tau = Parameter(name, 'tau', 0.1, 0.0, 10., 0.0, 10)
+        self.kT = XSParameter(name, 'kT', 1.0, 1.e-2, 100., 1e-4, 200, units='keV')
+        self.kTe = XSParameter(name, 'kTe', 50, 1., 200., 1.0, 200, units='keV', frozen=True)
+        self.tau = XSParameter(name, 'tau', 0.1, 0.0, 10., 0.0, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kTe, self.tau, self.norm))
 
@@ -3384,14 +3384,14 @@ class XScompmag(XSAdditiveModel):
     __function__ = "xscompmag"
 
     def __init__(self, name='compmag'):
-        self.kTbb = Parameter(name, 'kTbb', 1.0, 0.2, 10.0, 0.2, 10.0, units='keV')
-        self.kTe = Parameter(name, 'kTe', 5.0, 0.2, 2000.0, 0.2, 2000.0, units='keV')
-        self.tau = Parameter(name, 'tau', 0.5, 0.0, 10.0, 0.0, 10.0)
-        self.eta = Parameter(name, 'eta', 0.5, 0.01, 1.0, 0.01, 1.0)
-        self.beta0 = Parameter(name, 'beta0', 0.57, 1.0e-4, 1.0, 1.0e-4, 1.0)
-        self.r0 = Parameter(name, 'r0', 0.25, 1.0e-4, 100.0, 1.0e-4, 100.0)
-        self.A = Parameter(name, 'A', 0.001, 0, 1, 0, 1, frozen=True)
-        self.betaflag = Parameter(name, 'betaflag', 1, 0, 2, 0, 2, frozen=True)
+        self.kTbb = XSParameter(name, 'kTbb', 1.0, 0.2, 10.0, 0.2, 10.0, units='keV')
+        self.kTe = XSParameter(name, 'kTe', 5.0, 0.2, 2000.0, 0.2, 2000.0, units='keV')
+        self.tau = XSParameter(name, 'tau', 0.5, 0.0, 10.0, 0.0, 10.0)
+        self.eta = XSParameter(name, 'eta', 0.5, 0.01, 1.0, 0.01, 1.0)
+        self.beta0 = XSParameter(name, 'beta0', 0.57, 1.0e-4, 1.0, 1.0e-4, 1.0)
+        self.r0 = XSParameter(name, 'r0', 0.25, 1.0e-4, 100.0, 1.0e-4, 100.0)
+        self.A = XSParameter(name, 'A', 0.001, 0, 1, 0, 1, frozen=True)
+        self.betaflag = XSParameter(name, 'betaflag', 1, 0, 2, 0, 2, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kTbb, self.kTe, self.tau, self.eta, self.beta0, self.r0, self.A, self.betaflag, self.norm))
 
@@ -3420,8 +3420,8 @@ class XScompLS(XSAdditiveModel):
     __function__ = "compls"
 
     def __init__(self, name='compls'):
-        self.kT = Parameter(name, 'kT', 2., .01, 10., 1e-3, 20, units='keV')
-        self.tau = Parameter(name, 'tau', 10, .001, 100., 1e-4, 200)
+        self.kT = XSParameter(name, 'kT', 2., .01, 10., 1e-3, 20, units='keV')
+        self.tau = XSParameter(name, 'tau', 10, .001, 100., 1e-4, 200)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.tau, self.norm))
 
@@ -3501,25 +3501,25 @@ class XScompPS(XSAdditiveModel):
     __function__ = "C_xscompps"
 
     def __init__(self, name='compps'):
-        self.kTe = Parameter(name, 'kTe', 100., 20., 1.e5, 20.0, 1e5, units='keV')
-        self.EleIndex = Parameter(name, 'EleIndex', 2., 0.0, 5., 0.0, 5, frozen=True)
-        self.Gmin = Parameter(name, 'Gmin', -1., -1., 10., -1, 10, frozen=True)
-        self.Gmax = Parameter(name, 'Gmax', 1.e3, 10., 1.e4, 10, 1e4, frozen=True)
-        self.kTbb = Parameter(name, 'kTbb', 0.1, 0.001, 10., 0.001, 10, units='keV', frozen=True)
-        self.tau_y = Parameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.05, 3, aliases=["tauy"])
-        self.geom = Parameter(name, 'geom', 0.0, -5.0, 4.0, -5, 4, frozen=True)
-        self.HovR_cyl = Parameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.5, 2, frozen=True, aliases=["HRcyl"])
-        self.cosIncl = Parameter(name, 'cosIncl', 0.5, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.cov_frac = Parameter(name, 'cov_frac', 1.0, 0.0, 1.0, 0.0, 1, frozen=True)
-        self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e4, 0.0, 1e4, frozen=True)
-        self.Fe_ab_re = Parameter(name, 'Fe_ab_re', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.Me_ab = Parameter(name, 'Me_ab', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.xi = Parameter(name, 'xi', 0., 0., 1.e5, 0.0, 1e5, frozen=True)
-        self.Tdisk = Parameter(name, 'Tdisk', 1.e6, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
-        self.Betor10 = Parameter(name, 'Betor10', -10., -10., 10., -10, 10, frozen=True)
-        self.Rin = Parameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='Rs', frozen=True)
-        self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='Rs', frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kTe = XSParameter(name, 'kTe', 100., 20., 1.e5, 20.0, 1e5, units='keV')
+        self.EleIndex = XSParameter(name, 'EleIndex', 2., 0.0, 5., 0.0, 5, frozen=True)
+        self.Gmin = XSParameter(name, 'Gmin', -1., -1., 10., -1, 10, frozen=True)
+        self.Gmax = XSParameter(name, 'Gmax', 1.e3, 10., 1.e4, 10, 1e4, frozen=True)
+        self.kTbb = XSParameter(name, 'kTbb', 0.1, 0.001, 10., 0.001, 10, units='keV', frozen=True)
+        self.tau_y = XSParameter(name, 'tau_y', 1.0, 0.05, 3.0, 0.05, 3, aliases=["tauy"])
+        self.geom = XSParameter(name, 'geom', 0.0, -5.0, 4.0, -5, 4, frozen=True)
+        self.HovR_cyl = XSParameter(name, 'HovR_cyl', 1.0, 0.5, 2.0, 0.5, 2, frozen=True, aliases=["HRcyl"])
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.5, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.cov_frac = XSParameter(name, 'cov_frac', 1.0, 0.0, 1.0, 0.0, 1, frozen=True)
+        self.rel_refl = XSParameter(name, 'rel_refl', 0., 0., 1.e4, 0.0, 1e4, frozen=True)
+        self.Fe_ab_re = XSParameter(name, 'Fe_ab_re', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.Me_ab = XSParameter(name, 'Me_ab', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.xi = XSParameter(name, 'xi', 0., 0., 1.e5, 0.0, 1e5, frozen=True)
+        self.Tdisk = XSParameter(name, 'Tdisk', 1.e6, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
+        self.Betor10 = XSParameter(name, 'Betor10', -10., -10., 10., -10, 10, frozen=True)
+        self.Rin = XSParameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='Rs', frozen=True)
+        self.Rout = XSParameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='Rs', frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kTe, self.EleIndex, self.Gmin, self.Gmax, self.kTbb, self.tau_y, self.geom, self.HovR_cyl, self.cosIncl, self.cov_frac, self.rel_refl, self.Fe_ab_re, self.Me_ab, self.xi, self.Tdisk, self.Betor10, self.Rin, self.Rout, self.redshift, self.norm))
@@ -3549,8 +3549,8 @@ class XScompST(XSAdditiveModel):
     __function__ = "compst"
 
     def __init__(self, name='compst'):
-        self.kT = Parameter(name, 'kT', 2., .01, 100., 1e-3, 100, units='keV')
-        self.tau = Parameter(name, 'tau', 10, .001, 100., 1e-4, 200)
+        self.kT = XSParameter(name, 'kT', 2., .01, 100., 1e-3, 100, units='keV')
+        self.tau = XSParameter(name, 'tau', 10, .001, 100., 1e-4, 200)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.tau, self.norm))
 
@@ -3593,12 +3593,12 @@ class XScomptb(XSAdditiveModel):
     __function__ = "xscomptb"
 
     def __init__(self, name='comptb'):
-        self.kTs = Parameter(name, 'kTs', 1.0, 0.1, 10.0, 0.1, 10.0, units='keV')
-        self.gamma = Parameter(name, 'gamma', 3.0, 1.0, 10.0, 1.0, 10.0, frozen=True)
-        self.alpha = Parameter(name, 'alpha', 2.0, 0.0, 400.0, 0.0, 400.0)
-        self.delta = Parameter(name, 'delta', 20.0, 0.0, 200.0, 0.0, 200.0)
-        self.kTe = Parameter(name, 'kTe', 5.0, 0.2, 2000.0, 0.2, 2000.0, units='keV')
-        self.log_A = Parameter(name, 'log_A', 0.0, -8.0, 8.0, -8.0, 8.0)
+        self.kTs = XSParameter(name, 'kTs', 1.0, 0.1, 10.0, 0.1, 10.0, units='keV')
+        self.gamma = XSParameter(name, 'gamma', 3.0, 1.0, 10.0, 1.0, 10.0, frozen=True)
+        self.alpha = XSParameter(name, 'alpha', 2.0, 0.0, 400.0, 0.0, 400.0)
+        self.delta = XSParameter(name, 'delta', 20.0, 0.0, 200.0, 0.0, 200.0)
+        self.kTe = XSParameter(name, 'kTe', 5.0, 0.2, 2000.0, 0.2, 2000.0, units='keV')
+        self.log_A = XSParameter(name, 'log_A', 0.0, -8.0, 8.0, -8.0, 8.0)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kTs, self.gamma, self.alpha, self.delta, self.kTe, self.log_A, self.norm))
 
@@ -3692,26 +3692,26 @@ class XScompth(XSAdditiveModel):
     __function__ = "C_xscompth"
 
     def __init__(self, name='compth'):
-        self.theta = Parameter(name, 'theta', 1., 1e-6, 1.e6, 1e-6, 1e6, units='keV')
-        self.showbb = Parameter(name, 'showbb', 1.0, 0., 1.e4, 0.0, 1e4, frozen=True)
-        self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 1, 4e5, units='eV', frozen=True)
-        self.RefOn = Parameter(name, 'RefOn', -1.0, -2.0, 2.0, -2, 2, frozen=True)
-        self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 1e-4, 10, frozen=True)
-        self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 1e5, 1e16, units='cm', frozen=True)
-        self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 1.2, 1e3, frozen=True)
-        self.g_max = Parameter(name, 'g_max', 1.e3, 5., 1.e4, 5, 1e4, frozen=True)
-        self.G_inj = Parameter(name, 'G_inj', 2., 0., 5., 0.0, 5, frozen=True)
-        self.pairinj = Parameter(name, 'pairinj', 0., 0., 1., 0.0, 1, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, 2, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.1, 10, frozen=True, aliases=["AbHe"])
-        self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, 5000)
-        self.Beta = Parameter(name, 'Beta', -10., -10., 10., -10, 10, frozen=True)
-        self.Rin = Parameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='M', frozen=True)
-        self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='M', frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
+        self.theta = XSParameter(name, 'theta', 1., 1e-6, 1.e6, 1e-6, 1e6, units='keV')
+        self.showbb = XSParameter(name, 'showbb', 1.0, 0., 1.e4, 0.0, 1e4, frozen=True)
+        self.kT_bb = XSParameter(name, 'kT_bb', 200., 1., 4e5, 1, 4e5, units='eV', frozen=True)
+        self.RefOn = XSParameter(name, 'RefOn', -1.0, -2.0, 2.0, -2, 2, frozen=True)
+        self.tau_p = XSParameter(name, 'tau_p', 0.1, 1e-4, 10., 1e-4, 10, frozen=True)
+        self.radius = XSParameter(name, 'radius', 1.e7, 1.e5, 1.e16, 1e5, 1e16, units='cm', frozen=True)
+        self.g_min = XSParameter(name, 'g_min', 1.3, 1.2, 1.e3, 1.2, 1e3, frozen=True)
+        self.g_max = XSParameter(name, 'g_max', 1.e3, 5., 1.e4, 5, 1e4, frozen=True)
+        self.G_inj = XSParameter(name, 'G_inj', 2., 0., 5., 0.0, 5, frozen=True)
+        self.pairinj = XSParameter(name, 'pairinj', 0., 0., 1., 0.0, 1, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.Refl = XSParameter(name, 'Refl', 1., 0., 2., 0.0, 2, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.Ab_met = XSParameter(name, 'Ab_met', 1.0, 0.1, 10., 0.1, 10, frozen=True, aliases=["AbHe"])
+        self.T_disk = XSParameter(name, 'T_disk', 1.e6, 1e4, 1e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, 5000)
+        self.Beta = XSParameter(name, 'Beta', -10., -10., 10., -10, 10, frozen=True)
+        self.Rin = XSParameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='M', frozen=True)
+        self.Rout = XSParameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='M', frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.theta, self.showbb, self.kT_bb, self.RefOn, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
@@ -3749,11 +3749,11 @@ class XScompTT(XSAdditiveModel):
     __function__ = "xstitg"
 
     def __init__(self, name='comptt'):
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.T0 = Parameter(name, 'T0', 0.1, .01, 100., 1e-3, 100, units='keV')
-        self.kT = Parameter(name, 'kT', 50., 2.0, 500., 2.0, 500, units='keV')
-        self.taup = Parameter(name, 'taup', 1., .01, 100., 0.01, 200)
-        self.approx = Parameter(name, 'approx', 1.0, 0.0, 5.0, 0.0, 200, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.T0 = XSParameter(name, 'T0', 0.1, .01, 100., 1e-3, 100, units='keV')
+        self.kT = XSParameter(name, 'kT', 50., 2.0, 500., 2.0, 500, units='keV')
+        self.taup = XSParameter(name, 'taup', 1., .01, 100., 0.01, 200)
+        self.approx = XSParameter(name, 'approx', 1.0, 0.0, 5.0, 0.0, 200, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.redshift, self.T0, self.kT, self.taup, self.approx, self.norm))
 
@@ -3799,14 +3799,14 @@ class XScph(XSAdditiveModel):
     __function__ = "C_cph"
 
     def __init__(self, name='cph'):
-        self.peakT = Parameter(name, 'peakT', 2.2, 1e-1, 1e2, 1e-1, 1e2,
-                               units='keV')
-        self.Abund = Parameter(name, 'Abund', 1, 0, 1000, 0, 1000,
-                               frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, 0.0, 50, 0.0, 50,
-                                  frozen=True)
-        self.switch = Parameter(name, 'switch', 1,
-                                alwaysfrozen=True)
+        self.peakT = XSParameter(name, 'peakT', 2.2, 1e-1, 1e2, 1e-1, 1e2,
+                                 units='keV')
+        self.Abund = XSParameter(name, 'Abund', 1, 0, 1000, 0, 1000,
+                                 frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, 0.0, 50, 0.0, 50,
+                                    frozen=True)
+        self.switch = XSParameter(name, 'switch', 1,
+                                  alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.peakT, self.Abund, self.Redshift, self.switch, self.norm)
@@ -3840,26 +3840,26 @@ class XScplinear(XSAdditiveModel):
     __function__ = "C_cplinear"
 
     def __init__(self, name='cplinear'):
-        self.energy00 = Parameter(name, 'energy00', 0.5, 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy01 = Parameter(name, 'energy01', 1., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy02 = Parameter(name, 'energy02', 1.5, 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy03 = Parameter(name, 'energy03', 2., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy04 = Parameter(name, 'energy04', 3., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy05 = Parameter(name, 'energy05', 4., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy06 = Parameter(name, 'energy06', 5., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy07 = Parameter(name, 'energy07', 6., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy08 = Parameter(name, 'energy08', 7., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.energy09 = Parameter(name, 'energy09', 8., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
-        self.log_rate00 = Parameter(name, 'log_rate00', 0., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate01 = Parameter(name, 'log_rate01', 1., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate02 = Parameter(name, 'log_rate02', 0., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate03 = Parameter(name, 'log_rate03', 1., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate04 = Parameter(name, 'log_rate04', 0., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate05 = Parameter(name, 'log_rate05', 1., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate06 = Parameter(name, 'log_rate06', 0., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate07 = Parameter(name, 'log_rate07', 1., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate08 = Parameter(name, 'log_rate08', 0., -19.0, 19.0, -20, 20, frozen=True)
-        self.log_rate09 = Parameter(name, 'log_rate09', 1., -19.0, 19.0, -20, 20, frozen=True)
+        self.energy00 = XSParameter(name, 'energy00', 0.5, 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy01 = XSParameter(name, 'energy01', 1., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy02 = XSParameter(name, 'energy02', 1.5, 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy03 = XSParameter(name, 'energy03', 2., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy04 = XSParameter(name, 'energy04', 3., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy05 = XSParameter(name, 'energy05', 4., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy06 = XSParameter(name, 'energy06', 5., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy07 = XSParameter(name, 'energy07', 6., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy08 = XSParameter(name, 'energy08', 7., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.energy09 = XSParameter(name, 'energy09', 8., 0.0, 10.0, 0, 10, units='keV', alwaysfrozen=True)
+        self.log_rate00 = XSParameter(name, 'log_rate00', 0., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate01 = XSParameter(name, 'log_rate01', 1., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate02 = XSParameter(name, 'log_rate02', 0., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate03 = XSParameter(name, 'log_rate03', 1., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate04 = XSParameter(name, 'log_rate04', 0., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate05 = XSParameter(name, 'log_rate05', 1., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate06 = XSParameter(name, 'log_rate06', 0., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate07 = XSParameter(name, 'log_rate07', 1., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate08 = XSParameter(name, 'log_rate08', 0., -19.0, 19.0, -20, 20, frozen=True)
+        self.log_rate09 = XSParameter(name, 'log_rate09', 1., -19.0, 19.0, -20, 20, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.energy00, self.energy01, self.energy02, self.energy03,
@@ -3900,8 +3900,8 @@ class XScutoffpl(XSAdditiveModel):
     __function__ = "C_cutoffPowerLaw"
 
     def __init__(self, name='cutoffpl'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
-        self.HighECut = Parameter(name, 'HighECut', 15., 1., 500., 0.01, 500, units='keV')
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
+        self.HighECut = XSParameter(name, 'HighECut', 15., 1., 500., 0.01, 500, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.HighECut, self.norm))
 
@@ -3944,9 +3944,9 @@ class XSdisk(XSAdditiveModel):
     __function__ = "disk"
 
     def __init__(self, name='disk'):
-        self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 1e-4, 10)
-        self.CenMass = Parameter(name, 'CenMass', 1.4, .4, 10., 0.1, 20, units='Msun', frozen=True, aliases=["NSmass"])
-        self.Rinn = Parameter(name, 'Rinn', 1.03, 1.01, 1.03, 1.0, 1.04, frozen=True)
+        self.accrate = XSParameter(name, 'accrate', 1., 1e-3, 9., 1e-4, 10)
+        self.CenMass = XSParameter(name, 'CenMass', 1.4, .4, 10., 0.1, 20, units='Msun', frozen=True, aliases=["NSmass"])
+        self.Rinn = XSParameter(name, 'Rinn', 1.03, 1.01, 1.03, 1.0, 1.04, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.accrate, self.CenMass, self.Rinn, self.norm))
@@ -4006,14 +4006,14 @@ class XSdiskir(XSAdditiveModel):
     __function__ = "diskir"
 
     def __init__(self, name='diskir'):
-        self.kT_disk = Parameter(name, 'kT_disk', 1.0, 0.01, 5., 0.01, 5, units='keV')
-        self.Gamma = Parameter(name, 'Gamma', 1.7, 1.001, 5., 1.001, 10)
-        self.kT_e = Parameter(name, 'kT_e', 100., 5., 1.e3, 1.0, 1000, units='keV')
-        self.LcovrLd = Parameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, 10, aliases=["LcLd"])
-        self.fin = Parameter(name, 'fin', 1.e-1, 0.0, 1., 0.0, 1, frozen=True)
-        self.rirr = Parameter(name, 'rirr', 1.2, 1.0001, 10., 1.0001, 10)
-        self.fout = Parameter(name, 'fout', 1.e-4, 0.0, 1.e-1, 0.0, 0.1)
-        self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 3, 7)
+        self.kT_disk = XSParameter(name, 'kT_disk', 1.0, 0.01, 5., 0.01, 5, units='keV')
+        self.Gamma = XSParameter(name, 'Gamma', 1.7, 1.001, 5., 1.001, 10)
+        self.kT_e = XSParameter(name, 'kT_e', 100., 5., 1.e3, 1.0, 1000, units='keV')
+        self.LcovrLd = XSParameter(name, 'LcovrLd', 0.1, 0., 10., 0.0, 10, aliases=["LcLd"])
+        self.fin = XSParameter(name, 'fin', 1.e-1, 0.0, 1., 0.0, 1, frozen=True)
+        self.rirr = XSParameter(name, 'rirr', 1.2, 1.0001, 10., 1.0001, 10)
+        self.fout = XSParameter(name, 'fout', 1.e-4, 0.0, 1.e-1, 0.0, 0.1)
+        self.logrout = XSParameter(name, 'logrout', 5.0, 3.0, 7.0, 3, 7)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT_disk, self.Gamma, self.kT_e, self.LcovrLd, self.fin, self.rirr, self.fout, self.logrout, self.norm))
@@ -4045,7 +4045,7 @@ class XSdiskbb(XSAdditiveModel):
     __function__ = "xsdskb"
 
     def __init__(self, name='diskbb'):
-        self.Tin = Parameter(name, 'Tin', 1., 0., 1000., 0.0, 1000, units='keV')
+        self.Tin = XSParameter(name, 'Tin', 1., 0., 1000., 0.0, 1000, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Tin, self.norm))
 
@@ -4091,11 +4091,11 @@ class XSdiskline(XSAdditiveModel):
     __function__ = "C_diskline" if equal_or_greater_than("12.10.1") else "xsdili"
 
     def __init__(self, name='diskline'):
-        self.LineE = Parameter(name, 'LineE', 6.7, 0., 100., 0.0, 100, units='keV')
-        self.Betor10 = Parameter(name, 'Betor10', -2., -10., 20., -10, 20, frozen=True)
-        self.Rin_M = Parameter(name, 'Rin_M', 10., 6., 1000., 6.0, 10000, frozen=True, aliases=["RinM"])
-        self.Rout_M = Parameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, 10000000, frozen=True, aliases=["RoutM"])
-        self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg')
+        self.LineE = XSParameter(name, 'LineE', 6.7, 0., 100., 0.0, 100, units='keV')
+        self.Betor10 = XSParameter(name, 'Betor10', -2., -10., 20., -10, 20, frozen=True)
+        self.Rin_M = XSParameter(name, 'Rin_M', 10., 6., 1000., 6.0, 10000, frozen=True, aliases=["RinM"])
+        self.Rout_M = XSParameter(name, 'Rout_M', 1000., 0., 1000000., 0.0, 10000000, frozen=True, aliases=["RoutM"])
+        self.Incl = XSParameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Betor10, self.Rin_M, self.Rout_M, self.Incl, self.norm))
@@ -4139,10 +4139,10 @@ class XSdiskm(XSAdditiveModel):
     __function__ = "diskm"
 
     def __init__(self, name='diskm'):
-        self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 1e-4, 10)
-        self.NSmass = Parameter(name, 'NSmass', 1.4, .4, 10., 0.1, 20, units='Msun', frozen=True)
-        self.Rinn = Parameter(name, 'Rinn', 1.03, 1.01, 1.03, 1.0, 1.04, frozen=True)
-        self.alpha = Parameter(name, 'alpha', 1., .01, 10., 0.001, 20, frozen=True)
+        self.accrate = XSParameter(name, 'accrate', 1., 1e-3, 9., 1e-4, 10)
+        self.NSmass = XSParameter(name, 'NSmass', 1.4, .4, 10., 0.1, 20, units='Msun', frozen=True)
+        self.Rinn = XSParameter(name, 'Rinn', 1.03, 1.01, 1.03, 1.0, 1.04, frozen=True)
+        self.alpha = XSParameter(name, 'alpha', 1., .01, 10., 0.001, 20, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.accrate, self.NSmass, self.Rinn, self.alpha, self.norm))
 
@@ -4180,10 +4180,10 @@ class XSdisko(XSAdditiveModel):
     __function__ = "disko"
 
     def __init__(self, name='disko'):
-        self.accrate = Parameter(name, 'accrate', 1., 1e-3, 9., 1e-4, 10)
-        self.NSmass = Parameter(name, 'NSmass', 1.4, .4, 10., 0.1, 20, units='Msun', frozen=True)
-        self.Rinn = Parameter(name, 'Rinn', 1.03, 1.01, 1.03, 1.0, 1.04, frozen=True)
-        self.alpha = Parameter(name, 'alpha', 1., .01, 10., 0.001, 20, frozen=True)
+        self.accrate = XSParameter(name, 'accrate', 1., 1e-3, 9., 1e-4, 10)
+        self.NSmass = XSParameter(name, 'NSmass', 1.4, .4, 10., 0.1, 20, units='Msun', frozen=True)
+        self.Rinn = XSParameter(name, 'Rinn', 1.03, 1.01, 1.03, 1.0, 1.04, frozen=True)
+        self.alpha = XSParameter(name, 'alpha', 1., .01, 10., 0.001, 20, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.accrate, self.NSmass, self.Rinn, self.alpha, self.norm))
 
@@ -4216,8 +4216,8 @@ class XSdiskpbb(XSAdditiveModel):
     __function__ = "diskpbb"
 
     def __init__(self, name='diskpbb'):
-        self.Tin = Parameter(name, 'Tin', 1.0, 0.1, 10.0, 0.1, 10, units='keV')
-        self.p = Parameter(name, 'p', 0.75, 0.5, 1.0, 0.5, 1)
+        self.Tin = XSParameter(name, 'Tin', 1.0, 0.1, 10.0, 0.1, 10, units='keV')
+        self.p = XSParameter(name, 'p', 0.75, 0.5, 1.0, 0.5, 1)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Tin, self.p, self.norm))
 
@@ -4250,8 +4250,8 @@ class XSdiskpn(XSAdditiveModel):
     __function__ = "xsdiskpn"
 
     def __init__(self, name='diskpn'):
-        self.T_max = Parameter(name, 'T_max', 1., 1e-3, 100, 1e-4, 200, units='keV')
-        self.R_in = Parameter(name, 'R_in', 6., 6., 1000., 6.0, 1000, units='R_g')
+        self.T_max = XSParameter(name, 'T_max', 1., 1e-3, 100, 1e-4, 200, units='keV')
+        self.R_in = XSParameter(name, 'R_in', 6., 6., 1000., 6.0, 1000, units='R_g')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.T_max, self.R_in, self.norm))
 
@@ -4284,8 +4284,8 @@ class XSeplogpar(XSAdditiveModel):
     __function__ = "eplogpar"
 
     def __init__(self, name='eplogpar'):
-        self.Ep = Parameter(name, 'Ep', .1, 1.e-6, 1.e2, 1e-10, 1e4, units='keV')
-        self.beta = Parameter(name, 'beta', 0.2, -4., 4., -4, 4)
+        self.Ep = XSParameter(name, 'Ep', .1, 1.e-6, 1.e2, 1e-10, 1e4, units='keV')
+        self.beta = XSParameter(name, 'beta', 0.2, -4., 4., -4, 4)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Ep, self.beta, self.norm))
 
@@ -4382,26 +4382,26 @@ class XSeqpair(XSAdditiveModel):
     __function__ = "C_xseqpair"
 
     def __init__(self, name='eqpair'):
-        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 1e-6, 1e6, aliases=["l_hl_s"])
-        self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, 1e4)
-        self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 1, 4e5, units='eV', frozen=True)
-        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, 0.9999, aliases=["l_ntl_h"])
-        self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 1e-4, 10, frozen=True)
-        self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 1e5, 1e16, units='cm', frozen=True)
-        self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 1.2, 1e3, frozen=True)
-        self.g_max = Parameter(name, 'g_max', 1.e3, 5., 1.e4, 5, 1e4, frozen=True)
-        self.G_inj = Parameter(name, 'G_inj', 2., 0., 5., 0.0, 5, frozen=True)
-        self.pairinj = Parameter(name, 'pairinj', 0., 0., 1., 0.0, 1, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, 2, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.1, 10, frozen=True, aliases=["AbHe"])
-        self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, 5000)
-        self.Beta = Parameter(name, 'Beta', -10., -10., 10., -10, 10, frozen=True)
-        self.Rin = Parameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='M', frozen=True)
-        self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='M', frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
+        self.l_hovl_s = XSParameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 1e-6, 1e6, aliases=["l_hl_s"])
+        self.l_bb = XSParameter(name, 'l_bb', 100., 0., 1.e4, 0.0, 1e4)
+        self.kT_bb = XSParameter(name, 'kT_bb', 200., 1., 4e5, 1, 4e5, units='eV', frozen=True)
+        self.l_ntol_h = XSParameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, 0.9999, aliases=["l_ntl_h"])
+        self.tau_p = XSParameter(name, 'tau_p', 0.1, 1e-4, 10., 1e-4, 10, frozen=True)
+        self.radius = XSParameter(name, 'radius', 1.e7, 1.e5, 1.e16, 1e5, 1e16, units='cm', frozen=True)
+        self.g_min = XSParameter(name, 'g_min', 1.3, 1.2, 1.e3, 1.2, 1e3, frozen=True)
+        self.g_max = XSParameter(name, 'g_max', 1.e3, 5., 1.e4, 5, 1e4, frozen=True)
+        self.G_inj = XSParameter(name, 'G_inj', 2., 0., 5., 0.0, 5, frozen=True)
+        self.pairinj = XSParameter(name, 'pairinj', 0., 0., 1., 0.0, 1, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.Refl = XSParameter(name, 'Refl', 1., 0., 2., 0.0, 2, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.Ab_met = XSParameter(name, 'Ab_met', 1.0, 0.1, 10., 0.1, 10, frozen=True, aliases=["AbHe"])
+        self.T_disk = XSParameter(name, 'T_disk', 1.e6, 1e4, 1e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, 5000)
+        self.Beta = XSParameter(name, 'Beta', -10., -10., 10., -10, 10, frozen=True)
+        self.Rin = XSParameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='M', frozen=True)
+        self.Rout = XSParameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='M', frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
@@ -4499,26 +4499,26 @@ class XSeqtherm(XSAdditiveModel):
     __function__ = "C_xseqth"
 
     def __init__(self, name='eqtherm'):
-        self.l_hovl_s = Parameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 1e-6, 1e6, aliases=["l_hl_s"])
-        self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, 1e4)
-        self.kT_bb = Parameter(name, 'kT_bb', 200., 1., 4e5, 1, 4e5, units='eV', frozen=True)
-        self.l_ntol_h = Parameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, 0.9999, aliases=["l_ntl_h"])
-        self.tau_p = Parameter(name, 'tau_p', 0.1, 1e-4, 10., 1e-4, 10, frozen=True)
-        self.radius = Parameter(name, 'radius', 1.e7, 1.e5, 1.e16, 1e5, 1e16, units='cm', frozen=True)
-        self.g_min = Parameter(name, 'g_min', 1.3, 1.2, 1.e3, 1.2, 1e3, frozen=True)
-        self.g_max = Parameter(name, 'g_max', 1.e3, 5., 1.e4, 5, 1e4, frozen=True)
-        self.G_inj = Parameter(name, 'G_inj', 2., 0., 5., 0.0, 5, frozen=True)
-        self.pairinj = Parameter(name, 'pairinj', 0., 0., 1., 0.0, 1, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.Refl = Parameter(name, 'Refl', 1., 0., 2., 0.0, 2, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.Ab_met = Parameter(name, 'Ab_met', 1.0, 0.1, 10., 0.1, 10, frozen=True, aliases=["AbHe"])
-        self.T_disk = Parameter(name, 'T_disk', 1.e6, 1e4, 1e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, 5000)
-        self.Beta = Parameter(name, 'Beta', -10., -10., 10., -10, 10, frozen=True)
-        self.Rin = Parameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='M', frozen=True)
-        self.Rout = Parameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='M', frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
+        self.l_hovl_s = XSParameter(name, 'l_hovl_s', 1., 1e-6, 1.e6, 1e-6, 1e6, aliases=["l_hl_s"])
+        self.l_bb = XSParameter(name, 'l_bb', 100., 0., 1.e4, 0.0, 1e4)
+        self.kT_bb = XSParameter(name, 'kT_bb', 200., 1., 4e5, 1, 4e5, units='eV', frozen=True)
+        self.l_ntol_h = XSParameter(name, 'l_ntol_h', 0.5, 0., 0.9999, 0.0, 0.9999, aliases=["l_ntl_h"])
+        self.tau_p = XSParameter(name, 'tau_p', 0.1, 1e-4, 10., 1e-4, 10, frozen=True)
+        self.radius = XSParameter(name, 'radius', 1.e7, 1.e5, 1.e16, 1e5, 1e16, units='cm', frozen=True)
+        self.g_min = XSParameter(name, 'g_min', 1.3, 1.2, 1.e3, 1.2, 1e3, frozen=True)
+        self.g_max = XSParameter(name, 'g_max', 1.e3, 5., 1.e4, 5, 1e4, frozen=True)
+        self.G_inj = XSParameter(name, 'G_inj', 2., 0., 5., 0.0, 5, frozen=True)
+        self.pairinj = XSParameter(name, 'pairinj', 0., 0., 1., 0.0, 1, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.50, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.Refl = XSParameter(name, 'Refl', 1., 0., 2., 0.0, 2, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.Ab_met = XSParameter(name, 'Ab_met', 1.0, 0.1, 10., 0.1, 10, frozen=True, aliases=["AbHe"])
+        self.T_disk = XSParameter(name, 'T_disk', 1.e6, 1e4, 1e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 0.0, 0.0, 1000.0, 0.0, 5000)
+        self.Beta = XSParameter(name, 'Beta', -10., -10., 10., -10, 10, frozen=True)
+        self.Rin = XSParameter(name, 'Rin', 10., 6.001, 1.e3, 6.001, 1e4, units='M', frozen=True)
+        self.Rout = XSParameter(name, 'Rout', 1.e3, 0., 1.e6, 0.0, 1e6, units='M', frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.l_hovl_s, self.l_bb, self.kT_bb, self.l_ntol_h, self.tau_p, self.radius, self.g_min, self.g_max, self.G_inj, self.pairinj, self.cosIncl, self.Refl, self.Fe_abund, self.Ab_met, self.T_disk, self.xi, self.Beta, self.Rin, self.Rout, self.redshift, self.norm))
@@ -4558,9 +4558,9 @@ class XSequil(XSAdditiveModel):
     __function__ = "C_equil"
 
     def __init__(self, name='equil'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.redshift, self.norm))
 
@@ -4587,7 +4587,7 @@ class XSexpdec(XSAdditiveModel):
     __function__ = "xsxpdec"
 
     def __init__(self, name='expdec'):
-        self.factor = Parameter(name, 'factor', 1.0, 0., 100.0, 0.0, 100)
+        self.factor = XSParameter(name, 'factor', 1.0, 0., 100.0, 0.0, 100)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.factor, self.norm))
 
@@ -4614,7 +4614,7 @@ class XSezdiskbb(XSAdditiveModel):
     __function__ = "ezdiskbb"
 
     def __init__(self, name='ezdiskbb'):
-        self.T_max = Parameter(name, 'T_max', 1., 0.01, 100., 0.01, 100, units='keV')
+        self.T_max = XSParameter(name, 'T_max', 1., 0.01, 100., 0.01, 100, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.T_max, self.norm))
 
@@ -4647,8 +4647,8 @@ class XSgaussian(XSAdditiveModel):
     __function__ = "C_gaussianLine" if equal_or_greater_than("12.9.1") else "xsgaul"
 
     def __init__(self, name='gaussian'):
-        self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
-        self.Sigma = Parameter(name, 'Sigma', 0.1, 0., 10., 0.0, 20, units='keV')
+        self.LineE = XSParameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.1, 0., 10., 0.0, 20, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.norm))
 
@@ -4703,12 +4703,12 @@ class XSgadem(XSAdditiveModel):
     __function__ = "C_gaussDem"
 
     def __init__(self, name='gadem'):
-        self.Tmean = Parameter(name, 'Tmean', 4.0, 0.01, 10, 0.01, 20, units='keV', frozen=True)
-        self.Tsigma = Parameter(name, 'Tsigma', 0.1, 0.01, 1.e2, 0.01, 1e2, units='keV')
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.abundanc = Parameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 2, alwaysfrozen=True)
+        self.Tmean = XSParameter(name, 'Tmean', 4.0, 0.01, 10, 0.01, 20, units='keV', frozen=True)
+        self.Tsigma = XSParameter(name, 'Tsigma', 0.1, 0.01, 1.e2, 0.01, 1e2, units='keV')
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.abundanc = XSParameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.abundanc, self.Redshift,
@@ -4759,11 +4759,11 @@ class XSgnei(XSAdditiveModel):
     __function__ = "C_gnei"
 
     def __init__(self, name='gnei'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV', aliases=["kT_ave"])
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.meankT = XSParameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV', aliases=["kT_ave"])
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau, self.meankT, self.redshift, self.norm))
@@ -4816,12 +4816,12 @@ class XSgrad(XSAdditiveModel):
     __function__ = "grad"
 
     def __init__(self, name='grad'):
-        self.D = Parameter(name, 'D', 10.0, 0.0, 10000., 0.0, 10000, units='kpc', frozen=True)
-        self.i = Parameter(name, 'i', 0.0, 0.0, 90.0, 0.0, 90, units='deg', frozen=True)
-        self.Mass = Parameter(name, 'Mass', 1.0, 0.0, 100.0, 0.0, 100, units='solar')
-        self.Mdot = Parameter(name, 'Mdot', 1.0, 0.0, 100.0, 0.0, 100, units='1e18')
-        self.TclovTef = Parameter(name, 'TclovTef', 1.7, 1.0, 10.0, 1.0, 10, frozen=True, aliases=["TclTef"])
-        self.refflag = Parameter(name, 'refflag', 1.0, -1.0, 1.0, -1, 1, frozen=True)
+        self.D = XSParameter(name, 'D', 10.0, 0.0, 10000., 0.0, 10000, units='kpc', frozen=True)
+        self.i = XSParameter(name, 'i', 0.0, 0.0, 90.0, 0.0, 90, units='deg', frozen=True)
+        self.Mass = XSParameter(name, 'Mass', 1.0, 0.0, 100.0, 0.0, 100, units='solar')
+        self.Mdot = XSParameter(name, 'Mdot', 1.0, 0.0, 100.0, 0.0, 100, units='1e18')
+        self.TclovTef = XSParameter(name, 'TclovTef', 1.7, 1.0, 10.0, 1.0, 10, frozen=True, aliases=["TclTef"])
+        self.refflag = XSParameter(name, 'refflag', 1.0, -1.0, 1.0, -1, 1, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.D, self.i, self.Mass, self.Mdot, self.TclovTef, self.refflag, self.norm))
@@ -4880,15 +4880,15 @@ class XSgrbcomp(XSAdditiveModel):
     __function__ = "xsgrbcomp"
 
     def __init__(self, name='grbcomp'):
-        self.kTs = Parameter(name, 'kTs', 1.0, 0.0, 20., 0.0, 20.0, units='keV')
-        self.gamma = Parameter(name, 'gamma', 3.0, 0.0, 10.0, 0.0, 10.0)
-        self.kTe = Parameter(name, 'kTe', 100.0, 0.2, 2000., 0.2, 2000., units='keV')
-        self.tau = Parameter(name, 'tau', 5.0, 0.0, 200., 0.0, 200.)
-        self.beta = Parameter(name, 'beta', 0.2, 0.0, 1.0, 0.0, 1.0)
-        self.fbflag = Parameter(name, 'fbflag', 0.0, 0.0, 1.0, 0.0, 1.0, frozen=True)
-        self.log_A = Parameter(name, 'log_A', 5.0, -8., 8., -8., 8., frozen=True)
-        self.z = Parameter(name, 'z', 0.0, 0.0, 10., 0.0, 10., frozen=True)
-        self.a_boost = Parameter(name, 'a_boost', 5.0, 0., 30., 0., 30., frozen=True)
+        self.kTs = XSParameter(name, 'kTs', 1.0, 0.0, 20., 0.0, 20.0, units='keV')
+        self.gamma = XSParameter(name, 'gamma', 3.0, 0.0, 10.0, 0.0, 10.0)
+        self.kTe = XSParameter(name, 'kTe', 100.0, 0.2, 2000., 0.2, 2000., units='keV')
+        self.tau = XSParameter(name, 'tau', 5.0, 0.0, 200., 0.0, 200.)
+        self.beta = XSParameter(name, 'beta', 0.2, 0.0, 1.0, 0.0, 1.0)
+        self.fbflag = XSParameter(name, 'fbflag', 0.0, 0.0, 1.0, 0.0, 1.0, frozen=True)
+        self.log_A = XSParameter(name, 'log_A', 5.0, -8., 8., -8., 8., frozen=True)
+        self.z = XSParameter(name, 'z', 0.0, 0.0, 10., 0.0, 10., frozen=True)
+        self.a_boost = XSParameter(name, 'a_boost', 5.0, 0., 30., 0., 30., frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kTs, self.gamma, self.kTe, self.tau, self.beta, self.fbflag, self.log_A, self.z, self.a_boost, self.norm))
 
@@ -4929,9 +4929,9 @@ class XSgrbm(XSAdditiveModel):
     __function__ = "xsgrbm"
 
     def __init__(self, name='grbm'):
-        self.alpha = Parameter(name, 'alpha', -1., -3., +2., -10, 5)
-        self.beta = Parameter(name, 'beta', -2., -5., +2., -10, 10)
-        self.tem = Parameter(name, 'tem', +300., +50., +1000., 10, 10000, units='keV', aliases=["temp"])
+        self.alpha = XSParameter(name, 'alpha', -1., -3., +2., -10, 5)
+        self.beta = XSParameter(name, 'beta', -2., -5., +2., -10, 10)
+        self.tem = XSParameter(name, 'tem', +300., +50., +1000., 10, 10000, units='keV', aliases=["temp"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.tem, self.norm))
@@ -4975,10 +4975,10 @@ class XShatm(XSAdditiveModel):
     __function__ = "C_hatm"
 
     def __init__(self, name='hatm'):
-        self.T = Parameter(name, 'T', 3.0, 0.5, 10.0, 0.5, 10.0, units='MK')
-        self.NSmass = Parameter(name, 'NSmass', 1.4, 0.6, 2.8, 0.6, 2.8,
-                                units='Msun')
-        self.NSrad = Parameter(name, 'NSrad', 10.0, 5.0, 23.0, 5.0, 23.0, units='km')
+        self.T = XSParameter(name, 'T', 3.0, 0.5, 10.0, 0.5, 10.0, units='MK')
+        self.NSmass = XSParameter(name, 'NSmass', 1.4, 0.6, 2.8, 0.6, 2.8,
+                                  units='Msun')
+        self.NSrad = XSParameter(name, 'NSrad', 10.0, 5.0, 23.0, 5.0, 23.0, units='km')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.T, self.NSmass, self.NSrad, self.norm))
@@ -5048,32 +5048,32 @@ class XSjet(XSAdditiveModel):
     __function__ = "jet"
 
     def __init__(self, name='jet'):
-        self.mass = Parameter(name, 'mass', 1e9, 1., 1e10, 1., 1e10,
-                              units='solar', frozen=True)
-        self.Dco = Parameter(name, 'Dco', 3350.6, 1., 1e8, 1., 1e8,
-                             units='Mpc', frozen=True)
-        self.log_mdot = Parameter(name, 'log_mdot', -1., -5., 2., -5., 2.,
-                                  units='logL/LEdd')
-        self.thetaobs = Parameter(name, 'thetaobs', 3., 0., 90., 0., 90.,
-                                  units='deg', frozen=True)
-        self.BulkG = Parameter(name, 'BulkG', 13., 1., 100., 1., 100, frozen=True)
-        self.phi = Parameter(name, 'phi', 0.1, 1e-2, 1e2, 1e-2, 1e2,
-                             units='rad', frozen=True)
-        self.zdiss = Parameter(name, 'zdiss', 1275., 10., 1e4, 10., 1e4,
-                               units='Rg', frozen=True)
-        self.B = Parameter(name, 'B', 2.6, 1e-2, 15., 1e-2, 15.,
-                           units='Gau', frozen=True)
-        self.logPrel = Parameter(name, 'logPrel', 43.3, 40., 48., 40., 48., frozen=True)
-        self.gmin_inj = Parameter(name, 'gmin_inj', 1.0, 1., 1e3, 1., 1e3, frozen=True)
-        self.gbreak = Parameter(name, 'gbreak', 300., 10., 1e4, 10., 1e4, frozen=True)
-        self.gmax = Parameter(name, 'gmax', 3e3, 1e3, 1e6, 1e3, 1e6, frozen=True)
-        self.s1 = Parameter(name, 's1', 1., -1., 1., -1., 1., frozen=True)
-        self.s2 = Parameter(name, 's2', 2.7, 1., 5., 1., 5., frozen=True)
-        self.z = Parameter(name, 'z', 0.0, 0., 10., 0., 10., frozen=True)
+        self.mass = XSParameter(name, 'mass', 1e9, 1., 1e10, 1., 1e10,
+                                units='solar', frozen=True)
+        self.Dco = XSParameter(name, 'Dco', 3350.6, 1., 1e8, 1., 1e8,
+                               units='Mpc', frozen=True)
+        self.log_mdot = XSParameter(name, 'log_mdot', -1., -5., 2., -5., 2.,
+                                    units='logL/LEdd')
+        self.thetaobs = XSParameter(name, 'thetaobs', 3., 0., 90., 0., 90.,
+                                    units='deg', frozen=True)
+        self.BulkG = XSParameter(name, 'BulkG', 13., 1., 100., 1., 100, frozen=True)
+        self.phi = XSParameter(name, 'phi', 0.1, 1e-2, 1e2, 1e-2, 1e2,
+                               units='rad', frozen=True)
+        self.zdiss = XSParameter(name, 'zdiss', 1275., 10., 1e4, 10., 1e4,
+                                 units='Rg', frozen=True)
+        self.B = XSParameter(name, 'B', 2.6, 1e-2, 15., 1e-2, 15.,
+                             units='Gau', frozen=True)
+        self.logPrel = XSParameter(name, 'logPrel', 43.3, 40., 48., 40., 48., frozen=True)
+        self.gmin_inj = XSParameter(name, 'gmin_inj', 1.0, 1., 1e3, 1., 1e3, frozen=True)
+        self.gbreak = XSParameter(name, 'gbreak', 300., 10., 1e4, 10., 1e4, frozen=True)
+        self.gmax = XSParameter(name, 'gmax', 3e3, 1e3, 1e6, 1e3, 1e6, frozen=True)
+        self.s1 = XSParameter(name, 's1', 1., -1., 1., -1., 1., frozen=True)
+        self.s2 = XSParameter(name, 's2', 2.7, 1., 5., 1., 5., frozen=True)
+        self.z = XSParameter(name, 'z', 0.0, 0., 10., 0., 10., frozen=True)
         # Note: alwaysfrozen is set for norm based on the documentation,
         # since there's no way to determine this from the model.dat file
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval,
-                              alwaysfrozen=True)
+                                alwaysfrozen=True)
         XSAdditiveModel.__init__(self, name,
                                  (self.mass, self.Dco, self.log_mdot, self.thetaobs,
                                   self.BulkG, self.phi, self.zdiss, self.B, self.logPrel,
@@ -5135,15 +5135,15 @@ class XSkerrbb(XSAdditiveModel):
     __function__ = "C_kerrbb"
 
     def __init__(self, name='kerrbb'):
-        self.eta = Parameter(name, 'eta', 0., 0., 1.0, 0.0, 1, frozen=True)
-        self.a = Parameter(name, 'a', 0., -1., 0.9999, -1, 0.9999)
-        self.i = Parameter(name, 'i', 30., 0., 85., 0.0, 85, units='deg', frozen=True)
-        self.Mbh = Parameter(name, 'Mbh', 1., 0., 100., 0.0, 100, units='Msun')
-        self.Mdd = Parameter(name, 'Mdd', 1., 0., 1000., 0.0, 1000, units='Mdd0')
-        self.Dbh = Parameter(name, 'Dbh', 10., 0., 10000., 0.0, 10000, units='kpc', frozen=True)
-        self.hd = Parameter(name, 'hd', 1.7, 1., 10., 1, 10, frozen=True)
-        self.rflag = Parameter(name, 'rflag', 1., alwaysfrozen=True)
-        self.lflag = Parameter(name, 'lflag', 0., alwaysfrozen=True)
+        self.eta = XSParameter(name, 'eta', 0., 0., 1.0, 0.0, 1, frozen=True)
+        self.a = XSParameter(name, 'a', 0., -1., 0.9999, -1, 0.9999)
+        self.i = XSParameter(name, 'i', 30., 0., 85., 0.0, 85, units='deg', frozen=True)
+        self.Mbh = XSParameter(name, 'Mbh', 1., 0., 100., 0.0, 100, units='Msun')
+        self.Mdd = XSParameter(name, 'Mdd', 1., 0., 1000., 0.0, 1000, units='Mdd0')
+        self.Dbh = XSParameter(name, 'Dbh', 10., 0., 10000., 0.0, 10000, units='kpc', frozen=True)
+        self.hd = XSParameter(name, 'hd', 1.7, 1., 10., 1, 10, frozen=True)
+        self.rflag = XSParameter(name, 'rflag', 1., alwaysfrozen=True)
+        self.lflag = XSParameter(name, 'lflag', 0., alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.eta, self.a, self.i, self.Mbh, self.Mdd, self.Dbh, self.hd, self.rflag, self.lflag, self.norm))
 
@@ -5195,13 +5195,13 @@ class XSkerrd(XSAdditiveModel):
     __function__ = "C_kerrd" if equal_or_greater_than("12.10.0") else "C_kerrdisk"
 
     def __init__(self, name='kerrd'):
-        self.distance = Parameter(name, 'distance', 1., 0.01, 1000., 0.01, 1000, units='kpc', frozen=True)
-        self.TcoloTeff = Parameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 1.0, 2, frozen=True, aliases=["TcolTeff"])
-        self.M = Parameter(name, 'M', 1.0, 0.1, 100., 0.1, 100, units='solar')
-        self.Mdot = Parameter(name, 'Mdot', 1.0, 0.01, 100., 0.01, 100, units='1e18')
-        self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
-        self.Rin = Parameter(name, 'Rin', 1.235, 1.235, 100., 1.235, 100, units='Rg', frozen=True)
-        self.Rout = Parameter(name, 'Rout', 1e5, 1e4, 1e8, 1e4, 1e8, units='Rg', frozen=True)
+        self.distance = XSParameter(name, 'distance', 1., 0.01, 1000., 0.01, 1000, units='kpc', frozen=True)
+        self.TcoloTeff = XSParameter(name, 'TcoloTeff', 1.5, 1.0, 2.0, 1.0, 2, frozen=True, aliases=["TcolTeff"])
+        self.M = XSParameter(name, 'M', 1.0, 0.1, 100., 0.1, 100, units='solar')
+        self.Mdot = XSParameter(name, 'Mdot', 1.0, 0.01, 100., 0.01, 100, units='1e18')
+        self.Incl = XSParameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
+        self.Rin = XSParameter(name, 'Rin', 1.235, 1.235, 100., 1.235, 100, units='Rg', frozen=True)
+        self.Rout = XSParameter(name, 'Rout', 1e5, 1e4, 1e8, 1e4, 1e8, units='Rg', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.distance, self.TcoloTeff, self.M, self.Mdot, self.Incl, self.Rin, self.Rout, self.norm))
@@ -5261,15 +5261,15 @@ class XSkerrdisk(XSAdditiveModel):
     __function__ = "spin"
 
     def __init__(self, name='kerrdisk'):
-        self.lineE = Parameter(name, 'lineE', 6.4, 0.1, 100., 0.1, 100, units='keV', frozen=True)
-        self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -10, 10, frozen=True)
-        self.Index2 = Parameter(name, 'Index2', 3., -10., 10., -10, 10, frozen=True)
-        self.r_br_g = Parameter(name, 'r_br_g', 6.0, 1.0, 400., 1.0, 400, frozen=True, aliases=["r_brg"])
-        self.a = Parameter(name, 'a', 0.998, 0.01, 0.998, 0.01, 0.998)
-        self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
-        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, 1.0, 400., 1.0, 400, frozen=True, aliases=["Rinms"])
-        self.Rout_ms = Parameter(name, 'Rout_ms', 400., 1.0, 400., 1.0, 400, frozen=True, aliases=["Routms"])
-        self.z = Parameter(name, 'z', 0., 0., 10., 0.0, 10, frozen=True)
+        self.lineE = XSParameter(name, 'lineE', 6.4, 0.1, 100., 0.1, 100, units='keV', frozen=True)
+        self.Index1 = XSParameter(name, 'Index1', 3., -10., 10., -10, 10, frozen=True)
+        self.Index2 = XSParameter(name, 'Index2', 3., -10., 10., -10, 10, frozen=True)
+        self.r_br_g = XSParameter(name, 'r_br_g', 6.0, 1.0, 400., 1.0, 400, frozen=True, aliases=["r_brg"])
+        self.a = XSParameter(name, 'a', 0.998, 0.01, 0.998, 0.01, 0.998)
+        self.Incl = XSParameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
+        self.Rin_ms = XSParameter(name, 'Rin_ms', 1.0, 1.0, 400., 1.0, 400, frozen=True, aliases=["Rinms"])
+        self.Rout_ms = XSParameter(name, 'Rout_ms', 400., 1.0, 400., 1.0, 400, frozen=True, aliases=["Routms"])
+        self.z = XSParameter(name, 'z', 0., 0., 10., 0.0, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index1, self.Index2, self.r_br_g, self.a, self.Incl, self.Rin_ms, self.Rout_ms, self.z, self.norm))
@@ -5338,35 +5338,35 @@ class XSkyconv(XSConvolutionKernel):
     __function__ = "kyconv"
 
     def __init__(self, name='xskyconv'):
-        self.a = Parameter(name, 'a', 0.9982, min=0.0, max=1.0,
-                           hard_min=0.0, hard_max=1.0, frozen=False,
-                           units='GM/c')
-        self.theta_o = Parameter(name, 'theta_o', 30.0, min=0.0, max=89.0,
-                                 hard_min=0.0, hard_max=89.0, frozen=False,
-                                 units='deg')
-        self.rin = Parameter(name, 'rin', 1.0, min=1.0, max=1000.0,
-                             hard_min=1.0, hard_max=1000.0, frozen=True,
-                             units='GM/c^2')
-        self.ms = Parameter(name, 'ms', 1.0, min=0.0, max=1.0,
-                            hard_min=0.0, hard_max=1.0, frozen=True)
-        self.rout = Parameter(name, 'rout', 400.0, min=1.0, max=1000.0,
+        self.a = XSParameter(name, 'a', 0.9982, min=0.0, max=1.0,
+                             hard_min=0.0, hard_max=1.0, frozen=False,
+                             units='GM/c')
+        self.theta_o = XSParameter(name, 'theta_o', 30.0, min=0.0, max=89.0,
+                                   hard_min=0.0, hard_max=89.0, frozen=False,
+                                   units='deg')
+        self.rin = XSParameter(name, 'rin', 1.0, min=1.0, max=1000.0,
+                               hard_min=1.0, hard_max=1000.0, frozen=True,
+                               units='GM/c^2')
+        self.ms = XSParameter(name, 'ms', 1.0, min=0.0, max=1.0,
+                              hard_min=0.0, hard_max=1.0, frozen=True)
+        self.rout = XSParameter(name, 'rout', 400.0, min=1.0, max=1000.0,
+                                hard_min=1.0, hard_max=1000.0, frozen=True,
+                                units='GM/c^2')
+        self.alpha = XSParameter(name, 'alpha', 3.0, min=-20.0, max=20.0,
+                                 hard_min=-20.0, hard_max=20.0, frozen=True)
+        self.beta = XSParameter(name, 'beta', 3.0, min=-20.0, max=20.0,
+                                hard_min=-20.0, hard_max=20.0, frozen=True)
+        self.rb = XSParameter(name, 'rb', 400.0, min=1.0, max=1000.0,
                               hard_min=1.0, hard_max=1000.0, frozen=True,
                               units='GM/c^2')
-        self.alpha = Parameter(name, 'alpha', 3.0, min=-20.0, max=20.0,
-                               hard_min=-20.0, hard_max=20.0, frozen=True)
-        self.beta = Parameter(name, 'beta', 3.0, min=-20.0, max=20.0,
-                              hard_min=-20.0, hard_max=20.0, frozen=True)
-        self.rb = Parameter(name, 'rb', 400.0, min=1.0, max=1000.0,
-                            hard_min=1.0, hard_max=1000.0, frozen=True,
-                            units='GM/c^2')
-        self.zshift = Parameter(name, 'zshift', 0.0, min=-0.999, max=10.0,
-                                hard_min=-0.999, hard_max=10.0, frozen=True)
-        self.limb = Parameter(name, 'limb', 0.0, min=0.0, max=2.0,
-                              hard_min=0.0, hard_max=2.0, frozen=True)
-        self.ne_loc = Parameter(name, 'ne_loc', 100.0, min=3.0, max=5000.0,
-                                hard_min=3.0, hard_max=5000.0, frozen=True)
-        self.normal = Parameter(name, 'normal', 1.0, min=-1.0, max=100.0,
-                                hard_min=-1.0, hard_max=100.0, frozen=True)
+        self.zshift = XSParameter(name, 'zshift', 0.0, min=-0.999, max=10.0,
+                                  hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.limb = XSParameter(name, 'limb', 0.0, min=0.0, max=2.0,
+                                hard_min=0.0, hard_max=2.0, frozen=True)
+        self.ne_loc = XSParameter(name, 'ne_loc', 100.0, min=3.0, max=5000.0,
+                                  hard_min=3.0, hard_max=5000.0, frozen=True)
+        self.normal = XSParameter(name, 'normal', 1.0, min=-1.0, max=100.0,
+                                  hard_min=-1.0, hard_max=100.0, frozen=True)
 
         pars = (self.a, self.theta_o, self.rin, self.ms, self.rout,
                 self.alpha, self.beta, self.rb, self.zshift, self.limb,
@@ -5431,22 +5431,22 @@ class XSkyrline(XSAdditiveModel):
     __function__ = "kyrline"
 
     def __init__(self, name='kyrline'):
-        self.a = Parameter(name, 'a', 0.9982, 0, 1, 0, 1, units='GM/c')
-        self.theta_o = Parameter(name, 'theta_o', 30, 0, 89, 0, 89, units='deg')
-        self.rin = Parameter(name, 'rin', 1, 1, 1000, 1, 1000, units='GM/c^2',
-                             frozen=True)
-        self.ms = Parameter(name, 'ms', 1, 0, 1, 0, 1, alwaysfrozen=True)
-        self.rout = Parameter(name, 'rout', 400, 1, 1000, 1, 1000, units='GM/c^2',
-                              frozen=True)
-        self.Erest = Parameter(name, 'Erest', 6.4, 1, 99, 1, 99, units='keV',
+        self.a = XSParameter(name, 'a', 0.9982, 0, 1, 0, 1, units='GM/c')
+        self.theta_o = XSParameter(name, 'theta_o', 30, 0, 89, 0, 89, units='deg')
+        self.rin = XSParameter(name, 'rin', 1, 1, 1000, 1, 1000, units='GM/c^2',
                                frozen=True)
-        self.alpha = Parameter(name, 'alpha', 3, -20, 20, -20, 20, frozen=True)
-        self.beta = Parameter(name, 'beta', 3, -20, 20, -20, 20, frozen=True)
-        self.rb = Parameter(name, 'rb', 400, 1, 1000, 1, 1000, units='GM/c^2',
-                            frozen=True)
-        self.zshift = Parameter(name, 'zshift', 0, -0.999, 10, -0.999, 10,
+        self.ms = XSParameter(name, 'ms', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self.rout = XSParameter(name, 'rout', 400, 1, 1000, 1, 1000, units='GM/c^2',
                                 frozen=True)
-        self.limb = Parameter(name, 'limb', 1, 0, 2, 0, 2, frozen=True)
+        self.Erest = XSParameter(name, 'Erest', 6.4, 1, 99, 1, 99, units='keV',
+                                 frozen=True)
+        self.alpha = XSParameter(name, 'alpha', 3, -20, 20, -20, 20, frozen=True)
+        self.beta = XSParameter(name, 'beta', 3, -20, 20, -20, 20, frozen=True)
+        self.rb = XSParameter(name, 'rb', 400, 1, 1000, 1, 1000, units='GM/c^2',
+                              frozen=True)
+        self.zshift = XSParameter(name, 'zshift', 0, -0.999, 10, -0.999, 10,
+                                  frozen=True)
+        self.limb = XSParameter(name, 'limb', 1, 0, 2, 0, 2, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.a, self.theta_o, self.rin, self.ms, self.rout,
@@ -5498,11 +5498,11 @@ class XSlaor(XSAdditiveModel):
     __function__ = "C_laor" if equal_or_greater_than("12.10.1") else "C_xslaor"
 
     def __init__(self, name='laor'):
-        self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, 100, units='keV')
-        self.Index = Parameter(name, 'Index', 3., -10., 10., -10, 10, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 1.235, 400, frozen=True, aliases=["RinG"])
-        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 1.235, 400, frozen=True, aliases=["RoutG"])
-        self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
+        self.lineE = XSParameter(name, 'lineE', 6.4, 0., 100., 0.0, 100, units='keV')
+        self.Index = XSParameter(name, 'Index', 3., -10., 10., -10, 10, frozen=True)
+        self.Rin_G = XSParameter(name, 'Rin_G', 1.235, 1.235, 400., 1.235, 400, frozen=True, aliases=["RinG"])
+        self.Rout_G = XSParameter(name, 'Rout_G', 400., 1.235, 400., 1.235, 400, frozen=True, aliases=["RoutG"])
+        self.Incl = XSParameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.norm))
@@ -5559,13 +5559,13 @@ class XSlaor2(XSAdditiveModel):
     __function__ = "C_laor2"
 
     def __init__(self, name='laor2'):
-        self.lineE = Parameter(name, 'lineE', 6.4, 0., 100., 0.0, 100, units='keV')
-        self.Index = Parameter(name, 'Index', 3., -10., 10., -10, 10, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 1.235, 1.235, 400., 1.235, 400, frozen=True, aliases=["RinG"])
-        self.Rout_G = Parameter(name, 'Rout_G', 400., 1.235, 400., 1.235, 400, frozen=True, aliases=["RoutG"])
-        self.Incl = Parameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
-        self.Rbreak = Parameter(name, 'Rbreak', 20., 1.235, 400., 1.235, 400, frozen=True)
-        self.Index1 = Parameter(name, 'Index1', 3., -10., 10., -10, 10, frozen=True)
+        self.lineE = XSParameter(name, 'lineE', 6.4, 0., 100., 0.0, 100, units='keV')
+        self.Index = XSParameter(name, 'Index', 3., -10., 10., -10, 10, frozen=True)
+        self.Rin_G = XSParameter(name, 'Rin_G', 1.235, 1.235, 400., 1.235, 400, frozen=True, aliases=["RinG"])
+        self.Rout_G = XSParameter(name, 'Rout_G', 400., 1.235, 400., 1.235, 400, frozen=True, aliases=["RoutG"])
+        self.Incl = XSParameter(name, 'Incl', 30., 0., 90., 0.0, 90, units='deg', frozen=True)
+        self.Rbreak = XSParameter(name, 'Rbreak', 20., 1.235, 400., 1.235, 400, frozen=True)
+        self.Index1 = XSParameter(name, 'Index1', 3., -10., 10., -10, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lineE, self.Index, self.Rin_G, self.Rout_G, self.Incl, self.Rbreak, self.Index1, self.norm))
@@ -5606,10 +5606,10 @@ class XSlogpar(XSAdditiveModel):
     __function__ = "C_logpar" if equal_or_greater_than("12.10.1") else "logpar"
 
     def __init__(self, name='logpar'):
-        self.alpha = Parameter(name, 'alpha', 1.5, 0., 4., 0.0, 4)
-        self.beta = Parameter(name, 'beta', 0.2, -4., 4., -4, 4)
-        self.pivotE = Parameter(name, 'pivotE', 1.0, units='keV',
-                                alwaysfrozen=True)
+        self.alpha = XSParameter(name, 'alpha', 1.5, 0., 4., 0.0, 4)
+        self.beta = XSParameter(name, 'beta', 0.2, -4., 4., -4, 4)
+        self.pivotE = XSParameter(name, 'pivotE', 1.0, units='keV',
+                                  alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.alpha, self.beta, self.pivotE, self.norm)
@@ -5645,8 +5645,8 @@ class XSlorentz(XSAdditiveModel):
     __function__ = "C_lorentzianLine" if equal_or_greater_than("12.9.1") else "xslorz"
 
     def __init__(self, name='lorentz'):
-        self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
-        self.Width = Parameter(name, 'Width', 0.1, 0., 10., 0.0, 20, units='keV')
+        self.LineE = XSParameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
+        self.Width = XSParameter(name, 'Width', 0.1, 0., 10., 0.0, 20, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Width, self.norm))
 
@@ -5690,10 +5690,10 @@ class XSmeka(XSAdditiveModel):
     __function__ = "C_meka" if equal_or_greater_than("12.9.1") else "xsmeka"
 
     def __init__(self, name='meka'):
-        self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 1e-3, 1e2, units='keV')
-        self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 1.e-3, 1.e2, 1e-3, 1e2, units='keV')
+        self.nH = XSParameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self.norm))
 
@@ -5737,11 +5737,11 @@ class XSmekal(XSAdditiveModel):
     __function__ = "C_mekal" if equal_or_greater_than("12.9.1") else "xsmekl"
 
     def __init__(self, name='mekal'):
-        self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.nH = XSParameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.Abundanc, self.redshift, self.switch, self.norm))
@@ -5785,11 +5785,11 @@ class XSmkcflow(XSAdditiveModel):
     __function__ = "C_xsmkcf"
 
     def __init__(self, name='mkcflow'):
-        self.lowT = Parameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, 5)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
+        self.lowT = XSParameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.highT = XSParameter(name, 'highT', 4., 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 5., 0.0, 5)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, 0, 1, 0, 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.Abundanc, self.redshift, self.switch,
@@ -5832,10 +5832,10 @@ class XSnei(XSAdditiveModel):
     __function__ = "C_nei"
 
     def __init__(self, name='nei'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau, self.redshift, self.norm))
 
@@ -5878,9 +5878,9 @@ class XSnlapec(XSAdditiveModel):
     __function__ = "C_nlapec"
 
     def __init__(self, name='nlapec'):
-        self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.redshift, self.norm))
 
@@ -5927,12 +5927,12 @@ class XSnpshock(XSAdditiveModel):
     __function__ = "C_npshock"
 
     def __init__(self, name='npshock'):
-        self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_b = Parameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau_l = Parameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
-        self.Tau_u = Parameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT_a = XSParameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_b = XSParameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau_l = XSParameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
+        self.Tau_u = XSParameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.Abundanc, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
@@ -5971,10 +5971,10 @@ class XSnsa(XSAdditiveModel):
     __function__ = "nsa"
 
     def __init__(self, name='nsa'):
-        self.LogT_eff = Parameter(name, 'LogT_eff', 6.0, 5.0, 7.0, 5, 7, units='K')
-        self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 2.5, 0.5, 2.5, units='Msun')
-        self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 20., 5.0, 20, units='km')
-        self.MagField = Parameter(name, 'MagField', 0.0, 0.0, 5.e13, 0.0, 5e13, units='G', frozen=True)
+        self.LogT_eff = XSParameter(name, 'LogT_eff', 6.0, 5.0, 7.0, 5, 7, units='K')
+        self.M_ns = XSParameter(name, 'M_ns', 1.4, 0.5, 2.5, 0.5, 2.5, units='Msun')
+        self.R_ns = XSParameter(name, 'R_ns', 10.0, 5.0, 20., 5.0, 20, units='km')
+        self.MagField = XSParameter(name, 'MagField', 0.0, 0.0, 5.e13, 0.0, 5e13, units='G', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LogT_eff, self.M_ns, self.R_ns, self.MagField, self.norm))
 
@@ -6010,9 +6010,9 @@ class XSnsagrav(XSAdditiveModel):
     __function__ = "nsagrav"
 
     def __init__(self, name='nsagrav'):
-        self.LogT_eff = Parameter(name, 'LogT_eff', 6.0, 5.5, 6.5, 5.5, 6.5, units='K')
-        self.NSmass = Parameter(name, 'NSmass', 1.4, 0.3, 2.5, 0.3, 2.5, units='Msun')
-        self.NSrad = Parameter(name, 'NSrad', 10.0, 6.0, 20., 6.0, 20, units='km')
+        self.LogT_eff = XSParameter(name, 'LogT_eff', 6.0, 5.5, 6.5, 5.5, 6.5, units='K')
+        self.NSmass = XSParameter(name, 'NSmass', 1.4, 0.3, 2.5, 0.3, 2.5, units='Msun')
+        self.NSrad = XSParameter(name, 'NSrad', 10.0, 6.0, 20., 6.0, 20, units='km')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LogT_eff, self.NSmass, self.NSrad, self.norm))
 
@@ -6045,10 +6045,10 @@ class XSnsatmos(XSAdditiveModel):
     __function__ = "nsatmos"
 
     def __init__(self, name='nsatmos'):
-        self.LogT_eff = Parameter(name, 'LogT_eff', 6.0, 5.0, 6.5, 5.0, 6.5, units='K')
-        self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3, units='Msun')
-        self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30., 5.0, 30, units='km')
-        self.dist = Parameter(name, 'dist', 10.0, 0.1, 100.0, 0.1, 100, units='kpc')
+        self.LogT_eff = XSParameter(name, 'LogT_eff', 6.0, 5.0, 6.5, 5.0, 6.5, units='K')
+        self.M_ns = XSParameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3, units='Msun')
+        self.R_ns = XSParameter(name, 'R_ns', 10.0, 5.0, 30., 5.0, 30, units='km')
+        self.dist = XSParameter(name, 'dist', 10.0, 0.1, 100.0, 0.1, 100, units='kpc')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LogT_eff, self.M_ns, self.R_ns, self.dist, self.norm))
 
@@ -6084,9 +6084,9 @@ class XSnsmax(XSAdditiveModel):
     __function__ = _f77_or_c_12100("nsmax")
 
     def __init__(self, name='nsmax'):
-        self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.8, 5.5, 6.8, units='K')
-        self.redshift = Parameter(name, 'redshift', 0.1, 1.0e-5, 1.5, 1.0e-5, 2.0)
-        self.specfile = Parameter(name, 'specfile', 1200, alwaysfrozen=True)
+        self.logTeff = XSParameter(name, 'logTeff', 6.0, 5.5, 6.8, 5.5, 6.8, units='K')
+        self.redshift = XSParameter(name, 'redshift', 0.1, 1.0e-5, 1.5, 1.0e-5, 2.0)
+        self.specfile = XSParameter(name, 'specfile', 1200, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.redshift, self.specfile, self.norm))
@@ -6126,11 +6126,11 @@ class XSnsmaxg(XSAdditiveModel):
     __function__ = _f77_or_c_12100("nsmaxg")
 
     def __init__(self, name='nsmaxg'):
-        self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.9, 5.5, 6.9, units='K')
-        self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
-        self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
-        self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self.specfile = Parameter(name, 'specfile', 1200, alwaysfrozen=True)
+        self.logTeff = XSParameter(name, 'logTeff', 6.0, 5.5, 6.9, 5.5, 6.9, units='K')
+        self.M_ns = XSParameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
+        self.R_ns = XSParameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
+        self.dist = XSParameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
+        self.specfile = XSParameter(name, 'specfile', 1200, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
@@ -6170,11 +6170,11 @@ class XSnsx(XSAdditiveModel):
     __function__ = _f77_or_c_12100("nsx")
 
     def __init__(self, name='nsx'):
-        self.logTeff = Parameter(name, 'logTeff', 6.0, 5.5, 6.7, 5.5, 6.7, units='K')
-        self.M_ns = Parameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
-        self.R_ns = Parameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
-        self.dist = Parameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
-        self.specfile = Parameter(name, 'specfile', 6, alwaysfrozen=True)
+        self.logTeff = XSParameter(name, 'logTeff', 6.0, 5.5, 6.7, 5.5, 6.7, units='K')
+        self.M_ns = XSParameter(name, 'M_ns', 1.4, 0.5, 3.0, 0.5, 3.0, units='Msun')
+        self.R_ns = XSParameter(name, 'R_ns', 10.0, 5.0, 30.0, 5.0, 30.0, units='km')
+        self.dist = XSParameter(name, 'dist', 1.0, 0.01, 100.0, 0.01, 100.0, units='kpc')
+        self.specfile = XSParameter(name, 'specfile', 6, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.logTeff, self.M_ns, self.R_ns, self.dist, self.specfile, self.norm))
@@ -6241,21 +6241,21 @@ class XSnteea(XSAdditiveModel):
     __function__ = "C_xsnteea"
 
     def __init__(self, name='nteea'):
-        self.l_nth = Parameter(name, 'l_nth', 100., 0., 1.e4, 0.0, 1e4)
-        self.l_bb = Parameter(name, 'l_bb', 100., 0., 1.e4, 0.0, 1e4)
-        self.f_refl = Parameter(name, 'f_refl', 0., 0., 4., 0.0, 4)
-        self.kT_bb = Parameter(name, 'kT_bb', 10., 1., 100., 1.0, 100, frozen=True)
-        self.g_max = Parameter(name, 'g_max', 1.e3, 5., 1.e4, 5.0, 1e4, frozen=True)
-        self.l_th = Parameter(name, 'l_th', 0., 0., 1.e4, 0.0, 1e4, frozen=True)
-        self.tau_p = Parameter(name, 'tau_p', 0., 0., 10., 0.0, 10, frozen=True)
-        self.G_inj = Parameter(name, 'G_inj', 0., 0., 5., 0.0, 5, frozen=True)
-        self.g_min = Parameter(name, 'g_min', 1.3, 1., 1.e3, 1, 1e3, frozen=True)
-        self.g_0 = Parameter(name, 'g_0', 1.3, 1., 5., 1.0, 5, frozen=True)
-        self.radius = Parameter(name, 'radius', 1.e13, 1.e5, 1.e16, 1e5, 1e16, frozen=True)
-        self.pair_esc = Parameter(name, 'pair_esc', 0., 0., 1., 0.0, 1, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.l_nth = XSParameter(name, 'l_nth', 100., 0., 1.e4, 0.0, 1e4)
+        self.l_bb = XSParameter(name, 'l_bb', 100., 0., 1.e4, 0.0, 1e4)
+        self.f_refl = XSParameter(name, 'f_refl', 0., 0., 4., 0.0, 4)
+        self.kT_bb = XSParameter(name, 'kT_bb', 10., 1., 100., 1.0, 100, frozen=True)
+        self.g_max = XSParameter(name, 'g_max', 1.e3, 5., 1.e4, 5.0, 1e4, frozen=True)
+        self.l_th = XSParameter(name, 'l_th', 0., 0., 1.e4, 0.0, 1e4, frozen=True)
+        self.tau_p = XSParameter(name, 'tau_p', 0., 0., 10., 0.0, 10, frozen=True)
+        self.G_inj = XSParameter(name, 'G_inj', 0., 0., 5., 0.0, 5, frozen=True)
+        self.g_min = XSParameter(name, 'g_min', 1.3, 1., 1.e3, 1, 1e3, frozen=True)
+        self.g_0 = XSParameter(name, 'g_0', 1.3, 1., 5., 1.0, 5, frozen=True)
+        self.radius = XSParameter(name, 'radius', 1.e13, 1.e5, 1.e16, 1e5, 1e16, frozen=True)
+        self.pair_esc = XSParameter(name, 'pair_esc', 0., 0., 1., 0.0, 1, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.l_nth, self.l_bb, self.f_refl, self.kT_bb, self.g_max, self.l_th, self.tau_p, self.G_inj, self.g_min, self.g_0, self.radius, self.pair_esc, self.cosIncl, self.Fe_abund, self.redshift, self.norm))
 
@@ -6295,11 +6295,11 @@ class XSnthComp(XSAdditiveModel):
     __function__ = "C_nthcomp"
 
     def __init__(self, name='nthcomp'):
-        self.Gamma = Parameter(name, 'Gamma', 1.7, 1.001, 5., 1.001, 10.)
-        self.kT_e = Parameter(name, 'kT_e', 100., 5., 1.e3, 1., 1.e3, units='keV')
-        self.kT_bb = Parameter(name, 'kT_bb', 0.1, 1.e-3, 10., 1.e-3, 10., units='keV', frozen=True)
-        self.inp_type = Parameter(name, 'inp_type', 0., 0., 1., 0., 1., units='0/1', frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10., frozen=True)
+        self.Gamma = XSParameter(name, 'Gamma', 1.7, 1.001, 5., 1.001, 10.)
+        self.kT_e = XSParameter(name, 'kT_e', 100., 5., 1.e3, 1., 1.e3, units='keV')
+        self.kT_bb = XSParameter(name, 'kT_bb', 0.1, 1.e-3, 10., 1.e-3, 10., units='keV', frozen=True)
+        self.inp_type = XSParameter(name, 'inp_type', 0., 0., 1., 0., 1., units='0/1', frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10., frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Gamma, self.kT_e, self.kT_bb, self.inp_type, self.redshift, self.norm))
 
@@ -6369,19 +6369,19 @@ class XSoptxagn(XSAdditiveModel):
     __function__ = "optxagn"
 
     def __init__(self, name='optxagn'):
-        self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 1.0, 1e9, units='solar', frozen=True)
-        self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.01, 1e9, units='Mpc', frozen=True)
-        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -10, 2, aliases=["logLLEdd"])
-        self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, 0.998, frozen=True)
-        self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 1.0, 100, units='rg')
-        self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 3.0, 7, frozen=True)
-        self.kT_e = Parameter(name, 'kT_e', 0.2, 0.01, 10, 0.01, 10, units='keV')
-        self.tau = Parameter(name, 'tau', 10., 0.1, 100, 0.1, 100)
-        self.Gamma = Parameter(name, 'Gamma', 2.1, 0.5, 5., 0.5, 10)
-        self.fpl = Parameter(name, 'fpl', 1.e-4, 0.0, 1.e-1, 0.0, 1e-1)
-        self.fcol = Parameter(name, 'fcol', 2.4, 1.0, 5, 1.0, 5, frozen=True)
-        self.tscat = Parameter(name, 'tscat', 1.e5, 1e4, 1e5, 1e4, 1e5, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, 10, frozen=True)
+        self.mass = XSParameter(name, 'mass', 1e7, 1.0, 1.e9, 1.0, 1e9, units='solar', frozen=True)
+        self.dist = XSParameter(name, 'dist', 100, 0.01, 1.e9, 0.01, 1e9, units='Mpc', frozen=True)
+        self.logLoLEdd = XSParameter(name, 'logLoLEdd', -1., -10., 2, -10, 2, aliases=["logLLEdd"])
+        self.astar = XSParameter(name, 'astar', 0.0, 0., 0.998, 0.0, 0.998, frozen=True)
+        self.rcor = XSParameter(name, 'rcor', 10.0, 1., 100., 1.0, 100, units='rg')
+        self.logrout = XSParameter(name, 'logrout', 5.0, 3.0, 7.0, 3.0, 7, frozen=True)
+        self.kT_e = XSParameter(name, 'kT_e', 0.2, 0.01, 10, 0.01, 10, units='keV')
+        self.tau = XSParameter(name, 'tau', 10., 0.1, 100, 0.1, 100)
+        self.Gamma = XSParameter(name, 'Gamma', 2.1, 0.5, 5., 0.5, 10)
+        self.fpl = XSParameter(name, 'fpl', 1.e-4, 0.0, 1.e-1, 0.0, 1e-1)
+        self.fcol = XSParameter(name, 'fcol', 2.4, 1.0, 5, 1.0, 5, frozen=True)
+        self.tscat = XSParameter(name, 'tscat', 1.e5, 1e4, 1e5, 1e4, 1e5, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., 0., 10., 0.0, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.fcol, self.tscat, self.Redshift, self.norm))
@@ -6451,17 +6451,17 @@ class XSoptxagnf(XSAdditiveModel):
     __function__ = "optxagnf"
 
     def __init__(self, name='optxagnf'):
-        self.mass = Parameter(name, 'mass', 1e7, 1.0, 1.e9, 1.0, 1e9, units='solar', frozen=True)
-        self.dist = Parameter(name, 'dist', 100, 0.01, 1.e9, 0.01, 1e9, units='Mpc', frozen=True)
-        self.logLoLEdd = Parameter(name, 'logLoLEdd', -1., -10., 2, -10, 2, aliases=["logLLEdd"])
-        self.astar = Parameter(name, 'astar', 0.0, 0., 0.998, 0.0, 0.998, frozen=True)
-        self.rcor = Parameter(name, 'rcor', 10.0, 1., 100., 1.0, 100, units='rg')
-        self.logrout = Parameter(name, 'logrout', 5.0, 3.0, 7.0, 3.0, 7, frozen=True)
-        self.kT_e = Parameter(name, 'kT_e', 0.2, 0.01, 10, 0.01, 10, units='keV')
-        self.tau = Parameter(name, 'tau', 10., 0.1, 100, 0.1, 100)
-        self.Gamma = Parameter(name, 'Gamma', 2.1, 1.05, 5., 1.05, 10.0)
-        self.fpl = Parameter(name, 'fpl', 1.e-4, 0.0, 1., 0.0, 1)
-        self.Redshift = Parameter(name, 'Redshift', 0., 0., 10., 0.0, 10, frozen=True)
+        self.mass = XSParameter(name, 'mass', 1e7, 1.0, 1.e9, 1.0, 1e9, units='solar', frozen=True)
+        self.dist = XSParameter(name, 'dist', 100, 0.01, 1.e9, 0.01, 1e9, units='Mpc', frozen=True)
+        self.logLoLEdd = XSParameter(name, 'logLoLEdd', -1., -10., 2, -10, 2, aliases=["logLLEdd"])
+        self.astar = XSParameter(name, 'astar', 0.0, 0., 0.998, 0.0, 0.998, frozen=True)
+        self.rcor = XSParameter(name, 'rcor', 10.0, 1., 100., 1.0, 100, units='rg')
+        self.logrout = XSParameter(name, 'logrout', 5.0, 3.0, 7.0, 3.0, 7, frozen=True)
+        self.kT_e = XSParameter(name, 'kT_e', 0.2, 0.01, 10, 0.01, 10, units='keV')
+        self.tau = XSParameter(name, 'tau', 10., 0.1, 100, 0.1, 100)
+        self.Gamma = XSParameter(name, 'Gamma', 2.1, 1.05, 5., 1.05, 10.0)
+        self.fpl = XSParameter(name, 'fpl', 1.e-4, 0.0, 1., 0.0, 1)
+        self.Redshift = XSParameter(name, 'Redshift', 0., 0., 10., 0.0, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.mass, self.dist, self.logLoLEdd, self.astar, self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma, self.fpl, self.Redshift, self.norm))
@@ -6499,9 +6499,9 @@ class XSpegpwrlw(XSAdditiveModel):
     __function__ = "xspegp"
 
     def __init__(self, name='pegpwrlw'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
-        self.eMin = Parameter(name, 'eMin', 2., -100., 1.e10, -100, 1e10, units='keV', frozen=True)
-        self.eMax = Parameter(name, 'eMax', 10., -100., 1.e10, -100, 1e10, units='keV', frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
+        self.eMin = XSParameter(name, 'eMin', 2., -100., 1.e10, -100, 1e10, units='keV', frozen=True)
+        self.eMax = XSParameter(name, 'eMax', 10., -100., 1.e10, -100, 1e10, units='keV', frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.eMin, self.eMax, self.norm))
 
@@ -6553,13 +6553,13 @@ class XSpexmon(XSAdditiveModel):
     __function__ = "pexmon"
 
     def __init__(self, name='pexmon'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 2., 1.1, 2.5, 1.1, 2.5)
-        self.foldE = Parameter(name, 'foldE', 1000., 1., 1.e6, 1.0, 1e6, units='keV', frozen=True)
-        self.rel_refl = Parameter(name, 'rel_refl', -1, -1.e6, 1.e6, -1e6, 1e6, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
-        self.abund = Parameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.0, 100., 0.0, 100, frozen=True)
-        self.Incl = Parameter(name, 'Incl', 60., 0., 85.0, 0.0, 85, units='deg')
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 2., 1.1, 2.5, 1.1, 2.5)
+        self.foldE = XSParameter(name, 'foldE', 1000., 1., 1.e6, 1.0, 1e6, units='keV', frozen=True)
+        self.rel_refl = XSParameter(name, 'rel_refl', -1, -1.e6, 1.e6, -1e6, 1e6, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0., 4., 0.0, 4, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.0, 100., 0.0, 100, frozen=True)
+        self.Incl = XSParameter(name, 'Incl', 60., 0., 85.0, 0.0, 85, units='deg')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.foldE, self.rel_refl, self.redshift, self.abund, self.Fe_abund, self.Incl, self.norm))
 
@@ -6614,13 +6614,13 @@ class XSpexrav(XSAdditiveModel):
     __function__ = "C_xspexrav"
 
     def __init__(self, name='pexrav'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 2., -9., 9., -10, 10)
-        self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
-        self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e6, 0, 1e6)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.abund = Parameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 2., -9., 9., -10, 10)
+        self.foldE = XSParameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
+        self.rel_refl = XSParameter(name, 'rel_refl', 0., 0., 1.e6, 0, 1e6)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.foldE, self.rel_refl, self.redshift, self.abund, self.Fe_abund, self.cosIncl, self.norm))
 
@@ -6679,15 +6679,15 @@ class XSpexriv(XSAdditiveModel):
     __function__ = "C_xspexriv"
 
     def __init__(self, name='pexriv'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 2., -9., 9., -10, 10)
-        self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
-        self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 1.e6, 0, 1e6)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.abund = Parameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
-        self.T_disk = Parameter(name, 'T_disk', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 1., 0., 1.e3, 0.0, 5e3, units='erg cm/s')
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 2., -9., 9., -10, 10)
+        self.foldE = XSParameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
+        self.rel_refl = XSParameter(name, 'rel_refl', 0., 0., 1.e6, 0, 1e6)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.0, 1.e6, 0.0, 1e6, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, 0.05, 0.95, 0.05, 0.95, frozen=True)
+        self.T_disk = XSParameter(name, 'T_disk', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 1., 0., 1.e3, 0.0, 5e3, units='erg cm/s')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.foldE, self.rel_refl, self.redshift, self.abund, self.Fe_abund, self.cosIncl, self.T_disk, self.xi, self.norm))
 
@@ -6735,16 +6735,16 @@ class XSplcabs(XSAdditiveModel):
     __function__ = "xsp1tr"
 
     def __init__(self, name='plcabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.nmax = Parameter(name, 'nmax', 1, alwaysfrozen=True)
-        self.FeAbun = Parameter(name, 'FeAbun', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.FeKedge = Parameter(name, 'FeKedge', 7.11, 7., 10., 7.0, 10, units='KeV', frozen=True)
-        self.PhoIndex = Parameter(name, 'PhoIndex', 2., -2., 9., -3, 10)
-        self.HighECut = Parameter(name, 'HighECut', 95., 1., 100., 0.01, 200., units='keV', frozen=True)
-        self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, frozen=True)
-        self.acrit = Parameter(name, 'acrit', 1., 0.0, 1.0, 0.0, 1, frozen=True)
-        self.FAST = Parameter(name, 'FAST', 0, alwaysfrozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.nmax = XSParameter(name, 'nmax', 1, alwaysfrozen=True)
+        self.FeAbun = XSParameter(name, 'FeAbun', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.FeKedge = XSParameter(name, 'FeKedge', 7.11, 7., 10., 7.0, 10, units='KeV', frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 2., -2., 9., -3, 10)
+        self.HighECut = XSParameter(name, 'HighECut', 95., 1., 100., 0.01, 200., units='keV', frozen=True)
+        self.foldE = XSParameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, frozen=True)
+        self.acrit = XSParameter(name, 'acrit', 1., 0.0, 1.0, 0.0, 1, frozen=True)
+        self.FAST = XSParameter(name, 'FAST', 0, alwaysfrozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.nH, self.nmax, self.FeAbun, self.FeKedge, self.PhoIndex,
@@ -6780,7 +6780,7 @@ class XSpowerlaw(XSAdditiveModel):
     __function__ = "C_powerLaw"
 
     def __init__(self, name='powerlaw'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.norm))
 
@@ -6847,11 +6847,11 @@ class XSpshock(XSAdditiveModel):
     __function__ = "C_pshock"
 
     def __init__(self, name='pshock'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau_l = Parameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
-        self.Tau_u = Parameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau_l = XSParameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
+        self.Tau_u = XSParameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
@@ -6899,18 +6899,18 @@ class XSqsosed(XSAdditiveModel):
     __function__ = "qsosed"
 
     def __init__(self, name='qsosed'):
-        self.mass = Parameter(name, 'mass', 1e7, 1e5, 1e10, 1e5, 1e10,
-                              'solar', frozen=True)
-        self.dist = Parameter(name, 'dist', 100, 0.01, 1e9, 0.01, 1e9,
-                              'Mpc', frozen=True)
-        self.logmdot = Parameter(name, 'logmdot', -1, -1.65, 0.39, -1.65, 0.39, units='Ledd')
-        self.astar = Parameter(name, 'astar', 0.0, -1, 0.998, -1, 0.998,
-                               frozen=True)
-        self.cosi = Parameter(name, 'cosi', 0.5, 0.05, 1.0, 0.05, 1.0,
-                              frozen=True)
+        self.mass = XSParameter(name, 'mass', 1e7, 1e5, 1e10, 1e5, 1e10,
+                                'solar', frozen=True)
+        self.dist = XSParameter(name, 'dist', 100, 0.01, 1e9, 0.01, 1e9,
+                                'Mpc', frozen=True)
+        self.logmdot = XSParameter(name, 'logmdot', -1, -1.65, 0.39, -1.65, 0.39, units='Ledd')
+        self.astar = XSParameter(name, 'astar', 0.0, -1, 0.998, -1, 0.998,
+                                 frozen=True)
+        self.cosi = XSParameter(name, 'cosi', 0.5, 0.05, 1.0, 0.05, 1.0,
+                                frozen=True)
 
-        self.redshift = Parameter(name, 'redshift', 0, 0, 5, 0, 5,
-                                  frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0, 0, 5, 0, 5,
+                                    frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.mass, self.dist, self.logmdot, self.astar, self.cosi,
@@ -6951,9 +6951,9 @@ class XSraymond(XSAdditiveModel):
     __function__ = "C_raysmith" if equal_or_greater_than("12.9.1") else "xsrays"
 
     def __init__(self, name='raymond'):
-        self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1., 0., 5., 0.0, 5, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.redshift, self.norm))
 
@@ -6982,8 +6982,8 @@ class XSredge(XSAdditiveModel):
     __function__ = "xredge"
 
     def __init__(self, name='redge'):
-        self.edge = Parameter(name, 'edge', 1.4, 0.001, 100., 0.001, 100, units='keV')
-        self.kT = Parameter(name, 'kT', 1., 0.001, 100., 0.001, 100, units='keV')
+        self.edge = XSParameter(name, 'edge', 1.4, 0.001, 100., 0.001, 100, units='keV')
+        self.kT = XSParameter(name, 'kT', 1., 0.001, 100., 0.001, 100, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.edge, self.kT, self.norm))
 
@@ -7048,19 +7048,19 @@ class XSrefsch(XSAdditiveModel):
     __function__ = "xsrefsch"
 
     def __init__(self, name='refsch'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 2., -9., 9., -10, 10)
-        self.foldE = Parameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
-        self.rel_refl = Parameter(name, 'rel_refl', 0., 0., 2., 0.0, 2)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.abund = Parameter(name, 'abund', 1., 0.5, 10., 0.5, 10, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
-        self.Incl = Parameter(name, 'Incl', 30., 19., 87., 19, 87, units='deg', frozen=True)
-        self.T_disk = Parameter(name, 'T_disk', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 1., 0., 1.e3, 0.0, 5e3, units='ergcm/s')
-        self.Betor10 = Parameter(name, 'Betor10', -2., -10., 20., -10, 20, frozen=True)
-        self.Rin = Parameter(name, 'Rin', 10., 6., 1000., 6.0, 10000, units='R_g', frozen=True)
-        self.Rout = Parameter(name, 'Rout', 1000., 0., 1000000., 0.0, 10000000, units='R_g', frozen=True)
-        self.accuracy = Parameter(name, 'accuracy', 30., 30., 100000., 30.0, 100000, frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 2., -9., 9., -10, 10)
+        self.foldE = XSParameter(name, 'foldE', 100., 1., 1.e6, 1.0, 1e6, units='keV')
+        self.rel_refl = XSParameter(name, 'rel_refl', 0., 0., 2., 0.0, 2)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1., 0.5, 10., 0.5, 10, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0.1, 10., 0.1, 10, frozen=True)
+        self.Incl = XSParameter(name, 'Incl', 30., 19., 87., 19, 87, units='deg', frozen=True)
+        self.T_disk = XSParameter(name, 'T_disk', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 1., 0., 1.e3, 0.0, 5e3, units='ergcm/s')
+        self.Betor10 = XSParameter(name, 'Betor10', -2., -10., 20., -10, 20, frozen=True)
+        self.Rin = XSParameter(name, 'Rin', 10., 6., 1000., 6.0, 10000, units='R_g', frozen=True)
+        self.Rout = XSParameter(name, 'Rout', 1000., 0., 1000000., 0.0, 10000000, units='R_g', frozen=True)
+        self.accuracy = XSParameter(name, 'accuracy', 30., 30., 100000., 30.0, 100000, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.foldE, self.rel_refl, self.redshift, self.abund, self.Fe_abund, self.Incl, self.T_disk, self.xi, self.Betor10, self.Rin, self.Rout, self.accuracy, self.norm))
 
@@ -7103,11 +7103,11 @@ class XSrnei(XSAdditiveModel):
     __function__ = "C_rnei"
 
     def __init__(self, name='rnei'):
-        self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_init = Parameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
+        self.kT = XSParameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.Abundanc, self.Tau, self.redshift, self.norm))
 
@@ -7152,11 +7152,11 @@ class XSsedov(XSAdditiveModel):
     __function__ = "C_sedov"
 
     def __init__(self, name='sedov'):
-        self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_b = Parameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT_a = XSParameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_b = XSParameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.Abundanc, self.Tau, self.redshift, self.norm))
 
@@ -7203,15 +7203,15 @@ class XSsirf(XSAdditiveModel):
     __function__ = "C_sirf"
 
     def __init__(self, name='sirf'):
-        self.tin = Parameter(name,    'tin', 1., 0.01, 100., 0.01, 1000., units='keV')
-        self.rin = Parameter(name,    'rin', 1.e-2, 1.e-5, 1.0, 1.e-6, 10, units='rsph')
-        self.rout = Parameter(name,   'rout', 100., 0.1, 1.e8, 0.1, 1.e8, units='rsph')
-        self.theta = Parameter(name,  'theta', 22.9, 1., 89., 0., 90., units='deg')
-        self.incl = Parameter(name,   'incl', 0., -90., 90., -90., 90., units='deg', frozen=True)
-        self.valpha = Parameter(name, 'valpha', -0.5, -1.0, 2., -1.5, 5., frozen=True)
-        self.gamma = Parameter(name,  'gamma', 1.333, 0.5, 10., 0.5, 10., frozen=True)
-        self.mdot = Parameter(name,   'mdot', 1000., 0.5, 1.e7, 0.5, 1.e7, frozen=True)
-        self.irrad = Parameter(name,  'irrad', 2., 0., 10., 0., 20., frozen=True)
+        self.tin = XSParameter(name,    'tin', 1., 0.01, 100., 0.01, 1000., units='keV')
+        self.rin = XSParameter(name,    'rin', 1.e-2, 1.e-5, 1.0, 1.e-6, 10, units='rsph')
+        self.rout = XSParameter(name,   'rout', 100., 0.1, 1.e8, 0.1, 1.e8, units='rsph')
+        self.theta = XSParameter(name,  'theta', 22.9, 1., 89., 0., 90., units='deg')
+        self.incl = XSParameter(name,   'incl', 0., -90., 90., -90., 90., units='deg', frozen=True)
+        self.valpha = XSParameter(name, 'valpha', -0.5, -1.0, 2., -1.5, 5., frozen=True)
+        self.gamma = XSParameter(name,  'gamma', 1.333, 0.5, 10., 0.5, 10., frozen=True)
+        self.mdot = XSParameter(name,   'mdot', 1000., 0.5, 1.e7, 0.5, 1.e7, frozen=True)
+        self.irrad = XSParameter(name,  'irrad', 2., 0., 10., 0., 20., frozen=True)
         self.norm = Parameter(name,   'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.tin, self.rin, self.rout, self.theta,
                                               self.incl, self.valpha, self.gamma, self.mdot,
@@ -7269,23 +7269,23 @@ class XSslimbh(XSAdditiveModel):
     __function__ = "slimbbmodel"
 
     def __init__(self, name='slimbh'):
-        self.M = Parameter(name, 'M', 10.0, 0.0, 1000.0, 0.0, 1000.0, units='Msun',
-                           frozen=True)
-        self.a = Parameter(name, 'a', 0.0, 0.0, 0.999, 0.0, 0.999, units='GM/c')
-        self.lumin = Parameter(name, 'lumin', 0.5, 0.05, 1.0, 0.05, 1.0,
-                               units='L_Edd')
-        self.alpha = Parameter(name, 'alpha', 0.1, 0.005, 0.1, 0.005, 0.1,
-                               frozen=True)
-        self.inc = Parameter(name, 'inc', 60.0, 0.0, 85.0, 0.0, 85.0,
-                             units='deg', frozen=True)
-        self.D = Parameter(name, 'D', 10.0, 0.0, 1e4, 0.0, 1e4, units='kpc',
-                           frozen=True)
-        self.f_hard = Parameter(name, 'f_hard', -1.0, -10.0, 10.0, -10.0, 10.0,
-                                frozen=True)
-        self.lflag = Parameter(name, 'lflag', 1.0, alwaysfrozen=True)
-        self.vflag = Parameter(name, 'vflag', 1.0, alwaysfrozen=True)
+        self.M = XSParameter(name, 'M', 10.0, 0.0, 1000.0, 0.0, 1000.0, units='Msun',
+                             frozen=True)
+        self.a = XSParameter(name, 'a', 0.0, 0.0, 0.999, 0.0, 0.999, units='GM/c')
+        self.lumin = XSParameter(name, 'lumin', 0.5, 0.05, 1.0, 0.05, 1.0,
+                                 units='L_Edd')
+        self.alpha = XSParameter(name, 'alpha', 0.1, 0.005, 0.1, 0.005, 0.1,
+                                 frozen=True)
+        self.inc = XSParameter(name, 'inc', 60.0, 0.0, 85.0, 0.0, 85.0,
+                               units='deg', frozen=True)
+        self.D = XSParameter(name, 'D', 10.0, 0.0, 1e4, 0.0, 1e4, units='kpc',
+                             frozen=True)
+        self.f_hard = XSParameter(name, 'f_hard', -1.0, -10.0, 10.0, -10.0, 10.0,
+                                  frozen=True)
+        self.lflag = XSParameter(name, 'lflag', 1.0, alwaysfrozen=True)
+        self.vflag = XSParameter(name, 'vflag', 1.0, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval,
-                              frozen=True)
+                                frozen=True)
         XSAdditiveModel.__init__(self, name,
                                  (self.M, self.a, self.lumin, self.alpha,
                                   self.inc, self.D, self.f_hard,
@@ -7339,16 +7339,16 @@ class XSsnapec(XSAdditiveModel):
     __function__ = "C_snapec"
 
     def __init__(self, name='snapec'):
-        self.kT = Parameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64.0, units='keV')
-        self.N_SNe = Parameter(name, 'N_SNe', 1., 0.0, 1e20, 0, 1e20, units='10^9')
+        self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64.0, units='keV')
+        self.N_SNe = XSParameter(name, 'N_SNe', 1., 0.0, 1e20, 0, 1e20, units='10^9')
         # QUS: if this is a percentage, why is the maximum not 100?
-        self.R = Parameter(name, 'R', 1., 0.0, 1e20, 0, 1e20)
-        self.SNIModelIndex = Parameter(name, 'SNIModelIndex', 1.,
-                                       0.0, 125, 0, 125, alwaysfrozen=True)
-        self.SNIIModelIndex = Parameter(name, 'SNIIModelIndex', 1.,
-                                        0.0, 125, 0, 125, alwaysfrozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., 0.0, 10.0,
-                                  frozen=True)
+        self.R = XSParameter(name, 'R', 1., 0.0, 1e20, 0, 1e20)
+        self.SNIModelIndex = XSParameter(name, 'SNIModelIndex', 1.,
+                                         0.0, 125, 0, 125, alwaysfrozen=True)
+        self.SNIIModelIndex = XSParameter(name, 'SNIIModelIndex', 1.,
+                                          0.0, 125, 0, 125, alwaysfrozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., 0.0, 10.0,
+                                    frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.N_SNe, self.R,
@@ -7391,8 +7391,8 @@ class XSsrcut(XSAdditiveModel):
     __function__ = "srcut"
 
     def __init__(self, name='srcut'):
-        self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 1e-5, 1)
-        self.break_ = Parameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 1e10, 1e25, 'Hz', aliases=["breakfreq"])
+        self.alpha = XSParameter(name, 'alpha', 0.5, 0.3, 0.8, 1e-5, 1)
+        self.break_ = XSParameter(name, 'break_', 2.42E17, 1.E15, 1.E19, 1e10, 1e25, 'Hz', aliases=["breakfreq"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.alpha, self.break_, self.norm))
@@ -7428,8 +7428,8 @@ class XSsresc(XSAdditiveModel):
     __function__ = "sresc"
 
     def __init__(self, name='sresc'):
-        self.alpha = Parameter(name, 'alpha', 0.5, 0.3, 0.8, 1e-5, 1)
-        self.rolloff = Parameter(name, 'rolloff', 2.42E17, 1.E15, 1.E19, 1e10, 1e25, units='Hz')
+        self.alpha = XSParameter(name, 'alpha', 0.5, 0.3, 0.8, 1e-5, 1)
+        self.rolloff = XSParameter(name, 'rolloff', 2.42E17, 1.E15, 1.E19, 1e10, 1e25, units='Hz')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.alpha, self.rolloff, self.norm))
 
@@ -7465,8 +7465,8 @@ class XSssa(XSAdditiveModel):
     __function__ = "ssa"
 
     def __init__(self, name='ssa'):
-        self.te = Parameter(name, 'te', 0.1, 0.01, 0.5, 0.01, 0.5)
-        self.y = Parameter(name, 'y', 0.7, 1e-4, 1e3, 1e-4, 1e3)
+        self.te = XSParameter(name, 'te', 0.1, 0.01, 0.5, 0.01, 0.5)
+        self.y = XSParameter(name, 'y', 0.7, 1e-4, 1e3, 1e-4, 1e3)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.te, self.y, self.norm))
 
@@ -7499,8 +7499,8 @@ class XSstep(XSAdditiveModel):
     __function__ = "xsstep"
 
     def __init__(self, name='step'):
-        self.Energy = Parameter(name, 'Energy', 6.5, 0., 100., 0.0, 100, units='keV')
-        self.Sigma = Parameter(name, 'Sigma', 0.1, 0., 10., 0.0, 20, units='keV')
+        self.Energy = XSParameter(name, 'Energy', 6.5, 0., 100., 0.0, 100, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.1, 0., 10., 0.0, 20, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.Energy, self.Sigma, self.norm))
 
@@ -7555,10 +7555,10 @@ class XStapec(XSAdditiveModel):
     __function__ = "C_tapec"
 
     def __init__(self, name='tapec'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
-        self.kTi = Parameter(name, 'kTi', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
-        self.Abundanc = Parameter(name, 'Abundanc', 1.0, 0.0, 5.0, 0.0, 5.0)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
+        self.kTi = XSParameter(name, 'kTi', 1.0, 0.008, 64.0, 0.008, 64.0, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, 0.0, 5.0, 0.0, 5.0)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.kTi, self.Abundanc, self.Redshift, self.norm))
@@ -7596,21 +7596,21 @@ class XSvapec(XSAdditiveModel):
     __function__ = "C_vapec" if equal_or_greater_than("12.9.1") else "xsvape"
 
     def __init__(self, name='vapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.norm))
 
@@ -7650,8 +7650,8 @@ class XSvbremss(XSAdditiveModel):
     __function__ = "xsbrmv"
 
     def __init__(self, name='vbremss'):
-        self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
-        self.HeovrH = Parameter(name, 'HeovrH', 1.0, 0., 100., 0.0, 100, aliases=["HeH"])
+        self.kT = XSParameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
+        self.HeovrH = XSParameter(name, 'HeovrH', 1.0, 0., 100., 0.0, 100, aliases=["HeH"])
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.HeovrH, self.norm))
@@ -7698,41 +7698,41 @@ class XSvcph(XSAdditiveModel):
     __function__ = "C_vcph"
 
     def __init__(self, name='vcph'):
-        self.peakT = Parameter(name, 'peakT', 2.2, 1e-1, 1e2, 1e-1, 1e2,
-                               units='keV')
+        self.peakT = XSParameter(name, 'peakT', 2.2, 1e-1, 1e2, 1e-1, 1e2,
+                                 units='keV')
 
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 1000.0,
-                           frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 1000.0,
-                           frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 1000.0,
-                           frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Na = Parameter(name, 'Na', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 1000.0,
-                           frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000.0,
-                            frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, 0.0, 50, 0.0, 50,
-                                  frozen=True)
-        self.switch = Parameter(name, 'switch', 1,
-                                alwaysfrozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 1000.0,
+                             frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 1000.0,
+                             frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 1000.0,
+                             frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 1000.0,
+                             frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000.0,
+                              frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, 0.0, 50, 0.0, 50,
+                                    frozen=True)
+        self.switch = XSParameter(name, 'switch', 1,
+                                  alwaysfrozen=True)
 
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
@@ -7778,20 +7778,20 @@ class XSvequil(XSAdditiveModel):
     __function__ = "C_vequil"
 
     def __init__(self, name='vequil'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.norm))
 
@@ -7840,25 +7840,25 @@ class XSvgadem(XSAdditiveModel):
     __function__ = "C_vgaussDem"
 
     def __init__(self, name='vgadem'):
-        self.Tmean = Parameter(name, 'Tmean', 4.0, 0.01, 10, 0.01, 20, units='keV', frozen=True)
-        self.Tsigma = Parameter(name, 'Tsigma', 0.1, 0.01, 1.e2, 0.01, 1e2, units='keV')
-        self.nH = Parameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Na = Parameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 2, alwaysfrozen=True)
+        self.Tmean = XSParameter(name, 'Tmean', 4.0, 0.01, 10, 0.01, 20, units='keV', frozen=True)
+        self.Tsigma = XSParameter(name, 'Tsigma', 0.1, 0.01, 1.e2, 0.01, 1e2, units='keV')
+        self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 10., 0.0, 10, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 2, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.Tmean, self.Tsigma, self.nH, self.He, self.C, self.N, self.O,
@@ -7912,23 +7912,23 @@ class XSvgnei(XSAdditiveModel):
     __function__ = "C_vgnei"
 
     def __init__(self, name='vgnei'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV', aliases=["kT_ave"])
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.meankT = XSParameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV', aliases=["kT_ave"])
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.meankT, self.redshift, self.norm))
@@ -7967,23 +7967,23 @@ class XSvmeka(XSAdditiveModel):
     __function__ = "C_vmeka" if equal_or_greater_than("12.9.1") else "xsvmek"
 
     def __init__(self, name='vmeka'):
-        self.kT = Parameter(name, 'kT', 1., 1.e-3, 1.e2, 1e-3, 100, units='keV')
-        self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 1.e-3, 1.e2, 1e-3, 100, units='keV')
+        self.nH = XSParameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.norm))
 
@@ -8026,24 +8026,24 @@ class XSvmekal(XSAdditiveModel):
     __function__ = "C_vmekal" if equal_or_greater_than("12.9.1") else "xsvmkl"
 
     def __init__(self, name='vmekal'):
-        self.kT = Parameter(name, 'kT', 1., 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.nH = Parameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, alwaysfrozen=True)
+        self.kT = XSParameter(name, 'kT', 1., 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.nH = XSParameter(name, 'nH', 1., 1.e-5, 1.e19, 1e-6, 1e20, units='cm-3', frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na,
@@ -8089,24 +8089,24 @@ class XSvmcflow(XSAdditiveModel):
     __function__ = "C_xsvmcf"
 
     def __init__(self, name='vmcflow'):
-        self.lowT = Parameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.highT = Parameter(name, 'highT', 4., 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., 0, 10, frozen=True)
-        self.switch = Parameter(name, 'switch', 1, alwaysfrozen=True)
+        self.lowT = XSParameter(name, 'lowT', 0.1, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.highT = XSParameter(name, 'highT', 4., 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., 0, 10, frozen=True)
+        self.switch = XSParameter(name, 'switch', 1, alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.lowT, self.highT, self.He, self.C, self.N, self.O, self.Ne, self.Na,
@@ -8152,22 +8152,22 @@ class XSvnei(XSAdditiveModel):
     __function__ = "C_vnei"
 
     def __init__(self, name='vnei'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.redshift, self.norm))
 
@@ -8216,24 +8216,24 @@ class XSvnpshock(XSAdditiveModel):
     __function__ = "C_vnpshock"
 
     def __init__(self, name='vnpshock'):
-        self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_b = Parameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau_l = Parameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
-        self.Tau_u = Parameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT_a = XSParameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_b = XSParameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau_l = XSParameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
+        self.Tau_u = XSParameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
@@ -8273,9 +8273,9 @@ class XSvoigt(XSAdditiveModel):
     __function__ = "C_voigtLine"
 
     def __init__(self, name='voigt'):
-        self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
-        self.Sigma = Parameter(name, 'Sigma', 0.01, 0., 10., 0.0, 20, units='keV')
-        self.Gamma = Parameter(name, 'Gamma', 0.01, 0., 10., 0.0, 20, units='keV')
+        self.LineE = XSParameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.01, 0., 10., 0.0, 20, units='keV')
+        self.Gamma = XSParameter(name, 'Gamma', 0.01, 0., 10., 0.0, 20, units='keV')
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.LineE, self.Sigma, self.Gamma,
@@ -8322,23 +8322,23 @@ class XSvpshock(XSAdditiveModel):
     __function__ = "C_vpshock"
 
     def __init__(self, name='vpshock'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau_l = Parameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
-        self.Tau_u = Parameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau_l = XSParameter(name, 'Tau_l', 0.0, 0., 5.e13, 0.0, 5e13, units='s/cm^3', frozen=True)
+        self.Tau_u = XSParameter(name, 'Tau_u', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
@@ -8374,20 +8374,20 @@ class XSvraymond(XSAdditiveModel):
     __function__ = "C_vraysmith" if equal_or_greater_than("12.9.1") else "xsvrys"
 
     def __init__(self, name='vraymond'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.redshift, self.norm))
 
@@ -8432,23 +8432,23 @@ class XSvrnei(XSAdditiveModel):
     __function__ = "C_vrnei"
 
     def __init__(self, name='vrnei'):
-        self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_init = Parameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1.0, 0., 1., 0.0, 1.0, frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
+        self.kT = XSParameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, 0., 1., 0.0, 1.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.redshift, self.norm))
 
@@ -8495,23 +8495,23 @@ class XSvsedov(XSAdditiveModel):
     __function__ = "C_vsedov"
 
     def __init__(self, name='vsedov'):
-        self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_b = Parameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT_a = XSParameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_b = XSParameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, 0., 1., 0.0, 1, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 10000, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.e8, 5.e13, 1e8, 5e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.redshift, self.norm))
 
@@ -8559,22 +8559,22 @@ class XSvtapec(XSAdditiveModel):
     __function__ = "C_vtapec"
 
     def __init__(self, name='vtapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.kTi = Parameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.He = Parameter(name, 'He', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.kTi = XSParameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.He = XSParameter(name, 'He', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.kTi, self.He, self.C, self.N, self.O,
@@ -8615,38 +8615,38 @@ class XSvvapec(XSAdditiveModel):
     __function__ = "C_vvapec" if equal_or_greater_than("12.9.1") else "xsvvap"
 
     def __init__(self, name='vvapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.norm))
 
@@ -8698,40 +8698,40 @@ class XSvvgnei(XSAdditiveModel):
     __function__ = "C_vvgnei"
 
     def __init__(self, name='vvgnei'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.meankT = Parameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV', aliases=["kT_ave"])
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.meankT = XSParameter(name, 'meankT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV', aliases=["kT_ave"])
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.meankT, self.redshift, self.norm))
@@ -8776,39 +8776,39 @@ class XSvvnei(XSAdditiveModel):
     __function__ = "C_vvnei"
 
     def __init__(self, name='vvnei'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.redshift, self.norm))
 
@@ -8858,41 +8858,41 @@ class XSvvnpshock(XSAdditiveModel):
     __function__ = "C_vvnpshock"
 
     def __init__(self, name='vvnpshock'):
-        self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_b = Parameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Tau_l = Parameter(name, 'Tau_l', 0.0, 0.0, 5.0e13, 0.0, 5.0e13, units='s/cm^3', frozen=True)
-        self.Tau_u = Parameter(name, 'Tau_u', 1.0e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT_a = XSParameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_b = XSParameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.0100, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Tau_l = XSParameter(name, 'Tau_l', 0.0, 0.0, 5.0e13, 0.0, 5.0e13, units='s/cm^3', frozen=True)
+        self.Tau_u = XSParameter(name, 'Tau_u', 1.0e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
@@ -8938,40 +8938,40 @@ class XSvvpshock(XSAdditiveModel):
     __function__ = "C_vvpshock"
 
     def __init__(self, name='vvpshock'):
-        self.kT = Parameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Tau_l = Parameter(name, 'Tau_l', 0.0, 0.0, 5.0e13, 0.0, 5.0e13, units='s/cm^3', frozen=True)
-        self.Tau_u = Parameter(name, 'Tau_u', 1.0e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10.0, -0.999, 10.0, frozen=True)
+        self.kT = XSParameter(name, 'kT', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Tau_l = XSParameter(name, 'Tau_l', 0.0, 0.0, 5.0e13, 0.0, 5.0e13, units='s/cm^3', frozen=True)
+        self.Tau_u = XSParameter(name, 'Tau_u', 1.0e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10.0, -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
@@ -9017,40 +9017,40 @@ class XSvvrnei(XSAdditiveModel):
     __function__ = "C_vvrnei"
 
     def __init__(self, name='vvrnei'):
-        self.kT = Parameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_init = Parameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
+        self.kT = XSParameter(name, 'kT', 0.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.redshift, self.norm))
 
@@ -9098,40 +9098,40 @@ class XSvvsedov(XSAdditiveModel):
     __function__ = "C_vvsedov"
 
     def __init__(self, name='vvsedov'):
-        self.kT_a = Parameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
-        self.kT_b = Parameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.01, 79.9, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
-        self.Tau = Parameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
+        self.kT_a = XSParameter(name, 'kT_a', 1.0, 0.0808, 79.9, 0.0808, 79.9, units='keV')
+        self.kT_b = XSParameter(name, 'kT_b', 0.5, 0.0100, 79.9, 0.01, 79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 1.e11, 1.0e8, 5.0e13, 1.0e8, 5.0e13, units='s/cm^3')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.redshift, self.norm))
 
@@ -9178,39 +9178,39 @@ class XSvvtapec(XSAdditiveModel):
     __function__ = "C_vvtapec"
 
     def __init__(self, name='vvtapec'):
-        self.kT = Parameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.kTi = Parameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Li = Parameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Be = Parameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.B = Parameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.F = Parameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.P = Parameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.K = Parameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Sc = Parameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ti = Parameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.V = Parameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mn = Parameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cu = Parameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Zn = Parameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
+        self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.kTi = XSParameter(name, 'kTi', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.B = XSParameter(name, 'B', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.F = XSParameter(name, 'F', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.P = XSParameter(name, 'P', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.K = XSParameter(name, 'K', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.V = XSParameter(name, 'V', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10, -0.999, 10)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name,
                                  (self.kT, self.kTi, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.norm))
@@ -9246,9 +9246,9 @@ class XSzagauss(XSAdditiveModel):
     __function__ = "C_zagauss"
 
     def __init__(self, name='zagauss'):
-        self.LineE = Parameter(name, 'LineE', 10.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
-        self.Sigma = Parameter(name, 'Sigma', 1.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
-        self.Redshift = Parameter(name, 'Redshift', 0., -0.999, 10.0, -0.999, 10.0, frozen=True)
+        self.LineE = XSParameter(name, 'LineE', 10.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
+        self.Sigma = XSParameter(name, 'Sigma', 1.0, 0.0, 1.0e6, 0.0, 1.0e6, units='A')
+        self.Redshift = XSParameter(name, 'Redshift', 0., -0.999, 10.0, -0.999, 10.0, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.Redshift, self.norm))
 
@@ -9282,8 +9282,8 @@ class XSzbbody(XSAdditiveModel):
     __function__ = "xszbod"
 
     def __init__(self, name='zbbody'):
-        self.kT = Parameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.redshift, self.norm))
 
@@ -9323,11 +9323,11 @@ class XSzbknpower(XSAdditiveModel):
     __function__ = "C_zBrokenPowerLaw"
 
     def __init__(self, name='zbknpower'):
-        self.PhoIndx1 = Parameter(name, 'PhoIndx1', 1., -2., 9., -3, 10)
-        self.BreakE = Parameter(name, 'BreakE', 5., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
-        self.PhoIndx2 = Parameter(name, 'PhoIndx2', 2., -2., 9., -3, 10)
-        self.Redshift = Parameter(name, 'Redshift', 0, -0.999, 10, -0.999, 10,
-                                  frozen=True)
+        self.PhoIndx1 = XSParameter(name, 'PhoIndx1', 1., -2., 9., -3, 10)
+        self.BreakE = XSParameter(name, 'BreakE', 5., 1.e-2, 1.e6, 0.0, 1e6, units='keV')
+        self.PhoIndx2 = XSParameter(name, 'PhoIndx2', 2., -2., 9., -3, 10)
+        self.Redshift = XSParameter(name, 'Redshift', 0, -0.999, 10, -0.999, 10,
+                                    frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.PhoIndx1, self.BreakE, self.PhoIndx2, self.Redshift,
@@ -9370,8 +9370,8 @@ class XSzbremss(XSAdditiveModel):
     __function__ = "xszbrm"
 
     def __init__(self, name='zbremss'):
-        self.kT = Parameter(name, 'kT', 7.0, 1.e-4, 100., 1e-4, 200, units='keV')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.kT = XSParameter(name, 'kT', 7.0, 1.e-4, 100., 1e-4, 200, units='keV')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.kT, self.redshift, self.norm))
 
@@ -9413,9 +9413,9 @@ class XSzcutoffpl(XSAdditiveModel):
     __function__ = "C_zcutoffPowerLaw"
 
     def __init__(self, name='zcutoffpl'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
-        self.HighECut = Parameter(name, 'HighECut', 15., 1., 500., 0.01, 500, units='keV')
-        self.Redshift = Parameter(name, 'Redshift', 0.0, -0.999, 10., -0.999, 10., frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
+        self.HighECut = XSParameter(name, 'HighECut', 15., 1., 500., 0.01, 500, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, -0.999, 10., -0.999, 10., frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.HighECut, self.Redshift, self.norm))
 
@@ -9450,9 +9450,9 @@ class XSzgauss(XSAdditiveModel):
     __function__ = "C_xszgau"
 
     def __init__(self, name='zgauss'):
-        self.LineE = Parameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
-        self.Sigma = Parameter(name, 'Sigma', 0.1, 0., 10., 0.0, 20, units='keV')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.LineE = XSParameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.1, 0., 10., 0.0, 20, units='keV')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.redshift, self.norm))
 
@@ -9529,17 +9529,17 @@ class XSzkerrbb(XSAdditiveModel):
     __function__ = "C_zkerrbb"
 
     def __init__(self, name='zkerrbb'):
-        self.eta = Parameter(name, 'eta', 0., 0., 1.0, 0.0, 1, frozen=True)
-        self.a = Parameter(name, 'a', 0.5, -0.99, 0.9999, -0.99, 0.9999)
-        self.i = Parameter(name, 'i', 30., 0., 85., 0.0, 85, units='deg', frozen=True)
-        self.Mbh = Parameter(name, 'Mbh', 1e7, 3, 1e10, 3.0, 1e10, units='M_sun')
-        self.Mdd = Parameter(name, 'Mdd', 1., 1e-4, 1e4, 1e-5, 1e5, units='M0yr')
-        self.z = Parameter(name, 'z', 0.01, 0., 10., 0.0, 10, frozen=True)
-        self.fcol = Parameter(name, 'fcol', 2.0, -100, 100, -100, 100, frozen=True,
-                              # Parameter was mis-labelled until 4.14.0
-                              aliases=['hd'])
-        self.rflag = Parameter(name, 'rflag', 1., alwaysfrozen=True)
-        self.lflag = Parameter(name, 'lflag', 1., alwaysfrozen=True)
+        self.eta = XSParameter(name, 'eta', 0., 0., 1.0, 0.0, 1, frozen=True)
+        self.a = XSParameter(name, 'a', 0.5, -0.99, 0.9999, -0.99, 0.9999)
+        self.i = XSParameter(name, 'i', 30., 0., 85., 0.0, 85, units='deg', frozen=True)
+        self.Mbh = XSParameter(name, 'Mbh', 1e7, 3, 1e10, 3.0, 1e10, units='M_sun')
+        self.Mdd = XSParameter(name, 'Mdd', 1., 1e-4, 1e4, 1e-5, 1e5, units='M0yr')
+        self.z = XSParameter(name, 'z', 0.01, 0., 10., 0.0, 10, frozen=True)
+        self.fcol = XSParameter(name, 'fcol', 2.0, -100, 100, -100, 100, frozen=True,
+                                # Parameter was mis-labelled until 4.14.0
+                                aliases=['hd'])
+        self.rflag = XSParameter(name, 'rflag', 1., alwaysfrozen=True)
+        self.lflag = XSParameter(name, 'lflag', 1., alwaysfrozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.eta, self.a, self.i, self.Mbh, self.Mdd, self.z, self.fcol, self.rflag, self.lflag, self.norm))
 
@@ -9581,12 +9581,12 @@ class XSzlogpar(XSAdditiveModel):
     __function__ = "C_zLogpar"
 
     def __init__(self, name='zlogpar'):
-        self.alpha = Parameter(name, 'alpha', 1.5, 0., 4., 0.0, 4)
-        self.beta = Parameter(name, 'beta', 0.2, -4., 4., -4, 4)
-        self.pivotE = Parameter(name, 'pivotE', 1.0, units='keV',
-                                alwaysfrozen=True)
-        self.Redshift = Parameter(name, 'Redshift', 0, -0.999, 10, -0.999, 10,
-                                  frozen=True)
+        self.alpha = XSParameter(name, 'alpha', 1.5, 0., 4., 0.0, 4)
+        self.beta = XSParameter(name, 'beta', 0.2, -4., 4., -4, 4)
+        self.pivotE = XSParameter(name, 'pivotE', 1.0, units='keV',
+                                  alwaysfrozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0, -0.999, 10, -0.999, 10,
+                                    frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
 
         pars = (self.alpha, self.beta, self.pivotE, self.Redshift, self.norm)
@@ -9624,8 +9624,8 @@ class XSzpowerlw(XSAdditiveModel):
     __function__ = "C_zpowerLaw"
 
     def __init__(self, name='zpowerlw'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 1., -2., 9., -3, 10)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval)
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.redshift, self.norm))
 
@@ -9661,12 +9661,12 @@ class XSabsori(XSMultiplicativeModel):
     __function__ = "C_xsabsori"
 
     def __init__(self, name='absori'):
-        self.PhoIndex = Parameter(name, 'PhoIndex', 2., 0., 4., 0.0, 4, frozen=True)
-        self.nH = Parameter(name, 'nH', 1., 0., 100., 0.0, 100, units='10^22 atoms / cm^2')
-        self.Temp_abs = Parameter(name, 'Temp_abs', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
-        self.xi = Parameter(name, 'xi', 1., 0., 1.e3, 0.0, 5000)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1., 0., 1.e6, 0.0, 1e6, frozen=True)
+        self.PhoIndex = XSParameter(name, 'PhoIndex', 2., 0., 4., 0.0, 4, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 100., 0.0, 100, units='10^22 atoms / cm^2')
+        self.Temp_abs = XSParameter(name, 'Temp_abs', 3.e4, 1.e4, 1.e6, 1e4, 1e6, units='K', frozen=True)
+        self.xi = XSParameter(name, 'xi', 1., 0., 1.e3, 0.0, 5000)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1., 0., 1.e6, 0.0, 1e6, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.PhoIndex, self.nH, self.Temp_abs, self.xi, self.redshift, self.Fe_abund))
 
 
@@ -9703,14 +9703,14 @@ class XSacisabs(XSMultiplicativeModel):
     __function__ = _f77_or_c_12100("acisabs")
 
     def __init__(self, name='acisabs'):
-        self.Tdays = Parameter(name, 'Tdays', 850., 0., 10000., 0.0, 10000, units='days', frozen=True)
+        self.Tdays = XSParameter(name, 'Tdays', 850., 0., 10000., 0.0, 10000, units='days', frozen=True)
         self.norm = Parameter(name, 'norm', 0.00722, 0., 1., 0.0, hugeval, frozen=True)
-        self.tauinf = Parameter(name, 'tauinf', 0.582, 0., 1., 0.0, 1, frozen=True)
-        self.tefold = Parameter(name, 'tefold', 620., 1., 10000., 1.0, 10000, units='days', frozen=True)
-        self.nC = Parameter(name, 'nC', 10., 0., 50., 0.0, 50, frozen=True)
-        self.nH = Parameter(name, 'nH', 20., 1., 50., 1.0, 50, frozen=True)
-        self.nO = Parameter(name, 'nO', 2., 0., 50., 0.0, 50, frozen=True)
-        self.nN = Parameter(name, 'nN', 1., 0., 50., 0.0, 50, frozen=True)
+        self.tauinf = XSParameter(name, 'tauinf', 0.582, 0., 1., 0.0, 1, frozen=True)
+        self.tefold = XSParameter(name, 'tefold', 620., 1., 10000., 1.0, 10000, units='days', frozen=True)
+        self.nC = XSParameter(name, 'nC', 10., 0., 50., 0.0, 50, frozen=True)
+        self.nH = XSParameter(name, 'nH', 20., 1., 50., 1.0, 50, frozen=True)
+        self.nO = XSParameter(name, 'nO', 2., 0., 50., 0.0, 50, frozen=True)
+        self.nN = XSParameter(name, 'nN', 1., 0., 50., 0.0, 50, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.Tdays, self.norm, self.tauinf, self.tefold, self.nC, self.nH, self.nO, self.nN))
 
 
@@ -9738,7 +9738,7 @@ class XSconstant(XSMultiplicativeModel):
     __function__ = "xscnst"
 
     def __init__(self, name='constant'):
-        self.factor = Parameter(name, 'factor', 1., 0.0, 1.e10, 0.0, 1e10)
+        self.factor = XSParameter(name, 'factor', 1., 0.0, 1.e10, 0.0, 1e10)
         XSMultiplicativeModel.__init__(self, name, (self.factor,))
 
 
@@ -9762,7 +9762,7 @@ class XScabs(XSMultiplicativeModel):
     __function__ = "xscabs"
 
     def __init__(self, name='cabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
         XSMultiplicativeModel.__init__(self, name, (self.nH,))
 
 
@@ -9794,11 +9794,11 @@ class XScyclabs(XSMultiplicativeModel):
     __function__ = "xscycl"
 
     def __init__(self, name='cyclabs'):
-        self.Depth0 = Parameter(name, 'Depth0', 2.0, 0., 100., 0.0, 100)
-        self.E0 = Parameter(name, 'E0', 30.0, 1.0, 100., 1.0, 100, units='keV')
-        self.Width0 = Parameter(name, 'Width0', 10.0, 1.0, 100., 1.0, 100, units='keV', frozen=True)
-        self.Depth2 = Parameter(name, 'Depth2', 0.0, 0., 100., 0.0, 100, frozen=True)
-        self.Width2 = Parameter(name, 'Width2', 20.0, 1.0, 100., 1.0, 100, units='keV', frozen=True)
+        self.Depth0 = XSParameter(name, 'Depth0', 2.0, 0., 100., 0.0, 100)
+        self.E0 = XSParameter(name, 'E0', 30.0, 1.0, 100., 1.0, 100, units='keV')
+        self.Width0 = XSParameter(name, 'Width0', 10.0, 1.0, 100., 1.0, 100, units='keV', frozen=True)
+        self.Depth2 = XSParameter(name, 'Depth2', 0.0, 0., 100., 0.0, 100, frozen=True)
+        self.Width2 = XSParameter(name, 'Width2', 20.0, 1.0, 100., 1.0, 100, units='keV', frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.Depth0, self.E0, self.Width0, self.Depth2, self.Width2))
 
 
@@ -9824,8 +9824,8 @@ class XSdust(XSMultiplicativeModel):
     __function__ = "xsdust"
 
     def __init__(self, name='dust'):
-        self.Frac = Parameter(name, 'Frac', 0.066, 0., 1., 0.0, 1, frozen=True)
-        self.Halosz = Parameter(name, 'Halosz', 2., 0., 1.e5, 0.0, 1e5, frozen=True)
+        self.Frac = XSParameter(name, 'Frac', 0.066, 0., 1., 0.0, 1, frozen=True)
+        self.Halosz = XSParameter(name, 'Halosz', 2., 0., 1.e5, 0.0, 1e5, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.Frac, self.Halosz))
 
 
@@ -9855,8 +9855,8 @@ class XSedge(XSMultiplicativeModel):
     __function__ = "xsedge"
 
     def __init__(self, name='edge'):
-        self.edgeE = Parameter(name, 'edgeE', 7.0, 0., 100., 0.0, 100, units='keV')
-        self.MaxTau = Parameter(name, 'MaxTau', 1., 0., 5., 0.0, 10)
+        self.edgeE = XSParameter(name, 'edgeE', 7.0, 0., 100., 0.0, 100, units='keV')
+        self.MaxTau = XSParameter(name, 'MaxTau', 1., 0., 5., 0.0, 10)
         XSMultiplicativeModel.__init__(self, name, (self.edgeE, self.MaxTau))
 
 
@@ -9880,7 +9880,7 @@ class XSexpabs(XSMultiplicativeModel):
     __function__ = "xsabsc"
 
     def __init__(self, name='expabs'):
-        self.LowECut = Parameter(name, 'LowECut', 2., 0., 100., 0.0, 200, units='keV')
+        self.LowECut = XSParameter(name, 'LowECut', 2., 0., 100., 0.0, 200, units='keV')
         XSMultiplicativeModel.__init__(self, name, (self.LowECut,))
 
 
@@ -9908,9 +9908,9 @@ class XSexpfac(XSMultiplicativeModel):
     __function__ = "xsexp"
 
     def __init__(self, name='expfac'):
-        self.Ampl = Parameter(name, 'Ampl', 1., 0., 1.e5, 0.0, 1e6)
-        self.Factor = Parameter(name, 'Factor', 1., 0., 1.e5, 0.0, 1e6)
-        self.StartE = Parameter(name, 'StartE', 0.5, 0., 1.e5, 0.0, 1e6, units='keV', frozen=True)
+        self.Ampl = XSParameter(name, 'Ampl', 1., 0., 1.e5, 0.0, 1e6)
+        self.Factor = XSParameter(name, 'Factor', 1., 0., 1.e5, 0.0, 1e6)
+        self.StartE = XSParameter(name, 'StartE', 0.5, 0., 1.e5, 0.0, 1e6, units='keV', frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.Ampl, self.Factor, self.StartE))
 
 
@@ -9945,9 +9945,9 @@ class XSgabs(XSMultiplicativeModel):
     __function__ = "C_gaussianAbsorptionLine"
 
     def __init__(self, name='gabs'):
-        self.LineE = Parameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, 1e6, units='keV')
-        self.Sigma = Parameter(name, 'Sigma', 0.01, 0., 10., 0.0, 20, units='keV')
-        self.Strength = Parameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, 1e6, aliases=["Tau"])
+        self.LineE = XSParameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, 1e6, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.01, 0., 10., 0.0, 20, units='keV')
+        self.Strength = XSParameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, 1e6, aliases=["Tau"])
 
         XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Sigma, self.Strength))
 
@@ -9990,11 +9990,10 @@ class XSheilin(XSMultiplicativeModel):
     __function__ = "xsphei"
 
     def __init__(self, name='heilin'):
-        self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.e6, 0.0, 1.0e6, units='10^22 atoms / cm^2')
-        self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
+        self.nHeI = XSParameter(name, 'nHeI', 1.e-5, 0.0, 1.e6, 0.0, 1.0e6, units='10^22 atoms / cm^2')
+        self.b = XSParameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
+        self.z = XSParameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
 
-        # TODO: correct self.nHei to self.nHeI
         XSMultiplicativeModel.__init__(self, name, (self.nHei, self.b, self.z))
 
 
@@ -10024,8 +10023,8 @@ class XShighecut(XSMultiplicativeModel):
     __function__ = "xshecu"
 
     def __init__(self, name='highecut'):
-        self.cutoffE = Parameter(name, 'cutoffE', 10., 1.e-2, 1.e6, 1e-4, 1e6, units='keV')
-        self.foldE = Parameter(name, 'foldE', 15., 1.e-2, 1.e6, 1e-4, 1e6, units='keV')
+        self.cutoffE = XSParameter(name, 'cutoffE', 10., 1.e-2, 1.e6, 1e-4, 1e6, units='keV')
+        self.foldE = XSParameter(name, 'foldE', 15., 1.e-2, 1.e6, 1e-4, 1e6, units='keV')
         XSMultiplicativeModel.__init__(self, name, (self.cutoffE, self.foldE))
 
     def guess(self, dep, *args, **kwargs):
@@ -10072,14 +10071,14 @@ class XShrefl(XSMultiplicativeModel):
     __function__ = "xshrfl"
 
     def __init__(self, name='hrefl'):
-        self.thetamin = Parameter(name, 'thetamin', 0., 0.0, 90., 0.0, 90, frozen=True)
-        self.thetamax = Parameter(name, 'thetamax', 90., 0.0, 90., 0.0, 90, frozen=True)
-        self.thetaobs = Parameter(name, 'thetaobs', 60., 0.0, 90., 0.0, 90)
-        self.Feabun = Parameter(name, 'Feabun', 1., 0.0, 100., 0.0, 200, frozen=True)
-        self.FeKedge = Parameter(name, 'FeKedge', 7.11, 7.0, 10., 7.0, 10, units='keV', frozen=True)
-        self.Escfrac = Parameter(name, 'Escfrac', 1.0, 0.0, 500., 0.0, 1000)
-        self.covfac = Parameter(name, 'covfac', 1.0, 0.0, 500., 0.0, 1000)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.thetamin = XSParameter(name, 'thetamin', 0., 0.0, 90., 0.0, 90, frozen=True)
+        self.thetamax = XSParameter(name, 'thetamax', 90., 0.0, 90., 0.0, 90, frozen=True)
+        self.thetaobs = XSParameter(name, 'thetaobs', 60., 0.0, 90., 0.0, 90)
+        self.Feabun = XSParameter(name, 'Feabun', 1., 0.0, 100., 0.0, 200, frozen=True)
+        self.FeKedge = XSParameter(name, 'FeKedge', 7.11, 7.0, 10., 7.0, 10, units='keV', frozen=True)
+        self.Escfrac = XSParameter(name, 'Escfrac', 1.0, 0.0, 500., 0.0, 1000)
+        self.covfac = XSParameter(name, 'covfac', 1.0, 0.0, 500., 0.0, 1000)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.thetamin, self.thetamax, self.thetaobs, self.Feabun, self.FeKedge, self.Escfrac, self.covfac, self.redshift))
 
 
@@ -10120,68 +10119,68 @@ class XSismabs(XSMultiplicativeModel):
 
     def __init__(self, name='ismabs'):
 
-        self.H = Parameter(name, 'H', 0.1, 0.0, 1e5, 0, 1e6, units='10^22')
-        self.HeII = Parameter(name, 'HeII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.CI = Parameter(name, 'CI', 33.1, 0.0, 1e5, 0, 1e6,
-                            units='10^16')
-        self.CII = Parameter(name, 'CII', 0.0, 0.0, 1e5, 0, 1e6,
-                             units='10^16', frozen=True)
-        self.CIII = Parameter(name, 'CIII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.NI = Parameter(name, 'NI', 8.32, 0.0, 1e5, 0, 1e6,
-                            units='10^16')
-        self.NII = Parameter(name, 'NII', 0.0, 0.0, 1e5, 0, 1e6,
-                             units='10^16', frozen=True)
-        self.NIII = Parameter(name, 'NIII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.OI = Parameter(name, 'OI', 67.6, 0.0, 1e5, 0, 1e6,
-                            units='10^16')
-        self.OII = Parameter(name, 'OII', 0.0, 0.0, 1e5, 0, 1e6,
-                             units='10^16', frozen=True)
-        self.OIII = Parameter(name, 'OIII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.NeI = Parameter(name, 'NeI', 12.0, 0.0, 1e5, 0, 1e6,
-                             units='10^16')
-        self.NeII = Parameter(name, 'NeII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.NeIII = Parameter(name, 'NeIII', 0.0, 0.0, 1e5, 0, 1e6,
+        self.H = XSParameter(name, 'H', 0.1, 0.0, 1e5, 0, 1e6, units='10^22')
+        self.HeII = XSParameter(name, 'HeII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.CI = XSParameter(name, 'CI', 33.1, 0.0, 1e5, 0, 1e6,
+                              units='10^16')
+        self.CII = XSParameter(name, 'CII', 0.0, 0.0, 1e5, 0, 1e6,
                                units='10^16', frozen=True)
-        self.MgI = Parameter(name, 'MgI', 3.8, 0.0, 1e5, 0, 1e6,
-                             units='10^16')
-        self.MgII = Parameter(name, 'MgII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.MgIII = Parameter(name, 'MgIII', 0.0, 0.0, 1e5, 0, 1e6,
+        self.CIII = XSParameter(name, 'CIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.NI = XSParameter(name, 'NI', 8.32, 0.0, 1e5, 0, 1e6,
+                              units='10^16')
+        self.NII = XSParameter(name, 'NII', 0.0, 0.0, 1e5, 0, 1e6,
                                units='10^16', frozen=True)
+        self.NIII = XSParameter(name, 'NIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.OI = XSParameter(name, 'OI', 67.6, 0.0, 1e5, 0, 1e6,
+                              units='10^16')
+        self.OII = XSParameter(name, 'OII', 0.0, 0.0, 1e5, 0, 1e6,
+                               units='10^16', frozen=True)
+        self.OIII = XSParameter(name, 'OIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.NeI = XSParameter(name, 'NeI', 12.0, 0.0, 1e5, 0, 1e6,
+                               units='10^16')
+        self.NeII = XSParameter(name, 'NeII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.NeIII = XSParameter(name, 'NeIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                 units='10^16', frozen=True)
+        self.MgI = XSParameter(name, 'MgI', 3.8, 0.0, 1e5, 0, 1e6,
+                               units='10^16')
+        self.MgII = XSParameter(name, 'MgII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.MgIII = XSParameter(name, 'MgIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                 units='10^16', frozen=True)
         # SiI and SI conflict, so add in underscores to differentiate.
         #
-        self.Si_I = Parameter(name, 'Si_I', 3.35, 0.0, 1e5, 0, 1e6,
-                              units='10^16')
-        self.Si_II = Parameter(name, 'Si_II', 0.0, 0.0, 1e5, 0, 1e6,
-                               units='10^16', frozen=True)
-        self.Si_III = Parameter(name, 'Si_III', 0.0, 0.0, 1e5, 0, 1e6,
+        self.Si_I = XSParameter(name, 'Si_I', 3.35, 0.0, 1e5, 0, 1e6,
+                                units='10^16')
+        self.Si_II = XSParameter(name, 'Si_II', 0.0, 0.0, 1e5, 0, 1e6,
+                                 units='10^16', frozen=True)
+        self.Si_III = XSParameter(name, 'Si_III', 0.0, 0.0, 1e5, 0, 1e6,
+                                  units='10^16', frozen=True)
+        self.S_I = XSParameter(name, 'S_I', 2.14, 0.0, 1e5, 0, 1e6,
+                               units='10^16')
+        self.S_II = XSParameter(name, 'S_II', 0.0, 0.0, 1e5, 0, 1e6,
                                 units='10^16', frozen=True)
-        self.S_I = Parameter(name, 'S_I', 2.14, 0.0, 1e5, 0, 1e6,
-                             units='10^16')
-        self.S_II = Parameter(name, 'S_II', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.S_III = Parameter(name, 'S_III', 0.0, 0.0, 1e5, 0, 1e6,
-                               units='10^16', frozen=True)
-        self.ArI = Parameter(name, 'ArI', 0.25, 0.0, 1e5, 0, 1e6,
-                             units='10^16')
-        self.ArII = Parameter(name, 'ArII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.ArIII = Parameter(name, 'ArIII', 0.0, 0.0, 1e5, 0, 1e6,
-                               units='10^16', frozen=True)
-        self.CaI = Parameter(name, 'CaI', 0.22, 0.0, 1e5, 0, 1e6,
-                             units='10^16')
-        self.CaII = Parameter(name, 'CaII', 0.0, 0.0, 1e5, 0, 1e6,
-                              units='10^16', frozen=True)
-        self.CaIII = Parameter(name, 'CaIII', 0.0, 0.0, 1e5, 0, 1e6,
-                               units='10^16', frozen=True)
-        self.Fe = Parameter(name, 'Fe', 3.16, 0.0, 1e5, 0, 1e6, units='10^16')
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
-                                  frozen=True)
+        self.S_III = XSParameter(name, 'S_III', 0.0, 0.0, 1e5, 0, 1e6,
+                                 units='10^16', frozen=True)
+        self.ArI = XSParameter(name, 'ArI', 0.25, 0.0, 1e5, 0, 1e6,
+                               units='10^16')
+        self.ArII = XSParameter(name, 'ArII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.ArIII = XSParameter(name, 'ArIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                 units='10^16', frozen=True)
+        self.CaI = XSParameter(name, 'CaI', 0.22, 0.0, 1e5, 0, 1e6,
+                               units='10^16')
+        self.CaII = XSParameter(name, 'CaII', 0.0, 0.0, 1e5, 0, 1e6,
+                                units='10^16', frozen=True)
+        self.CaIII = XSParameter(name, 'CaIII', 0.0, 0.0, 1e5, 0, 1e6,
+                                 units='10^16', frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 3.16, 0.0, 1e5, 0, 1e6, units='10^16')
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.H, self.HeII,
                                         self.CI,
@@ -10247,10 +10246,10 @@ class XSismdust(XSMultiplicativeModel):
     __function__ = "ismdust"
 
     def __init__(self, name='ismdust'):
-        self.msil = Parameter(name, 'msil', 1.0, 0.0, 1e4, 0, 1e5, units='10^-4')
-        self.mgra = Parameter(name, 'mgra', 1.0, 0.0, 1e4, 0, 1e5, units='10^-4')
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
-                                  frozen=True)
+        self.msil = XSParameter(name, 'msil', 1.0, 0.0, 1e4, 0, 1e5, units='10^-4')
+        self.mgra = XSParameter(name, 'mgra', 1.0, 0.0, 1e4, 0, 1e5, units='10^-4')
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.msil, self.mgra,
                                         self.redshift))
@@ -10285,7 +10284,7 @@ class XSlogconst(XSMultiplicativeModel):
     __function__ = "C_logconst"
 
     def __init__(self, name='logconst'):
-        self.logfact = Parameter(name, 'logfact', 0.0, -20.0, 20, -20, 20)
+        self.logfact = XSParameter(name, 'logfact', 0.0, -20.0, 20, -20, 20)
         XSMultiplicativeModel.__init__(self, name, (self.logfact, ))
 
 
@@ -10318,7 +10317,7 @@ class XSlog10con(XSMultiplicativeModel):
     __function__ = "C_log10con"
 
     def __init__(self, name='log10con'):
-        self.log10fac = Parameter(name, 'log10fac', 0.0, -20.0, 20, -20, 20)
+        self.log10fac = XSParameter(name, 'log10fac', 0.0, -20.0, 20, -20, 20)
         XSMultiplicativeModel.__init__(self, name, (self.log10fac, ))
 
 
@@ -10359,10 +10358,10 @@ class XSlyman(XSMultiplicativeModel):
     __function__ = "xslyman"
 
     def __init__(self, name='lyman'):
-        self.n = Parameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, units='10^22 atoms / cm^2', aliases=["nHeI"])
-        self.b = Parameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
-        self.z = Parameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
-        self.ZA = Parameter(name, 'ZA', 1.0, 1.0, 2.0, 1.0, 2.0)
+        self.n = XSParameter(name, 'n', 1.e-5, 0.0, 1.0e6, 0.0, 1.0e6, units='10^22 atoms / cm^2', aliases=["nHeI"])
+        self.b = XSParameter(name, 'b', 10.0, 1.0, 1.0e5, 1.0, 1.0e6, units='km/s')
+        self.z = XSParameter(name, 'z', 0.0, -1.0e-3, 1.0e5, -1.0e-3, 1.0e5, aliases=["redshift"])
+        self.ZA = XSParameter(name, 'ZA', 1.0, 1.0, 2.0, 1.0, 2.0)
 
         XSMultiplicativeModel.__init__(self, name, (self.n, self.b, self.z, self.ZA))
 
@@ -10391,9 +10390,9 @@ class XSnotch(XSMultiplicativeModel):
     __function__ = "xsntch"
 
     def __init__(self, name='notch'):
-        self.LineE = Parameter(name, 'LineE', 3.5, 0., 20., 0.0, 20, units='keV')
-        self.Width = Parameter(name, 'Width', 1., 0., 20., 0.0, 20, units='keV')
-        self.CvrFract = Parameter(name, 'CvrFract', 1., 0., 1., 0.0, 1, frozen=True)
+        self.LineE = XSParameter(name, 'LineE', 3.5, 0., 20., 0.0, 20, units='keV')
+        self.Width = XSParameter(name, 'Width', 1., 0., 20., 0.0, 20, units='keV')
+        self.CvrFract = XSParameter(name, 'CvrFract', 1., 0., 1., 0.0, 1, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Width, self.CvrFract))
 
     def guess(self, dep, *args, **kwargs):
@@ -10432,9 +10431,9 @@ class XSolivineabs(XSMultiplicativeModel):
     __function__ = "olivineabs"
 
     def __init__(self, name='olivineabs'):
-        self.moliv = Parameter(name, 'moliv', 1.0, 0.0, 1e4, 0, 1e5, units='10^-4')
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
-                                  frozen=True)
+        self.moliv = XSParameter(name, 'moliv', 1.0, 0.0, 1e4, 0, 1e5, units='10^-4')
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.moliv, self.redshift))
 
@@ -10465,8 +10464,8 @@ class XSpcfabs(XSMultiplicativeModel):
     __function__ = "xsabsp"
 
     def __init__(self, name='pcfabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.CvrFract = Parameter(name, 'CvrFract', 0.5, 0.05, 0.95, 0.0, 1)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.CvrFract = XSParameter(name, 'CvrFract', 0.5, 0.05, 0.95, 0.0, 1)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.CvrFract))
 
 
@@ -10500,7 +10499,7 @@ class XSphabs(XSMultiplicativeModel):
     __function__ = "xsphab"
 
     def __init__(self, name='phabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
         XSMultiplicativeModel.__init__(self, name, (self.nH,))
 
 
@@ -10526,8 +10525,8 @@ class XSplabs(XSMultiplicativeModel):
     __function__ = "xsplab"
 
     def __init__(self, name='plabs'):
-        self.index = Parameter(name, 'index', 2.0, 0.0, 5., 0.0, 5)
-        self.coef = Parameter(name, 'coef', 1.0, 0.0, 100., 0.0, 100)
+        self.index = XSParameter(name, 'index', 2.0, 0.0, 5., 0.0, 5)
+        self.coef = XSParameter(name, 'coef', 1.0, 0.0, 100., 0.0, 100)
         XSMultiplicativeModel.__init__(self, name, (self.index, self.coef))
 
 
@@ -10561,9 +10560,9 @@ class XSpwab(XSMultiplicativeModel):
     __function__ = "C_xspwab"
 
     def __init__(self, name='pwab'):
-        self.nHmin = Parameter(name, 'nHmin', 1., 1.e-7, 1.e5, 1e-7, 1e6, units='10^22 atoms / cm^2')
-        self.nHmax = Parameter(name, 'nHmax', 2., 1.e-7, 1.e5, 1e-7, 1e6, units='10^22 atoms / cm^2')
-        self.beta = Parameter(name, 'beta', 1.0, -10., 10, -10, 20, frozen=True)
+        self.nHmin = XSParameter(name, 'nHmin', 1., 1.e-7, 1.e5, 1e-7, 1e6, units='10^22 atoms / cm^2')
+        self.nHmax = XSParameter(name, 'nHmax', 2., 1.e-7, 1.e5, 1e-7, 1e6, units='10^22 atoms / cm^2')
+        self.beta = XSParameter(name, 'beta', 1.0, -10., 10, -10, 20, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nHmin, self.nHmax, self.beta))
 
 
@@ -10597,7 +10596,7 @@ class XSredden(XSMultiplicativeModel):
     __function__ = "xscred"
 
     def __init__(self, name='redden'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, 10, aliases=["EBV"])
+        self.E_BmV = XSParameter(name, 'E_BmV', 0.05, 0., 10., 0.0, 10, aliases=["EBV"])
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
@@ -10632,10 +10631,10 @@ class XSsmedge(XSMultiplicativeModel):
     __function__ = "xssmdg"
 
     def __init__(self, name='smedge'):
-        self.edgeE = Parameter(name, 'edgeE', 7.0, 0.1, 100., 0.1, 100, units='keV')
-        self.MaxTau = Parameter(name, 'MaxTau', 1., 0., 5., 0.0, 10)
-        self.index = Parameter(name, 'index', -2.67, -10., 10., -10, 10, frozen=True)
-        self.width = Parameter(name, 'width', 10., 0.01, 100., 0.01, 100)
+        self.edgeE = XSParameter(name, 'edgeE', 7.0, 0.1, 100., 0.1, 100, units='keV')
+        self.MaxTau = XSParameter(name, 'MaxTau', 1., 0., 5., 0.0, 10)
+        self.index = XSParameter(name, 'index', -2.67, -10., 10., -10, 10, frozen=True)
+        self.width = XSParameter(name, 'width', 10., 0.01, 100., 0.01, 100)
         XSMultiplicativeModel.__init__(self, name, (self.edgeE, self.MaxTau, self.index, self.width))
 
 
@@ -10661,8 +10660,8 @@ class XSspexpcut(XSMultiplicativeModel):
     __function__ = "C_superExpCutoff"
 
     def __init__(self, name='spexpcut'):
-        self.Ecut = Parameter(name, 'Ecut', 10.0, 0.0, 1e6, 0.0, 1e6, units='keV')
-        self.alpha = Parameter(name, 'alpha', 1.0, -5.0, 5.0, -5, 5)
+        self.Ecut = XSParameter(name, 'Ecut', 10.0, 0.0, 1e6, 0.0, 1e6, units='keV')
+        self.alpha = XSParameter(name, 'alpha', 1.0, -5.0, 5.0, -5, 5)
         XSMultiplicativeModel.__init__(self, name, (self.Ecut, self.alpha))
 
 
@@ -10696,12 +10695,12 @@ class XSspline(XSMultiplicativeModel):
     __function__ = "xsspln"
 
     def __init__(self, name='spline'):
-        self.Estart = Parameter(name, 'Estart', 0.1, 0., 100., 0.0, 100, units='keV')
-        self.Ystart = Parameter(name, 'Ystart', 1., -1.e6, 1.e6, -1e6, 1e6)
-        self.Yend = Parameter(name, 'Yend', 1., -1.e6, 1.e6, -1e6, 1e6)
-        self.YPstart = Parameter(name, 'YPstart', 0., -1.e6, 1.e6, -1e6, 1e6)
-        self.YPend = Parameter(name, 'YPend', 0., -1.e6, 1.e6, -1e6, 1e6)
-        self.Eend = Parameter(name, 'Eend', 15., 0., 100., 0.0, 100, units='keV')
+        self.Estart = XSParameter(name, 'Estart', 0.1, 0., 100., 0.0, 100, units='keV')
+        self.Ystart = XSParameter(name, 'Ystart', 1., -1.e6, 1.e6, -1e6, 1e6)
+        self.Yend = XSParameter(name, 'Yend', 1., -1.e6, 1.e6, -1e6, 1e6)
+        self.YPstart = XSParameter(name, 'YPstart', 0., -1.e6, 1.e6, -1e6, 1e6)
+        self.YPend = XSParameter(name, 'YPend', 0., -1.e6, 1.e6, -1e6, 1e6)
+        self.Eend = XSParameter(name, 'Eend', 15., 0., 100., 0.0, 100, units='keV')
         XSMultiplicativeModel.__init__(self, name, (self.Estart, self.Ystart, self.Yend, self.YPstart, self.YPend, self.Eend))
 
 
@@ -10725,7 +10724,7 @@ class XSSSS_ice(XSMultiplicativeModel):
     __function__ = "xssssi"
 
     def __init__(self, name='sss_ice'):
-        self.clumps = Parameter(name, 'clumps', 0.0, 0., 10., 0.0, 10)
+        self.clumps = XSParameter(name, 'clumps', 0.0, 0., 10., 0.0, 10)
         XSMultiplicativeModel.__init__(self, name, (self.clumps,))
 
 
@@ -10761,10 +10760,10 @@ class XSswind1(XSMultiplicativeModel):
     __function__ = _f77_or_c_12100("swind1")
 
     def __init__(self, name='swind1'):
-        self.column = Parameter(name, 'column', 6., 3., 50., 3.0, 50)
-        self.log_xi = Parameter(name, 'log_xi', 2.5, 2.1, 4.1, 2.1, 4.1, aliases=["logxi"])
-        self.sigma = Parameter(name, 'sigma', 0.1, 0., 0.5, 0.0, 0.5)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.column = XSParameter(name, 'column', 6., 3., 50., 3.0, 50)
+        self.log_xi = XSParameter(name, 'log_xi', 2.5, 2.1, 4.1, 2.1, 4.1, aliases=["logxi"])
+        self.sigma = XSParameter(name, 'sigma', 0.1, 0., 0.5, 0.0, 0.5)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.column, self.log_xi, self.sigma, self.redshift))
 
@@ -10798,7 +10797,7 @@ class XSTBabs(XSMultiplicativeModel):
     __function__ = "C_tbabs"
 
     def __init__(self, name='tbabs'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.nH = XSParameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
         XSMultiplicativeModel.__init__(self, name, (self.nH,))
 
 
@@ -10840,11 +10839,11 @@ class XSTBfeo(XSMultiplicativeModel):
     __function__ = "C_tbfeo"
 
     def __init__(self, name='tbfeo'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1.e5, 0.0, 1.0e6, units='10^22')
-        self.O = Parameter(name, 'O', 1., 0.0, 5.0, -1.0e38, 1.0e38)
-        self.Fe = Parameter(name, 'Fe', 1., 0.0, 5.0, -1.0e38, 1.0e38)
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
-                                  frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 1.e5, 0.0, 1.0e6, units='10^22')
+        self.O = XSParameter(name, 'O', 1., 0.0, 5.0, -1.0e38, 1.0e38)
+        self.Fe = XSParameter(name, 'Fe', 1., 0.0, 5.0, -1.0e38, 1.0e38)
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.nH, self.O, self.Fe,
                                         self.redshift))
@@ -10884,9 +10883,9 @@ class XSTBgas(XSMultiplicativeModel):
     __function__ = "C_tbgas"
 
     def __init__(self, name='tbgas'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1.e5, 0.0, 1.0e6, units='10^22')
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
-                                  frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 1.e5, 0.0, 1.0e6, units='10^22')
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.nH, self.redshift))
 
@@ -10931,12 +10930,12 @@ class XSTBgrain(XSMultiplicativeModel):
     __function__ = "C_tbgrain"
 
     def __init__(self, name='tbgrain'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.h2 = Parameter(name, 'h2', 0.2, 0., 1., 0.0, 1, frozen=True)
-        self.rho = Parameter(name, 'rho', 1., 0., 5., 0.0, 5, units='g/cm^3', frozen=True)
-        self.amin = Parameter(name, 'amin', 0.025, 0., 0.25, 0.0, 0.25, units='mum', frozen=True)
-        self.amax = Parameter(name, 'amax', 0.25, 0., 1., 0.0, 1, units='mum', frozen=True)
-        self.PL = Parameter(name, 'PL', 3.5, 0., 5., 0.0, 5, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.h2 = XSParameter(name, 'h2', 0.2, 0., 1., 0.0, 1, frozen=True)
+        self.rho = XSParameter(name, 'rho', 1., 0., 5., 0.0, 5, units='g/cm^3', frozen=True)
+        self.amin = XSParameter(name, 'amin', 0.025, 0., 0.25, 0.0, 0.25, units='mum', frozen=True)
+        self.amax = XSParameter(name, 'amax', 0.25, 0., 1., 0.0, 1, units='mum', frozen=True)
+        self.PL = XSParameter(name, 'PL', 3.5, 0., 5., 0.0, 5, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.h2, self.rho, self.amin, self.amax, self.PL))
 
 
@@ -10987,48 +10986,48 @@ class XSTBvarabs(XSMultiplicativeModel):
     __function__ = "C_tbvabs"
 
     def __init__(self, name='tbvarabs'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.He = Parameter(name, 'He', 1., 0., 1., 0.0, 1, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1., 0.0, 1, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1., 0.0, 1, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1., 0.0, 1, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1., 0.0, 1, frozen=True)
-        self.H2 = Parameter(name, 'H2', 0.2, 0., 1., 0.0, 1, frozen=True)
-        self.rho = Parameter(name, 'rho', 1., 0., 5., 0.0, 5, units='g/cm^3', frozen=True)
-        self.amin = Parameter(name, 'amin', 0.025, 0., 0.25, 0.0, 0.25, units='mum', frozen=True)
-        self.amax = Parameter(name, 'amax', 0.25, 0., 1., 0.0, 1, units='mum', frozen=True)
-        self.PL = Parameter(name, 'PL', 3.5, 0., 5., 0.0, 5, frozen=True)
-        self.H_dep = Parameter(name, 'H_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.He_dep = Parameter(name, 'He_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.C_dep = Parameter(name, 'C_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.N_dep = Parameter(name, 'N_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.O_dep = Parameter(name, 'O_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ne_dep = Parameter(name, 'Ne_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Na_dep = Parameter(name, 'Na_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Mg_dep = Parameter(name, 'Mg_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Al_dep = Parameter(name, 'Al_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Si_dep = Parameter(name, 'Si_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.S_dep = Parameter(name, 'S_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Cl_dep = Parameter(name, 'Cl_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ar_dep = Parameter(name, 'Ar_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ca_dep = Parameter(name, 'Ca_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Cr_dep = Parameter(name, 'Cr_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Fe_dep = Parameter(name, 'Fe_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Co_dep = Parameter(name, 'Co_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.Ni_dep = Parameter(name, 'Ni_dep', 1., 0., 1., 0.0, 1, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.He = XSParameter(name, 'He', 1., 0., 1., 0.0, 1, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1., 0.0, 1, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1., 0.0, 1, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1., 0.0, 1, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1., 0.0, 1, frozen=True)
+        self.H2 = XSParameter(name, 'H2', 0.2, 0., 1., 0.0, 1, frozen=True)
+        self.rho = XSParameter(name, 'rho', 1., 0., 5., 0.0, 5, units='g/cm^3', frozen=True)
+        self.amin = XSParameter(name, 'amin', 0.025, 0., 0.25, 0.0, 0.25, units='mum', frozen=True)
+        self.amax = XSParameter(name, 'amax', 0.25, 0., 1., 0.0, 1, units='mum', frozen=True)
+        self.PL = XSParameter(name, 'PL', 3.5, 0., 5., 0.0, 5, frozen=True)
+        self.H_dep = XSParameter(name, 'H_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.He_dep = XSParameter(name, 'He_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.C_dep = XSParameter(name, 'C_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.N_dep = XSParameter(name, 'N_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.O_dep = XSParameter(name, 'O_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ne_dep = XSParameter(name, 'Ne_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Na_dep = XSParameter(name, 'Na_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Mg_dep = XSParameter(name, 'Mg_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Al_dep = XSParameter(name, 'Al_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Si_dep = XSParameter(name, 'Si_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.S_dep = XSParameter(name, 'S_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Cl_dep = XSParameter(name, 'Cl_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ar_dep = XSParameter(name, 'Ar_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ca_dep = XSParameter(name, 'Ca_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Cr_dep = XSParameter(name, 'Cr_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Fe_dep = XSParameter(name, 'Fe_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Co_dep = XSParameter(name, 'Co_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.Ni_dep = XSParameter(name, 'Ni_dep', 1., 0., 1., 0.0, 1, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni, self.H2, self.rho, self.amin, self.amax, self.PL, self.H_dep, self.He_dep, self.C_dep, self.N_dep, self.O_dep, self.Ne_dep, self.Na_dep, self.Mg_dep, self.Al_dep, self.Si_dep, self.S_dep, self.Cl_dep, self.Ar_dep, self.Ca_dep, self.Cr_dep, self.Fe_dep, self.Co_dep, self.Ni_dep, self.redshift))
 
 
@@ -11068,10 +11067,10 @@ class XSTBpcf(XSMultiplicativeModel):
     __function__ = "C_tbpcf"
 
     def __init__(self, name='tbpcf'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1.e5, 0.0, 1.0e6, units='10^22')
-        self.pcf = Parameter(name, 'pcf', 0.5, 0, 1.0, 0, 1.0)
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
-                                  frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 1.e5, 0.0, 1.0e6, units='10^22')
+        self.pcf = XSParameter(name, 'pcf', 0.5, 0, 1.0, 0, 1.0)
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.nH, self.pcf, self.redshift))
 
@@ -11130,70 +11129,70 @@ class XSTBrel(XSMultiplicativeModel):
     __function__ = "C_tbrel"
 
     def __init__(self, name='tbrel'):
-        self.nH = Parameter(name, 'nH', 0.0, -1e5, 1e5, -1e6, 1.0e6, units='10^22 atoms / cm^2')
-        self.He = Parameter(name, 'He', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 5., 0.0, 1e38, frozen=True)
-        self.H2 = Parameter(name, 'H2', 0.2, 0., 1., 0.0, 1.0, frozen=True)
-        self.rho = Parameter(name, 'rho', 1., 0., 5., 0.0, 5.0, units='g/cm^3',
-                             frozen=True)
-        self.amin = Parameter(name, 'amin', 0.025, 0., 0.25, 0.0, 0.25,
-                              units='mum', frozen=True)
-        self.amax = Parameter(name, 'amax', 0.25, 0., 1., 0.0, 1.0,
-                              units='mum', frozen=True)
-        self.PL = Parameter(name, 'PL', 3.5, 0., 5., 0.0, 5.0, frozen=True)
-        self.H_dep = Parameter(name, 'H_dep', 1., 0., 1., 0.0, 1.0,
+        self.nH = XSParameter(name, 'nH', 0.0, -1e5, 1e5, -1e6, 1.0e6, units='10^22 atoms / cm^2')
+        self.He = XSParameter(name, 'He', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 5., 0.0, 1e38, frozen=True)
+        self.H2 = XSParameter(name, 'H2', 0.2, 0., 1., 0.0, 1.0, frozen=True)
+        self.rho = XSParameter(name, 'rho', 1., 0., 5., 0.0, 5.0, units='g/cm^3',
                                frozen=True)
-        self.He_dep = Parameter(name, 'He_dep', 1., 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.C_dep = Parameter(name, 'C_dep', 0.5, 0., 1., 0.0, 1.0,
-                               frozen=True)
-        self.N_dep = Parameter(name, 'N_dep', 1., 0., 1., 0.0, 1.0,
-                               frozen=True)
-        self.O_dep = Parameter(name, 'O_dep', 0.6, 0., 1., 0.0, 1.0,
-                               frozen=True)
-        self.Ne_dep = Parameter(name, 'Ne_dep', 1., 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Na_dep = Parameter(name, 'Na_dep', 0.25, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Mg_dep = Parameter(name, 'Mg_dep', 0.2, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Al_dep = Parameter(name, 'Al_dep', 0.02, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Si_dep = Parameter(name, 'Si_dep', 0.1, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.S_dep = Parameter(name, 'S_dep', 0.6, 0., 1., 0.0, 1.0,
-                               frozen=True)
-        self.Cl_dep = Parameter(name, 'Cl_dep', 0.5, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Ar_dep = Parameter(name, 'Ar_dep', 1., 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Ca_dep = Parameter(name, 'Ca_dep', 0.003, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Cr_dep = Parameter(name, 'Cr_dep', 0.03, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Fe_dep = Parameter(name, 'Fe_dep', 0.3, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Co_dep = Parameter(name, 'Co_dep', 0.05, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.Ni_dep = Parameter(name, 'Ni_dep', 0.04, 0., 1., 0.0, 1.0,
-                                frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+        self.amin = XSParameter(name, 'amin', 0.025, 0., 0.25, 0.0, 0.25,
+                                units='mum', frozen=True)
+        self.amax = XSParameter(name, 'amax', 0.25, 0., 1., 0.0, 1.0,
+                                units='mum', frozen=True)
+        self.PL = XSParameter(name, 'PL', 3.5, 0., 5., 0.0, 5.0, frozen=True)
+        self.H_dep = XSParameter(name, 'H_dep', 1., 0., 1., 0.0, 1.0,
+                                 frozen=True)
+        self.He_dep = XSParameter(name, 'He_dep', 1., 0., 1., 0.0, 1.0,
                                   frozen=True)
+        self.C_dep = XSParameter(name, 'C_dep', 0.5, 0., 1., 0.0, 1.0,
+                                 frozen=True)
+        self.N_dep = XSParameter(name, 'N_dep', 1., 0., 1., 0.0, 1.0,
+                                 frozen=True)
+        self.O_dep = XSParameter(name, 'O_dep', 0.6, 0., 1., 0.0, 1.0,
+                                 frozen=True)
+        self.Ne_dep = XSParameter(name, 'Ne_dep', 1., 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Na_dep = XSParameter(name, 'Na_dep', 0.25, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Mg_dep = XSParameter(name, 'Mg_dep', 0.2, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Al_dep = XSParameter(name, 'Al_dep', 0.02, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Si_dep = XSParameter(name, 'Si_dep', 0.1, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.S_dep = XSParameter(name, 'S_dep', 0.6, 0., 1., 0.0, 1.0,
+                                 frozen=True)
+        self.Cl_dep = XSParameter(name, 'Cl_dep', 0.5, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Ar_dep = XSParameter(name, 'Ar_dep', 1., 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Ca_dep = XSParameter(name, 'Ca_dep', 0.003, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Cr_dep = XSParameter(name, 'Cr_dep', 0.03, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Fe_dep = XSParameter(name, 'Fe_dep', 0.3, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Co_dep = XSParameter(name, 'Co_dep', 0.05, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.Ni_dep = XSParameter(name, 'Ni_dep', 0.04, 0., 1., 0.0, 1.0,
+                                  frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., 0.0, 10., -1.0, 10.0,
+                                    frozen=True)
         pars = (self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na,
                 self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca,
                 self.Cr, self.Fe, self.Co, self.Ni, self.H2, self.rho,
@@ -11231,7 +11230,7 @@ class XSuvred(XSMultiplicativeModel):
     __function__ = "xsred"
 
     def __init__(self, name='uvred'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, 10, aliases=["EBV"])
+        self.E_BmV = XSParameter(name, 'E_BmV', 0.05, 0., 10., 0.0, 10, aliases=["EBV"])
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV,))
 
@@ -11266,24 +11265,24 @@ class XSvarabs(XSMultiplicativeModel):
     __function__ = "xsabsv"
 
     def __init__(self, name='varabs'):
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 10000, units='sH22', frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 10000, units='sHe22', frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 10000, units='sC22', frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 10000, units='sN22', frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 10000, units='sO22', frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 10000, units='sNe22', frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 10000, units='sNa22', frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 10000, units='sMg22', frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 10000, units='sAl22', frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 10000, units='sSi22', frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 10000, units='sS22', frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 10000, units='sCl22', frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 10000, units='sAr22', frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 10000, units='sCa22', frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 10000, units='sCr22', frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 10000, units='sFe22', frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 10000, units='sCo22', frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 10000, units='sNi22', frozen=True)
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 10000, units='sH22', frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 10000, units='sHe22', frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 10000, units='sC22', frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 10000, units='sN22', frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 10000, units='sO22', frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 10000, units='sNe22', frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 10000, units='sNa22', frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 10000, units='sMg22', frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 10000, units='sAl22', frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 10000, units='sSi22', frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 10000, units='sS22', frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 10000, units='sCl22', frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 10000, units='sAr22', frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 10000, units='sCa22', frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 10000, units='sCr22', frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 10000, units='sFe22', frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 10000, units='sCo22', frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 10000, units='sNi22', frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.H, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni))
 
 
@@ -11319,24 +11318,24 @@ class XSvphabs(XSMultiplicativeModel):
     __function__ = "xsvphb"
 
     def __init__(self, name='vphabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni))
 
 
@@ -11364,7 +11363,7 @@ class XSwabs(XSMultiplicativeModel):
     __function__ = "xsabsw"
 
     def __init__(self, name='wabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
         XSMultiplicativeModel.__init__(self, name, (self.nH,))
 
 
@@ -11394,8 +11393,8 @@ class XSwndabs(XSMultiplicativeModel):
     __function__ = "xswnab"
 
     def __init__(self, name='wndabs'):
-        self.nH = Parameter(name, 'nH', 1., 0., 10., 0.0, 20, units='10^22 atoms / cm^2')
-        self.WindowE = Parameter(name, 'WindowE', 1., .05, 20., 0.03, 20, units='keV')
+        self.nH = XSParameter(name, 'nH', 1., 0., 10., 0.0, 20, units='10^22 atoms / cm^2')
+        self.WindowE = XSParameter(name, 'WindowE', 1., .05, 20., 0.03, 20, units='keV')
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.WindowE))
 
 
@@ -11449,19 +11448,19 @@ class XSxion(XSMultiplicativeModel):
     __function__ = "xsxirf"
 
     def __init__(self, name='xion'):
-        self.height = Parameter(name, 'height', 5., 0.0, 1.e2, 0.0, 1e2, units='r_s')
-        self.lxovrld = Parameter(name, 'lxovrld', 0.3, 0.02, 100, 0.02, 100, aliases=["lxld"])
-        self.rate = Parameter(name, 'rate', 0.05, 1.e-3, 1., 1e-3, 1)
-        self.cosAng = Parameter(name, 'cosAng', 0.9, 0., 1., 0.0, 1)
-        self.inner = Parameter(name, 'inner', 3., 2., 1.e3, 2.0, 1000, units='r_s')
-        self.outer = Parameter(name, 'outer', 100., 2.1, 1.e5, 2.1, 1e5, units='r_s')
-        self.index = Parameter(name, 'index', 2.0, 1.6, 2.2, 1.6, 2.2)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
-        self.Feabun = Parameter(name, 'Feabun', 1., 0., 5., 0.0, 5, frozen=True)
-        self.E_cut = Parameter(name, 'E_cut', 150., 20., 300., 20.0, 300, units='keV')
-        self.Ref_type = Parameter(name, 'Ref_type', 1., 1., 3., 1.0, 3, frozen=True)
-        self.Rel_smear = Parameter(name, 'Rel_smear', 4., 1., 4., 1.0, 4, frozen=True)
-        self.Geometry = Parameter(name, 'Geometry', 1., 1., 4., 1.0, 4, frozen=True)
+        self.height = XSParameter(name, 'height', 5., 0.0, 1.e2, 0.0, 1e2, units='r_s')
+        self.lxovrld = XSParameter(name, 'lxovrld', 0.3, 0.02, 100, 0.02, 100, aliases=["lxld"])
+        self.rate = XSParameter(name, 'rate', 0.05, 1.e-3, 1., 1e-3, 1)
+        self.cosAng = XSParameter(name, 'cosAng', 0.9, 0., 1., 0.0, 1)
+        self.inner = XSParameter(name, 'inner', 3., 2., 1.e3, 2.0, 1000, units='r_s')
+        self.outer = XSParameter(name, 'outer', 100., 2.1, 1.e5, 2.1, 1e5, units='r_s')
+        self.index = XSParameter(name, 'index', 2.0, 1.6, 2.2, 1.6, 2.2)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Feabun = XSParameter(name, 'Feabun', 1., 0., 5., 0.0, 5, frozen=True)
+        self.E_cut = XSParameter(name, 'E_cut', 150., 20., 300., 20.0, 300, units='keV')
+        self.Ref_type = XSParameter(name, 'Ref_type', 1., 1., 3., 1.0, 3, frozen=True)
+        self.Rel_smear = XSParameter(name, 'Rel_smear', 4., 1., 4., 1.0, 4, frozen=True)
+        self.Geometry = XSParameter(name, 'Geometry', 1., 1., 4., 1.0, 4, frozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.height, self.lxovrld, self.rate, self.cosAng, self.inner, self.outer, self.index, self.redshift, self.Feabun, self.E_cut, self.Ref_type, self.Rel_smear, self.Geometry))
 
@@ -11499,12 +11498,12 @@ class XSxscat(XSMultiplicativeModel):
     __function__ = "C_xscatmodel"
 
     def __init__(self, name='xscat'):
-        self.NH = Parameter(name, 'NH', 1., 0., 1000.0, 0.0, 1000.0, units='10^22')
-        self.Xpos = Parameter(name, 'Xpos', 0.5, 0, 0.99, 0, 0.999)
-        self.Rext = Parameter(name, 'Rext', 10.0, 0, 235.0, 0, 240.0, 'arcsec',
-                              frozen=True)
-        self.DustModel = Parameter(name, 'DustModel', 1,
-                                   alwaysfrozen=True)
+        self.NH = XSParameter(name, 'NH', 1., 0., 1000.0, 0.0, 1000.0, units='10^22')
+        self.Xpos = XSParameter(name, 'Xpos', 0.5, 0, 0.99, 0, 0.999)
+        self.Rext = XSParameter(name, 'Rext', 10.0, 0, 235.0, 0, 240.0, 'arcsec',
+                                frozen=True)
+        self.DustModel = XSParameter(name, 'DustModel', 1,
+                                     alwaysfrozen=True)
         XSMultiplicativeModel.__init__(self, name,
                                        (self.NH, self.Xpos, self.Rext,
                                         self.DustModel))
@@ -11542,10 +11541,10 @@ class XSzbabs(XSMultiplicativeModel):
     __function__ = "xszbabs"
 
     def __init__(self, name='zbabs'):
-        self.nH = Parameter(name, 'nH', 1.e-4, 0.0, 1.0e5, 0.0, 1.0e6, units='10^22 atoms / cm^2')
-        self.nHeI = Parameter(name, 'nHeI', 1.e-5, 0.0, 1.0e5, 0.0, 1.0e6, units='10^22 atoms / cm^2')
-        self.nHeII = Parameter(name, 'nHeII', 1.e-6, 0.0, 1.0e5, 0.0, 1.0e6, units='10^22 atoms / cm^2')
-        self.z = Parameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6, aliases=["redshift"])
+        self.nH = XSParameter(name, 'nH', 1.e-4, 0.0, 1.0e5, 0.0, 1.0e6, units='10^22 atoms / cm^2')
+        self.nHeI = XSParameter(name, 'nHeI', 1.e-5, 0.0, 1.0e5, 0.0, 1.0e6, units='10^22 atoms / cm^2')
+        self.nHeII = XSParameter(name, 'nHeII', 1.e-6, 0.0, 1.0e5, 0.0, 1.0e6, units='10^22 atoms / cm^2')
+        self.z = XSParameter(name, 'z', 0.0, 0.0, 1.0e5, 0.0, 1.0e6, aliases=["redshift"])
 
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.nHeI, self.nHeII, self.z))
 
@@ -11583,10 +11582,10 @@ class XSzdust(XSMultiplicativeModel):
     __function__ = "mszdst"
 
     def __init__(self, name='zdust'):
-        self.method = Parameter(name, 'method', 1, 1, 3, 1, 3, alwaysfrozen=True)
-        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, 100, aliases=["EBV"])
-        self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, 20, frozen=True)
+        self.method = XSParameter(name, 'method', 1, 1, 3, 1, 3, alwaysfrozen=True)
+        self.E_BmV = XSParameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, 100, aliases=["EBV"])
+        self.Rv = XSParameter(name, 'Rv', 3.1, 0.0, 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0.0, 0.0, 20., 0.0, 20, frozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.method, self.E_BmV, self.Rv, self.redshift))
 
@@ -11619,9 +11618,9 @@ class XSzedge(XSMultiplicativeModel):
     __function__ = "xszedg"
 
     def __init__(self, name='zedge'):
-        self.edgeE = Parameter(name, 'edgeE', 7.0, 0., 100., 0.0, 100, units='keV')
-        self.MaxTau = Parameter(name, 'MaxTau', 1., 0., 5., 0.0, 10)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.edgeE = XSParameter(name, 'edgeE', 7.0, 0., 100., 0.0, 100, units='keV')
+        self.MaxTau = XSParameter(name, 'MaxTau', 1., 0., 5., 0.0, 10)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.edgeE, self.MaxTau, self.redshift))
 
 
@@ -11653,9 +11652,9 @@ class XSzhighect(XSMultiplicativeModel):
     __function__ = "xszhcu"
 
     def __init__(self, name='zhighect'):
-        self.cutoffE = Parameter(name, 'cutoffE', 10., 1.e-2, 100., 1e-4, 200, units='keV')
-        self.foldE = Parameter(name, 'foldE', 15., 1.e-2, 100., 1e-4, 200, units='keV')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.cutoffE = XSParameter(name, 'cutoffE', 10., 1.e-2, 100., 1e-4, 200, units='keV')
+        self.foldE = XSParameter(name, 'foldE', 15., 1.e-2, 100., 1e-4, 200, units='keV')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.cutoffE, self.foldE, self.redshift))
 
     def guess(self, dep, *args, **kwargs):
@@ -11690,9 +11689,9 @@ class XSzigm(XSMultiplicativeModel):
     __function__ = "zigm"
 
     def __init__(self, name='zigm'):
-        self.redshift = Parameter(name, 'redshift', 0.0, alwaysfrozen=True)
-        self.model = Parameter(name, 'model', 0, alwaysfrozen=True)
-        self.lyman_limit = Parameter(name, 'lyman_limit', 1, alwaysfrozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0.0, alwaysfrozen=True)
+        self.model = XSParameter(name, 'model', 0, alwaysfrozen=True)
+        self.lyman_limit = XSParameter(name, 'lyman_limit', 1, alwaysfrozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.redshift, self.model, self.lyman_limit))
 
@@ -11725,9 +11724,9 @@ class XSzpcfabs(XSMultiplicativeModel):
     __function__ = "xszabp"
 
     def __init__(self, name='zpcfabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.CvrFract = Parameter(name, 'CvrFract', 0.5, 0.05, 0.95, 0.0, 1)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.CvrFract = XSParameter(name, 'CvrFract', 0.5, 0.05, 0.95, 0.0, 1)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.CvrFract, self.redshift))
 
 
@@ -11763,8 +11762,8 @@ class XSzphabs(XSMultiplicativeModel):
     __function__ = "xszphb"
 
     def __init__(self, name='zphabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.redshift))
 
 
@@ -11800,10 +11799,10 @@ class XSzxipcf(XSMultiplicativeModel):
     __function__ = _f77_or_c_12100("zxipcf")
 
     def __init__(self, name='zxipcf'):
-        self.Nh = Parameter(name, 'Nh', 10, 0.05, 500, 0.05, 500, units='10^22 atoms / cm^2')
-        self.log_xi = Parameter(name, 'log_xi', 3, -3, 6, -3, 6, aliases=["logxi"])
-        self.CvrFract = Parameter(name, 'CvrFract', 0.5, 0., 1., 0.0, 1)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.Nh = XSParameter(name, 'Nh', 10, 0.05, 500, 0.05, 500, units='10^22 atoms / cm^2')
+        self.log_xi = XSParameter(name, 'log_xi', 3, -3, 6, -3, 6, aliases=["logxi"])
+        self.CvrFract = XSParameter(name, 'CvrFract', 0.5, 0., 1., 0.0, 1)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.Nh, self.log_xi, self.CvrFract, self.redshift))
 
@@ -11840,8 +11839,8 @@ class XSzredden(XSMultiplicativeModel):
     __function__ = "xszcrd"
 
     def __init__(self, name='zredden'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.05, 0., 10., 0.0, 10, aliases=["EBV"])
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.E_BmV = XSParameter(name, 'E_BmV', 0.05, 0., 10., 0.0, 10, aliases=["EBV"])
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.redshift))
 
@@ -11878,10 +11877,10 @@ class XSzsmdust(XSMultiplicativeModel):
     __function__ = "msldst"
 
     def __init__(self, name='zsmdust'):
-        self.E_BmV = Parameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, 100, aliases=["EBV"])
-        self.ExtIndex = Parameter(name, 'ExtIndex', 1.0, -10.0, 10., -10, 10)
-        self.Rv = Parameter(name, 'Rv', 3.1, 0.0, 10., 0.0, 10, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0.0, 0.0, 20., 0.0, 20, units='z', frozen=True)
+        self.E_BmV = XSParameter(name, 'E_BmV', 0.1, 0.0, 100., 0.0, 100, aliases=["EBV"])
+        self.ExtIndex = XSParameter(name, 'ExtIndex', 1.0, -10.0, 10., -10, 10)
+        self.Rv = XSParameter(name, 'Rv', 3.1, 0.0, 10., 0.0, 10, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0.0, 0.0, 20., 0.0, 20, units='z', frozen=True)
 
         XSMultiplicativeModel.__init__(self, name, (self.E_BmV, self.ExtIndex, self.Rv, self.redshift))
 
@@ -11917,8 +11916,8 @@ class XSzTBabs(XSMultiplicativeModel):
     __function__ = "C_ztbabs"
 
     def __init__(self, name='ztbabs'):
-        self.nH = Parameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 1E5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.redshift))
 
 
@@ -11954,25 +11953,25 @@ class XSzvarabs(XSMultiplicativeModel):
     __function__ = "xszvab"
 
     def __init__(self, name='zvarabs'):
-        self.H = Parameter(name, 'H', 1., 0., 1000., 0.0, 10000, units='sH22', frozen=True)
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 10000, units='sHe22', frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 10000, units='sC22', frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 10000, units='sN22', frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 10000, units='sO22', frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 10000, units='sNe22', frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 10000, units='sNa22', frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 10000, units='sMg22', frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 10000, units='sAl22', frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 10000, units='sSi22', frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 10000, units='sS22', frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 10000, units='sCl22', frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 10000, units='sAr22', frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 10000, units='sCa22', frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 10000, units='sCr22', frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 10000, units='sFe22', frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 10000, units='sCo22', frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 10000, units='sNi22', frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.H = XSParameter(name, 'H', 1., 0., 1000., 0.0, 10000, units='sH22', frozen=True)
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 10000, units='sHe22', frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 10000, units='sC22', frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 10000, units='sN22', frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 10000, units='sO22', frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 10000, units='sNe22', frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 10000, units='sNa22', frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 10000, units='sMg22', frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 10000, units='sAl22', frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 10000, units='sSi22', frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 10000, units='sS22', frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 10000, units='sCl22', frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 10000, units='sAr22', frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 10000, units='sCa22', frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 10000, units='sCr22', frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 10000, units='sFe22', frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 10000, units='sCo22', frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 10000, units='sNi22', frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.H, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni, self.redshift))
 
 
@@ -12004,11 +12003,11 @@ class XSzvfeabs(XSMultiplicativeModel):
     __function__ = "xszvfe"
 
     def __init__(self, name='zvfeabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.metals = Parameter(name, 'metals', 1., 0.0, 100., 0.0, 100)
-        self.FEabun = Parameter(name, 'FEabun', 1., 0.0, 100., 0.0, 100)
-        self.FEKedge = Parameter(name, 'FEKedge', 7.11, 7.0, 9.5, 7.0, 9.5, units='keV')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.metals = XSParameter(name, 'metals', 1., 0.0, 100., 0.0, 100)
+        self.FEabun = XSParameter(name, 'FEabun', 1., 0.0, 100., 0.0, 100)
+        self.FEKedge = XSParameter(name, 'FEKedge', 7.11, 7.0, 9.5, 7.0, 9.5, units='keV')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.metals, self.FEabun, self.FEKedge, self.redshift))
 
 
@@ -12046,25 +12045,25 @@ class XSzvphabs(XSMultiplicativeModel):
     __function__ = "xszvph"
 
     def __init__(self, name='zvphabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.He = Parameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.C = Parameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.N = Parameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.O = Parameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ne = Parameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Na = Parameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Mg = Parameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Al = Parameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Si = Parameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.S = Parameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cl = Parameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ar = Parameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ca = Parameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Cr = Parameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Fe = Parameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Co = Parameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.Ni = Parameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.He = XSParameter(name, 'He', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.C = XSParameter(name, 'C', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.N = XSParameter(name, 'N', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.O = XSParameter(name, 'O', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.S = XSParameter(name, 'S', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni, self.redshift))
 
 
@@ -12094,8 +12093,8 @@ class XSzwabs(XSMultiplicativeModel):
     __function__ = "xszabs"
 
     def __init__(self, name='zwabs'):
-        self.nH = Parameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0.0, 1.e5, 0.0, 1e6, units='10^22 atoms / cm^2')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.redshift))
 
 
@@ -12127,9 +12126,9 @@ class XSzwndabs(XSMultiplicativeModel):
     __function__ = "xszwnb"
 
     def __init__(self, name='zwndabs'):
-        self.nH = Parameter(name, 'nH', 1., 0., 10., 0.0, 20, units='10^22 atoms / cm^2')
-        self.WindowE = Parameter(name, 'WindowE', 1., .05, 20., 0.03, 20, units='keV')
-        self.redshift = Parameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
+        self.nH = XSParameter(name, 'nH', 1., 0., 10., 0.0, 20, units='10^22 atoms / cm^2')
+        self.WindowE = XSParameter(name, 'WindowE', 1., .05, 20., 0.03, 20, units='keV')
+        self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.WindowE, self.redshift))
 
 
@@ -12189,15 +12188,15 @@ class XScflux(XSConvolutionKernel):
     _calc = _xspec.C_cflux
 
     def __init__(self, name='xscflux'):
-        self.Emin = Parameter(name, 'Emin', 0.5, min=0.0, max=1e6,
-                              hard_min=0.0, hard_max=1e6, frozen=True,
-                              units='keV')
-        self.Emax = Parameter(name, 'Emax', 10.0, min=0.0, max=1e6,
-                              hard_min=0.0, hard_max=1e6, frozen=True,
-                              units='keV')
-        self.lg10Flux = Parameter(name, 'lg10Flux', -12.0, min=-100.0,
-                                  max=100.0, hard_min=-100.0, hard_max=100.0,
-                                  frozen=False, units='cgs')
+        self.Emin = XSParameter(name, 'Emin', 0.5, min=0.0, max=1e6,
+                                hard_min=0.0, hard_max=1e6, frozen=True,
+                                units='keV')
+        self.Emax = XSParameter(name, 'Emax', 10.0, min=0.0, max=1e6,
+                                hard_min=0.0, hard_max=1e6, frozen=True,
+                                units='keV')
+        self.lg10Flux = XSParameter(name, 'lg10Flux', -12.0, min=-100.0,
+                                    max=100.0, hard_min=-100.0, hard_max=100.0,
+                                    frozen=False, units='cgs')
         XSConvolutionKernel.__init__(self, name, (self.Emin,
                                                   self.Emax,
                                                   self.lg10Flux
@@ -12269,17 +12268,17 @@ class XSclumin(XSConvolutionKernel):
     __function__ = "C_clumin"
 
     def __init__(self, name='xsclumin'):
-        self.Emin = Parameter(name, 'Emin', 0.5, min=0.0, max=1e6,
-                              hard_min=0.0, hard_max=1e6, frozen=True,
-                              units='keV')
-        self.Emax = Parameter(name, 'Emax', 10.0, min=0.0, max=1e6,
-                              hard_min=0.0, hard_max=1e6, frozen=True,
-                              units='keV')
-        self.Redshift = Parameter(name, 'Redshift', 0, min=-0.999, max=10,
-                                  hard_min=-0.999, hard_max=10, frozen=True)
-        self.lg10Lum = Parameter(name, 'lg10Lum', 40.0, min=-100.0,
-                                 max=100.0, hard_min=-100.0, hard_max=100.0,
-                                 frozen=False, units='cgs')
+        self.Emin = XSParameter(name, 'Emin', 0.5, min=0.0, max=1e6,
+                                hard_min=0.0, hard_max=1e6, frozen=True,
+                                units='keV')
+        self.Emax = XSParameter(name, 'Emax', 10.0, min=0.0, max=1e6,
+                                hard_min=0.0, hard_max=1e6, frozen=True,
+                                units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0, min=-0.999, max=10,
+                                    hard_min=-0.999, hard_max=10, frozen=True)
+        self.lg10Lum = XSParameter(name, 'lg10Lum', 40.0, min=-100.0,
+                                   max=100.0, hard_min=-100.0, hard_max=100.0,
+                                   frozen=False, units='cgs')
         XSConvolutionKernel.__init__(self, name, (self.Emin,
                                                   self.Emax,
                                                   self.Redshift,
@@ -12326,15 +12325,15 @@ class XScpflux(XSConvolutionKernel):
     _calc = _xspec.C_cpflux
 
     def __init__(self, name='xscpflux'):
-        self.Emin = Parameter(name, 'Emin', 0.5, min=0.0, max=1e6,
-                              hard_min=0.0, hard_max=1e6, frozen=True,
-                              units='keV')
-        self.Emax = Parameter(name, 'Emax', 10.0, min=0.0, max=1e6,
-                              hard_min=0.0, hard_max=1e6, frozen=True,
-                              units='keV')
-        self.Flux = Parameter(name, 'Flux', 1.0, min=0.0, max=1e10,
-                              hard_min=0.0, hard_max=1e10,
-                              frozen=False, units='')
+        self.Emin = XSParameter(name, 'Emin', 0.5, min=0.0, max=1e6,
+                                hard_min=0.0, hard_max=1e6, frozen=True,
+                                units='keV')
+        self.Emax = XSParameter(name, 'Emax', 10.0, min=0.0, max=1e6,
+                                hard_min=0.0, hard_max=1e6, frozen=True,
+                                units='keV')
+        self.Flux = XSParameter(name, 'Flux', 1.0, min=0.0, max=1e10,
+                                hard_min=0.0, hard_max=1e10,
+                                frozen=False, units='')
         XSConvolutionKernel.__init__(self, name, (self.Emin,
                                                   self.Emax,
                                                   self.Flux
@@ -12379,11 +12378,11 @@ class XSgsmooth(XSConvolutionKernel):
     _calc = _xspec.C_gsmooth
 
     def __init__(self, name='xsgsmooth'):
-        self.Sig_6keV = Parameter(name, 'Sig_6keV', 1.0, min=0.0, max=10.0,
-                                  hard_min=0.0, hard_max=20.0,
-                                  frozen=False, units='keV', aliases=['SigAt6keV'])
-        self.Index = Parameter(name, 'Index', 0.0, min=-1.0, max=1.0,
-                               hard_min=-1.0, hard_max=1.0, frozen=True)
+        self.Sig_6keV = XSParameter(name, 'Sig_6keV', 1.0, min=0.0, max=10.0,
+                                    hard_min=0.0, hard_max=20.0,
+                                    frozen=False, units='keV', aliases=['SigAt6keV'])
+        self.Index = XSParameter(name, 'Index', 0.0, min=-1.0, max=1.0,
+                                 hard_min=-1.0, hard_max=1.0, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Sig_6keV, self.Index))
 
 
@@ -12436,21 +12435,21 @@ class XSireflect(XSConvolutionKernel):
     _calc = _xspec.C_ireflct
 
     def __init__(self, name='xsireflect'):
-        self.rel_refl = Parameter(name, 'rel_refl', 0.0, min=-1.0, max=1e6,
-                                  hard_min=-1.0, hard_max=1e6, frozen=False)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
-                                  hard_min=-0.999, hard_max=10.0, frozen=True)
-        self.abund = Parameter(name, 'abund', 1.0, min=0.0, max=1e6,
-                               hard_min=0.0, hard_max=1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.0, max=1e6,
-                                  hard_min=0.0, hard_max=1e6, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, min=0.05, max=0.95,
-                                 hard_min=0.05, hard_max=0.95, frozen=True)
-        self.T_disk = Parameter(name, 'T_disk', 3e4, min=1e4, max=1e6,
-                                hard_min=1e4, hard_max=1e6, frozen=True,
-                                units='K')
-        self.xi = Parameter(name, 'xi', 1.0, min=0.0, max=1e3, hard_min=0.0,
-                            hard_max=5e3, frozen=True, units='erg cm/s')
+        self.rel_refl = XSParameter(name, 'rel_refl', 0.0, min=-1.0, max=1e6,
+                                    hard_min=-1.0, hard_max=1e6, frozen=False)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, min=0.05, max=0.95,
+                                   hard_min=0.05, hard_max=0.95, frozen=True)
+        self.T_disk = XSParameter(name, 'T_disk', 3e4, min=1e4, max=1e6,
+                                  hard_min=1e4, hard_max=1e6, frozen=True,
+                                  units='K')
+        self.xi = XSParameter(name, 'xi', 1.0, min=0.0, max=1e3, hard_min=0.0,
+                              hard_max=5e3, frozen=True, units='erg cm/s')
         XSConvolutionKernel.__init__(self, name, (self.rel_refl,
                                                   self.Redshift,
                                                   self.abund,
@@ -12499,15 +12498,15 @@ class XSkdblur(XSConvolutionKernel):
     _calc = _xspec.C_kdblur
 
     def __init__(self, name='xskdblur'):
-        self.Index = Parameter(name, 'Index', 3.0, min=-10.0, max=10.0,
-                               hard_min=-10.0, hard_max=10.0, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 4.5, min=1.235, max=400.0,
-                               hard_min=1.235, hard_max=400.0, frozen=True)
-        self.Rout_G = Parameter(name, 'Rout_G', 100.0, min=1.235, max=400.0,
-                                hard_min=1.235, hard_max=400.0, frozen=True)
-        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
-                              hard_min=0.0, hard_max=90.0, frozen=False,
-                              units='deg')
+        self.Index = XSParameter(name, 'Index', 3.0, min=-10.0, max=10.0,
+                                 hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Rin_G = XSParameter(name, 'Rin_G', 4.5, min=1.235, max=400.0,
+                                 hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Rout_G = XSParameter(name, 'Rout_G', 100.0, min=1.235, max=400.0,
+                                  hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Incl = XSParameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                                hard_min=0.0, hard_max=90.0, frozen=False,
+                                units='deg')
         XSConvolutionKernel.__init__(self, name, (self.Index,
                                                   self.Rin_G,
                                                   self.Rout_G,
@@ -12557,19 +12556,19 @@ class XSkdblur2(XSConvolutionKernel):
     _calc = _xspec.C_kdblur2
 
     def __init__(self, name='xskdblur2'):
-        self.Index = Parameter(name, 'Index', 3.0, min=-10.0, max=10.0,
-                               hard_min=-10.0, hard_max=10.0, frozen=True)
-        self.Rin_G = Parameter(name, 'Rin_G', 4.5, min=1.235, max=400.0,
-                               hard_min=1.235, hard_max=400.0, frozen=True)
-        self.Rout_G = Parameter(name, 'Rout_G', 100.0, min=1.235, max=400.0,
-                                hard_min=1.235, hard_max=400.0, frozen=True)
-        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
-                              hard_min=0.0, hard_max=90.0, frozen=False,
-                              units='deg')
-        self.Rbreak = Parameter(name, 'Rbreak', 20.0, min=1.235, max=400.0,
-                                hard_min=1.235, hard_max=400.0, frozen=True)
-        self.Index1 = Parameter(name, 'Index1', 3.0, min=-10.0, max=10.0,
-                                hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Index = XSParameter(name, 'Index', 3.0, min=-10.0, max=10.0,
+                                 hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Rin_G = XSParameter(name, 'Rin_G', 4.5, min=1.235, max=400.0,
+                                 hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Rout_G = XSParameter(name, 'Rout_G', 100.0, min=1.235, max=400.0,
+                                  hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Incl = XSParameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                                hard_min=0.0, hard_max=90.0, frozen=False,
+                                units='deg')
+        self.Rbreak = XSParameter(name, 'Rbreak', 20.0, min=1.235, max=400.0,
+                                  hard_min=1.235, hard_max=400.0, frozen=True)
+        self.Index1 = XSParameter(name, 'Index1', 3.0, min=-10.0, max=10.0,
+                                  hard_min=-10.0, hard_max=10.0, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Index,
                                                   self.Rin_G,
                                                   self.Rout_G,
@@ -12627,21 +12626,21 @@ class XSkerrconv(XSConvolutionKernel):
     def __init__(self, name='xskerrconv'):
         # ARGH: they are labelled Index1/Index2 but I used Index/Index1 here
         #
-        self.Index = Parameter(name, 'Index', 3.0, min=-10.0, max=10.0,
-                               hard_min=-10.0, hard_max=10.0, frozen=True)
-        self.Index1 = Parameter(name, 'Index1', 3.0, min=-10.0, max=10.0,
-                                hard_min=-10.0, hard_max=10.0, frozen=True)
-        self.r_br_g = Parameter(name, 'r_br_g', 6.0, min=1.0, max=400.0,
-                                hard_min=1.0, hard_max=400.0, frozen=True)
-        self.a = Parameter(name, 'a', 0.998, min=0.0, max=0.998,
-                           hard_min=0.0, hard_max=0.998, frozen=False)
-        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
-                              hard_min=0.0, hard_max=90.0, frozen=False,
-                              units='deg')
-        self.Rin_ms = Parameter(name, 'Rin_ms', 1.0, min=1.0, max=400.0,
-                                hard_min=1.0, hard_max=400.0, frozen=True)
-        self.Rout_ms = Parameter(name, 'Rout_ms', 400.0, min=1.0, max=400.0,
-                                 hard_min=1.0, hard_max=400.0, frozen=True)
+        self.Index = XSParameter(name, 'Index', 3.0, min=-10.0, max=10.0,
+                                 hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.Index1 = XSParameter(name, 'Index1', 3.0, min=-10.0, max=10.0,
+                                  hard_min=-10.0, hard_max=10.0, frozen=True)
+        self.r_br_g = XSParameter(name, 'r_br_g', 6.0, min=1.0, max=400.0,
+                                  hard_min=1.0, hard_max=400.0, frozen=True)
+        self.a = XSParameter(name, 'a', 0.998, min=0.0, max=0.998,
+                             hard_min=0.0, hard_max=0.998, frozen=False)
+        self.Incl = XSParameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                                hard_min=0.0, hard_max=90.0, frozen=False,
+                                units='deg')
+        self.Rin_ms = XSParameter(name, 'Rin_ms', 1.0, min=1.0, max=400.0,
+                                  hard_min=1.0, hard_max=400.0, frozen=True)
+        self.Rout_ms = XSParameter(name, 'Rout_ms', 400.0, min=1.0, max=400.0,
+                                   hard_min=1.0, hard_max=400.0, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Index,
                                                   self.Index1,
                                                   self.r_br_g,
@@ -12690,11 +12689,11 @@ class XSlsmooth(XSConvolutionKernel):
     _calc = _xspec.C_lsmooth
 
     def __init__(self, name='xslsmooth'):
-        self.Sig_6keV = Parameter(name, 'Sig_6keV', 1.0, min=0.0, max=10.0,
-                                  hard_min=0.0, hard_max=20.0, frozen=False,
-                                  units='keV', aliases=['SigAt6keV'])
-        self.Index = Parameter(name, 'Index', 0.0, min=-1.0, max=1.0,
-                               hard_min=-1.0, hard_max=1.0, frozen=True)
+        self.Sig_6keV = XSParameter(name, 'Sig_6keV', 1.0, min=0.0, max=10.0,
+                                    hard_min=0.0, hard_max=20.0, frozen=False,
+                                    units='keV', aliases=['SigAt6keV'])
+        self.Index = XSParameter(name, 'Index', 0.0, min=-1.0, max=1.0,
+                                 hard_min=-1.0, hard_max=1.0, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Sig_6keV, self.Index))
 
 
@@ -12724,7 +12723,7 @@ class XSpartcov(XSConvolutionKernel):
     _calc = _xspec.C_PartialCovering
 
     def __init__(self, name='xspartcov'):
-        self.CvrFract = Parameter(name, 'CvrFract', 0.5, min=0.05, max=0.95,
+        self.CvrFract = XSParameter(name, 'CvrFract', 0.5, min=0.05, max=0.95,
                                   hard_min=0.0, hard_max=1.0, frozen=False)
         XSConvolutionKernel.__init__(self, name, (self.CvrFract,))
 
@@ -12765,16 +12764,16 @@ class XSrdblur(XSConvolutionKernel):
     _calc = _xspec.C_rdblur
 
     def __init__(self, name='xsrdblur'):
-        self.Betor10 = Parameter(name, 'Betor10', -2.0, min=-10.0, max=20.0,
-                                 hard_min=-10.0, hard_max=20.0, frozen=True)
-        self.Rin_M = Parameter(name, 'Rin_M', 10.0, min=6.0, max=1000.0,
-                               hard_min=6.0, hard_max=10000.0, frozen=True)
-        self.Rout_M = Parameter(name, 'Rout_M', 1000.0, min=0.0,
-                                max=1000000.0, hard_min=0.0,
-                                hard_max=10000000.0, frozen=True)
-        self.Incl = Parameter(name, 'Incl', 30.0, min=0.0, max=90.0,
-                              hard_min=0.0, hard_max=90.0, frozen=False,
-                              units='deg')
+        self.Betor10 = XSParameter(name, 'Betor10', -2.0, min=-10.0, max=20.0,
+                                   hard_min=-10.0, hard_max=20.0, frozen=True)
+        self.Rin_M = XSParameter(name, 'Rin_M', 10.0, min=6.0, max=1000.0,
+                                 hard_min=6.0, hard_max=10000.0, frozen=True)
+        self.Rout_M = XSParameter(name, 'Rout_M', 1000.0, min=0.0,
+                                  max=1000000.0, hard_min=0.0,
+                                  hard_max=10000000.0, frozen=True)
+        self.Incl = XSParameter(name, 'Incl', 30.0, min=0.0, max=90.0,
+                                hard_min=0.0, hard_max=90.0, frozen=False,
+                                units='deg')
         XSConvolutionKernel.__init__(self, name, (self.Betor10,
                                                   self.Rin_M,
                                                   self.Rout_M,
@@ -12829,16 +12828,16 @@ class XSreflect(XSConvolutionKernel):
     _calc = _xspec.C_reflct
 
     def __init__(self, name='xsreflect'):
-        self.rel_refl = Parameter(name, 'rel_refl', 0.0, min=-1.0, max=1e6,
-                                  hard_min=-1.0, hard_max=1e6, frozen=False)
-        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
-                                  hard_min=-0.999, hard_max=10.0, frozen=True)
-        self.abund = Parameter(name, 'abund', 1.0, min=0.0, max=1e6,
-                               hard_min=0.0, hard_max=1e6, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.0, max=1e6,
-                                  hard_min=0.0, hard_max=1e6, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.45, min=0.05, max=0.95,
-                                 hard_min=0.05, hard_max=0.95, frozen=True)
+        self.rel_refl = XSParameter(name, 'rel_refl', 0.0, min=-1.0, max=1e6,
+                                    hard_min=-1.0, hard_max=1e6, frozen=False)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+        self.abund = XSParameter(name, 'abund', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.45, min=0.05, max=0.95,
+                                   hard_min=0.05, hard_max=0.95, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.rel_refl,
                                                   self.Redshift,
                                                   self.abund,
@@ -12897,16 +12896,16 @@ class XSrfxconv(XSConvolutionKernel):
     __function__ = "C_rfxconv"
 
     def __init__(self, name='xsrfxconv'):
-        self.rel_refl = Parameter(name, 'rel_refl', -1.0, min=-1.0, max=1e6,
-                                  hard_min=-1.0, hard_max=1e6)
-        self.redshift = Parameter(name, 'redshift', 0.0, min=0.0, max=4.0,
-                                  hard_min=0.0, hard_max=4.0, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.5, max=3,
-                                  hard_min=0.5, hard_max=3, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.5, min=0.05, max=0.95,
-                                 hard_min=0.05, hard_max=0.95, frozen=True)
-        self.log_xi = Parameter(name, 'log_xi', 1.0, min=1.0, max=6.0,
-                                hard_min=1.0, hard_max=6.0)
+        self.rel_refl = XSParameter(name, 'rel_refl', -1.0, min=-1.0, max=1e6,
+                                    hard_min=-1.0, hard_max=1e6)
+        self.redshift = XSParameter(name, 'redshift', 0.0, min=0.0, max=4.0,
+                                    hard_min=0.0, hard_max=4.0, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1.0, min=0.5, max=3,
+                                    hard_min=0.5, hard_max=3, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.5, min=0.05, max=0.95,
+                                   hard_min=0.05, hard_max=0.95, frozen=True)
+        self.log_xi = XSParameter(name, 'log_xi', 1.0, min=1.0, max=6.0,
+                                  hard_min=1.0, hard_max=6.0)
         XSConvolutionKernel.__init__(self, name, (self.rel_refl,
                                                   self.redshift,
                                                   self.Fe_abund,
@@ -12945,8 +12944,8 @@ class XSrgsxsrc(XSConvolutionKernel):
     _calc = _xspec.rgsxsrc
 
     def __init__(self, name='xsrgsxsrc'):
-        self.order = Parameter(name, 'order', -1.0, min=-3.0, max=-1,
-                               hard_min=-3.0, hard_max=-1, frozen=True)
+        self.order = XSParameter(name, 'order', -1.0, min=-3.0, max=-1,
+                                 hard_min=-3.0, hard_max=-1, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.order,))
 
 
@@ -12982,12 +12981,12 @@ class XSsimpl(XSConvolutionKernel):
     _calc = _xspec.C_simpl
 
     def __init__(self, name='xssimpl'):
-        self.Gamma = Parameter(name, 'Gamma', 2.3, min=1.1, max=4.0,
-                               hard_min=1.0, hard_max=5.0, frozen=False)
-        self.FracSctr = Parameter(name, 'FracSctr', 0.05, min=0.0, max=0.4,
-                                  hard_min=0.0, hard_max=1.0, frozen=False)
-        self.UpScOnly = Parameter(name, 'UpScOnly', 1.0, min=0.0, max=100.0,
-                                  hard_min=0.0, hard_max=100.0, frozen=True)
+        self.Gamma = XSParameter(name, 'Gamma', 2.3, min=1.1, max=4.0,
+                                 hard_min=1.0, hard_max=5.0, frozen=False)
+        self.FracSctr = XSParameter(name, 'FracSctr', 0.05, min=0.0, max=0.4,
+                                    hard_min=0.0, hard_max=1.0, frozen=False)
+        self.UpScOnly = XSParameter(name, 'UpScOnly', 1.0, min=0.0, max=100.0,
+                                    hard_min=0.0, hard_max=100.0, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Gamma,
                                                   self.FracSctr,
                                                   self.UpScOnly
@@ -13046,18 +13045,18 @@ class XSthcomp(XSConvolutionKernel):
 
     def __init__(self, name='xsthcomp'):
         # TODO: allow negative
-        self.Gamma_tau = Parameter(name, 'Gamma_tau', 1.7, min=1.001, max=5.0,
-                                   hard_min=1.001, hard_max=10.0, frozen=False)
-        self.kT_e = Parameter(name, 'kT_e', 50.0, min=0.5, max=150.0,
-                              hard_min=0.5, hard_max=150.0, units='keV',
-                              frozen=False)
+        self.Gamma_tau = XSParameter(name, 'Gamma_tau', 1.7, min=1.001, max=5.0,
+                                     hard_min=1.001, hard_max=10.0, frozen=False)
+        self.kT_e = XSParameter(name, 'kT_e', 50.0, min=0.5, max=150.0,
+                                hard_min=0.5, hard_max=150.0, units='keV',
+                                frozen=False)
         # In XSPEC 12.11.0 the parameter was named FracSctr, and thanks to a typo
         # it was stored as the parameter FracStr.
-        self.cov_frac = Parameter(name, 'cov_frac', 1.0, min=0.0, max=1.0,
-                                  hard_min=0.0, hard_max=1.0, frozen=False,
-                                  aliases=["FracSctr", "FracStr"])
-        self.z = Parameter(name, 'z', 0.0, min=0.0, max=5.0,
-                           hard_min=0.0, hard_max=5.0, frozen=True)
+        self.cov_frac = XSParameter(name, 'cov_frac', 1.0, min=0.0, max=1.0,
+                                    hard_min=0.0, hard_max=1.0, frozen=False,
+                                    aliases=["FracSctr", "FracStr"])
+        self.z = XSParameter(name, 'z', 0.0, min=0.0, max=5.0,
+                             hard_min=0.0, hard_max=5.0, frozen=True)
 
         XSConvolutionKernel.__init__(self, name, (self.Gamma_tau,
                                                   self.kT_e,
@@ -13104,12 +13103,12 @@ class XSvashift(XSConvolutionKernel):
     __function__ = "C_vashift"
 
     def __init__(self, name='xsvashift'):
-        self.Velocity = Parameter(name, 'Velocity', 0.0,
-                                  min=-1e4, max=1e4,
-                                  hard_min=-1e4, hard_max=1e4,
-                                  units='km/s', frozen=True,
-                                  # Parameter was mis-labelled until 4.14.0
-                                  aliases=['Redshift'])
+        self.Velocity = XSParameter(name, 'Velocity', 0.0,
+                                    min=-1e4, max=1e4,
+                                    hard_min=-1e4, hard_max=1e4,
+                                    units='km/s', frozen=True,
+                                    # Parameter was mis-labelled until 4.14.0
+                                    aliases=['Redshift'])
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
@@ -13151,12 +13150,12 @@ class XSvmshift(XSConvolutionKernel):
     __function__ = "C_vmshift"
 
     def __init__(self, name='xsvmshift'):
-        self.Velocity = Parameter(name, 'Velocity', 0.0,
-                                  min=-1e4, max=1e4,
-                                  hard_min=-1e4, hard_max=1e4,
-                                  units='km/s', frozen=True,
-                                  # Parameter was mis-labelled until 4.14.0
-                                  aliases=['Redshift'])
+        self.Velocity = XSParameter(name, 'Velocity', 0.0,
+                                    min=-1e4, max=1e4,
+                                    hard_min=-1e4, hard_max=1e4,
+                                    units='km/s', frozen=True,
+                                    # Parameter was mis-labelled until 4.14.0
+                                    aliases=['Redshift'])
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
@@ -13212,19 +13211,19 @@ class XSxilconv(XSConvolutionKernel):
     __function__ = "C_xilconv"
 
     def __init__(self, name='xsxilconv'):
-        self.rel_refl = Parameter(name, 'rel_refl', -1.0, min=-1.0, max=1e6,
-                                  hard_min=-1.0, hard_max=1e6)
-        self.redshift = Parameter(name, 'redshift', 0.0, min=0.0, max=4.0,
-                                  hard_min=0.0, hard_max=4.0, frozen=True)
-        self.Fe_abund = Parameter(name, 'Fe_abund', 1.0, min=0.5, max=3.0,
-                                  hard_min=0.5, hard_max=3.0, frozen=True)
-        self.cosIncl = Parameter(name, 'cosIncl', 0.5, min=0.05, max=0.95,
-                                 hard_min=0.05, hard_max=0.95, frozen=True)
-        self.log_xi = Parameter(name, 'log_xi', 1.0, min=1.0, max=6,
-                                hard_min=1.0, hard_max=6)
-        self.cutoff = Parameter(name, 'cutoff', 300.0, min=20.0, max=300.0,
-                                hard_min=20.0, hard_max=300.0,
-                                units='keV', frozen=True)
+        self.rel_refl = XSParameter(name, 'rel_refl', -1.0, min=-1.0, max=1e6,
+                                    hard_min=-1.0, hard_max=1e6)
+        self.redshift = XSParameter(name, 'redshift', 0.0, min=0.0, max=4.0,
+                                    hard_min=0.0, hard_max=4.0, frozen=True)
+        self.Fe_abund = XSParameter(name, 'Fe_abund', 1.0, min=0.5, max=3.0,
+                                    hard_min=0.5, hard_max=3.0, frozen=True)
+        self.cosIncl = XSParameter(name, 'cosIncl', 0.5, min=0.05, max=0.95,
+                                   hard_min=0.05, hard_max=0.95, frozen=True)
+        self.log_xi = XSParameter(name, 'log_xi', 1.0, min=1.0, max=6,
+                                  hard_min=1.0, hard_max=6)
+        self.cutoff = XSParameter(name, 'cutoff', 300.0, min=20.0, max=300.0,
+                                  hard_min=20.0, hard_max=300.0,
+                                  units='keV', frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.rel_refl,
                                                   self.redshift,
                                                   self.Fe_abund,
@@ -13265,8 +13264,8 @@ class XSzashift(XSConvolutionKernel):
     _calc = _xspec.C_zashift
 
     def __init__(self, name='xszashift'):
-        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
-                                  hard_min=-0.999, hard_max=10, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Redshift,))
 
 
@@ -13301,8 +13300,8 @@ class XSzmshift(XSConvolutionKernel):
     _calc = _xspec.C_zmshift
 
     def __init__(self, name='xszmshift'):
-        self.Redshift = Parameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
-                                  hard_min=-0.999, hard_max=10, frozen=True)
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10, frozen=True)
         XSConvolutionKernel.__init__(self, name, (self.Redshift,))
 
 
@@ -13365,18 +13364,18 @@ class XSbwcycl(XSAdditiveModel):
     __function__ = "beckerwolff"  # "c_beckerwolff"  do not have a direct interface to c_xxx
 
     def __init__(self, name='bwcycl'):
-        self.Radius = Parameter(name, 'Radius', 10, 5, 20, 5, 20, units='km', frozen=True)
-        self.Mass = Parameter(name, 'Mass', 1.4, 1, 3, 1, 3, units='Solar', frozen=True)
-        self.csi = Parameter(name, 'csi', 1.5, 0.01, 20, 0.01, 20)
-        self.delta = Parameter(name, 'delta', 1.8, 0.01, 20, 0.01, 20)
-        self.B = Parameter(name, 'B', 4, 0.01, 100, 0.01, 100, units='1e12G')
-        self.Mdot = Parameter(name, 'Mdot', 1, 1e-6, 1e6, 1e-6, 1e6, units='1e17g/s')
-        self.Te = Parameter(name, 'Te', 5, 0.1, 100, 0.1, 100, units='keV')
-        self.r0 = Parameter(name, 'r0', 44, 10, 1000, 10, 1000, units='m')
-        self.D = Parameter(name, 'D', 5, 1, 20, 1, 20, units='kpc', frozen=True)
-        self.BBnorm = Parameter(name, 'BBnorm', 0.0, 0, 100, 0, 100, frozen=True)
-        self.CYCnorm = Parameter(name, 'CYCnorm', 1.0, -1, 100, -1, 100, frozen=True)
-        self.FFnorm = Parameter(name, 'FFnorm', 1.0, -1, 100, -1, 100, frozen=True)
+        self.Radius = XSParameter(name, 'Radius', 10, 5, 20, 5, 20, units='km', frozen=True)
+        self.Mass = XSParameter(name, 'Mass', 1.4, 1, 3, 1, 3, units='Solar', frozen=True)
+        self.csi = XSParameter(name, 'csi', 1.5, 0.01, 20, 0.01, 20)
+        self.delta = XSParameter(name, 'delta', 1.8, 0.01, 20, 0.01, 20)
+        self.B = XSParameter(name, 'B', 4, 0.01, 100, 0.01, 100, units='1e12G')
+        self.Mdot = XSParameter(name, 'Mdot', 1, 1e-6, 1e6, 1e-6, 1e6, units='1e17g/s')
+        self.Te = XSParameter(name, 'Te', 5, 0.1, 100, 0.1, 100, units='keV')
+        self.r0 = XSParameter(name, 'r0', 44, 10, 1000, 10, 1000, units='m')
+        self.D = XSParameter(name, 'D', 5, 1, 20, 1, 20, units='kpc', frozen=True)
+        self.BBnorm = XSParameter(name, 'BBnorm', 0.0, 0, 100, 0, 100, frozen=True)
+        self.CYCnorm = XSParameter(name, 'CYCnorm', 1.0, -1, 100, -1, 100, frozen=True)
+        self.FFnorm = XSParameter(name, 'FFnorm', 1.0, -1, 100, -1, 100, frozen=True)
         self.norm = Parameter(name, 'norm', 1.0, 0.0, 1.0e24, 0.0, hugeval, frozen=True)
 
         XSAdditiveModel.__init__(self, name, (self.Radius, self.Mass, self.csi, self.delta,

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1060,6 +1060,14 @@ class XSParameter(XSBaseParameter):
                     default_min=default_min,
                     default_max=default_max)
 
+    def hard_min_changed(self):
+        """Has the hard limit (min) been changed from it's default value?"""
+        return self._xspec_hard_min != self.hard_min
+
+    def hard_max_changed(self):
+        """Has the hard limit (max) been changed from it's default value?"""
+        return self._xspec_hard_max != self.hard_max
+
 
 class XSModel(RegriddableModel1D, metaclass=ModelMeta):
     """The base class for XSPEC models.

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -96,7 +96,8 @@ def get_xspec_models():
     # Could just exclude any names that end in 'Model', but this
     # could remove valid model names, so be explicit.
     for n in ['XSModel', 'XSMultiplicativeModel', 'XSAdditiveModel',
-              'XSTableModel', 'XSConvolutionModel', 'XSConvolutionKernel']:
+              'XSTableModel', 'XSConvolutionModel', 'XSConvolutionKernel',
+              'XSBaseParameter', 'XSParameter']:
         remove_item(model_names, n)
 
     # The sirf model - in 12.8.2 and up to 12.9.0d at least - includes

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -403,8 +403,14 @@ def test_xpec_tablemodel_outofbound(clean_astro_ui, make_data_path):
     # when used in the test suite it appears that the tmod
     # global symbol is not created, so need to access the component
     tmod = ui.get_model_component('tmod')
+    elo = numpy.arange(1, 5)
+    ehi = elo + 1
+
+    print(tmod)
+
     with pytest.raises(ParameterErr) as e:
-        tmod.calc([0., .2, 1., 1.], numpy.arange(1, 5), numpy.arange(2, 6))
+        tmod.calc([0., .2, 1., 1.], elo, ehi)
+
     assert 'minimum' in str(e)
 
 

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -94,7 +94,8 @@ def test_check_no_extra_xspec_convolution_models():
     from sherpa.astro import xspec
 
     exclude = ['XSModel', 'XSAdditiveModel', 'XSMultiplicativeModel',
-               'XSConvolutionModel', 'XSConvolutionKernel']
+               'XSConvolutionModel', 'XSConvolutionKernel',
+               'XSBaseParameter', 'XSParameter']
 
     names = [(n, getattr(xspec, n))
              for n in dir(xspec)


### PR DESCRIPTION
# Summary

XSPEC model parameters now use the same limits for soft and hard (the hard limit from the model.dat file). This is handled by the XSBaseParameter class which is used for XSPEC table models. The XSParameter class, which extends this and is used by most other parameters, allows the user to change the hard limits of the model. This follows XSPEC, and allows using some models which are documented as supporting a value outside the normal parameter range (normally by setting the value to a negative value). Note that this is potentially dangerous (it could crash the program) so should be used carefully. It is strongly suggested that any parameter set to a value outside of the original limits is also frozen.

# Details

Fixes #1202. I have investigated several different approaches (one of which you can see in this set of commits but has since been changed) and ended up with a similar system to XSPEC: we allow the hard limits to be changed and then it's up to the user to be careful.

To do this we have two classes: `XSBaseParameter` extends `Parameter` and `XSParameter` extends `XSBaseParameter`.

`XSBaseParameter`, has two changes:

1. It stores the original soft and hard limits in the `_xspec_soft/hard_min/max` attributes; this is mainly so we can track what the orignanl values were (for debugging/testing) but is currently unused
2. It uses the hard_min/max range for the soft limits when calling `Parameter.__init__`.

The `XSParameter` class

1. allows a user to set the `hard_min` and `hard_max` values. Any change to `hard_xxx` is copied to `xxx`.
2. over-rides the set method to allow `hard_min` and `hard_max` attributes.

It is interesting to see what tests fail thanks to these changes. Other than some internal changes (e.g. the addition of an XSxxx class we need to filter out of some checks) we can see changes in things like error analysis when the upper limit that was calculated is now outside the valid range for that parameter, and presumably subtle differences thanks to limit changes and how the optimizer deals with hitting the boundary.

One interesting choice is when to use Parameter, XSBaseParameter, or XSParameter. For table models I use XSBaseParameter since we know that it is dangerous for them to set a value outside the default hard range (see #743). For most other parameters we use XSParameter. The norm parameter (last one in additive models) is not technically an XSPEC parameter (i.e. we apply the parameter when evaluating the model) so we can just use the standard Parameter class for this.

# Notes

I had experimented with a version where we set the `hard_min` and `hard_max` values to `-hugeval` and `hugeval` but this caused a number of our "sample flux" tests to fail because we suddenly were trying to set nH to a value < 0 when sampling the distribution. So this version ended up being rejected.

The original implementation let a user set a value outside the hard limits, automatically freezing it. In some ways this is a nicer interface, as it's less to do, but the code to implement this started to fill up with special-case behavior that I felt wasn't worth the effort to implement, test, and - most-importantly - document to the user.

So I ended up with an XSPEC-like approach. I do not expect this feature to be used often so we do not need to spend time improvng the ergonomics.

# Example

The `fpl` parameter from [optxagn](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelOptxagn.html) is labelled as

> The fraction of the power below rcor which is emitted in the hard comptonisation component. If this parameter is negative then only the hard Compton component is used.

```python
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find xpaget on your PATH'
>>> from sherpa.astro.xspec import get_xsversion
>>> get_xsversion()
'12.11.1d'
>>> xsoptxagn.mdl
<XSoptxagn model instance 'xsoptxagn.mdl'>
>>> print(mdl)
xsoptxagn.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.mass     frozen        1e+07            1        1e+09      solar
   mdl.dist     frozen          100         0.01        1e+09        Mpc
   mdl.logLoLEdd thawed           -1          -10            2
   mdl.astar    frozen            0            0        0.998
   mdl.rcor     thawed           10            1          100         rg
   mdl.logrout  frozen            5            3            7
   mdl.kT_e     thawed          0.2         0.01           10        keV
   mdl.tau      thawed           10          0.1          100
   mdl.Gamma    thawed          2.1          0.5           10
   mdl.fpl      thawed       0.0001            0          0.1
   mdl.fcol     frozen          2.4            1            5
   mdl.tscat    frozen       100000        10000       100000
   mdl.Redshift frozen            0            0           10
   mdl.norm     thawed            1            0        1e+24
>>> print(mdl.fpl)
val         = 0.0001
min         = 0.0
max         = 0.1
units       =
frozen      = False
link        = None
default_val = 0.0001
default_min = 0.0
default_max = 0.1
>>> mdl.fpl.min
0.0
>>> mdl.fpl.hard_min
0.0
```

But we can't set it negative!

```python
>>> mdl.fpl = -1
Traceback (most recent call last):
...
sherpa.utils.err.ParameterErr: parameter mdl.fpl has a minimum of 0
```

Now we can! The preferred style is to use the set method since you can change the minimum, value, and frozen flag in one call:

```python
>>> mdl.fpl.set(val=-1, hard_min=-1, frozen=True)
>>> print(mdl.fpl)
val         = -1.0
min         = -1.0
max         = 0.1
units       =
frozen      = True
link        = None
default_val = -1.0
default_min = 0.0
default_max = 0.1
>>> mdl.fpl.min
-1.0
>>> mdl.fpl.hard_min
-1.0
```

You can do it separately

```python
>>> mdl.fpl.hard_min = -1
>>> mdl.fpl = -1
>>> mdl.fpl.freeze()
```

Note that setting `hard_min` also sets `min` (and `hard_max` will set `max`) as a convenience and because we don't really have a soft vs hard distinction for XSPEC parameters like we do for Sherpa parameters.

Note that normal Sherpa parameters can not have their hard range changed - we can see this with the `norm` parameter of this model:

```python
>>> type(mdl.fpl)
<class 'sherpa.astro.xspec.XSParameter'>
>>> type(mdl.norm)
<class 'sherpa.models.parameter.Parameter'>
>>> mdl.norm.hard_min = -10
Traceback (most recent call last):
 ...
AttributeError: can't set attribute
>>> mdl.norm.set(hard_min=-10)
Traceback (most recent call last):
...TypeError: set() got an unexpected keyword argument 'hard_min'
```

# Example

The serialization code used by `save_all` needed to be updated to recognize a model which has had it's hard-limit range changed. As an example

```python
>>> from sherpa.astro.ui import *
>>> xsoptxagn.mfl
<XSoptxagn model instance 'xsoptxagn.mfl'>
>>> mfl.fpl.set(hard_min=-1, val=-1, frozen=True)
>>> save_all('test.shp')
```

This creates, in `test.shp`

```
mfl.fpl.hard_min    = -1.0
mfl.fpl.default_val = -1.0
mfl.fpl.default_min = 0.0
mfl.fpl.default_max = 0.1
mfl.fpl.val     = -1.0
mfl.fpl.min     = -1.0
mfl.fpl.max     = 0.1
mfl.fpl.units   = ""
mfl.fpl.frozen  = True
```

# Alternatives / Future work

Perhaps instead of tweaking `hard_min`/`hard_max` behavior I should tweak `min`/`max` (as they can be thought of being synonymous) so you'd just say

```python
>>> mdl.fpl.set(min=-1, val=-1)
```

and this would auto-magically shift the hard limits as well as the soft? I think this sounds sensible.

I'd like to add a `XSNormParameter` class (name to be bike-shedded) which is just for the `norm` parameter of additive models, as there are times it's useful to be able to determine which parameter "scales" the overall model. The XSAdditiveModel class should then add this automatically if not already set in the calling class. But this is all for a later PR.

Probably need to improve docs