### PR TITLE
Allow users to freeze models

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -326,7 +326,7 @@ import numpy
 
 from sherpa.models.regrid import EvaluationSpace1D, ModelDomainRegridder1D, EvaluationSpace2D, ModelDomainRegridder2D
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit
-from sherpa.utils.err import ModelErr
+from sherpa.utils.err import ModelErr, ParameterErr
 from sherpa.utils import formatting
 
 from .parameter import Parameter
@@ -792,6 +792,29 @@ class Model(NoNewAttributesAfterInit):
 
         for p in self.pars:
             p.reset()
+
+    def freeze(self):
+        """Freeze any thawed parameters of the model."""
+
+        for p in self.pars:
+            p.freeze()
+
+    def thaw(self):
+        """Thaw any frozen parameters of the model.
+
+        Those parameters that are marked as "always frozen" are
+        skipped.
+
+        """
+
+        # Note that we have to handle "always frozen" cases, but rather
+        # than asking for permission we just handle the failure case.
+        #
+        for p in self.pars:
+            try:
+                p.thaw()
+            except ParameterErr:
+                continue
 
 
 class CompositeModel(Model):

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1226,7 +1226,6 @@ def test_cache_clear_multiple(caplog):
     assert c._cache_ctr['misses'] == 0
 
 
-@pytest.mark.xfail
 def test_model_freeze():
     """Can we freeze all the parameters in a model?"""
 
@@ -1243,7 +1242,6 @@ def test_model_freeze():
     assert mdl.thawedpars == []
 
 
-@pytest.mark.xfail
 def test_model_thaw():
     """Can we freeze all the parameters in a model?"""
 
@@ -1259,7 +1257,6 @@ def test_model_thaw():
     assert mdl.thawedpars == pytest.approx(expected)
 
 
-@pytest.mark.xfail
 def test_model_freeze_already_frozen():
     """Check it's a no-op rather than an error"""
 
@@ -1271,7 +1268,6 @@ def test_model_freeze_already_frozen():
     assert mdl.thawedpars == []
 
 
-@pytest.mark.xfail
 def test_model_thaw_already_thawed():
     """Check it's a no-op rather than an error"""
 
@@ -1282,7 +1278,6 @@ def test_model_thaw_already_thawed():
     assert mdl.thawedpars == [1.0]
 
 
-@pytest.mark.xfail
 def test_model_freeze_alwaysfrozen():
     """Check it's a no-op rather than an error for an alwaysfrozen parameter"""
 
@@ -1294,7 +1289,6 @@ def test_model_freeze_alwaysfrozen():
     assert mdl.thawedpars == []
 
 
-@pytest.mark.xfail
 def test_model_thaw_alwaysfrozen():
     """Check we skip an alwaysfrozen parameter"""
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1243,7 +1243,7 @@ def test_model_freeze():
 
 
 def test_model_thaw():
-    """Can we freeze all the parameters in a model?"""
+    """Can we thaw all the parameters in a model?"""
 
     mdl = Polynom1D()
     expected = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0]

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -879,3 +879,35 @@ def test_thaw_no_arguments(clean_ui):
     ui.thaw()
     assert ui.get_num_par_thawed() == 2
     assert ui.get_num_par_frozen() == 2
+
+
+@pytest.mark.parametrize("string", [True, False])
+def test_freeze_invalid_arguments(string, clean_ui):
+    """We error out with an invalid argument"""
+
+    mdl = ui.create_model_component("logparabola", "mdl")
+    ui.set_source(mdl)
+
+    with pytest.raises(ArgumentTypeErr) as ae:
+        if string:
+            ui.freeze("1")
+        else:
+            ui.freeze(1)
+
+    assert str(ae.value) == "'par' must be a parameter or model object or expression string"
+
+
+@pytest.mark.parametrize("string", [True, False])
+def test_thaw_invalid_arguments(string, clean_ui):
+    """We error out with an invalid argument"""
+
+    mdl = ui.create_model_component("logparabola", "mdl")
+    ui.set_source(mdl)
+
+    with pytest.raises(ArgumentTypeErr) as ae:
+        if string:
+            ui.thaw("1")
+        else:
+            ui.thaw(1)
+
+    assert str(ae.value) == "'par' must be a parameter or model object or expression string"

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -7522,14 +7522,17 @@ class Session(NoNewAttributesAfterInit):
                 if not p.alwaysfrozen:
                     getattr(p, action)()
 
-    # DOC-TODO: is this the best way to document the arguments?
     def freeze(self, *args):
         """Fix model parameters so they are not changed by a fit.
 
-        If called with no arguments, then all parameters
-        of models in source expressions are frozen. The
-        arguments can be parameters or models (in which case
-        all parameters of the model are frozen).
+        The arguments can be parameters or models, in which case all
+        parameters of the model are frozen. If no arguments are
+        given then nothing is changed.
+
+        Parameters
+        ----------
+        args : sequence of str or Parameter or Model
+            The parameters or models to freeze.
 
         See Also
         --------
@@ -7571,14 +7574,17 @@ class Session(NoNewAttributesAfterInit):
         for p in par:
             self._freeze_thaw_par_or_model(p, 'freeze')
 
-    # DOC-TODO: is this the best way to document the arguments?
     def thaw(self, *args):
         """Allow model parameters to be varied during a fit.
 
-        If called with no arguments, then all parameters
-        of models in source expressions are thawed. The
-        arguments can be parameters or models (in which case
-        all parameters of the model are thawed).
+        The arguments can be parameters or models, in which case all
+        parameters of the model are thawed. If no arguments are
+        given then nothing is changed.
+
+        Parameters
+        ----------
+        args : sequence of str or Parameter or Model
+            The parameters or models to thaw.
 
         See Also
         --------
@@ -7594,6 +7600,11 @@ class Session(NoNewAttributesAfterInit):
         The `freeze` function can be used to reverse this setting,
         so that parameters are "frozen" and so remain constant during
         a fit.
+
+        Certain parameters may be marked as "always frozen", in which
+        case using the parameter in a call to `thaw` will raise an
+        error. If the model is sent to `thaw` then the "always frozen"
+        parameter will be skipped.
 
         Examples
         --------
@@ -7630,10 +7641,10 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        par
+        par : str or Parameter
            The parameter to link.
         val
-           The value - wihch can be a numeric value or a function
+           The value - which can be a numeric value or a function
            of other model parameters, to set `par` to.
 
         See Also
@@ -7701,7 +7712,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        par
+        par : str or Parameter
            The parameter to unlink. If the parameter is not linked
            then nothing happens.
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -7508,20 +7508,6 @@ class Session(NoNewAttributesAfterInit):
         """
         self._check_par(par).set(val, min, max, frozen)
 
-    def _freeze_thaw_par_or_model(self, par, action):
-        if isinstance(par, string_types):
-            par = self._eval_model_expression(par, 'parameter or model')
-
-        _check_type(par, (sherpa.models.Parameter, sherpa.models.Model), 'par',
-                    'a parameter or model object or expression string')
-
-        if isinstance(par, sherpa.models.Parameter):
-            getattr(par, action)()
-        else:
-            for p in par.pars:
-                if not p.alwaysfrozen:
-                    getattr(p, action)()
-
     def freeze(self, *args):
         """Fix model parameters so they are not changed by a fit.
 
@@ -7570,9 +7556,15 @@ class Session(NoNewAttributesAfterInit):
         >>> freeze(gal.nh, src.abund)
 
         """
-        par = list(args)
-        for p in par:
-            self._freeze_thaw_par_or_model(p, 'freeze')
+        for par in list(args):
+            if isinstance(par, string_types):
+                par = self._eval_model_expression(par, 'parameter or model')
+
+            try:
+                par.freeze()
+            except AttributeError:
+                raise ArgumentTypeErr('badarg', 'par',
+                                      'a parameter or model object or expression string')
 
     def thaw(self, *args):
         """Allow model parameters to be varied during a fit.
@@ -7627,9 +7619,16 @@ class Session(NoNewAttributesAfterInit):
         >>> thaw(gal.nh, src.abund)
 
         """
-        par = list(args)
-        for p in par:
-            self._freeze_thaw_par_or_model(p, 'thaw')
+        for par in list(args):
+            if isinstance(par, string_types):
+                par = self._eval_model_expression(par, 'parameter or model')
+
+            try:
+                par.thaw()
+            except AttributeError:
+                raise ArgumentTypeErr('badarg', 'par',
+                                      'a parameter or model object or expression string')
+
 
     def link(self, par, val):
         """Link a parameter to a value.


### PR DESCRIPTION
# Summary

Models can now be frozen or thawed, which just calls the requested on all the parameters of the model (except for "alwaysfrozen" parameters which are skipped). This is only relevant for users who are accessing the objects directly since the ui versions of freeze and thaw already implemented this behavior. Fixes #1080.

The documentation for the freeze and thaw routines in the ui code has been fixed to correctly describe what happens when used with no arguments (nothing is changed).

# Details

In adding the following functionality I realized that the `sherpa[.astro].ui.freeze/thaw` functions were documented incorrectly: they suggested that they did something when called with no arguments when they actually do nothing. I added tests to show that they do nothing and then fixed the documentation. We **could** change the code here, but I strongly advise against it as I think it is likely to cause more problems than to help users.

We were already able to say

```
>>> from sherpa import ui
>>> ui.set_source(ui.polynom1d.m1 + ui.gauss1d.m2)
>>> ui.thaw(m1)
```

but we couldn't say the "equivalent" with objects. Well, now you can:

```
>>> from sherpa.models.basic import Gauss1D
>>> mdl = Gauss1D()
>>> mdl.freeze()
```

This is a minor improvement, but it does actually make implementation of the `ui.thaw(mdl)` version a teensy-bit nicer, as well as moving some code to be "more Pythonic" , in that it uses duck typing/asking for forgiveness rather than instance checks and asking for permission (although this is only a small change so it's not worth spending too much time on it).

# Corner case

Some models have one - or more - parameters that are marked as "always frozen". For example the `ref` parameter of `sherpa.models.basic.LogParabola` is one such. If you try to thaw the individual parameter you get an error (`ParameterErr`) , but when thawing the whole model we just skip this parameter. This is how the `ui.thaw` routine worked, so we replicate this for the `thaw` method added to the model class. 

So, in CIAO 4.14 we have the following, where `thaw(mdl.ref)` fails but `thaw(mdl)` passes:

```
sherpa-4.14.0> logparabola.mdl
-------------> logparabola.mdl()
<LogParabola model instance 'logparabola.mdl'>

sherpa-4.14.0> print(mdl)
logparabola.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.ref      frozen            1 -3.40282e+38  3.40282e+38
   mdl.c1       thawed            1 -3.40282e+38  3.40282e+38
   mdl.c2       thawed            1 -3.40282e+38  3.40282e+38
   mdl.ampl     thawed            1            0  3.40282e+38

sherpa-4.14.0> thaw(mdl.ref)
ParameterErr: parameter mdl.ref is always frozen and cannot be thawed

sherpa-4.14.0> thaw(mdl)

sherpa-4.14.0> print(mdl)
logparabola.mdl
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mdl.ref      frozen            1 -3.40282e+38  3.40282e+38
   mdl.c1       thawed            1 -3.40282e+38  3.40282e+38
   mdl.c2       thawed            1 -3.40282e+38  3.40282e+38
   mdl.ampl     thawed            1            0  3.40282e+38

sherpa-4.14.0> mdl.thaw()
AttributeError: 'LogParabola' object has no attribute 'thaw'
```

With this PR we can no perform this last line:

```
>>> from sherpa.models.basic import LogParabola
>>> mdl = LogParabola()
>>> mdl.ref.thaw()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-main/sherpa/models/parameter.py", line 663, in thaw
    self.frozen = False
  File "/home/dburke/sherpa/sherpa-main/sherpa/utils/__init__.py", line 171, in __setattr__
    object.__setattr__(self, name, val)
  File "/home/dburke/sherpa/sherpa-main/sherpa/models/parameter.py", line 455, in _set_frozen
    raise ParameterErr('alwaysfrozen', self.fullname)
sherpa.utils.err.ParameterErr: parameter logparabola.ref is always frozen and cannot be thawed
>>> print(mdl)
logparabola
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   logparabola.ref frozen            1 -3.40282e+38  3.40282e+38
   logparabola.c1 thawed            1 -3.40282e+38  3.40282e+38
   logparabola.c2 thawed            1 -3.40282e+38  3.40282e+38
   logparabola.ampl thawed            1            0  3.40282e+38
>>> mdl.freeze()
>>> print(mdl)
logparabola
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   logparabola.ref frozen            1 -3.40282e+38  3.40282e+38
   logparabola.c1 frozen            1 -3.40282e+38  3.40282e+38
   logparabola.c2 frozen            1 -3.40282e+38  3.40282e+38
   logparabola.ampl frozen            1            0  3.40282e+38
>>> mdl.thaw()
>>> print(mdl)
logparabola
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   logparabola.ref frozen            1 -3.40282e+38  3.40282e+38
   logparabola.c1 thawed            1 -3.40282e+38  3.40282e+38
   logparabola.c2 thawed            1 -3.40282e+38  3.40282e+38
   logparabola.ampl thawed            1            0  3.40282e+38
```