### PR TITLE
Add script and docs for pre-commit hook to update copyright

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -652,11 +652,11 @@ Never forget to update the year of the copyright notice?
 
 Git offers `pre-commit hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`_
 that can do file checks for you before a commit is executed. The script in
-`sherpa/pre-commit` will check if the copyright notice in any of the files in the
+`scripts/pre-commit` will check if the copyright notice in any of the files in the
 current commit must be updated and, if so, add the current year to the copyright notice
 and abort the commit so that you can manually check before commiting again.
 
-To use this opt-in functionality, simply copy the file to the appropriate location:
+To use this opt-in functionality, simply copy the file to the appropriate location::
 
   cp scripts/pre-commit .git/hooks
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -646,6 +646,20 @@ available.
       by addtive and then multiplicative models, using an alphabetical
       sorting - and to the appropriate ``inheritance-diagram`` rule.
 
+
+Never forget to update the year of the copyright notice?
+--------------------------------------------------------
+
+Git offers `pre-commit hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`_
+that can do file checks for you before a commit is executed. The script in
+`sherpa/pre-commit` will check if the copyright notice in any of the files in the
+current commit must be updated and, if so, add the current year to the copyright notice
+and abort the commit so that you can manually check before commiting again.
+
+To use this opt-in functionality, simply copy the file to the appropriate location:
+
+  cp scripts/pre-commit .git/hooks
+
 Notes
 =====
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -32,7 +32,7 @@ copyr = re.compile(r"(?P<comment>(#|//))\s*Copyright \(C\) (?P<years>[0-9,\s]+)(
 # Only apply this to C or Python files since sherpa does not use
 # copyright statements in others files, also, do not change in extern
 # directory.
-ftype = re.compile(r"^((?!extern).)*(hh|cc|c|py)$")
+ftype = re.compile(r"^((?!extern).)*(hh|cc|c|h|py)$")
 changed = 0
 
 if __name__ == '__main__':

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -32,7 +32,7 @@ copyr = re.compile(r"(?P<comment>(#|//))\s*Copyright \(C\) (?P<years>[0-9,\s]+)(
 # Only apply this to C or Python files since sherpa does not use
 # copyright statements in others files, also, do not change in extern
 # directory.
-ftype = re.compile(r"^((?!extern).)*(hh|cc|py)$")
+ftype = re.compile(r"^((?!extern).)*(hh|cc|c|py)$")
 changed = 0
 
 if __name__ == '__main__':

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -58,7 +58,7 @@ if __name__ == '__main__':
                               '  ' + m.group('institution'), end='')
                 else:
                     print(line, end='')
-            subprocess.Popen("git add " + f, shell=True)
+            # subprocess.Popen("git add " + f, shell=True)
         except FileNotFoundError:
             # file was removed with "git rm" so there is nothing to check here
             pass

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -29,6 +29,9 @@ import sys
 
 year = str(datetime.datetime.now().year)
 copyr = re.compile(r"(?P<comment>(#|//))\s*Copyright \(C\) (?P<years>[0-9,\s]+)(?P<institution>[\w\s]*)")
+# Only apply this to C or Python files since sherpa does not use 
+# copyright statements in others.
+ftype = re.compile(r"(hh|cc|py)$")
 changed = 0
 
 if __name__ == '__main__':
@@ -36,6 +39,7 @@ if __name__ == '__main__':
     proc = subprocess.Popen("git diff --name-only --staged",
                             shell=True, stdout=subprocess.PIPE)
     filenames = proc.stdout.read().decode().split()
+    filenames = [f for f in filenames if ftype.match(f)]
 
     for f in filenames:
         try:

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#
+#  Copyright (C) 2022
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+'''Git pre-commit hook to update the copyright year in Sherpa code files
+'''
+from __future__ import print_function
+import datetime
+import fileinput
+import re
+import subprocess
+import sys
+
+year = str(datetime.datetime.now().year)
+copyr = re.compile(r"(?P<comment>(#|//))\s*Copyright \(C\) (?P<years>[0-9,\s]+)(?P<institution>[\w\s]*)")
+changed = 0
+
+if __name__ == '__main__':
+
+    proc = subprocess.Popen("git diff --name-only --staged",
+                             shell=True, stdout=subprocess.PIPE)
+    filenames = proc.stdout.read().decode().split()
+
+    for line in fileinput.input(files=filenames, inplace=True):
+        m = copyr.match(line)
+        if m and year not in m.group('years'):
+            changed = 1
+            print(m.group('comment') +
+                  '  Copyright (C) ' + m.group('years').strip() +
+                  ', ' + year)
+            # sometimes instition will be empty, because it's not on
+            # this line but on the next. If not, move it to the next.
+            if m.group('institution'):
+                print(m.group('comment') +
+                      '  ' + m.group('institution'), end='')
+        else:
+            print(line, end='')
+
+    for f in filenames:
+        subprocess.Popen("git add " + f, shell=True)
+    if changed:
+        print("""Message from your pre-commit hook script: 
+I updated copyright statements in one or more files for you. 
+After doing that, I aborted the commit, so you can check yourself that 
+it's alright before you commit again. 
+Commit with ' --no-verify' option to skip this check.""", file=sys.stderr)
+        sys.exit(changed)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -34,30 +34,34 @@ changed = 0
 if __name__ == '__main__':
 
     proc = subprocess.Popen("git diff --name-only --staged",
-                             shell=True, stdout=subprocess.PIPE)
+                            shell=True, stdout=subprocess.PIPE)
     filenames = proc.stdout.read().decode().split()
 
-    for line in fileinput.input(files=filenames, inplace=True):
-        m = copyr.match(line)
-        if m and year not in m.group('years'):
-            changed = 1
-            print(m.group('comment') +
-                  '  Copyright (C) ' + m.group('years').strip() +
-                  ', ' + year)
-            # sometimes instition will be empty, because it's not on
-            # this line but on the next. If not, move it to the next.
-            if m.group('institution'):
-                print(m.group('comment') +
-                      '  ' + m.group('institution'), end='')
-        else:
-            print(line, end='')
-
     for f in filenames:
-        subprocess.Popen("git add " + f, shell=True)
+        try:
+            for line in fileinput.input(files=filenames, inplace=True):
+                m = copyr.match(line)
+                if m and year not in m.group('years'):
+                    changed = 1
+                    print(m.group('comment') +
+                          '  Copyright (C) ' + m.group('years').strip() +
+                          ', ' + year)
+                    # sometimes group institution will be empty, because it's
+                    # on the next text line. If not, move it there.
+                    if m.group('institution'):
+                        print(m.group('comment') +
+                              '  ' + m.group('institution'), end='')
+                else:
+                    print(line, end='')
+            subprocess.Popen("git add " + f, shell=True)
+        except FileNotFoundError:
+            # file was removed with "git rm" so there is nothing to check here
+            pass
+
     if changed:
-        print("""Message from your pre-commit hook script: 
-I updated copyright statements in one or more files for you. 
-After doing that, I aborted the commit, so you can check yourself that 
-it's alright before you commit again. 
+        print("""Message from your pre-commit hook script:
+I updated copyright statements in one or more files for you.
+After doing that, I aborted the commit, so you can check yourself that
+it's alright before you commit again.
 Commit with ' --no-verify' option to skip this check.""", file=sys.stderr)
         sys.exit(changed)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -29,9 +29,10 @@ import sys
 
 year = str(datetime.datetime.now().year)
 copyr = re.compile(r"(?P<comment>(#|//))\s*Copyright \(C\) (?P<years>[0-9,\s]+)(?P<institution>[\w\s]*)")
-# Only apply this to C or Python files since sherpa does not use 
-# copyright statements in others.
-ftype = re.compile(r"(hh|cc|py)$")
+# Only apply this to C or Python files since sherpa does not use
+# copyright statements in others files, also, do not change in extern
+# directory.
+ftype = re.compile(r"^((?!extern).)*(hh|cc|py)$")
 changed = 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary
Add example script for a git pre-commit hook that checks the copyright is up to date.

# Details
This PR adds a script to the `scripts` directory that can be used as a git pre-commit hook; docs are added to the developer section to explain how to use it. Since git hooks are local (they are not tracked in the repro itself) users have to actively copy their example script into their local `.git/hooks`. In that sense this is a documentation-only PR, it add docs and a script that might be used, but without the user installing (copying into the right place) this script, it won't ever run. Not on CI, not for anyone else and even if it's installed, it can always be skipped for special cases. Thus, this PR can't possibly break anything.