### PR TITLE
Add codecov.yml to fix path issue and update codecov uploader

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,38 @@
+codecov:
+  require_ci_to_pass: yes
+  #this handles notifications for bots (slack, gitter, etc)
+  notify:    
+    after_n_builds: 8 #wait for 8 of the builds to finish and send their reports to send a notice, default is 2
+    wait_for_ci: yes
+  
+coverage:
+  precision: 2
+  round: down
+  range: "70...100" # aiming for 70 min coverage to be "good". default
+  # While codecov reports are buggy, we'll keep this informational. This means even if reports fail, Actions doesn't.
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+# This handles the github comment on PRs
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+  after_n_builds: 8 # wait for 8 builds to finish and send their reports to make a comment, default 2
+  
+# Fix issue with 'work/sherpa/sherpa' being considered a seperate directory 
+fixes:
+  - "work/sherpa/sherpa/::"  # move path   e.g., "before/path" => "after/path"

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -30,12 +30,10 @@ if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
 if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
 smokevars="${XSPECTEST} ${FITSTEST} -v 3"
 
-# Install coverage tooling and run tests using setuptools
 if [ ${TEST} == submodule ]; then
-    # pip install pytest-cov codecov;
-    conda install -yq pytest-cov codecov;
-    python setup.py -q test -a "--cov sherpa --cov-report term" || exit 1;
-    codecov;
+    conda install -yq pytest-cov;
+
+    python setup.py -q test -a "--cov sherpa --cov-report xml" || exit 1;
 fi
 
 # Run smoke test
@@ -45,8 +43,9 @@ sherpa_smoke ${smokevars} || exit 1
 # Run regression tests using sherpa_test
 if [ ${TEST} == package ] || [ ${TEST} == none ]; then
     cd $HOME;
-    conda install -yq pytest-cov codecov;
-    # This automatically picks up the sherpatest modile when TEST==package
-    sherpa_test --cov sherpa --cov-report term || exit 1;
-    codecov;
+    conda install -yq pytest-cov;
+    
+    # This automatically picks up the sherpatest module when TEST==package
+    sherpa_test --cov sherpa --cov-report xml || exit 1;
 fi
+

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -125,3 +125,10 @@ jobs:
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda activate build
         source .github/scripts/test.sh
+
+    - name: upload coverage
+      uses: codecov/codecov-action@v2
+      with:
+        # only select the reports that we know are coverage reports, from linux conda, mac conda, and pip
+        files: /home/runner/work/sherpa/sherpa/coverage.xml,/Users/runner/work/sherpa/sherpa/coverage.xml,/home/runner/coverage.xml
+        verbose: true

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -82,10 +82,16 @@ jobs:
       if: matrix.test-data == 'submodule'
       run: |
         pip install -r test_requirements.txt
-        pip install pytest-cov codecov
-        # cd ${HOME}
-        pytest --cov=sherpa
-        codecov
+        pip install pytest-cov 
+
+        pytest --cov=sherpa --cov-report=xml
+
+    - name: upload coverage
+      uses: codecov/codecov-action@v2
+      with:
+        # only select the reports that we know are coverage reports, from linux conda, mac conda, and pip
+        files: /home/runner/work/sherpa/sherpa/coverage.xml,/Users/runner/work/sherpa/sherpa/coverage.xml,/home/runner/coverage.xml
+        verbose: true
 
     - name: Smoke Test
       env: 


### PR DESCRIPTION
supersedes #1321, done to fix head branch.

# Summary
Fix path parsing issue on codecov as well as updated for the new codecov uploader

# Details

In investigating the codecov reports jumping around a lot and just not making a whole lot of sense (#903), it seems the file tree for every report has been split between the normal project root, "sherpa" and a failed attempt by codecov to fix some more complex paths from conda builds to "work/sherpa/sherpa/sherpa", causing inconsistencies in the reports. trying to examine these files on codecov in the 'work/sherpa/sherpa/sherpa' dir reports as not found, leading to strange behavior. This means all our reports since the beginning is not accurate. 

This PR is to fix with codecov's [path fix](https://docs.codecov.com/docs/fixing-paths) and also introduce a way to configure reports for enhancements in the future if we want them (such as reorganizing reports by test type, system, etc, or changing how reports are evaluated and displayed).

This PR also fixes #1320, changing the codecov installation in CI from conda/pip (the deprecated bash version), instead, using the codecov actions from Github. This also plays into the previous issue surprisingly. The codecov Github action exposes the selection of reports, which revealed that reports returned to codecov was several files, all but one of them being coverage reports. These were (likely) interfering with codecov, resulting in the strange issues we've been seeing.

## specific changes
Add a codecov.yml
- sets path fix from "work/sherpa/sherpa" to "" to correct weird path settings
- sets the number of builds to 8, in order to match those returned from CI jobs.
- tell codecov to only report 'informative'ly, to keep reports from failing CI runs (TBD if this is kept)

Move codecov install for all CI tests into a codecov task
- This action uses the new uploader, solving the deprecation issue
- exposes the file selection for each report, setting it results in reports, not including unrelated files codecov guessed to be correct, possibly confusing reports.
- change coverage reports from "term" to "xml", codecov prefers xml anyway, and couldn't find them with term.