### PR TITLE
XSPEC minimum version is now 12.10.1

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -296,7 +296,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.12.1 down to 12.9.0. It may build against
+:term:`XSPEC` versions 12.12.1 down to 12.10.1. It may build against
 newer versions, but if it does it will not provide access to any new
 models in the release. The following sections of the `XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__
@@ -415,13 +415,13 @@ available.
 
    Current version: `helpers/xspec_config.py <https://github.com/sherpa/sherpa/blob/master/helpers/xspec_config.py>`_.
 
-   When adding support for XSPEC 12.11.1, the top-level
+   When adding support for XSPEC 12.12.1, the top-level
    ``SUPPORTED_VERSIONS`` list was changed to include the triple
-   ``(12, 11, 1)``::
+   ``(12, 12, 1)``::
 
-     SUPPORTED_VERSIONS = [(12, 9, 0), (12, 9, 1),
-                           (12, 10, 0), (12, 10, 1),
-                           (12, 11, 0), (12, 11, 1)]
+     SUPPORTED_VERSIONS = [(12, 10, 1),
+                           (12, 11, 0), (12, 11, 1),
+                           (12, 12, 0), (12, 12, 1)]
 
    This list is used to select which functions to include when
    compiling the C++ interface code. For reference, the defines are
@@ -436,7 +436,7 @@ available.
 
 #. Attempt to build the XSPEC interface with::
 
-     pip install -e .
+     pip install -e . --verbose
 
    This requires that the ``xspec_config`` section of the ``setup.cfg``
    file has been set up correctly for the new XSPEC release. The exact
@@ -531,27 +531,31 @@ available.
 
       Current version: `sherpa/astro/xspec/src/_xspec.cc <https://github.com/sherpa/sherpa/blob/master/sherpa/astro/xspec/src/_xspec.cc>`_.
 
-      New functions are added to the ``XspecMethods`` array,
-      using macros defined in ``sherpa/include/sherpa/astro/xspec_extension.hh``,
-      and should be surrounded by a pre-processor check for the
-      version symbol added to ``helpers/xspec_config.py``.
+      New functions are added to the ``XspecMethods`` array, using
+      macros defined in
+      ``sherpa/include/sherpa/astro/xspec_extension.hh``, and should
+      be surrounded by a pre-processor check for the version symbol
+      added to ``helpers/xspec_config.py``.
 
       As an example::
 
-        #ifdef XSPEC_12_10_1
-          XSPECMODELFCT_NORM( agnsed, 16 ),
+        #ifdef XSPEC_12_12_0
+	  XSPECMODELFCT_C_NORM( C_wDem, 8 )
         #endif
 
-      adds support for the ``agnsed`` function, but only for XSPEC
-      12.10.1 and later. Note that the symbol name used here is
+      adds support for the ``C_wDem`` function, but only for XSPEC
+      12.12.0 and later. Note that the symbol name used here is
       **not** the XSPEC model name (the first argument of the model
       definition from ``model.dat``), but the function name (the fifth
-      argument of the model definition (although for the ``agnsed``
-      example they are the same).
+      argument of the model definition)::
 
-      Some models have changed the name of the function over time,
-      so the pre-processor directive may need to be more complex, such
-      as::
+        % grep C_wDem $HEADAS/../spectral/manager/model.dat
+        wdem          7  0.         1.e20           C_wDem   add  0
+
+      Some models have changed the name of the function over time, so
+      the pre-processor directive may need to be more complex, such as
+      the following (although now we no-longer support XSPEC 12.10.0
+      this particular example has been removed from the code)::
 
         #ifdef XSPEC_12_10_0
           XSPECMODELFCT_C_NORM( C_nsmaxg, 6 ),
@@ -596,12 +600,12 @@ available.
       declaration should look like (replacing ``func`` with the
       function name, and note the trailing underscore)::
 
-        void func_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
+        xsf77Call func_;
 
       and for model functions called ``c_func``, the prefixless
       version should be declared as::
 
-        void func(const double* energy, int nFlux, const double* params, int spectrumNumber, double* flux, double* fluxError, const char* initStr);
+        xsccCall func;
 
       If you are unsure, do not add a declaration and then try to
       build Sherpa: the compiler should fail with an indication of

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.12.1, 12.12.0, 12.11.1, 12.11.0,
-       12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, or 12.9.0.
+       Sherpa can be built to use XSPEC versions 12.12.1, 12.12.0, 12.11.1,
+       12.11.0, and 12.10.1 (patch level `a` or later).

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -218,31 +218,24 @@ options changed to match the location of the local installation.
 XSPEC
 ^^^^^
 
-.. note::
-
-   The version number of XSPEC **must** be specified using the
-   ``xspec_version`` configuration option, as described below. This is
-   a change from previous releases of Sherpa, but is required in order
-   to support changes made in XSPEC 12.10.0.
-
 Sherpa can be built to use the Astronomy models provided by
 :term:`XSPEC`. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
 
     with-xspec = False
-    xspec_version = 12.9.0
+    xspec_version = 12.10.1
     xspec_lib_dirs = None
     xspec_include_dirs = None
-    xspec_libraries = XSFunctions XSModel XSUtil XS
+    xspec_libraries = XSFunctions XSUtil XS
     cfitsio_lib_dirs = None
-    cfitsio_libraries = cfitsio
+    cfitsio_libraries =
     ccfits_lib_dirs = None
-    ccfits_libraries = CCfits
+    ccfits_libraries =
     wcslib_lib_dirs = None
-    wcslib_libraries = wcs
+    wcslib_libraries =
     gfortran_lib_dirs = None
-    gfortran_libraries = gfortran
+    gfortran_libraries =
 
 To build the :py:mod:`sherpa.astro.xspec` module, the
 ``with-xspec`` option must be set to ``True`` **and** the
@@ -318,36 +311,11 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.26.1 of HEASOFT.
 
-6. If the full XSPEC 12.10.0 system has been built then use::
-
-       with-xspec = True
-       xspec_version = 12.10.0
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSModel XSUtil XS hdsp_3.0
-       ccfits_libraries = CCfits_2.5
-       wcslib_libraries = wcs-5.16
-
-7. If the full XSPEC 12.9.x system has been built then use::
-
-       with-xspec = True
-       xspec_version = 12.9.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSModel XSUtil XS
-       ccfits_libraries = CCfits_2.5
-       wcslib_libraries = wcs-5.16
-
-   changing ``12.9.1`` to ``12.9.0`` as appropriate.
-
-8. If the model-only build of XSPEC has been installed, then
-   the configuration is similar, but the library names may
-   not need version numbers and locations, depending on how the
+6. If the model-only build of XSPEC - created with the
+   ``--enable-xs-models-only`` flag when building HEASOFT - has been
+   installed, then the configuration is similar, but the library names
+   may not need version numbers and locations, depending on how the
    ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
-
-   Note that XSPEC 12.10.0 introduces a new ``--enable-xs-models-only``
-   flag when building HEASOFT which simplifies the installation of
-   these extra libraries, but can cause problems for the Sherpa build.
 
 A common problem is to set one or both of the ``xspec_lib_dirs``
 and ``xspec_lib_include`` options to the value of ``$HEADAS`` instead of

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -122,16 +122,16 @@ class xspec_config(Command):
 
         macros = []
         if self.xspec_version:
-            self.announce(f"Found XSPEC version: {self.xspec_version}", 2)
+            self.announce(f"Found XSPEC version: {self.xspec_version}", level=2)
             xspec_version = get_version(self.xspec_version)
+
+            if xspec_version < MIN_VERSION:
+                raise ValueError(f"XSPEC Version {xspec_version} is less than {MIN_VERSION}, which is the earliest supported version for Sherpa")
 
             for version in SUPPORTED_VERSIONS:
                 if xspec_version >= version:
                     major, minor, micro = version
                     macros += [(f'XSPEC_{major}_{minor}_{micro}', None)]
-
-            if xspec_version < MIN_VERSION:
-                self.warn("XSPEC Version is less than {MIN_VERSION}, which is the minimal supported version for Sherpa")
 
             if xspec_version > MAX_VERSION:
                 self.warn(f"XSPEC Version is greater than {MAX_VERSION}, which is the latest supported version for Sherpa")

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -28,8 +28,7 @@ from .extensions import build_ext
 # major, minor, and micro. We drop the patch level - e.g.
 # "c" in "12.12.0c" as that is not helpful to track here.
 #
-SUPPORTED_VERSIONS = [(12, 9, 0), (12, 9, 1),
-                      (12, 10, 0), (12, 10, 1),
+SUPPORTED_VERSIONS = [(12, 10, 1),
                       (12, 11, 0), (12, 11, 1),
                       (12, 12, 0), (12, 12, 1)]
 
@@ -81,7 +80,7 @@ class xspec_config(Command):
     description = "Configure XSPEC Models external module (optional) "
     user_options = [
                     ('with-xspec', None, "Whether sherpa must build the XSPEC module (default False)"),
-                    ('xspec-version', None, "the XSPEC version (default 12.9.0)"),
+                    ('xspec-version', None, "the XSPEC version (default 12.10.1)"),
                     ('xspec-lib-dirs', None, "Where the xspec libraries are located, if with-xspec is True"),
                     ('xspec-libraries', None, "Name of the libraries that should be linked for xspec"),
                     ('cfitsio-lib-dirs', None, "Where the cfitsio libraries are located, if with-xspec is True"),
@@ -96,10 +95,11 @@ class xspec_config(Command):
 
     def initialize_options(self):
         self.with_xspec = False
-        self.xspec_version = '12.9.0'
+        self.xspec_version = '12.10.1'
         self.xspec_include_dirs = ''
         self.xspec_lib_dirs = ''
-        self.xspec_libraries = 'XSFunctions XSModel XSUtil XS'
+        # This is set up for how CIAO builds XSPEC; other users may require more libraries
+        self.xspec_libraries = 'XSFunctions XSUtil XS'
         self.cfitsio_include_dirs = ''
         self.cfitsio_lib_dirs = ''
         self.cfitsio_libraries = ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -210,23 +210,16 @@ source-dir = docs
 
 # If with-xspec is True, make sure to point Sherpa to right
 # XSPEC-related libraries and to indicate the XSPEC version.
-# As of XSPEC 12.10.0, determining the version os XSPEC at build
-# time is too complex and unreliable. If you have XSPEC 12.9.0
-# you can leave the version option commented out.
 #
 # The xspec_include_dirs and xspec_lib_dirs items should be set
 # to $HEADAS/include and $HEADAS/lib respectively (expand out the
 # environment variable).
 #
-# If you are using a full XSPEC build, then add the correct version
-# numbers to the cfitsio, CCfits, and wcs libraries used in the build,
-# if necessary. For XSPEC 12.11.1 (HEAsoft 6.28) this means using
-# CCfits_2.5, wcs-5.19.1, and hdsp_6.28.
-#
-# For XSPEC 12.10.0 and later, the xspec_libraries line should
-# be changed to
-#
-#   xspec_libraries = XSFunctions XSUtil XS hdsp_<version>
+# If you are using a full XSPEC build, then it may be necessary to add
+# the correct version numbers to the cfitsio, CCfits, and wcs
+# libraries used in the build, if necessary. For XSPEC 12.11.1
+# (HEAsoft 6.28) this means using CCfits_2.5, wcs-5.19.1, and
+# hdsp_6.28.
 #
 # If you are using the models-only XSPEC build, then the cfitsio_lib_dirs,
 # ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if
@@ -235,10 +228,10 @@ source-dir = docs
 #
 # The gfortran_lib_dirs should be set if needed.
 #
-#xspec_version = 12.9.0
+#xspec_version = 12.10.1
 #xspec_lib_dirs = None
 #xspec_include_dirs = None
-#xspec_libraries = XSFunctions XSModel XSUtil XS
+#xspec_libraries = XSFunctions XSUtil XS hdsp_6.26  # change 6.26 to the correct version
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio
 #ccfits_lib_dirs = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -217,9 +217,8 @@ source-dir = docs
 #
 # If you are using a full XSPEC build, then it may be necessary to add
 # the correct version numbers to the cfitsio, CCfits, and wcs
-# libraries used in the build, if necessary. For XSPEC 12.11.1
-# (HEAsoft 6.28) this means using CCfits_2.5, wcs-5.19.1, and
-# hdsp_6.28.
+# libraries used in the build. For XSPEC 12.11.1 (HEAsoft 6.28)
+# this means using CCfits_2.5, wcs-5.19.1, and hdsp_6.28.
 #
 # If you are using the models-only XSPEC build, then the cfitsio_lib_dirs,
 # ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,8 +20,8 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.12.1, 12.12.0, 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
-of XSPEC [1]_, and can be built against the model library or the full
+Sherpa supports versions 12.12.1, 12.12.0, 12.11.1, 12.11.0, and 12.10.1 of
+XSPEC [1]_, and can be built against the model library or the full
 application.  There is no guarantee of support for older or newer
 versions of XSPEC.
 
@@ -31,7 +31,7 @@ XSPEC version - including patch level - the module is using::
 
    >>> from sherpa.astro import xspec
    >>> xspec.get_xsversion()
-   '12.11.1'
+   '12.12.1'
 
 Initializing XSPEC
 ------------------
@@ -41,14 +41,12 @@ are set to H_0=70, q_0=0.0, and lambda_0=0.73 (they can be changed with
 `set_xscosmo`).
 
 The other settings - for example for the abundance and cross-section
-tables - follow the standard rules for XSPEC. For XSPEC versions prior
-to 12.10.1, this means that the abundance table uses the 'angr'
-setting and the cross sections the 'bcmc' setting (see `set_xsabund`
-and `set_xsxsect` for full details). As of XSPEC 12.10.1, the values
-are now taken from the user's XSPEC configuration file - either
-``~/.xspec/Xspec.init`` or ``$HEADAS/../spectral/manager/Xspec.init`` -
-for these settings. The default value for the photo-ionization table
-in this case is now 'vern' rather than 'bcmc'.
+tables - follow the standard rules for XSPEC. This means that the
+values are taken from the user's XSPEC configuration file - either
+``~/.xspec/Xspec.init`` or ``$HEADAS/../spectral/manager/Xspec.init``
+- for these settings (in particular note that the default value for
+the photo-ionization table is 'vern' rather than 'bcmc' which used to
+be the case in XSPEC 12.10.0 and earlier).
 
 The default chatter setting - used by models to inform users of
 issues - was set to 0 (which hid the messages) until Sherpa 4.14.0,
@@ -860,12 +858,6 @@ __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'get_xsstate')
 
 
-def _f77_or_c_12100(name):
-    """Models which changed from Fortran to C linkage in 12.10.0"""
-
-    return "C_" + name if equal_or_greater_than("12.10.0") else name
-
-
 class XSBaseParameter(Parameter):
     """An XSPEC parameter.
 
@@ -1331,34 +1323,15 @@ class XSTableModel(XSModel):
             warnings.warn(emsg, FutureWarning)
             # raise TypeError(emsg)
 
-        # The function used depends on XSPEC version and, prior
-        # to XSPEC 12.10.1, the type of table.
-        #
-        # It should also not be a run-time decision, since the
-        # logic could be in __init__, but that can be changed
-        # at a later date.
-        #
         for param, value in zip(self.pars, p):
             if value < param._hard_min:
                 raise ParameterErr('edge', self.name, 'minimum', param._hard_min)
             if value > param._hard_max:
                 raise ParameterErr('edge', self.name, 'maximum', param._hard_max)
 
-        if hasattr(_xspec, 'tabint'):
-            tabtype = 'add' if self.addmodel else 'exp' if self.etable else 'mul'
-            return _xspec.tabint(p, *args,
-                                 filename=self.filename, tabtype=tabtype)
-
-        # Technicaly this should be updated to add support for etable models
-        # but this interface is no-longer supported so there's no way for
-        # me to add the necessary code.
-        #
-        if self.addmodel:
-            func = _xspec.xsatbl
-        else:
-            func = _xspec.xsmtbl
-
-        return func(p, *args, filename=self.filename)
+        tabtype = 'add' if self.addmodel else 'exp' if self.etable else 'mul'
+        return _xspec.tabint(p, *args,
+                             filename=self.filename, tabtype=tabtype)
 
 
 # TODO: we should add the norm parameter in the __init__ call, unless
@@ -1684,7 +1657,6 @@ class XSagauss(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.LineE, self.Sigma, self.norm))
 
 
-@version_at_least("12.10.1")
 class XSagnsed(XSAdditiveModel):
     """The XSPEC agnsed model: AGN SED model
 
@@ -1743,10 +1715,6 @@ class XSagnsed(XSAdditiveModel):
     See Also
     --------
     XSagnslim, XSqsosed
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.1 or later.
 
     References
     ----------
@@ -2003,7 +1971,6 @@ class XSbapec(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSbtapec(XSAdditiveModel):
     """The XSPEC btapec model: velocity broadened APEC emission spectrum with separate continuum and line temperatures.
 
@@ -2034,10 +2001,6 @@ class XSbtapec(XSAdditiveModel):
     See Also
     --------
     XSbapec, XSbvtapec, XSbvvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -2444,7 +2407,6 @@ class XSbremss(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSbrnei(XSAdditiveModel):
     """The XSPEC brnei model: velocity-broadened non-equilibrium recombining collisional plasma.
 
@@ -2474,10 +2436,6 @@ class XSbrnei(XSAdditiveModel):
     See Also
     --------
     XSbvrnei, XSbvvrnei, XSnei, XSgnei, XSrnei, XSvrnei, XSvvrnei
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -2554,7 +2512,6 @@ class XSbvapec(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSbvrnei(XSAdditiveModel):
     """The XSPEC bvrnei model: velocity-broadened non-equilibrium recombining collisional plasma.
 
@@ -2583,10 +2540,6 @@ class XSbvrnei(XSAdditiveModel):
     See Also
     --------
     XSbrnei, XSbvvrnei, XSnei, XSgnei, XSrnei, XSvrnei, XSvvrnei
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -2620,7 +2573,6 @@ class XSbvrnei(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSbvtapec(XSAdditiveModel):
     """The XSPEC bvtapec model: velocity broadened APEC emission spectrum with separate continuum and line temperatures.
 
@@ -2649,10 +2601,6 @@ class XSbvtapec(XSAdditiveModel):
     See Also
     --------
     XSbapec, XSbtapec, XSbvvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -2760,7 +2708,6 @@ class XSbvvapec(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSbvvrnei(XSAdditiveModel):
     """The XSPEC bvvrnei model: velocity-broadened non-equilibrium recombining collisional plasma.
 
@@ -2790,10 +2737,6 @@ class XSbvvrnei(XSAdditiveModel):
     See Also
     --------
     XSbrnei, XSbvrnei, XSnei, XSgnei, XSrnei, XSvrnei, XSvvrnei
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -2846,7 +2789,6 @@ class XSbvvrnei(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.kT_init, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.Redshift, self.Velocity, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSbvvtapec(XSAdditiveModel):
     """The XSPEC bvvtapec model: velocity broadened APEC emission spectrum with separate continuum and line temperatures.
 
@@ -2874,10 +2816,6 @@ class XSbvvtapec(XSAdditiveModel):
     See Also
     --------
     XSbapec, XSbtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -2962,7 +2900,7 @@ class XSc6mekl(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("c6mekl")
+    __function__ = "C_c6mekl"
 
     def __init__(self, name='c6mekl'):
         self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
@@ -3017,7 +2955,7 @@ class XSc6pmekl(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("c6pmekl")
+    __function__ = "C_c6pmekl"
 
     def __init__(self, name='c6pmekl'):
         self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
@@ -3072,7 +3010,7 @@ class XSc6pvmkl(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("c6pvmkl")
+    __function__ = "C_c6pvmkl"
 
     def __init__(self, name='c6pvmkl'):
         self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
@@ -3140,7 +3078,7 @@ class XSc6vmekl(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("c6vmekl")
+    __function__ = "C_c6vmekl"
 
     def __init__(self, name='c6vmekl'):
         self.CPcoef1 = XSParameter(name, 'CPcoef1', 1.0, -1, 1, -1, 1)
@@ -3174,7 +3112,6 @@ class XSc6vmekl(XSAdditiveModel):
                                               self.redshift, self.switch, self.norm))
 
 
-@version_at_least("12.9.1")
 class XScarbatm(XSAdditiveModel):
     """The XSPEC carbatm model: Nonmagnetic carbon atmosphere of a neutron star.
 
@@ -3197,10 +3134,6 @@ class XScarbatm(XSAdditiveModel):
     See Also
     --------
     XShatm
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -3836,7 +3769,6 @@ class XScompTT(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.redshift, self.T0, self.kT, self.taup, self.approx, self.norm))
 
 
-@version_at_least("12.10.1")
 class XScph(XSAdditiveModel):
     """The XSPEC cph model: Cooling + heating model for cool core clusters
 
@@ -3862,10 +3794,6 @@ class XScph(XSAdditiveModel):
     See Also
     --------
     XSmkcflow, XSvcph
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.1 or later.
 
     References
     ----------
@@ -4905,7 +4833,6 @@ class XSgrad(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.D, self.i, self.Mass, self.Mdot, self.TclovTef, self.refflag, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSgrbcomp(XSAdditiveModel):
     """The XSPEC grbcomp model: Comptonization for GRB prompt emission.
 
@@ -4943,10 +4870,6 @@ class XSgrbcomp(XSAdditiveModel):
     See Also
     --------
     XSgrbjet, XSgrbm
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -5095,7 +5018,6 @@ class XSgrbm(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.alpha, self.beta, self.tem, self.norm))
 
 
-@version_at_least("12.9.1")
 class XShatm(XSAdditiveModel):
     """The XSPEC hatm model: Nonmagnetic hydrogen atmosphere of a neutron star.
 
@@ -5119,10 +5041,6 @@ class XShatm(XSAdditiveModel):
     --------
     XScarbatm
 
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -5142,7 +5060,6 @@ class XShatm(XSAdditiveModel):
                                  (self.T, self.NSmass, self.NSrad, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSjet(XSAdditiveModel):
     """The XSPEC jet model: Leptonic relativistic jet model.
 
@@ -5191,10 +5108,6 @@ class XSjet(XSAdditiveModel):
     See Also
     --------
     XSoptxagnf
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -5438,7 +5351,6 @@ class XSkerrdisk(XSAdditiveModel):
         param_apply_limits(pos, self.lineE, **kwargs)
 
 
-@version_at_least("12.10.1")
 class XSkyconv(XSConvolutionKernel):
     """The XSPEC kyconv convolution model: convolution using a relativistic line from axisymmetric accretion disk
 
@@ -5483,8 +5395,6 @@ class XSkyconv(XSConvolutionKernel):
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
-
-    This model is only available when used with XSPEC 12.10.1 or later.
 
     References
     ----------
@@ -5532,7 +5442,6 @@ class XSkyconv(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, pars)
 
 
-@version_at_least("12.10.1")
 class XSkyrline(XSAdditiveModel):
     """The XSPEC kyrline model: relativistic line from axisymmetric accretion disk
 
@@ -5572,8 +5481,6 @@ class XSkyrline(XSAdditiveModel):
 
     Notes
     -----
-    This model is only available when used with XSPEC 12.10.1 or later.
-
     Early releases of XSPEC 12.10.1 refer to the first parameter as
     a/M. As this is not a valid Python name, the parameter has been
     renamed "a" to better match other XSPEC models (after consultation
@@ -6239,7 +6146,7 @@ class XSnsmax(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("nsmax")
+    __function__ = "C_nsmax"
 
     def __init__(self, name='nsmax'):
         self.logTeff = XSParameter(name, 'logTeff', 6.0, 5.5, 6.8, 5.5, 6.8, units='K')
@@ -6281,7 +6188,7 @@ class XSnsmaxg(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("nsmaxg")
+    __function__ = "C_nsmaxg"
 
     def __init__(self, name='nsmaxg'):
         self.logTeff = XSParameter(name, 'logTeff', 6.0, 5.5, 6.9, 5.5, 6.9, units='K')
@@ -6325,7 +6232,7 @@ class XSnsx(XSAdditiveModel):
 
     """
 
-    __function__ = _f77_or_c_12100("nsx")
+    __function__ = "C_nsx"
 
     def __init__(self, name='nsx'):
         self.logTeff = XSParameter(name, 'logTeff', 6.0, 5.5, 6.7, 5.5, 6.7, units='K')
@@ -7014,7 +6921,6 @@ class XSpshock(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.Abundanc, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
 
-@version_at_least("12.10.1")
 class XSqsosed(XSAdditiveModel):
     """The XSPEC qsosed model: AGN SED model
 
@@ -7042,10 +6948,6 @@ class XSqsosed(XSAdditiveModel):
     See Also
     --------
     XSagnsed
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.1 or later.
 
     References
     ----------
@@ -7376,7 +7278,6 @@ class XSsirf(XSAdditiveModel):
                                               self.irrad, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSslimbh(XSAdditiveModel):
     """The XSPEC slimbh model: Stationary slim accretion disk.
 
@@ -7412,10 +7313,6 @@ class XSslimbh(XSAdditiveModel):
     norm
         The normalization of the model: see [1]_ for an explanation
         of the units.
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -7453,7 +7350,6 @@ class XSslimbh(XSAdditiveModel):
 # NOTE: we do not support the smaug model yet
 
 
-@version_at_least("12.9.1")
 class XSsnapec(XSAdditiveModel):
     """The XSPEC snapec model: galaxy cluster spectrum using SN yields.
 
@@ -7482,10 +7378,6 @@ class XSsnapec(XSAdditiveModel):
     See Also
     --------
     XSapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -7592,7 +7484,6 @@ class XSsresc(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.alpha, self.rolloff, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSssa(XSAdditiveModel):
     """The XSPEC ssa model: Strangeon star atmosphere.
 
@@ -7608,10 +7499,6 @@ class XSssa(XSAdditiveModel):
     norm
         This represents (R/d)^2, where d is the distance to the star in
         units of 10 kpc.
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -7668,7 +7555,6 @@ class XSstep(XSAdditiveModel):
         param_apply_limits(pos, self.Energy, **kwargs)
 
 
-@version_at_least("12.9.1")
 class XStapec(XSAdditiveModel):
     """The XSPEC tapec model: APEC emission spectrum with separate continuum and line temperatures.
 
@@ -7698,10 +7584,6 @@ class XStapec(XSAdditiveModel):
     See Also
     --------
     XSbtapec, XSvtapec, XSvvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -7815,7 +7697,6 @@ class XSvbremss(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.HeovrH, self.norm))
 
 
-@version_at_least("12.10.1")
 class XSvcph(XSAdditiveModel):
     """The XSPEC vcph model: Cooling + heating model for cool core clusters
 
@@ -7841,10 +7722,6 @@ class XSvcph(XSAdditiveModel):
     See Also
     --------
     XSmkcflow, XScph
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.1 or later.
 
     References
     ----------
@@ -8396,7 +8273,6 @@ class XSvnpshock(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau_l, self.Tau_u, self.redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSvoigt(XSAdditiveModel):
     """The XSPEC voigt model: Voigt line profile.
 
@@ -8416,10 +8292,6 @@ class XSvoigt(XSAdditiveModel):
     See Also
     --------
     XSgauss, XSlorentz
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -8674,7 +8546,6 @@ class XSvsedov(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSvtapec(XSAdditiveModel):
     """The XSPEC vtapec model: APEC emission spectrum with separate continuum and line temperatures.
 
@@ -8702,10 +8573,6 @@ class XSvtapec(XSAdditiveModel):
     See Also
     --------
     XSbvtapec, XStapec, XSvvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -9294,7 +9161,6 @@ class XSvvsedov(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT_a, self.kT_b, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.redshift, self.norm))
 
 
-@version_at_least("12.9.1")
 class XSvvtapec(XSAdditiveModel):
     """The XSPEC vvtapec model: APEC emission spectrum with separate continuum and line temperatures.
 
@@ -9321,10 +9187,6 @@ class XSvvtapec(XSAdditiveModel):
     See Also
     --------
     XSbvvtapec, XStapec, XSvtapec
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -9673,7 +9535,6 @@ class XSzbbody(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.redshift, self.norm))
 
 
-@version_at_least("12.10.1")
 class XSzbknpower(XSAdditiveModel):
     """The XSPEC zbknpower model: broken power law.
 
@@ -9761,7 +9622,6 @@ class XSzbremss(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kT, self.redshift, self.norm))
 
 
-@version_at_least("12.10.0")
 class XSzcutoffpl(XSAdditiveModel):
     """The XSPEC zcutoffpl model: power law, high energy exponential cutoff.
 
@@ -9783,10 +9643,6 @@ class XSzcutoffpl(XSAdditiveModel):
     See Also
     --------
     XSbknpower, XSbkn2pow, XSzcutoffpl, XSpowerlaw, XSzpowerlw
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.0 or later.
 
     References
     ----------
@@ -9929,7 +9785,6 @@ class XSzkerrbb(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.eta, self.a, self.i, self.Mbh, self.Mdd, self.z, self.fcol, self.rflag, self.lflag, self.norm))
 
 
-@version_at_least("12.10.1")
 class XSzlogpar(XSAdditiveModel):
     """The XSPEC zlogpar model: log-parabolic blazar model.
 
@@ -9951,10 +9806,6 @@ class XSzlogpar(XSAdditiveModel):
     See Also
     --------
     XSlogpar
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.10.1 or later.
 
     References
     ----------
@@ -10085,7 +9936,7 @@ class XSacisabs(XSMultiplicativeModel):
 
     """
 
-    __function__ = _f77_or_c_12100("acisabs")
+    __function__ = "C_acisabs"
 
     def __init__(self, name='acisabs'):
         self.Tdays = XSParameter(name, 'Tdays', 850., 0., 10000., 0.0, 10000, units='days', frozen=True)
@@ -10467,7 +10318,6 @@ class XShrefl(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.thetamin, self.thetamax, self.thetaobs, self.Feabun, self.FeKedge, self.Escfrac, self.covfac, self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSismabs(XSMultiplicativeModel):
     """The XSPEC ismabs model: A high resolution ISM absorption model with variable columns for individual ions.
 
@@ -10490,8 +10340,6 @@ class XSismabs(XSMultiplicativeModel):
     for Silicon and Sulfur include an underscore character after the
     element name to avoid conflict: that is Si_I and S_I refer to
     the XSPEC SiI and SI parameters respectively.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11142,7 +10990,7 @@ class XSswind1(XSMultiplicativeModel):
 
     """
 
-    __function__ = _f77_or_c_12100("swind1")
+    __function__ = "C_swind1"
 
     def __init__(self, name='swind1'):
         self.column = XSParameter(name, 'column', 6., 3., 50., 3.0, 50)
@@ -11186,7 +11034,6 @@ class XSTBabs(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.nH,))
 
 
-@version_at_least("12.9.1")
 class XSTBfeo(XSMultiplicativeModel):
     """The XSPEC TBfeo model: ISM grain absorption.
 
@@ -11212,8 +11059,6 @@ class XSTBfeo(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11234,7 +11079,6 @@ class XSTBfeo(XSMultiplicativeModel):
                                         self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSTBgas(XSMultiplicativeModel):
     """The XSPEC TBgas model: ISM grain absorption.
 
@@ -11255,8 +11099,6 @@ class XSTBgas(XSMultiplicativeModel):
     -----
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11416,7 +11258,6 @@ class XSTBvarabs(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni, self.H2, self.rho, self.amin, self.amax, self.PL, self.H_dep, self.He_dep, self.C_dep, self.N_dep, self.O_dep, self.Ne_dep, self.Na_dep, self.Mg_dep, self.Al_dep, self.Si_dep, self.S_dep, self.Cl_dep, self.Ar_dep, self.Ca_dep, self.Cr_dep, self.Fe_dep, self.Co_dep, self.Ni_dep, self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSTBpcf(XSMultiplicativeModel):
     """The XSPEC TBpcf model: ISM grain absorption.
 
@@ -11440,8 +11281,6 @@ class XSTBpcf(XSMultiplicativeModel):
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -11460,7 +11299,6 @@ class XSTBpcf(XSMultiplicativeModel):
                                        (self.nH, self.pcf, self.redshift))
 
 
-@version_at_least("12.9.1")
 class XSTBrel(XSMultiplicativeModel):
     """The XSPEC TBrel model: ISM grain absorption.
 
@@ -11501,8 +11339,6 @@ class XSTBrel(XSMultiplicativeModel):
     -----
     The `set_xsabund` function changes the relative abundances of
     the elements, in particular the "wilm" setting.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -11850,7 +11686,6 @@ class XSxion(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.height, self.lxovrld, self.rate, self.cosAng, self.inner, self.outer, self.index, self.redshift, self.Feabun, self.E_cut, self.Ref_type, self.Rel_smear, self.Geometry))
 
 
-@version_at_least("12.9.1")
 class XSxscat(XSMultiplicativeModel):
     """The XSPEC xscat model: dust scattering.
 
@@ -11868,10 +11703,6 @@ class XSxscat(XSMultiplicativeModel):
         The radius of the circular extraction region, in arcsec.
     DustModel
         The dust model used: see [1]_ for more information.
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -12225,7 +12056,7 @@ class XSzxipcf(XSMultiplicativeModel):
 
     """
 
-    __function__ = _f77_or_c_12100("zxipcf")
+    __function__ = "C_zxipcf"
 
     def __init__(self, name='zxipcf'):
         self.Nh = XSParameter(name, 'Nh', 10, 0.05, 500, 0.05, 500, units='10^22 atoms / cm^2')
@@ -12632,7 +12463,6 @@ class XScflux(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.9.1")
 class XSclumin(XSConvolutionKernel):
     """The XSPEC clumin convolution model: calculate luminosity
 
@@ -12667,8 +12497,6 @@ class XSclumin(XSConvolutionKernel):
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
     emission component (or components) at 1.
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -13278,7 +13106,6 @@ class XSreflect(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.9.1")
 class XSrfxconv(XSConvolutionKernel):
     """The XSPEC rfxconv convolution model: angle-dependent reflection from an ionized disk
 
@@ -13315,8 +13142,6 @@ class XSrfxconv(XSConvolutionKernel):
     the ``set_xsxset`` function to set the value of the RFXCONV_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------
@@ -13497,7 +13322,6 @@ class XSthcomp(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.9.1")
 class XSvashift(XSConvolutionKernel):
     """The XSPEC vashift convolution model: velocity shift an additive model.
 
@@ -13523,8 +13347,6 @@ class XSvashift(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -13544,7 +13366,6 @@ class XSvashift(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
-@version_at_least("12.9.1")
 class XSvmshift(XSConvolutionKernel):
     """The XSPEC vmshift convolution model: velocity shift a multiplicative model.
 
@@ -13570,8 +13391,6 @@ class XSvmshift(XSConvolutionKernel):
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
 
-    This model is only available when used with XSPEC 12.9.1 or later.
-
     References
     ----------
 
@@ -13591,7 +13410,6 @@ class XSvmshift(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, (self.Velocity,))
 
 
-@version_at_least("12.9.1")
 class XSxilconv(XSConvolutionKernel):
     """The XSPEC xilconv convolution model: angle-dependent reflection from an ionized disk
 
@@ -13630,8 +13448,6 @@ class XSxilconv(XSConvolutionKernel):
     the ``set_xsxset`` function to set the value of the XILCONV_PRECISION
     keyword, which defines the fractional precision. The default is 0.01
     (1%).
-
-    This model is only available when used with XSPEC 12.9.1 or later.
 
     References
     ----------

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -114,35 +114,17 @@
 
 extern "C" {
 
-#ifdef XSPEC_12_10_1
   xsf77Call agnsed_;
   xsf77Call qsosed_;
-#endif
 
 #ifdef XSPEC_12_11_0
   xsf77Call agnslim_;
-#endif
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xsaped_;
-  xsf77Call xsbape_;
 #endif
 
   xsf77Call xsblbd_;
   xsf77Call xsbbrd_;
   xsf77Call xsbmc_;
   xsf77Call xsbrms_;
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xsbvpe_;
-#endif
-
-#ifndef XSPEC_12_10_0
-  xsf77Call c6mekl_;
-  xsf77Call c6pmekl_;
-  xsf77Call c6pvmkl_;
-  xsf77Call c6vmekl_;
-#endif
 
   xsf77Call cemekl_;
   xsf77Call compbb_;
@@ -152,9 +134,6 @@ extern "C" {
   xsf77Call disk_;
   xsf77Call diskir_;
   xsf77Call xsdskb_;
-#ifndef XSPEC_12_10_1
-  xsf77Call xsdili_;
-#endif
   xsf77Call diskm_;
   xsf77Call disko_;
   xsf77Call diskpbb_;
@@ -162,77 +141,36 @@ extern "C" {
   xsf77Call xsxpdec_;
   xsf77Call ezdiskbb_;
 
-#ifndef XSPEC_12_9_1
-  xsf77Call xsgaul_;
-#endif
-
   xsf77Call grad_;
 
-#ifdef XSPEC_12_10_0
   xsccCall xsgrbcomp;
 
   xsf77Call jet_;
-#endif
 
   xsf77Call xsgrbm_;
   xsf77Call spin_;
 
-#ifdef XSPEC_12_10_1
   xsf77Call kyrline_;
-#endif
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xslorz_;
-  xsf77Call xsmeka_;
-  xsf77Call xsmekl_;
-#endif
 
   xsf77Call nsa_;
   xsf77Call nsagrav_;
   xsf77Call nsatmos_;
 
-#ifndef XSPEC_12_10_0
-  xsf77Call nsmax_;
-#endif
-
   xsf77Call xspegp_;
   xsf77Call xsp1tr_;
   xsf77Call xsposm_;
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xsrays_;
-#endif
 
   xsf77Call xredge_;
   xsf77Call xsrefsch_;
   xsf77Call srcut_;
   xsf77Call sresc_;
-#ifdef XSPEC_12_10_0
   xsf77Call ssa_;
-#endif
   xsf77Call xsstep_;
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xsvape_;
-#endif
 
   xsf77Call xsbrmv_;
 
-#ifndef XSPEC_12_9_1
-  xsf77Call xsvmek_;
-  xsf77Call xsvmkl_;
-#endif
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xsvrys_;
-#endif
-
   xsf77Call xszbod_;
   xsf77Call xszbrm_;
-
-#ifndef XSPEC_12_10_0
-  xsf77Call acisabs_;
-#endif
 
   xsf77Call xscnst_;
   xsf77Call xscabs_;
@@ -252,10 +190,6 @@ extern "C" {
   xsf77Call xsspln_;
   xsf77Call xssssi_;
 
-#ifndef XSPEC_12_10_0
-  xsf77Call swind1_;
-#endif
-
   xsf77Call xsred_;
   xsf77Call xsabsv_;
   xsf77Call xsvphb_;
@@ -268,10 +202,6 @@ extern "C" {
   xsf77Call xszabp_;
   xsf77Call xszphb_;
 
-#ifndef XSPEC_12_10_0
-  xsf77Call zxipcf_;
-#endif
-
   xsf77Call xszcrd_;
   xsf77Call msldst_;
   xsf77Call xszvab_;
@@ -280,17 +210,8 @@ extern "C" {
   xsf77Call xszabs_;
   xsf77Call xszwnb_;
 
-
-#ifndef XSPEC_12_9_1
-  xsf77Call xsbvvp_;
-  xsf77Call xsvvap_;
-#endif
-
   xsf77Call zigm_;
 
-#ifndef XSPEC_12_10_1
-  xsf77Call logpar_;
-#endif
   xsf77Call eplogpar_;
   xsf77Call optxagn_;
   xsf77Call optxagnf_;
@@ -300,19 +221,12 @@ extern "C" {
   xsccCall xscompmag;
   xsccCall xscomptb;
 
-#ifndef XSPEC_12_10_0
-  xsf77Call nsmaxg_;
-  xsf77Call nsx_;
-#endif
-
 //multiplicative
   xsf77Call xsphei_;
   xsf77Call xslyman_;
   xsccCall xszbabs;
 
-#ifdef XSPEC_12_9_1
   xsccCall slimbbmodel;
-#endif
 
 #ifdef XSPEC_12_11_0
   xsccCall beckerwolff;
@@ -324,9 +238,7 @@ extern "C" {
   xsF77Call olivineabs_;
 #else
 
-#ifdef XSPEC_12_9_1
   xsf77Call ismabs_;
-#endif
 
 #ifdef XSPEC_12_11_0
   xsf77Call ismdust_;
@@ -335,28 +247,12 @@ extern "C" {
 
 #endif // XSPEC_12_12_1
 
-// XSPEC table models; in XSPEC 12.10.1 these have been consolidated
-// into the tabint routine, but that is only available to C++, and
-// so is defined in sherpa/include/sherpa/astro/xspec_extension.hh
-// In XSPEC 12.11.0 tabint is available in C scope (but is again
-// defined in xspec_extension.hh as it doesn't need to be visible
-// here).
-//
-#ifndef XSPEC_12_10_1
-void xsatbl(float* ear, int ne, float* param, const char* filenm, int ifl,
-	    float* photar, float* photer);
-void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl,
-	    float* photar, float* photer);
-#endif
-
 // XSPEC convolution models
 //
 
   xsf77Call rgsxsrc_;
 
-#ifdef XSPEC_12_10_1
   xsf77Call kyconv_;
-#endif
 
 #ifdef XSPEC_12_11_0
   xsf77Call thcompf_;
@@ -457,17 +353,6 @@ static int _sherpa_init_xspec_library()
     csmph0( 70.0 );
     csmpq0( 0.0 );
     csmpl0( 0.73 );
-
-    // Work around a XSPEC 12.10.0 issue where the atomdb version is
-    // hardcoded to 3.0.7 for the models-only build but it should be
-    // 3.0.9. This is fixed in the yet-to-be-released 12.10.1 (hence
-    // the attempt to only restrict to 12.10.0).
-    //
-#if defined (XSPEC_12_10_0) && !defined (XSPEC_12_10_1)
-    char atomdbVersion1210[6] = "3.0.9";
-    atomdbVersion1210[5] = '\0';
-    FPATDV(atomdbVersion1210);
-#endif
 
   } catch(...) {
 
@@ -958,22 +843,15 @@ static PyMethodDef XSpecMethods[] = {
     (PyCFunction)get_model_data_path, METH_NOARGS, NULL },
   FCTSPEC(set_xspath_manager, set_manager_data_path),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_NORM( agnsed, 16 ),
   XSPECMODELFCT_NORM( qsosed, 7 ),
-#endif
 
 #ifdef XSPEC_12_11_0
   XSPECMODELFCT_NORM( agnslim, 15 ),
 #endif
 
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_apec, 4 ),
   XSPECMODELFCT_C_NORM( C_bapec, 5 ),
-#else
-  XSPECMODELFCT_NORM( xsaped, 4 ),
-  XSPECMODELFCT_NORM( xsbape, 5 ),
-#endif
   XSPECMODELFCT_NORM( xsblbd, 2 ),
   XSPECMODELFCT_NORM( xsbbrd, 2 ),
   XSPECMODELFCT_C_NORM( C_xsbexrav, 10 ),
@@ -983,26 +861,13 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_sirf, 10 ),
   XSPECMODELFCT_NORM( xsbmc, 4 ),
   XSPECMODELFCT_NORM( xsbrms, 2 ),
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_brnei, 7 ),
-#endif
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_bvapec, 17 ),
-#else
-  XSPECMODELFCT_NORM( xsbvpe, 17 ),
-#endif
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_bvrnei, 19 ),
   XSPECMODELFCT_C_NORM( C_c6mekl, 11 ),
   XSPECMODELFCT_C_NORM( C_c6pmekl, 11 ),
   XSPECMODELFCT_C_NORM( C_c6pvmkl, 24 ),
   XSPECMODELFCT_C_NORM( C_c6vmekl, 24 ),
-#else
-  XSPECMODELFCT_NORM( c6mekl, 11 ),
-  XSPECMODELFCT_NORM( c6pmekl, 11 ),
-  XSPECMODELFCT_NORM( c6pvmkl, 24 ),
-  XSPECMODELFCT_NORM( c6vmekl, 24 ),
-#endif
   XSPECMODELFCT_NORM( cemekl, 7 ),
   XSPECMODELFCT_C_NORM( C_cemVMekal, 20 ),
   XSPECMODELFCT_C_NORM( C_xscflw, 6 ),
@@ -1015,11 +880,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( disk, 4 ),
   XSPECMODELFCT_NORM( diskir, 9 ),
   XSPECMODELFCT_NORM( xsdskb, 2 ),
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_diskline, 6 ),
-#else
-  XSPECMODELFCT_NORM( xsdili, 6 ),
-#endif
   XSPECMODELFCT_NORM( diskm, 5 ),
   XSPECMODELFCT_NORM( disko, 5 ),
   XSPECMODELFCT_NORM( diskpbb, 3 ),
@@ -1027,16 +888,10 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_equil, 4 ),
   XSPECMODELFCT_NORM( xsxpdec, 2 ),
   XSPECMODELFCT_NORM( ezdiskbb, 2 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_gaussianLine, 3 ),
-#else
-  XSPECMODELFCT_NORM( xsgaul, 3 ),
-#endif
   XSPECMODELFCT_C_NORM( C_gnei, 6 ),
   XSPECMODELFCT_NORM( grad, 7 ),
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( xsgrbcomp, 10 ),
-#endif
   XSPECMODELFCT_NORM( xsgrbm, 4 ),
   XSPECMODELFCT_C_NORM( C_kerrbb, 10 ),
 
@@ -1044,36 +899,16 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_zkerrbb, 10 ),
 #endif
 
-#ifdef XSPEC_12_10_0
-  /* From an email from Craig Gordon at HEASARC:
-     12.10.0 and later: for kerrd call C_kerrd. For earlier versions kerrd should call C_kerrdisk.
-     (the model.dat file gives C_kerrdisk up to 12.10.1b)
-  */
   XSPECMODELFCT_C_NORM( C_kerrd, 8 ),
-#else
-  XSPECMODELFCT_C_NORM( C_kerrdisk, 8 ),
-#endif
   XSPECMODELFCT_NORM( spin, 10 ),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_NORM( kyrline, 12 ),
-#endif
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_laor, 6 ),
-#else
-  XSPECMODELFCT_C_NORM( C_xslaor, 6 ),
-#endif
   XSPECMODELFCT_C_NORM( C_laor2, 8 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_lorentzianLine, 3 ),
   XSPECMODELFCT_C_NORM( C_meka, 5 ),
   XSPECMODELFCT_C_NORM( C_mekal, 6 ),
-#else
-  XSPECMODELFCT_NORM( xslorz, 3 ),
-  XSPECMODELFCT_NORM( xsmeka, 5 ),
-  XSPECMODELFCT_NORM( xsmekl, 6 ),
-#endif
   XSPECMODELFCT_C_NORM( C_xsmkcf, 6 ),
   XSPECMODELFCT_C_NORM( C_nei, 5 ),
   XSPECMODELFCT_C_NORM( C_nlapec, 4 ),
@@ -1081,11 +916,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( nsa, 5 ),
   XSPECMODELFCT_NORM( nsagrav, 4 ),
   XSPECMODELFCT_NORM( nsatmos, 5 ),
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_nsmax, 4 ),
-#else
-  XSPECMODELFCT_NORM( nsmax, 4 ),
-#endif
   XSPECMODELFCT_C_NORM( C_xsnteea, 16 ),
   XSPECMODELFCT_C_NORM( C_nthcomp, 6 ),
   XSPECMODELFCT_NORM( xspegp, 4 ),
@@ -1095,76 +926,45 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_powerLaw, 2 ),
   XSPECMODELFCT_NORM( xsposm, 1 ),
   XSPECMODELFCT_C_NORM( C_pshock, 6 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM(C_raysmith, 4 ),
-#else
-  XSPECMODELFCT_NORM( xsrays, 4 ),
-#endif
   XSPECMODELFCT_NORM( xredge, 3 ),
   XSPECMODELFCT_NORM( xsrefsch, 14 ),
 
   XSPECMODELFCT_C_NORM( C_sedov, 6 ),
   XSPECMODELFCT_NORM( srcut, 3 ),
   XSPECMODELFCT_NORM( sresc, 3 ),
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_NORM( ssa, 3 ),
-#endif
   XSPECMODELFCT_NORM( xsstep, 3 ),
 
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vapec, 16 ),
-#else
-  XSPECMODELFCT_NORM( xsvape, 16 ),
-#endif
   XSPECMODELFCT_NORM( xsbrmv, 3 ),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_vcph, 18 ),
-#endif
 
   XSPECMODELFCT_C_NORM( C_vequil, 15 ),
   XSPECMODELFCT_C_NORM( C_vgnei, 18 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vmeka, 18 ),
   XSPECMODELFCT_C_NORM( C_vmekal, 19 ),
-#else
-  XSPECMODELFCT_NORM( xsvmek, 18 ),
-  XSPECMODELFCT_NORM( xsvmkl, 19 ),
-#endif
   XSPECMODELFCT_C_NORM( C_xsvmcf, 19 ),
   XSPECMODELFCT_C_NORM( C_vnei, 17 ),
   XSPECMODELFCT_C_NORM( C_vnpshock, 19 ),
   XSPECMODELFCT_C_NORM( C_vpshock, 18 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_vraysmith, 15 ),
-#else
-  XSPECMODELFCT_NORM( xsvrys, 15 ),
-#endif
   XSPECMODELFCT_C_NORM( C_vsedov, 18 ),
   XSPECMODELFCT_NORM( xszbod, 3 ),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_zBrokenPowerLaw, 5 ),
-#endif
 
   XSPECMODELFCT_NORM( xszbrm, 3 ),
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_zcutoffPowerLaw, 4),
-#endif
   XSPECMODELFCT_C_NORM( C_xszgau, 4 ),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_zLogpar, 5 ),
-#endif
 
   XSPECMODELFCT_C_NORM( C_zpowerLaw, 3 ),
   XSPECMODELFCT_C( C_xsabsori, 6 ),
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C( C_acisabs, 8 ),
-#else
-  XSPECMODELFCT( acisabs, 8 ),
-#endif
 
   XSPECMODELFCT( xscnst, 1 ),
   XSPECMODELFCT( xscabs, 1 ),
@@ -1187,11 +987,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT( xsspln, 6 ),
   XSPECMODELFCT( xssssi, 1 ),
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C( C_swind1, 4 ),
-#else
-  XSPECMODELFCT( swind1, 4 ),
-#endif
 
   XSPECMODELFCT_C( C_tbabs, 1 ),
   XSPECMODELFCT_C( C_tbgrain, 6 ),
@@ -1208,11 +1004,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT( xszabp, 3 ),
   XSPECMODELFCT( xszphb, 2 ),
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C( C_zxipcf, 4 ),
-#else
-  XSPECMODELFCT( zxipcf, 4 ),
-#endif
 
   XSPECMODELFCT( xszcrd, 2 ),
   XSPECMODELFCT( msldst, 4 ),
@@ -1223,34 +1015,21 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT( xszabs, 2 ),
   XSPECMODELFCT( xszwnb, 3 ),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_cph, 5 ),
-#endif
 
   XSPECMODELFCT_C_NORM( C_cplinear, 21 ),
   XSPECMODELFCT_C_NORM( C_xseqpair, 21 ),
   XSPECMODELFCT_C_NORM( C_xseqth, 21 ),
   XSPECMODELFCT_C_NORM( C_xscompth, 21 ),
-#ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM( C_bvvapec, 34 ),
   XSPECMODELFCT_C_NORM( C_vvapec, 33 ),
-#else
-  XSPECMODELFCT_NORM( xsbvvp, 34 ),
-  XSPECMODELFCT_NORM( xsvvap, 33 ),
-#endif
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_bvvrnei, 36 ),
-#endif
   XSPECMODELFCT( zigm, 3 ),
   // New XSPEC 12.7.1 models
   XSPECMODELFCT_C_NORM( C_gaussDem, 7 ),
   XSPECMODELFCT_C_NORM( C_vgaussDem, 20 ),
   XSPECMODELFCT_NORM( eplogpar, 3 ),
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_C_NORM( C_logpar, 4 ),
-#else
-  XSPECMODELFCT_NORM( logpar, 4 ),
-#endif
   XSPECMODELFCT_NORM( optxagn, 14 ),
   XSPECMODELFCT_NORM( optxagnf, 12 ),
   XSPECMODELFCT_NORM( pexmon, 8 ),
@@ -1263,13 +1042,8 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( xscompmag, 9 ), // DJB thinks it's okay to use the C++ wrapper for C
   XSPECMODELFCT_C_NORM( xscomptb, 7 ), // DJB thinks it's okay to use the C++ wrapper for C
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_C_NORM( C_nsmaxg, 6 ),
   XSPECMODELFCT_C_NORM( C_nsx, 6 ),
-#else
-  XSPECMODELFCT_NORM( nsmaxg, 6 ),
-  XSPECMODELFCT_NORM( nsx, 6 ),
-#endif
 
   XSPECMODELFCT_C_NORM( C_rnei, 6 ),
   XSPECMODELFCT_C_NORM( C_vrnei, 18 ),
@@ -1294,37 +1068,22 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C( xszbabs, 4 ), // DJB thinks it's okay to use the C++ wrapper for C
 
   // XSPEC table models
-#ifdef XSPEC_12_10_1
   KWSPEC(tabint, sherpa::astro::xspec::xspectablemodel),
-#else
-  KWSPEC(xsatbl, sherpa::astro::xspec::xspectablemodel<true, xsatbl>),
-  KWSPEC(xsmtbl, sherpa::astro::xspec::xspectablemodel<false, xsmtbl>),
-#endif
 
   // XSPEC convolution models
   XSPECMODELFCT_CON(C_cflux, 3),
   XSPECMODELFCT_CON(C_cpflux, 3),
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_CON(C_gsmooth, 2),
-#else
-  XSPECMODELFCT_CON(C_xsgsmt, 2),
-#endif
 
   XSPECMODELFCT_CON(C_ireflct, 7),
   XSPECMODELFCT_CON(C_kdblur, 4),
   XSPECMODELFCT_CON(C_kdblur2, 6),
   XSPECMODELFCT_CON(C_spinconv, 7),
 
-#ifdef XSPEC_12_10_1
   XSPECMODELFCT_CON_F77(kyconv, 12),
-#endif
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_CON(C_lsmooth, 2),
-#else
-  XSPECMODELFCT_CON(C_xslsmt, 2),
-#endif
 
   XSPECMODELFCT_CON(C_PartialCovering, 1),
   XSPECMODELFCT_CON(C_rdblur, 4),
@@ -1342,7 +1101,6 @@ static PyMethodDef XSpecMethods[] = {
   // Models from 12.9.1
   //
   //
-  #ifdef XSPEC_12_9_1
   XSPECMODELFCT_C_NORM(C_btapec, 6),
   XSPECMODELFCT_C_NORM(C_bvtapec, 18),
   XSPECMODELFCT_C_NORM(C_bvvtapec, 35),
@@ -1373,11 +1131,8 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_vashift, 1),
   XSPECMODELFCT_CON(C_vmshift, 1),
   XSPECMODELFCT_CON(C_xilconv, 6),
-  #endif
 
-#ifdef XSPEC_12_10_0
   XSPECMODELFCT_NORM(jet, 16),
-#endif
 
 #ifdef XSPEC_12_12_1
   XSPECMODELFCT_DBL(ismdust, 3),

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -99,13 +99,6 @@ def get_xspec_models():
               'XSBaseParameter', 'XSParameter']:
         remove_item(model_names, n)
 
-    # The sirf model - in 12.8.2 and up to 12.9.0d at least - includes
-    # a read outside of an array. This has been seen to cause occasional
-    # errors in the Sherpa test case, so it is removed from the test
-    # for now. This problem has been reported to the XSPEC developers,
-    # so it will hopefully be fixed in one of ther 12.9.0 patches.
-    remove_item(model_names, 'XSsirf')
-
     # the grbjet model with XSPEC 12.12.0 (and presumably 12.12.0.a) can
     # occasionally evaluate to all 0's. This has been reported, but for now
     # skip this model.
@@ -191,13 +184,6 @@ def assert_is_finite(vals, modelcls, label):
     emsg = "model {} is finite [{}]".format(modelcls, label)
     assert numpy.isfinite(vals).all(), emsg
 
-    # XSPEC 12.10.0 defaults to ATOMDB version 3.0.7 but
-    # provides files for 3.0.9 (this is okay for the application
-    # as it is automatically over-written by the XSPEC init file,
-    # but not for the models-only build we use). With this
-    # mis-match, APEC-style models return all 0 values, so check
-    # for this.
-    #
     # Some models seem to return 0's, so skip them for now:
     # these models have a default redshift parameter of 0 but
     # the code complains if z <= 0 and returns 0's.

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -82,7 +82,6 @@ extern "C" {
 // was moved into C scope. In XSPEC 12.12.1 the signature was changed
 // to mark more arguments as const.
 //
-#ifdef XSPEC_12_10_1
 #ifdef XSPEC_12_11_0
 extern "C" {
 #endif
@@ -99,8 +98,6 @@ extern "C" {
 
 #ifdef XSPEC_12_11_0
 }
-#endif
-
 #endif
 
 
@@ -1025,8 +1022,6 @@ PyObject* xspecmodelfct_con_f77( PyObject* self, PyObject* args ) {
 // for now have a run-time check rather than multiple versions
 // of this routine.
 //
-#ifdef XSPEC_12_10_1
-
 PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 {
 
@@ -1097,114 +1092,6 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds )
 
 }
 
-#else
-
-typedef void (*XSpecFuncVal)( float* ear, int ne, float* param, const char* filenm, int ifl, float* photar, float* photer );
-
-template <bool HasNorm, XSpecFuncVal XSpecFunc>
-PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds ) {
-
-        PyArgTupleBase();
-
-	FloatArray pars;
-	DoubleArray xlo;
-	DoubleArray xhi;
-	char *filename;
-	static char *kwlist[] = {(char*)"pars", (char*)"xlo", (char*)"xhi",
-			(char*)"filename", NULL};
-
-        // The grid arrays could be cast to FloatArray here, saving
-        // conversion later on in this routine. However, that can then
-        // lead to differences in the identification of non-contiguous
-        // bins, or whether a grid is monotonic and non-overlapping [*]
-        // (e.g. if a source expression contains both a FORTRAN
-        // and C style model), so stick to this approach for now.
-        //
-        // [*] although these checks are currently commented out
-        //
-	if ( !PyArg_ParseTupleAndKeywords( args, kwds, (char*)"O&O&|O&s", kwlist,
-			(converter)convert_to_contig_array< FloatArray >,
-			&pars,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xlo,
-			(converter)convert_to_contig_array< DoubleArray >,
-			&xhi,
-			&filename) )
-          return NULL;
-
-	npy_intp npars = pars.get_size();
-
-        // xspecTableModel<XSpecFunc> xspec_model = xspecTableModel<XSpecFunc>( );
-        // try {
-        //   FloatArray result;
-        //   xspec_model.eval(HasNorm, xlo, xhi, npars, pars, filename, NULL, result);
-        //   // Apply normalization if required
-        //   if ( HasNorm )
-        //     for (int i = 0; i < xlo.get_size(); i++)
-        //       result[i] *= pars[npars - 1];   // NOTE: NumPars not sent to template
-        //   return result.return_new_ref();
-        // } catch(std::runtime_error& re) {
-        //   return NULL;
-        // } catch(...) {
-        //   // Even though the XSPEC model function is Fortran, it could call
-        //   // C++ functions, so swallow exceptions here
-        //   PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
-        //   return NULL;
-        // }
-
-        //
-	// The grid to send to XSPEC (double precision).
-	//
-	std::vector<SherpaFloat> ear;
-        std::vector<int> gaps_index;
-	create_grid(xlo, xhi, ear, gaps_index);
-
-	int nelem = int( xlo.get_size() );
-	int ngrid = ear.size();
-	int ifl = 1;
-
-        // convert to 32-byte float
-        std::vector<FloatArrayType> fear(ngrid);
-	CONVERTARRAY(ear, fear, ngrid);
-
-	// Number of bins to send to XSPEC
-	int nout = ngrid;
-	if (xhi) nout--;
-
-	FloatArray result, error;
-	create_output(nout, result, error);
-
-	// Swallow exceptions here
-
-        try {
-
-          int npts = ngrid - 1;
-          XSpecFunc( &fear[0], npts, &pars[0], filename, ifl,
-                     &result[0], &error[0] );
-
-	} catch(...) {
-
-          PyErr_SetString( PyExc_ValueError,
-                           (char*)"XSPEC model evaluation failed" );
-          return NULL;
-
-	}
-
-	int ngaps = (int) gaps_index.size();
-	if (ngaps > 0) {
-	  finalize_grid(nelem, result, gaps_index);
-	}
-
-	// Apply normalization if required
-	if ( HasNorm )
-          for (int i = 0; i < nelem; i++)
-            result[i] *= pars[npars - 1];  // NOTE: NumPars not sent to template
-
-	return result.return_new_ref();
-
-}
-
-#endif
 
 } } } /* namespace xspec, namespace astro, namespace sherpa */
 


### PR DESCRIPTION
# Summary

Bump the minimum-supported version of XSPEC from 12.9.0 to 12.10.1.

# Details

This requires #1676 which was broken out to make things a bit easier to review and avoid (hopefully) catastrophic conflicts.

There are four main areas to be changed

- documentation
- the actual enforcement of the minimum version (which is in `helpers/xspec_extension.py` and is a small change
- removal of the conditional code in the C++ code (note: we still have some conditional code but that is expected as there are new models in 12.11.* / 12.12.0 that need to be handled)
- the Python code has some tests, documentation, and support for models prior to 12.10.1 that can be removed now

One change I have made is that we now error out if the XSPEC version is too old. As we know the code can't compile against we may as well error out earlier, with a useful error message, rather than later with some undefined symbol or missing include file message. This is more relevant for the follow-up PR to move to 12.12.0 as the minimum supported version!

My long-term aim is to actually require 12.12.0 or later as the minimum version, since that opens up extra changes, but that's a larger change (see #1609, which is built on top if this PR). This change does simplify a lot of code (and XSPEC 12.10.1 is "old", so I would be surprised anyone is still using it with Sherpa).

I have run this locally with XSPEC 12.12.0 (using a local build of XSPEC) and with `xspec-modelsonly=12.10.1` - the CI run handles the `xspec-modelsonly=12.11.1` case (this was with an earlier version of the PR but since then we've added XSPEC 12.12.1 to the CI runs).