### PR TITLE
Make `DataPHA.get_x()` work if channels are not counted starting at 1.

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2224,7 +2224,7 @@ class DataPHA(Data1D):
 
     def _channel_to_energy(self, val, group=True, response_id=None):
         elo, ehi = self._get_ebins(response_id=response_id, group=group)
-        val = numpy.asarray(val).astype(numpy.int_) - 1
+        val = numpy.asarray(val - self.channel[0]).astype(numpy.int_)
         try:
             return (elo[val] + ehi[val]) / 2.0
         except IndexError:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1359,6 +1359,8 @@ class DataPHA(Data1D):
         The statistical and systematic errors for the data, if
         defined.
     bin_lo, bin_hi : array or None, optional
+        lower / upper bound for channels, in keV. If an ARF and/or RMF
+        is loaded, the values in the ARF will be used instead.
     grouping : array of int or None, optional
     quality : array of int or None, optional
     exposure : number or None, optional
@@ -1972,7 +1974,6 @@ class DataPHA(Data1D):
             resp = instrument.Response1D(self)
 
         return resp
-
 
     def _get_ebins(self, response_id=None, group=True):
         """Return the low and high edges of the independent axis.

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2622,3 +2622,20 @@ def test_pha_channel0_subtract():
         np.array([0, 1, 2, 0, 3, 1], dtype=np.int16)
     assert p1.get_dep(filter=True) == pytest.approx(expected[1:4])
     assert p0.get_dep(filter=True) == pytest.approx(expected[2:5])
+
+
+@pytest.mark.parametrize("channels", [[0, 1, 2, 3],
+                                      [1, 2, 3, 4],
+                                      [5, 6, 7, 8]])
+def test_pha_channel_noarfrmf(channels):
+    '''Check correct energies are returned for channels starting at 0 or 1.
+
+    Regression test for https://github.com/sherpa/sherpa/issues/1305
+    '''
+    bins = np.array([.2, .4, .6, .8, 1.])
+    testpha = DataPHA(name='testdata',
+                      channel=np.arange(4),
+                      counts=np.array([5, 6, 7, 8]),
+                      bin_lo=bins[:-1], bin_hi=bins[1:])
+    testpha.set_analysis('energy')
+    assert testpha.get_x() == pytest.approx([.3, .5, .7, .9])


### PR DESCRIPTION
## Summary
Make `DataPHA.get_x()` work if channels are not counted starting at 1.

## Details
See #1305 for details. OGIP allows any number as starting number to count channels, but calls out 0 and 1 as examples. Of course, this may break in other parts of the code, but let's fix them as we find them.

### Note
I'm pushing this up without running the tests locally because it's a pretty simple change and I don't have right now time to debug why I can't build sherpa locally any more. (some libraries not found).