### PR TITLE
Modified region code to remove implicit prototype error

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -384,20 +384,6 @@ C++ compilers to use if not found by ``setup.py``.
 
    That is, the variable is set to a space, not the empty string.
 
-.. note::
-
-   If you are building with Clang version 12, you will
-   encounter build issues in the region area related to an implicit
-   declaration. If so, pre-pending the following to your pip install
-   or python setup.py install line should resolve the build issues::
-
-     CFLAGS='-Wno-implicit-function-declaration' pip install .
-
-   (Note that on MacOS, "gcc" is usually just an alias to Clang. Unless
-   you specifically install a gcc from a different source, you are
-   likely to run into this problem, even if you believe that your
-   compiler is invoked with `gcc`.)
-
 A standard installation
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/extern/region-4.14/src/reglexer.l
+++ b/extern/region-4.14/src/reglexer.l
@@ -1,6 +1,6 @@
 %{
 /*                                                                
-**  Copyright (C) 2007  Smithsonian Astrophysical Observatory 
+**  Copyright (C) 2007,2022  Smithsonian Astrophysical Observatory 
 */                                                                
 
 /*                                                                          */
@@ -32,7 +32,7 @@
 char     *regParseStr;
 char     *regParseStrEnd;
 regRegion *my_Gregion;
-
+void     regYYrestart(FILE*);
 
   #ifdef FLEX_SCANNER
   #define YY_INPUT(b,r,ms)      (r = reg_flex_input(b,ms))

--- a/extern/region-4.14/src/regparser.y
+++ b/extern/region-4.14/src/regparser.y
@@ -1,7 +1,7 @@
 
 %{
 /*                                                                
-**  Copyright (C) 2007  Smithsonian Astrophysical Observatory 
+**  Copyright (C) 2007,2022  Smithsonian Astrophysical Observatory 
 */                                                                
 
 /*                                                                          */
@@ -28,6 +28,7 @@
 extern char     *regParseStr;
 extern char     *regParseStrEnd;
 extern regRegion *my_Gregion;
+extern void      regYYrestart(FILE*);
 static int world_coord;
 static int world_size;
 int test_link_jcm( void );


### PR DESCRIPTION
**Summary**

This change updates the extern region code in sherpa to resolve a missing prototype which causes build issues with clang 12.0.

**Details**

Changes to remove build error on clang:

     regparser.y:629:5: error: implicit declaration of function 'regYYrestart' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]

and remove the workaround added to docs/install.rst in #1142:

    .. note::

       Additionally, if you are building with Clang version 12, you will
       encounter build issues in the region area related to an implicit
       declaration. If so, pre-pending the following to your pip install
       or python setup.py install line should resolve the build issues::

         CFLAGS='-Wno-implicit-function-declaration'

       (Note that on MacOS, "gcc" is usually just an alias to Clang. Unless
       you specifically install a gcc from a different source, you are
       likely to run into this problem, even if you believe that your
       compiler is invoked with `gcc`.)

The changes coincide with updates to the CIAO region library code issued in bug fix SL-251.