### PR TITLE
WIP: fix maxfev & TODO, save 1 fct eval

### DIFF
--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -404,6 +404,8 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
 
         grid = numpy.mgrid[list_ranges]
         mynfev = pow(N, npar)
+        if maxfev is not None:
+            mynfev = min(maxfev, mynfev)
         grid = list(map(numpy.ravel, grid))
         sequence = []
         for index in range(mynfev):

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -422,6 +422,9 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
         ranges = []
         for index in range(npar):
             ranges.append([xmin[index], xmax[index]])
+        if method is not None:
+            # save some nfevs for method
+            num -= 1
         sequence = make_sequence(ranges, num)
     else:
         if not numpy.iterable(sequence):

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2007, 2015, 2016, 2018, 2019, 2020, 2021, 2022
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,8 @@
 import pytest
 
 from sherpa.optmethods import _tstoptfct
-from sherpa.optmethods.optfcts import lmdif, minim, montecarlo, neldermead
+from sherpa.optmethods.optfcts import lmdif, minim, montecarlo, neldermead, \
+    grid_search
 from sherpa.utils import _ncpus
 
 
@@ -49,10 +50,15 @@ def tst_opt(opt, fct, npar, reltol=1.0e-3, abstol=1.0e-3):
 
 
 ###############################################################################
+def test_gridsearch_maxfev():
+    fct = _tstoptfct.rosenbrock
+    x0, xmin, xmax, fmin = init(fct.__name__, 2)
+    result = grid_search(fct, x0, xmin, xmax, maxfev=4)
+    assert result[4]['nfev'] == 4
+
 @pytest.mark.parametrize("opt", [lmdif, minim, montecarlo, neldermead])
 def test_rosenbrock(opt, npar=4):
     tst_opt(opt, _tstoptfct.rosenbrock, npar)
-
 
 @pytest.mark.parametrize("opt", [pytest.param(lmdif, marks=pytest.mark.xfail),
                                  pytest.param(minim, marks=pytest.mark.xfail),

--- a/sherpa/optmethods/tests/test_optmethods.py
+++ b/sherpa/optmethods/tests/test_optmethods.py
@@ -56,6 +56,12 @@ def test_gridsearch_maxfev():
     result = grid_search(fct, x0, xmin, xmax, maxfev=4)
     assert result[4]['nfev'] == 4
 
+def test_gridsearch_maxfev():
+    fct = _tstoptfct.rosenbrock
+    x0, xmin, xmax, fmin = init(fct.__name__, 2)
+    result = grid_search(fct, x0, xmin, xmax, num=2, method='nEldErmEad')
+    assert result[4]['nfev'] == 313
+
 @pytest.mark.parametrize("opt", [lmdif, minim, montecarlo, neldermead])
 def test_rosenbrock(opt, npar=4):
     tst_opt(opt, _tstoptfct.rosenbrock, npar)


### PR DESCRIPTION
# Note

This PR limits the number of function evaluation in the  ```gridsearch``` optimization method if the default option ```maxfev``` is set to an integer (assuming it is > 0, but does not check).
 
Not sure why this stupid method was written since the number of function of evaluation is num^npar where num is the option parameter ```num``` and npar is the number of free parameters. 