### PR TITLE
Improve writing out data objects as a table (fix #47)

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4170,8 +4170,8 @@ class DataPHA(Data1D):
 
 class DataIMG(Data2D):
     "Image data set, including functions for coordinate transformations"
-    _fields = Data2D._fields
-    _extra_fields = ("sky", "eqpos", "coord", "header")
+
+    _extra_fields = ("sky", "eqpos", "coord")
 
     def _get_coord(self):
         return self._coord
@@ -4591,8 +4591,6 @@ class DataIMG(Data2D):
 
 
 class DataIMGInt(DataIMG):
-    _fields = Data2DInt._fields
-    _extra_fields = ("sky", "eqpos", "coord")
 
     def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None,
                  staterror=None, syserror=None, sky=None, eqpos=None,

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -247,31 +247,29 @@ def make_metadata(header, items):
     return meta
 
 
-def _extract_fields(obj, stop, summary, open_block=True):
-    """Extract the fields up until the stop field.
+def _extract_fields(obj, summary):
+    """Extract the "column" fields.
+
+    Write out the _fields values (that are not None) for the Data
+    object. The _extra_fields values are ignored, as thet are assumed
+    to be icluded in separate "metadata" section.
 
     Parameters
     ----------
     obj : Data instance
-        It has to have a _fields attribute
-    stop : str
-        The attribute at which to stop (and is not included).
     summary : str
         The label for the details tab.
-    open_block : bool, optional
-        Is the details tab open or closed?
 
     Returns
     -------
     html : str
         The HTML for this section.
+
     """
 
     meta = []
-    for f in obj._fields[1:]:
-        if f == stop:
-            break
-
+    fields = [f for f in obj._fields if f != 'name']
+    for f in fields:
         v = getattr(obj, f)
         if v is None:
             continue
@@ -279,7 +277,7 @@ def _extract_fields(obj, stop, summary, open_block=True):
         meta.append((f.upper(), v))
 
     return formatting.html_section(meta, summary=summary,
-                                   open_block=open_block)
+                                   open_block=True)
 
 
 def html_pha(pha):
@@ -298,7 +296,7 @@ def html_pha(pha):
         out = None
 
     if out is None:
-        out = _extract_fields(pha, 'grouped', 'PHA Data')
+        out = _extract_fields(pha, 'PHA Data')
 
     ls.append(out)
 
@@ -477,7 +475,7 @@ def html_arf(arf):
         out = None
 
     if out is None:
-        out = _extract_fields(arf, 'exposure', 'ARF Data')
+        out = _extract_fields(arf, 'ARF Data')
 
     ls.append(out)
 
@@ -539,7 +537,7 @@ def html_rmf(rmf):
     if svg is not None:
         out = formatting.html_svg(svg, 'RMF Plot')
     else:
-        out = _extract_fields(rmf, 'ethresh', 'RMF Data')
+        out = _extract_fields(rmf, 'RMF Data')
 
     ls.append(out)
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -251,8 +251,8 @@ def _extract_fields(obj, summary):
     """Extract the "column" fields.
 
     Write out the _fields values (that are not None) for the Data
-    object. The _extra_fields values are ignored, as thet are assumed
-    to be icluded in separate "metadata" section.
+    object. The _extra_fields values are ignored, as they are assumed
+    to be included in separate "metadata" section.
 
     Parameters
     ----------

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1031,14 +1031,6 @@ class DataARF(DataOgipResponse):
         self.energ_hi = energ_hi
         Data1DInt.__init__(self, name, energ_lo, energ_hi, specresp)
 
-    def __str__(self):
-        # Print the metadata first
-        try:
-            ss = Data.__str__(self)
-        except:
-            ss = self._fields
-        return ss
-
     def _repr_html_(self):
         """Return a HTML (string) representation of the ARF
         """
@@ -1162,18 +1154,6 @@ class DataRMF(DataOgipResponse):
         self._lo = energ_lo
         self._hi = energ_hi
         Data1DInt.__init__(self, name, energ_lo, energ_hi, matrix)
-
-    def __str__(self):
-        # Print the metadata first
-        old = self._fields
-        ss = old
-        try:
-            self._fields = tuple(filter((lambda x: x != 'header'),
-                                        self._fields))
-            ss = Data.__str__(self)
-        finally:
-            self._fields = old
-        return ss
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the RMF
@@ -1615,18 +1595,6 @@ class DataPHA(Data1D):
         self.units = 'channel'
         self.quality_filter = None
         Data1D.__init__(self, name, channel, counts, staterror, syserror)
-
-    def __str__(self):
-        # Print the metadata first
-        old = self._fields
-        ss = old
-        try:
-            self._fields = tuple(filter((lambda x: x != 'header'),
-                                        self._fields))
-            ss = Data.__str__(self)
-        finally:
-            self._fields = old
-        return ss
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the PHA
@@ -4246,18 +4214,6 @@ class DataIMG(Data2D):
         self.header = {} if header is None else header
         self._region = None
         Data2D.__init__(self, name, x0, x1, y, shape, staterror, syserror)
-
-    def __str__(self):
-        # Print the metadata first
-        old = self._fields
-        ss = old
-        try:
-            self._fields = tuple(filter((lambda x: x != 'header'),
-                                        self._fields))
-            ss = Data.__str__(self)
-        finally:
-            self._fields = old
-        return ss
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the data

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -308,17 +308,15 @@ def html_pha(pha):
         meta.append(('Identifier', pha.name))
 
     if pha.exposure is not None:
-        meta.append(('Exposure', '{:g} s'.format(pha.exposure)))
+        meta.append(('Exposure', f'{pha.exposure:g} s'))
 
     meta.append(('Number of bins', len(pha.channel)))
-
-    meta.append(('Channel range', '{} - {}'.format(int(pha.channel[0]),
-                                                   int(pha.channel[-1]))))
+    meta.append(('Channel range', f'{int(pha.channel[0])} - {int(pha.channel[-1])}'))
 
     # Although assume the counts are integers, do not force this
     cmin = pha.counts.min()
     cmax = pha.counts.max()
-    meta.append(('Count range', '{} - {}'.format(cmin, cmax)))
+    meta.append(('Count range', f'{cmin} - {cmax}'))
 
     if pha.background_ids != []:
         if pha.subtracted:
@@ -334,7 +332,7 @@ def html_pha(pha):
     if pha.grouping is not None:
         if pha.grouped:
             ngrp = pha.apply_grouping(pha.counts).size
-            msg = 'Applied ({} groups)'.format(ngrp)
+            msg = f'Applied ({ngrp} groups)'
         else:
             msg = 'Not applied'
 
@@ -345,7 +343,7 @@ def html_pha(pha):
     fexpr = pha.get_filter_expr()
     bintype = 'groups' if pha.grouped else 'channels'
     nbins = pha.get_dep(filter=True).size
-    meta.append(('Using', '{} with {} {}'.format(fexpr, nbins, bintype)))
+    meta.append(('Using', f'{fexpr} with {nbins} {bintype}'))
 
     ls.append(formatting.html_section(meta, summary='Summary',
                                       open_block=True))
@@ -370,7 +368,7 @@ def html_pha(pha):
                           ('HDUCLAS2', 'Data stored'),
                           ('HDUCLAS3', 'Data format'),
                           ('HDUCLAS4', 'PHA format'),
-                          ('XFLT0001', 'XEPC filter 0001')])
+                          ('XFLT0001', 'XSPEC filter 0001')])
 
     if meta is not None:
         ls.append(formatting.html_section(meta, summary='Metadata'))
@@ -398,7 +396,7 @@ def _calc_erange(elo, ehi):
     e1 = elo[0]
     e2 = ehi[-1]
     emin, emax = (e1, e2) if e1 <= e2 else (e2, e1)
-    erange = '{:g} - {:g} keV'.format(emin, emax)
+    erange = f'{emin:g} - {emax:g} keV'
 
     # Randomly pick 1% as the cut-off for a constant bin width
     #
@@ -411,9 +409,9 @@ def _calc_erange(elo, ehi):
         dedelta = 1
 
     if dedelta <= 0.01:
-        erange += ', bin size {:g} keV'.format(demax)
+        erange += f', bin size {demax:g} keV'
     else:
-        erange += ', bin size {:g} - {:g} keV'.format(demin, demax)
+        erange += f', bin size {demin:g} - {demax:g} keV'
 
     return erange
 
@@ -436,7 +434,7 @@ def _calc_wrange(wlo, whi):
     w1 = wlo[0]
     w2 = whi[-1]
     wmin, wmax = (w1, w2) if w1 <= w2 else (w2, w1)
-    wrange = '{:g} - {:g} &#8491;'.format(wmin, wmax)
+    wrange = f'{wmin:g} - {wmax:g} &#8491;'
 
     # Randomly pick 1% as the cut-off for a constant bin width
     #
@@ -449,9 +447,9 @@ def _calc_wrange(wlo, whi):
         dwdelta = 1
 
     if dwdelta <= 0.01:
-        wrange += ', bin size {:g} &#8491;'.format(dwmax)
+        wrange += f', bin size {dwmax:g} &#8491;'
     else:
-        wrange += ', bin size {:g} - {:g} &#8491;'.format(dwmin, dwmax)
+        wrange += f', bin size {dwmin:g} - {dwmax:g} &#8491;'
 
     return wrange
 
@@ -489,7 +487,7 @@ def html_arf(arf):
         meta.append(('Identifier', arf.name))
 
     if arf.exposure is not None:
-        meta.append(('Exposure', '{:g} s'.format(arf.exposure)))
+        meta.append(('Exposure', f'{arf.exposure:g} s'))
 
     meta.append(('Number of bins', len(arf.specresp)))
 
@@ -504,7 +502,7 @@ def html_arf(arf):
 
     a1 = numpy.min(arf.specresp)
     a2 = numpy.max(arf.specresp)
-    meta.append(('Area range', '{:g} - {:g} cm<sup>2</sup>'.format(a1, a2)))
+    meta.append(('Area range', f'{a1:g} - {a2:g} cm<sup>2</sup>'))
 
     ls.append(formatting.html_section(meta, summary='Summary',
                                       open_block=True))
@@ -556,12 +554,11 @@ def html_rmf(rmf):
     erange = _calc_erange(rmf.energ_lo, rmf.energ_hi)
     if rmf.ethresh is not None and rmf.energ_lo[0] <= rmf.ethresh:
         # Not entirely happy with the wording of this
-        erange += ' (minimum threshold of {} was used)'.format(rmf.ethresh)
+        erange += f' (minimum threshold of {rmf.ethresh} was used)'
 
     meta.append(('Energy range', erange))
 
-    meta.append(('Channel range', '{} - {}'.format(int(rmf.offset),
-                                                   int(rmf.offset + rmf.detchans - 1))))
+    meta.append(('Channel range', f'{int(rmf.offset)} - {int(rmf.offset + rmf.detchans - 1)}'))
 
     # Could show the energy range as given by e_min/e_max but
     # is this useful?
@@ -603,11 +600,11 @@ def html_img(img):
 
     svg = img_plot(img)
     if svg is not None:
-        out = formatting.html_svg(svg, '{} Plot'.format(dtype))
+        out = formatting.html_svg(svg, f'{dtype} Plot')
         summary = ''
     else:
         # Only add prefix to summary if there's no plot
-        summary = '{} '.format(dtype)
+        summary = f'{dtype} '
 
         # Summary properties
         #
@@ -649,7 +646,7 @@ def html_img(img):
         meta.append(('Pixel size', img.sky.cdelt))
 
         ls.append(formatting.html_section(meta,
-                                          summary='Coordinates: {}'.format(img.sky.name)))
+                                          summary=f'Coordinates: {img.sky.name}'))
 
     if img.eqpos is not None:
         meta = []
@@ -663,7 +660,7 @@ def html_img(img):
         meta.append(('Equinox', img.eqpos.equinox))
 
         ls.append(formatting.html_section(meta,
-                                          summary='Coordinates: {}'.format(img.eqpos.name)))
+                                          summary=f'Coordinates: {img.eqpos.name}'))
 
     meta = make_metadata(img.header,
                          [('TELESCOP', 'Mission or Satellite'),
@@ -732,7 +729,7 @@ def simulate_rmf_plot(rmf):
         for energy in energies:
             mdl.pos = energy
             y = rmf.apply_rmf(mdl(elo, ehi))
-            ax.plot(x, y, label='{:.2g} keV'.format(energy))
+            ax.plot(x, y, label=f'{energy:.2g} keV')
 
         # Try to get the legend centered nicely below the plot
         fig.legend(loc='center', ncol=nlines, bbox_to_anchor=(0.0, 0, 1, 0.1))
@@ -815,8 +812,8 @@ def img_plot(img):
             ax.set_xlim(filtered[0], filtered[2])
             ax.set_ylim(filtered[1], filtered[3])
 
-        ax.set_xlabel('X ({})'.format(lbl))
-        ax.set_ylabel('Y ({})'.format(lbl))
+        ax.set_xlabel(f'X ({lbl})')
+        ax.set_ylabel(f'Y ({lbl})')
         if img.name is not None and img.name != '':
             ax.set_title(img.name)
 
@@ -899,7 +896,7 @@ class DataOgipResponse(Data1DInt):
         rtype = self._ui_name
 
         if elo.size != ehi.size:
-            raise ValueError("The energy arrays must have the same size, not {} and {}" .format(elo.size, ehi.size))
+            raise ValueError(f"The energy arrays must have the same size, not {elo.size} and {ehi.size}")
 
         if ethresh is not None and ethresh <= 0.0:
             raise ValueError("ethresh is None or > 0")
@@ -907,7 +904,7 @@ class DataOgipResponse(Data1DInt):
         if (elo >= ehi).any():
             # raise DataErr('ogip-error', rtype, label,
             #               'has at least one bin with ENERG_HI < ENERG_LO')
-            wmsg = "The {} '{}' ".format(rtype, label) + \
+            wmsg = f"The {rtype} '{label}' " + \
                    'has at least one bin with ENERG_HI < ENERG_LO'
             warnings.warn(wmsg)
 
@@ -921,7 +918,7 @@ class DataOgipResponse(Data1DInt):
         if nincreasing > 0 and nincreasing != len(increasing):
             # raise DataErr('ogip-error', rtype, label,
             #               'has a non-monotonic ENERG_LO array')
-            wmsg = "The {} '{}' ".format(rtype, label) + \
+            wmsg = f"The {rtype} '{label}' " + \
                    'has a non-monotonic ENERG_LO array'
             warnings.warn(wmsg)
 
@@ -942,19 +939,19 @@ class DataOgipResponse(Data1DInt):
                 if ehi[startidx] <= ethresh:
                     raise DataErr('ogip-error', rtype, label,
                                   'has an ENERG_HI value <= the replacement ' +
-                                  'value of {}'.format(ethresh))
+                                  f'value of {ethresh}')
 
                 elo = elo.copy()
                 elo[startidx] = ethresh
                 wmsg = "The minimum ENERG_LO in the " + \
-                       "{} '{}' was 0 and has been ".format(rtype, label) + \
-                       "replaced by {}".format(ethresh)
+                       f"{rtype} '{label}' was 0 and has been " + \
+                       f"replaced by {ethresh}"
                 warnings.warn(wmsg)
 
             elif e0 < 0.0:
                 # raise DataErr('ogip-error', rtype, label,
                 #               'has an ENERG_LO value < 0')
-                wmsg = "The {} '{}' ".format(rtype, label) + \
+                wmsg = f"The {rtype} '{label}' " + \
                        'has an ENERG_LO value < 0'
                 warnings.warn(wmsg)
 
@@ -1143,7 +1140,7 @@ class DataRMF(DataOgipResponse):
         energ_lo, energ_hi = self._validate(name, energ_lo, energ_hi, ethresh)
 
         if offset < 0:
-            raise ValueError("offset must be >=0, not {}".format(offset))
+            raise ValueError(f"offset must be >=0, not {offset}")
         self.energ_lo = energ_lo
         self.energ_hi = energ_hi
         self.offset = offset
@@ -2219,7 +2216,7 @@ class DataPHA(Data1D):
         try:
             return mid[val]
         except IndexError:
-            raise DataErr('invalid group number: {}'.format(val))
+            raise DataErr(f'invalid group number: {val}')
 
     def _channel_to_energy(self, val, group=True, response_id=None):
         elo, ehi = self._get_ebins(response_id=response_id, group=group)
@@ -2406,7 +2403,7 @@ class DataPHA(Data1D):
         """
 
         if units not in ['counts', 'rate']:
-            raise ValueError("Invalid units argument: {}".format(units))
+            raise ValueError(f"Invalid units argument: {units}")
 
         if bkg_id not in self.background_ids:
             return None
@@ -3682,9 +3679,8 @@ class DataPHA(Data1D):
 
         if self.plot_fac:
             from sherpa.plot import backend
-            latex = backend.get_latex_for_string(
-                '^{}'.format(self.plot_fac))
-            ylabel += ' X {}{}'.format(self.units.capitalize(), latex)
+            latex = backend.get_latex_for_string(f'^{self.plot_fac}')
+            ylabel += f' X {self.units.capitalize()}{latex}'
 
         return ylabel
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1005,7 +1005,8 @@ class DataARF(DataOgipResponse):
 
     """
     _ui_name = "ARF"
-    _fields = ("name", "energ_lo", "energ_hi", "specresp", "bin_lo", "bin_hi", "exposure", "ethresh")
+    _fields = ("name", "energ_lo", "energ_hi", "specresp", "bin_lo", "bin_hi")
+    _extra_fields = ("exposure", "ethresh")
 
     def _get_specresp(self):
         return self._specresp
@@ -1131,8 +1132,9 @@ class DataRMF(DataOgipResponse):
 
     """
     _ui_name = "RMF"
-    _fields = ("name", "detchans", "energ_lo", "energ_hi", "n_grp", "f_chan", "n_chan", "matrix", "offset", "e_min",
-               "e_max", "ethresh")
+    _fields = ("name", "energ_lo", "energ_hi", "n_grp", "f_chan", "n_chan", "matrix", "e_min",
+               "e_max")
+    _extra_fields = ("detchans", "offset", "ethresh")
 
     def __init__(self, name, detchans, energ_lo, energ_hi, n_grp, f_chan,
                  n_chan, matrix, offset=1, e_min=None, e_max=None,
@@ -1434,9 +1436,9 @@ class DataPHA(Data1D):
     .. [3] Private communication with Keith Arnaud
 
     """
-    _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'bin_lo', 'bin_hi', 'grouping', 'quality',
-               'exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate', 'plot_fac', 'response_ids',
-               'background_ids')
+    _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'bin_lo', 'bin_hi', 'grouping', 'quality')
+    _extra_fields = ('exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate',
+                     'plot_fac', 'response_ids', 'background_ids')
 
     def _get_grouped(self):
         return self._grouped
@@ -4202,7 +4204,8 @@ class DataPHA(Data1D):
 
 class DataIMG(Data2D):
     "Image data set, including functions for coordinate transformations"
-    _fields = Data2D._fields + ("sky", "eqpos", "coord", "header")
+    _fields = Data2D._fields
+    _extra_fields = ("sky", "eqpos", "coord", "header")
 
     def _get_coord(self):
         return self._coord
@@ -4634,7 +4637,8 @@ class DataIMG(Data2D):
 
 
 class DataIMGInt(DataIMG):
-    _fields = Data2DInt._fields + ("sky", "eqpos", "coord")
+    _fields = Data2DInt._fields
+    _extra_fields = ("sky", "eqpos", "coord")
 
     def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None,
                  staterror=None, syserror=None, sky=None, eqpos=None,

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -610,24 +610,32 @@ def read_pha(arg, use_errors=False, use_background=False):
 def _pack_table(dataset):
     """Identify the columns in the data.
 
-    This relies on the _fields attribute containing the
-    data columns, and _extra_fields the extra information
-    (other than the name column).
+    This relies on the _fields attribute containing the data columns,
+    and _extra_fields the extra information (other than the name
+    column). We only return values from _fields that contain data.
+
+    Parameters
+    ----------
+    dataset : sherpa.data.Data instance
+
+    Returns
+    -------
+    data : dict
+        The dictionary containing the columns to write out.
 
     """
-    names = dataset._fields
     data = {}
     for name in dataset._fields:
         if name == 'name':
             continue
 
         val = getattr(dataset, name)
-        if val is  None:
+        if val is None:
             continue
 
         data[name] = val
 
-    return data, list(data.keys())
+    return data
 
 
 def _pack_image(dataset):
@@ -760,7 +768,8 @@ def write_table(filename, dataset, ascii=True, clobber=False):
     read_table
 
     """
-    data, names = _pack_table(dataset)
+    data = _pack_table(dataset)
+    names = list(data.keys())
     backend.set_table_data(filename, data, names, ascii=ascii, clobber=clobber)
 
 
@@ -837,7 +846,8 @@ def pack_table(dataset):
     >>> tbl = pack_table(d)
 
     """
-    data, names = _pack_table(dataset)
+    data = _pack_table(dataset)
+    names = list(data.keys())
     return backend.set_table_data('', data, names, packup=True)
 
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -610,10 +610,24 @@ def read_pha(arg, use_errors=False, use_background=False):
 def _pack_table(dataset):
     """Identify the columns in the data.
 
+    This relies on the _fields attribute containing the
+    data columns, and _extra_fields the extra information
+    (other than the name column).
+
     """
     names = dataset._fields
-    data = {name: getattr(dataset, name) for name in names}
-    return data, names
+    data = {}
+    for name in dataset._fields:
+        if name == 'name':
+            continue
+
+        val = getattr(dataset, name)
+        if val is  None:
+            continue
+
+        data[name] = val
+
+    return data, list(data.keys())
 
 
 def _pack_image(dataset):

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1179,12 +1179,8 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
 
     tbl = pycrates.TABLECrate()
 
-    col_names = [name for name in col_names if data[name] is not None]
-    col_names.remove('name')
     try:
         for name in col_names:
-            if data[name] is None:
-                continue
             _set_column(tbl, name, data[name])
 
     finally:

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1011,7 +1011,6 @@ def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
         raise IOErr("filefound", filename)
 
     col_names = list(col_names)
-    col_names.remove("name")
 
     # The code used to create a header containing the
     # exposure, backscal, and areascal keywords, but this has

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -908,7 +908,6 @@ def test_img_get_bounding_mask_filtered(make_test_image):
     d = make_test_image
     d.notice2d('ellipse(4260,3840,3,2,0)')
     ans = d.get_bounding_mask()
-    print(np.where(ans[0]))
 
     mask = np.zeros(5 * 7, dtype=bool)
     for i in [3,  8,  9, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 22, 23, 24,
@@ -1371,8 +1370,6 @@ def test_pha_get_ylabel_yfac1(override_plot_backend):
     # This is ugly - hopefully #1191 will fix this
     #
     ylabel = pha.get_ylabel()
-    print(ylabel)
-    print(backend.__name__)
     if backend.__name__.endswith('.dummy_backend'):
         assert ylabel == 'Counts/channel X Channel^1'
     else:

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -185,7 +185,7 @@ def test_rmf_real(make_data_path, override_plot_backend):
 
     r = d._repr_html_()
 
-    check(r, 'RMF', '9774.rmf', 'DETCHANS', nmeta=6)
+    check(r, 'RMF', '9774.rmf', 'N_GRP', nmeta=6)
 
     assert '<div class="dataname">Identifier</div><div class="dataval">9774.rmf</div>' in r
     assert '<div class="dataname">Number of channels</div><div class="dataval">1024</div>' in r

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -22,6 +22,8 @@
 
 """
 
+import warnings
+
 import numpy as np
 
 import pytest
@@ -195,6 +197,42 @@ def test_rmf_real(make_data_path, override_plot_backend):
     assert '<div class="dataname">Matrix contents</div><div class="dataval">REDIST</div>' in r
 
 
+@requires_data
+@requires_fits
+def test_rmf_real_bad_energy(make_data_path, override_plot_backend):
+    """Read in a RMF that triggers the energy_thresh change"""
+    from sherpa.astro.io import read_rmf
+
+    infile = make_data_path("MNLup_2138_0670580101_EMOS1_S001_spec.rmf")
+    with warnings.catch_warnings(record=True) as ws:
+        d = read_rmf(infile)
+
+    expected = f"The minimum ENERG_LO in the RMF '{infile}' was 0 and has been replaced by 1e-10"
+    assert len(ws) == 1
+    assert ws[0].category == UserWarning
+    assert str(ws[0].message) == expected
+
+    d.name = 'test.rmf'
+
+    r = d._repr_html_()
+
+    check(r, 'RMF', 'test.rmf', 'N_GRP', nmeta=6)
+
+    assert '<div class="dataname">Identifier</div><div class="dataval">test.rmf</div>' in r
+    assert '<div class="dataname">Number of channels</div><div class="dataval">800</div>' in r
+    assert '<div class="dataname">Number of energies</div><div class="dataval">2400</div>' in r
+    assert '<div class="dataname">Energy range</div><div class="dataval">1e-10 - 12 keV, bin size 0.00500011 keV (minimum threshold of 1e-10 was used)</div>' in r
+    assert '<div class="dataname">Channel range</div><div class="dataval">0 - 799</div>' in r
+
+    assert '<div class="dataname">Mission or Satellite</div><div class="dataval">XMM</div>' in r
+    assert '<div class="dataname">Instrument or Detector</div><div class="dataval">EMOS1</div>' in r
+    assert '<div class="dataname">Instrument filter</div><div class="dataval">Medium</div>' in r
+    assert '<div class="dataname">The channel type</div><div class="dataval">PI</div>' in r
+    assert '<div class="dataname">The minimum probability threshold</div><div class="dataval">1e-06</div>' in r
+    assert '<div class="dataname">Matrix contents</div><div class="dataval">REDIST</div>' in r
+
+
+
 @pytest.mark.parametrize('header', [None, {}, TEST_HEADER])
 def test_img(header,
              override_plot_backend, old_numpy_printing):
@@ -283,3 +321,48 @@ def test_img_real_filtered(coord, make_data_path,
     assert '<div class="dataval">[ 4096.5  4096.5]</div>' in r
     assert '<div class="dataval">[-0.000137  0.000137]</div>' in r
     assert '<div class="dataval">destreak - CAT3.0.2</div>' in r
+
+
+def test_low_level_calc_erange_constant():
+    """Easiest just to call this directly rather than fake up data"""
+
+    de = 0.2
+    elo = 0.1 + de * np.arange(1, 5)
+    ehi = elo + de
+
+    expected = "0.3 - 1.1 keV, bin size 0.2 keV"
+    assert data._calc_erange(elo, ehi) == expected
+
+
+def test_low_level_calc_wrange_constant():
+    """Easiest just to call this directly rather than fake up data"""
+
+    # Should we invert the arguments?
+    dw = 0.2
+    wlo = 0.1 + dw * np.arange(1, 5)
+    whi = wlo + dw
+
+    expected = "0.3 - 1.1 &#8491;, bin size 0.2 &#8491;"
+    assert data._calc_wrange(wlo, whi) == expected
+
+
+def test_low_level_calc_erange_variable():
+    """Easiest just to call this directly rather than fake up data"""
+
+    ebins = np.asarray([0.1, 0.2, 0.4, 0.55, 0.7, 0.8, 0.85])
+    elo = ebins[:-1]
+    ehi = ebins[1:]
+
+    expected = "0.1 - 0.85 keV, bin size 0.05 - 0.2 keV"
+    assert data._calc_erange(elo, ehi) == expected
+
+
+def test_low_level_calc_wrange_variable():
+    """Easiest just to call this directly rather than fake up data"""
+
+    wbins = np.asarray([0.1, 0.2, 0.4, 0.55, 0.7, 0.8, 0.85])
+    wlo = wbins[:-1]
+    whi = wbins[1:]
+
+    expected = "0.1 - 0.85 &#8491;, bin size 0.05 - 0.2 &#8491;"
+    assert data._calc_wrange(wlo, whi) == expected

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
+# Copyright (C) 2020, 2021
+# Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -45,21 +46,21 @@ def check(r, summary, name, label, nmeta):
     assert r is not None
 
     if plot.backend.name == 'pylab':
-        assert '<summary>{} Plot</summary>'.format(summary) in r
+        assert f'<summary>{summary} Plot</summary>' in r
         assert '<svg ' in r
 
     else:
-        assert '<summary>{} Data ('.format(summary) in r
-        assert '<div class="dataname">{}</div>'.format(label) in r
+        assert f'<summary>{summary} Data (' in r
+        assert f'<div class="dataname">{label}</div>' in r
         assert '<svg ' not in r
 
     assert '<summary>Summary (' in r
     if nmeta == 0:
         assert '<summary>Metadata' not in r
     else:
-        assert '<summary>Metadata ({})'.format(nmeta) in r
+        assert f'<summary>Metadata ({nmeta})' in r
 
-    assert '<div class="dataval">{}</div>'.format(name) in r
+    assert f'<div class="dataval">{name}</div>' in r
 
 
 @pytest.mark.parametrize('header', [None, {}, TEST_HEADER])

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -312,12 +312,11 @@ def test_save_table_data1d(ascii, reader, tmp_path, clean_astro_ui):
     assert d.syserror is None
 
 
-@pytest.mark.xfail  # see issue #47
 @requires_fits
 @pytest.mark.parametrize("ascii,reader",
                          [(True, ui.unpack_ascii), (False, ui.unpack_table)])
 def test_save_table_pha(ascii, reader, tmp_path, clean_astro_ui):
-    """Does save_table work? [PHA]"""
+    """Does save_table work? [PHA] See issue #47"""
 
     x = np.arange(1, 11, dtype=np.int16)
     ui.load_arrays(1, x, x, ui.DataPHA)
@@ -332,10 +331,13 @@ def test_save_table_pha(ascii, reader, tmp_path, clean_astro_ui):
     outfile = tmp_path / "table.dat"
     ui.save_table(str(outfile), ascii=ascii)
 
-    # How do we check the save_table output? At the moment the
-    # code is broken so it's not obvious what it's meant to
-    # be.
-    d = reader(str(outfile))
+    # The channel and counts arrays are written out. Things
+    # we check
+    #  - column names (CHANNEL and COUNTS)
+    #  - the data can be read back in
+    #  - we don't read in statistical errors
+    #
+    d = reader(str(outfile), colkeys=["CHANNEL", "COUNTS"])
     assert isinstance(d, ui.Data1D)
     assert d.x == pytest.approx(x)
     assert d.y == pytest.approx(x)

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -316,22 +316,21 @@ def test_save_table_data1d(ascii, reader, tmp_path, clean_astro_ui):
 @requires_fits
 @pytest.mark.parametrize("ascii,reader",
                          [(True, ui.unpack_ascii), (False, ui.unpack_table)])
-@pytest.mark.parametrize("bid,expected",
-                         [(None, [0] * 10),
-                          (1, [5, 0, 0, 0, 0, 0, 0, 0, 0, 2])])
-def test_save_table_pha(ascii, reader, bid, expected, tmp_path, clean_astro_ui):
+def test_save_table_pha(ascii, reader, tmp_path, clean_astro_ui):
     """Does save_table work? [PHA]"""
 
     x = np.arange(1, 11, dtype=np.int16)
     ui.load_arrays(1, x, x, ui.DataPHA)
+    ui.set_quality(1, [0] * 10)
+
+    # Note that the background is ignored on output
+    #
     bkg = ui.DataPHA('bkg', x, x)
     ui.set_bkg(bkg)
-
-    ui.set_quality([0] * 10)
-    ui.set_quality([5, 0, 0, 0, 0, 0, 0, 0, 0, 2], bkg_id=1)
+    ui.set_quality(1, [5, 0, 0, 0, 0, 0, 0, 0, 0, 2], bkg_id=1)
 
     outfile = tmp_path / "table.dat"
-    ui.save_table(str(outfile), bkg_id=bid, ascii=ascii)
+    ui.save_table(str(outfile), ascii=ascii)
 
     # How do we check the save_table output? At the moment the
     # code is broken so it's not obvious what it's meant to

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -83,9 +83,9 @@ def _check(array):
 
     if hasattr(array, "shape"):
         if len(array.shape) != 1:
-            raise TypeError("Data arrays should be 1-dimensional. Did you call 'flatten()' on {}?)".format(array))
+            raise TypeError(f"Data arrays should be 1-dimensional. Did you call 'flatten()' on {array}?)")
     else:
-        warnings.warn("Converting array {} to numpy array.".format(array))
+        warnings.warn(f"Converting array {array} to numpy array.")
         array = numpy.asanyarray(array)
         return _check(array)
     return array
@@ -93,28 +93,28 @@ def _check(array):
 
 def _check_nomask(array):
     if hasattr(array, 'mask'):
-        warnings.warn('Input array {} has a mask attribute. Because masks are supported for dependent variables only the mask attribute of the independent array is ignored and values `behind the mask` are used.'.format(array))
+        warnings.warn(f'Input array {array} has a mask attribute. Because masks are supported for dependent variables only the mask attribute of the independent array is ignored and values `behind the mask` are used.')
     return array
 
 
 def _check_dep(array):
     if not hasattr(array, 'mask'):
         return _check(array), True
-    else:
-        # We know the mask convention is opposite to sherpa
-        if isinstance(array, numpy.ma.MaskedArray):
-            return _check(array), ~array.mask
-        # We don't know what the mask convention is
-        else:
-            warnings.warn('Format of mask for array {} not supported thus the mask is is ignored and values `behind the mask` are used. Set .mask attribute manually or use "set_filter" function.'.format(array))
-            return _check(array), True
+
+    # We know the mask convention is opposite to sherpa
+    if isinstance(array, numpy.ma.MaskedArray):
+        return _check(array), ~array.mask
+
+    # We don't know what the mask convention is
+    warnings.warn(f'Format of mask for array {array} not supported thus the mask is is ignored and values `behind the mask` are used. Set .mask attribute manually or use "set_filter" function.')
+    return _check(array), True
 
 
 def _check_err(array, masktemplate):
     '''Accept array without mask or with a mask that matches the template'''
     if hasattr(array, 'mask') and \
        (not hasattr(masktemplate, 'mask') or not numpy.all(array.mask == masktemplate.mask)):
-        warnings.warn('The mask of {} differs from the mask of the dependent array, only the mask of the dependent array is used in Sherpa.'.format(array))
+        warnings.warn(f'The mask of {array} differs from the mask of the dependent array, only the mask of the dependent array is used in Sherpa.')
     return array
 
 
@@ -1709,7 +1709,7 @@ def html_data1d(data):
     plotter = DataPlot()
     plotter.prepare(data)
 
-    summary = '{} Plot'.format(dtype)
+    summary = f'{dtype} Plot'
     try:
         out = backend.as_html_plot(plotter, summary)
     except AttributeError:
@@ -1730,9 +1730,11 @@ def html_data1d(data):
     #
     fexpr = data.get_filter_expr()
     nbins = data.get_dep(filter=True).size
-    meta.append(('Using', '{} with {} bins'.format(fexpr, nbins)))
+    meta.append(('Using', f'{fexpr} with {nbins} bins'))
 
-    # Rely on the _fields ordering, ending at staterror
+    # Rely on the _fields ordering, ending at staterror. This
+    # ignores _extra_fields.
+    #
     for f in data._fields[1:]:
         if f == 'staterror':
             break
@@ -1745,7 +1747,7 @@ def html_data1d(data):
     if data.syserror is not None:
         meta.append(('Systematic error', data.syserror))
 
-    ls = [formatting.html_section(meta, summary=dtype + ' Summary',
+    ls = [formatting.html_section(meta, summary=f'{dtype} Summary',
                                   open_block=True)]
     return formatting.html_from_sections(data, ls)
 
@@ -1763,7 +1765,7 @@ def html_data1dint(data):
     plotter = DataHistogramPlot()
     plotter.prepare(data)
 
-    summary = '{} Plot'.format(dtype)
+    summary = f'{dtype} Plot'
     try:
         out = backend.as_html_plot(plotter, summary)
     except AttributeError:
@@ -1784,7 +1786,7 @@ def html_data1dint(data):
     #
     fexpr = data.get_filter_expr()
     nbins = data.get_dep(filter=True).size
-    meta.append(('Using', '{} with {} bins'.format(fexpr, nbins)))
+    meta.append(('Using', f'{fexpr} with {nbins} bins'))
 
     # Rely on the _fields ordering, ending at staterror
     for f in data._fields[1:]:
@@ -1799,7 +1801,7 @@ def html_data1dint(data):
     if data.syserror is not None:
         meta.append(('Systematic error', data.syserror))
 
-    ls = [formatting.html_section(meta, summary=dtype + ' Summary',
+    ls = [formatting.html_section(meta, summary=f'{dtype} Summary',
                                   open_block=True)]
     return formatting.html_from_sections(data, ls)
 
@@ -1849,6 +1851,6 @@ def html_data2d(data):
     if data.syserror is not None:
         meta.append(('Systematic error', data.syserror))
 
-    ls = [formatting.html_section(meta, summary=dtype + ' Summary',
+    ls = [formatting.html_section(meta, summary=f'{dtype} Summary',
                                   open_block=True)]
     return formatting.html_from_sections(data, ls)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -612,43 +612,60 @@ class BaseData(metaclass=ABCMeta):
 
 # DATA-NOTE: ND Data cannot be plotted
 class Data(NoNewAttributesAfterInit, BaseData):
+    """Generic, N-Dimensional data sets.
+
+    A data class is the collection of a data space and a number of
+    data arrays for the dependent variable and associated errors.
+
+    Parameters
+    ----------
+    name : string
+        name of this dataset
+    indep: tuple of array_like
+        the tuple of independent arrays.
+    y : array_like
+        The values of the dependent observable. If this is a numpy
+        masked array, the mask will used to initialize a mask.
+    staterror : array_like
+        the statistical error associated with the data
+    syserror : array_like
+        the systematic error associated with the data
+
+    Notes
+    -----
+
+    This class can be extended by classes definining data sets of
+    specific dimensionality. Extending classes should override the
+    `_init_data_space` method.
+
+    This class provides most of the infrastructure for extending
+    classes for free.
+
+    Data classes contain a ``mask`` attribute, which can be used
+    ignore certain values in the array when fitting or plotting that
+    data. The convention in Sherpa is that ``True`` marks a values as
+    *valid* and ``False`` as *invalid* (note that this is opposite to
+    the numpy convention). When a `Data` instance is initialized with
+    a dependent array that has a ``mask`` attribute (e.g. numpy masked
+    array), it will attempt to convert that mask to the Sherpa
+    convention and raise a warning otherwise. In any case, the user
+    can set ``data.mask`` after initialization if that conversion does
+    not yield the expected result.
+
     """
-    Data class for generic, N-Dimensional data sets, where N depends on the number of independent axes passed during
-    initialization.
 
-    A data class is the collection of a data space and a number of data arrays for the dependent variable and
-    associated errors.
-
-    This class can be extended by classes definining data sets of specific dimensionality. Extending classes should
-    override the `_init_data_space` method.
-
-    This class provides most of the infrastructure for extending classes for free.
-
-    Data classes contain a ``mask`` attribute, which can be used ignore certain values in the array
-    when fitting or plotting that data. The convention in Sherpa is that ``True`` marks a values as
-    *valid* and ``False`` as *invalid* (note that this is opposite to the numpy convention). When a `Data`
-    instance is initialized with a dependent array that has a ``mask`` attribute (e.g. numpy masked array),
-    it will attempt to convert that mask to the Sherpa convention and raise a warning otherwise. In any case,
-    the user can set ``data.mask`` after initialization if that conversion does not yield the expected result.
-    """
     _fields = ("name", "indep", "dep", "staterror", "syserror")
+    """The main data values stored by the object (as a tuple).
+
+    This is used to identify the column data - that is values that
+    can be written out in tabular form - other than the "name"
+    field. Other fields are listed in _extra_fields.
+    """
+
+    _extra_fields = ()
+    """Any extra fields that should be displayed by str(object)."""
 
     def __init__(self, name, indep, y, staterror=None, syserror=None):
-        """
-        Parameters
-        ----------
-        name : basestring
-            name of this dataset
-        indep: tuple of array_like
-            the tuple of independent arrays.
-        y : array_like
-            The values of the dependent observable. If this is a numpy masked array,
-            the mask will used to initialize a mask.
-        staterror : array_like
-            the statistical error associated with the data
-        syserror : array_like
-            the systematic error associated with the data
-        """
         self.name = name
         self._data_space = self._init_data_space(Filter(), *indep)
         self.y, self.mask = _check_dep(y)
@@ -984,10 +1001,10 @@ class Data(NoNewAttributesAfterInit, BaseData):
     def __str__(self):
         """
         Return a listing of the attributes listed in self._fields and,
-        if present, self._extra_fields.
+        if set, self._extra_fields.
         """
 
-        fields = self._fields + getattr(self, '_extra_fields', ())
+        fields = self._fields + self._extra_fields
         fdict = dict(zip(fields, [getattr(self, f) for f in fields]))
         return print_fields(fields, fdict)
 
@@ -1672,7 +1689,8 @@ class Data2DInt(Data2D):
     """
     2-D integrated data set
     """
-    _fields = ("name", "x0lo", "x1lo", "x0hi", "x1hi", "y", "shape", "staterror", "syserror")
+    _fields = ("name", "x0lo", "x1lo", "x0hi", "x1hi", "y", "staterror", "syserror")
+    _extra_fields = ("shape", )
 
     def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None, staterror=None, syserror=None):
         self.shape = shape

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1005,13 +1005,13 @@ class Data(NoNewAttributesAfterInit, BaseData):
         """
 
         fields = self._fields + self._extra_fields
-        fdict = dict(zip(fields, [getattr(self, f) for f in fields]))
+        fdict = {f: getattr(self, f) for f in fields}
         return print_fields(fields, fdict)
 
     def __repr__(self):
-        r = '<%s data set instance' % type(self).__name__
+        r = f'<{type(self).__name__} data set instance'
         if hasattr(self, 'name'):
-            r += " '%s'" % self.name
+            r += f" '{self.name}'"
         r += '>'
         return r
 


### PR DESCRIPTION
# Summary

Fix writing out of PHA datasets as a generic table (both ASCII and FITS formats). Fixes #47 

# Details

This is a follow on to #1355 to address #47 - the fact that writing out a PHA dataset as a "table", rather than a PHA file, fails (in different ways for different I/O backends).

The I/O routines use the `_fields` attribute of a data object to determine what "columns" to write out, but this fails for certain cases - image style classes can contain a `shape` attribute which doesn't match the data, and PHA objects contain both scalar values (e.g. `exposure` is a float and `grouped` is a bool) as well as lists (`response_ids` and `backgrounds_ids`) that don't match the column data.

The `_fields` attribute is also used for the `__str__` method (i.e. string output), and the `Data` class supports an `_extra_fields` attribute - which is added to the `_fields` sequence for output, **BUT** no class actually uses this. In this PR we

a) add a `_extra_fields` attribute to `Data` - so that all classes will contain it - but make it `()` so that it doesn't add any extra information
b) switch those classes which have both column and "non-column" fields so that these "non-column" fields are in `_extra_fields`
c) a minor clean up in the `io` code for accessing the `_fields` values to send through to the backend - so now the backend `set_table_data` is sent the data to write, not a dictionary that needs to be post-processed to remove the `name` field and any values set to `None`

After fixing #47 there is some work that basically removes many of the `__str__` methods of the `Data` sub-classes, as they don't really make sense.

The final commit cleans up the Jupyter notebook code for PHA, ARF, and RMF objects as we can now use all the `_fields` entries when creating a data table - which is **only** used when there's no plot backend - rather than stop at some arbitrary entry.

I've ran the tests with a build using crates and things pass.

# Notes

I think that routines like `sherpa.astro.io._pack_pha` probably should be moved into the `DataPHA` class to make it easier to add new classes, but I also don't want these classes getting too large and unwieldy, so need to think about this (e.g. how generic can we make this serialization logic?). They are related to this PR as it's all about "how do we determine what to write out or not" but is not to be done in this PR. It's more just a reminder of myself to look at this to see if it's worth an issue.

# Examples

### Before this change

```
>>> print(pha)
name           = sherpa-test-data/sherpatest/3c273.pi
channel        = Float64[1024]
counts         = Float64[1024]
staterror      = None
syserror       = None
bin_lo         = None
bin_hi         = None
grouping       = Int16[1024]
quality        = Int16[1024]
exposure       = 38564.608926889
backscal       = 2.5264364698914e-06
areascal       = 1.0
grouped        = True
subtracted     = False
units          = energy
rate           = True
plot_fac       = 0
response_ids   = [1]
background_ids = [1]
```

```
>>> print(arf)
name     = sherpa-test-data/sherpatest/3c273.arf
energ_lo = Float64[1090]
energ_hi = Float64[1090]
specresp = Float64[1090]
bin_lo   = None
bin_hi   = None
exposure = 38564.141454905
ethresh  = 1e-10
```

```
>>> print(rmf)
name     = sherpa-test-data/sherpatest/3c273.rmf
detchans = 1024
energ_lo = Float64[1090]
energ_hi = Float64[1090]
n_grp    = UInt64[1090]
f_chan   = UInt32[2002]
n_chan   = UInt32[2002]
matrix   = Float64[61834]
offset   = 1
e_min    = Float64[1024]
e_max    = Float64[1024]
ethresh  = 1e-10
```

### After this change

```
>>> print(pha)
name           = sherpa-test-data/sherpatest/3c273.pi
channel        = Float64[1024]
counts         = Float64[1024]
staterror      = None
syserror       = None
bin_lo         = None
bin_hi         = None
grouping       = Int16[1024]
quality        = Int16[1024]
exposure       = 38564.608926889
backscal       = 2.5264364698914e-06
areascal       = 1.0
grouped        = True
subtracted     = False
units          = energy
rate           = True
plot_fac       = 0
response_ids   = [1]
background_ids = [1]
```

```
>>> print(arf)
name     = sherpa-test-data/sherpatest/3c273.arf
energ_lo = Float64[1090]
energ_hi = Float64[1090]
specresp = Float64[1090]
bin_lo   = None
bin_hi   = None
exposure = 38564.141454905
ethresh  = 1e-10
```

```
>>> print(rmf)
name     = sherpa-test-data/sherpatest/3c273.rmf
energ_lo = Float64[1090]
energ_hi = Float64[1090]
n_grp    = UInt64[1090]
f_chan   = UInt32[2002]
n_chan   = UInt32[2002]
matrix   = Float64[61834]
e_min    = Float64[1024]
e_max    = Float64[1024]
detchans = 1024
offset   = 1
ethresh  = 1e-10
```


