### PR TITLE
Minor internal code cleanup tracking errors

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -47,8 +47,7 @@ from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
 def test_load_table_model_fails_with_dir(tmp_path):
     """Check that the function fails with invalid input: directory
 
-    The temporary directory is used for this (the test is skipped if
-    it does not exist).
+    The temporary directory is used for this.
     """
 
     tmpdir = tmp_path / 'load_table_model'
@@ -67,8 +66,7 @@ def test_load_table_model_fails_with_dir(tmp_path):
 def test_load_xstable_model_fails_with_dir(tmp_path):
     """Check that the function fails with invalid input: directory
 
-    The temporary directory is used for this (the test is skipped if
-    it does not exist).
+    The temporary directory is used for this.
     """
 
     tmpdir = tmp_path / 'load_xstable_model'

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,20 +20,16 @@
 # Basic tests of sherpa.astro.ui.utils routines.
 #
 # This supplements test_astro_ui_ui.py (in that tests are being moved
-# out of a single file) but uses pytest instead of unittest.
+# out of a single file)
 #
 
 import os
-import tempfile
 
 import pytest
 
-# from numpy.testing import assert_almost_equal
-
 from sherpa.astro import ui
+from sherpa.utils.err import ArgumentTypeErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
-
-tmpdir = tempfile.gettempdir()
 
 
 # Note that the logic in load_table_model is quite convoluted,
@@ -48,38 +44,40 @@ tmpdir = tempfile.gettempdir()
 #
 
 @requires_fits
-@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
-                    reason='temp directory does not exist')
-def test_load_table_model_fails_with_dir():
+def test_load_table_model_fails_with_dir(tmp_path):
     """Check that the function fails with invalid input: directory
 
     The temporary directory is used for this (the test is skipped if
     it does not exist).
     """
 
+    tmpdir = tmp_path / 'load_table_model'
+    tmpdir.mkdir()
+
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
-        ui.load_table_model('tmpdir', tmpdir)
+        ui.load_table_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 
 
 @requires_fits
 @requires_xspec
-@pytest.mark.skipif(not(os.path.isdir(tmpdir)),
-                    reason='temp directory does not exist')
-def test_load_xstable_model_fails_with_dir():
+def test_load_xstable_model_fails_with_dir(tmp_path):
     """Check that the function fails with invalid input: directory
 
     The temporary directory is used for this (the test is skipped if
     it does not exist).
     """
 
+    tmpdir = tmp_path / 'load_xstable_model'
+    tmpdir.mkdir()
+
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOError):
-        ui.load_xstable_model('tmpdir', tmpdir)
+        ui.load_xstable_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 
@@ -172,3 +170,25 @@ def test_load_xstable_model_fails_with_text_column(make_data_path):
         ui.load_xstable_model('stringcol', infile)
 
     assert ui.list_model_components() == []
+
+
+class NonIterableObject:
+    """Something that tuple(..) of will error out on"""
+
+    pass
+
+
+@pytest.mark.parametrize("func",
+                         [ui.notice2d_id, ui.ignore2d_id,
+                          ui.notice2d_image, ui.ignore2d_image])
+def test_spatial_filter_errors_out_invalid_id(func):
+    """Just check we create the expected error message.
+
+    Somewhat contrived.
+    """
+
+    ids = NonIterableObject()
+    with pytest.raises(ArgumentTypeErr) as te:
+        func(ids)
+
+    assert str(te.value) == "'ids' must be an identifier or list of identifiers"""

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -28,7 +28,7 @@ import numpy
 import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, \
     create_non_delta_rmf, has_pha_response
-from sherpa.ui.utils import _argument_type_error, _check_type
+from sherpa.ui.utils import _check_type
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
     send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
@@ -7046,8 +7046,8 @@ class Session(sherpa.ui.utils.Session):
             try:
                 ids = tuple(ids)
             except TypeError:
-                _argument_type_error('ids',
-                                     'an identifier or list of identifiers')
+                raise ArgumentTypeErr('badarg', 'ids',
+                                      'an identifier or list of identifiers') from None
 
         for id in ids:
             _check_type(self.get_data(id), sherpa.astro.data.DataIMG,
@@ -7106,8 +7106,8 @@ class Session(sherpa.ui.utils.Session):
             try:
                 ids = tuple(ids)
             except TypeError:
-                _argument_type_error('ids',
-                                     'an identifier or list of identifiers')
+                raise ArgumentTypeErr('badarg', 'ids',
+                                      'an identifier or list of identifiers') from None
 
         for id in ids:
             _check_type(self.get_data(id), sherpa.astro.data.DataIMG,
@@ -7164,8 +7164,8 @@ class Session(sherpa.ui.utils.Session):
             try:
                 ids = tuple(ids)
             except TypeError:
-                _argument_type_error('ids',
-                                     'an identifier or list of identifiers')
+                raise ArgumentTypeErr('badarg', 'ids',
+                                      'an identifier or list of identifiers') from None
 
         for id in ids:
             _check_type(self.get_data(id), sherpa.astro.data.DataIMG,
@@ -7228,8 +7228,8 @@ class Session(sherpa.ui.utils.Session):
             try:
                 ids = tuple(ids)
             except TypeError:
-                _argument_type_error('ids',
-                                     'an identifier or list of identifiers')
+                raise ArgumentTypeErr('badarg', 'ids',
+                                      'an identifier or list of identifiers') from None
 
         for id in ids:
             _check_type(self.get_data(id), sherpa.astro.data.DataIMG,

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2017, 2019, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -22,23 +23,24 @@ There is a copy of this test in sherpa/ui/astro/tests/ that needs
 to be kept up to date.
 """
 
-from sherpa.utils.testing import requires_plotting, requires_xspec
-from sherpa.ui.utils import Session
+from io import StringIO
+import logging
+from unittest.mock import patch
+
 from numpy.testing import assert_array_equal
+
+import pytest
+
 from sherpa.models import parameter
 import sherpa.models.basic
 from sherpa import estmethods as est
 from sherpa import optmethods as opt
 from sherpa import stats
+from sherpa.ui.utils import Session
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     IdentifierErr, SessionErr
-
-import pytest
-
-from unittest.mock import patch
-
-from io import StringIO
-
+from sherpa.utils.logging import SherpaVerbosity
+from sherpa.utils.testing import requires_plotting, requires_xspec
 
 TEST = [1, 2, 3]
 TEST2 = [4, 5, 6]
@@ -579,3 +581,246 @@ def test_error_estimate_not_run(name):
         func()
 
     assert str(exc.value) == "data set bob has not been set"
+
+
+def test_set_source_invalid():
+
+    s = Session()
+    with pytest.raises(ArgumentErr) as ae:
+        s.set_source('2 * made_up.foo')
+
+    assert str(ae.value) == "invalid model expression: name 'made_up' is not defined"
+
+
+def test_paramprompt_default():
+    """The default setting is False."""
+
+    s = Session()
+    assert not s._paramprompt
+
+
+@pytest.mark.parametrize("flag", [True, "yes", "yeS", 1, "1", "on", "ON"])
+def test_paramprompt_set_true(flag):
+    """The default setting is False."""
+
+    s = Session()
+    s.paramprompt(flag)
+    assert s._paramprompt
+
+
+@pytest.mark.parametrize("flag", [False, "no", "No", 0, "0", "off", "OFF"])
+def test_paramprompt_set_false(flag):
+    """The default setting is False."""
+
+    s = Session()
+    s._paramprompt = True
+    s.paramprompt(flag)
+    assert not s._paramprompt
+
+
+def test_paramprompt_single_parameter_works(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO("223")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 0
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(223)
+    assert mdl.c0.min < -3e38
+    assert mdl.c0.max > 3e38
+
+
+def test_paramprompt_single_parameter_min_works(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO(",-100")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 0
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(1)
+    assert mdl.c0.min == pytest.approx(-100)
+    assert mdl.c0.max > 3e38
+
+
+def test_paramprompt_single_parameter_max_works(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO(",,100")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 0
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(1)
+    assert mdl.c0.min < -3e38
+    assert mdl.c0.max == pytest.approx(100)
+
+
+def test_paramprompt_single_parameter_combo_works(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO("-2,-10,10")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 0
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(-2)
+    assert mdl.c0.min == pytest.approx(-10)
+    assert mdl.c0.max == pytest.approx(10)
+
+
+def test_paramprompt_single_parameter_check_invalid(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO("typo\n-200")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 1
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "Please provide a float value; could not convert string to float: 'typo'"
+
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(-200)
+    assert mdl.c0.min < -3e38
+    assert mdl.c0.max > 3e38
+
+
+def test_paramprompt_single_parameter_check_invalid_min(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO(",typo\n,-200")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 1
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "Please provide a float value; could not convert string to float: 'typo'"
+
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(1)
+    assert mdl.c0.min == pytest.approx(-200)
+    assert mdl.c0.max > 3e38
+
+
+def test_paramprompt_single_parameter_check_invalid_max(caplog):
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO("-2,,typo\n-200,,-2")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 1
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "Please provide a float value; could not convert string to float: 'typo'"
+
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(-200)
+    assert mdl.c0.min < -3e38
+    assert mdl.c0.max == pytest.approx(-2)
+
+
+def test_paramprompt_single_parameter_check_invalid_max_out_of_bound(caplog):
+    """Note this creates two warnings"""
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.paramprompt(True)
+    assert len(caplog.records) == 0
+
+    with SherpaVerbosity('INFO'):
+        with patch("sys.stdin", StringIO(",,typo\n,,-200")):
+            s.set_source("scale1d.bob")
+
+    assert len(caplog.records) == 2
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "Please provide a float value; could not convert string to float: 'typo'"
+
+    lname, lvl, msg = caplog.record_tuples[1]
+    assert lname == "sherpa.models.parameter"
+    assert lvl == logging.WARN
+    assert msg == "parameter bob.c0 greater than new maximum; bob.c0 reset to -200"
+
+    mdl = s.get_model_component('bob')
+    assert mdl.c0.val == pytest.approx(-200)
+    assert mdl.c0.min < -3e38
+    assert mdl.c0.max == pytest.approx(-200)
+
+
+def test_add_user_pars_modelname_not_a_string():
+
+    s = Session()
+    with pytest.raises(ArgumentTypeErr) as exc:
+        s.add_user_pars(23, ['x'])
+
+    assert str(exc.value) == "'model name' must be a string"
+
+
+def test_add_user_pars_modelname_not_a_model1():
+
+    s = Session()
+    with pytest.raises(ArgumentTypeErr) as exc:
+        s.add_user_pars('not a model', ['x'])
+
+    assert str(exc.value) == "'not a model' must be a user model"
+
+
+def test_add_user_pars_modelname_not_a_model2():
+    """Use an actual model, but not a user model"""
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+    s.create_model_component('scale1d', 'foo')
+    with pytest.raises(ArgumentTypeErr) as exc:
+        s.add_user_pars('foo', ['x'])
+
+    assert str(exc.value) == "'foo' must be a user model"

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -5860,15 +5860,9 @@ class Session(NoNewAttributesAfterInit):
         if not self._paramprompt:
             return
 
-        try:
-            get_user_input = raw_input
-        except NameError:
-            get_user_input = input
-
         for par in pars:
             while True:
-                inval = get_user_input("%s parameter value [%g] " %
-                                       (par.fullname, par.val))
+                inval = input(f"{par.fullname} parameter value [{par.val}] ")
                 if inval == "":
                     break
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1900,13 +1900,13 @@ class Session(NoNewAttributesAfterInit):
         >>> set_iter_method('none')
 
         """
-        if isinstance(meth, string_types):
-            if meth in self._itermethods:
-                self._current_itermethod = self._itermethods[meth]
-            else:
-                raise TypeError(meth + ' is not an iterative fitting method')
-        else:
+        if not isinstance(meth, string_types):
             _argument_type_error(meth, 'a string')
+
+        if meth in self._itermethods:
+            self._current_itermethod = self._itermethods[meth]
+        else:
+            raise TypeError(f'{meth} is not an iterative fitting method')
 
     def set_iter_method_opt(self, optname, val):
         """Set an option for the iterative-fitting scheme.
@@ -5682,8 +5682,8 @@ class Session(NoNewAttributesAfterInit):
     def _eval_model_expression(self, expr, typestr='model'):
         try:
             return eval(expr, self._model_globals, self._model_components)
-        except:
-            raise ArgumentErr('badexpr', typestr, sys.exc_info()[1])
+        except Exception as exc:
+            raise ArgumentErr('badexpr', typestr, sys.exc_info()[1]) from exc
 
     def list_model_ids(self):
         """List of all the data sets with a source expression.
@@ -5881,21 +5881,21 @@ class Session(NoNewAttributesAfterInit):
                     try:
                         val = float(tokens[0])
                     except Exception as e:
-                        info("Please provide a float value; " + str(e))
+                        info(f"Please provide a float value; {e}")
                         continue
 
                 if ntokens > 1 and tokens[1] != '':
                     try:
                         minval = float(tokens[1])
                     except Exception as e:
-                        info("Please provide a float value; " + str(e))
+                        info(f"Please provide a float value; {e}")
                         continue
 
                 if ntokens > 2 and tokens[2] != '':
                     try:
                         maxval = float(tokens[2])
                     except Exception as e:
-                        info("Please provide a float value; " + str(e))
+                        info(f"Please provide a float value; {e}")
                         continue
 
                 try:
@@ -8187,7 +8187,7 @@ class Session(NoNewAttributesAfterInit):
 
                 model.guess(*self.get_data(id).to_guess(), **kwargs)
             except NotImplementedError:
-                info('WARNING: No guess found for %s' % model.name)
+                info(f'WARNING: No guess found for {model.name}')
             return
 
         ids, f = self._get_fit(self._fix_id(id))
@@ -12035,7 +12035,7 @@ class Session(NoNewAttributesAfterInit):
             try:
                 plotname = allowed_types[plottype]
             except KeyError:
-                raise ArgumentErr('badplottype', plottype)
+                raise ArgumentErr('badplottype', plottype) from None
 
             # Collect the arguments for the get_<>_plot/contour
             # call. Loop through until we hit a supported

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -73,17 +73,6 @@ def _is_integer(val):
     return isinstance(val, (int, numpy.integer))
 
 
-def _fix_array(arg, argname, ndims=1):
-    try:
-        arg = numpy.asarray(arg, SherpaFloat)
-        if len(arg.shape) != ndims:
-            raise TypeError
-    except TypeError:
-        raise ArgumentTypeErr('badarg', argname, f'a {ndims}-D array') from None
-
-    return arg
-
-
 def _is_subclass(t1, t2):
     return inspect.isclass(t1) and issubclass(t1, t2) and (t1 is not t2)
 
@@ -5406,17 +5395,6 @@ class Session(NoNewAttributesAfterInit):
         if require and (cmpt is None):
             raise IdentifierErr('nomodelcmpt', name)
         return cmpt
-
-    def _get_user_stat(self, statname):
-        userstat = statname
-        if not isinstance(statname, sherpa.stats.Stat):
-            if type(statname) is not str:
-                raise ArgumentTypeErr('badarg', "stat name",
-                                      "an instance or a string")
-
-            userstat = self._get_model_component(statname, True)
-
-        return userstat
 
     # DOC-TODO: can send in a model variable, but this is just the
     # identity function, so not worth documenting


### PR DESCRIPTION
# Summary

Minor internal changes to how some errors are raised. There should be no user-visible differences due to this changes.

# Details

For several cases where errors are caught and re-thrown we now use the `from` statement to say whether to link the original and new error: mostly these are `from None` since this simplifies the traceback, but in at least one case we do link errors (which also improves the traceback). This is only useful if you hit an error and are looking at the tracebaack!

In doing the above I noted we had a routine whose sole purpose was to raise an error. This made it hard to do the `from None` case and whilst this could have been addressed, I felt it was cleared to just raise the error directly - it does not significantly increase the code and, I believe, actually makes it a little easier to follow (since you had to know that the original routine raised an error when reading the code).

There's a couple of unused routines (one is now unused because of the earlier changes) that have been removed, and some minor code-style changes (e.g. moving a check on whether an argument is valid to the start of the routine).

After creating these changes I ran them through CI to see what lines were untested and then added tests to cover those cases.