### PR TITLE
Clean up the data tests

### DIFF
--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -148,22 +148,23 @@ def test_base_data_instantiation():
         BaseData()
 
 
-@pytest.mark.xfail(reason="DataND did not serve any purpose and had a misleading name")
-def test_base_datand_instantiation():
-    DataND()
-
-
-@pytest.mark.xfail(reason="methods did not belong and were removed")
-@pytest.mark.parametrize("data", (Data, Data2D, Data2DInt, Data1DInt), indirect=True)
+@pytest.mark.parametrize("data", (Data, Data2D, Data2DInt), indirect=True)
 def test_data_get_x(data):
-    with pytest.raises(NameError):
+    with pytest.raises(AttributeError):
         data.get_x()
 
 
-@pytest.mark.xfail(reason="methods did not belong and were removed")
+@pytest.mark.xfail
+@pytest.mark.parametrize("data", (Data1DInt, ), indirect=True)
+def test_data_get_x_special(data):
+    # XFAIL: These classes still provide get_x
+    with pytest.raises(AttributeError):
+        data.get_x()
+
+
 @pytest.mark.parametrize("data", DATA_1D_CLASSES, indirect=True)
 def test_data_get_x0(data):
-    with pytest.raises(NameError):
+    with pytest.raises(AttributeError):
         data.get_x0()
 
 
@@ -189,7 +190,7 @@ def test_load_arrays(data_for_load_arrays):
     numpy.testing.assert_array_equal(new_data.get_dep(), data.get_dep())
 
 
-# DATA-NOTE: In the current Sherpa DataND cannot be correctly loaded using load_arrays
+# DATA-NOTE: In the current Sherpa Data cannot be correctly loaded using load_arrays
 @pytest.mark.xfail
 @pytest.mark.parametrize("data_for_load_arrays", (Data, ), indirect=True)
 def test_load_arrays_data(data_for_load_arrays):
@@ -214,10 +215,9 @@ def test_load_arrays_no_errors(data_no_errors):
     numpy.testing.assert_array_equal(new_data.get_dep(), data.get_dep())
 
 
-@pytest.mark.xfail(reason="methods did not belong and were removed")
 @pytest.mark.parametrize("data", DATA_1D_CLASSES, indirect=True)
 def test_data_get_x1(data):
-    with pytest.raises(DataErr):
+    with pytest.raises(AttributeError):
         data.get_x1()
 
 
@@ -567,32 +567,22 @@ def test_data_1d_to_component_plot(data):
     numpy.testing.assert_array_equal(actual[5], expected[5])
 
 
-@pytest.mark.xfail(reason="methods did not belong and were removed")
-@pytest.mark.parametrize("data", (Data, ), indirect=True)
+@pytest.mark.parametrize("data", (Data, Data1D, Data1DInt), indirect=True)
 def test_data_to_contour(data):
-    with pytest.raises(DataErr):
+    with pytest.raises(AttributeError):
         data.to_contour()
 
 
-@pytest.mark.xfail(reason="methods did not belong and were removed")
-@pytest.mark.parametrize("data", (Data, ), indirect=True)
+@pytest.mark.parametrize("data", (Data, Data2D, Data2DInt), indirect=True)
 def test_data_to_plot(data):
-    with pytest.raises(DataErr):
+    with pytest.raises(AttributeError):
         data.to_plot()
 
 
-@pytest.mark.xfail(reason="methods did not belong and were removed")
-@pytest.mark.parametrize("data", (Data, ), indirect=True)
+@pytest.mark.parametrize("data", (Data, Data2D, Data2DInt), indirect=True)
 def test_data_to_component_plot(data):
-    with pytest.raises(DataErr):
+    with pytest.raises(AttributeError):
         data.to_component_plot()
-
-
-@pytest.mark.xfail(reason="methods did not belong and were removed")
-@pytest.mark.parametrize("data", (Data1D, ), indirect=True)
-def test_data_1d_to_contour(data):
-    with pytest.raises(DataErr):
-        data.to_contour()
 
 
 def test_data_simul_fit(data_simul_fit):
@@ -760,11 +750,10 @@ def test_data2_get_imgerr(data):
     numpy.testing.assert_array_equal(data.get_imgerr(), expected_error)
 
 
-@pytest.mark.xfail(reason="Didn't really make sense to have this method for 2D classes")
 @pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
 def test_data2_get_xerr(data):
-    # DATA-NOTE: why is this true for Data2DInt as well?
-    assert data.get_xerr() is None
+    with pytest.raises(AttributeError):
+        data.get_xerr()
 
 
 @pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -372,10 +372,15 @@ def test_data_get_dep_filter(data):
     numpy.testing.assert_array_equal(data.get_dep(filter=True), Y_ARRAY[:X_THRESHOLD + 1])
 
 
-@pytest.mark.parametrize("data", (Data1D, ), indirect=True)
+@pytest.mark.parametrize("data", (Data1D, Data1DInt), indirect=True)
 def test_data_set_dep_filter(data):
-    data.set_dep([0, 1])
-    numpy.testing.assert_array_equal(data.get_dep(filter=True), [0, 1])
+    # This used to be [0, 1] but why would we want this, so check we
+    # can call set_dep with the expected argument size.
+    #
+    data.set_dep([0, 1] * 5)
+    numpy.testing.assert_array_equal(data.get_dep(filter=True), [0, 1] * 5)
+
+    # There's also support for scalar values.
     data.set_dep(0)
     numpy.testing.assert_array_equal(data.get_dep(filter=True), [0] * Y_ARRAY.size)
 


### PR DESCRIPTION
# Summary

Clean up of the data tests which were added as part of the data-class rework in #614.

# Details

Apologies that the commits are discussed oiut-of order (ie second one is desvribed first).

The data hierarchy was re-worked in #614 and as part of this @olaurino added a number of basic tests. Some of these tests now test "old" behavior, and are marked as xfail (since they now fail). For instance, we no longer have a `DataND` class, and so trying to create one is now going to fail, but we still have a test for this. The second commit cleans up the test suite to either:

- change the test from being marked `xfail` to one that passes (so, for example. instead of checking whether we can call a particular method we now check to make sure that method is not defined)
- or remove the test (e.g. checking that you can create a `DataND` object when we now no-longer define this class)

It has been a long time now since #614 so it makes sense to clean up the test suite. Note however that this does not remove all the xfail tests in `sherpa/tests/test_data.py`.
 
The first commit enhances the "can we create a data object with no error values" tests. Previously the test was just for the base `Data` class, which is actually not that useful, as we don't expect users to use this class. It makes more sense to test "user" classes, so we now include tests with the data classes defined in `sherpa.data`. One change is that we no-longer test the base `Data` case, but I believe that the old version of the test - which only used the `Data` class - actually had a logical error in how the `Data` object was being created (I believe the `Session` class, which powers the UI interface, does not support the base `Data` class, just the explicit versions, such as `Data1D` and `Data2DInt`, but we don't explicitly say  this anywhere).

The third commit - `Tests: tweak a test of set_dep handling` - changes a test of the `set_dep` routine: first by adding a test with `Data1DInt` to match the existing `Data1D` test; and second by calling `set_dep` with the correct number of elements (in this case 10) rather than the 2 that was in use. It is not clear what a 2-element array means here (since technically the filter is no-longer valid), so using a "sensible" value makes sense. I plan to address what exactly a `set_dep` call does with an invalid length argument as part of #1436 but we need changes like this in first.

This was found working on #1436 but is separate from that work.