### PR TITLE
revert readline fix

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -49,6 +49,6 @@ fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC} ${DOCSBUILD}"
 
 # Create and activate conda build environment
-conda create --yes -n build python=${PYTHONVER}  readline=8.1.0 pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
+conda create --yes -n build python=${PYTHONVER} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
 
 conda activate build


### PR DESCRIPTION
Looks like readline has been fixed by anaconda, I've tested it on both a minimal install (just python and readline=8.1.2) and a sherpa CI run, and everything looks good.

I wasn't sure if we want to do this with a new commit (as I've done here) or just remove the previous commit. As I'm not sure how to do the second option cleanly, I've just done the first.