### PR TITLE
Write-up that environment varaible in setup.cfg need to be expanded

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -133,7 +133,14 @@ variable ``ASCDS_LIB`` is set to the include directory, when the conda
 environment is activated. Thus, all that is needed is to disable the
 build of external dependencies and to set directories. The following
 lists the lines in ``setup.cfg`` that need to be modified (adjust
-xspec version as needed)::
+xspec version as needed). Note, however, that due to the way that the setup
+and install process works, environment variables need to be expanded by hand.
+So, if your ``ASCDS_LIB`` is set to, e.g.,
+``/data/user/conda/envs/sherpaciao/lib``,
+then you need to expand a line like
+``fftw-include_dirs=${ASCDS_LIB}/../include``
+to ``fftw-include_dirs=/data/user/conda/envs/sherpaciao/lib/../include``
+in the following list::
 
     # GROUP Python module
     disable-group=True

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -133,14 +133,7 @@ variable ``ASCDS_LIB`` is set to the include directory, when the conda
 environment is activated. Thus, all that is needed is to disable the
 build of external dependencies and to set directories. The following
 lists the lines in ``setup.cfg`` that need to be modified (adjust
-xspec version as needed). Note, however, that due to the way that the setup
-and install process works, environment variables need to be expanded by hand.
-So, if your ``ASCDS_LIB`` is set to, e.g.,
-``/data/user/conda/envs/sherpaciao/lib``,
-then you need to expand a line like
-``fftw-include_dirs=${ASCDS_LIB}/../include``
-to ``fftw-include_dirs=/data/user/conda/envs/sherpaciao/lib/../include``
-in the following list::
+xspec version as needed)::
 
     # GROUP Python module
     disable-group=True
@@ -172,6 +165,14 @@ in the following list::
     xspec_version = 12.10.1
     xspec_lib_dirs = ${ASCDS_LIB}
     xspec_include_dirs = ${ASCDS_LIB}/../include
+
+.. note::
+   Due to the way that the setup and install process works, environment
+   variables need to be expanded by hand. So, if your ``ASCDS_LIB`` is set to
+   ``/data/user/conda/envs/sherpaciao/lib`` then you need to expand a line like
+   ``fftw-include_dirs=${ASCDS_LIB}/../include``
+   to ``fftw-include_dirs=/data/user/conda/envs/sherpaciao/lib/../include``
+   in the list above.
 
 To avoid accidentially commiting the modified ``setup.cfg`` into git,
 the file can be marked as "assumed unchanged".


### PR DESCRIPTION
## Summary
Add a detail to developer docs about compiling in a conda ciao environment

fixes #1324
[skip ci]
(since this only changes text in the docs, not in the code)