### PR TITLE
pinning readline to 8.1.0

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -49,6 +49,6 @@ fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC} ${DOCSBUILD}"
 
 # Create and activate conda build environment
-conda create --yes -n build python=${PYTHONVER} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
+conda create --yes -n build python=${PYTHONVER}  readline=8.1.0 pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
 
 conda activate build


### PR DESCRIPTION
Pinning readline to 8.1.0 in the conda setup script, as readline 8.1.2 is broken on conda defaults at the moment.

This is to be reverted as soon as conda resolves the readline issue. 

