### PR TITLE
Add requires group test decorators

### DIFF
--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2014, 2015, 2016, 2018, 2019, 2020, 2021
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -26,7 +26,7 @@ import numpy as np
 
 import pytest
 
-from sherpa.utils.testing import requires_fits, requires_stk
+from sherpa.utils.testing import requires_fits, requires_group, requires_stk
 from sherpa.astro import ui
 from sherpa.astro import datastack
 from sherpa.astro.datastack import DataStack
@@ -797,6 +797,7 @@ def test_operations_datastack_subtract(ds_setup, ds_datadir):
 
 @requires_fits
 @requires_stk
+@requires_group
 def test_operations_datastack_group(ds_setup, ds_datadir):
     '''We are testing one of several grouping schemes here.'''
     datadir = ds_datadir

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2017, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -24,7 +25,8 @@ import numpy as np
 
 import pytest
 
-from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
+from sherpa.utils.testing import requires_data, requires_fits, requires_group, \
+    requires_xspec
 from sherpa.astro import ui
 from sherpa.models.basic import Box1D, Const1D
 
@@ -83,6 +85,7 @@ def assert_staterr(use_errors):
 
 @requires_fits
 @requires_data
+@requires_group
 @pytest.mark.parametrize("use_errors", [True, False])
 def test_scaling_staterr(make_data_path, use_errors):
     '''Regression test for https://github.com/sherpa/sherpa/issues/800
@@ -107,6 +110,7 @@ def test_scaling_staterr(make_data_path, use_errors):
 
 @requires_fits
 @requires_data
+@requires_group
 @pytest.mark.parametrize("use_errors", [True, False])
 def test_scaling_staterr_pha2(make_data_path, use_errors):
     '''Regression test for https://github.com/sherpa/sherpa/issues/800

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -28,7 +28,7 @@ from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.utils import parse_expr
 from sherpa.utils.err import DataErr
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 
 def _monotonic_warning(response_type, filename):
@@ -881,6 +881,7 @@ def test_rmf_get_x_unit():
 
 
 # https://github.com/sherpa/sherpa/pull/766
+@requires_group
 def test_ungroup():
     '''Make sure that ungrouped data can be ungrouped.
 
@@ -2538,6 +2539,7 @@ def test_pha_channel0_filtering():
     assert p0.get_dep(filter=True) == pytest.approx(counts[2:7])
 
 
+@requires_group
 def test_pha_channel0_grouping():
     """If channel starts at 0 does grouping still work?"""
 
@@ -2584,6 +2586,7 @@ def test_pha_channel0_grouping():
     assert p0.get_dep(filter=True) == pytest.approx(expected[2:5])
 
 
+@requires_group
 def test_pha_channel0_subtract():
     """If channel starts at 0 can we subtract the background?"""
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1067,6 +1067,7 @@ def test_get_filter_channel_ungrouped(make_data_path):
 
 @requires_data
 @requires_fits
+@requires_group
 def test_get_filter_channel_grouped(make_data_path):
     """What does get_filter return for grouped channel data.
 
@@ -1097,6 +1098,7 @@ def test_get_filter_channel_grouped(make_data_path):
 
 @requires_data
 @requires_fits
+@requires_group
 def test_get_filter_channel_grouped_prefiltered(make_data_path):
     """Add an energy filter before switching to channel space
 
@@ -1125,6 +1127,7 @@ def test_get_filter_channel_grouped_prefiltered(make_data_path):
 
 @requires_data
 @requires_fits
+@requires_group
 @pytest.mark.parametrize("analysis", ["energy", "wavelength", "channel"])
 def test_grouping_nofilter(analysis, make_data_path):
     """Can we change grouping (no filter).
@@ -1219,6 +1222,7 @@ def test_get_noticed_channels(analysis, make_data_path):
 
 @requires_data
 @requires_fits
+@requires_group
 @pytest.mark.parametrize("analysis", ["energy", "wavelength", "channel"])
 def test_grouping_filter(analysis, make_data_path):
     """Can we change grouping with energy units.
@@ -1251,6 +1255,7 @@ def test_grouping_filter(analysis, make_data_path):
 
 @requires_data
 @requires_fits
+@requires_group
 @pytest.mark.parametrize("analysis", ["energy", "wavelength", "channel"])
 def test_grouping_filtering_binning(analysis, make_data_path):
     """Low-level testing of test_grouping_filtering.

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -31,7 +31,7 @@ from sherpa.astro.data import DataARF, DataIMG, DataPHA
 from sherpa.astro.instrument import create_delta_rmf
 from sherpa.astro.utils._region import Region
 from sherpa.utils.err import DataErr
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 
 def test_can_not_group_ungrouped():
@@ -419,6 +419,7 @@ def test_288_b_energy():
     assert pha.mask == pytest.approx([True, False, True])
 
 
+@requires_group
 def test_grouping_non_numpy():
     """Historically the group* calls would fail oddly if y is not numpy
 
@@ -440,6 +441,7 @@ def test_grouping_non_numpy():
     assert pha.quality == pytest.approx(quality)
 
 
+@requires_group
 def test_416_a():
     """The first test case from issue #416
 
@@ -488,6 +490,7 @@ def test_416_a():
     assert dep == pytest.approx([3, 1])
 
 
+@requires_group
 def test_416_b(caplog):
     """The second test case from issue #416
 
@@ -540,6 +543,7 @@ def test_416_b(caplog):
         ]
 
 
+@requires_group
 def test_416_c():
     """The third test case from issue #416
 

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -54,7 +55,7 @@ from sherpa.models.basic import Const1D, StepHi1D
 from sherpa.stats import Chi2DataVar, CStat
 from sherpa.utils.err import ArgumentErr, DataErr
 
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 from sherpa.astro import ui
 
@@ -1373,6 +1374,7 @@ def test_get_staterror_file_errors_bg(filt, noticed, make_data_path):
 
 @requires_data
 @requires_fits
+@requires_group
 @pytest.mark.parametrize("filt", [False, True])
 @pytest.mark.parametrize("noticed", [False, True])
 def test_get_staterror_file_errors_bg_regrouped(filt, noticed, make_data_path):

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -28,7 +28,7 @@ from sherpa.data import Data1D
 from sherpa.models import Const1D
 from sherpa.ui.utils import Session
 from sherpa.utils.err import IdentifierErr
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 
 # bug #303
@@ -52,6 +52,7 @@ def test_show_bkg_model_with_bkg(make_data_path):
 
 
 # Fix 476 - this should be in sherpa/ui/tests/test_session.py
+@requires_group
 def test_zero_division_calc_stat():
     ui = AstroSession()
     x = numpy.arange(100)

--- a/sherpa/astro/ui/tests/test_astro_supports_pha2.py
+++ b/sherpa/astro/ui/tests/test_astro_supports_pha2.py
@@ -36,7 +36,7 @@ import pytest
 
 import numpy as np
 
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, requires_group
 from sherpa.utils.err import IdentifierErr
 
 from sherpa.astro import ui
@@ -191,6 +191,7 @@ def test_load_pha2(loader, id0, ids, make_data_path, caplog, clean_astro_ui):
 
 @requires_data
 @requires_fits
+@requires_group
 def test_load_pha2_compare_meg_order1(make_data_path, clean_astro_ui):
     """Do we read in the MEG +/-1 orders?"""
 
@@ -389,6 +390,7 @@ def test_list_response_ids_pha1(make_data_path, clean_astro_ui):
 
 @requires_data
 @requires_fits
+@requires_group
 def test_746(make_data_path, clean_astro_ui):
     """Test https://github.com/sherpa/sherpa/issues/746
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -404,6 +404,7 @@ def test_bug38_filtering(make_data_path):
 
 @requires_fits
 @requires_data
+@requires_group
 def test_bug38_filtering_grouping(make_data_path):
     """Low-level tests related to bugs #38, #917: filter+group"""
 


### PR DESCRIPTION
# Summary

Ensure the tests that require the group library are marked with the requires_group decorator.

# Details

To hit the need for this we need to be building with the following set in `setup.cfg`, which is rare, but necessary to get python 3.10 testing started thanks to #1316 

```
disable-group=True
```