### PR TITLE
Fix issue with delete_model_component

### DIFF
--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -912,7 +912,7 @@ def test_delete_model_component_invalid_argument():
 
 
 def test_delete_model_component_not_a_component():
-    """We could allow the component to be deleted this way"""
+    """Check correct error message for non-exitant model"""
 
     s = Session()
     with pytest.raises(IdentifierErr) as te:

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -921,7 +921,6 @@ def test_delete_model_component_not_a_component():
     assert str(te.value) == "model component 'tst' does not exist"
 
 
-@pytest.mark.xfail
 def test_delete_model_component_warning(caplog):
     """Check we get a warning (which ends up being issue #16)"""
 
@@ -956,11 +955,8 @@ def test_issue_16():
     assert s.list_model_ids() == [1, 'tst']
     assert s.list_model_components() == ['pl1', 'pltst']
 
-    # This should not be throwing an error
     s.delete_model(id='tst')
-    with pytest.raises(KeyError):
-        s.delete_model_component("pltst")
-
+    s.delete_model_component("pltst")
     s.delete_data(id='tst')
 
     assert s.list_data_ids() == [1]

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -939,6 +939,8 @@ def test_delete_model_component_warning(caplog):
     assert lvl == logging.WARNING
     assert msg == "the model component 'gauss1d.mdl2' is found in model 1 and cannot be deleted"
 
+    assert s.list_model_components() == ['mdl', 'mdl2']
+
 
 def test_issue_16():
     """Check one of the examples from #16"""


### PR DESCRIPTION
# Summary

The delete_model_component call could fail in certain circumstances, so fix those cases. Fixes #16 

# Details

The first commit is to add tests to check the existing code. The next commit fixes #16, which is just a problem with the code not recognizing that a key may not exist. The replacement code does slightly more work than it needs to do (i.e. if all the logic were in the if statement it could take advantage of lazy evaluation) but this is not a time critical routine and ease-of-reading is a benefit here.