### PR TITLE
Keep .rc file backwards compatible

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -102,6 +102,10 @@ for iotry in io_opt:
         break
     except ImportError:
         pass
+else:
+    # None of the options in the rc file work, e.g. because it's an old file
+    # that does not have dummy listed
+    import sherpa.astro.io.dummy_backend as backend
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info

--- a/sherpa/astro/io/tests/test_backend_switch.py
+++ b/sherpa/astro/io/tests/test_backend_switch.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2022
 #  MIT
 #
 #
@@ -71,7 +71,7 @@ io_pkg : not_a_module
     with patch("sherpa.get_config", lambda: str(conf)):
         mod = importlib.reload(io)
 
-    assert mod.backend is None
+    assert mod.backend is io.dummy_backend
 
     # Restore the import
     mod = importlib.reload(io)

--- a/sherpa/sherpa-standalone.rc
+++ b/sherpa/sherpa-standalone.rc
@@ -1,10 +1,22 @@
 # SHERPA_VERSION 4.14.2
 [options]
-# Plotting packages available- pylab
-plot_pkg   : pylab dummy
+# Plotting backends (space separated list)
+# will be tried in order, the first one the imports is set as default
+# plotting backend. If no listed backend can be imported, Sherpa sets
+# a dummy backend as default.
+# The backend can be changed in a running sherpa session.
+# The following line would try all available backends:
+# plot_pkg   : pylab dummy
+plot_pkg   : pylab
 
 # IO packages (space separated list) in the order they will be tried
-io_pkg     : crates pyfits dummy
+# The first backend that imports successfully is set as default I/O backend.
+# If no listed backend can be imported, Sherpa sets
+# a dummy backend as default.
+# The backend can be changed in a running sherpa session.
+# The following line would try all available backends:
+# io_pkg   : crates pyfits dummy
+io_pkg     : pyfits
 
 [statistics]
 # If true, use truncation value in Cash, C-stat

--- a/sherpa/sherpa-standalone.rc
+++ b/sherpa/sherpa-standalone.rc
@@ -1,7 +1,7 @@
 # SHERPA_VERSION 4.14.2
 [options]
 # Plotting backends (space separated list)
-# will be tried in order, the first one the imports is set as default
+# will be tried in order, the first one that imports is set as default
 # plotting backend. If no listed backend can be imported, Sherpa sets
 # a dummy backend as default.
 # The backend can be changed in a running sherpa session.

--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -1,10 +1,22 @@
 # SHERPA_VERSION 4.14.2
 [options]
-# Plotting packages available- pylab
-plot_pkg   : pylab dummy
+# Plotting backends (space separated list)
+# will be tried in order, the first one the imports is set as default
+# plotting backend. If no listed backend can be imported, Sherpa sets
+# a dummy backend as default.
+# The backend can be changed in a running sherpa session.
+# The following line would try all available backends:
+# plot_pkg   : pylab dummy
+plot_pkg   : pylab
 
 # IO packages (space separated list) in the order they will be tried
-io_pkg     : crates pyfits dummy
+# The first backend that imports successfully is set as default I/O backend.
+# If no listed backend can be imported, Sherpa sets
+# a dummy backend as default.
+# The backend can be changed in a running sherpa session.
+# The following line would try all available backends:
+# io_pkg   : crates pyfits dummy
+io_pkg     : crates
 
 [statistics]
 # If true, use truncation value in Cash, C-stat

--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -1,7 +1,7 @@
 # SHERPA_VERSION 4.14.2
 [options]
 # Plotting backends (space separated list)
-# will be tried in order, the first one the imports is set as default
+# will be tried in order, the first one that imports is set as default
 # plotting backend. If no listed backend can be imported, Sherpa sets
 # a dummy backend as default.
 # The backend can be changed in a running sherpa session.

--- a/sherpa/sherpa.rc
+++ b/sherpa/sherpa.rc
@@ -5,7 +5,8 @@
 # plotting backend. If no listed backend can be imported, Sherpa sets
 # a dummy backend as default.
 # The backend can be changed in a running sherpa session.
-# The following line would try all available backends:
+# The following line would try all available backends until it finds one that imports correctly 
+# (i.e. all dependencies are available):
 # plot_pkg   : pylab dummy
 plot_pkg   : pylab
 


### PR DESCRIPTION
# Summary
Default rc files will work in older version of sherpa as well.

# Details
There are two changes here:
- Only list one option for backends in rc file
  That way, default rc files will work with older versions of sherpa.
- Add a mechanism to use the dummy IO backend evne if not listed since
  (see line above) we can no longer assume it is.