### PR TITLE
Allow conf/covar/proj to be used with XSPEC model parameters (regression)

### DIFF
--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -245,7 +245,7 @@ class Const2(Const):
         Const.__init__(self, name, (self.con, ))
 
 
-@pytest.mark.parametrize("mdlcls", [Const1, pytest.param(Const2, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("mdlcls", [Const1, Const2])
 @pytest.mark.parametrize("method,getter",
                          [(ui.covar, ui.get_covar_results),
                           (ui.conf, ui.get_conf_results),

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -535,6 +535,50 @@ def test_err_estimate_single_parameter(strings, idval, otherids, clean_ui):
     assert res.parmaxes == pytest.approx([ERR_EST_C1_MAX])
 
 
+@pytest.mark.parametrize("strings", [False, True])
+@pytest.mark.parametrize("idval,otherids",
+                         [(1, (2, 3)),
+                          (2, [3, 1]),
+                          (3, [2, 1])])
+def test_err_estimate_model_all_frozen(strings, idval, otherids, clean_ui):
+    """What happens when the model is all frozen?"""
+
+    # This is a bit ugly
+    if strings:
+        idval = str(idval)
+        if type(otherids) == tuple:
+            otherids = (str(otherids[0]), str(otherids[1]))
+        else:
+            otherids = [str(otherids[0]), str(otherids[1])]
+
+    datasets = tuple([idval] + list(otherids))
+
+    setup_err_estimate_multi_ids(strings=strings)
+
+    zero = ui.create_model_component("scale1d", "zero")
+    zero.c0 = 0
+    zero.c0.freeze()
+
+    for id in datasets:
+        # In this case we have
+        #   orig == mdl
+        # but let's be explicit in case the code changes
+        #
+        orig = ui.get_source(id)
+        ui.set_source(id, orig + zero)
+
+    ui.fit(idval, *otherids)
+
+    ui.conf(*datasets, zero)
+    res = ui.get_conf_results()
+
+    assert res.datasets == datasets
+    assert res.parnames == ("mdl.c0", "mdl.c1")
+
+    assert res.parmins == pytest.approx([ERR_EST_C0_MIN, ERR_EST_C1_MIN])
+    assert res.parmaxes == pytest.approx([ERR_EST_C0_MAX, ERR_EST_C1_MAX])
+
+
 def test_show_all_empty(clean_ui):
     """Checks several routines at once!"""
 

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -428,7 +428,6 @@ def test_err_estimate_multi_ids(strings, idval, otherids, clean_ui):
     assert res.parmaxes == pytest.approx([ERR_EST_C0_MAX, ERR_EST_C1_MAX])
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("strings", [False, True])
 @pytest.mark.parametrize("idval,otherids",
                          [(1, (2, 3)),

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -482,7 +482,7 @@ def test_err_estimate_model(strings, idval, otherids, clean_ui):
 
     # I wanted to have zero.co thawed at this stage, but then we can not
     # use the ERR_EST_C0/1_xxx values as the fit has changed (and mdl.c0
-    # anbd zero.c0 are degenerate to boot).
+    # and zero.c0 are degenerate to boot).
     #
     ui.conf(*datasets, mdl)
     res = ui.get_conf_results()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9701,9 +9701,19 @@ class Session(NoNewAttributesAfterInit):
                 continue
 
             if isinstance(arg, sherpa.models.Model):
+                norig = len(parlist)
                 for par in arg.pars:
                     if not par.frozen:
                         parlist.append(par)
+
+                # If there were no free parameters then error out.
+                # Should this be a ParameterErr or a ModelErr? Neither
+                # have an existing label for this case. Pick ParameterErr
+                # to match the case when a single parameter is frozen.
+                #
+                if len(parlist) == norig:
+                    emsg = f"Model '{arg.name}' has no thawed parameters"
+                    raise sherpa.utils.err.ParameterErr(emsg)
 
                 continue
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9705,17 +9705,16 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         id : int or str, optional
-           The data set that provides the data. If not given then
-           all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
-           Other data sets to use in the calculation.
-        parameters : optional
+           The data set, or sets, that provides the data. If not given
+           then all data sets with an associated model are used
+           simultaneously.
+        parameters : sherpa.models.parameter.Parameter, optional
            The default is to calculate the confidence limits on all
-           thawed parameters of the model, or models, for all the
-           data sets. The evaluation can be restricted by listing
-           the parameters to use. Note that each parameter should be
-           given as a separate argument, rather than as a list.
-           For example ``covar(g1.ampl, g1.sigma)``.
+           thawed parameters of the model, or models, for all the data
+           sets. The evaluation can be restricted by listing the
+           parameters to use. Note that each parameter should be given
+           as a separate argument, rather than as a list.  For example
+           ``covar(g1.ampl, g1.sigma)``.
 
         See Also
         --------
@@ -9808,7 +9807,7 @@ class Session(NoNewAttributesAfterInit):
         identifiers "obs1", "obs5", and "obs6". This will still use
         the 1.6 sigma setting from the previous run.
 
-        >>> covar("obs1", ["obs5", "obs6"], clus.kt)
+        >>> covar("obs1", "obs5", "obs6", clus.kt)
 
         """
         self._covariance_results = self._est_errors(args, 'covariance')
@@ -9831,17 +9830,16 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         id : int or str, optional
-           The data set that provides the data. If not given then
-           all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
-           Other data sets to use in the calculation.
-        parameters : optional
+           The data set, or sets, that provides the data. If not given
+           then all data sets with an associated model are used
+           simultaneously.
+        parameters : sherpa.models.parameter.Parameter, optional
            The default is to calculate the confidence limits on all
-           thawed parameters of the model, or models, for all the
-           data sets. The evaluation can be restricted by listing
-           the parameters to use. Note that each parameter should be
-           given as a separate argument, rather than as a list.
-           For example ``conf(g1.ampl, g1.sigma)``.
+           thawed parameters of the model, or models, for all the data
+           sets. The evaluation can be restricted by listing the
+           parameters to use. Note that each parameter should be given
+           as a separate argument, rather than as a list.  For example
+           ``conf(g1.ampl, g1.sigma)``.
 
         See Also
         --------
@@ -10003,7 +10001,7 @@ class Session(NoNewAttributesAfterInit):
         identifiers "obs1", "obs5", and "obs6". This will still use
         the 1.6 sigma setting from the previous run.
 
-        >>> conf("obs1", ["obs5", "obs6"], clus.kt)
+        >>> conf("obs1", "obs5", "obs6", clus.kt)
 
         Only use two cores when evaluating the errors for the parameters
         used in the model for data set 3:
@@ -10034,17 +10032,16 @@ class Session(NoNewAttributesAfterInit):
         Parameters
         ----------
         id : int or str, optional
-           The data set that provides the data. If not given then
-           all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
-           Other data sets to use in the calculation.
-        parameters : optional
+           The data set, or sets, that provides the data. If not given
+           then all data sets with an associated model are used
+           simultaneously.
+        parameters : sherpa.models.parameter.Parameter, optional
            The default is to calculate the confidence limits on all
-           thawed parameters of the model, or models, for all the
-           data sets. The evaluation can be restricted by listing
-           the parameters to use. Note that each parameter should be
-           given as a separate argument, rather than as a list.
-           For example ``proj(g1.ampl, g1.sigma)``.
+           thawed parameters of the model, or models, for all the data
+           sets. The evaluation can be restricted by listing the
+           parameters to use. Note that each parameter should be given
+           as a separate argument, rather than as a list.  For example
+           ``proj(g1.ampl, g1.sigma)``.
 
         See Also
         --------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9674,9 +9674,11 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        args : sequence of sherpa.models.Parameter, int, or str
-            The dataset (when an niteger or str) to evaluate or the
-            model parameter to apply the error estimate on.
+        args : sequence of sherpa.models.Parameter, sherpa.models.Model, int, or str
+            The dataset (when an integer or str) to evaluate, the
+            model parameter to apply the error estimate on (must be
+            thawed), or a model frmo which all the thawed parameters
+            are used.
         methodname : str
             One of the valid error estimates (sub-classes of
             sherpa.estmethods.EstMethod).
@@ -9696,6 +9698,13 @@ class Session(NoNewAttributesAfterInit):
                     raise sherpa.utils.err.ParameterErr('frozen', arg.fullname)
 
                 parlist.append(arg)
+                continue
+
+            if isinstance(arg, sherpa.models.Model):
+                for par in arg.pars:
+                    if not par.frozen:
+                        parlist.append(par)
+
                 continue
 
             if id is None:
@@ -9731,13 +9740,15 @@ class Session(NoNewAttributesAfterInit):
            The data set, or sets, that provides the data. If not given
            then all data sets with an associated model are used
            simultaneously.
-        parameters : sherpa.models.parameter.Parameter, optional
+        parameter : sherpa.models.parameter.Parameter, optional
            The default is to calculate the confidence limits on all
            thawed parameters of the model, or models, for all the data
            sets. The evaluation can be restricted by listing the
            parameters to use. Note that each parameter should be given
            as a separate argument, rather than as a list.  For example
            ``covar(g1.ampl, g1.sigma)``.
+        model : sherpa.models.model.Model, optional
+           Select all the thawed parameters in the model.
 
         See Also
         --------
@@ -9832,6 +9843,12 @@ class Session(NoNewAttributesAfterInit):
 
         >>> covar("obs1", "obs5", "obs6", clus.kt)
 
+        Estimate the errors for all the thawed parameters from the
+        ``line`` model and the ``clus.kt`` parameter for datasets 1,
+        3, and 4:
+
+        >>> covar(1, 3, 4, line, clus.kt)
+
         """
         self._covariance_results = self._est_errors(args, 'covariance')
 
@@ -9856,13 +9873,15 @@ class Session(NoNewAttributesAfterInit):
            The data set, or sets, that provides the data. If not given
            then all data sets with an associated model are used
            simultaneously.
-        parameters : sherpa.models.parameter.Parameter, optional
+        parameter : sherpa.models.parameter.Parameter, optional
            The default is to calculate the confidence limits on all
            thawed parameters of the model, or models, for all the data
            sets. The evaluation can be restricted by listing the
            parameters to use. Note that each parameter should be given
            as a separate argument, rather than as a list.  For example
            ``conf(g1.ampl, g1.sigma)``.
+        model : sherpa.models.model.Model, optional
+           Select all the thawed parameters in the model.
 
         See Also
         --------
@@ -10032,6 +10051,12 @@ class Session(NoNewAttributesAfterInit):
         >>> set_conf_opt('numcores', 2)
         >>> conf(3)
 
+        Estimate the errors for all the thawed parameters from the
+        ``line`` model and the ``clus.kt`` parameter for datasets 1,
+        3, and 4:
+
+        >>> conf(1, 3, 4, line, clus.kt)
+
         """
         self._confidence_results = self._est_errors(args, 'confidence')
 
@@ -10058,13 +10083,15 @@ class Session(NoNewAttributesAfterInit):
            The data set, or sets, that provides the data. If not given
            then all data sets with an associated model are used
            simultaneously.
-        parameters : sherpa.models.parameter.Parameter, optional
+        parameter : sherpa.models.parameter.Parameter, optional
            The default is to calculate the confidence limits on all
            thawed parameters of the model, or models, for all the data
            sets. The evaluation can be restricted by listing the
            parameters to use. Note that each parameter should be given
            as a separate argument, rather than as a list.  For example
            ``proj(g1.ampl, g1.sigma)``.
+        model : sherpa.models.model.Model, optional
+           Select all the thawed parameters in the model.
 
         See Also
         --------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -9671,7 +9671,7 @@ class Session(NoNewAttributesAfterInit):
         parlist = []
         otherids = ()
         for arg in args:
-            if type(arg) is sherpa.models.Parameter:
+            if isinstance(arg, sherpa.models.Parameter):
                 if arg.frozen is False:
                     parlist.append(arg)
                 else:

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9677,7 +9677,7 @@ class Session(NoNewAttributesAfterInit):
         args : sequence of sherpa.models.Parameter, sherpa.models.Model, int, or str
             The dataset (when an integer or str) to evaluate, the
             model parameter to apply the error estimate on (must be
-            thawed), or a model frmo which all the thawed parameters
+            thawed), or a model from which all the thawed parameters
             are used.
         methodname : str
             One of the valid error estimates (sub-classes of


### PR DESCRIPTION
# Summary

Ensure that conf, covar, and proj can be called with an XSPEC model parameter.  Fixes #1397. 

Improve the documentation for these commands and allow a model to be given as an argument, which will then use all the free parameters in the model.

# Details

A number of tests have been added to check the `conf`/`covar`/`proj` functionality beyond issue #1397 as it turns out we weren't testing them. This includes calling with multiple datasets, selecting a subset of parameter values, and some error checks.

In doing this I realised the existing documentation for `conf` and `covar` was wrong, as it said you should use

    conf(1, [2, 3])

to select multiple datasets (when not just defaulting to them all). I have added a test to check that this does fail (as it should) and a test for the correct syntax, which is

    conf(1, 2, 3)

The documentation has been updated to match the correct behavior.

There are a number of small code-style changes made to the module to better match Python idioms. I have added some checks to ensure the code is covered, but it turns out we do have existing tests of this functionality.

The bug that caused #1397 was that we were checking for a `sherpa.models.parameter.Parameter` object directly, with

    type(arg) is Parameter

rather than allowing sub-classes (which is what we now have with XSPEC models thanks to #1259), so the fix is to change the logic to

    isinstance(arg, Parameter).

I have manually checked both `sherpa.ui.utils` and `sherpa.astro.ui.utils` and we don't appear to have this problem elsewhere (that is, the other places where we care about getting a parameter we use an `isinstance` call).

For the check for #1397 I do not use an XSPEC model parameter (as that would only be run in a subset of runs). Instead the code creates new models that use either a `sherpa.models.parameter.Parameter` parameter or a subclass of it.

To improve the use of the `conf`/... commands, you can now give a model and it'll include all the free parameters in the list. So, whereas before you had to say (I'm using a Sherpa model so that we don't get hit by #1397!)

```
sherpa-4.14.0> conf(pl)
ArgumentTypeErr: identifiers must be integers or strings

sherpa-4.14.0> conf(pl.gamma, pl.ampl)
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
pl.ampl lower bound:    -1.79892e-05
pl.ampl upper bound:    3.20435e-05
pl.gamma lower bound:   -0.100573
pl.gamma upper bound:   0.148243
Dataset               = 1
Confidence Method     = confidence
Iterative Fit Method  = None
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   pl.gamma          1.95164    -0.100573     0.148243
   pl.ampl       0.000184129 -1.79892e-05  3.20435e-05
```

you can now say

```
>>> conf(pl)
WARNING: data set 1 has associated backgrounds, but they have not been subtracted, nor have background models been set
pl.ampl lower bound:    -1.79892e-05
pl.ampl upper bound:    3.20435e-05
pl.gamma lower bound:   -0.100573
pl.gamma upper bound:   0.148243
Dataset               = 1
Confidence Method     = confidence
Iterative Fit Method  = None
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   pl.gamma          1.95164    -0.100573     0.148243
   pl.ampl       0.000184129 -1.79892e-05  3.20435e-05
```

(you can still say the version listing each parameter if you want).