### PR TITLE
RTD: update copyright year and fix WCS library

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ for mod_name in ['sherpa.utils._utils',
                  'sherpa.astro.utils._utils',
                  'sherpa.astro.utils._pileup',
                  'sherpa.astro.utils._region',
+                 'sherpa.astro.utils._wcs',
                  'sherpa.astro.models._modelfcts',
                  'sherpa.astro.io.pyfits_backend',
                  'sherpa.image.DS9',
@@ -287,7 +288,7 @@ main_doc = 'index'
 
 # General information about the project.
 project = 'Sherpa'
-copyright = '2019-2021, Chandra X-ray Center, Smithsonian Astrophysical Observatory.'
+copyright = '2019-2022, Chandra X-ray Center, Smithsonian Astrophysical Observatory.'
 author = 'Chandra X-ray Center, Smithsonian Astrophysical Observatory'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
# Summary

Update the sphinx build instructions so that changes from PR #1414 will be documented correctly on systems where the documentation is being built without first compiling the code (such as read-the-docs).

# Details

PR #1414 added documentation for the sherpa.astro.io.wcs module but this requires access to a compiled extension so we need to mock it to build the documentation (when not also building the code).

Updated the copyright year whilst I was here.