### PR TITLE
Doc: switch default sphinx role

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,10 @@ import os
 import shutil
 import sys
 
+from sphinx_astropy.conf.v1 import intersphinx_mapping, default_role
+
 import sphinx_rtd_theme
+
 
 # Based on http://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
 #
@@ -146,11 +149,16 @@ extensions = [
     # of warning messages (about missing links) that I don't have time
     # to investigate.
     'sphinx.ext.napoleon',
-    # 'numpydoc.numpydoc'
+    # 'numpydoc.numpydoc',
+    'sphinx.ext.intersphinx',
+    'sphinx_astropy.ext.intersphinx_toggle',
     'sphinx_astropy.ext.edit_on_github',
     # notebooks
     'nbsphinx'
 ]
+# Imported from sphinx_astropy so we don't have to maintain the list
+# of servers
+# intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # notebook support
 # - for now never execute a notebook
@@ -313,8 +321,11 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#
-# default_role = None
+# Imported from sphinx_astropy
+# default_role = 'obj'
+
+# Setting from sphinx_astropy for numpydoc xref settings
+numpydoc_xref_param_type = True
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -20,18 +20,18 @@
 
 """Tools for creating, storing, inspecting, and manipulating data sets.
 
-The main classes for representing data sets are :py:class:`Data1D`,
-:py:class:`Data1DInt`, and :py:class:`Data2D`, to handle (x, y), (xlo,
+The main classes for representing data sets are `Data1D`,
+`Data1DInt`, and `Data2D`, to handle (x, y), (xlo,
 xhi, y), and (x1, x2, y) data, although there are also
-more-specialized cases, such as :py:class:`Data1DAsymmetricErrs`. These
-classes build on the :py:class:`Data` class, which supports dynamic
+more-specialized cases, such as `Data1DAsymmetricErrs`. These
+classes build on the `Data` class, which supports dynamic
 filtering of data - to select a subset of the data range - as well as
 data access and model evaluation to match the data range.
 
-The :py:class:`Filter` class is used to handle data filtering - that
-is, to combine filters such as selecting the range a to b (`notice`)
-and hiding the range c to d (`ignore`). This is used with the
-:py:class:`DataSpace1D` and :py:class:`DataSpace2D` classes to handle
+The `Filter` class is used to handle data filtering - that
+is, to combine filters such as selecting the range a to b (``notice``)
+and hiding the range c to d (``ignore``). This is used with the
+`DataSpace1D` and `DataSpace2D` classes to handle
 evaluating models on different grids to the data, and then converting
 back to the data space, whether by rebinnig or interpolation.
 
@@ -50,8 +50,8 @@ References
 Examples
 --------
 
-Create a data set representing the independent axis (`x`) and
-dependent axis (`y`) then filter to select only those values between
+Create a data set representing the independent axis (``x``) and
+dependent axis (``y``) then filter to select only those values between
 500-520 and 530-700:
 
 >>> d1 = Data1D('example', x, y)
@@ -614,6 +614,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         Return the dimensions of this data space as a tuple of tuples.
         The first element in the tuple is a tuple with the dimensions of the data space, while the second element
         provides the size of the dependent array.
+
         Returns
         -------
         tuple
@@ -625,6 +626,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
     def indep(self):
         """
         Return the grid of the data space associated with this data set.
+
         Returns
         -------
         tuple of array_like
@@ -784,7 +786,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         Returns
         -------
-        axis : array or `None`
+        axis : array or None
            The systematic error for each data point. A value of
            `None` is returned if the data set has no systematic
            errors.
@@ -918,7 +920,7 @@ class DataSimulFit(NoNewAttributesAfterInit):
         The name for the collection of data.
     datasets : sequence of Data objects
         The datasets to be stored; there must be at least one. They are
-        assumed to behave as sherpa.data.Data objects, but there is no
+        assumed to behave as `sherpa.data.Data` objects, but there is no
         check for this condition.
 
     Attributes
@@ -1168,7 +1170,9 @@ class Data1D(Data):
 
 class Data1DAsymmetricErrs(Data1D):
     """1-D data set with asymmetric errors
-    Note: elo and ehi shall be stored as delta values from y"""
+
+    Note: elo and ehi shall be stored as delta values from y
+    """
 
     _fields = ("name", "x", "y", "staterror", "syserror", "elo", "ehi")
 
@@ -1381,7 +1385,6 @@ def html_data1d(data):
     """HTML representation: Data1D
 
     If have matplotlib then plot the data, otherwise summarize it.
-
     """
 
     from sherpa.plot import DataPlot, backend
@@ -1436,7 +1439,6 @@ def html_data1dint(data):
     """HTML representation: Data1DInt
 
     If have matplotlib then plot the data, otherwise summarize it.
-
     """
 
     from sherpa.plot import DataHistogramPlot, backend

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1339,7 +1339,7 @@ class Fit(NoNewAttributesAfterInit):
         `sherpa.utils.err.EstErr`
            If any parameter in parlist is not valid (i.e. is not
            thawed or is not a member of the model expression being
-           fit), or if the statistic is `~sherpa.optmethods.LeastSq`,
+           fit), or if the statistic is `~sherpa.stats.LeastSq`,
            or if the reduced chi-square value of the current parameter
            values is larger than the ``max_rstat`` option (for
            chi-square statistics).

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -227,7 +227,7 @@ class FitResults(NoNewAttributesAfterInit):
        statistic value, or a larger value, if the assumed model is
        true and the current model parameters are the true parameter
        values. This will be `None` if the value can not be calculated
-       with the current statistic (e.g.  the Cash statistic).
+       with the current statistic (e.g. the Cash statistic).
     rstat : number or None
        The reduced statistic value (the `statval` field divided by
        `dof`). This is not calculated for all statistics.
@@ -1006,11 +1006,12 @@ class Fit(NoNewAttributesAfterInit):
     stat : `sherpa.stats.Stat` or `None`, optional
        The statistic object to use. If not given then
        `Chi2Gehrels` is used.
-    method : sherpa.optmethods.OptMethod instance or None, optional
-       The optimiser to use. If not given then `LevMar` is used.
-    estmethod : sherpa.estmethod.EstMethod instance or None, optional
+    method : `sherpa.optmethods.OptMethod` instance or None, optional
+       The optimiser to use. If not given then `sherpa.optmethods.LevMar`
+       is used.
+    estmethod : `sherpa.estmethods.EstMethod` or None, optional
        The class used to calculate errors. If not given then
-       `Covariance` is used.
+       `sherpa.estmethods.Covariance` is used.
     itermethod_opts : dict or None, optional
        If set, defines the iterated-fit method and options to use.
        It is passed through to `IterFit`.
@@ -1115,7 +1116,7 @@ class Fit(NoNewAttributesAfterInit):
 
         See Also
         --------
-        `calc_chisqr`, `calc_stat_info`
+        calc_chisqr, calc_stat_info
 
         """
 
@@ -1287,7 +1288,7 @@ class Fit(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        *others : :py:class:`sherpa.fit.Fit` instances
+        *others : `sherpa.fit.Fit` instances
             The ``data`` and ``model`` attributes of these arguments
             are used, along with those from the object.
 
@@ -1324,7 +1325,7 @@ class Fit(NoNewAttributesAfterInit):
             the associated optimisation method instance to use. This
             is only used if the method is changed, as described in
             the Notes section below.
-        parlist : sequence of `sherpa.model.parameter.Parameter` or None, optional
+        parlist : sequence of `sherpa.models.parameter.Parameter` or None, optional
             The names of the parameters for which the errors should
             be calculated. If set to `None` then all the thawed
             parameters are used.
@@ -1338,7 +1339,7 @@ class Fit(NoNewAttributesAfterInit):
         `sherpa.utils.err.EstErr`
            If any parameter in parlist is not valid (i.e. is not
            thawed or is not a member of the model expression being
-           fit), or if the statistic is `LeastSq`,
+           fit), or if the statistic is `~sherpa.optmethods.LeastSq`,
            or if the reduced chi-square value of the current parameter
            values is larger than the ``max_rstat`` option (for
            chi-square statistics).

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -70,7 +70,7 @@ class StatInfoResults(NoNewAttributesAfterInit):
     ids : sequence of int or str
        The data set ids (it may be a tuple or array) included in the
        results.
-    bkg_ids: sequence of int or str, or `None`
+    bkg_ids: sequence of int or str, or None
        The background data set ids (it may be a tuple or array)
        included in the results, if any.
     statname : str
@@ -82,16 +82,15 @@ class StatInfoResults(NoNewAttributesAfterInit):
     dof: int
        The number of degrees of freedom in the fit (the number of
        bins minus the number of free parameters).
-    qval: number or `None`
+    qval: number or None
        The Q-value (probability) that one would observe the reduced
        statistic value, or a larger value, if the assumed model is
        true and the current model parameters are the true parameter
        values. This will be `None` if the value can not be calculated
        with the current statistic (e.g. the Cash statistic).
-    rstat: number of `None`
+    rstat: number or None
        The reduced statistic value (the `statval` field divided by
        `dof`). This is not calculated for all statistics.
-
     """
 
     # The fields to include in the __str__ output.
@@ -158,8 +157,8 @@ def _cleanup_chi2_name(stat, data):
 
     Parameters
     ----------
-    stat : a sherpa.stats.Stat instance
-    data : a sherpa.data.Data or sherpa.data.DataSimulFit instance
+    stat : `sherpa.stats.Stat`
+    data : `sherpa.data.Data` or `sherpa.data.DataSimulFit`
 
     Returns
     -------
@@ -197,9 +196,9 @@ class FitResults(NoNewAttributesAfterInit):
 
     Attributes
     ----------
-    datasets : sequence of int or str, or `None`
+    datasets : sequence of int or str, or None
        A sequence of the data set ids included in the results.
-    itermethodname : str or `None`
+    itermethodname : str or None
        What iterated-fit scheme was used, if any.
     methodname : str
        The name of the optimisation method used (in lower case).
@@ -217,19 +216,19 @@ class FitResults(NoNewAttributesAfterInit):
     istatval : number
        The statistic value at the start of the fit.
     dstatval : number
-       The change in the statistic value (`istatval - statval`).
+       The change in the statistic value (``istatval - statval``).
     numpoints : int
        The number of bins used in the fits.
     dof : int
        The number of degrees of freedom in the fit (the number of
        bins minus the number of free parameters).
-    qval : number or `None`
+    qval : number or None
        The Q-value (probability) that one would observe the reduced
        statistic value, or a larger value, if the assumed model is
        true and the current model parameters are the true parameter
        values. This will be `None` if the value can not be calculated
        with the current statistic (e.g.  the Cash statistic).
-    rstat : number or `None`
+    rstat : number or None
        The reduced statistic value (the `statval` field divided by
        `dof`). This is not calculated for all statistics.
     message : str
@@ -240,10 +239,10 @@ class FitResults(NoNewAttributesAfterInit):
        The number of model evaluations made during the fit.
     extra_output
        The ``extra_output`` field from the fit.
-    covar : tuple or `None`
+    covar : tuple or None
        The covariance matrix from the best-fit location, if provided
        by the optimiser.
-    modelvals : NumPy array
+    modelvals : `array`
        The values of the best-fit model evaluated for the data.
 
     """
@@ -391,7 +390,6 @@ class ErrorEstResults(NoNewAttributesAfterInit):
        The number of fits performed during the error analysis.
     extra_output
        The ``extra_output`` field from the fit.
-
     """
 
     # The fields to include in the __str__ output.
@@ -637,7 +635,7 @@ class IterFit(NoNewAttributesAfterInit):
 
         Raises
         ------
-        sherpa.utils.err.FitErr
+        `sherpa.utils.err.FitErr`
             This exception is raised if the statistic is not supported.
             This method can only be used with Chi-Square statistics
             with errors.
@@ -775,9 +773,9 @@ class IterFit(NoNewAttributesAfterInit):
                  statkwargs=None, cache=True):
         """Exclude points that are significately far away from the best fit.
 
-        The `sigmarej` scheme is based on the IRAF `sfit` function
+        The `sigmarej` scheme is based on the IRAF ``sfit`` function
         [3]_, where after a fit data points are excluded if the value
-        of `(data-model) / error` exceeds a threshold, and the data
+        of ``(data-model) / error`` exceeds a threshold, and the data
         re-fit. This removal of data points continues until the fit
         has converged or a maximum number of iterations has been reached.
         The error removal can be asymmetric, since there are separate
@@ -785,7 +783,7 @@ class IterFit(NoNewAttributesAfterInit):
 
         Raises
         ------
-        sherpa.utils.err.FitErr
+        `sherpa.utils.err.FitErr`
             This exception is raised if the statistic is not
             supported. This method can only be used with
             Chi-Square statistics with errors.
@@ -1000,23 +998,22 @@ class Fit(NoNewAttributesAfterInit):
 
     Parameters
     ----------
-    data : sherpa.data.Data or sherpa.data.DataSimulFit instance
+    data : `sherpa.data.Data` or `sherpa.data.DataSimulFit`
        The data to be fit.
-    model : sherpa.models.model.Model or sherpa.models.model.SimulFitModel instance
-       The model to fit to the data. It should match the `data` parameter
-       (i.e. be a SimulFitModel object when data is a DataSimulFit).
-    stat : sherpa.stats.Stat instance or None, optional
+    model : `sherpa.models.model.Model` or `sherpa.models.model.SimulFitModel`
+       The model to fit to the data. It should match the ``data`` parameter
+       (i.e. be a `SimulFitModel` object when data is a `DataSimulFit`).
+    stat : `sherpa.stats.Stat` or `None`, optional
        The statistic object to use. If not given then
-       :py:class:`~sherpa.stats.Chi2Gehrels` is used.
+       `Chi2Gehrels` is used.
     method : sherpa.optmethods.OptMethod instance or None, optional
-       The optimiser to use. If not given then
-       :py:class:`~sherpa.optmethods.LevMar` is used.
+       The optimiser to use. If not given then `LevMar` is used.
     estmethod : sherpa.estmethod.EstMethod instance or None, optional
        The class used to calculate errors. If not given then
-       :py:class:`~sherpa.estmethods.Covariance` is used.
+       `Covariance` is used.
     itermethod_opts : dict or None, optional
        If set, defines the iterated-fit method and options to use.
-       It is passed through to :py:class:`~sherpa.fit.IterFit`.
+       It is passed through to `IterFit`.
 
     """
 
@@ -1085,7 +1082,7 @@ class Fit(NoNewAttributesAfterInit):
     def guess(self, **kwargs):
         """Guess parameter values and limits.
 
-        The model's :py:meth:`~sherpa.models.model.Model.guess` method
+        The model's `sherpa.models.model.Model.guess` method
         is called with the data values (the dependent axis of the
         data set) and the ``kwargs`` arguments.
         """
@@ -1118,7 +1115,7 @@ class Fit(NoNewAttributesAfterInit):
 
         See Also
         --------
-        calc_chisqr, calc_stat_info
+        `calc_chisqr`, `calc_stat_info`
 
         """
 
@@ -1132,16 +1129,15 @@ class Fit(NoNewAttributesAfterInit):
 
         Returns
         -------
-        chisq : array or `None`
+        chisq : array or None
            The chi-square value for each bin of the data, using the
-           current statistic (as set by `set_stat`).  A value of
-           `None` is returned if the statistic is not a chi-square
+           current statistic.
+           A value of `None` is returned if the statistic is not a chi-square
            distribution.
 
         See Also
         --------
         calc_stat, calc_stat_info
-
         """
 
         # Since there is some setup work needed before calling
@@ -1161,7 +1157,7 @@ class Fit(NoNewAttributesAfterInit):
 
         Returns
         -------
-        statinfo : StatInfoResults instance
+        statinfo : `StatInfoResults` instance
            The current statistic value.
 
         See Also
@@ -1191,7 +1187,7 @@ class Fit(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        outfile : str or `None`, optional
+        outfile : str or None, optional
            If not `None` then information on the fit is written to
            this file.
         clobber : bool, optional
@@ -1201,12 +1197,12 @@ class Fit(NoNewAttributesAfterInit):
 
         Returns
         -------
-        fitres : FitResults instance
+        fitres : `FitResults`
 
         Raises
         ------
-        sherpa.utils.err.FitErr
-           This is raised if `clobber` is `False` and `outfile` already
+        `sherpa.utils.err.FitErr`
+           This is raised if ``clobber`` is ``False`` and ``outfile`` already
            exists or if all the bins have been masked out of the fit.
 
         See Also
@@ -1215,7 +1211,7 @@ class Fit(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The file created when `outfile` is set is a simple ASCII
+        The file created when ``outfile`` is set is a simple ASCII
         file with a header line containing the text
         "# nfev statistic" and then a list of the thawed parameters,
         and then one line for each iteration, with the values separated
@@ -1291,13 +1287,13 @@ class Fit(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        *others : sherpa.fit.Fit instances
+        *others : :py:class:`sherpa.fit.Fit` instances
             The ``data`` and ``model`` attributes of these arguments
             are used, along with those from the object.
 
         Returns
         -------
-        fitres : FitResults instance
+        fitres : `FitResults`
 
         See Also
         --------
@@ -1323,26 +1319,26 @@ class Fit(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        methoddict : dict or `None`, optional
+        methoddict : dict or None, optional
             A dictionary mapping from lower-cased method name to
             the associated optimisation method instance to use. This
             is only used if the method is changed, as described in
             the Notes section below.
-        parlist : seqquence of sherpa.model.parameter.Parameter instances or `None`, optional
+        parlist : sequence of `sherpa.model.parameter.Parameter` or None, optional
             The names of the parameters for which the errors should
             be calculated. If set to `None` then all the thawed
             parameters are used.
 
         Returns
         -------
-        res : ErrorEstResults instance
+        res : ErrorEstResults
 
         Raises
         ------
-        sherpa.utils.err.EstErr
+        `sherpa.utils.err.EstErr`
            If any parameter in parlist is not valid (i.e. is not
            thawed or is not a member of the model expression being
-           fit), or if the statistic is :py:class:`~sherpa.stats.LeastSq`,
+           fit), or if the statistic is `LeastSq`,
            or if the reduced chi-square value of the current parameter
            values is larger than the ``max_rstat`` option (for
            chi-square statistics).
@@ -1358,10 +1354,10 @@ class Fit(NoNewAttributesAfterInit):
         new best-fit location. This can repeat until the ``maxfits``
         option is reached.
 
-        Unless the :py:class:`~sherpa.estmethods.Covariance` estimator
-        is being used, ot the ``fast`` option is unset, then the method
-        will be changed to :py:class:`~sherpa.optmethods.NelderMead` (for
-        likelihood-based statistics) or :py:class:`~sherpa.optmethods.LevMar`
+        Unless the `~sherpa.estmethods.Covariance` estimator
+        is being used, or the ``fast`` option is unset, then the method
+        will be changed to `~sherpa.optmethods.NelderMead` (for
+        likelihood-based statistics) or `~sherpa.optmethods.LevMar`
         (for chi-square based statistics) whilst calculating the
         errors.
         """

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -186,7 +186,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
     Data lines are separated into columns - splitting by the
     ``sep`` comment - and then converted to NumPy arrays.
     If the ``require_floats`` argument is `True` then the
-    column will be converted to a floating point number
+    column will be converted to a floating-point number
     type, with an error raised if this fails.
 
     An error is raised if the number of columns per row

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -138,7 +138,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
        in the file). This is ignored if ``colkeys`` is given.
     colkeys : array of str, optional
        An array of the column name to read in. The default is
-       ``None``.
+       `None`.
     sep : str, optional
        The separator character. The default is ``' '``.
     dstype : data class to use, optional
@@ -146,7 +146,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
     comment : str, optional
        The comment character. The default is ``'#'``.
     require_floats : bool, optional
-       If ``True`` (the default), non-numeric data values will
+       If `True` (the default), non-numeric data values will
        raise a `ValueError`.
 
     Returns
@@ -158,12 +158,12 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
 
     Raises
     ------
-    sherpa.utils.IOErr
+    sherpa.utils.err.IOErr
        Raised if a requested column is missing or the file appears
        to be a binary file.
     ValueError
        If a column value can not be converted into a numeric value
-       and the ``require_floats`` parameter is True.
+       and the `require_floats` parameter is `True`.
 
     See Also
     --------
@@ -185,8 +185,8 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
 
     Data lines are separated into columns - splitting by the
     ``sep`` comment - and then converted to NumPy arrays.
-    If the ``require_floats`` argument is ``True`` then the
-    column will be converted to the `sherpa.utils.SherpaFloat`
+    If the ``require_floats`` argument is `True` then the
+    column will be converted to a floating point number
     type, with an error raised if this fails.
 
     An error is raised if the number of columns per row
@@ -259,10 +259,10 @@ def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
        The name of the ASCII file to read in.
     ncols : int, optional
        The number of columns to read in (the first ``ncols`` columns
-       in the file). This is ignored if ``colkeys`` is given.
+       in the file). This is ignored if `colkeys` is given.
     colkeys : array of str, optional
        An array of the column name to read in. The default is
-       ``None``.
+       `None`.
     sep : str, optional
        The separator character. The default is ``' '``.
     dstype : data class to use, optional
@@ -270,7 +270,7 @@ def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
     comment : str, optional
        The comment character. The default is ``'#'``.
     require_floats : bool, optional
-       If ``True`` (the default), non-numeric data values will
+       If `True` (the default), non-numeric data values will
        raise a `ValueError`.
 
     Returns
@@ -281,12 +281,12 @@ def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
 
     Raises
     ------
-    sherpa.utils.IOErr
+    sherpa.utils.err.IOErr
        Raised if a requested column is missing or the file appears
        to be a binary file.
     ValueError
        If a column value can not be converted into a numeric value
-       and the ``require_floats`` parameter is True.
+       and the `require_floats` parameter is True.
 
     See Also
     --------
@@ -334,9 +334,9 @@ def read_arrays(*args):
     ----------
     col1, ... coln : array_like
        The data columns.
-    dstype : optional, default=`sherpa.data.Data1D`
+    dstype : optional
        The data type to create. It must be a subclass of
-       `sherpa.data.BaseData`.
+       `sherpa.data.BaseData` and defaults to `sherpa.data.Data1D`
 
     Returns
     -------
@@ -346,7 +346,7 @@ def read_arrays(*args):
 
     Raises
     ------
-    sherpa.utils.IOErr
+    sherpa.utils.err.IOErr
        Raised if no arrays are sent in.
 
     See Also
@@ -396,14 +396,14 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
     args : array_like
        The arrays to write out.
     fields : array_like of str
-       The column names (should match the size of ``args`` if given).
+       The column names (should match the size of `args` if given).
     sep : str, optional
        The separator character. The default is ``' '``.
     comment : str, optional
        The comment character. The default is ``'#'``. This is only used
-       to write out the column names when ``fields`` is not None.
+       to write out the column names when `fields` is not `None`.
     clobber : bool, optional
-       If ``filename`` is not ``None``, then this flag controls
+       If `filename` is not `None`, then this flag controls
        whether an existing file can be overwritten (``True``)
        or if it raises an exception (``False``, the default
        setting).
@@ -416,7 +416,7 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
     Raises
     ------
     sherpa.utils.err.IOErr
-       If ``filename`` already exists and ``clobber`` is ``False``
+       If `filename` already exists and `clobber` is `False`
        or if there is no data to write.
 
     See Also
@@ -493,9 +493,9 @@ def write_data(filename, dataset, fields=None, sep=' ', comment='#',
        write out the column names (after converting to upper case)
        before the data.
     clobber : bool, optional
-       If ``filename`` is not ``None``, then this flag controls
-       whether an existing file can be overwritten (``True``)
-       or if it raises an exception (``False``, the default
+       If `filename` is not `None`, then this flag controls
+       whether an existing file can be overwritten (`True`)
+       or if it raises an exception (`False`, the default
        setting).
     linebreak : str, optional
        Indicate a new line. The default is ``'\\n'``.
@@ -506,7 +506,7 @@ def write_data(filename, dataset, fields=None, sep=' ', comment='#',
     Raises
     ------
     sherpa.utils.err.IOErr
-       If ``filename`` already exists and ``clobber`` is ``False``
+       If `filename` already exists and `clobber` is `False`
        or if there is no data to write.
 
     See Also

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -79,23 +79,28 @@ class Stat(NoNewAttributesAfterInit):
     def _bundle_inputs(data, model):
         """Convert input into SimulFit instances.
 
-        Convert the inputs into DataSimulFit and SimulFitModel
+        Convert the inputs into `sherpa.data.DataSimulFit` and
+        `sherpa.models.model.SimulFitModel`
         instances.
 
         Parameters
         ----------
-        data : a Data or DataSimulFit instance
+        data : `sherpa.data.Data` or `sherpa.data.DataSimulFit`
             The data set, or sets, to use.
-        model : a Model or SimulFitModel instance
-            The model expression, or expressions. If a SimulFitModel
+        model : `sherpa.models.model.Model` or `sherpa.models.model.SimulFitModel`
+            The model expression, or expressions. If a
+            `~sherpa.models.model.SimulFitModel`
             is given then it must match the number of data sets in the
             data parameter.
 
         Returns
         -------
-        data, model : DataSimulFit instance, SimulFitModel instance
-            If the input was a SimulFit object then this is just
-            the input value.
+        data : `sherpa.data.DataSimulFit`
+            If the input was a `~sherpa.data.DataSimulFit` object
+            then this is just the input value.
+        model : `sherpa.models.model.SimulFitModel`
+            If the input was a `~sherpa.models.model.SimulFitModel`
+            object then this is just the input value.
         """
 
         if not isinstance(data, DataSimulFit):
@@ -112,7 +117,7 @@ class Stat(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        data : a DataSimulFit instance
+        data : `sherpa.data.DataSimulFit`
             The data sets to use.
 
         Raises
@@ -143,9 +148,9 @@ class Stat(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        data : a DataSimulFit instance
+        data : `sherpa.data.DataSimulFit`
             The data sets to use.
-        model : a SimulFitModel instance
+        model : `sherpa.models.model.SimulFitModel`
             The model expressions for each data set. It must match
             the data parameter (the models are in the same order
             as the data objects).
@@ -173,18 +178,21 @@ class Stat(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        data : a Data or DataSimulFit instance
+        data : `sherpa.data.Data` or `sherpa.data.DataSimulFit`
             The data set, or sets, to use.
-        model : a Model or SimulFitModel instance
+        model : `sherpa.models.model.Model` or `sherpa.models.model.SimulFitModel`
             The model expressions for each data set. It must match
             the data parameter (the models are in the same order
             as the data objects).
 
         Returns
         -------
-        data, model : DataSimulFit instance, SimulFitModel instance
-            If the input was a SimulFit object then this is just
-            the input value.
+        data : `sherpa.data.DataSimulFit`
+            If the input was a `~sherpa.data.DataSimulFit` object
+            then this is just the input value.
+        model : `sherpa.models.model.SimulFitModel`
+            If the input was a `~sherpa.models.model.SimulFitModel`
+            object then this is just the input value.
         """
 
         if self._calc is None:
@@ -235,17 +243,20 @@ class Stat(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        data : a Data or DataSimulFit instance
+        data : `sherpa.data.Data` or `sherpa.data.DataSimulFit`
             The data set, or sets, to use.
-        model : a Model or SimulFitModel instance
-            The model expression, or expressions. If a SimulFitModel
+        model :  `sherpa.models.model.Model` or `sherpa.models.model.SimulFitModel`
+            The model expression, or expressions. If a
+            `sherpa.models.model.SimulFitModel`
             is given then it must match the number of data sets in the
             data parameter.
 
         Returns
         -------
-        statval, fvec : number, array of numbers
-            The statistic value and the per-bin "statistic" value.
+        statval : number
+            The value of the statistic.
+        fvec : array of numbers
+            The per-bin "statistic" value.
 
         """
 
@@ -268,11 +279,16 @@ class Stat(NoNewAttributesAfterInit):
 
         Returns
         -------
-        rstat, qval : float or NaN or None, float or NaN or None
-            The reduced statistic and q value. If the statistic does not support
-            a goodness of fit then the return values are None. If it does then
-            NaN is returned if either the number of degrees of freedom is 0
-            (or less), or the statistic value is less than 0.
+        rstat : float or NaN or None
+            The reduced statistic. If the statistic does not support
+            a goodness of fit then the return value is `None`. If it does
+            then NaN is returned if either the number of degrees of freedom is
+            0 (or less), or the statistic value is less than 0.
+        qval : float or NaN or None
+            The q value. If the statistic does not support
+            a goodness of fit then the return values are `None`. If it does
+            then NaN is returned if either the number of degrees of freedom is
+            0 (or less), or the statistic value is less than 0.
 
         """
 
@@ -568,10 +584,11 @@ class Chi2(Stat):
 
         Parameters
         ----------
-        data : a Data or DataSimulFit instance
+        data :  `sherpa.data.Data` or `sherpa.data.DataSimulFit`
             The data set, or sets, to use.
-        model : a Model or SimulFitModel instance
-            The model expression, or expressions. If a SimulFitModel
+        model : `sherpa.models.model.Model` or `sherpa.models.model.SimulFitModel`
+            The model expression, or expressions. If a
+            `sherpa.models.model.SimulFitModel`
             is given then it must match the number of data sets in the
             data parameter.
 


### PR DESCRIPTION
## Summary
Multiply the number of working references on readthedocs, while at the same time reduce verbosity in the docstrings.

## Details
I proposal to switch the sphinx "default role" (the rules that sphinx uses to for \`text like this\`) to "obj". Before, text in single backticks would just be rendered in a different font and only text marked up with an explicit sphinx role (e.g. `:py:func:`) would generate a link. Given the multiple uses of the docstring (source for sphinx, ahelp, and read directly in e.g. ipython with tab completion), that extra role markup can be distracting and we've used it very sparingly in the past. On the other hand, Sherpa has many specialized classes and it's very convenient to just click on "sherpa.models.model.SimulFitModel" to see what that class does and how to initialize it instead of reaching though all of readthedocs to find the documenation of that class.
Fortunately, sphinx offers a  way around that dilemma: The "default role" (https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html). I've set this to "obj", but "any" could be an alternative.

Also improving the intersphinx and xref numpy settings means that a lot more words will be linked automatically, further reducing the need for backticks.

In particular,

- in parameter descriptions, certain words (including "None") will be recognized even without backticks.
- numpy xref brings in a list of more words, most importantly "array", which always means " numpy array" for use and is sometimes even written as "numpy array instance" - a very long way to say "array". Now, the link will make clear what type of array it is. For people investigating the doctring in Python itself, it should be clear that an array is a numy array (and in fact in many cases a dask or pnumpy array might work, too).

While working on the docs, I'm also starting to do the following clean-up:

- remove excess use of "instance" as in "a sherpa.models.parameter.Parameter instance". Everything in Python is an instance and we don't say "float instance" either. If the parameter to a function really did not require an instance, but the class itself, then the type would be "class" or "type".

## Status

I've (mostly) fixed-up one particular file as an example to show the benefits (will link to old and new version of one or more html help files, once sphinx as run and rendered them). 

## Plan
I'm asking @DougBurke for a review in this stage to check that (a) this is not a stupid idea  in general and (b) this would not cause undue burden when generating ahelp files. (In that case, I can probably help wit ha custom sphinx extension).

If we agree to merge something like this, I will extend this PR to fix up more of the doc strings, in particular all relating to fitting. However, we have so many open PRs, that it's not a good strategy to make one giant PR of everything because that would lead to too many merge conflicts as this or other PRS are mergers and all remaining PRS need rebasing. Instead, I would go through module by module and open separate PRS that can be reviewed and merged on a much shorter timescale.

Again, note that having unresolved links for the "any" role only gives us more sphinx warnings, but does not break the look of the documentation or make the CI fail.
