### PR TITLE
Ensure FITS column access is case insensitive  for the pyfits I/O backend (fix #143)

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -141,10 +141,10 @@ def _add_keyword(hdrlist, name, val):
 
 
 def _try_col(hdu, name, dtype=SherpaFloat, fix_type=False):
-    if name not in hdu.columns.names:
+    try:
+        col = hdu.data.field(name)
+    except KeyError:
         return None
-
-    col = hdu.data.field(name)
 
     if isinstance(col, _VLF):
         col = numpy.concatenate([numpy.asarray(row) for row in col])
@@ -158,10 +158,10 @@ def _try_col(hdu, name, dtype=SherpaFloat, fix_type=False):
 
 
 def _try_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
-    if name not in hdu.columns.names:
-        return (None,)
-
-    col = hdu.data.field(name)
+    try:
+        col = hdu.data.field(name)
+    except KeyError:
+        return (None, )
 
     if isinstance(col, _VLF):
         col = numpy.concatenate([numpy.asarray(row) for row in col])
@@ -175,10 +175,10 @@ def _try_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
 
 
 def _try_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
-    if name not in hdu.columns.names:
+    try:
+        col = hdu.data.field(name)
+    except KeyError:
         return numpy.array([None] * size)
-
-    col = hdu.data.field(name)
 
     if isinstance(col, _VLF):
         col = numpy.concatenate([numpy.asarray(row) for row in col])

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -237,12 +237,15 @@ def _try_vec_or_key(hdu, name, size, dtype=SherpaFloat, fix_type=False):
 # effort to emulate with the astropy backend.
 
 def _infer_and_check_filename(filename):
-    fname = filename  # keep filename unchanged
-    if not os.path.exists(fname):
-        fname += '.gz'  # try to find a gzipped version, following CXC/Crates conventions.
-        if not os.path.exists(fname):  # fail fast
-            raise IOErr('filenotfound', filename)  # error message reports the original filename requested
-    return fname
+    if os.path.exists(filename):
+        return filename
+
+    gzname = f"{filename}.gz"
+    if os.path.exists(gzname):
+        return gzname
+
+    # error message reports the original filename requested
+    raise IOErr('filenotfound', filename)
 
 
 def is_binary_file(filename):

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -25,7 +25,8 @@ import numpy as np
 
 import pytest
 
-from sherpa.data import Data1D
+from sherpa.data import Data1D, Data2DInt
+from sherpa.astro import io
 from sherpa.astro import ui
 from sherpa.models.basic import Box1D, Const1D
 from sherpa.utils.err import IOErr
@@ -276,15 +277,13 @@ def test_read_ideal_rmf():
     and let's do EBOUNDS then MATRIX blocks.
     """
 
-    from sherpa.astro.io import read_rmf
-
     ebins = np.arange(0.15, 0.2, 0.01)
     elo = ebins[:-1]
     ehi = ebins[1:]
 
     with NamedTemporaryFile() as f:
         fake_rmf(f.name)
-        r = read_rmf(f.name)
+        r = io.read_rmf(f.name)
 
     # Can we read in the data
     #
@@ -366,8 +365,6 @@ def test_fits_file_missing_column(make_data_path):
 
     """
 
-    from sherpa.astro import io
-
     infile = make_data_path("1838_rprofile_rmid.fits")
 
     with pytest.raises(IOErr) as err:
@@ -383,3 +380,154 @@ def test_fits_file_missing_column(make_data_path):
     #
     assert str(err.value).startswith("Required column 'FOO' not found in ") or \
         str(err.value).startswith("Required column 'Foo' not found in ")
+
+
+def test_read_arrays_no_data():
+    """This can run even with the dummy backend"""
+    with pytest.raises(IOErr) as err:
+        io.read_arrays()
+
+    assert str(err.value) == "no arrays found to be loaded"
+
+
+@requires_fits
+def test_read_arrays_no_data_but_dstype():
+    """This is a slightly-different error path than read_arrays()"""
+
+    with pytest.raises(IOErr) as err:
+        io.read_arrays(Data2DInt)
+
+    assert str(err.value) == "no arrays found to be loaded"
+
+
+@requires_fits
+@pytest.mark.parametrize("dstype,dname,nargs",
+                         [(Data1D, 'Data1D', 2),
+                          (Data2DInt, 'Data2DInt', 5)])
+def test_read_arrays_not_enough_data(dstype, dname, nargs):
+
+    with pytest.raises(TypeError) as err:
+        io.read_arrays([1, 2, 3], dstype)
+
+    assert str(err.value) == f"data set '{dname}' takes at least {nargs} args"
+
+
+@requires_fits
+def test_read_arrays_not_an_array_type():
+
+    with pytest.raises(IOErr) as err:
+        io.read_arrays("foo")
+
+    assert str(err.value) == "'foo' must be a Numpy array, list, or tuple"
+
+
+@requires_fits
+def test_read_arrays_data1d():
+
+    dset = io.read_arrays([1, 2, 3], (4, 5, 6), np.asarray([0.1, 0.2, 0.1]))
+    assert isinstance(dset, Data1D)
+    assert dset.name == ''
+    assert dset.x == pytest.approx(np.asarray([1, 2, 3]))
+    assert dset.y == pytest.approx(np.asarray([4, 5, 6]))
+    assert dset.staterror == pytest.approx(np.asarray([0.1, 0.2, 0.1]))
+    assert dset.syserror is None
+
+    # Check it creates NumPy arrays
+    assert isinstance(dset.x, np.ndarray)
+    assert isinstance(dset.y, np.ndarray)
+    assert isinstance(dset.staterror, np.ndarray)
+
+
+@requires_fits
+def test_read_arrays_data1d_combined():
+
+    arg = np.asarray([[1, 4, 0.2, 0.1],
+                      [2, 5, 0.3, 0.05]])
+    dset = io.read_arrays(arg)
+    assert isinstance(dset, Data1D)
+    assert dset.name == ''
+    assert dset.x == pytest.approx(np.asarray([1, 2]))
+    assert dset.y == pytest.approx(np.asarray([4, 5]))
+    assert dset.staterror == pytest.approx(np.asarray([0.2, 0.3]))
+    assert dset.syserror == pytest.approx(np.asarray([0.1, 0.05]))
+
+    # Check it creates NumPy arrays
+    assert isinstance(dset.x, np.ndarray)
+    assert isinstance(dset.y, np.ndarray)
+    assert isinstance(dset.staterror, np.ndarray)
+    assert isinstance(dset.syserror, np.ndarray)
+
+
+@requires_fits
+@pytest.mark.parametrize("arg", [[], None, (None, None)])
+def test_write_arrays_no_data(arg):
+
+    with pytest.raises(IOErr) as err:
+        io.write_arrays('/dev/null', arg, clobber=True)
+
+    assert str(err.value) == "please supply array(s) to write to file"
+
+
+@requires_fits
+def test_write_arrays_wrong_lengths():
+
+    with pytest.raises(IOErr) as err:
+        io.write_arrays('/dev/null', ([1, 2], [1, 2, 3]), clobber=True)
+
+    assert str(err.value) == "not all arrays are of equal length"
+
+
+@requires_fits
+def test_write_arrays_wrong_field_length():
+
+    with pytest.raises(IOErr) as err:
+        io.write_arrays('/dev/null', ([1, 2], [1, 2]), fields=['a', 'b', 'c'], clobber=True)
+
+    assert str(err.value) == "Expected 2 columns but found 3"
+
+
+@requires_fits
+def test_write_arrays_clobber(tmp_path):
+
+    outfile = tmp_path / 'test.dat'
+    outfile.write_text('x')
+
+    with pytest.raises(IOErr) as err:
+        io.write_arrays(str(outfile), None, clobber=False)
+
+    emsg = str(err.value)
+    assert emsg.startswith("file '")
+    assert emsg.endswith("test.dat' exists and clobber is not set")
+
+
+@requires_data
+@requires_fits
+def test_read_table_pha(make_data_path):
+    """Do we pick up CHANNEL and COUNTS by default?"""
+
+    # This file has columns:
+    #   CHANNEL
+    #   PI
+    #   COUNTS
+    #   STAT_ERR
+    #   COUNT_RATE
+    # Check we pick up CHANNEL and COUNTS
+    #
+    infile = make_data_path('source.pi')
+    tbl = io.read_table(infile)
+    assert isinstance(tbl, Data1D)
+    assert len(tbl.x) == 1024
+    assert len(tbl.y) == 1024
+    assert tbl.staterror is None
+    assert tbl.syserror is None
+
+    # These are meant to be integer values so we can test
+    # for equality. Except that it depends on the backend:
+    # pyfits returns Int32 whereas crates returns Float64.
+    #
+    assert tbl.x == pytest.approx(np.arange(1, 1025))
+    assert tbl.y.min() == pytest.approx(0)
+    assert tbl.y[0] == pytest.approx(0)
+    assert tbl.y[-1] == pytest.approx(128)
+    assert tbl.y[:-1].max() == pytest.approx(78)
+    assert np.argmax(tbl.y[:-1]) == 74

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -319,7 +319,6 @@ def test_read_ideal_rmf():
     assert y == pytest.approx(expected, rel=2e-6)
 
 
-@pytest.mark.xfail  # see #143
 @requires_fits
 @requires_data
 def test_fits_file_lower_case(make_data_path):

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -460,28 +460,31 @@ def test_read_arrays_data1d_combined():
 
 @requires_fits
 @pytest.mark.parametrize("arg", [[], None, (None, None)])
-def test_write_arrays_no_data(arg):
+def test_write_arrays_no_data(arg, tmp_path):
 
+    tmpfile = tmp_path / 'test.dat'
     with pytest.raises(IOErr) as err:
-        io.write_arrays('/dev/null', arg, clobber=True)
+        io.write_arrays(str(tmpfile), arg, clobber=True)
 
     assert str(err.value) == "please supply array(s) to write to file"
 
 
 @requires_fits
-def test_write_arrays_wrong_lengths():
+def test_write_arrays_wrong_lengths(tmp_path):
 
+    tmpfile = tmp_path / 'test.dat'
     with pytest.raises(IOErr) as err:
-        io.write_arrays('/dev/null', ([1, 2], [1, 2, 3]), clobber=True)
+        io.write_arrays(str(tmpfile), ([1, 2], [1, 2, 3]), clobber=True)
 
     assert str(err.value) == "not all arrays are of equal length"
 
 
 @requires_fits
-def test_write_arrays_wrong_field_length():
+def test_write_arrays_wrong_field_length(tmp_path):
 
+    tmpfile = tmp_path / 'test.dat'
     with pytest.raises(IOErr) as err:
-        io.write_arrays('/dev/null', ([1, 2], [1, 2]), fields=['a', 'b', 'c'], clobber=True)
+        io.write_arrays(str(tmpfile), ([1, 2], [1, 2]), fields=['a', 'b', 'c'], clobber=True)
 
     assert str(err.value) == "Expected 2 columns but found 3"
 

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2017, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,17 +20,14 @@
 
 import importlib
 import os
-import unittest
-
-import numpy
-
-from sherpa.utils._utils import sao_fcmp
 
 try:
     import pytest
     HAS_PYTEST = True
 except ImportError:
     HAS_PYTEST = False
+
+from sherpa.utils.err import RuntimeErr
 
 
 def _get_datadir():
@@ -79,7 +77,7 @@ def set_datadir(datadir):
 
     if not os.path.exists(datadir) or not os.path.isdir(datadir) \
        or not os.listdir(datadir):
-        raise OSError("datadir={} is empty or not a directory".format(datadir))
+        raise OSError(f"datadir={datadir} is empty or not a directory")
 
     global DATADIR
     DATADIR = datadir
@@ -106,8 +104,10 @@ def has_package_from_list(*packages):
         try:
             importlib.import_module(package)
             return True
-        except:
-            # We can have ImportError but also RuntimeErr
+        except (ImportError, RuntimeErr):
+            # Apparently we need to also catch RuntimeErr (the Sherpa
+            # version) as sherpa.image.DS9 can raise it (e.g. when
+            # DS9 is not installed).
             pass
     return False
 
@@ -160,9 +160,12 @@ if HAS_PYTEST:
         return requires_package(msg, *packages)(test_function)
 
     def requires_fits(test_function):
-        """
-        Returns True if there is an importable backend for FITS I/O.
-        Used to skip tests requiring fits_io
+        """Returns True if there is an importable backend for FITS I/O.
+
+        Used to skip tests requiring fits_io. As we now allow a dummy
+        backend to be loaded, even when we can import the underlying
+        I/O code, the meaning of this is now unclear.
+
         """
         packages = ('astropy.io.fits',
                     'pycrates',

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -160,11 +160,11 @@ if HAS_PYTEST:
         return requires_package(msg, *packages)(test_function)
 
     def requires_fits(test_function):
-        """Returns True if there is an importable backend for FITS I/O.
+        """Returns True if a working backend for FITS I/O is importable.
 
-        Used to skip tests requiring fits_io. As we now allow a dummy
-        backend to be loaded, even when we can import the underlying
-        I/O code, the meaning of this is now unclear.
+        Used to skip tests requiring fits_io. The dummy backend itself
+        is not a "working backend" in the sense that it cannot be used to
+        read or write files.
 
         """
         packages = ('astropy.io.fits',


### PR DESCRIPTION
# Summary

Allow FITS colummn access with the pyfits backend to be case insensitive. Fixes #143.

# Details

It turns out #143 was down to being unable to say

    unpack_table(fitsfile, colkeys=["emid", "mdl"])

when the FITS file has the `TTYPE<n>` keywords in lower case, not upper case. The fix is easy and more Pythonic than the old version.

I also add a few tests to cover certain error conditions that haven't been tested in the pyfits backend.

# Example

We now get (astropy backend)

```
>>> from sherpa.astro import ui
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
WARNING: failed to import sherpa.plot.pylab_backend; plotting routines will not be available
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> ui.load_table_model('mdl', 'pl_gamma2.fits', colkeys=['emid', 'mdl'])
>>>
```

whereas with the current main branch (or close to it, it's actually the 4.14.0 branch) you get

```
>>> from sherpa.astro import ui
>>> ui.load_table_model('mdl', 'pl_gamma2.fits', colkeys=['emid', 'mdl'])
Traceback (most recent call last):
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9846, in load_table_model
    self.load_xstable_model(modelname, filename)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9760, in load_xstable_model
    tablemodel = xspec.read_xstable_model(modelname, filename, etable=etable)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/xspec/__init__.py", line 827, in
read_xstable_model
    hdr = read_hdr(filename, blockname=blkname, hdrkeys=hdrkeys)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/io/pyfits_backend.py", line 411,
in get_header_data
    hdr[key] = _require_key(hdu, key, dtype=str)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/io/pyfits_backend.py", line 101,
in _require_key
    raise IOErr('nokeyword', hdu._file.name, name)
sherpa.utils.err.IOErr: file 'pl_gamma2.fits' does not have a 'HDUCLAS1' keyword

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9652, in _read_user_model
    data = self.unpack_ascii(filename, *args, **kwargs)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 1188, in unpack_ascii
    return sherpa.astro.io.read_ascii(filename, ncols, colkeys, dstype,
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/io/__init__.py", line 274, in read_ascii
    colnames, cols, name = backend.get_ascii_data(filename, ncols=ncols,
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/io.py", line 224, in get_ascii_data
    raise IOErr('notascii', filename)
sherpa.utils.err.IOErr: file 'pl_gamma2.fits' does not appear to be ASCII

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9663, in _read_user_model
    data = self.unpack_table(filename, *args, **kwargs)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 994, in unpack_table
    return sherpa.astro.io.read_table(filename, ncols, colkeys, dstype)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/io/__init__.py", line 216, in read_table
    colnames, cols, name, hdr = backend.get_table_data(arg, ncols, colkeys)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/io/pyfits_backend.py", line 467,
in get_table_data
    for col in _require_tbl_col(hdu, name, fix_type=fix_type):
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/io/pyfits_backend.py", line 206,
in _require_tbl_col
    raise IOErr('reqcol', name, hdu._file.name)
sherpa.utils.err.IOErr: Required column 'EMID' not found in pl_gamma2.fits

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9855, in load_table_model
    x, y = self._read_user_model(filename, *args, **kwargs)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9676, in _read_user_model
    data = self.unpack_image(filename, *args, **kwargs)
TypeError: unpack_image() got an unexpected keyword argument 'colkeys'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in load_table_model
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/astro/ui/utils.py", line 9860, in load_table_model
    data = sherpa.io.read_data(filename, ncols=2)
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/io.py", line 325, in read_data
    colnames, args, name = get_ascii_data(filename, ncols, colkeys,
  File "/home/dburke/anaconda/envs/ciaot-17-11-2021/lib/python3.8/site-packages/sherpa/io.py", line 224, in get_ascii_data
    raise IOErr('notascii', filename)
sherpa.utils.err.IOErr: file 'pl_gamma2.fits' does not appear to be ASCII
```
```
