### PR TITLE
fix a compiler bug on macOS

### DIFF
--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -97,17 +97,20 @@ namespace sherpa { namespace astro { namespace xspec {
       //
       struct NoError : std::runtime_error
       {
-	using std::runtime_error::runtime_error;
+	NoError(const char* msg) : std::runtime_error(msg) {}
+	NoError(const std::string& msg) : std::runtime_error(msg) {}
       };
 
       struct ValueError : std::runtime_error
       {
-	using std::runtime_error::runtime_error;
+	ValueError(const char* msg) : std::runtime_error(msg) {}
+	ValueError(const std::string& msg) : std::runtime_error(msg) {}
       };
 
       struct TypeError : std::runtime_error
       {
-	using std::runtime_error::runtime_error;
+	TypeError(const char* msg) : std::runtime_error(msg) {}
+	TypeError(const std::string& msg) : std::runtime_error(msg) {}
       };
 
 typedef sherpa::Array< float, NPY_FLOAT > FloatArray;


### PR DESCRIPTION
# Note

Made the following changes:


(ciao-4.14) dudley:sherpa saoguest$ git diff sherpa/include/sherpa/astro/xspec_extension.hh
```C++
diff --git a/sherpa/include/sherpa/astro/xspec_extension.hh b/sherpa/include/sherpa/astro/xspec_extension.hh
index f0e67776..006edc11 100644
--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -97,17 +97,20 @@ namespace sherpa { namespace astro { namespace xspec {
       //
       struct NoError : std::runtime_error
       {
-       using std::runtime_error::runtime_error;
+       NoError(const char* msg) : std::runtime_error(msg) {}
+       NoError(const std::string& msg) : std::runtime_error(msg) {}
       };
 
       struct ValueError : std::runtime_error
       {
-       using std::runtime_error::runtime_error;
+       ValueError(const char* msg) : std::runtime_error(msg) {}
+       ValueError(const std::string& msg) : std::runtime_error(msg) {}
       };
 
       struct TypeError : std::runtime_error
       {
-       using std::runtime_error::runtime_error;
+       TypeError(const char* msg) : std::runtime_error(msg) {}
+       TypeError(const std::string& msg) : std::runtime_error(msg) {}
```

Sure enough, it compiles fine on _dudley_ now:

(ciao-4.14) dudley:sherpa saoguest$ touch sherpa/include/sherpa/astro/xspec_extension.hh 
(ciao-4.14) dudley:sherpa saoguest$ python setup.py develop
```bash
running sherpa_config
warning: sherpa_config: built configure string['./configure', '--prefix=/Users/saoguest/dtn/sherpa/build', '--with-pic', '--enable-standalone', '--disable-maintainer-mode', '--enable-stuberrorlib', '--disable-shared', '--enable-shared=libgrp,stklib', '--enable-region', '--enable-group', '--enable-stk', '--enable-wcs']

running xspec_config
Found XSPEC version: 12.12.0
running develop
/Users/saoguest/dtn/miniconda/envs/ciao-4.14/lib/python3.8/site-packages/setuptools/command/easy_install.py:156: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/Users/saoguest/dtn/miniconda/envs/ciao-4.14/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
running build_scripts
running egg_info
running build_src
/Users/saoguest/dtn/miniconda/envs/ciao-4.14/lib/python3.8/site-packages/setuptools/command/egg_info.py:624: SetuptoolsDeprecationWarning: Custom 'build_py' does not implement 'get_data_files_without_manifest'.
Please extend command classes from setuptools instead of distutils.
  warnings.warn(
writing manifest file 'sherpa.egg-info/SOURCES.txt'
running build_ext
```