### PR TITLE
Splitup model expressions

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -864,7 +864,7 @@ class CompositeModel(Model):
         for part in self.parts:
             try:
                 self.is_discrete = self.is_discrete or part.is_discrete
-            except:
+            except AttributeError:
                 warning("Could not determine whether the model is discrete.\n" +
                         "This probably means that you have restored a session saved with a previous version of Sherpa.\n" +
                         "Falling back to assuming that the model is continuous.\n")

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1234,7 +1234,7 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
         self.arg = self.wrapobj(arg)
         self.op = op
         self.opstr = opstr
-        CompositeModel.__init__(self, ('%s(%s)' % (opstr, self.arg.name)),
+        CompositeModel.__init__(self, f'{opstr}({self.arg.name})',
                                 (self.arg,))
 
     def calc(self, p, *args, **kwargs):
@@ -1290,8 +1290,7 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
         self.opstr = opstr
 
         CompositeModel.__init__(self,
-                                ('(%s %s %s)' %
-                                 (self.lhs.name, opstr, self.rhs.name)),
+                                f'({self.lhs.name} {opstr} {self.rhs.name})',
                                 (self.lhs, self.rhs))
 
     def regrid(self, *args, **kwargs):
@@ -1342,7 +1341,7 @@ class FilterModel(CompositeModel, ArithmeticModel):
             filter_str = self._make_filter_str(filter)
 
         CompositeModel.__init__(self,
-                                ('(%s)[%s]' % (self.model.name, filter_str)),
+                                f'({self.model.name})[{filter_str}]',
                                 (self.model,))
 
     @staticmethod
@@ -1438,8 +1437,7 @@ class NestedModel(CompositeModel, ArithmeticModel):
         self.otherargs = otherargs
         self.otherkwargs = otherkwargs
         CompositeModel.__init__(self,
-                                ('%s(%s)' %
-                                 (self.outer.name, self.inner.name)),
+                                f'{self.outer.name}({self.inner.name})',
                                 (self.outer, self.inner))
 
     def startup(self, cache=False):
@@ -1489,8 +1487,7 @@ class RegridWrappedModel(CompositeModel, ArithmeticModel):
             self.wrapper.integrate = model.integrate
 
         CompositeModel.__init__(self,
-                                "{}({})".format(self.wrapper.name,
-                                                self.model.name),
+                                f"{self.wrapper.name}({self.model.name})",
                                 (self.model, ))
 
     def calc(self, p, *args, **kwargs):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -927,6 +927,15 @@ class CompositeModel(Model):
             except AttributeError:
                 pass
 
+    def create(self, *args):
+        """Create a copy of the object.
+
+        Note that it will re-use model components rather than
+        re-creating them.
+        """
+
+        raise NotImplementedError()
+
 
 class SimulFitModel(CompositeModel):
     """Store multiple models.
@@ -1240,6 +1249,23 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
     def calc(self, p, *args, **kwargs):
         return self.op(self.arg.calc(p, *args, **kwargs))
 
+    def create(self, *args):
+        """Create a version of unary-op model applied to model.
+
+        Parameters
+        ----------
+        model : Model instance
+
+        Returns
+        -------
+        applied : UnaryOpModel instance
+        """
+
+        if len(args) != 1:
+            raise TypeError("create() missing 1 required positional argument: model")
+
+        return self.__class__(args[0], self.op, self.opstr)
+
 
 class BinaryOpModel(CompositeModel, RegriddableModel):
     """Combine two model expressions.
@@ -1323,6 +1349,24 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
                              (type(self.lhs).__name__, len(lhs),
                               type(self.rhs).__name__, len(rhs)))
         return val
+
+    def create(self, *args):
+        """Create a version of binary-op model applied to the models.
+
+        Parameters
+        ----------
+        lhs, rhs : Model instance
+
+        Returns
+        -------
+        applied : BinaryOpModel instance
+        """
+
+        if len(args) != 2:
+            raise TypeError("create() missing 2 required positional arguments: lhs, rhs")
+
+        return self.__class__(args[0], args[1], self.op, self.opstr)
+
 
 
 # TODO: do we actually make use of this functionality anywhere?

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -36,8 +36,8 @@ import pytest
 
 from sherpa.utils.err import ModelErr
 from sherpa.models.model import ArithmeticModel, ArithmeticConstantModel, \
-    ArithmeticFunctionModel, BinaryOpModel, FilterModel, Model, NestedModel, \
-    UnaryOpModel, RegridWrappedModel, modelCacher1d
+    ArithmeticFunctionModel, BinaryOpModel, CompositeModel, FilterModel, \
+    Model, NestedModel, UnaryOpModel, RegridWrappedModel, modelCacher1d
 from sherpa.models.parameter import Parameter, hugeval, tinyval
 from sherpa.models.basic import Sin, Const1D, Box1D, Polynom1D, Scale1D, \
     Integrate1D
@@ -1224,3 +1224,43 @@ def test_cache_clear_multiple(caplog):
     assert c._cache_ctr['check'] == 0
     assert c._cache_ctr['hits'] == 0
     assert c._cache_ctr['misses'] == 0
+
+
+def test_compositemodel_create():
+    c = CompositeModel('bob', ())
+    with pytest.raises(NotImplementedError):
+        c.create()
+
+
+def test_unaryopmodel_create():
+    b = Box1D()
+    b.xlow = 10
+    b.xhi = 20
+    b.ampl.set(12, max=13)
+    c = -b
+
+    x = numpy.arange(5, 25, 2)
+
+    n = c.create(b)
+
+    assert n(x) == pytest.approx(c(x))
+
+
+def test_binaryopmodel_create():
+    b1 = Box1D()
+    b1.xlow = 10
+    b1.xhi = 20
+    b1.ampl.set(12, max=13)
+
+    b2 = Box1D()
+    b2.xlow = 12
+    b2.xhi = 22
+    b2.ampl.set(-5, min=-5)
+
+    c = b1 + b2
+
+    x = numpy.arange(5, 25, 2)
+
+    n = c.create(b1, b2)
+
+    assert n(x) == pytest.approx(c(x))


### PR DESCRIPTION
Is this useful functionality (it was originally built to allow a `plot_model_components` command to be able to display the individual components without requiring the user to manually create the expressions)?

It is a relatively large code change for what feels like a small user-level change.

What does it mean for future "fancy" model classes?

# Summary

Allow a model expression to be split up into separate "additive" terms (based on the XSPEC nomenclature).

# Details

The aim is to be able to separate out a model expression into individual meaningful components (in XSPEC terminology a set of multiplicative models applied to an additive model). These expressions can then be used downstream - e.g. to allow a user to plot up all the individual components of a model in a "meaningful" way. The implementation does **not** use the XSPEC additive and multiplicative classes, since this is meant to be a generic solution. Instead it tries to expand the binary operations we support to change an expression like

    a * (b + c)

to

    a * b + a * c

# Notes

The `expand` and `separate` methods are added to the classes and also there's functions with these names which essentiallly just call the underlying methods.

# TODO

Need to look at instrument-style responses (e.g. convolution/RMF, multiplication/ARF, and non-linear/pileup)  to decide if you want to expand the contents - i.e. when you have

    resp(1234.56 * a * (b + x))

should it come back with

    resp(1234.56 * a * b + 1234.56 * a * x)

or not bother (since we can't guarantee that

    resp(a + b) == resp(a) + resp(b)

[we know it isn't the case for pileup]

# Examples

With the following setup to create four model components (in real life they'd have different models but that's not relevant here):

```
>>> from sherpa.models.basic import Const1D
>>> a = Const1D('a'); b = Const1D('b'); c = Const1D('c'); d = Const1D('d')
```

A very-simple expression. Note that it does not `expand` (i.e. the call returns the input`) but we can `separate` the additive terms:

```
>>> mdl = a + (b * c - d * a)
>>> mdl
<BinaryOpModel model instance '(a + ((b * c) - (d * a)))'>
>>> mdl.name
'(a + ((b * c) - (d * a)))'
>>> mdl.expand()
<BinaryOpModel model instance '(a + ((b * c) - (d * a)))'>
>>> mdl.separate()
[<Const1D model instance 'a'>, <BinaryOpModel model instance '(b * c)'>, <UnaryOpModel model instance '-((d * a))'>]
>>> for expr in mdl.separate():
...     print(expr.name)
...
a
(b * c)
-((d * a))
```

Here's the expression I meant to write, which we can see does `expand`, which you can then `separate` to get the additive terms (but only after expansion):

```
>>> mdl2 = a * (b * c - d * a)
>>> mdl2.name
'(a * ((b * c) - (d * a)))'
>>> mdl2.expand()
<BinaryOpModel model instance '((a * (b * c)) - (a * (d * a)))'>
>>> mdl2.expand().name
'((a * (b * c)) - (a * (d * a)))'
>>> mdl2.separate()  # NOTE: this doesn't do anything, you need to expand first
[<BinaryOpModel model instance '(a * ((b * c) - (d * a)))'>]
>>> mdl2.expand().separate()
[<BinaryOpModel model instance '(a * (b * c))'>, <UnaryOpModel model instance '-((a * (d * a)))'>]
>>> for expr in mdl2.expand().separate():
...     print(expr.name)
...
(a * (b * c))
-((a * (d * a)))
```

Here's some more:

```
>>> m1 = a + b
>>> m2 = c + d
>>> (m1 * m2)
<BinaryOpModel model instance '((a + b) * (c + d))'>
>>> (m1 * m2).expand()
<BinaryOpModel model instance '((((a * c) + (b * c)) + (a * d)) + (b * d))'>
>>> for cpt in (m1 * m2).expand().separate():
...     print(cpt.name)
...
(a * c)
(b * c)
(a * d)
(b * d)
>>> m1 = a - b
>>> (m1 * m2).expand()
<BinaryOpModel model instance '((((a * c) - (b * c)) + (a * d)) + (b * d))'>
>>> for cpt in (m1 * m2).expand().separate():
...     print(cpt.name)
...
(a * c)
-((b * c))
(a * d)
(b * d)
>>> (m1 * m2) - (d - c)
<BinaryOpModel model instance '(((a - b) * (c + d)) - (d - c))'>
>>> ((m1 * m2) - (d - c)).expand()
<BinaryOpModel model instance '(((((a * c) - (b * c)) + (a * d)) + (b * d)) - (d - c))'>
>>> for cpt in ((m1 * m2) - (d - c)).expand().separate():
...     print(cpt.name)
...
(a * c)
-((b * c))
(a * d)
(b * d)
-(d)
-(-(c))
```

Here's a more-realistic example, showing that we need to handle responses:

```
>>> set_source(xsphabs.gal * (powlaw1d.pl + xsapec.blob))
>>> get_source().name
'(xsphabs.gal * (powlaw1d.pl + xsapec.blob))'
>>> get_source().expand().name
'((xsphabs.gal * powlaw1d.pl) + (xsphabs.gal * xsapec.blob))'
>>> for cpt in get_source().expand().separate():
...     print(cpt)
...
(xsphabs.gal * powlaw1d.pl)
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   gal.nH       thawed            1            0        1e+06 10^22 atoms / cm^2
   pl.gamma     thawed            1          -10           10
   pl.ref       frozen            1 -3.40282e+38  3.40282e+38
   pl.ampl      thawed            1            0  3.40282e+38
(xsphabs.gal * xsapec.blob)
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   gal.nH       thawed            1            0        1e+06 10^22 atoms / cm^2
   blob.kT      thawed            1        0.008           64        keV
   blob.Abundanc frozen            1            0            5
   blob.redshift frozen            0       -0.999           10
   blob.norm    thawed            1            0        1e+24
>>> get_model().name
'apply_rmf(apply_arf((38564.608926889 * (xsphabs.gal * (powlaw1d.pl + xsapec.blob)))))'
>>> get_model().expand().name
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-master/sherpa/models/model.py", line 946, in expand
    raise NotImplementedError()
NotImplementedError
```