### PR TITLE
minimize C++ code duplications (rebase)

### DIFF
--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,4 +1,4 @@
-//  Copyright (C) 2007, 2015-2018, 2019, 2020, 2021
+//  Copyright (C) 2007, 2015-2018, 2019, 2020, 2021, 2022
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -120,216 +120,210 @@ int _sherpa_init_xspec_library();
 extern "C" {
 
 #ifdef XSPEC_12_10_1
-void agnsed_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void qsosed_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call agnsed_;
+  xsf77Call qsosed_;
 #endif
 
 #ifdef XSPEC_12_11_0
-void agnslim_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call agnslim_;
 #endif
 
 #ifndef XSPEC_12_9_1
-void xsaped_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsbape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsaped_;
+  xsf77Call xsbape_;
 #endif
 
-void xsblbd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsbbrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsbmc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsbrms_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsblbd_;
+  xsf77Call xsbbrd_;
+  xsf77Call xsbmc_;
+  xsf77Call xsbrms_;
 
 #ifndef XSPEC_12_9_1
-void xsbvpe_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsbvpe_;
 #endif
 
 #ifndef XSPEC_12_10_0
-void c6mekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void c6pmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void c6pvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void c6vmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call c6mekl_;
+  xsf77Call c6pmekl_;
+  xsf77Call c6pvmkl_;
+  xsf77Call c6vmekl_;
 #endif
 
-void cemekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void compbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void compls_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void compst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xstitg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void disk_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void diskir_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsdskb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call cemekl_;
+  xsf77Call compbb_;
+  xsf77Call compls_;
+  xsf77Call compst_;
+  xsf77Call xstitg_;
+  xsf77Call disk_;
+  xsf77Call diskir_;
+  xsf77Call xsdskb_;
 #ifndef XSPEC_12_10_1
-void xsdili_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsdili_;
 #endif
-void diskm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void disko_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void diskpbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsdiskpn_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsxpdec_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void ezdiskbb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call diskm_;
+  xsf77Call disko_;
+  xsf77Call diskpbb_;
+  xsf77Call xsdiskpn_;
+  xsf77Call xsxpdec_;
+  xsf77Call ezdiskbb_;
 
 #ifndef XSPEC_12_9_1
-void xsgaul_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsgaul_;
 #endif
 
-void grad_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call grad_;
 
 #ifdef XSPEC_12_10_0
-// Note: have dropped the leading 'c_' for this model
-void xsgrbcomp(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  xsccCall xsgrbcomp;
 
-void jet_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call jet_;
 #endif
 
-void xsgrbm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void spin_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsgrbm_;
+  xsf77Call spin_;
 
 #ifdef XSPEC_12_10_1
-void kyrline_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call kyrline_;
 #endif
 
 #ifndef XSPEC_12_9_1
-void xslorz_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsmeka_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsmekl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xslorz_;
+  xsf77Call xsmeka_;
+  xsf77Call xsmekl_;
 #endif
 
-void nsa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void nsagrav_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void nsatmos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call nsa_;
+  xsf77Call nsagrav_;
+  xsf77Call nsatmos_;
 
 #ifndef XSPEC_12_10_0
-void nsmax_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call nsmax_;
 #endif
 
-void xspegp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsp1tr_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsposm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xspegp_;
+  xsf77Call xsp1tr_;
+  xsf77Call xsposm_;
 
 #ifndef XSPEC_12_9_1
-void xsrays_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsrays_;
 #endif
 
-void xredge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsrefsch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void srcut_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void sresc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xredge_;
+  xsf77Call xsrefsch_;
+  xsf77Call srcut_;
+  xsf77Call sresc_;
 #ifdef XSPEC_12_10_0
-void ssa_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call ssa_;
 #endif
-void xsstep_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsstep_;
 
 #ifndef XSPEC_12_9_1
-void xsvape_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsvape_;
 #endif
 
-void xsbrmv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsbrmv_;
 
 #ifndef XSPEC_12_9_1
-void xsvmek_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsvmkl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsvmek_;
+  xsf77Call xsvmkl_;
 #endif
 
 #ifndef XSPEC_12_9_1
-void xsvrys_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsvrys_;
 #endif
 
-void xszbod_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszbrm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xszbod_;
+  xsf77Call xszbrm_;
 
 #ifndef XSPEC_12_10_0
-void acisabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call acisabs_;
 #endif
 
-void xscnst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xscabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xscycl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsedge_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsabsc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsexp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xshecu_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xshrfl_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsntch_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsabsp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsphab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsplab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xscred_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xssmdg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsspln_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xssssi_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xscnst_;
+  xsf77Call xscabs_;
+  xsf77Call xscycl_;
+  xsf77Call xsdust_;
+  xsf77Call xsedge_;
+  xsf77Call xsabsc_;
+  xsf77Call xsexp_;
+  xsf77Call xshecu_;
+  xsf77Call xshrfl_;
+  xsf77Call xsntch_;
+  xsf77Call xsabsp_;
+  xsf77Call xsphab_;
+  xsf77Call xsplab_;
+  xsf77Call xscred_;
+  xsf77Call xssmdg_;
+  xsf77Call xsspln_;
+  xsf77Call xssssi_;
 
 #ifndef XSPEC_12_10_0
-void swind1_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call swind1_;
 #endif
 
-void xsred_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsabsv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsvphb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsabsw_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xswnab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsxirf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void mszdst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszedg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszhcu_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszabp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszphb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsred_;
+  xsf77Call xsabsv_;
+  xsf77Call xsvphb_;
+  xsf77Call xsabsw_;
+  xsf77Call xswnab_;
+  xsf77Call xsxirf_;
+  xsf77Call mszdst_;
+  xsf77Call xszedg_;
+  xsf77Call xszhcu_;
+  xsf77Call xszabp_;
+  xsf77Call xszphb_;
 
 #ifndef XSPEC_12_10_0
-void zxipcf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call zxipcf_;
 #endif
 
-void xszcrd_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void msldst_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszvab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszvfe_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszvph_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszwnb_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xszcrd_;
+  xsf77Call msldst_;
+  xsf77Call xszvab_;
+  xsf77Call xszvfe_;
+  xsf77Call xszvph_;
+  xsf77Call xszabs_;
+  xsf77Call xszwnb_;
 
 
 #ifndef XSPEC_12_9_1
-void xsbvvp_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xsvvap_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call xsbvvp_;
+  xsf77Call xsvvap_;
 #endif
 
-void zigm_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call zigm_;
 
 #ifndef XSPEC_12_10_1
-void logpar_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call logpar_;
 #endif
-void eplogpar_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void optxagn_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void optxagnf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void pexmon_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call eplogpar_;
+  xsf77Call optxagn_;
+  xsf77Call optxagnf_;
+  xsf77Call pexmon_;
 
 // additive
-void xscompmag(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-void xscomptb(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  xsccCall xscompmag;
+  xsccCall xscomptb;
 
 #ifndef XSPEC_12_10_0
-void nsmaxg_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void nsx_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call nsmaxg_;
+  xsf77Call nsx_;
 #endif
 
 //multiplicative
-void xsphei_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xslyman_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void xszbabs(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  xsf77Call xsphei_;
+  xsf77Call xslyman_;
+  xsccCall xszbabs;
 
 #ifdef XSPEC_12_9_1
-void ismabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-// Note: have dropped the leading 'c_' for this model
-void slimbbmodel(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  xsf77Call ismabs_;
+  xsccCall slimbbmodel;
 #endif
 
 #ifdef XSPEC_12_11_0
-void ismdust_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-void olivineabs_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
-
-// Note: have dropped the leading 'c_' for this model
-// TODO: should look at whether we want to fix this as now have a
-//       number of c_xxx functions in model.dat
-void beckerwolff(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+  xsf77Call ismdust_;
+  xsf77Call olivineabs_;
+  xsccCall beckerwolff;
 #endif
 
 
@@ -350,22 +344,20 @@ void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 // XSPEC convolution models
 //
 
-void rgsxsrc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call rgsxsrc_;
 
 #ifdef XSPEC_12_10_1
-void kyconv_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call kyconv_;
 #endif
 
 #ifdef XSPEC_12_11_0
-void thcompf_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsf77Call thcompf_;
 #endif
 
 // XSPEC 12.12.0 changes
 #ifdef XSPEC_12_12_0
-// Note: have dropped the leading 'c_' for this model to follow xsgrbcomp
-void xsgrbjet(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
-
-void zxipab_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+  xsccCall xsgrbjet;
+  xsf77Call zxipab_;
 #endif
 
 }

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -302,10 +302,16 @@ def test_evaluate_model():
     assert (out > 0).all()
 
 
+# Select a few models which are likely to cover
+# additive/multiplicative and language (e.g. FORTRAN vs C/C++).
+#
+BASIC_MODELS = ['powerlaw', 'gaussian',
+                'vapec',  # pick this as scientifically "useful"
+                'constant', 'wabs']
+
+
 @requires_xspec
-@pytest.mark.parametrize('model', ['powerlaw', 'gaussian',
-                                   'vapec',  # pick this as scientifically "useful"
-                                   'constant', 'wabs'])
+@pytest.mark.parametrize('model', BASIC_MODELS)
 def test_lowlevel(model):
     """The XSPEC class interface requires lo,hi but the low-level allows just x
 
@@ -334,6 +340,26 @@ def test_lowlevel(model):
     assert y1[:-1] == pytest.approx(y2)
     assert y1[-1] == 0.0
     assert (y2 > 0).all()
+
+
+@requires_xspec
+@pytest.mark.parametrize('model', BASIC_MODELS)
+def test_lowlevel_checks_too_many_arguments(model):
+    """Check we get a sensible error when called with no arguments.
+
+    Note that this tests the interface to the actual XSPEC model
+    not the Python class.
+    """
+
+    import sherpa.astro.xspec as xs
+
+    cls = getattr(xs, 'XS{}'.format(model))
+    mdl = cls()
+
+    with pytest.raises(TypeError) as exc:
+        mdl._calc()
+
+    assert str(exc.value) == "function takes at least 2 arguments (0 given)"
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -342,15 +342,21 @@ def test_checks_input_length():
     mdl = xs.XSpowerlaw()
 
     # Check when input array is too small (< 2 elements)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as exc1:
         mdl([0.1], [0.2])
 
+    assert str(exc1.value) == "input array must have at least 2 elements, found 1"
+
     # Check when input arrays are not the same size.
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as exc2:
         mdl([0.1, 0.2, 0.3], [0.2, 0.3])
 
-    with pytest.raises(TypeError):
+    assert str(exc2.value) == "input arrays are not the same size: 3 and 2"
+
+    with pytest.raises(TypeError) as exc3:
         mdl([0.1, 0.2], [0.2, 0.3, 0.4])
+
+    assert str(exc3.value) == "input arrays are not the same size: 2 and 3"
 
 
 @requires_xspec
@@ -363,16 +369,25 @@ def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_pa
     mdl = ui.get_model_component('mdl')
 
     # Check when input array is too small (< 2 elements)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as exc1:
         mdl([0.1], [0.2])
+
+    emsg = "input array must have at least 2 elements, found 1"
+    assert str(exc1.value) == emsg
 
     # Check when input arrays are not the same size (when the
     # low and high bin edges are given)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as exc2:
         mdl([0.1, 0.2, 0.3], [0.2, 0.3])
 
-    with pytest.raises(TypeError):
+    emsg = "input arrays are not the same size: 3 and 2"
+    assert str(exc2.value) == emsg
+
+    with pytest.raises(TypeError) as exc3:
         mdl([0.1, 0.2], [0.2, 0.3, 0.4])
+
+    emsg = "input arrays are not the same size: 2 and 3"
+    assert str(exc3.value) == emsg
 
 
 @requires_xspec
@@ -533,11 +548,17 @@ def test_convolution_model_cpflux_noncontiguous():
     pars = [0.2, 0.8, lflux]
     y1 = numpy.zeros(elo.size)
 
-    with pytest.raises(ValueError):
+    emsg = "XSPEC convolution model requires a contiguous grid"
+
+    with pytest.raises(ValueError) as exc1:
         xs._xspec.C_cpflux(pars, y1, elo, ehi)
 
-    with pytest.raises(ValueError):
+    assert str(exc1.value) == emsg
+
+    with pytest.raises(ValueError) as exc2:
         xs._xspec.C_cpflux(pars, y1, wlo, whi)
+
+    assert str(exc2.value) == emsg
 
 
 @requires_xspec

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2009, 2015, 2017, 2020, 2021  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2009, 2015, 2017, 2020, 2021, 2022
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -29,6 +30,8 @@
 #include <sstream>
 #include <iostream>
 #include <algorithm>
+#include <stdexcept>
+
 #include "sherpa/fcmp.hh"
 
 // Prior to XSPEC 12.10.1, the table models were split into different
@@ -61,6 +64,10 @@ namespace sherpa { namespace astro { namespace xspec {
 
 typedef sherpa::Array< float, NPY_FLOAT > FloatArray;
 typedef float FloatArrayType;
+typedef void (*XSpecFuncRef)( float* ear, int* ne, float* param, int* ifl, float* photar, float* photer );
+typedef void (*XSpecFuncVal)( float* ear, int ne, float* param, const char* filenm, int ifl, float* photar, float* photer );
+typedef void (*XSpecFuncDouble)( const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr );
+
 
 // Try and support the use of std::transform while still building
 // against C++-98 compilers.
@@ -146,8 +153,8 @@ template <typename CType, int ArrayType>
 static bool create_grid(const sherpa::Array<CType, ArrayType> &xlo,
 			const sherpa::Array<CType, ArrayType> &xhi,
 			std::vector<CType> &ear,
-			std::vector<int> &gaps_index,
-			std::vector<CType> &gaps_edges) {
+			std::vector<int> &gaps_index ) {
+  std::vector<CType> gaps_edges;
 
   int nelem = int( xlo.get_size() );
   if ( nelem < 2 ) {
@@ -445,291 +452,438 @@ static bool create_output(int nbins, T &a, T &b) {
 
 } /* create_output */
 
-
-template <npy_intp NumPars, bool HasNorm,
-void (*XSpecFunc)( float* ear, int* ne, float* param, int* ifl,
-		float* photar, float* photer )>
-PyObject* xspecmodelfct( PyObject* self, PyObject* args )
-{
-
+      class PyArgTupleBase {
+      public:
+        PyArgTupleBase( ) {
 #ifdef INIT_XSPEC
 	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          return NULL;
+          throw std::runtime_error("Unable to initialize XSpec");
 #endif
+        }
 
-	FloatArray pars;
-	DoubleArray xlo;
-	DoubleArray xhi;
+      };
 
-        // The grid arrays could be cast to FloatArray here, saving
-        // conversion later on in this routine. However, that can then
-        // lead to differences in the identification of non-contiguous
-        // bins, or whether a grid is monotonic and non-overlapping [*]
-        // (e.g. if a source expression contains both a FORTRAN
-        // and C style model), so stick to this approach for now.
-        //
-        // [*] although these checks are currently commented out
-        //
-	if ( !PyArg_ParseTuple( args, (char*)"O&O&|O&",
-			(converter)convert_to_contig_array< FloatArray >,
-			&pars,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xlo,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xhi ) )
-          return NULL;
+      template <typename RealArray>
+      class PyArgTuple3 : public PyArgTupleBase {
+      public:
+        PyArgTuple3( PyObject* args, npy_intp NumPars, RealArray& pars,
+                     DoubleArray& xlo, DoubleArray& xhi ) :
+          PyArgTupleBase( ) {
+          //
+          // The grid arrays could be cast to FloatArray here, saving
+          // conversion later on in this routine. However, that can then
+          // lead to differences in the identification of non-contiguous
+          // bins, or whether a grid is monotonic and non-overlapping [*]
+          // (e.g. if a source expression contains both a FORTRAN
+          // and C style model), so stick to this approach for now.
+          //
+          // [*] although these checks are currently commented out
+          //
+          if ( !PyArg_ParseTuple( args, (char*)"O&O&|O&",
+                                  (converter)convert_to_contig_array< RealArray >,
+                                  &pars,
+                                  (converter)convert_to_contig_array< DoubleArray >,
+                                  &xlo,
+                                  (converter)convert_to_contig_array< DoubleArray >,
+                                  &xhi ) )
+            throw std::runtime_error("Error Parsing args");
+          npy_intp npars = pars.get_size();
+          if ( NumPars != npars ) {
+            std::ostringstream err;
+            err << "expected " << NumPars << " parameters, got " << npars;
+            PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+            throw std::runtime_error(err.str());
+          }
+          return;
+        };
+      };
 
-	npy_intp npars = pars.get_size();
+      template <typename RealArray>
+      class PyArgTuple4 : public PyArgTupleBase {
+      public:
+        PyArgTuple4( PyObject* args, npy_intp NumPars, RealArray& pars,
+                     RealArray& fluxes, DoubleArray& xlo, DoubleArray& xhi ) :
+          PyArgTupleBase( ) {
+          //
+          // The arguments are parsed as
+          //   pars, fluxes, xlo
+          //   pars, fluxes, xlo, xhi
+          // where fluxes is the spectrum that is to be convolved
+          // by the model.
+          //
+          if ( !PyArg_ParseTuple( args, (char*)"O&O&O&|O&",
+                                  (converter)convert_to_contig_array< RealArray >,
+                                  &pars,
+                                  (converter)convert_to_contig_array< RealArray >,
+                                  &fluxes,
+                                  (converter)convert_to_contig_array< DoubleArray >,
+                                  &xlo,
+                                  (converter)convert_to_contig_array< DoubleArray >,
+                                  &xhi ) )
+            throw std::runtime_error("Error Parsing args");
+          npy_intp npars = pars.get_size();
+          if ( NumPars != npars ) {
+            std::ostringstream err;
+            err << "expected " << NumPars << " parameters, got " << npars;
+            PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+            throw std::runtime_error(err.str());
+          }
+          return;
+        };
+      };
 
-	if ( NumPars != npars ) {
-          std::ostringstream err;
-          err << "expected " << NumPars << " parameters, got " << npars;
-          PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-          return NULL;
-	}
+      template<typename Real, typename RealArray>
+      class xspecModelFctBase {
+      public:
 
-	// The grid to send to XSPEC (double precision).
-	//
-	std::vector<SherpaFloat> ear;
-        std::vector<SherpaFloat> gaps_edges;
+        virtual ~xspecModelFctBase( ) { }
+
+        xspecModelFctBase( PyObject* arg, npy_intp numpars, bool hasnorm )
+          : args(arg), ifl(1), NumPars(numpars), HasNorm(hasnorm) { }
+
+        virtual void call_xspec( RealArray& result ) { }
+
+        void eval( RealArray& result ) {
+
+          PyArgTuple3<RealArray>( args, NumPars, pars, xlo, xhi );
+
+          //
+          // The grid to send to XSPEC (double precision).
+          //
+          if (!create_grid(xlo, xhi, ear, gaps_index))
+            throw std::runtime_error("Unable to create grid");
+
+          nelem = int( xlo.get_size() );
+          ngrid = ear.size();
+          npts = ngrid - 1;
+
+          // Number of bins to send to XSPEC
+          int nout = ngrid;
+          if (xhi) nout--;
+
+          if (!create_output(nout, result, error))
+            throw std::runtime_error("Unable to create output");
+
+          call_xspec( result );
+
+          int ngaps = gaps_index.size();
+          if (ngaps > 0) {
+            finalize_grid(nelem, result, gaps_index);
+          }
+
+          // Apply normalization if required
+          if ( HasNorm )
+            for (int i = 0; i < nelem; i++)
+              result[i] *= pars[NumPars - 1];
+
+        } // eval
+
+        const char* get_err_msg( ) { return "XSPEC model evaluation failed"; }
+
+      protected:
+
+        PyObject* args;
+        int ifl, ngrid, npts;;
+        std::vector<SherpaFloat> ear;
+        RealArray pars, error;
+
+      private:
+
+        int NumPars, HasNorm, nelem;
         std::vector<int> gaps_index;
-	if (!create_grid(xlo, xhi, ear, gaps_index, gaps_edges)) {
-	  return NULL;
-	}
+        DoubleArray xlo, xhi;
 
-	int nelem = int( xlo.get_size() );
-	int ngrid = ear.size();
-	int ifl = 1;
+      }; // class xspecModelFctBase
 
-        // convert to 32-byte float
-        std::vector<FloatArrayType> fear(ngrid);
-	CONVERTARRAY(ear, fear, ngrid);
+      template<typename Real, typename RealArray, XSpecFuncDouble XSpecFunc>
+      class xspecModelFctC : public xspecModelFctBase<Real, RealArray>  {
+      public:
 
-	// Number of bins to send to XSPEC
-	int nout = ngrid;
-	if (xhi) nout--;
+        xspecModelFctC( PyObject* args, npy_intp NumPars, bool HasNorm )
+          : xspecModelFctBase<Real, RealArray>( args, NumPars, HasNorm ) { }
 
-	FloatArray result, error;
-	if (!create_output(nout, result, error)) {
-	  return NULL;
-	}
+        void call_xspec( RealArray& result ) {
+          XSpecFunc( &this->ear[0], this->npts, &this->pars[0], this->ifl,
+                     &result[0], &this->error[0], NULL );
+          return;
+        }
 
-	// Even though the XSPEC model function is Fortran, it could call
-	// C++ functions, so swallow exceptions here
+      }; // class xspecModelFctC
 
-	try {
+      template<typename Real, typename RealArray, XSpecFuncRef XSpecFunc>
+      class xspecModelFctF : public xspecModelFctBase<Real, RealArray>  {
+      public:
 
-          int npts = ngrid - 1;
-          XSpecFunc( &fear[0], &npts, &pars[0], &ifl,
-                     &result[0], &error[0] );
+        xspecModelFctF( PyObject* args, npy_intp NumPars, bool HasNorm )
+          : xspecModelFctBase<Real, RealArray>( args, NumPars, HasNorm ) { }
 
-	} catch(...) {
+        void call_xspec( RealArray& result ) {
+          // convert to 32-byte float
+          std::vector<float> fear(this->ngrid);
+          CONVERTARRAY(this->ear, fear, this->ngrid);
+          XSpecFunc( &fear[0], &this->npts, &this->pars[0], &this->ifl,
+                     &result[0], &this->error[0] );
+          return;
+        }
 
-          PyErr_SetString( PyExc_ValueError,
-                           (char*)"XSPEC model evaluation failed" );
-          return NULL;
+      }; // class xspecModelFctF
 
-	}
 
-	int ngaps = (int) gaps_index.size();
-	if (ngaps > 0) {
-	  finalize_grid(nelem, result, gaps_index);
-	}
+      template<typename Real, typename RealArray>
+      class xspecModelFctConBase {
+      public:
 
-	// Apply normalization if required
-	if ( HasNorm )
-          for (int i = 0; i < nelem; i++)
-            result[i] *= pars[NumPars - 1];
+        virtual ~xspecModelFctConBase( ) { }
 
-	return result.return_new_ref();
+        xspecModelFctConBase( PyObject* arg, npy_intp numpars )
+          : args(arg), ifl(1), NumPars(numpars) { }
+
+        virtual void call_xspec( RealArray& result ) { }
+
+        void eval( RealArray& result ) {
+
+          PyArgTuple4<RealArray>( args, NumPars, pars, fluxes, xlo, xhi );
+
+          // XSpec traditionally refers to the input energy grid as ear.
+          // std::vector<SherpaFloat> ear;
+          if (!create_contiguous_grid(xlo, xhi, ear))
+            throw std::runtime_error("Unable to create contiguous grid");
+
+          nelem = xlo.get_size();
+          ngrid = ear.size();
+          npts = ngrid - 1;
+
+          // For now require the fluxes array to have the same
+          // size as the input grid. If xhi is not given then
+          // technically fluxes should be one less, but this is
+          // likely to cause problems (as it doesn't match how
+          // the rest of the interface works).
+          if( nelem != fluxes.get_size() ) {
+            std::ostringstream err;
+            err << "flux array does not match the input grid: " << nelem
+                << " and " << fluxes.get_size();
+            PyErr_SetString( PyExc_TypeError, err.str().c_str() );
+            throw std::runtime_error(err.str());
+          }
+
+          // Number of bins to send to XSPEC
+          int nout = ngrid;
+          if (xhi) nout--;
+
+          if (!create_output(nout, result, error))
+            throw std::runtime_error("Unable to create output");
+
+          // Copy over the flux array
+          std::copy(&fluxes[0], &fluxes[nout], &result[0]);
+
+          call_xspec( result );
+
+        } // eval
+
+        const char* get_err_msg( ) { return "XSPEC convolution model evaluation failed"; }
+
+      protected:
+
+        PyObject* args;
+        int ifl, ngrid, npts;;
+        std::vector<SherpaFloat> ear;
+        RealArray pars, error;
+
+      private:
+
+        int NumPars, HasNorm, nelem;
+        std::vector<int> gaps_index;
+        DoubleArray xlo, xhi;
+        RealArray fluxes;
+
+      }; // class xspecModelFctConBase
+
+      template<typename Real, typename RealArray, XSpecFuncDouble XSpecFunc>
+      class xspecModelFctConC : public xspecModelFctConBase<Real, RealArray>  {
+      public:
+
+        xspecModelFctConC( PyObject* arg, npy_intp numpars )
+          : xspecModelFctConBase<Real, RealArray>( arg, numpars ) { }
+
+        void call_xspec( RealArray& result ) {
+          XSpecFunc( &this->ear[0], this->npts, &this->pars[0], this->ifl,
+                     &result[0], &this->error[0], NULL );
+          return;
+        }
+
+      }; // class xspecModelFctConC
+
+      template<typename Real, typename RealArray, XSpecFuncRef XSpecFunc>
+      class xspecModelFctConF : public xspecModelFctConBase<Real, RealArray>  {
+      public:
+
+        xspecModelFctConF( PyObject* args, npy_intp NumPars )
+          : xspecModelFctConBase<Real, RealArray>( args, NumPars ) { }
+
+        void call_xspec( RealArray& result ) {
+          // convert to 32-byte float
+          std::vector<float> fear(this->ngrid);
+          CONVERTARRAY(this->ear, fear, this->ngrid);
+          XSpecFunc( &fear[0], &this->npts, &this->pars[0], &this->ifl,
+                     &result[0], &this->error[0] );
+          return;
+        }
+
+      }; // class xspecModelFctConF
+
+      class xspecTableModelBase {
+      public:
+
+        virtual ~xspecTableModelBase( ) { }
+
+        xspecTableModelBase( int arg ) : ifl(arg) { }
+
+        virtual void call_xspec( std::vector<FloatArrayType>& fear,
+                                 FloatArray& pars, npy_intp npars,
+                                 char* filename, char*tabtype,
+                                 FloatArray& result ) { }
+
+        void eval( bool HasNorm, DoubleArray& xlo, DoubleArray& xhi,
+                   npy_intp npars, FloatArray& pars, char* filename,
+                   char* tabtype, FloatArray& result ) {
+
+          //
+          // The grid to send to XSPEC (double precision).
+          //
+          if (!create_grid(xlo, xhi, ear, gaps_index))
+            throw std::runtime_error("Unable to create grid");
+
+          nelem = xlo.get_size();
+          ngrid = ear.size();
+          npts = ngrid - 1;
+          ifl = 1;
+
+          // convert to 32-byte float
+          std::vector<FloatArrayType> fear(ngrid);
+          CONVERTARRAY(ear, fear, ngrid);
+
+          // Number of bins to send to XSPEC
+          nout = ngrid;
+          if (xhi) nout--;
+
+          if (!create_output(nout, result, error))
+            throw std::runtime_error("Unable to create output");
+
+          // Swallow exceptions here
+
+          call_xspec(fear, pars, npars, filename, tabtype, result);
+
+          ngaps = gaps_index.size();
+          if (ngaps > 0) {
+            finalize_grid(nelem, result, gaps_index);
+          }
+
+        } // eval
+
+        const char* get_err_msg( ) { return "XSPEC model evaluation failed"; }
+
+      protected:
+        int npts, ifl;
+        FloatArray error;
+
+      private:
+        int nelem, nout, ngrid, ngaps;
+        std::vector<SherpaFloat> ear;
+        std::vector<int> gaps_index;
+
+      }; // class xspecTableModelBase
+
+
+      class xspecTableModelTabint : public xspecTableModelBase {
+      public:
+        xspecTableModelTabint( ) : xspecTableModelBase(1) { }
+        void call_xspec( std::vector<FloatArrayType>& fear,
+                         FloatArray& pars, npy_intp npars,
+                         char* filename, char*tabtype,
+                         FloatArray& result ) {
+          tabint( &fear[0], this->npts, &pars[0], npars,
+                  filename, this->ifl, tabtype,
+                  &result[0], &this->error[0] );
+        }
+      }; // class xspecTableModelTabint
+
+      //
+      // In theory the following should work but have not tested, yet
+      //
+      // template<XSpecFuncVal XSpecFunc>
+      // class xspecTableModel : public xspecTableModelBase {
+      // public:
+      //   xspecTableModel( ) : xspecTableModelBase(1) { }
+      //   void call_xspec( std::vector<FloatArrayType>& fear,
+      //                    FloatArray& pars, npy_intp npars,
+      //                    int char* filename, char*tabtype,
+      //                    FloatArray& result ) {
+      //     XSpecFunc( &fear[0], this->npts, &pars[0], filename,
+      //                this->ifl, &result[0], &this->error[0] );
+
+      //   }
+
+      // }; // class xspecTableModel
+
+
+template <npy_intp NumPars, bool HasNorm, XSpecFuncRef XSpecFunc>
+PyObject* xspecmodelfct( PyObject* self, PyObject* args ) {
+
+  xspecModelFctF<float, FloatArray, XSpecFunc> xspec_model =
+    xspecModelFctF<float, FloatArray, XSpecFunc>( args, NumPars, HasNorm );
+  try {
+    FloatArray result;
+    xspec_model.eval( result );
+    return result.return_new_ref();
+  } catch(std::runtime_error& re) {
+    return NULL;
+  } catch(...) {
+    // Even though the XSPEC model function is Fortran, it could call
+    // C++ functions, so swallow exceptions here
+    PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+    return NULL;
+  }
 
 }
 
+template <npy_intp NumPars, bool HasNorm, XSpecFuncDouble XSpecFunc>
+PyObject* xspecmodelfct_C( PyObject* self, PyObject* args ) {
 
-template <npy_intp NumPars, bool HasNorm,
-void (*XSpecFunc)( const double* energy, int nFlux,
-		const double* params, int spectrumNumber,
-		double* flux, double* fluxError,
-		const char* initStr )>
-PyObject* xspecmodelfct_C( PyObject* self, PyObject* args )
-{
-
-#ifdef INIT_XSPEC
-	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          return NULL;
-#endif
-
-	DoubleArray pars;
-	DoubleArray xlo;
-	DoubleArray xhi;
-
-	if ( !PyArg_ParseTuple( args, (char*)"O&O&|O&",
-			(converter)convert_to_contig_array< DoubleArray >,
-			&pars,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xlo,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xhi ) )
-          return NULL;
-
-	npy_intp npars = pars.get_size();
-
-	if ( NumPars != npars ) {
-          std::ostringstream err;
-          err << "expected " << NumPars << " parameters, got " << npars;
-          PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-          return NULL;
-	}
-
-	// The grid to send to XSPEC (double precision).
-	//
-	std::vector<SherpaFloat> ear;
-        std::vector<SherpaFloat> gaps_edges;
-        std::vector<int> gaps_index;
-	if (!create_grid(xlo, xhi, ear, gaps_index, gaps_edges)) {
-	  return NULL;
-	}
-
-	int nelem = int( xlo.get_size() );
-	int ngrid = ear.size();
-        int ifl = 1;
-
-	// Number of bins to send to XSPEC
-	int nout = ngrid;
-	if (xhi) nout--;
-
-	DoubleArray result, error;
-	if (!create_output(nout, result, error)) {
-	  return NULL;
-	}
-
-	try {
-
-          int npts = ngrid - 1;
-          XSpecFunc( &ear[0], npts, &pars[0], ifl,
-                     &result[0], &error[0], NULL );
-
-	} catch(...) {
-
-          PyErr_SetString( PyExc_ValueError,
-                           (char*)"XSPEC model evaluation failed" );
-          return NULL;
-
-	}
-
-	int ngaps = (int) gaps_index.size();
-	if (ngaps > 0) {
-	  finalize_grid(nelem, result, gaps_index);
-	}
-
-	// Apply normalization if required
-	if ( HasNorm )
-          for (int i = 0; i < nelem; i++)
-            result[i] *= pars[NumPars - 1];
-
-	return result.return_new_ref();
+  xspecModelFctC<double, DoubleArray, XSpecFunc> xspec_model =
+    xspecModelFctC<double, DoubleArray, XSpecFunc>( args, NumPars, HasNorm );
+  try {
+    DoubleArray result;
+    xspec_model.eval( result );
+    return result.return_new_ref();
+  } catch(std::runtime_error& re) {
+    return NULL;
+  } catch(...) {
+    PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+    return NULL;
+  }
 
 }
+
 
 // Handle convolution models, which are assumed to have C-style
 // linkage.
 //
 // This template does not support non-contiguous grids.
-template <npy_intp NumPars,
-void (*XSpecFunc)( const double* energy, int nFlux,
-		const double* params, int spectrumNumber,
-		double* flux, double* fluxError,
-		const char* initStr )>
-PyObject* xspecmodelfct_con( PyObject* self, PyObject* args )
-{
+template <npy_intp NumPars, XSpecFuncDouble XSpecFunc>
+PyObject* xspecmodelfct_con( PyObject* self, PyObject* args ) {
 
-#ifdef INIT_XSPEC
-	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          return NULL;
-#endif
-
-	DoubleArray pars;
-	DoubleArray xlo;
-	DoubleArray xhi;
-	DoubleArray fluxes;
-
-        // The arguments are parsed as
-        //   pars, fluxes, xlo
-        //   pars, fluxes, xlo, xhi
-        // where fluxes is the spectrum that is to be convolved
-        // by the model.
-        //
-	if ( !PyArg_ParseTuple( args, (char*)"O&O&O&|O&",
-			(converter)convert_to_contig_array< DoubleArray >,
-			&pars,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&fluxes,
-			(converter)convert_to_contig_array< DoubleArray >,
-                        &xlo,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xhi ) )
-          return NULL;
-
-	npy_intp npars = pars.get_size();
-
-	if ( NumPars != npars ) {
-          std::ostringstream err;
-          err << "expected " << NumPars << " parameters, got " << npars;
-          PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-          return NULL;
-	}
-
-        // XSpec traditionally refers to the input energy grid as ear.
-        std::vector<SherpaFloat> ear;
-	if (!create_contiguous_grid(xlo, xhi, ear)) {
-	  return NULL;
-	}
-
-	int nelem = int( xlo.get_size() );
-	int ngrid = ear.size();
-        int ifl = 1;
-
-        // For now require the fluxes array to have the same
-        // size as the input grid. If xhi is not given then
-        // technically fluxes should be one less, but this is
-        // likely to cause problems (as it doesn't match how
-        // the rest of the interface works).
-        if( nelem != int(fluxes.get_size()) ) {
-          std::ostringstream err;
-          err << "flux array does not match the input grid: " << nelem
-              << " and " << int( fluxes.get_size() );
-          PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-          return NULL;
-        }
-
-	// Number of bins to send to XSPEC
-	int nout = ngrid;
-	if (xhi) nout--;
-
-	DoubleArray result, error;
-	if (!create_output(nout, result, error)) {
-	  return NULL;
-	}
-
-        // Copy over the flux array
-        for (int i = 0; i < nout; i++)
-          result[i] = fluxes[i];
-
-	try {
-
-          int npts = ngrid - 1;
-          XSpecFunc( &ear[0], npts, &pars[0], ifl,
-                     &result[0], &error[0], NULL );
-
-	} catch(...) {
-
-          PyErr_SetString( PyExc_ValueError,
-                           (char*)"XSPEC convolution model evaluation failed" );
-          return NULL;
-
-	}
-
-	return result.return_new_ref();
+  xspecModelFctConC<double, DoubleArray, XSpecFunc> xspec_model =
+    xspecModelFctConC<double, DoubleArray, XSpecFunc>( args, NumPars );
+  try {
+    DoubleArray result;
+    xspec_model.eval(result);
+    return result.return_new_ref();
+  } catch(std::runtime_error& re) {
+    return NULL;
+  } catch(...) {
+    PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+    return NULL;
+  }
 
 }
 
@@ -737,105 +891,23 @@ PyObject* xspecmodelfct_con( PyObject* self, PyObject* args )
 // F77 in the name (rather than have the FORTRAN interface be "default"
 // version as it for the additive and multiplicative models).
 //
-template <npy_intp NumPars,
-	  void (*XSpecFunc)( float* ear, int* ne, float* param, int* ifl,
-			     float* photar, float* photer )>
-PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args )
-{
+template <npy_intp NumPars, XSpecFuncRef XSpecFunc>
+PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args ) {
 
-#ifdef INIT_XSPEC
-	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          return NULL;
-#endif
-
-	// Follow xspecmodelfct template for handling the grid arrays
-	// in double precision
-	FloatArray pars;
-	DoubleArray xlo;
-	DoubleArray xhi;
-	FloatArray fluxes;
-
-        // The arguments are parsed as
-        //   pars, fluxes, xlo
-        //   pars, fluxes, xlo, xhi
-        // where fluxes is the spectrum that is to be convolved
-        // by the model.
-        //
-	if ( !PyArg_ParseTuple( args, (char*)"O&O&O&|O&",
-			(converter)convert_to_contig_array< FloatArray >,
-			&pars,
-			(converter)convert_to_contig_array< FloatArray >,
-			&fluxes,
-			(converter)convert_to_contig_array< DoubleArray >,
-                        &xlo,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xhi ) )
-          return NULL;
-
-	npy_intp npars = pars.get_size();
-
-	if ( NumPars != npars ) {
-          std::ostringstream err;
-          err << "expected " << NumPars << " parameters, got " << npars;
-          PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-          return NULL;
-	}
-
-        // XSpec traditionally refers to the input energy grid as ear.
-        std::vector<SherpaFloat> ear;
-	if (!create_contiguous_grid(xlo, xhi, ear)) {
-	  return NULL;
-	}
-
-	int nelem = int( xlo.get_size() );
-	int ngrid = ear.size();
-        int ifl = 1;
-
-        // For now require the fluxes array to have the same
-        // size as the input grid. If xhi is not given then
-        // technically fluxes should be one less, but this is
-        // likely to cause problems (as it doesn't match how
-        // the rest of the interface works).
-        if( nelem != int(fluxes.get_size()) ) {
-          std::ostringstream err;
-          err << "flux array does not match the input grid: " << nelem
-              << " and " << int( fluxes.get_size() );
-          PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-          return NULL;
-        }
-
-        // convert to 32-byte float
-        std::vector<FloatArrayType> fear(ngrid);
-	CONVERTARRAY(ear, fear, ngrid);
-
-	// Number of bins to send to XSPEC
-	int nout = ngrid;
-	if (xhi) nout--;
-
-	FloatArray result, error;
-	if (!create_output(nout, result, error)) {
-	  return NULL;
-	}
-
-        // Copy over the flux array
-        for (int i = 0; i < nout; i++)
-          result[i] = fluxes[i];
-
-	try {
-
-          int npts = ngrid - 1;
-          XSpecFunc( &fear[0], &npts, &pars[0], &ifl,
-                     &result[0], &error[0] );
-
-	} catch(...) {
-
-          PyErr_SetString( PyExc_ValueError,
-                           (char*)"XSPEC convolution model evaluation failed" );
-          return NULL;
-
-	}
-
-	return result.return_new_ref();
+  xspecModelFctConF<float, FloatArray, XSpecFunc> xspec_model =
+    xspecModelFctConF<float, FloatArray, XSpecFunc>( args, NumPars );
+  try {
+    FloatArray result;
+    xspec_model.eval( result );
+    return result.return_new_ref();
+  } catch(std::runtime_error& re) {
+    return NULL;
+  } catch(...) {
+    // Even though the XSPEC model function is Fortran, it could call
+    // C++ functions, so swallow exceptions here
+    PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+    return NULL;
+  }
 
 }
 
@@ -851,10 +923,7 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args )
 PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 {
 
-#ifdef INIT_XSPEC
-	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          return NULL;
-#endif
+        PyArgTupleBase();
 
 	FloatArray pars;
 	DoubleArray xlo;
@@ -892,79 +961,35 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
         npy_intp npars = pars.get_size();
         if (HasNorm) { npars -= 1; }
 
-	// The grid to send to XSPEC (double precision).
-	//
-	std::vector<SherpaFloat> ear;
-        std::vector<SherpaFloat> gaps_edges;
-        std::vector<int> gaps_index;
-	if (!create_grid(xlo, xhi, ear, gaps_index, gaps_edges)) {
-	  return NULL;
-	}
-
-	int nelem = int( xlo.get_size() );
-	int ngrid = ear.size();
-	int ifl = 1;
-
-        // convert to 32-byte float
-        std::vector<FloatArrayType> fear(ngrid);
-	CONVERTARRAY(ear, fear, ngrid);
-
-	// Number of bins to send to XSPEC
-	int nout = ngrid;
-	if (xhi) nout--;
-
-	FloatArray result, error;
-	if (!create_output(nout, result, error)) {
-	  return NULL;
-	}
-
-	// Swallow exceptions here
-
+        xspecTableModelTabint xspec_model = xspecTableModelTabint( );
         try {
-
-          int npts = ngrid - 1;
-          tabint( &fear[0], npts, &pars[0], npars,
-                  filename, ifl, tabtype,
-                  &result[0], &error[0] );
-
-	} catch(...) {
-
-          PyErr_SetString( PyExc_ValueError,
-                           (char*)"XSPEC model evaluation failed" );
+          FloatArray result;
+          xspec_model.eval(HasNorm, xlo, xhi, npars, pars, filename, tabtype, result);
+          // Apply normalization if required (note that npars
+          // has been reduced by 1 if HasNorm is true, so it is
+          // correct to use npars and not 'npars - 1' here).
+          //
+          if ( HasNorm )
+            for (int i = 0; i < xlo.get_size(); i++)
+              result[i] *= pars[npars];
+          return result.return_new_ref();
+        } catch(std::runtime_error& re) {
           return NULL;
-
-	}
-
-	int ngaps = (int) gaps_index.size();
-	if (ngaps > 0) {
-	  finalize_grid(nelem, result, gaps_index);
-	}
-
-	// Apply normalization if required (note that npars
-        // has been reduced by 1 if HasNorm is true, so it is
-        // correct to use npars and not 'npars - 1' here).
-        //
-	if ( HasNorm )
-          for (int i = 0; i < nelem; i++)
-            result[i] *= pars[npars];
-
-	return result.return_new_ref();
+        } catch(...) {
+          // Even though the XSPEC model function is Fortran, it could call
+          // C++ functions, so swallow exceptions here
+          PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+          return NULL;
+        }
 
 }
 
 #else
 
-template <bool HasNorm,
-void (*XSpecFunc)( float* ear, int ne, float* param,
-		const char* filenm, int ifl, float* photar,
-		float* photer )>
-PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
-{
+template <bool HasNorm, XSpecFuncVal XSpecFunc>
+PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds ) {
 
-#ifdef INIT_XSPEC
-	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          return NULL;
-#endif
+        PyArgTupleBase();
 
 	FloatArray pars;
 	DoubleArray xlo;
@@ -994,12 +1019,30 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 
 	npy_intp npars = pars.get_size();
 
+        // xspecTableModel<XSpecFunc> xspec_model = xspecTableModel<XSpecFunc>( );
+        // try {
+        //   FloatArray result;
+        //   xspec_model.eval(HasNorm, xlo, xhi, npars, pars, filename, NULL, result);
+        //   // Apply normalization if required
+        //   if ( HasNorm )
+        //     for (int i = 0; i < xlo.get_size(); i++)
+        //       result[i] *= pars[npars - 1];   // NOTE: NumPars not sent to template
+        //   return result.return_new_ref();
+        // } catch(std::runtime_error& re) {
+        //   return NULL;
+        // } catch(...) {
+        //   // Even though the XSPEC model function is Fortran, it could call
+        //   // C++ functions, so swallow exceptions here
+        //   PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+        //   return NULL;
+        // }
+
+        //
 	// The grid to send to XSPEC (double precision).
 	//
 	std::vector<SherpaFloat> ear;
-        std::vector<SherpaFloat> gaps_edges;
         std::vector<int> gaps_index;
-	if (!create_grid(xlo, xhi, ear, gaps_index, gaps_edges)) {
+	if (!create_grid(xlo, xhi, ear, gaps_index)) {
 	  return NULL;
 	}
 

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -94,11 +94,6 @@ namespace sherpa { namespace astro { namespace xspec {
 typedef sherpa::Array< float, NPY_FLOAT > FloatArray;
 typedef float FloatArrayType;
 
-typedef void (*XSpecFuncRef)( const float* ear, const int& ne, const float* param, const int& ifl, float* photar, float* photer );
-typedef void (*XSpecFuncVal)( float* ear, int ne, float* param, const char* filenm, int ifl, float* photar, float* photer );
-typedef void (*XSpecFuncDouble)( const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr );
-
-
 // Try and support the use of std::transform while still building
 // against C++-98 compilers.
 //
@@ -625,7 +620,7 @@ static bool create_output(int nbins, T &a, T &b) {
 
       }; // class xspecModelFctBase
 
-      template<typename Real, typename RealArray, XSpecFuncDouble XSpecFunc>
+      template<typename Real, typename RealArray, xsccCall XSpecFunc>
       class xspecModelFctC : public xspecModelFctBase<Real, RealArray>  {
       public:
 
@@ -640,7 +635,7 @@ static bool create_output(int nbins, T &a, T &b) {
 
       }; // class xspecModelFctC
 
-      template<typename Real, typename RealArray, XSpecFuncRef XSpecFunc>
+      template<typename Real, typename RealArray, xsf77Call XSpecFunc>
       class xspecModelFctF : public xspecModelFctBase<Real, RealArray>  {
       public:
 
@@ -728,7 +723,7 @@ static bool create_output(int nbins, T &a, T &b) {
 
       }; // class xspecModelFctConBase
 
-      template<typename Real, typename RealArray, XSpecFuncDouble XSpecFunc>
+      template<typename Real, typename RealArray, xsccCall XSpecFunc>
       class xspecModelFctConC : public xspecModelFctConBase<Real, RealArray>  {
       public:
 
@@ -743,7 +738,7 @@ static bool create_output(int nbins, T &a, T &b) {
 
       }; // class xspecModelFctConC
 
-      template<typename Real, typename RealArray, XSpecFuncRef XSpecFunc>
+      template<typename Real, typename RealArray, xsf77Call XSpecFunc>
       class xspecModelFctConF : public xspecModelFctConBase<Real, RealArray>  {
       public:
 
@@ -856,7 +851,7 @@ static bool create_output(int nbins, T &a, T &b) {
       // }; // class xspecTableModel
 
 
-template <npy_intp NumPars, bool HasNorm, XSpecFuncRef XSpecFunc>
+template <npy_intp NumPars, bool HasNorm, xsf77Call XSpecFunc>
 PyObject* xspecmodelfct( PyObject* self, PyObject* args ) {
 
   xspecModelFctF<float, FloatArray, XSpecFunc> xspec_model =
@@ -876,7 +871,7 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args ) {
 
 }
 
-template <npy_intp NumPars, bool HasNorm, XSpecFuncDouble XSpecFunc>
+template <npy_intp NumPars, bool HasNorm, xsccCall XSpecFunc>
 PyObject* xspecmodelfct_C( PyObject* self, PyObject* args ) {
 
   xspecModelFctC<double, DoubleArray, XSpecFunc> xspec_model =
@@ -899,7 +894,7 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args ) {
 // linkage.
 //
 // This template does not support non-contiguous grids.
-template <npy_intp NumPars, XSpecFuncDouble XSpecFunc>
+template <npy_intp NumPars, xsccCall XSpecFunc>
 PyObject* xspecmodelfct_con( PyObject* self, PyObject* args ) {
 
   xspecModelFctConC<double, DoubleArray, XSpecFunc> xspec_model =
@@ -921,7 +916,7 @@ PyObject* xspecmodelfct_con( PyObject* self, PyObject* args ) {
 // F77 in the name (rather than have the FORTRAN interface be "default"
 // version as it for the additive and multiplicative models).
 //
-template <npy_intp NumPars, XSpecFuncRef XSpecFunc>
+template <npy_intp NumPars, xsf77Call XSpecFunc>
 PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args ) {
 
   xspecModelFctConF<float, FloatArray, XSpecFunc> xspec_model =
@@ -1015,6 +1010,8 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 }
 
 #else
+
+typedef void (*XSpecFuncVal)( float* ear, int ne, float* param, const char* filenm, int ifl, float* photar, float* photer );
 
 template <bool HasNorm, XSpecFuncVal XSpecFunc>
 PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds ) {

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -861,12 +861,12 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args ) {
     FloatArray result;
     xspec_model.eval( result );
     return result.return_new_ref();
-  } catch(NoError& re) {
+  } catch(const NoError& re) {
     return NULL;
-  } catch(ValueError& re) {
+  } catch(const ValueError& re) {
     PyErr_SetString( PyExc_ValueError, re.what() );
     return NULL;
-  } catch(TypeError& re) {
+  } catch(const TypeError& re) {
     PyErr_SetString( PyExc_TypeError, re.what() );
     return NULL;
   } catch(...) {
@@ -887,12 +887,12 @@ PyObject* xspecmodelfct_C( PyObject* self, PyObject* args ) {
     DoubleArray result;
     xspec_model.eval( result );
     return result.return_new_ref();
-  } catch(NoError& re) {
+  } catch(const NoError& re) {
     return NULL;
-  } catch(ValueError& re) {
+  } catch(const ValueError& re) {
     PyErr_SetString( PyExc_ValueError, re.what() );
     return NULL;
-  } catch(TypeError& re) {
+  } catch(const TypeError& re) {
     PyErr_SetString( PyExc_TypeError, re.what() );
     return NULL;
   } catch(...) {
@@ -916,12 +916,12 @@ PyObject* xspecmodelfct_con( PyObject* self, PyObject* args ) {
     DoubleArray result;
     xspec_model.eval(result);
     return result.return_new_ref();
-  } catch(NoError& re) {
+  } catch(const NoError& re) {
     return NULL;
-  } catch(ValueError& re) {
+  } catch(const ValueError& re) {
     PyErr_SetString( PyExc_ValueError, re.what() );
     return NULL;
-  } catch(TypeError& re) {
+  } catch(const TypeError& re) {
     PyErr_SetString( PyExc_TypeError, re.what() );
     return NULL;
   } catch(...) {
@@ -944,12 +944,12 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args ) {
     FloatArray result;
     xspec_model.eval( result );
     return result.return_new_ref();
-  } catch(NoError& re) {
+  } catch(const NoError& re) {
     return NULL;
-  } catch(ValueError& re) {
+  } catch(const ValueError& re) {
     PyErr_SetString( PyExc_ValueError, re.what() );
     return NULL;
-  } catch(TypeError& re) {
+  } catch(const TypeError& re) {
     PyErr_SetString( PyExc_TypeError, re.what() );
     return NULL;
   } catch(...) {
@@ -1023,12 +1023,12 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
             for (int i = 0; i < xlo.get_size(); i++)
               result[i] *= pars[npars];
           return result.return_new_ref();
-	} catch(NoError& re) {
+	} catch(const NoError& re) {
 	  return NULL;
-	} catch(ValueError& re) {
+	} catch(const ValueError& re) {
 	  PyErr_SetString( PyExc_ValueError, re.what() );
 	  return NULL;
-	} catch(TypeError& re) {
+	} catch(const TypeError& re) {
 	  PyErr_SetString( PyExc_TypeError, re.what() );
 	  return NULL;
         } catch(...) {

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -34,6 +34,35 @@
 
 #include "sherpa/fcmp.hh"
 
+// We should be able to just include funcType.h but our XSPEC conda
+// builds, at least for testing/12.11.1, do not include this file,
+// so we just include what we need.
+//
+// #ifdef XSPEC_12_12_0
+// #include "XSFunctions/Utilities/funcType.h"
+// #else
+// #include "funcType.h"
+// #endif
+
+#include "xsTypes.h"   // get Real typedef
+
+extern "C" {
+
+        typedef void (xsf77Call) (const float* energyArray,
+                                  const int& Nenergy,
+                                  const float* parameterValues,
+                                  const int& spectrumNumber,
+                                  float* flux,
+                                  float* fluxError);
+        typedef void (xsccCall)   (const Real* energyArray,
+                                   int Nenergy,
+                                   const Real* parameterValues,
+                                   int spectrumNumber,
+                                   Real* flux,
+                                   Real* fluxError,
+                                   const char* initString);
+}
+
 // Prior to XSPEC 12.10.1, the table models were split into different
 // functions. These functions are defined in _xspec.cc.
 //
@@ -64,7 +93,8 @@ namespace sherpa { namespace astro { namespace xspec {
 
 typedef sherpa::Array< float, NPY_FLOAT > FloatArray;
 typedef float FloatArrayType;
-typedef void (*XSpecFuncRef)( float* ear, int* ne, float* param, int* ifl, float* photar, float* photer );
+
+typedef void (*XSpecFuncRef)( const float* ear, const int& ne, const float* param, const int& ifl, float* photar, float* photer );
 typedef void (*XSpecFuncVal)( float* ear, int ne, float* param, const char* filenm, int ifl, float* photar, float* photer );
 typedef void (*XSpecFuncDouble)( const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr );
 
@@ -583,7 +613,7 @@ static bool create_output(int nbins, T &a, T &b) {
       protected:
 
         PyObject* args;
-        int ifl, ngrid, npts;;
+        int ifl, ngrid, npts;
         std::vector<SherpaFloat> ear;
         RealArray pars, error;
 
@@ -621,7 +651,7 @@ static bool create_output(int nbins, T &a, T &b) {
           // convert to 32-byte float
           std::vector<float> fear(this->ngrid);
           CONVERTARRAY(this->ear, fear, this->ngrid);
-          XSpecFunc( &fear[0], &this->npts, &this->pars[0], &this->ifl,
+          XSpecFunc( &fear[0], this->npts, &this->pars[0], this->ifl,
                      &result[0], &this->error[0] );
           return;
         }
@@ -724,7 +754,7 @@ static bool create_output(int nbins, T &a, T &b) {
           // convert to 32-byte float
           std::vector<float> fear(this->ngrid);
           CONVERTARRAY(this->ear, fear, this->ngrid);
-          XSpecFunc( &fear[0], &this->npts, &this->pars[0], &this->ifl,
+          XSpecFunc( &fear[0], this->npts, &this->pars[0], this->ifl,
                      &result[0], &this->error[0] );
           return;
         }


### PR DESCRIPTION
# Summary

Remove code duplication in the XSPEC module.

# Details

This is #1330 which has been rebased to the latest main branch, and then extended to take advantage of XSPEC-provided typedefs. Once we are able to remove support for XSPEC < 12.12.0 we can simplify the code more, but that doesn't need to be included in this PR.

The code to support XSPEC typedefs is partly dependent on how we package XSPEC as a conda package - the "Switch to XSPEC typedefs" commit has a section where the `xsf77Call` and `xsccCall` typedefs are defined which really should be taken from `funcType.h` (pre 12.12.0) or `XSFunctions/Utilities/funcType.h` (>= 12.12.0) but our `xspecmodel-modelsonly` conda build does not include this file [*], so I've hard-coded them (they haven't changed for a LONG time, if ever).

[*] we currently do not have a 12.12.0 version of the xspec-modelsonly conda package

The remaining commits tweak how the C++-to-Python translation of errors is handled. The C++ code throws errors and then the "interface" code  - that is the code that is called by the Python routine to marshal data from Python to C++ and then back again - has to decide what to do with these errors. The chosen approach is based around three classes that extend std::runtime_error (the names are not particularly great):

- `NoError`
- `TypeError`
- `ValueError`

which indicate to the caller how to convert the error message to Python [**].

[**] In Python the error handling is done by setting the error "status" by the `PyErr_SetString` function and then returning `NULL` (actually, there are other related routines that could be called but we'll stick with this one here)

An alternative approach would be to call `PyErr_SetString` at the location of the error and then throw `NoError` so we know we don't need to do anything else. This might be better than having to add `TypeError` and `ValueError` classes.

The reason why I went with this approach was that:

a) there are cases when all we should do is return NULL since a Python C routine has already set up the error string - for this code this is true of `PyArg_ParseTuple` and variants - that is we don't want to replace the error message they have created - which is why `NoError` was added. I have added a test to check some of these cases.

b) some routines can cause a Python `TypeError` or `ValueError` to be raised, depending on the error (e.g. `create_grid`). This lead to the addition of `ValueError` and `TypeError` C++ classes. I have added tests to check some of these cases.

It is likely that this code will not work properly prior to XSPEC 12.10.1 but this was released a long time ago, we don't have a CI run that can test this, and I want to bump the minimum-supported-verision to exclude this case (see #1391).

There is one "interesting" error case left, which is when the library initialization code fails. Instead of an `"Unable to initalize Xspec"` message - which was never very helpful - we'll get some other message (dependent on the model type). However, I plan to remove this case as discussed in #1388 - so I have not spent much time on this case. 