### PR TITLE
tests: allow use of 'pytest --import-mode=importlib'

### DIFF
--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2014, 2015, 2016, 2018, 2019, 2020, 2021
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,9 +18,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import os
-import tempfile
 import logging
+import os
+import sys
+import tempfile
 
 import numpy as np
 
@@ -29,7 +30,12 @@ import pytest
 from sherpa.utils.testing import requires_fits, requires_stk
 from sherpa.astro import ui
 from sherpa.astro import datastack
-from sherpa.astro.datastack import DataStack
+
+# We can't seem to use a relative import here so hack the
+# path to allow it to be loaded (needed to support
+# pytest 6.2-ish 'pytest --import-mode=importlib')
+#
+sys.path.append(os.path.dirname(__file__))
 from acis_bkg_model import acis_bkg_model
 
 logger = logging.getLogger('sherpa')


### PR DESCRIPTION
# Summary

Support 'pytest --import-mode=importlib' added in pytest 6.0.

# Details

It's not clear that the import mode is going to change to importlib after all, but it's an interesting issue. For some definition of interesting.

This is a hack to support the importlib mode. Unfortunately the "correct" way, which @hamogu says is to add a `sherpa/astro/datastack/tests/__init__.py` file instead fails for me with the following (I also tried changing the import statement to `from .acis_bkg_model import acis_bkg_model` but this also fails).

Note the comment on pytest (in fact the whole issue):

- https://github.com/pytest-dev/pytest/issues/7245#issuecomment-685053997

```
%  pytest --import-mode=importlib
==================================================== test session starts =====================================================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/dburke/sherpa/sherpa-master, configfile: pytest.ini
plugins: forked-1.3.0, xdist-2.4.0, doctestplus-0.11.0
collected 5436 items / 1 error / 5435 selected

=========================================================== ERRORS ===========================================================
______________________________ ERROR collecting sherpa/astro/datastack/tests/test_datastack.py _______________________________
ImportError while importing test module '/home/dburke/sherpa/sherpa-master/sherpa/astro/datastack/tests/test_datastack.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
sherpa/astro/datastack/tests/test_datastack.py:39: in <module>
    from acis_bkg_model import acis_bkg_model
E   ModuleNotFoundError: No module named 'acis_bkg_model'
------------------------------------------------------ Captured stdout -------------------------------------------------------
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================== 1 error in 2.86s ======================================================
```

# Notes

Interestingly, I have long been annoyed that I can't run `pytest` if I've done an install

```
% pip install .
% pytest
==================================================== test session starts =====================================================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/dburke/sherpa/sherpa-master, configfile: pytest.ini
plugins: forked-1.3.0, xdist-2.4.0, doctestplus-0.11.0
collected 0 items / 1 error

=========================================================== ERRORS ===========================================================
_______________________________________________ ERROR collecting test session ________________________________________________
../../anaconda/envs/sherpa-master/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
../../anaconda/envs/sherpa-master/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
sherpa/conftest.py:30: in <module>
    from sherpa.utils.testing import get_datadir, set_datadir
sherpa/utils/__init__.py:42: in <module>
    from sherpa.utils._utils import hist1d, hist2d
E   ModuleNotFoundError: No module named 'sherpa.utils._utils'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================== 1 error in 0.75s ======================================================
```

but with this new mode it seems to work

```
% pytest --import-mode=importlib
==================================================== test session starts =====================================================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/dburke/sherpa/sherpa-master, configfile: pytest.ini
plugins: forked-1.3.0, xdist-2.4.0, doctestplus-0.11.0
collected 5449 items

sherpa/astro/datastack/tests/test_datastack.py .............                                                           [  0%]
sherpa/astro/io/tests/test_io.py s.sssss.                                                                              [  0%]
...
SKIPPED [1] sherpa/utils/tests/test_utils_unit.py:268: required test data missing
=========================== 4300 passed, 1072 skipped, 75 xfailed, 2 xpassed in 135.31s (0:02:15) ============================
```
