### PR TITLE
Tests: mark those that require the group module

### DIFF
--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2018, 2019, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2018, 2019, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,7 +22,8 @@ import numpy
 
 import pytest
 
-from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group, requires_xspec
 
 from sherpa.models import Polynom1D, SimulFitModel
 from sherpa.models.basic import Gauss1D
@@ -33,6 +35,7 @@ from sherpa.astro import ui
 
 
 @requires_data
+@requires_group
 @requires_fits
 @requires_xspec
 def test_ARFModelPHA(make_data_path, clean_astro_ui):

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021
+#  Copyright (C) 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -31,7 +31,7 @@ import pytest
 from sherpa.astro import ui
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_plotting, requires_xspec
+    requires_group, requires_plotting, requires_xspec
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, \
     IdentifierErr, IOErr, ModelErr
 import sherpa.astro.utils
@@ -2395,6 +2395,7 @@ def test_sample_flux_pha_bkg_no_source(idval, make_data_path, clean_astro_ui,
 
 @requires_data
 @requires_fits
+@requires_group
 @requires_xspec
 @pytest.mark.parametrize("idval", [1, 2])
 def test_sample_flux_pha_bkg(idval, make_data_path, clean_astro_ui,

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2020, 2021
+#  Copyright (C) 2007, 2015, 2016, 2018, 2020, 2021, 2022
 #       Smithsonian Astrophysical Observatory
 #
 #
@@ -37,7 +37,7 @@ from sherpa.stats import Cash, CStat, WStat, LeastSq, UserStat, \
     Chi2Gehrels, Chi2ConstVar, Chi2ModVar, Chi2XspecVar, Chi2DataVar
 from sherpa.utils.err import StatErr
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec
+    requires_group, requires_xspec
 
 logger = logging.getLogger("sherpa")
 
@@ -397,6 +397,7 @@ def compare_results(expected, got, tol=1e-6):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2xspecvar_stat(hide_logging, reset_xspec, setup_group):
@@ -418,6 +419,7 @@ def test_chi2xspecvar_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2modvar_stat(hide_logging, reset_xspec, setup_group):
@@ -439,6 +441,7 @@ def test_chi2modvar_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2constvar_stat(hide_logging, reset_xspec, setup_group):
@@ -460,6 +463,7 @@ def test_chi2constvar_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2gehrels_stat(hide_logging, reset_xspec, setup_group):
@@ -481,6 +485,7 @@ def test_chi2gehrels_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_leastsq_stat(hide_logging, reset_xspec, setup_group):
@@ -545,6 +550,7 @@ def test_cash_stat(stat, hide_logging, reset_xspec, setup):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 @pytest.mark.parametrize('stat', [MyChiWithBkg, MyChiNoBkg])
@@ -590,6 +596,7 @@ def test_mycash(stat, hide_logging, reset_xspec, setup_bkg):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 @pytest.mark.parametrize('stat', [MyChiWithBkg, MyChiNoBkg])

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,13 +30,14 @@ import pytest
 
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, \
-    requires_xspec, requires_fits
+    requires_xspec, requires_fits, requires_group
 
 from sherpa.astro import ui
 from sherpa.models.basic import Gauss2D
 
 
 @requires_xspec
+@requires_group
 @requires_fits
 @requires_data
 def test_plot_pvalue(make_data_path, clean_astro_ui, hide_logging):


### PR DESCRIPTION
# Summary

Note a number of tests that require the group module.

# Details

It is possible to build Sherpa with no group module but it's uncommon and we don't currently have a CI run that checks this. Which means we can end up not marking those cases that are known to fail. Let's fix this.

We could add a pip CI run to test this but

- this is not an often-used combination
- I have a bunch of much-more-important changes that completely re-work the CI runs that I do not want to break at this time