### PR TITLE
RTD fix missing and changed symbols

### DIFF
--- a/docs/overview/astro_io.rst
+++ b/docs/overview/astro_io.rst
@@ -8,12 +8,6 @@ The sherpa.astro.io module
 
    .. rubric:: Attributes
 
-   .. autosummary::
-      :toctree: api
-
-      backend
-
-
    .. rubric:: Functions
 
    .. autosummary::

--- a/docs/plots/plot.rst
+++ b/docs/plots/plot.rst
@@ -57,15 +57,6 @@ The sherpa.plot module
       RegionProjection
       RegionUncertainty
 
-   .. rubric:: Functions
-
-   .. autosummary::
-      :toctree: api
-
-      begin
-      end
-      exceptions
-
 Class Inheritance Diagram
 =========================
 


### PR DESCRIPTION
# Summary

Update the ReadTheDocs build to cope with changes in #1191

# Details

PR #1191 removed these symbols, so remove them from the documentation, and we don't seem to pick up the backend documentation so remove it.

Found when building the docs for an unrelated PR.