### PR TITLE
Reduce concurrent runs to github actions

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -1,6 +1,12 @@
 name: Conda CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '*'
+  pull_request:
 
 env:
   sherpa_channel: sherpa
@@ -24,11 +30,11 @@ jobs:
             matplotlib-version: 3
             xspec-version: 12.10.1s
 
-          - name: Linux Minimum Setup 
+          - name: Linux Minimum Setup
             os: ubuntu-latest
             python-version: 3.8
             numpy-version: 1.18
-            install-type: develop 
+            install-type: develop
             test-data: none
 
           - name: Linux Full Build (Python 3.9)
@@ -41,7 +47,7 @@ jobs:
             xspec-version: 12.11.1
 
           - name: Linux Full Build (Python 3.8)
-            os: ubuntu-latest 
+            os: ubuntu-latest
             python-version: 3.8
             install-type: develop
             fits: astropy
@@ -55,13 +61,13 @@ jobs:
             numpy-version: 1.19
             install-type: install
             fits: astropy
-            test-data: submodule 
+            test-data: submodule
             matplotlib-version: 3
             xspec-version: 12.10.1s
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.9 
+            python-version: 3.9
             install-type: install
             test-data: package
             matplotlib-version: 3
@@ -70,7 +76,7 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             numpy-version: 1.18
-            install-type: develop 
+            install-type: develop
             fits: astropy
             test-data: none
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -1,6 +1,12 @@
 name: Pip CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '*'
+  pull_request:
 
 jobs:
   tests:
@@ -9,11 +15,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Linux Minimum Setup 
+          - name: Linux Minimum Setup
             os: ubuntu-latest
             python-version: 3.8
             numpy-pkg: 'numpy>=1.18,<1.19'
-            install-type: develop 
+            install-type: develop
             test-data: none
 
           - name: Linux Build (w/o Astropy or Xspec)
@@ -28,7 +34,7 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             numpy-pkg: 'numpy'
-            install-type: develop 
+            install-type: develop
             fits-pkg: 'astropy'
             test-data: none
 
@@ -36,7 +42,7 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             numpy-pkg: 'numpy'
-            install-type: develop 
+            install-type: develop
             fits-pkg: 'astropy'
             test-data: submodule
 
@@ -44,7 +50,7 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v2
       with:
-        submodules: 'True'      
+        submodules: 'True'
 
     - name: Pip Testing Setup - Python
       uses: actions/setup-python@v2
@@ -61,8 +67,8 @@ jobs:
         if [ ! -n "${NUMPYVER}" ] ; then
           NUMPYVER='numpy'
         fi
-        pip install ${NUMPYVER} ${FITSBUILD} ${MATPLOTLIBVER} 
-        
+        pip install ${NUMPYVER} ${FITSBUILD} ${MATPLOTLIBVER}
+
     - name: Build Sherpa
       run: |
         python setup.py ${{ matrix.install-type }}
@@ -88,7 +94,7 @@ jobs:
         codecov
 
     - name: Smoke Test
-      env: 
+      env:
         FITS: ${{ matrix.fits-pkg }}
       run: |
         smokevars="-v 3"


### PR DESCRIPTION
## Summary
Run GH actions only of pull requests and direct push to main, but not for pushed to all branches

## Details
With current main, I see GH actions run twice every time I update a PR with a new commit: Once in the sherpa/sherpa repro (where the PR is) and once in my fork (hamogu/sherpa), see e.g.
https://github.com/sherpa/sherpa/pull/1182/checks?check_run_id=3454426337 and  https://github.com/hamogu/sherpa/actions/runs/1179131780 .
If I don't keep hamogu/sherpa/main up-to-date (and I usually don't, because I don't use that branch at all; I work from sherpa/sherpa/main, which is the most up-to-date version), then the results of the runs can differ as in the example above which is confusing.  Also, it's a waste of electrons and CPU cycles.

I *think* that the root cause is that actions runs for both the PR (because `on: pull_request` is set) as well as on all changes to a branch like hamogu/sherpa/multisim in the examples above, because `on: push` is set). So, I suggest to limit this to direct pushes to the main branch in this PR.
I can't claim to 100% understand github actions, but this makes sense to me and it's what e.g. astropy does, where I don't see the double runs.

Of course, it's possible that other people use the CI in they local branches before they open a PR and want this feature. (I run local tests in one environment and when those pass, I open a PR where the entire CI runs on the theory that, once it passes in one environment, it's usually good enough to be looked at). @DougBurke  what do you think?