### PR TITLE
RTD: include parse_xspec_model_description

### DIFF
--- a/docs/overview/astro_utils_xspec.rst
+++ b/docs/overview/astro_utils_xspec.rst
@@ -12,4 +12,4 @@ The sherpa.astro.utils.xspec module
       :toctree: api
 
       create_xspec_code
-      parse_xspec_model_file
+      parse_xspec_model_description


### PR DESCRIPTION
# Summary

Fix a link on the Read The Docs pages from PR #1260 

# Details

During #1260 I renamed parse_xspec_model_file to parse_xspec_model_description but never caught the link in the documentation.