### PR TITLE
Work around issue #1334

### DIFF
--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -848,6 +848,7 @@ class ReNormalizerModel1DInt(CompositeModel, ArithmeticModel):
 
 # TODO: more tests when regridding the models
 
+@pytest.mark.xfail  # see #1334
 def test_regrid1d_works_with_convolution_style():
     """This doesn't really test more than the previous
     model-evaluation tests.

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -645,7 +646,8 @@ def test_create_expr_mask_size_error(mask):
 
 @pytest.mark.parametrize("val,expected",
                          [(numpy.int16(3), "3"),
-                          (numpy.float32(3), "3.0")])
+                          pytest.param(numpy.float32(3), "3.0", marks=pytest.mark.xfail)  # see #1334
+                          ])
 def test_create_expr_singleton(val, expected):
     """Simple test of create_expr with no mask."""
 


### PR DESCRIPTION
# Summary

Allow the GitHub tests to pass while we work out what is happening with #1334

# Details

Mark the two tests noted in #1334 as xfail so that the CI builds will still work. This is not a fix, just a band aid.

I originally had added code that allowed the tests to pass

- `str(np.float(3))`
- calling the convolution call a second time

but it is probably cleaner to use xfail (as we can check when the tests actually work as the tests will tell you about the xpassed tests - e.g.

```
============================ 4959 passed, 406 skipped, 78 xfailed, 2 xpassed in 270.72s (0:04:30) ============================
```