### PR TITLE
Add sphinx_rtd_theme to sphinx extensions and set min version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,7 +154,8 @@ extensions = [
     'sphinx_astropy.ext.intersphinx_toggle',
     'sphinx_astropy.ext.edit_on_github',
     # notebooks
-    'nbsphinx'
+    'nbsphinx',
+    'sphinx_rtd_theme',
 ]
 # Imported from sphinx_astropy so we don't have to maintain the list
 # of servers

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,3 +13,4 @@ dependencies:
     - ipykernel
     - nbsphinx
     - sphinx-astropy
+    - sphinx_rtd_theme>=1.0.0

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,4 +1,0 @@
-numpy
-sphinx_astropy
-ipykernel
-nbsphinx


### PR DESCRIPTION
# Summary
Our readthedocs pages have had some visual issues (in particular, bullets point where missing from output) for a while. This fixes that by ensuring we are using a recent version of the sphinx theme.
Note: This **only** effects the docs rendered on readthedocs, there is **no** change for users, for CM, for conda builds etc.

# Details
The gory details the problem are here: https://github.com/readthedocs/sphinx_rtd_theme/issues/1115 (see linked issue if you really want more. The bottom line is that (ironically) a more recent version of the readthedocs sphinx theme then the one used by default on readthedocs fixes this issue.

readthedocs in general recommends pinning all packages used for the doc build, but issues are so infrequent that I think it's more efficient for us to investigate if the need arises.

At the same time, this PR removes the `rtd-pip-requirements` file since it's not been used for a while, but it confused me to no end that any changes in that file have no effect.
