### PR TITLE
Remove `point` plotting in backend

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -88,7 +88,7 @@ backend.init()
 
 plotter = backend
 
-__all__ = ('Plot', 'Contour', 'Point', 'Histogram',
+__all__ = ('Plot', 'Contour', 'Histogram',
            'HistogramPlot', 'DataHistogramPlot',
            'ModelHistogramPlot', 'SourceHistogramPlot',
            'PDFPlot', 'CDFPlot', 'LRHistogram',
@@ -2711,9 +2711,9 @@ class Confidence2D(DataContour, Point):
 
         # Note: the user arguments are not applied to the point
         #
-        point = Point()
-        point.point_prefs = self.point_prefs
-        point.point(self.parval0, self.parval1,
+        point = Plot()
+        point.plot_prefs = self.point_prefs
+        point.plot(self.parval0, self.parval1,
                     overplot=True, clearwindow=False)
 
         if self.log[0]:

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -308,7 +308,7 @@ class Plot(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        x, y
+        x, y : array-like (scalar, list, or array)
            The data values to plot. They should have the same length.
         yerr, xerr : optional
            The symmetric errors to apply to the y or x values, or `None`

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -30,7 +30,7 @@ from sherpa.utils import formatting
 from sherpa.plot.utils import histogram_line
 
 
-__all__ = ('clear_window', 'point', 'plot', 'histo', 'contour', 'set_subplot',
+__all__ = ('clear_window', 'plot', 'histo', 'contour', 'set_subplot',
            'init', 'get_split_plot_defaults', 'get_plot_defaults', 'begin',
            'end', 'get_data_plot_defaults', 'get_model_plot_defaults',
            'exceptions', 'get_fit_plot_defaults', 'get_resid_plot_defaults',
@@ -191,20 +191,6 @@ def find_zorder(axes):
         return max(zs) + 0.1
 
     return None
-
-
-def point(x, y, overplot=True, clearwindow=False,
-          symbol=None, alpha=None,
-          color=None):
-
-    axes = setup_axes(overplot, clearwindow)
-
-    if color is None:
-        style = '{}'.format(symbol)
-    else:
-        style = '{}{}'.format(color, symbol)
-
-    axes.plot(numpy.array([x]), numpy.array([y]), style, alpha=alpha)
 
 
 def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
@@ -586,7 +572,7 @@ def get_plot_defaults():
 
 
 def get_point_defaults():
-    return get_keyword_defaults(point, 2)
+    return {'marker': None, 'alpha': None, 'color': None}
 
 
 def get_histo_defaults():
@@ -595,7 +581,7 @@ def get_histo_defaults():
 
 def get_confid_point_defaults():
     d = get_point_defaults()
-    d['symbol'] = '+'
+    d['marker'] = '+'
     return d
 
 


### PR DESCRIPTION
# Summary
Remove the `point` method in the definition of the plotting backend.

# Details
The definition of the `point` method in the backend was inconsistent with the other plotting methods in argument (e.g. it lacked parameters such as title, xlabel, ...) and in parameter names (what was called symbol here, is called marker
elsewhere).
The `point` method is just a thin wrapper around `plot` itself - `plot` supports scatter plots with symbols, so it can be removed.

For users, this is an API change in that `point_prefs` attribute of the `Confidence2D` plot object now has an entry `marker` instead of `symbol`, so anyone who manually set the `symbol` in that dictionary will have to update their code to set the `marker` instead. (If this sounds esoteric, that's because it is. I doubt that anyone outside the dev group has ever set `symbol` in the `point_prefs` manually.)

# Context
In the context of #1356, I'm trying to understand how plotting backends are
defined and to write down a formal API that we can test existing and future
backends against. I'm also hoping to be able to automate some of the code
translating plotting options from sherpa to different backends (e.g. in Sherpa
`+` is a maker, while in bokeh the same marker is called `"plus"`) and the fact
that the calling signature of `point` was so different from `plot`, `histogram`,
and friends is that problem for that. Since `point` is only a warpper around `plot`,
removing the entire method simplifies the definition of plotting backends at
no cost.

PRs #1191 and #1356 will have to be rebased on this and modified (for #1356 this is a simplification), so it would be great to make a decision on this soon.

# Test
We do not test pixel-by-pixel outcomes, so, for reference, here is an example plot that looks exactly the same before and after applying this PR:
```
import numpy as np
from sherpa.astro import ui
x = np.arange(100)
ui.load_arrays('test', x, x + np.random.rand(100))
ui.set_source('test', ui.polynom1d('poly'))
poly.c1.frozen=False
ui.fit('test')
ui.reg_proj(poly.c0, poly.c1)
```
![image](https://user-images.githubusercontent.com/498688/142881045-ce08d21a-0451-4dce-9aef-dd887bb765f9.png)
