### PR TITLE
Minor clean up of the data routines

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3388,7 +3388,7 @@ must be an integer.""")
         else:
             val = SherpaFloat(val)
             dep = numpy.array([val] * len(self.get_indep()[0]))
-        setattr(self, 'counts', dep)
+        self.counts = dep
 
     def get_staterror(self, filter=False, staterrfunc=None):
         """Return the statistical error.

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1921,7 +1921,7 @@ def test_1209_response(mode, fexpr, make_data_path):
 @requires_fits
 @requires_data
 def test_1209_background(make_data_path):
-    """Do we pick up the header keywords from the backkground?
+    """Do we pick up the header keywords from the background?
 
     This is related to issue #1209
 

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -123,7 +123,7 @@ def compile_energy_grid(arglist):
 
 
 def bounds_check(lo, hi):
-    """Ensure that the imits of a filter make sense.
+    """Ensure that the limits of a filter make sense.
 
     Note that if only one of them is given we always return
     that value first.
@@ -397,7 +397,7 @@ def _counts(data, lo, hi, func, *args):
 
     It is then time to restore the original filter, which is done in a
     finally block so that any errors calling func or the notice calls
-    does not change the data object.
+    do not change the data object.
 
     The use of the name counts is a bit of a mis-nomer as this could
     be used on non-PHA data, but the user only sees this via

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2008, 2016, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2008, 2016, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -375,8 +376,8 @@ def _counts(data, lo, hi, func, *args):
         data.notice()  # clear filter
         data.notice(lo, hi)
         counts = func(*args).sum()
-        data.notice()
     finally:
+        # restore the old filter
         data.mask = old_mask
         if old_quality_filter is not None:
             data.quality_filter = old_quality_filter
@@ -386,20 +387,14 @@ def _counts(data, lo, hi, func, *args):
 
 def _counts2d(data, reg, func, *args):
     old_mask = data.mask
-    coord = getattr(data, 'coord', None)
     old_region = getattr(data, '_region', None)
     try:
         data.notice2d()  # save and clear filter
-
         data.notice2d(reg)
         counts = func(*args).sum()
-        data.notice2d()
     finally:
+        # restore the old filter
         data.mask = old_mask
-
-        if coord is not None:
-            data.set_coord(coord)
-
         if old_region is not None:
             data._region = old_region
 

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -249,7 +249,7 @@ def make_data(data_class):
     # We want to provide PHA tests that check out the grouping and
     # quality handling (but it is not worth trying all different
     # variants), so we have "grp" for grouping and no quality [*], and
-    # "qual" for groupbing and quality.
+    # "qual" for grouping and quality.
     #
     # [*] by which I mean we have not called ignore_bad, not that
     # there is no quality array.

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2017, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2017, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -497,17 +498,14 @@ def test_stats_calc_stat_wstat_diffbins():
     data, model = setup_single_pha(True, False, background=True)
 
     # Tweak data to have one-less bin than the background
+    counts = data.counts[:-1]
+    staterr = data.staterror[:-1]
+    grouping = data.grouping[:-1]
+
     data.channel = data.channel[:-1]
-    data.counts = data.channel[:-1]
-    for attr in ['staterror', 'syserror', 'grouping', 'quality',
-                 'backscal']:
-        val = getattr(data, attr)
-        if val is not None:
-            try:
-                setattr(data, attr, val[:-1])
-            except TypeError:
-                # assume a scalar, so leave be
-                pass
+    data.counts = counts
+    data.staterror = staterr
+    data.grouping = grouping
 
     # There is no Sherpa error for this, which seems surprising
     with pytest.raises(TypeError):


### PR DESCRIPTION
# Summary

Address several minor code-style changes in the data handling (code and tests).

# Details

This was found working on #1436 but is separate from that work (i.e. can be reviewed separately).

There are two code changes

1. one in handling the `calc_data_sum`/`calc_data_sum2d` (and model variants) routines in the UI layer
2. one in how the `set_dep` method is written for the `DataPHA` class

The first change has two parts

a) removal of unnecessary filters - namely the `notice`/`notice2d` call after summing the data; this is not needed since we explicitly reset the filter in the `fnially` block and so over-ride this call
b) for the 2D case the code would store the coord setting and then reset it, but this is pointless since we don't change the coord setting

Both of these are just changes to stop doing things we don't need to do annd to simplify things for later work (e.g. #1436).

The second change is just a style change, using the more Pythonic `self.channel = val` rather than `setattr(self, "channel") = val`.

For the tests the second commit fixes a logical error in the test: the test just needs a PHA dataset with a different number of channels to the background so it takes the source dataset and removes the last bin from the data fields. We don't actually care what the values are, so I hadn't noticed I'd accidentally set the counts array to match the channel array. This fixes this and simplifies the code a bit to be more explicit about what values it needs to change (ie which are set and an array). I don't know why I wrote the original code to be "generic" - ie to handle any PHA data set it was sent - when it doesn't need to be in this case.

The last commit - `Tests: add explicit tests for calc_data_sum/calc_data_sum2d` - adds some explicit checks of the code in `sherpa.astro.utils`, primarily to ensure we have a case with a quality array, as I noted that this was not being covered by our existing tests (and is related to the code clean up in this PR). I've tried to be systematic, so there's a bunch of unit-like tests checking whether the `calc_data_sum` or `calc_data_sum2d` routines behave as we'd expect (although there are some cases, in particular with the quality array, when it's not obvious what we want the code to do, so in this case the tests are more like regression tests, checking that we will at least know if the behavior changes).
