### PR TITLE
Minor clean up of the data code

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -134,6 +134,17 @@ __all__ = ('DataARF', 'DataRMF', 'DataPHA', 'DataIMG', 'DataIMGInt', 'DataRosatR
 
 
 def _notice_resp(chans, arf, rmf):
+    """Notice the channel range for the associated responses
+
+    Parameters
+    ----------
+    chans : ndarray
+        The noticed channel values.
+    arf : sherpa.astro.data.DataARF or None
+    rmf : sherpa.astro.data.DataRMF or None
+
+    """
+
     bin_mask = None
 
     if rmf is not None and arf is not None:
@@ -2843,7 +2854,7 @@ must be an integer.""")
         """Exclude channels marked as bad.
 
         Ignore any bin in the PHA data set which has a quality value
-        that is larger than zero.
+        that is not equal to zero.
 
         Raises
         ------
@@ -2852,8 +2863,7 @@ must be an integer.""")
 
         See Also
         --------
-        ignore : Exclude data from the fit.
-        notice : Include data in the fit.
+        ignore, notice
 
         Notes
         -----
@@ -3825,6 +3835,24 @@ must be an integer.""")
         return expand_grouped_mask(self.mask, groups)
 
     def get_noticed_expr(self):
+        """Returns the current set of noticed channels.
+
+        The values returned are always in channels, no matter the
+        current analysis setting.
+
+        Returns
+        -------
+        expr : str
+            The noticed channel range as a string of comma-separated
+            "low-high" values. As these are channel filters the low
+            and high values are inclusive. If all channels have been
+            filtered out then "No noticed channels" is returned.
+
+        See Also
+        --------
+        get_filter, get_noticed_channels
+
+        """
         chans = self.get_noticed_channels()
         if self.mask is False or len(chans) == 0:
             return 'No noticed channels'
@@ -3848,6 +3876,19 @@ must be an integer.""")
             channel units, which uses ``format="%i"``).
         delim : str, optional
             The string used to mark the low-to-high range.
+
+        Returns
+        -------
+        expr : str
+            The noticed channel range as a string of comma-separated
+            ranges, where the low and high values are separated by
+            the `delim` string. The units of the ranges are controlled
+            by the analysis setting. If all bins have been
+            filtered out then "No noticed bins" is returned.
+
+        See Also
+        --------
+        get_noticed_channels, get_noticed_expr
 
         Examples
         --------

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2008, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1626,7 +1626,7 @@ must be an integer.""")
         self._plot_fac = 0
         self.units = "channel"
         self.quality_filter = None
-        Data1D.__init__(self, name, channel, counts, staterror, syserror)
+        super().__init__(name, channel, counts, staterror, syserror)
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the PHA
@@ -4347,7 +4347,7 @@ class DataIMG(Data2D):
         self.coord = coord
         self.header = {} if header is None else header
         self._region = None
-        Data2D.__init__(self, name, x0, x1, y, shape, staterror, syserror)
+        super().__init__(name, x0, x1, y, shape, staterror, syserror)
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the data

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1184,7 +1184,7 @@ def test_pha_remove_grouping(make_test_pha):
 
     # Can we remove the grouping column?
     pha.grouping = None
-    # This thinks that pha.grouped is sill set
+    # This thinks that pha.grouped is still set
     assert not pha.grouped
     d2 = pha.get_dep(filter=True)
     assert d2 == pytest.approx(no_data)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1321,7 +1321,7 @@ def test_pha_change_grouping_rounding(label, make_test_pha):
     """What happens with non-integer values?
 
     Unlike test_pha_change_grouping/quality_type we can more-easily
-    use the same input array, whicih makes it easier to test both
+    use the same input array, which makes it easier to test both
     columns with the same routine. It is actually unclear what
     we should do with input like this - should we error out,
     silently truncate, or perhaps warn the user. For the moment

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015, 2016, 2017, 2019, 2020, 2021
+#  Copyright (C) 2008, 2015, 2016, 2017, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -134,7 +134,7 @@ class DataSpace1D(EvaluationSpace1D):
             the x axis of this data space
         """
         self.filter = filter
-        EvaluationSpace1D.__init__(self, _check_nomask(x))
+        super().__init__(_check_nomask(x))
 
     def get(self, filter=False):
         """
@@ -200,7 +200,7 @@ class IntegratedDataSpace1D(EvaluationSpace1D):
             the higher bounds array of this data space
         """
         self.filter = filter
-        EvaluationSpace1D.__init__(self, _check_nomask(xlo), _check_nomask(xhi))
+        super().__init__(_check_nomask(xlo), _check_nomask(xhi))
 
     def get(self, filter=False):
         """
@@ -1059,7 +1059,7 @@ class DataSimulFit(NoNewAttributesAfterInit):
         self.name = name
         self.datasets = tuple(datasets)
         self.numcores = numcores
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def eval_model_to_fit(self, modelfuncs):
         if self.numcores == 1:
@@ -1130,7 +1130,7 @@ class Data1D(Data):
     _fields = ("name", "x", "y", "staterror", "syserror")
 
     def __init__(self, name, x, y, staterror=None, syserror=None):
-        Data.__init__(self, name, (x, ), y, staterror, syserror)
+        super().__init__(name, (x, ), y, staterror, syserror)
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the data
@@ -1390,7 +1390,7 @@ class Data1DAsymmetricErrs(Data1D):
     def __init__(self, name, x, y, elo, ehi, staterror=None, syserror=None):
         self.elo = elo
         self.ehi = ehi
-        Data1D.__init__(self, name, x, y, staterror=staterror, syserror=syserror)
+        super().__init__(name, x, y, staterror=staterror, syserror=syserror)
 
     def get_yerr(self, filter=False, staterrfunc=None):
         return self.elo, self.ehi
@@ -1572,7 +1572,7 @@ class Data2D(Data):
 
     def __init__(self, name, x0, x1, y, shape=None, staterror=None, syserror=None):
         self.shape = shape
-        Data.__init__(self, name, (x0, x1), y, staterror, syserror)
+        super().__init__(name, (x0, x1), y, staterror, syserror)
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the data


### PR DESCRIPTION
# Summary

Improves the docstrings for DataPHA, adds tests for several corner-cases, and makes some minor code improvements to the code.

# Details

This was found when looking at #1160, #1427 and related, but have been pulled out as it would be nice to get the functionality tested and the minor code improvements added before I spend a lot of time getting stuck on the general topics.

The code changes are that we now use `super()` rather than explicitly calling the parent class in the `__init__` method. We can not do this for all classes in the data/astro.data hierarchy as we don't always have a "clean" hierarchy (and is not something I am planning on addressing here).

A number of tests are labelled as `xfail` rather than just accepting the current behavior. We could change this, but I plan to add PRs to address these tests in the 4.14.1 time frame so they hopefully won't last long.