### PR TITLE
Fix Inconsistent behavior in save_arrays when optional parameter ascii = True/False (Fixes issue #1251)

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1135,10 +1135,6 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
 
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
-    if ascii:
-        write_arrays(filename, args, fields, clobber=clobber)
-        return
-
     if not clobber and os.path.isfile(filename):
         raise IOErr("filefound", filename)
 
@@ -1155,11 +1151,15 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         if len(arg) != size:
             raise IOErr('arraysnoteq')
 
-    if fields is None:
+    if not ascii and fields is None:
         fields = ['col%i' % (ii + 1) for ii in range(len(args))]
 
-    if len(args) != len(fields):
+    if fields is not None and len(args) != len(fields):
         raise IOErr("wrongnumcols", len(args), len(fields))
+
+    if ascii:
+        write_arrays(filename, args, fields, clobber=clobber)
+        return
 
     cols = []
     for val, name in zip(args, fields):

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -33,7 +33,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import RMFModelPHA
 from sherpa.astro import ui
 from sherpa.data import Data1D
-from sherpa.utils.err import ArgumentErr, DataErr, IdentifierErr, StatErr
+from sherpa.utils.err import ArgumentErr, DataErr, IdentifierErr, IOErr, StatErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_group, requires_xspec
@@ -712,6 +712,23 @@ def test_save_arrays_ASCII(colnames):
         return ui.unpack_ascii(filename, ncols=3)
 
     save_arrays(colnames=colnames, fits=False, read_func=read_func)
+
+
+
+@requires_fits
+@pytest.mark.parametrize("ascii_type", [False, True])
+def test_save_arrays_colmismatch_errs(ascii_type):
+    with pytest.raises(IOErr) as exc:
+        a = numpy.asarray([1, 3, 5])
+        b = numpy.asarray([4, 6, 8])
+        c = a*b
+        fields = ["odd", "even"]
+        #ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
+        #ui.save_arrays(ofh.name, [a, b, c], fields=fields,
+        ui.save_arrays("bogus_tempfile_name", [a, b, c], fields=fields,
+                   ascii=ascii_type, clobber=True)
+    assert 'Expected 3 columns but found 2' in str(exc.value)
+
 
 
 @requires_fits

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -723,8 +723,6 @@ def test_save_arrays_colmismatch_errs(ascii_type):
         b = numpy.asarray([4, 6, 8])
         c = a*b
         fields = ["odd", "even"]
-        #ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
-        #ui.save_arrays(ofh.name, [a, b, c], fields=fields,
         ui.save_arrays("bogus_tempfile_name", [a, b, c], fields=fields,
                    ascii=ascii_type, clobber=True)
     assert 'Expected 3 columns but found 2' in str(exc.value)


### PR DESCRIPTION
**Summary**

The behavior of the  save_arrays routine differs when using writing ascii vs binary files. In particular, an exception thrown when providing a different number of column names from data columns occurs for fits files but not ascii files. (Issue #1251 
Details)

**Details**

The pyfits back end save_arrays() routine was calling write_arrays for ascii files before handling exceptions for things such as clobber settings and inconsistent array sizes. The crates backend already correctly handled both instances. This change relocates the ascii write to occur after the checks so that the pyfits ascii and binary threads are consistent.

