### PR TITLE
Add Codebase Linting using Super-Linter GitHub Action

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,31 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: Lint Code Base
+
+on:
+  push:
+    branches: [ main, testing_lint ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # setting any VALIDATE_<lang> to true sets all unset validate envvars to false
+          VALIDATE_PYTHON_BLACK: true


### PR DESCRIPTION
So I decided to distract myself from the coming git-ocolypse migration and set up a super linter.

As it's set now, it will do a complete check using black python linter and you can see what would be changed in the whole codebase, but future versions would only check new code.

I know it's likely not to be taken, as there are concerns over massive whitespace changes, but I figured it'd be nice to have this explored.

I may make another check to see if any of the changes (apply them wholesale with no regard to what it will do) to see if it breaks anything. 