### PR TITLE
Tests: ensure sherpa smoke tests are done in a clean environment

### DIFF
--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021
+#  Copyright (C) 2016, 2018, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -132,6 +132,7 @@ class SmokeTest(unittest.TestCase):
         self.x = np.asarray([1, 2, 3])
         self.x2 = self.x + 1
         self.y = np.asarray([1, 2, 3])
+        ui.clean()
 
     def tearDown(self):
         ui.clean()
@@ -147,9 +148,8 @@ class SmokeTest(unittest.TestCase):
         ui.set_method("levmar")
         ui.fit()
         model = ui.get_model_component("p")
-        expected = [0, 1]
-        observed = [model.c0.val, model.c1.val]
-        assert_almost_equal(observed, expected)
+        assert_almost_equal(model.c0.val, 0)
+        assert_almost_equal(model.c1.val, 1)
 
     # Using skipIf directly as we need these tests to run when there is no pytest installed, so we can't use
     # the decorators in sherpa.utils.testing


### PR DESCRIPTION
# Summary

Ensure that the smoke tests are run in a clean environment.

# Details

This ensures that each smoke test runs in a clean environment, that is, sherpa.astro.ui.clean() has been called before running
the tests.

Without this you are subject to other tests that may have changed the statistic (e.g. to Cash) leading to the test failing. This was only a problem if pytest-xdist was used to run tests on multiple cores and you happen to hit certain conditions (depending on how many tests there are, their ordering, and how many cores were used with pytest-xdist). However, it makes sense to make sure we have a stable test here.