### PR TITLE
Update tests that were changed by #1246

### DIFF
--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1197,9 +1197,9 @@ def test_pickle_image_filter_none(make_test_image):
 
 @pytest.mark.parametrize("ignore,region,expected",
                          [(False, 'circle(4255, 3840, 20)', 'Circle(4255,3840,20)'),
-                          (True, 'circle(4255, 3840, 20)', '!Circle(4255,3840,20)'),
+                          (True, 'circle(4255, 3840, 20)', 'Field()&!Circle(4255,3840,20)'),
                           (False, 'circle(4255, 3840, 20) - field()', 'Circle(4255,3840,20)&!Field()'),
-                          (True, 'circle(4255, 3840, 20) - field()', '!Circle(4255,3840,20)|Field()'),
+                          (True, 'circle(4255, 3840, 20) - field()', 'Field()&!Circle(4255,3840,20)|Field()'),
                           ])
 def test_pickle_image_filter(ignore, region, expected, make_test_image):
     """Check we can pickle/unpickle with a region filter.

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -926,7 +926,7 @@ set_coord(1, 'logical')
 
 ######### Filter Data
 
-notice2d_id(1, "Circle(50,50,30)&Ellipse(40,75,30,20,320)&!RotBox(30,30,10,5,45)")
+notice2d_id(1, "Circle(50,50,30)&!RotBox(30,30,10,5,45)|Ellipse(40,75,30,20,320)")
 
 
 ######### Set Statistic
@@ -1670,8 +1670,8 @@ def test_restore_img_filter_model(make_data_path, clean_astro_ui):
     corig = ui.calc_stat()
 
     # sanity check
-    assert forig == 'Circle(50,50,30)&Ellipse(40,75,30,20,320)&!RotBox(30,30,10,5,45)'
-    assert sorig == pytest.approx(489.92761)
+    assert forig == 'Circle(50,50,30)&!RotBox(30,30,10,5,45)|Ellipse(40,75,30,20,320)'
+    assert sorig == pytest.approx(1861.978)
     assert corig == pytest.approx(7122.753868262877)
 
     compare(add_datadir_path(_canonical_img_filter_model))
@@ -1682,10 +1682,7 @@ def test_restore_img_filter_model(make_data_path, clean_astro_ui):
     cnew = ui.calc_stat()
     assert fnew == forig
     assert snew == pytest.approx(sorig)
-
-    # It should be this, but isn't for some reason
-    # assert cnew == pytest.approx(corig)
-    assert cnew == pytest.approx(1828.198211697685)
+    assert cnew == pytest.approx(corig)
 
 
 @requires_xspec


### PR DESCRIPTION
# Summary

Fix tests that started to fail once #1246 was merged.

# Details

This all comes down to the fact that 

1. I added tests to check the behavior for #1246 in PRs around the time of writing #1246
2. These tests were merged after #1246 was created
3. I never did a rebase when developing #1246 so I never picked up these new tests.

Serialization:

This test was added in #1247 which was merged after I had created PR #1246

Note that the behavior of this test nw makes sense (i.e. you get consistent behavior).

Data:

This test was added in #1244 which was created after #1246 was created. This is more a regression-style test, but I argue the output again makes more sense (but there's not a huge change here).