### PR TITLE
Ensure channel and count fields for PHA are aliases of independent and dependent axes

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1363,8 +1363,6 @@ class DataPHA(Data1D):
     ----------
     name : str
         Used to store the file name, for data read from a file.
-    channel
-    counts
     staterror
     syserror
     bin_lo
@@ -1592,8 +1590,9 @@ must be an integer.""")
         channel = _check(channel)
         counts = _check(counts)
 
-        self.channel = channel
-        self.counts = counts
+        # These are now aliases to indep and y so do not need to be set
+        # self.channel = channel
+        # self.counts = counts
         self.bin_lo = bin_lo
         self.bin_hi = bin_hi
         self.quality = quality
@@ -1627,6 +1626,32 @@ must be an integer.""")
         self.units = "channel"
         self.quality_filter = None
         super().__init__(name, channel, counts, staterror, syserror)
+
+    # Set up the aliases for channel and counts
+    #
+    @property
+    def channel(self):
+        """The channel array.
+
+        This is the first, and only, element of the indep attribute.
+        """
+        return self.indep[0]
+
+    @channel.setter
+    def channel(self, val):
+        self.indep = (val, )
+
+    @property
+    def counts(self):
+        """The counts array.
+
+        This is an alias for the y attribute.
+        """
+        return self.y
+
+    @counts.setter
+    def counts(self, val):
+        self.y = val
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the PHA

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021
+#  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -2630,3 +2630,43 @@ def test_pha_channel0_subtract():
         np.array([0, 1, 2, 0, 3, 1], dtype=np.int16)
     assert p1.get_dep(filter=True) == pytest.approx(expected[1:4])
     assert p0.get_dep(filter=True) == pytest.approx(expected[2:5])
+
+
+@pytest.mark.xfail
+def test_set_channel_sets_independent_axis():
+    """What happens if the channel attribute is set?
+
+    This is meant to check if the independent axis is also
+    changed to match the new channel setting.
+
+    """
+    chans = np.arange(1, 5)
+    counts = chans + 1
+    d = DataPHA("x", chans, counts)
+
+    # XFAIL: the independent axis is not changed
+    chans2 = np.arange(10, 20)
+    d.channel = chans2
+    assert len(d.indep) == 1
+    assert d.indep[0] == pytest.approx(chans2)
+    assert d.y == pytest.approx(counts)
+
+
+@pytest.mark.xfail
+def test_set_counts_sets_y_axis():
+    """What happens if the counts attribute is set?
+
+    This is meant to check if the dependent axis is also
+    changed to match the new counts setting.
+
+    """
+    chans = np.arange(1, 5)
+    counts = chans + 1
+    d = DataPHA("x", chans, counts)
+
+    # XFAIL: the y axis is not changed
+    counts2 = chans + 5
+    d.counts = counts2
+    assert len(d.indep) == 1
+    assert d.indep[0] == pytest.approx(chans)
+    assert d.y == pytest.approx(counts2)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2632,7 +2632,6 @@ def test_pha_channel0_subtract():
     assert p0.get_dep(filter=True) == pytest.approx(expected[2:5])
 
 
-@pytest.mark.xfail
 def test_set_channel_sets_independent_axis():
     """What happens if the channel attribute is set?
 
@@ -2644,7 +2643,6 @@ def test_set_channel_sets_independent_axis():
     counts = chans + 1
     d = DataPHA("x", chans, counts)
 
-    # XFAIL: the independent axis is not changed
     chans2 = np.arange(10, 20)
     d.channel = chans2
     assert len(d.indep) == 1
@@ -2652,7 +2650,6 @@ def test_set_channel_sets_independent_axis():
     assert d.y == pytest.approx(counts)
 
 
-@pytest.mark.xfail
 def test_set_counts_sets_y_axis():
     """What happens if the counts attribute is set?
 
@@ -2664,7 +2661,6 @@ def test_set_counts_sets_y_axis():
     counts = chans + 1
     d = DataPHA("x", chans, counts)
 
-    # XFAIL: the y axis is not changed
     counts2 = chans + 5
     d.counts = counts2
     assert len(d.indep) == 1

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1032,7 +1032,6 @@ def test_img_get_filter_compare_filtering(make_test_image):
     assert maska.max() == 1
 
 
-@pytest.mark.xfail
 def test_pha_change_channels(make_test_pha):
     """What happens if we change the channel/count values?
 
@@ -1065,13 +1064,11 @@ def test_pha_change_channels(make_test_pha):
     assert np.all(pha.get_indep()[0] == channels2)
     assert np.all(pha.get_dep() == counts2)
 
-    # XFAIL: These currently return the original data
     assert len(pha.indep) == 1
     assert np.all(pha.indep[0] == channels2)
     assert np.all(pha.dep == counts2)
 
 
-@pytest.mark.xfail
 def test_pha_add_channels(make_test_pha):
     """What happens if we increase the number of channels/counts?
 
@@ -1090,13 +1087,11 @@ def test_pha_add_channels(make_test_pha):
     assert np.all(pha.get_indep()[0] == channels2)
     assert np.all(pha.get_dep() == counts2)
 
-    # XFAIL: These currently return the original data
     assert len(pha.indep) == 1
     assert np.all(pha.indep[0] == channels2)
     assert np.all(pha.dep == counts2)
 
 
-@pytest.mark.xfail
 def test_pha_remove_channels(make_test_pha):
     """What happens if we decrease the number of channels/counts?
 
@@ -1115,7 +1110,6 @@ def test_pha_remove_channels(make_test_pha):
     assert np.all(pha.get_indep()[0] == channels2)
     assert np.all(pha.get_dep() == counts2)
 
-    # XFAIL: These currently return the original data
     assert len(pha.indep) == 1
     assert np.all(pha.indep[0] == channels2)
     assert np.all(pha.dep == counts2)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1032,6 +1032,95 @@ def test_img_get_filter_compare_filtering(make_test_image):
     assert maska.max() == 1
 
 
+@pytest.mark.xfail
+def test_pha_change_channels(make_test_pha):
+    """What happens if we change the channel/count values?
+
+    We have several ways of getting the independent and dependent
+    axes.
+    """
+    pha = make_test_pha
+
+    channels = [1, 2, 3, 4]
+    counts = [1, 2, 0, 3]
+    assert np.all(pha.channel == channels)
+    assert np.all(pha.counts == counts)
+
+    assert len(pha.get_indep()) == 1
+    assert np.all(pha.get_indep()[0] == channels)
+    assert np.all(pha.get_dep() == counts)
+
+    assert len(pha.indep) == 1
+    assert np.all(pha.indep[0] == channels)
+    assert np.all(pha.dep == counts)
+
+    channels2 = [2, 3, 4, 5]
+    counts2 = [20, 30, 20, 10]
+    pha.channel = channels2
+    pha.counts = counts2
+    assert np.all(pha.channel == channels2)
+    assert np.all(pha.counts == counts2)
+
+    assert len(pha.get_indep()) == 1
+    assert np.all(pha.get_indep()[0] == channels2)
+    assert np.all(pha.get_dep() == counts2)
+
+    # XFAIL: These currently return the original data
+    assert len(pha.indep) == 1
+    assert np.all(pha.indep[0] == channels2)
+    assert np.all(pha.dep == counts2)
+
+
+@pytest.mark.xfail
+def test_pha_add_channels(make_test_pha):
+    """What happens if we increase the number of channels/counts?
+
+    Extends test_pha_change_channels
+    """
+    pha = make_test_pha
+
+    channels2 = np.arange(1, 6, dtype=int)
+    counts2 = np.asarray([1, 2, 0, 3, 2], dtype=int)
+    pha.channel = channels2
+    pha.counts = counts2
+    assert np.all(pha.channel == channels2)
+    assert np.all(pha.counts == counts2)
+
+    assert len(pha.get_indep()) == 1
+    assert np.all(pha.get_indep()[0] == channels2)
+    assert np.all(pha.get_dep() == counts2)
+
+    # XFAIL: These currently return the original data
+    assert len(pha.indep) == 1
+    assert np.all(pha.indep[0] == channels2)
+    assert np.all(pha.dep == counts2)
+
+
+@pytest.mark.xfail
+def test_pha_remove_channels(make_test_pha):
+    """What happens if we decrease the number of channels/counts?
+
+    Extends test_pha_change_channels
+    """
+    pha = make_test_pha
+
+    channels2 = np.arange(1, 4, dtype=int)
+    counts2 = np.asarray([3, 1, 2], dtype=int)
+    pha.channel = channels2
+    pha.counts = counts2
+    assert np.all(pha.channel == channels2)
+    assert np.all(pha.counts == counts2)
+
+    assert len(pha.get_indep()) == 1
+    assert np.all(pha.get_indep()[0] == channels2)
+    assert np.all(pha.get_dep() == counts2)
+
+    # XFAIL: These currently return the original data
+    assert len(pha.indep) == 1
+    assert np.all(pha.indep[0] == channels2)
+    assert np.all(pha.dep == counts2)
+
+
 @pytest.mark.parametrize("requested,expected",
                          [("bin", "channel"), ("Bin", "channel"),
                           ("channel", "channel"), ("ChannelS", "channel"),


### PR DESCRIPTION
# Summary

Ensure that channel and the independent axis and counts and the dependent axis are synonymous for the DataPHA class. 

# Details

The `Data` setup has the independent and dependent axes (also known as "some form of x" and "y"). The `DataPHA` class extends this to include the `channel` and `counts` fields, which are essentially just different names for these two concepts, but the code did not enforce them. We have generally caught most cases where this caused a problem. but not all of them. This PR now makes `channel` an alias for the independent axis, and `counts` an alias for the `y` axis. Note that the independent axis is a tuple of components unlike `channel` so the aliasing requires a little bit of finessing.

The first commit just adds some explicit checks and then the second commit enforces the aliasing. We can see that it's only the new tests we added that need to be changed - that is, we haven't broken any existing PHA functionality.

This was identified as part of working on #1436 but I believe is separate from the validation work and so I've made this separate PR in the hope it is easier to review and we can get it merged sooner rather than later, as I have a bunch of planned changes which are already turning out to be an annoying pain to rebase.