### PR TITLE
Address usability issues with Data2DInt and DataIMGInt classes

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4742,6 +4742,42 @@ class DataIMGInt(DataIMG):
     def _init_data_space(self, filter, *data):
         return IntegratedDataSpace2D(filter, *data)
 
+    def get_x0(self, filter=False):
+        indep = self._data_space.get(filter)
+        return (indep.x0lo + indep.x0hi) / 2.0
+
+    def get_x1(self, filter=False):
+        indep = self._data_space.get(filter)
+        return (indep.x1lo + indep.x1hi) / 2.0
+
+    @property
+    def x0lo(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x0lo
+
+    @property
+    def x0hi(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x0hi
+
+    @property
+    def x1lo(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x1lo
+
+    @property
+    def x1hi(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x1hi
+
     def get_logical(self):
         coord = self.coord
         x0lo, x1lo, x0hi, x1hi = self.get_indep()

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4632,9 +4632,8 @@ class DataIMG(Data2D):
         x1_lo = x1_i.min()
         x1_hi = x1_i.max()
 
-        # TODO: subset mask and then ask its shape
-        shape = mask[x0_lo:x0_hi + 1, x1_lo:x1_hi + 1].shape
         mask = mask[x0_lo:x0_hi + 1, x1_lo:x1_hi + 1]
+        shape = mask.shape
         mask = mask.ravel()
         return mask, shape
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4641,8 +4641,9 @@ class DataIMG(Data2D):
         # FIXME add support for coords to image class -> DS9
         self._check_shape()
         y_img = self.filter_region(self.get_dep(False))
+        y_img = y_img.reshape(*self.shape)
         if yfunc is None:
-            return y_img.reshape(*self.shape)
+            return y_img
 
         m = self.eval_model_to_fit(yfunc)
         if numpy.iterable(self.mask):
@@ -4650,11 +4651,8 @@ class DataIMG(Data2D):
             # to the data size to preserve img shape and WCS coord
             m = pad_bounding_box(m, self.mask)
 
-        y_img = (y_img, self.filter_region(m))
-
-        y_img = (y_img[0].reshape(*self.shape),
-                 y_img[1].reshape(*self.shape))
-        return y_img
+        return (y_img,
+                self.filter_region(m).reshape(*self.shape))
 
     def get_axes(self):
         # FIXME: how to filter an axis when self.mask is size of self.y?

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2018,56 +2018,44 @@ def test_dataimgint_show(make_dataimgint):
     assert len(out) == 12
 
 
-@pytest.mark.xfail
 def test_dataimgint_x0lo(make_dataimgint):
     assert make_dataimgint.x0lo == pytest.approx([-5, -5])
 
 
-@pytest.mark.xfail
 def test_dataimgint_x1lo(make_dataimgint):
     assert make_dataimgint.x1lo == pytest.approx([10, 11])
 
 
-@pytest.mark.xfail
 def test_dataimgint_x0hi(make_dataimgint):
     assert make_dataimgint.x0hi == pytest.approx([-4, -4])
 
 
-@pytest.mark.xfail
 def test_dataimgint_x1hi(make_dataimgint):
     assert make_dataimgint.x1hi == pytest.approx([11, 12])
 
 
-@pytest.mark.xfail
 def test_dataimgint_get_x0(make_dataimgint):
-    """This copies the Data2DInt case but fails"""
     x0 = np.asarray([-5, -5])
     x = (x0 + x0 + 1) / 2
 
     assert (make_dataimgint.get_x0() == x).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_x0(make_dataimgint):
-    """This copies the Data2DInt case but fails"""
     x0 = np.asarray([-5, -5])
     x = (x0 + x0 + 1) / 2
 
     assert (make_dataimgint.x0 == x).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_get_x1(make_dataimgint):
-    """This copies the Data2DInt case but fails"""
     x1 = np.asarray([10, 11])
     x = (x1 + x1 + 1) / 2
 
     assert (make_dataimgint.get_x1() == x).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_x1(make_dataimgint):
-    """This copies the Data2DInt case but fails"""
     x1 = np.asarray([10, 11])
     x = (x1 + x1 + 1) / 2
 
@@ -2167,7 +2155,7 @@ def test_dataimgint_ignore_get_filter_expr(make_dataimgint):
     assert img.get_filter_expr() == ''
 
 
-@pytest.mark.xfail
+# given how notice test above fails, how is this working?
 def test_dataimgint_notice_get_x0(make_dataimgint):
     """basic notice call + get_x0"""
     img = make_dataimgint
@@ -2194,7 +2182,6 @@ def test_dataimgint_notice_get_y(make_dataimgint):
     assert (img.get_y(True) == np.asarray([10])).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_notice2d(make_dataimgint):
     """basic notice2d call.
 
@@ -2207,7 +2194,6 @@ def test_dataimgint_notice2d(make_dataimgint):
     assert (img.mask == np.asarray([True, False])).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_ignore2d(make_dataimgint):
     """basic ignore2d call.
 
@@ -2219,21 +2205,18 @@ def test_dataimgint_ignore2d(make_dataimgint):
     assert (img.mask == np.asarray([False, True])).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_notice2d_get_filter(make_dataimgint):
     img = make_dataimgint
     img.notice2d("rect(-100, 10, 100, 11)")
     assert img.get_filter() == 'Rectangle(-100,10,100,11)'
 
 
-@pytest.mark.xfail
 def test_dataimgint_notice2d_get_filter_expr(make_dataimgint):
     img = make_dataimgint
     img.notice2d("rect(-100, 10, 100, 11)")
     assert img.get_filter_expr() == 'Rectangle(-100,10,100,11)'
 
 
-@pytest.mark.xfail
 def test_dataimgint_notice2d_get_x0(make_dataimgint):
     """basic notice2d call + get_x0"""
     img = make_dataimgint
@@ -2242,7 +2225,6 @@ def test_dataimgint_notice2d_get_x0(make_dataimgint):
     assert (img.get_x0(True) == np.asarray([-4.5])).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_notice2d_get_x1(make_dataimgint):
     """basic notice2d call + get_x1"""
     img = make_dataimgint
@@ -2251,7 +2233,6 @@ def test_dataimgint_notice2d_get_x1(make_dataimgint):
     assert (img.get_x1(True) == np.asarray([10.5])).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_notice2d_get_y(make_dataimgint):
     """basic notice2d call + get_y"""
     img = make_dataimgint
@@ -2302,9 +2283,7 @@ def test_dataimgint_get_img_model_no_filter(make_dataimgint):
     assert (ivals[1] == np.asarray([[110.5], [120.5]])).all()
 
 
-@pytest.mark.xfail
 def test_dataimgint_get_max_pos(make_dataimgint):
-    """No idea wy this fails"""
     assert make_dataimgint.get_max_pos() == (-4.5, 10.5)
 
 
@@ -2383,7 +2362,6 @@ def test_dataimgint_sky(make_dataimgint):
     assert sky[3] == pytest.approx(x1 + 2)
 
 
-@pytest.mark.xfail
 def test_dataimgint_sky_coords_unchanged(make_dataimgint):
     """Just because sky is set we don't change axis data."""
 
@@ -2412,7 +2390,6 @@ def test_dataimgint_set_sky(make_dataimgint):
     assert img.coord == "physical"
 
 
-@pytest.mark.xfail
 def test_dataimgint_set_sky_x0hi(make_dataimgint):
     """x0hi is changed
 
@@ -2431,7 +2408,6 @@ def test_dataimgint_set_sky_x0hi(make_dataimgint):
     assert img.x0hi == pytest.approx(x)
 
 
-@pytest.mark.xfail
 def test_dataimgint_set_sky_get_x1(make_dataimgint):
     """get_x1 is changed
 
@@ -2450,7 +2426,6 @@ def test_dataimgint_set_sky_get_x1(make_dataimgint):
     assert img.get_x1() == pytest.approx(x)
 
 
-@pytest.mark.xfail
 def test_dataimgint_sky_coords_reset(make_dataimgint):
     """We can get back to the logical units
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2450,6 +2450,26 @@ def test_dataimgint_set_sky_get_x1(make_dataimgint):
     assert img.get_x1() == pytest.approx(x)
 
 
+@pytest.mark.xfail
+def test_dataimgint_sky_coords_reset(make_dataimgint):
+    """We can get back to the logical units
+
+    We only check one of the values.
+    """
+
+    img = make_dataimgint
+    img.sky= WCS("sky", "LINEAR",
+                 crval=[100.5, 110.5],
+                 crpix=[1.5, 2.5],
+                 cdelt=[2, 2])
+    img.set_coord("physical")
+    img.set_coord("logical")
+
+    x1 = np.asarray([10, 11])
+    x = (x1 + x1 + 1) / 2
+    assert img.get_x1() == pytest.approx(x)
+
+
 @pytest.mark.parametrize("dclass", [Data2D, DataIMG])
 def test_1379_evaluation_unintegrated(dclass):
     """Check that delta2d does not evaluate (i.e. only 0's).

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2233,7 +2233,6 @@ def test_dataimgint_create(make_dataimgint):
     assert img.header == {}
 
 
-@pytest.mark.xfail
 def test_dataimgint_show(make_dataimgint):
     """Check we can show a basic integrated image data set.
 
@@ -2247,22 +2246,20 @@ def test_dataimgint_show(make_dataimgint):
     #
     out = str(img).split("\n")
 
-    # I don't know what the correct output should be, so the
-    # x0/x0lo order could be wrong.
+    # Do we expect the x0/x1 output or x0lo/../x1hi
+    # output? For the moment just test what we do return.
     #
     assert out[0] == "name      = ival"
-    assert out[1] == "x0lo      = Int64[2]"
-    assert out[2] == "x1lo      = Int64[2]"
-    assert out[3] == "x0hi      = Int64[2]"
-    assert out[4] == "x1hi      = Int64[2]"
-    assert out[5] == "y         = Int64[2]"
-    assert out[6] == "shape     = (2, 1)"
-    assert out[7] == "staterror = None"
-    assert out[8] == "syserror  = None"
-    assert out[9] == "sky       = None"
-    assert out[10] == "eqpos     = None"
-    assert out[11] == "coord     = logical"
-    assert len(out) == 12
+    assert out[1] == "x0        = Float64[2]"
+    assert out[2] == "x1        = Float64[2]"
+    assert out[3] == "y         = Int64[2]"
+    assert out[4] == "shape     = (2, 1)"
+    assert out[5] == "staterror = None"
+    assert out[6] == "syserror  = None"
+    assert out[7] == "sky       = None"
+    assert out[8] == "eqpos     = None"
+    assert out[9] == "coord     = logical"
+    assert len(out) == 10
 
 
 def test_dataimgint_x0lo(make_dataimgint):

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1570,6 +1570,14 @@ class Data1DInt(Data1D):
 class Data2D(Data):
     _fields = ("name", "x0", "x1", "y", "shape", "staterror", "syserror")
 
+    # Why should we add shape to extra-fields instead? See #1359 to
+    # fix #47.
+    #
+    # It would change the notebook output slightly so we don't change
+    # for now.
+    #
+    # _extra_fields = ("shape", )
+
     def __init__(self, name, x0, x1, y, shape=None, staterror=None, syserror=None):
         self.shape = shape
         super().__init__(name, (x0, x1), y, staterror, syserror)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1759,6 +1759,34 @@ class Data2DInt(Data2D):
         Data.notice(self, (None, None, x0lo, x1lo), (x0hi, x1hi, None, None),
                     ignore=ignore, integrated=True)
 
+    @property
+    def x0lo(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x0lo
+
+    @property
+    def x0hi(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x0hi
+
+    @property
+    def x1lo(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x1lo
+
+    @property
+    def x1hi(self):
+        """
+        Property kept for compatibility
+        """
+        return self._data_space.x1hi
+
 
 # Notebook representations
 #

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1689,19 +1689,19 @@ class Data2D(Data):
 
         self._check_shape()
         y_img = self.get_y(False, yfunc)
-        if yfunc is not None:
-            y_img = (y_img[0].reshape(*self.shape),
-                     y_img[1].reshape(*self.shape))
-        else:
-            y_img = y_img.reshape(*self.shape)
-        return y_img
+        if yfunc is None:
+            return y_img.reshape(*self.shape)
+
+        return (y_img[0].reshape(*self.shape),
+                y_img[1].reshape(*self.shape))
 
     def get_imgerr(self):
         self._check_shape()
         err = self.get_error()
-        if err is not None:
-            err = err.reshape(*self.shape)
-        return err
+        if err is None:
+            return None
+
+        return err.reshape(*self.shape)
 
     def to_contour(self, yfunc=None):
         return (self.get_x0(True),

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1623,13 +1623,35 @@ class Data2D(Data):
         return ''
 
     def get_max_pos(self, dep=None):
+        """Return the coordinates of the maximum value.
+
+        Parameters
+        ----------
+        dep : ndarray or None, optional
+            The data to search and it must match the current data
+            filter. If not given then the dependent axis is used.
+
+        Returns
+        -------
+        coords : pair or list of pairs
+            The coordinates of the maximum location. The data values
+            match the values returned by `get_x0` and `get_x1`. If
+            there is only one maximum pixel then a pair is returned
+            otherwise a list of pairs is returned.
+
+        See Also
+        --------
+        get_dep, get_x0, get_x1
+
+        """
         if dep is None:
             dep = self.get_dep(True)
         x0 = self.get_x0(True)
         x1 = self.get_x1(True)
 
+        # TODO: Should be able to just use numpy.argmax
         pos = numpy.asarray(numpy.where(dep == dep.max())).squeeze()
-        if pos.ndim == 0:  # DATA-NOTE: Could this ever be False?!
+        if pos.ndim == 0:
             pos = int(pos)
             return x0[pos], x1[pos]
 
@@ -1639,6 +1661,24 @@ class Data2D(Data):
     # Also, we do not filter, as imager needs M x N (or
     # L x M x N) array
     def get_img(self, yfunc=None):
+        """Return the dependent axis as a 2D array.
+
+        The data is not filtered.
+
+        Parameters
+        ----------
+        yfunc : sherpa.models.model.Model instance or None, optional
+            If set then it is a model that is evaluated on the data
+            grid and returned along with the dependent axis.
+
+        Returns
+        -------
+        img : ndarray or (ndarray, ndarray)
+            The data as a 2D array or a pair of 2D arrays when yfunc
+            is set.
+
+        """
+
         self._check_shape()
         y_img = self.get_y(False, yfunc)
         if yfunc is not None:

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1469,7 +1469,6 @@ def test_data2dint_create(make_data2dint):
     assert not(hasattr(img, "header"))
 
 
-@pytest.mark.xfail
 def test_data2dint_show(make_data2dint):
     """Check we can show a basic integrated 2D data set.
 
@@ -1521,6 +1520,22 @@ def test_data2dint_x1(make_data2dint):
     x = (x1 + x1 + 1) / 2
 
     assert (make_data2dint.x1 == x).all()
+
+
+def test_data2dint_x0lo(make_data2dint):
+    assert (make_data2dint.x0lo == [-5, -5]).all()
+
+
+def test_data2dint_x0hi(make_data2dint):
+    assert (make_data2dint.x0hi == [-4, -4]).all()
+
+
+def test_data2dint_x1lo(make_data2dint):
+    assert (make_data2dint.x1lo == [10, 11]).all()
+
+
+def test_data2dint_x1hi(make_data2dint):
+    assert (make_data2dint.x1hi == [11, 12]).all()
 
 
 def test_data2dint_get_y(make_data2dint):
@@ -1686,8 +1701,7 @@ def test_data2dint_get_bounding_mask(make_data2dint):
                          ])
 def test_data2dint_method_is_none(method, make_data2dint):
     """Check those methods that return None"""
-    img = make_data2dint
-    func = getattr(img, method)
+    func = getattr(make_data2dint, method)
     assert func() is None
 
 
@@ -1697,6 +1711,5 @@ def test_data2dint_method_is_none(method, make_data2dint):
                          ])
 def test_data2dint_attribute_is_none(attribute, make_data2dint):
     """Check those attributes that return None"""
-    img = make_data2dint
-    attr = getattr(img, attribute)
+    attr = getattr(make_data2dint, attribute)
     assert attr is None


### PR DESCRIPTION
# Summary

Fix issues using the Data2DInt and DataIMGInt classes (#1379).

# Details

The first few commits include a number of tests to check basic features of the Data2DInt and DataIMGInt classes. Some of them are marked as xfail and these are fixed in later commits. Some of the tests are left as regression tests, so they will indicate if the current behavior has changed, as there are places where it's not obvious what the correct behavior is (in particular the get_axes call).

The immediate cause of #1379 is that the `__str__` method for the two classes could not find the `x0lo`, `x1lo`, `x0hi`, and `x1hi` attributes. It is likely that this was broken during the rework to the `Data` hierarchy in #614 but I have not verified this. In looking at the code it turns out that a number of other routines, related to accessing the independent axes - such as the `x0` attribute and the `get_x1()` call - are also broken because of these missing attributes.  This was found by adding the tests in the first few commits.

There are a few docstring changes and comments added before we get to the fixes.

The first set of fixes is in the `Fix show error for Data2DInt` commit. This is a deceptively simple fix, which is adding attribute accessors like the following to the `Data2DInt` class:

```
    @property
    def x0lo(self):
        """
        Property kept for compatibility
        """
        return self._data_space.x0lo
```

The docstring is based on the `xlo`/`xhi` accessors for the `Data1Dint` class, and it suggests that we are meant to use some other way to get at this data, but accessing the `_data_space` attribute directly can not be that, and there's no obvious way to get at this, unless it's meant to be the `get_evaluation_indep` method, but this is an undocumented method in the `Data1D` class and isn't defined in the `Data2D` class. Until we have this sorted out using these attributes seems to be the best way to get the code to work. Note that the number of xfail tests has dropped.

The next change in `Fix independent-axis access for DataIMGInt` is essentially the same for the `DataIMGInt` class, but we also need to override the `get_x0` and `get_x1` methods from the parent `Data2D` class (to match what `Data2DInt` does). Perhaps we could have some abstract class to add this "integrated" behavior so we don't need to replicate this, but that is a significantly-larger change than warranted by this issue. Note that the number of xfail tests has dropped.

The last commit just makes a few style changes to DataIMG/2D related methods. The idea is to try and exit a method quickly when it's the "easy" path. This makes the logic for the more-complex path easier to see (in part because we remove four spaces). I don't do too much of this as there are a number of similar changes in #1414 and I don't want to make this to annoying to merge.