### PR TITLE
Add missing export statement to clang 12 note

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -391,7 +391,7 @@ C++ compilers to use if not found by ``setup.py``.
    declaration. If so, pre-pending the following to your pip install
    or python setup.py install line should resolve the build issues::
 
-     export CFLAGS='-Wno-implicit-function-declaration'
+     CFLAGS='-Wno-implicit-function-declaration' pip install .
 
    (Note that on MacOS, "gcc" is usually just an alias to Clang. Unless
    you specifically install a gcc from a different source, you are

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -391,7 +391,7 @@ C++ compilers to use if not found by ``setup.py``.
    declaration. If so, pre-pending the following to your pip install
    or python setup.py install line should resolve the build issues::
 
-     CFLAGS='-Wno-implicit-function-declaration'
+     export CFLAGS='-Wno-implicit-function-declaration'
 
    (Note that on MacOS, "gcc" is usually just an alias to Clang. Unless
    you specifically install a gcc from a different source, you are


### PR DESCRIPTION
This PR adds the missing `export` statement to the installation note on clang 12. After the export the `pip install sherpa` worked successfully on my M1 system.