### PR TITLE
Address aarch/ppc64le test failures

### DIFF
--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -1,21 +1,27 @@
-name: Pip CI (arch)
+name: Weekly cron (arch)
 
-# AstroPy does this weekly; for now I need to get this working first
-#
-on: [push, pull_request]
+on:
+  schedule:
+    # when is a good time?
+    - cron: '0 23 * * SUN'
 
 jobs:
   tests:
     name: ${{ matrix.arch }}
     runs-on: ubuntu-18.04
+    if: (github.repository == 'sherpa/sherpa' && github.event_name == 'schedule')
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
 
           # The tests on ppc64le fail rather spectacularly,
-          # and it's not obvious why, so skip for now.
+          # and it's not obvious why, so skip for now. AstroPy also
+          # see some interesting errors so maybe there are problems
+          # with the emulation or NumPy or ...
+          # https://github.com/astropy/astropy/pull/11697
           #
           # - arch: ppc64le
 
@@ -65,6 +71,9 @@ jobs:
           source tests/bin/activate
 
           # without this we get configure errors when building fftw and I don't know why
+          # (this adds the --disable-dependency-tracking option). A google suggests it
+          # could be a make vs gmake issue but we can't easily change this (and it may
+          # not be the actual problem).
           #
           sed -i.orig "s|#configure=None|configure=--disable-maintainer-mode --enable-stuberrorlib --disable-shared --enable-shared=libgrp,stklib --disable-dependency-tracking|" setup.cfg
 

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -4,12 +4,15 @@ on:
   schedule:
     # when is a good time?
     - cron: '0 23 * * SUN'
+  pull_request:
+    # We also want this workflow triggered if the 'CI arch' label is added
+    # or present when PR is updated
+    types: [synchronize, labeled]
 
 jobs:
   tests:
-    name: ${{ matrix.arch }}
     runs-on: ubuntu-18.04
-    if: (github.repository == 'sherpa/sherpa' && github.event_name == 'schedule')
+    if: (github.repository == 'sherpa/sherpa' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'CI arch')))
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -1,0 +1,74 @@
+name: Pip CI (arch)
+
+# AstroPy does this weekly; for now I need to get this working first
+#
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: ${{ matrix.arch }}
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+
+          # The tests on ppc64le fail rather spectacularly,
+          # and it's not obvious why, so skip for now.
+          #
+          # - arch: ppc64le
+
+          # We currently do not have any user requests for this
+          # architecture.
+          #
+          # - arch: s390x
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      # As we do not include an I/O backend it is not worth checking out the data submodule.
+      #
+      # with:
+      #   submodules: 'True'
+
+    - name: Build and test
+      uses: uraimo/run-on-arch-action@v2.1.1
+      with:
+        arch: ${{ matrix.arch }}
+        distro: bullseye
+
+        shell: /bin/bash
+
+        # Based on AstroPy
+        install: |
+          echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+          apt-get update -q -y
+          apt-get install -q -y git \
+                                g++ \
+                                gfortran \
+                                flex \
+                                bison \
+                                make \
+                                pkg-config \
+                                python3 \
+                                python3-dev \
+                                python3-configobj \
+                                python3-numpy \
+                                python3-venv
+
+        # Follow AstroPy for now and do not install any external packages
+        # (I/O, plotting, or DS9).
+        #
+        run: |
+          python3 -m venv --system-site-packages tests
+          source tests/bin/activate
+
+          # without this we get configure errors when building fftw and I don't know why
+          #
+          sed -i.orig "s|#configure=None|configure=--disable-maintainer-mode --enable-stuberrorlib --disable-shared --enable-shared=libgrp,stklib --disable-dependency-tracking|" setup.cfg
+
+          pip3 install -e .
+          pip3 install pytest
+          pip3 install pytest-xdist  # not really needed here
+          python3 -m pytest

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -325,13 +325,22 @@ def test_regproj(old_numpy_printing, override_plot_backend):
 
     assert "<summary>RegionProjection (13)</summary>" in r
 
-    assert '<div class="dataname">parval0</div><div class="dataval">-0.5315772076542427</div>' in r
-    assert '<div class="dataname">parval1</div><div class="dataval">0.5854611101216837</div>' in r
+    # Issue #1372 shows that the numbers here can depend on the platform; as
+    # this test is not about whether the fit converged to the same solution
+    # the tests are very basic. An alternative would be to just place
+    # the values from the fit object into the strings, but then there is
+    # the problem that this test currently requires old_numpy_printing,
+    # so the results would not necessarily match.
+    #
+    assert '<div class="dataname">parval0</div><div class="dataval">-0.5' in r
+    assert '<div class="dataname">parval1</div><div class="dataval">0.5' in r
     assert '<div class="dataname">sigma</div><div class="dataval">(1, 2, 3)</div>' in r
 
-    assert '<div class="dataname">y</div><div class="dataval">[ 306.854444  282.795953  259.744431  237.699877  216.662291  196.631674\n' in r
+    # These values may depend on the platform so only very-limited check.
+    #
+    assert '<div class="dataname">y</div><div class="dataval">[ 30' in r
+    assert '<div class="dataname">levels</div><div class="dataval">[  3.6' in r
 
-    assert '<div class="dataname">levels</div><div class="dataval">[  3.606863   7.491188  13.140272]</div>' in r
     assert '<div class="dataname">min</div><div class="dataval">[-2, -1]</div>' in r
     assert '<div class="dataname">max</div><div class="dataval">[2, 2]</div>' in r
 

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
+# Copyright (C) 2020, 2021
+# Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -34,16 +35,20 @@ from sherpa.models.basic import Const1D, Gauss2D, Polynom1D
 from sherpa.stats import Chi2
 
 
+def plot_backend_is(name):
+    """Check we have the specified plot backend"""
+    return plot.backend.name == name
+
+
 def check_empty(r, summary, nsummary=0):
     """Is this an 'empty' response?"""
 
-    if plot.backend.name == 'pylab':
+    if plot_backend_is("pylab"):
         assert r is None
         return
 
     assert r is not None
-
-    assert '<summary>{} ({})</summary>'.format(summary, nsummary) in r
+    assert f"<summary>{summary} ({nsummary})</summary>" in r
 
 
 def check_full(r, summary, label, title, nsummary=0):
@@ -51,14 +56,14 @@ def check_full(r, summary, label, title, nsummary=0):
 
     assert r is not None
 
-    if plot.backend.name == 'pylab':
-        assert '<summary>{}</summary>'.format(summary) in r
-        assert '<svg ' in r
+    if plot_backend_is("pylab"):
+        assert f"<summary>{summary}</summary>" in r
+        assert "<svg " in r
         return
 
-    assert '<summary>{} ({})</summary>'.format(summary, nsummary) in r
-    assert '<div class="dataval">{}</div>'.format(label) in r
-    assert '<div class="dataval">{}</div>'.format(title) in r
+    assert f"<summary>{summary} ({nsummary})</summary>" in r
+    assert f'<div class="dataval">{label}</div>' in r
+    assert f'<div class="dataval">{title}</div>' in r
 
 
 def test_histogram(override_plot_backend):
@@ -205,13 +210,13 @@ def test_fit(override_plot_backend):
     # different to previous checks
     assert r is not None
 
-    if plot.backend.name == 'pylab':
-        assert '<summary>FitPlot</summary>' in r
-        assert '<svg ' in r
+    if plot_backend_is("pylab"):
+        assert "<summary>FitPlot</summary>" in r
+        assert "<svg " in r
         return
 
-    assert '<summary>DataPlot (' in r
-    assert '<summary>ModelPlot (' in r
+    assert "<summary>DataPlot (" in r
+    assert "<summary>ModelPlot (" in r
     assert '<div class="dataval">n n</div>' in r
     assert '<div class="dataval">Model</div>' in r
 
@@ -244,13 +249,13 @@ def test_fitcontour(override_plot_backend):
     # different to previous checks
     assert r is not None
 
-    if plot.backend.name == 'pylab':
-        assert '<summary>FitContour</summary>' in r
-        assert '<svg ' in r
+    if plot_backend_is("pylab"):
+        assert "<summary>FitContour</summary>" in r
+        assert "<svg " in r
         return
 
-    assert '<summary>DataContour (' in r
-    assert '<summary>ModelContour (' in r
+    assert "<summary>DataContour (" in r
+    assert "<summary>ModelContour (" in r
     assert '<div class="dataval">n n</div>' in r
     assert '<div class="dataval">Model</div>' in r
 
@@ -278,12 +283,12 @@ def test_intproj(old_numpy_printing, override_plot_backend):
     r = p._repr_html_()
     assert r is not None
 
-    if plot.backend.name == 'pylab':
-        assert '<summary>IntervalProjection</summary>' in r
-        assert '<svg ' in r
+    if plot_backend_is("pylab"):
+        assert "<summary>IntervalProjection</summary>" in r
+        assert "<svg " in r
         return
 
-    assert '<summary>IntervalProjection (8)</summary>' in r
+    assert "<summary>IntervalProjection (8)</summary>" in r
 
     assert '<div class="dataname">x</div><div class="dataval">[ 1.        1.555556  2.111111  2.666667  3.222222  3.777778  4.333333  4.888889\n  5.444444  6.      ]</div>' in r
     assert '<div class="dataname">nloop</div><div class="dataval">10</div>' in r
@@ -313,13 +318,12 @@ def test_regproj(old_numpy_printing, override_plot_backend):
     r = p._repr_html_()
     assert r is not None
 
-    if plot.backend.name == 'pylab':
-        assert '<summary>RegionProjection</summary>' in r
-        assert '<svg ' in r
+    if plot_backend_is("pylab"):
+        assert "<summary>RegionProjection</summary>" in r
+        assert "<svg " in r
         return
 
-    print(r)
-    assert '<summary>RegionProjection (13)</summary>' in r
+    assert "<summary>RegionProjection (13)</summary>" in r
 
     assert '<div class="dataname">parval0</div><div class="dataval">-0.5315772076542427</div>' in r
     assert '<div class="dataname">parval1</div><div class="dataval">0.5854611101216837</div>' in r

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -91,7 +91,6 @@
 #
 
 import numpy as np
-from numpy.testing import assert_almost_equal
 
 import pytest
 
@@ -662,8 +661,8 @@ def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
     # The __str__ and format methods use different formats when
     # displaying the numeric values. Unfortunately the format
     # method uses %g which - for the numbers here - can be less
-    # than 7 decimal places, so assert_almost_equal is not
-    # usable.
+    # than 7 decimal places, and initial testing with assert_almost_equal
+    # did not work so we used this approach instead.
     #
     def checkval_short(s, k, v):
         """Check that s == 'k = <v>'"""
@@ -2107,15 +2106,12 @@ def test_fit_multiple(stat, usestat, usesys, finalstat):
     assert fr.parnames[-1] == fr2.parnames[-1]
 
     if isinstance(statobj, Likelihood):
-        ndp = 0
+        ndp = 1
     else:
         ndp = 7
 
-    # pytest.approx does not have an equivalent of decimal;
-    # we could change this to an absolute tolerance
-    #
-    assert_almost_equal(fr2.parvals[-1], fr.parvals[-1],
-                        decimal=ndp)
+    rel = 10**(-ndp)
+    assert fr2.parvals[-1] == pytest.approx(fr.parvals[-1], rel=rel)
 
 
 @pytest.mark.parametrize("method,estmethod,usestat,usesys", [

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -455,8 +455,8 @@ def test_fit_raises_error_on_bgsubtraction(stat):
     with pytest.raises(FitErr) as excinfo:
         fit.fit()
 
-    emsg = '{} statistics cannot be used with '.format(statobj.name) + \
-           'background subtracted data'
+    emsg = f"{statobj.name} statistics cannot be used with " + \
+           "background subtracted data"
     assert str(excinfo.value) == emsg
 
 
@@ -653,10 +653,10 @@ def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
     # differences in precision/formatting can make this annoying.
     #
     def tostr_short(k, v):
-        return "{:9s} = {}".format(k, v)
+        return f"{k:9s} = {v}"
 
     def tostr_long(k, v):
-        return "{:21s} = {}".format(k, v)
+        return f"{k:21s} = {v}"
 
     # The __str__ and format methods use different formats when
     # displaying the numeric values. Unfortunately the format
@@ -676,7 +676,7 @@ def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
 
         assert s.startswith(tostr_long(k, ''))
         sval = s.split(' = ')[1]
-        assert sval == "%g" % (v, )
+        assert sval == f"{v:g}"
 
     # Validate __str__
     #
@@ -1702,7 +1702,7 @@ def test_fit_str_single(stat):
                 ("stat", stat.__name__),
                 ("method", "LevMar"),
                 ("estmethod", "Covariance")]
-    expected = "\n".join(["{:9s} = {}".format(*e) for e in expected])
+    expected = "\n".join([f"{k:9s} = {v}" for (k,v) in expected])
 
     assert out == expected
 
@@ -1730,7 +1730,7 @@ def test_fit_str_multiple(stat):
                 ("stat", stat.__name__),
                 ("method", "LevMar"),
                 ("estmethod", "Covariance")]
-    expected = "\n".join(["{:9s} = {}".format(*e) for e in expected])
+    expected = "\n".join([f"{k:9s} = {v}" for (k,v) in expected])
 
     assert out == expected
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -35,7 +35,8 @@
 # parameter values should also be adjusted to provide a better test of
 # the "q value" calculated for chi-square like statistics (at present
 # the value is often << 1e-7, which is the limit for
-# assert_almost_equal).
+# assert_almost_equal, although the tests are now being moved to
+# pytest.assert, which has similar behavior).
 #
 # Some of these tests may be superfluous (e.g. testing both the single
 # and multiple dataset handling for calc_chisqr with wstat), but given
@@ -547,7 +548,7 @@ def test_fit_calc_stat_single(stat, usestat, usesys, expected):
     # For now restrict the tests to using the default statistic values
     #
     fit = setup_stat_single(stat(), usestat, usesys)
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
 
 
 # Unfortunately the parameter choces mean that the qval values,
@@ -630,7 +631,7 @@ def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
     assert ans.bkg_ids is None
     assert ans.numpoints == 5
     assert ans.dof == 1
-    assert_almost_equal(ans.statval, expected)
+    assert ans.statval == pytest.approx(expected)
 
     # The logic for the statistical name is a bit complicated.
     statname = statobj.name
@@ -645,9 +646,9 @@ def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
         assert ans.rstat is None
 
     else:
-        assert_almost_equal(ans.qval, qval)
+        assert ans.qval == pytest.approx(qval)
         # as there's only 1 dof, statval == rstat
-        assert_almost_equal(ans.rstat, ans.statval)
+        assert ans.rstat == pytest.approx(ans.statval)
 
     # It is easiest just to do a direct string comparison, but
     # differences in precision/formatting can make this annoying.
@@ -669,7 +670,7 @@ def test_fit_calc_stat_info_single(stat, usestat, usesys, expected, qval):
 
         assert s.startswith(tostr_short(k, ''))
         sval = s.split(' = ')[1]
-        assert_almost_equal(float(sval), v)
+        assert float(sval) == pytest.approx(v)
 
     def checkval_long(s, k, v):
         """Check that s == 'k = <v>'"""
@@ -808,7 +809,7 @@ def test_fit_calc_chisqr_single(stat, usestat, usesys, expected):
     if expected is None:
         assert ans is None
     else:
-        assert_almost_equal(ans, expected)
+        assert ans == pytest.approx(expected)
 
 
 expected_multi_leastsq = 13837.0
@@ -895,12 +896,12 @@ def test_fit_calc_stat_multiple(stat, usestat, usesys, expected):
     statobj = stat()
     fit, fits = setup_stat_multiple(statobj, usestat, usesys, 1)
 
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
 
     # Test that the sum of the individual cases matches the expected
     # value.
     stats = [f.calc_stat() for f in fits]
-    assert_almost_equal(sum(stats), expected)
+    assert sum(stats) == pytest.approx(expected)
 
 
 # The choice of model parameter values does not create "good" fits,
@@ -1000,7 +1001,7 @@ def test_fit_calc_stat_info_multiple(stat, usestat, usesys, expected, qval):
     assert ans.bkg_ids is None
     assert ans.numpoints == nchannels
     assert ans.dof == ndof
-    assert_almost_equal(ans.statval, expected)
+    assert ans.statval == pytest.approx(expected)
 
     # The choice of ans.statname is interesting for chi-squared
     # cases, since it depends on whether usestat is True.
@@ -1015,8 +1016,8 @@ def test_fit_calc_stat_info_multiple(stat, usestat, usesys, expected, qval):
         assert ans.rstat is None
 
     else:
-        assert_almost_equal(ans.qval, qval)
-        assert_almost_equal(ans.rstat, ans.statval / ndof)
+        assert ans.qval == pytest.approx(qval, rel=1e-5)
+        assert ans.rstat == pytest.approx(ans.statval / ndof)
 
 
 chisqr_multi_leastsq = [4.0, 1.0, 9.0, 2500.0, 4900.0, 6400.0,
@@ -1147,9 +1148,9 @@ def test_fit_calc_chisqr_multiple(stat, usestat, usesys, expected):
         assert ans is None
         assert all([a is None for a in allans])
     else:
-        assert_almost_equal(ans, expected)
+        assert ans == pytest.approx(expected, rel=1e-5)
         combined = np.concatenate(allans)
-        assert_almost_equal(combined, expected)
+        assert combined == pytest.approx(expected, rel=1e-5)
 
 
 wstat_single_scalar_stat = 18.907726418126835
@@ -1224,7 +1225,7 @@ def test_fit_calc_stat_wstat_single(scalar, usestat, usesys,
     """
 
     fit = setup_pha_single(scalar, usestat, usesys, flo, fhi)
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
 
 
 # The qval values were calculated using changeset
@@ -1307,7 +1308,7 @@ def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
     # mdl.c0 is the only thawed parameter
     dof = nbin - 1
 
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
     assert isinstance(ans, StatInfoResults)
     assert ans.name == ""
     assert ans.statname == "wstat"
@@ -1315,10 +1316,10 @@ def test_fit_calc_stat_info_wstat_single(scalar, usestat, usesys,
     assert ans.bkg_ids is None
     assert ans.numpoints == nbin
     assert ans.dof == dof
-    assert_almost_equal(ans.statval, expected)
+    assert ans.statval == pytest.approx(expected)
 
-    assert_almost_equal(ans.qval, qval)
-    assert_almost_equal(ans.rstat, expected / dof)
+    assert ans.qval == pytest.approx(qval)
+    assert ans.rstat == pytest.approx(expected / dof)
 
 
 # Do not really need to go through all these options, but it's easy
@@ -1434,7 +1435,7 @@ def test_fit_calc_stat_wstat_grouped_single(flo, fhi, expected):
 
     # For now restrict to the default statistic values
     fit = Fit(src, mdl, stat=WStat())
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
 
 
 wstat_multi_all = 28.114709948
@@ -1471,12 +1472,12 @@ def test_fit_calc_stat_wstat_multiple(flo, fhi, expected):
     """
 
     fit, fits = setup_pha_multiple(flo, fhi)
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
 
     # Test that the sum of the individual cases matches the expected
     # value.
     stats = [f.calc_stat() for f in fits]
-    assert_almost_equal(sum(stats), expected)
+    assert sum(stats) == pytest.approx(expected)
 
 
 # Remember, the filter is only applied to the background for the third
@@ -1522,7 +1523,7 @@ def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected, qval):
 
     dof = nbin - 5
 
-    assert_almost_equal(fit.calc_stat(), expected)
+    assert fit.calc_stat() == pytest.approx(expected)
     assert isinstance(ans, StatInfoResults)
     assert ans.name == ""
     assert ans.statname == "wstat"
@@ -1530,10 +1531,10 @@ def test_fit_calc_stat_info_wstat_multiple(flo, fhi, nbin, expected, qval):
     assert ans.bkg_ids is None
     assert ans.numpoints == nbin
     assert ans.dof == dof
-    assert_almost_equal(ans.statval, expected)
+    assert ans.statval == pytest.approx(expected)
 
-    assert_almost_equal(ans.qval, qval)
-    assert_almost_equal(ans.rstat, expected / dof)
+    assert ans.qval == pytest.approx(qval)
+    assert ans.rstat == pytest.approx(expected / dof)
 
 
 @pytest.mark.parametrize("flo,fhi,expected", [
@@ -1670,13 +1671,13 @@ def test_fit_calc_stat_error_no_cache():
     def ans(delta, dy):
         return (delta / dy) ** 2
 
-    assert_almost_equal(f.calc_stat(), ans(1.0, 1.3))
+    assert f.calc_stat() == pytest.approx(ans(1.0, 1.3))
 
     d.y = np.asarray([3.1, 4.1])
     d.staterror = np.asarray([1.1, 1.5])
     m.c0 = 4.1
 
-    assert_almost_equal(f.calc_stat(), ans(1.0, 1.1))
+    assert f.calc_stat() == pytest.approx(ans(1.0, 1.1))
 
 
 @pytest.mark.parametrize("stat", [
@@ -1879,7 +1880,7 @@ def test_fit_single(stat, usestat, usesys, finalstat):
     assert fit.method.name == 'levmar'
     fr = fit.fit()
     assert fr.succeeded
-    assert_almost_equal(fr.statval, finalstat)
+    assert fr.statval == pytest.approx(finalstat)
 
 
 @pytest.mark.parametrize("stat,usestat,usesys,finalstat", [
@@ -1909,7 +1910,7 @@ def test_fit_single_nm(stat, usestat, usesys, finalstat):
     fit.method = NelderMead()
     fr = fit.fit()
     assert fr.succeeded
-    assert_almost_equal(fr.statval, finalstat)
+    assert fr.statval == pytest.approx(finalstat)
 
 
 # Since the background is being ignored in this fit (except for
@@ -1999,7 +2000,7 @@ def test_fit_single_pha(stat, scalar, usestat, usesys, filtflag, finalstat):
     assert fr.succeeded
     assert fr.numpoints == numpoints
     assert fr.dof == (numpoints - 1)
-    assert_almost_equal(fr.statval, finalstat)
+    assert fr.statval == pytest.approx(finalstat)
 
 
 # Calculated using LevMar
@@ -2081,12 +2082,12 @@ def test_fit_multiple(stat, usestat, usesys, finalstat):
     fit, _ = setup_stat_multiple(statobj, usestat, usesys, 1)
     fr = fit.fit()
     assert fr.succeeded
-    assert_almost_equal(fr.statval, finalstat)
+    assert fr.statval == pytest.approx(finalstat)
 
     fit, _ = setup_stat_multiple(statobj, usestat, usesys, 3)
     fr = fit.fit()
     assert fr.succeeded
-    assert_almost_equal(fr.statval, finalstat)
+    assert fr.statval == pytest.approx(finalstat)
 
     # As the datasets and models are independent, the fit
     # to just the third dataset should return the same parameter
@@ -2110,6 +2111,9 @@ def test_fit_multiple(stat, usestat, usesys, finalstat):
     else:
         ndp = 7
 
+    # pytest.approx does not have an equivalent of decimal;
+    # we could change this to an absolute tolerance
+    #
     assert_almost_equal(fr2.parvals[-1], fr.parvals[-1],
                         decimal=ndp)
 
@@ -2452,11 +2456,11 @@ def test_fit_iterfit_single_sigmarej_chi2(stat):
     expected_mask = [True, True, False, False, False, False, False]
     assert np.all(fit.data.mask == expected_mask)
 
-    assert_almost_equal(fr.statval, 0.0)
+    assert fr.statval == pytest.approx(0.0)
 
     mdl = fit.model
-    assert_almost_equal(mdl.c0.val, 8.722)
-    assert_almost_equal(mdl.c1.val, 2.458)
+    assert mdl.c0.val == pytest.approx(8.722)
+    assert mdl.c1.val == pytest.approx(2.458)
 
     assert fr.numpoints == 2
     assert fr.dof == 0
@@ -2483,11 +2487,11 @@ def test_fit_iterfit_single_sigmarej_chi2gehrels():
     expected_mask = [True, True, True, True, False, True, True]
     assert np.all(fit.data.mask == expected_mask)
 
-    assert_almost_equal(fr.statval, 0.1914790757)
+    assert fr.statval == pytest.approx(0.1914790757)
 
     mdl = fit.model
-    assert_almost_equal(mdl.c0.val, 9.69168196604)
-    assert_almost_equal(mdl.c1.val, 2.00600360315)
+    assert mdl.c0.val == pytest.approx(9.69168196604)
+    assert mdl.c1.val == pytest.approx(2.00600360315)
 
     assert fr.numpoints == 6
     assert fr.dof == 4
@@ -2517,11 +2521,11 @@ def test_fit_iterfit_single_sigmarej_ignore_chi2gehrels():
     expected_mask = [True, False, True, True, False, True, True]
     assert np.all(fit.data.mask == expected_mask)
 
-    assert_almost_equal(fr.statval, 0.1245627587)
+    assert fr.statval == pytest.approx(0.1245627587)
 
     mdl = fit.model
-    assert_almost_equal(mdl.c0.val, 9.25537857670)
-    assert_almost_equal(mdl.c1.val, 2.01845980545)
+    assert mdl.c0.val == pytest.approx(9.25537857670)
+    assert mdl.c1.val == pytest.approx(2.01845980545)
 
     assert fr.numpoints == 5
     assert fr.dof == 3

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1879,7 +1879,7 @@ def test_fit_single(stat, usestat, usesys, finalstat):
     assert fit.method.name == 'levmar'
     fr = fit.fit()
     assert fr.succeeded
-    assert fr.statval == pytest.approx(finalstat)
+    assert fr.statval == pytest.approx(finalstat, rel=7e-5)
 
 
 @pytest.mark.parametrize("stat,usestat,usesys,finalstat", [


### PR DESCRIPTION
# Summary

Update tests to that they pass on aarch64. Fixes #1372 

# Details

The fit tests were just an issue with coming up with a useful tolerance for pytest.approx. The notebook test is a bit harder - in part because of #1373 - but passes.

To verify these changes this PR adds a separate GH action run - currently called `ci-pip-arch.yml` - which is based on the AstroPy version. Technically we could run on `aarch64`, `ppc64le`, and `s390x` but

- there's been no request for `s390x` so skip this
- the `ppc64le` version causes a number of strange errors - e.g. a routine that should return a 2-element array returns more elements, or returning NaN. AstroPy have in fact turned off the ppc64le build because of similar issues; my assumption is that something in the emulation or the required packages we use is causing a problem

This action is run

- once a week, via cron
- for any PR that has the "CI arch" label added (as this one does)

although to validate things when the action is first added it was done  for all PRs and added before #1374 was fixed so we can verify that it fails (which it does).

So, this PR also adds the "CI arch" label.

We could remove the action, or maybe only make it rin on PRs labelled "CI arch" (but it's hard to know when to do this).