### PR TITLE
Comment: add link to the OSTI.GOV URL for the optimizing document

### DIFF
--- a/sherpa/optmethods/tests/tstoptfct.hh
+++ b/sherpa/optmethods/tests/tstoptfct.hh
@@ -27,6 +27,8 @@
 // "Algorithm 566: Fortran Subroutines for Testing Unconstrained
 // Optimization Software.", ACM TOMS, VOL. 7, PAGES 14-41 AND 136-140, 1981
 //
+// See also https://www.osti.gov/biblio/6650344
+//
 // The comments on the solutions were taken from the site:
 //
 // http://www.uni-graz.at/imawww/kuntsevich/solvopt/results/moreset.html

--- a/sherpa/optmethods/tests/tstoptfct.hh
+++ b/sherpa/optmethods/tests/tstoptfct.hh
@@ -31,7 +31,7 @@
 //
 // The comments on the solutions were taken from the site:
 //
-// http://www.uni-graz.at/imawww/kuntsevich/solvopt/results/moreset.html
+// https://web.archive.org/web/20060221201940/http://www.uni-graz.at/imawww/kuntsevich/solvopt/results/moreset.html
 //
 // Jan 2008 D. T. Nguyen
 //


### PR DESCRIPTION
# Summary

Add a reference to the OSTI.GOV technical report in the comments in the C++ code used for testing the optimization functions.

# Details

@dtnguyen2 mentioned this in a PR or issue and I keep on finding it hard to find, so adding it to the actual documentation is a good idea.