### PR TITLE
crates backend strip preceding/trailing whitespace when determining ascii file colnames (Fix #1262)

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -98,7 +98,7 @@ def get_filename_from_dmsyntax(filename, blockname=None):
                 last = line
                 line = fd.readline().strip()
             if (last is not None and
-                    (len(last.split(' ')) != len(line.split(' ')))):
+                    (len(last.strip('#').strip().split(' ')) != len(line.strip().split(' ')))):
                 colnames = False
         finally:
             fd.close()


### PR DESCRIPTION
**Summary**

This change modifies the crates backend ascii file handling to resolve issue #1262 where a test added in PR #1253 causes the tests to fail. 

**Details**

The crates backend was failing while running test_save_filter_data1. The test works with the default sherpa back end but failed in CIAO when using crates.  The issue was traced back to column name handling in the get_filename_from_dmsyntax routine. The code was tokenizing the '# colname1 colname2' line in the ascii table file to extract column names and comparing it against the first data line (line without # as first char). The check did not strip preceding/trailing whitespace so the comparison would fail since the data had a ' ' between the # and the column name.   

Removing the space in the datafile so that it looks like '#colname1 colname2' would allow the test to pass a more robust solution was to remove the preceding and trailing whitespace from the column name line and the data line to ensure both contain the same number of 'elements'.