### PR TITLE
XSPEC: initialize XSPEC library at load time

### DIFF
--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -376,7 +376,7 @@ void xsmtbl(float* ear, int ne, float* param, const char* filenm, int ifl,
 // of XSPEC being used when the sherpa.astro.xspec module is
 // being created. As the version requires a run-time check (that
 // is, the get_version call is made) then we know that we need to
-// initalize the XSPEC code when the Python module is installed.
+// initialize the XSPEC code when the Python module is installed.
 // So we no-longer need to support the lazy loading.
 //
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -166,9 +166,9 @@ known_warnings = {
 
             # It would be nice if we could find this out from first principles,
             # rather than only finding them from random CI runs
-            r"unclosed file <_io.BufferedReader name='/tmp/.*/data.dat'>",
-            r"unclosed file <_io.BufferedReader name='/tmp/.*/model.dat'>",
-            r"unclosed file <_io.BufferedReader name='/tmp/.*/resid.out'>",
+            r"unclosed file <_io.BufferedReader name='.*/data.dat'>",
+            r"unclosed file <_io.BufferedReader name='.*/model.dat'>",
+            r"unclosed file <_io.BufferedReader name='.*/resid.out'>",
 
             # Does this replace the versions above?
             r"unclosed file <_io.BufferedReader name='.*/aref_Cedge.fits'>",

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -507,10 +507,6 @@ static void create_output(int nbins, T &a, T &b) {
       class PyArgTupleBase {
       public:
         PyArgTupleBase( ) {
-#ifdef INIT_XSPEC
-	if ( EXIT_SUCCESS != INIT_XSPEC() )
-          throw std::runtime_error("Unable to initialize XSpec");
-#endif
         }
 
       };


### PR DESCRIPTION
# Summary

Simplify how and when the XSPEC model library is initialized. Fixes #1388 

# Details

Since we now require the module to be loaded to be able to create sherpa.astro.xspec (as we check the version of the
XSPEC library) then it is simpler to just initialize the XSPEC library when the module is created.

The old code used to be useful - in that it meant only people using an XSPEC model ended up having to initialize the XSPEC model library - but with changes to the way the XSPEC models were created, probably in #395, mean that we now need to call the `get_xsversion` routine from `sherpa.astro.xspec._xspec` when loading the `sherpa.astro.xspec` module (the version checks to support models that may have changed or not be available in the run-time version of XSPEC being used), which means that we may as well initialize the XSPEC library when the module is loaded.

This change means that #1389 is not really needed now - we just require that the xspec module has been loaded rather than exporting the initialization routine.