### PR TITLE
Improve the handling of image coordinates

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -935,3 +935,187 @@ We can view the model plot object::
     ylabel = y
     title  = Model
     histo_prefs = {'yerrorbars': False, 'ecolor': None, ... , 'linecolor': None}
+
+
+.. _dataimg_coords:
+
+Coordinate conversion for image data
+------------------------------------
+
+The :py:class:`sherpa.data.Data2D` class provides basic support for
+fitting models to two-dimensional data; that is, data with two
+independent axes (called "x0" and "x1" although they should be
+accessed via the :py:attr:`~sherpa.data.Data2D.indep` attribute).  The
+:py:class:`sherpa.astro.data.DataIMG` class extends the 2D support to
+include the concept of a coordinate system, allowing the independent
+axis to be one of:
+
+- ``logical``
+- ``image``
+- ``world``
+
+where the aim is that the logical system refers to a pixel number (no
+coordinate system), image is a linear transform of the logical system,
+and world identifies a projection from the image system onto the
+celestial sphere. However, there is no requirement that this
+categorization holds as it depends on whether the optional
+:py:attr:`~sherpa.astro.data.DataIMG.sky` and
+:py:attr:`~sherpa.astro.data.DataIMG.eqpos` attributes are set when
+the :py:class:`~sherpa.astro.data.DataIMG` object is created.
+
+Using a coordinate system directly
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the independent axes are known, and not calculated via a coordinate
+transform, then they can just be set when creating the
+:py:class:`~sherpa.astro.data.DataIMG` object, leaving the
+:py:attr:`~sherpa.astro.data.DataIMG.coord` attribute set to
+``logical``.
+
+  >>> x0 = np.asarray([1000, 1200, 2000])
+  >>> x1 = np.asarray([-500, 500, -500])
+  >>> y = np.asarray([10, 200, 30])
+  >>> d = DataIMG("example", x0, x1, y)
+  >>> print(d)
+  name      = example
+  x0        = Int64[3]
+  x1        = Int64[3]
+  y         = Int64[3]
+  shape     = None
+  staterror = None
+  syserror  = None
+  sky       = None
+  eqpos     = None
+  coord     = logical
+
+This can then be used to evaluate a two-dimensional model,
+such as :py:class:`~sherpa.models.basic.Gauss2D`:
+
+  >>> from sherpa.models.basic import Gauss2D
+  >>> mdl = Gauss2D()
+  >>> mdl.xpos = 1500
+  >>> mdl.ypos = -100
+  >>> mdl.fwhm = 1000
+  >>> mdl.ampl = 100
+  >>> print(mdl)
+  gauss2d
+     Param        Type          Value          Min          Max      Units
+     -----        ----          -----          ---          ---      -----
+     gauss2d.fwhm thawed         1000  1.17549e-38  3.40282e+38
+     gauss2d.xpos thawed         1500 -3.40282e+38  3.40282e+38
+     gauss2d.ypos thawed         -100 -3.40282e+38  3.40282e+38
+     gauss2d.ellip frozen            0            0        0.999
+     gauss2d.theta frozen            0     -6.28319      6.28319    radians
+     gauss2d.ampl thawed          100 -3.40282e+38  3.40282e+38
+  >>> d.eval_model(mdl)
+  array([32.08564744, 28.71745887, 32.08564744])
+
+Attempting to change the coordinate system with
+:py:class:`~sherpa.astro.data.DataIMF.set_coord` will error out with a
+:py:class:`sherpa.utils.err.DataErr` instance reporting that the data
+set does not specify a shape.
+
+The shape attribute
+^^^^^^^^^^^^^^^^^^^
+
+The ``shape`` argument can be set when creating a
+:py:class:`~sherpa.astro.data.DataIMG` object to indicate that the
+data represents an "image", that is a rectangular, contiguous, set of
+pixels. It is defined as ``(nx1, nx0)``, and so matches the ndarray
+``shape`` attribute from NumPy. Operations that treat the dataset as a
+2D grid often require that the ``shape`` attribute is set.
+
+  >>> x1, x0 = np.mgridp1L4, 1:5]
+  >>> y2 = (x0 - 2.5)**2 + (x1 - 2)**2
+  >>> y = np.sqrt(y2)
+  >>> d = DataIMG('img', x0.flatten(), x1.flatten(),
+  ...             y.flatten(), shape=y.shape)
+  >>> print(d)
+  name      = img
+  x0        = Int64[12]
+  x1        = Int64[12]
+  y         = Float64[12]
+  shape     = (3, 4)
+  staterror = None
+  syserror  = None
+  sky       = None
+  eqpos     = None
+  coord     = logical
+  >>> d.get_x0()
+  array([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4])
+  >>> d.get_x1()
+  array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3])
+  >>> d.get_dep()
+  array([1.80277564, 1.11803399, 1.11803399, 1.80277564, 1.5       ,
+         0.5       , 0.5       , 1.5       , 1.80277564, 1.11803399,
+         1.11803399, 1.80277564])
+  >>> d.get_axes()
+  (array([1., 2., 3., 4.]), array([1., 2., 3.]))
+  >>> d.get_dims()
+  (4, 3)
+
+Attempting to change the coordinate system with
+:py:class:`~sherpa.astro.data.DataIMF.set_coord` will error out with a
+:py:class:`sherpa.utils.err.DataErr` instance reporting that the data
+set does not contain the required coordinate system.
+
+Setting a coordinate system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :py:class:`sherpa.astro.io.wcs.WCS` class is used to add a
+coordinate system to an image. It has support for linear (translation
+and scale) and "wcs" - currently tangent-plane projections -
+conversions.
+
+  >>> from sherpa.astro.io.wcs import WCS
+  >>> sky = WCS("sky", "LINEAR", [1000,2000], [1, 1], [2, 2])
+  >>> x1, x0 = np.mgrid[1:3, 1:4]
+  >>> d = DataIMG("img", x0.flatten(), x1.flatten(), np.ones(x1.size), shape=x0.shape, sky=sky)
+  >>> print(d)
+  name      = img
+  x0        = Int64[6]
+  x1        = Int64[6]
+  y         = Float64[6]
+  shape     = (2, 3)
+  staterror = None
+  syserror  = None
+  sky       = sky
+   crval    = [1000.,2000.]
+   crpix    = [1.,1.]
+   cdelt    = [2.,2.]
+  eqpos     = None
+  coord     = logical
+
+With this we can change to the "physical" coordinate system, which
+represents the conversion sent to the ``sky`` argument, and so get the
+independent axis in the converted system with the
+:py:meth:`sherpa.astro.data.DataIMG.set_coord` method:
+
+  >>> d.get_axes()
+  (array([1., 2., 3.]), array([1., 2.]))
+  >>> d.set_coord("physical")
+  >>> d.get_axes()
+  (array([1000., 1002., 1004.]), array([2000., 2002.]))
+  >>> d.indep
+  (array([1000., 1002., 1004., 1000., 1002., 1004.]), array([2000., 2000., 2000., 2002., 2002., 2002.]))
+
+It is possible to switch back to the original coordinate system (the
+arguments sent in as ``x0`` and ``x1`` when creating the object):
+
+  >>> d.set_coord("logical")
+  >>> d.indep
+  (array([1, 2, 3, 1, 2, 3]), array([1, 1, 1, 2, 2, 2]))
+
+In Sherpa 4.14.0 and earlier, this conversion was handled by taking
+the current axes pair and applying the necessary WCS objects to create
+the selected coordinate system (that is, the argument to the
+`set_coord` call). This had the advantage of saving memory, as you
+only needed to retain the current pait of independent axes, but at the
+expense of losing fidelity when converting between the coordinate
+systems. This has been changed so that the original independent axes
+are now stored in the object, in the ``_orig_indep_axis`` attribute,
+and this is now used whenever the coordinate system is changed. This
+does increase the memory size of a `DataIMG` object, and makes it
+harder to load in picked files created with an old Sherpa version (the
+code will do it's best to create the necessary information but it is
+not guaranteed to work well in all cases).

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -963,13 +963,22 @@ categorization holds as it depends on whether the optional
 :py:attr:`~sherpa.astro.data.DataIMG.eqpos` attributes are set when
 the :py:class:`~sherpa.astro.data.DataIMG` object is created.
 
+.. _dataimg_no_shape:
+
 Using a coordinate system directly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+   It is expected that the `~sherpa.astro.data.DataIMG` object
+   is used with a rectangular grid of data and a ``shape`` attribute
+   set up to describe the grid shape, as used in the :ref:`next
+   section <dataimg_with_shape>`, but it is not required, as shown
+   here.
+
 If the independent axes are known, and not calculated via a coordinate
 transform, then they can just be set when creating the
-:py:class:`~sherpa.astro.data.DataIMG` object, leaving the
-:py:attr:`~sherpa.astro.data.DataIMG.coord` attribute set to
+`~sherpa.astro.data.DataIMG` object, leaving the
+`~sherpa.astro.data.DataIMG.coord` attribute set to
 ``logical``.
 
   >>> x0 = np.asarray([1000, 1200, 2000])
@@ -989,7 +998,7 @@ transform, then they can just be set when creating the
   coord     = logical
 
 This can then be used to evaluate a two-dimensional model,
-such as :py:class:`~sherpa.models.basic.Gauss2D`:
+such as `~sherpa.models.basic.Gauss2D`:
 
   >>> from sherpa.models.basic import Gauss2D
   >>> mdl = Gauss2D()
@@ -1011,21 +1020,23 @@ such as :py:class:`~sherpa.models.basic.Gauss2D`:
   array([32.08564744, 28.71745887, 32.08564744])
 
 Attempting to change the coordinate system with
-:py:class:`~sherpa.astro.data.DataIMF.set_coord` will error out with a
-:py:class:`sherpa.utils.err.DataErr` instance reporting that the data
+`~sherpa.astro.data.DataIMF.set_coord` will error out with a
+`~sherpa.utils.err.DataErr` instance reporting that the data
 set does not specify a shape.
+
+.. _dataimg_with_shape:
 
 The shape attribute
 ^^^^^^^^^^^^^^^^^^^
 
 The ``shape`` argument can be set when creating a
-:py:class:`~sherpa.astro.data.DataIMG` object to indicate that the
+`~sherpa.astro.data.DataIMG` object to indicate that the
 data represents an "image", that is a rectangular, contiguous, set of
 pixels. It is defined as ``(nx1, nx0)``, and so matches the ndarray
 ``shape`` attribute from NumPy. Operations that treat the dataset as a
 2D grid often require that the ``shape`` attribute is set.
 
-  >>> x1, x0 = np.mgridp1L4, 1:5]
+  >>> x1, x0 = np.mgrid[1:4, 1:5]
   >>> y2 = (x0 - 2.5)**2 + (x1 - 2)**2
   >>> y = np.sqrt(y2)
   >>> d = DataIMG('img', x0.flatten(), x1.flatten(),
@@ -1055,17 +1066,17 @@ pixels. It is defined as ``(nx1, nx0)``, and so matches the ndarray
   (4, 3)
 
 Attempting to change the coordinate system with
-:py:class:`~sherpa.astro.data.DataIMF.set_coord` will error out with a
-:py:class:`sherpa.utils.err.DataErr` instance reporting that the data
+`~sherpa.astro.data.DataIMF.set_coord` will error out with a
+`~sherpa.utils.err.DataErr` instance reporting that the data
 set does not contain the required coordinate system.
 
 Setting a coordinate system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`sherpa.astro.io.wcs.WCS` class is used to add a
+The `sherpa.astro.io.wcs.WCS` class is used to add a
 coordinate system to an image. It has support for linear (translation
-and scale) and "wcs" - currently tangent-plane projections -
-conversions.
+and scale) and "wcs" - currently only tangent-plane projections
+are supported - conversions.
 
   >>> from sherpa.astro.io.wcs import WCS
   >>> sky = WCS("sky", "LINEAR", [1000,2000], [1, 1], [2, 2])
@@ -1089,7 +1100,7 @@ conversions.
 With this we can change to the "physical" coordinate system, which
 represents the conversion sent to the ``sky`` argument, and so get the
 independent axis in the converted system with the
-:py:meth:`sherpa.astro.data.DataIMG.set_coord` method:
+`~sherpa.astro.data.DataIMG.set_coord` method:
 
   >>> d.get_axes()
   (array([1., 2., 3.]), array([1., 2.]))
@@ -1109,13 +1120,13 @@ arguments sent in as ``x0`` and ``x1`` when creating the object):
 In Sherpa 4.14.0 and earlier, this conversion was handled by taking
 the current axes pair and applying the necessary WCS objects to create
 the selected coordinate system (that is, the argument to the
-`set_coord` call). This had the advantage of saving memory, as you
+`~sherpa.astro.data.DataIMG.set_coord` call). This had the advantage of saving memory, as you
 only needed to retain the current pair of independent axes, but at the
 expense of losing fidelity when converting between the coordinate
 systems. This has been changed so that the original independent axes
 are now stored in the object, in the ``_orig_indep_axis`` attribute,
 and this is now used whenever the coordinate system is changed. This
-does increase the memory size of a `DataIMG` object, and makes it
+does increase the memory size of a `~sherpa.astro.data.DataIMG` object, and makes it
 harder to load in picked files created with an old Sherpa version (the
-code will do it's best to create the necessary information but it is
+code will do its best to create the necessary information but it is
 not guaranteed to work well in all cases).

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -1110,7 +1110,7 @@ In Sherpa 4.14.0 and earlier, this conversion was handled by taking
 the current axes pair and applying the necessary WCS objects to create
 the selected coordinate system (that is, the argument to the
 `set_coord` call). This had the advantage of saving memory, as you
-only needed to retain the current pait of independent axes, but at the
+only needed to retain the current pair of independent axes, but at the
 expense of losing fidelity when converting between the coordinate
 systems. This has been changed so that the original independent axes
 are now stored in the object, in the ``_orig_indep_axis`` attribute,

--- a/docs/overview/astro_io_wcs.rst
+++ b/docs/overview/astro_io_wcs.rst
@@ -1,0 +1,20 @@
+******************************
+The sherpa.astro.io.wcs module
+******************************
+
+.. currentmodule:: sherpa.astro.io.wcs
+
+.. automodule:: sherpa.astro.io.wcs
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      WCS
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram:: WCS
+   :parts: 1

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -55,4 +55,5 @@ Reference/API
    io
    astro
    astro_io
+   astro_io_wcs
    astro_utils_xspec

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4541,6 +4541,19 @@ this value.
     get_wcs = get_world
 
     def set_coord(self, coord):
+        """Change the coordinate setting.
+
+        This routine should be used rather than explicitly
+        setting the `coord` attribute of the object.
+
+        Parameters
+        ----------
+        coord : {'logical', 'image', 'physical', 'world', 'wcs'}
+            The coordinate system to use. Note that "image" is a
+            synomym for "logical" and "wcs" is a synomyn for "world".
+
+        """
+
         coord = str(coord).strip().lower()
         # Destroys original data to conserve memory for big imgs
         good = ('logical', 'image', 'physical', 'world', 'wcs')

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4565,7 +4565,8 @@ this value.
         elif coord == 'image':
             coord = 'logical'
 
-        # TODO: we could do nothing if coord == self.coord
+        if coord == self.coord:
+            return
 
         func = getattr(self, f'get_{coord}')
         self.indep = func()

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4312,9 +4312,19 @@ class DataIMG(Data2D):
 
     _extra_fields = ("sky", "eqpos", "coord")
 
-    def _get_coord(self):
+    @property
+    def coord(self):
+        """Return the coordinate setting.
+
+        The attribute is one of 'logical', 'physical', or
+        'world'. Use `set_coord` to change the setting.
+
+        """
         return self._coord
 
+    # We do not set this to @coord.setter as the attribute should be
+    # changed with set_coord when outside the methods of this class.
+    #
     def _set_coord(self, val):
         coord = str(val).strip().lower()
 
@@ -4333,26 +4343,12 @@ class DataIMG(Data2D):
 
         self._coord = coord
 
-    # Ideally we'd move the logic from set_coord into _set_coord,
-    # except that this does not work when calling __init__.
-    # The set_coord command is for use after the object has been
-    # created, but we still need to be able to set the field
-    # when creating the object, which leads to this. We could
-    # just make this a getter and not both a setter and getter!
-    #
-    coord = property(_get_coord, _set_coord,
-                     doc="""Coordinate system of independent axes.
-
-To change the setting use the set_coord method rather than change
-this value.
-""")
-
     def __init__(self, name, x0, x1, y, shape=None, staterror=None,
                  syserror=None, sky=None, eqpos=None, coord='logical',
                  header=None):
         self.sky = sky
         self.eqpos = eqpos
-        self.coord = coord
+        self._set_coord(coord)
         self.header = {} if header is None else header
         self._region = None
         super().__init__(name, x0, x1, y, shape, staterror, syserror)
@@ -4541,10 +4537,7 @@ this value.
     get_wcs = get_world
 
     def set_coord(self, coord):
-        """Change the coordinate setting.
-
-        This routine should be used rather than explicitly
-        setting the `coord` attribute of the object.
+        """Change the `coord` attribute.
 
         Parameters
         ----------
@@ -4765,7 +4758,7 @@ class DataIMGInt(DataIMG):
         self._region = None
         self.sky = sky
         self.eqpos = eqpos
-        self.coord = coord
+        self._set_coord(coord)
         self.header = {} if header is None else header
         self.shape = shape
         Data.__init__(self, name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4400,7 +4400,7 @@ class DataIMG(Data2D):
         # Unfortunately we can't re-create the original data used to
         # create the object, but we can fake it using the last-selected
         # coordinate system (which could lead to some issues for the
-        # world sytem - see #1390 - but there's little we can do here).
+        # world system - see #1380 - but there's little we can do here).
         # The two-step process is to get around the behavior of the
         # NoNewAttributesAfterInit parent class.
         #

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4312,6 +4312,12 @@ class DataIMG(Data2D):
 
     _extra_fields = ("sky", "eqpos", "coord")
 
+    sky = None
+    """The optional WCS object that converts to the physical coordinate system."""
+
+    eqpos = None
+    """The optional WCS object that converts to the world coordinate system."""
+
     @property
     def coord(self):
         """Return the coordinate setting.

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -211,7 +211,7 @@ def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
 
     >>> d = read_table('src.fits')
 
-    Create A `sherpa.data.Data1DInt` object from the first three
+    Create a `sherpa.data.Data1DInt` object from the first three
     columns in the file ``src.fits``:
 
     >>> d = read_table('src.fits', ncols=3, dstype=Data1DInt)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -889,6 +889,23 @@ def test_img_get_img_model_filter_some2(make_test_image):
     assert mval[good] == pytest.approx(expected2[good])
 
 
+def test_img_can_not_set_coord(make_test_image):
+    """The coord attribute is not writeable.
+
+    It used to be, but now we require the user to change
+    it with the set_coord method.
+    """
+    d = make_test_image
+
+    # This dataset does not have a physical system, but we
+    # do not get a DataErr but an AttributeError.
+    #
+    with pytest.raises(AttributeError) as ae:
+        d.coord = "physical"
+
+    assert str(ae.value) == "can't set attribute"
+
+
 def test_img_set_coord_invalid(make_test_image):
     """An invalid coord setting"""
     d = make_test_image

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -581,6 +581,59 @@ def make_test_image():
 
 
 @pytest.fixture
+def make_test_image_sky():
+    """A simple image with just sky WCS
+
+    """
+
+    crval = [2000.5, -5000.5]
+    cdelt = [2.0, 4.0]
+    crpix = [-2.0, 3.0]
+    sky = WCS("physical", "LINEAR", crval=crval, crpix=crpix, cdelt=cdelt)
+
+    # logical: x=1, 2, 3
+    #          y=1, 2
+    #
+    x1, x0 = np.mgrid[1:3, 1:4]
+    shape = x0.shape
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = np.ones(x0.size)
+    return DataIMG('sky-ey', x0, x1, y, shape=shape, sky=sky)
+
+
+# This is a regression test - the values were calculated by
+# Sherpa/WCS and not from first principles.
+#
+WORLD_X0 = np.asarray([30.10151131, 30., 29.89848869, 30.10154255, 30., 29.89845745])
+WORLD_X1 = np.asarray([ 9.89998487, 9.9000001, 9.89998487, 9.99998461, 10., 9.99998461])
+
+
+@pytest.fixture
+def make_test_image_world():
+    """A simple image with just world WCS
+
+    """
+
+    crval = [30, 10]
+    cdelt = [-0.1, 0.1]
+    crpix = [2.0, 2.0]
+    eqpos = WCS("world", "WCS", crval=crval, crpix=crpix, cdelt=cdelt)
+
+    # logical: x=1, 2, 3
+    #          y=1, 2
+    #
+    x1, x0 = np.mgrid[1:3, 1:4]
+    shape = x0.shape
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = np.ones(x0.size)
+    return DataIMG('world-ey', x0, x1, y, shape=shape, eqpos=eqpos)
+
+
+@pytest.fixture
 def make_test_pha():
     """A simple PHA"""
 
@@ -1936,6 +1989,255 @@ def test_pickle_image_filter(ignore, region, expected, make_test_image):
     d2 = pickle.loads(pickle.dumps(d))
     assert isinstance(d2._region, Region)
     assert str(d2._region) == expected
+
+
+def test_img_sky_create(make_test_image_sky):
+    d = make_test_image_sky
+    assert d.sky is not None
+    assert d.eqpos is None
+
+
+def test_img_world_create(make_test_image_world):
+    d = make_test_image_world
+    assert d.sky is None
+    assert d.eqpos is not None
+
+
+def test_img_sky_show(make_test_image_sky):
+    d = make_test_image_sky
+    out = str(d).split("\n")
+    assert out[0] == "name      = sky-ey"
+    assert out[1] == "x0        = Int64[6]"
+    assert out[2] == "x1        = Int64[6]"
+    assert out[3] == "y         = Float64[6]"
+    assert out[4] == "shape     = (2, 3)"
+    assert out[5] == "staterror = None"
+    assert out[6] == "syserror  = None"
+    assert out[7] == "sky       = physical"
+    assert out[8] == " crval    = [ 2000.5,-5000.5]"
+    assert out[9] == " crpix    = [-2., 3.]"
+    assert out[10] == " cdelt    = [2.,4.]"
+    assert out[11] == "eqpos     = None"
+    assert out[12] == "coord     = logical"
+    assert len(out) == 13
+
+
+def test_img_world_show(make_test_image_world):
+    d = make_test_image_world
+    out = str(d).split("\n")
+    assert out[0] == "name      = world-ey"
+    assert out[1] == "x0        = Int64[6]"
+    assert out[2] == "x1        = Int64[6]"
+    assert out[3] == "y         = Float64[6]"
+    assert out[4] == "shape     = (2, 3)"
+    assert out[5] == "staterror = None"
+    assert out[6] == "syserror  = None"
+    assert out[7] == "sky       = None"
+    assert out[8] == "eqpos     = world"
+    assert out[9] == " crval    = [30.,10.]"
+    assert out[10] == " crpix    = [2.,2.]"
+    assert out[11] == " cdelt    = [-0.1, 0.1]"
+    assert out[12] == " crota    = 0"
+    assert out[13] == " epoch    = 2000"
+    assert out[14] == " equinox  = 2000"
+    assert out[15] == "coord     = logical"
+    assert len(out) == 16
+
+
+def test_img_sky_pickle(make_test_image_sky):
+    """Very basic test of pickling"""
+    d = make_test_image_sky
+    d.set_coord("physical")
+
+    d2 = pickle.loads(pickle.dumps(d))
+    assert d2.coord == "physical"
+    assert d2.eqpos is None
+
+    # We don't have an easy way to check for WCS equivalence
+    # so just rely on string representation.
+    #
+    assert str(d2.sky) == str(d.sky)
+
+    # check the independent axes are converted
+    assert (d2.x0 == d.x0).all()
+    assert (d2.x1 == d.x1).all()
+
+
+def test_img_world_pickle(make_test_image_world):
+    """Very basic test of pickling"""
+    d = make_test_image_world
+    d.set_coord("wcs")
+
+    d2 = pickle.loads(pickle.dumps(d))
+    assert d2.coord == "world"
+    assert d2.sky is None
+
+    # We don't have an easy way to check for WCS equivalence
+    # so just rely on string representation.
+    #
+    assert str(d2.sky) == str(d.sky)
+
+    # check the independent axes are converted
+    assert (d2.x0 == d.x0).all()
+    assert (d2.x1 == d.x1).all()
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["logical"],
+                                  ["physical", "logical", "physical", "logical", "physical", "logical"]])
+def test_img_sky_logical(path, make_test_image_sky):
+    """The logical axes are as expected. Inspired by issue 1380."""
+    d = make_test_image_sky
+    for coord in path:
+        d.set_coord(coord)
+
+    x1, x0 = np.mgrid[1:3, 1:4]
+    assert (d.x0 == x0.flatten()).all()
+    assert (d.x1 == x1.flatten()).all()
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["logical"],
+                                  pytest.param(["world", "logical", "world", "logical", "world", "logical"], marks=pytest.mark.xfail)])
+def test_img_world_logical(path, make_test_image_world):
+    """The logical axes are as expected. Inspired by issue 1380."""
+    d = make_test_image_world
+    for coord in path:
+        d.set_coord(coord)
+
+    x1, x0 = np.mgrid[1:3, 1:4]
+    assert (d.x0 == x0.flatten()).all()
+    assert (d.x1 == x1.flatten()).all()
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["physical"],
+                                  ["logical", "physical", "logical", "physical", "logical"]])
+def test_img_sky_physical(path, make_test_image_sky):
+    """The physical axes are as expected. Inspired by issue 1380."""
+    d = make_test_image_sky
+    for coord in path:
+        d.set_coord(coord)
+
+    d.set_coord("physical")
+    x1, x0 = np.mgrid[1:3, 1:4]
+    x0 = (x0 + 2.0) * 2.0 + 2000.5
+    x1 = (x1 - 3.0) * 4.0 - 5000.5
+
+    assert (d.x0 == x0.flatten()).all()
+    assert (d.x1 == x1.flatten()).all()
+
+
+def test_img_world_physical(make_test_image_world):
+    """The physical axes are not defined."""
+    d = make_test_image_world
+    with pytest.raises(DataErr) as de:
+        d.set_coord("physical")
+
+    assert str(de.value) == "data set 'world-ey' does not contain a physical coordinate system"
+
+
+def test_img_sky_world(make_test_image_sky):
+    """The world axes are not defined."""
+    d = make_test_image_sky
+    with pytest.raises(DataErr) as de:
+        d.set_coord("world")
+
+    assert str(de.value) == "data set 'sky-ey' does not contain a world coordinate system"
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["logical"],
+                                  ["world", "logical", "world", "logical", "world", "logical"]])
+def test_img_world_world(path, make_test_image_world):
+    """The world axes are as expected. Inspired by issue 1380."""
+    d = make_test_image_world
+    for coord in path:
+        d.set_coord(coord)
+
+    d.set_coord("world")
+    assert d.x0 == pytest.approx(WORLD_X0)
+    assert d.x1 == pytest.approx(WORLD_X1)
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["physical"],
+                                  ["logical", "physical", "logical", "physical"]])
+def test_img_sky_get_logical(path, make_test_image_sky):
+    """Check get_logical works"""
+    d = make_test_image_sky
+    for coord in path:
+        d.set_coord(coord)
+
+    x1, x0 = np.mgrid[1:3, 1:4]
+    a, b = d.get_logical()
+    assert (a == x0.flatten()).all()
+    assert (b == x1.flatten()).all()
+
+
+@pytest.mark.parametrize("path", [[],
+                                  pytest.param(["world"], marks=pytest.mark.xfail),
+                                  pytest.param(["logical", "world", "logical", "world"], marks=pytest.mark.xfail)])
+def test_img_world_get_logical(path, make_test_image_world):
+    """Check get_logical works"""
+    d = make_test_image_world
+    for coord in path:
+        d.set_coord(coord)
+
+    x1, x0 = np.mgrid[1:3, 1:4]
+    a, b = d.get_logical()
+    assert (a == x0.flatten()).all()
+    assert (b == x1.flatten()).all()
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["logical"],
+                                  ["physical", "logical", "physical", "logical", "physical", "logical"]])
+def test_img_sky_get_physical(path, make_test_image_sky):
+    """Check get_physical works"""
+    d = make_test_image_sky
+    for coord in path:
+        d.set_coord(coord)
+
+    x1, x0 = np.mgrid[1:3, 1:4]
+    x0 = (x0 + 2.0) * 2.0 + 2000.5
+    x1 = (x1 - 3.0) * 4.0 - 5000.5
+
+    a, b = d.get_physical()
+    assert (a == x0.flatten()).all()
+    assert (b == x1.flatten()).all()
+
+
+def test_img_world_get_physical(make_test_image_world):
+    """Check get_physical errors out"""
+    d = make_test_image_world
+    with pytest.raises(DataErr) as de:
+        d.get_physical()
+
+    assert str(de.value) == "data set 'world-ey' does not contain a physical coordinate system"
+
+
+def test_img_sky_get_world(make_test_image_sky):
+    """Check get_world errors out"""
+    d = make_test_image_sky
+    with pytest.raises(DataErr) as de:
+        d.get_world()
+
+    assert str(de.value) == "data set 'sky-ey' does not contain a world coordinate system"
+
+
+@pytest.mark.parametrize("path", [[],
+                                  ["logical"],
+                                  ["world", "logical", "world", "logical"]])
+def test_img_world_get_world(path, make_test_image_world):
+    """Check get_world works"""
+    d = make_test_image_world
+    for coord in path:
+        d.set_coord(coord)
+
+    a, b = d.get_world()
+    assert a == pytest.approx(WORLD_X0)
+    assert b == pytest.approx(WORLD_X1)
 
 
 def test_arf_checks_energy_length():

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -4046,7 +4046,7 @@ def test_pha_model_plot_filter_range_1024_false(mask, expected, make_data_path, 
 
 @requires_fits
 @requires_data
-@pytest.mark.parametrize("coord", ["logical", "image", "physical", pytest.param("world", marks=pytest.mark.xfail), pytest.param("wcs", marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("coord", ["logical", "image", "physical", "world", "wcs"])
 def test_1380_plot(coord, make_data_path, clean_astro_ui):
     """The contour data should ideally remain the same.
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021
+#  Copyright (C) 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -4042,3 +4042,39 @@ def test_pha_model_plot_filter_range_1024_false(mask, expected, make_data_path, 
         ui.plot_model()
 
     assert ui.get_filter() == expected
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("coord", ["logical", "image", "physical", pytest.param("world", marks=pytest.mark.xfail), pytest.param("wcs", marks=pytest.mark.xfail)])
+def test_1380_plot(coord, make_data_path, clean_astro_ui):
+    """The contour data should ideally remain the same.
+
+    See also sherpa/astro/tests/test_astro_data2.py::test_1380_data
+
+    This is the actual bug report (it only fails when a valid plot
+    backend is present but we try even if there's no backend just
+    to check).
+
+    """
+
+    infile = make_data_path("image2.fits")
+    ui.load_image(infile)
+
+    img = ui.get_data()
+    assert isinstance(img, ui.DataIMG)
+    assert ui.get_coord() == "logical"
+
+    # All we do here is check we can call contour_data, not that the
+    # plot has actually done anything.
+    #
+    ui.contour_data()
+
+    # We can not call contour_data when the world coordinate-system
+    # is set, but fortunately this is not needed to trigger #1380;
+    # we just need the set_coord call.
+    #
+    ui.set_coord(coord)
+
+    ui.set_coord("logical")
+    ui.contour_data()

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -803,7 +803,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
     def set_dep(self, val):
         """
-        Set the dependent variable values"
+        Set the dependent variable values.
 
         Parameters
         ----------


### PR DESCRIPTION
# Summary

Address an error when converting between different coordinate systems for images. Fixes #1380.

The coord attribute of an image (DataIMG, DataIMGInt) can no longer be changed directly. This means that

    img.coord = "physical"

must be changed to

    img.set_coord("physical")

to ensure that the independent axes are calculated correctly.

# Details

Most of the commits are actually minor code clean ups and adding of tests, including ones that show #1380 and the underlying problem that caused this bug.

The first functional change comes in `The coord attribute is now readonly for DataIMG` which stops the `coord` attribue from being settable. At first glance this would appear to be a huge loss in functionaluty, but looking at the code we can see that the user should be using the `set_coord` method of the object rather than directly changing the `coord` attribute. This is because `set_coord` applies a number of changes to the object, such as actually updating the independent axes to match the selected coordinate system. Unfortunately we can't just move this logic into the `_set_coord` routine (which was the previous method used to set the attribute), as we need to be able to change the `coord` attribute during the `__init__` call, when we **DO NOT** want to do the extra work done by `set_coord`. I had previously added a comment to point out that a user being able to set `coord` attribute directly would lead to user confusion, so we now dis-allow it. Fortunately there are no uses of this functionality in the Sherpa code base (for example the UI set_coord routine calls the object's set_coord method). This is a breaking change for downstream users, but I argue that if they had used code like `img.coord = "physical"` then they were now in a state of getting undefined behavior, so it is good that this now fails.

As I write the above I've thought of possible ways that we could make lines like `img.coord = "physical"` work - which would essentially remove the need for the `set_coord` method - but I have not worked through the consequences. Also, we don't technically need this change in this PR as it is technically unrelated to #1380.

The fix for #1380 comes in the appropriately-named "Fix #1380" commit. The reason for the bug is given at https://github.com/sherpa/sherpa/issues/1380#issuecomment-1021400579 and the fix follows the approach mentioned by @hamogu at https://github.com/sherpa/sherpa/issues/1380#issuecomment-1021437084 

- when the object is created we store the original coordinate settings (the coordinate setting and the x0 and x1 arrays) in the `_orig_indep_axis` attribute
- when converting to a particular coordinate system - with the `get_logical`, `get_physical`, and `get_world` methods - we use the `_orig_indep_axis` data to calculate the requested coordinate system (or copy it when they are the same)
- `set_coord` calls the correct `get_logical/physical/world` routine, and so we are always creating the data in the same way

Prior to this commit the `get_logical/physical/world` routines would take the current coordinate system and use it to create the new coordinate system. That means that the sequence

    img.set_coord("physical")
    img.set_coord("world")
    img.set_coord("logical")

would convert logical to physical, then physical to world, then world to logical. This last step turned out to be lossy and so the calculated logical coordinates were now some small amount different than their original values. This would then mean that each "pixel" could now have widths/heights slightly-different from 1, resulting in the contour error (as it requires all the pixels to have the same width/height).

The new approach technically still has this problem, but only if the object is created using the world axes as it's inputs (since then the conversion from world to logical is likely to cause this problem). However, this is not the way we expect the objects to be created (although we do not dis-allow it).

One disadvantage to the new scheme - which was hinted at in a comment removed in this PR - is that we are increasing the memory use of DataMG objects to solve this problem. We now store the original x0, x1 arrays in the object, as well as the computed values when prior to this we only had to store the computed values.

This change does make loading in an old pickle file with an image difficult, as we did not store the original independent axes. To try and support this we add a `_orig_indep_axis` attribute if necessary when un-pickling, and set it to the currently-selected axis. This allow the `set_coord` method to be called on the object but can still show the #1380 data (but only for data unpickled from an old store file). There is no explicit test (I do not think it worth adding a picked file from 4.14.0 to the test data area), but I do add some basic pickle tests to check the current behavior. I have tested it manually. 

Could we solve this in some other way? Well, the problem comes from the fact that we can not guarantee that the WCS transformations are "perfectly invertible": i.e. that invert(apply(x, y)) is not guaranteed to exactly give x,y thanks to floating-point issues, particularly when combining the physical and world systems. We could do something like "always convert logical values to integer values", **but** we do not require that the x0/y0 values are integers when creating a `DataIMG` object, and I am not sure it would be a good change to make.

We could make it so that the `__init__` call is only ever sent in the `logical` coordinate system (that is, we don't allow `coord` as an argument to the constructor) which would then mean we could get rid of the `_physical_to_*` and `_world_to_*` methods (since we only ever call these via `_get_coordsys` and it depends on the coordinate system set when the object was created). However, I think that's for a different PR.

# Example of coord issue

In CIAO 4.14 we see the following

```
sherpa-4.14.0> load_image("image2.fits")

sherpa-4.14.0> img = get_data()

sherpa-4.14.0> l0 = img.get_x0()

sherpa-4.14.0> img.coord
'logical'

sherpa-4.14.0> l0[0:10]
array([ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10.])

sherpa-4.14.0> img.set_coord("physical")

sherpa-4.14.0> p0 = img.get_x0()

sherpa-4.14.0> p0[0:10]
array([3799.5, 3801.5, 3803.5, 3805.5, 3807.5, 3809.5, 3811.5, 3813.5,
       3815.5, 3817.5])

sherpa-4.14.0> img.coord = "logical"

sherpa-4.14.0> img.get_x0()[0:10]
array([3799.5, 3801.5, 3803.5, 3805.5, 3807.5, 3809.5, 3811.5, 3813.5,
       3815.5, 3817.5])
```

So, the last call has returned the "physical" system when it should have returned the logical units (i,e, `l0`). This is because the `img.coord = "logical"` call does not do the same setup as `img.set_coord("logical")` does. 

And then once we've done this we are "messed up" in that it's not obvious how to get the system back into a sensible state.

```
sherpa-4.14.0> img.set_coord("logical")

sherpa-4.14.0> img.get_x0()[0:10]
array([3799.5, 3801.5, 3803.5, 3805.5, 3807.5, 3809.5, 3811.5, 3813.5,
       3815.5, 3817.5])
```

With this PR we can no-longer change coord except via `set_coord` so it works out correctly:

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available

In [2]: load_image("image2.fits")

In [3]: img = get_data()

In [4]: img.get_x0()[0:10]
Out[4]: array([ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10.])

In [5]: img.coord
Out[5]: 'logical'

In [6]: img.set_coord("physical")

In [7]: img.get_x0()[0:10]
Out[7]:
array([3799.5, 3801.5, 3803.5, 3805.5, 3807.5, 3809.5, 3811.5, 3813.5,
       3815.5, 3817.5])

In [8]: img.coord = "logical"
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [8], in <module>
----> 1 img.coord = "logical"

File ~/sherpa/sherpa-main/sherpa/utils/__init__.py:171, in NoNewAttributesAfterInit.__setattr__(self, name, val)
    166     elif not callable(getattr(self, name)) and callable(val):
    167         raise AttributeError(("'%s' object attribute '%s' cannot be " +
    168                               "replaced with a callable attribute") %
    169                              (type(self).__name__, name))
--> 171 object.__setattr__(self, name, val)

AttributeError: can't set attribute

In [9]: img.get_x0()[0:10]
Out[9]:
array([3799.5, 3801.5, 3803.5, 3805.5, 3807.5, 3809.5, 3811.5, 3813.5,
       3815.5, 3817.5])

In [10]: img.coord
Out[10]: 'physical'

In [11]: img.set_coord("logical")

In [12]: img.coord
Out[12]: 'logical'

In [13]: img.get_x0()[0:10]
Out[13]: array([ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10.])
```