### PR TITLE
Minor cleanup of the I/O code

### DIFF
--- a/sherpa/astro/io/tests/test_backend_switch.py
+++ b/sherpa/astro/io/tests/test_backend_switch.py
@@ -17,6 +17,10 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+import importlib
+from unittest.mock import patch
+
 import pytest
 
 from sherpa.utils.testing import requires_data, requires_fits
@@ -50,3 +54,156 @@ def test_backend_switch(make_data_path):
     infile = make_data_path("9774.pi")
     ui.load_pha(infile)
     assert ui.get_data().name.endswith('9774.pi')
+
+
+def test_io_load_config_invalid_io_pkg(tmp_path):
+    """What happens when io_pkg is invalid?
+
+    Technically not a backend switch, but fits in with
+    the "reload" feature.
+    """
+
+    conf = tmp_path / 'test-config.rc'
+    conf.write_text("""[options]
+io_pkg : not_a_module
+""", encoding='ascii')
+
+    with patch("sherpa.get_config", lambda: str(conf)):
+        mod = importlib.reload(io)
+
+    assert mod.backend is None
+
+    # Restore the import
+    mod = importlib.reload(io)
+
+
+def test_io_load_config_ogip_min_energy_negative(tmp_path):
+    """What happens when ogip.minimum_energy is < 0?
+
+    Technically not a backend switch, but fits in with
+    the "reload" feature.
+    """
+
+    conf = tmp_path / 'test-config.rc'
+    conf.write_text("""[options]
+io_pkg : dummy
+
+[ogip]
+minimum_energy = -2
+""", encoding='ascii')
+
+    with patch("sherpa.get_config", lambda: str(conf)):
+        with pytest.raises(ValueError) as ve:
+            importlib.reload(io)
+
+    assert str(ve.value) == 'Invalid value for [ogip] minimum_energy config value; it must be None or a float > 0'
+
+    # Restore the import
+    importlib.reload(io)
+
+
+def test_io_load_config_ogip_min_energy_invalid(tmp_path):
+    """What happens when ogip.minimum_energy is not numeric?
+
+    Technically not a backend switch, but fits in with
+    the "reload" feature.
+    """
+
+    conf = tmp_path / 'test-config.rc'
+    conf.write_text("""[options]
+io_pkg : dummy
+
+[ogip]
+minimum_energy = foo
+""", encoding='ascii')
+
+    with patch("sherpa.get_config", lambda: str(conf)):
+        with pytest.raises(ValueError) as ve:
+            importlib.reload(io)
+
+    assert str(ve.value) == 'Invalid value for [ogip] minimum_energy config value; it must be None or a float > 0'
+
+    # Restore the import
+    importlib.reload(io)
+
+
+def test_io_load_config_ogip_min_energy_none(tmp_path):
+    """What happens when ogip.minimum_energy is none?
+
+    Technically not a backend switch, but fits in with
+    the "reload" feature.
+    """
+
+    conf = tmp_path / 'test-config.rc'
+    conf.write_text("""[options]
+io_pkg : dummy
+
+[ogip]
+minimum_energy = NONE
+""", encoding='ascii')
+
+    orig = io.ogip_emin
+    assert orig is not None
+
+    with patch("sherpa.get_config", lambda: str(conf)):
+        mod = importlib.reload(io)
+
+    assert mod.ogip_emin is None
+
+    # Restore the import
+    mod = importlib.reload(io)
+    assert mod.ogip_emin == orig
+
+
+def test_io_load_config_ogip_min_energy_set(tmp_path):
+    """What happens when ogip.minimum_energy is valid?
+
+    Technically not a backend switch, but fits in with
+    the "reload" feature.
+    """
+
+    conf = tmp_path / 'test-config.rc'
+    conf.write_text("""[options]
+io_pkg : dummy
+
+[ogip]
+minimum_energy = 0.2
+""", encoding='ascii')
+
+    orig = io.ogip_emin
+    assert orig is not None
+
+    with patch("sherpa.get_config", lambda: str(conf)):
+        mod = importlib.reload(io)
+
+    assert mod.ogip_emin == pytest.approx(0.2)
+
+    # Restore the import
+    mod = importlib.reload(io)
+    assert mod.ogip_emin == orig
+
+
+def test_io_load_config_ogip_min_energy_unset(tmp_path):
+    """What happens when ogip.minimum_energy is not set?
+
+    Technically not a backend switch, but fits in with
+    the "reload" feature.
+    """
+
+    conf = tmp_path / 'test-config.rc'
+    conf.write_text("""[options]
+io_pkg : dummy
+""", encoding='ascii')
+
+    orig = io.ogip_emin
+    assert orig is not None
+
+    with patch("sherpa.get_config", lambda: str(conf)):
+        mod = importlib.reload(io)
+
+    # the default is 1e-10, which should match orig
+    assert mod.ogip_emin == pytest.approx(1e-10)
+    assert orig == pytest.approx(1e-10)
+
+    # Restore the import
+    mod = importlib.reload(io)

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,21 +37,20 @@ def _is_subclass(t1, t2):
 
 def _check_args(size, dstype):
     # Find the number of required args minus self, filename
-    req_args = (get_num_args(dstype.__init__)[1] - 2)
+    req_args = get_num_args(dstype.__init__)[1] - 2
 
     if size < req_args:
         # raise IOErr('badargs', dstype.__name__, req_args)
-        raise TypeError("data set '%s' takes at least %s args" %
-                        (dstype.__name__, req_args))
+        raise TypeError(f"data set '{dstype.__name__}' takes at least {req_args} args")
 
 
 def read_file_data(filename, sep=' ', comment='#', require_floats=True):
     bad_chars = '\t\n\r,;: |'
-    fp = open(filename, 'r')
     raw_names = []
     rows = []
-    try:
-        for line in fp:
+
+    with open(filename, 'r') as fh:
+        for line in fh:
             for char in bad_chars:
                 if char in line:
                     # replace any bad chars in line with sep for tokenize
@@ -75,9 +75,6 @@ def read_file_data(filename, sep=' ', comment='#', require_floats=True):
                 # make list of row elements
                 rows.append(row)
 
-    finally:
-        fp.close()
-
     # rotate rows into list of columns
     cols = numpy.column_stack(rows)
 
@@ -88,7 +85,7 @@ def read_file_data(filename, sep=' ', comment='#', require_floats=True):
             args.append(col.astype(SherpaFloat))
         except ValueError:
             if require_floats:
-                raise ValueError("The file {} could not ".format(filename) +
+                raise ValueError(f"The file {filename} could not " +
                                  "be loaded, probably because it contained " +
                                  "spurious data and/or strings")
             args.append(col)
@@ -453,22 +450,20 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
             raise IOErr('arraysnoteq')
 
     args = numpy.column_stack(numpy.asarray(args))
-
-    f = open(filename, 'w')
-
-    if fields is not None:
-        f.write(comment + sep.join(fields) + linebreak)
-
     lines = []
     for arg in args:
         line = [format % elem for elem in arg]
         lines.append(sep.join(line))
 
-    f.write(linebreak.join(lines))
+    with open(filename, 'w') as fh:
 
-    # add a newline at end
-    f.write(linebreak)
-    f.close()
+        if fields is not None:
+            fh.write(comment + sep.join(fields) + linebreak)
+
+        fh.write(linebreak.join(lines))
+
+        # add a newline at end
+        fh.write(linebreak)
 
 
 def write_data(filename, dataset, fields=None, sep=' ', comment='#',


### PR DESCRIPTION
# Summary

Minor internal clean-up of the I/O code. There should be no user-visible changes.

# Details

There's a number of changes, mainly pointed out by pylint. This was originally meant to be a fix for #47 but these changes are worth taking AND the fix for #47 is likely to be larger than I originally expected.

There's technically one user-facing change, as there are two places where

```python
    try:
        something-complex()
    except:
        ignore-this-error()
```

has been changed to only catch `Exception` errors. Ideally we'd restrict further - e.g. to `OSError` - but without careful vetting I can't be sure this is safe. I strongly  believe that restricting to `Exception` is safe, as this only stops "non-Python" errors from being caught - like control-c or OOM cases. I have seen cases where control-c has not been noticed by Sherpa thanks to bits of (old) code like this, which is not ideal.
