### PR TITLE
test: add requires_data decorator

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -548,6 +548,7 @@ def test_counts(run_thread, fix_xspec):
     assert tlocals['pflux1'] == approx(1.6178938637, 1e-2)
 
 
+@requires_data
 @requires_fits
 @requires_xspec
 def test_stats_all(run_thread, fix_xspec):


### PR DESCRIPTION
# Summary

Add a needed decorator for a test. There's no functional change to the code.

# Details

This would only be triggered if you had a FITS backend but the test data was not available, in which case the test would fail because there was no data.