### PR TITLE
RTD: update the build-from-CIAO documentation

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -116,7 +116,7 @@ Conda can be used to install all the dependencies for Sherpa, including
     conda install -n sherpaciao --only-deps -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge sherpa
     conda activate sherpaciao
 
-The first line installes the full `CIAO release
+The first line installs the full `CIAO release
 <https://cxc.harvard.edu/ciao/>`_ and astropy, required for building
 and running tests locally.
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -107,7 +107,8 @@ How do I ...
 Install from source in conda
 ----------------------------
 
-Conda can be used to install all the dependencies for Sherpa.
+Conda can be used to install all the dependencies for Sherpa, including
+:term:`XSPEC`.
 
 ::
 
@@ -186,6 +187,7 @@ should be updated to match the output above::
     region-include_dirs=${ASCDS_INSTALL}/include
     region-lib-dirs=${ASCDS_INSTALL}/lib
     region-libraries=region ascdm
+    region-use-cxc-parser=True
 
     wcs=local
     wcs-include-dirs=${ASCDS_INSTALL}/include
@@ -224,12 +226,10 @@ After these steps, Sherpa can be built from source::
 
 .. warning::
 
-   There is a subtle difference in the region-library code when built
-   for CIAO or for Sherpa, even when using the above options. The CIAO
-   version supports using FITS and ASCII region files, rather than
-   only ASCII region files that standalone Sherpa supports. Please
+   This is not guaranteed to build Sherpa in exactly the same manner
+   as used by :term:`CIAO`. Please
    `create an issue <https://github.com/sherpa/sherpa/issues>`_ if
-   FITS region support is needed with standalone Sherpa.
+   this causes problems.
 
 Update the Zenodo citation information
 --------------------------------------

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -111,68 +111,95 @@ Conda can be used to install all the dependencies for Sherpa.
 
 ::
 
-    conda create -n sherpaciao -c https://cxc.cfa.harvard.edu/conda/ciao ds9 astropy ciao
-    conda install -n sherpaciao --only-deps -c https://cxc.cfa.harvard.edu/conda/ciao sherpa
-    conda install -n sherpaciao -c anaconda -c astropy sphinx graphviz sphinx-astropy sphinx_rtd_theme
+    conda create -n sherpaciao -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge ds9 astropy ciao
+    conda install -n sherpaciao --only-deps -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge sherpa
+    conda activate sherpaciao
 
 The first line installes the full `CIAO release
 <https://cxc.harvard.edu/ciao/>`_ and astropy, required for building
-and running tests locally. The last line adds all requirements for
-building the documentation.  Sherpa can use either astropy or crates
-as backend for reading and writing files. The default configuration in
-Sherpa is to use astropy. However, if crates is installed (e.g. by
-installing the `ciao` package) and selected as backend in `sherpa.rc`,
-then astropy can be omitted from the install (but is still needed to
-build the docs).
+and running tests locally.
+
+If you want to also build the documentation then add (after you have
+activated the environment)::
+
+    conda install pandoc
+    pip install sphinx graphviz sphinx-astropy sphinx_rtd_theme nbsphinx ipykernel
+
+.. note::
+   Sherpa can be configured to use crates (from CIAO) or astropy for
+   it's I/O backend by changing the contents of the file
+   ``.sherpa-standalone.rc`` in your home directory. This file can be
+   found, once CIAO is installed, by using the `~sherpa.get_config`
+   routine::
+
+     % python -c 'import sherpa; print(sherpa.get_config())'
+     /home/happysherpauser/.sherpa-standalone.rc
+
+   If Sherpa was installed as part of CIAO then the file will be
+   called ``.sherpa.rc``.
+
+   The ``io_pkg`` line in this file can be changed to select
+   ``crates`` rather than ``pyfits`` which would mean that ``astropy``
+   does not need to be installed (although it would be needed to build
+   the documentation).
 
 As described in :ref:`build-from-source`, the file ``setup.cfg`` in
 the root directory of the sherpa source needs to be modified to
 configure the build. This is particularly easy in this setup, where
 all external dependencies are installed in conda and the enviroment
-variable ``ASCDS_LIB`` is set to the include directory, when the conda
-environment is activated. Thus, all that is needed is to disable the
-build of external dependencies and to set directories. The following
-lists the lines in ``setup.cfg`` that need to be modified (adjust
-xspec version as needed)::
+variable ``ASCDS_INSTALL`` (or ``CONDA_PREFIX``, which has the same
+value) can be used. For most cases, the ``scripts/use_ciao_config``
+script can be used::
 
-    # GROUP Python module
+  % ./scripts/use_ciao_config
+  Found XSPEC version: 12.12.0
+  Updating setup.cfg
+  % git diff setup.cfg
+  ...
+
+Otherwise the file can be edited manually. First find out what
+XSPEC version is present with::
+
+  % conda list xspec-modelsonly --json | grep version
+      "version": "12.12.0"
+
+then change the ``setup.cfg`` to change the following lines, noting
+that the `${ASCDS_INSTALL}` environment variable **must** be
+replaced by its actual value, and the ``xspec_version`` line
+should be updated to match the output above::
+
+    bdist_wheel = sherpa_config xspec_config bdist_wheel
+
+    install_dir=${ASCDS_INSTALL}
+
+    configure=None
+
     disable-group=True
-
-    # File Stack Python module
     disable-stk=True
 
-    # FFTW Library
     fftw=local
-    fftw-include_dirs=${ASCDS_LIB}/../include
-    fftw-lib-dirs=${ASCDS_LIB}
+    fftw-include_dirs=${ASCDS_INSTALL}/include
+    fftw-lib-dirs=${ASCDS_INSTALL}/lib
     fftw-libraries=fftw3
 
-    # Region Library
     region=local
-    region-include_dirs=${ASCDS_LIB}/../include
-    region-lib-dirs=${ASCDS_LIB}
+    region-include_dirs=${ASCDS_INSTALL}/include
+    region-lib-dirs=${ASCDS_INSTALL}/lib
     region-libraries=region ascdm
 
-    # WCS Subroutines
     wcs=local
-    wcs-include-dirs=${ASCDS_LIB}/../include
-    wcs-lib-dirs=${ASCDS_LIB}
+    wcs-include-dirs=${ASCDS_INSTALL}/include
+    wcs-lib-dirs=${ASCDS_INSTALL}/lib
     wcs-libraries=wcs
 
-    # XSPEC Models
-    [xspec_config]
     with-xspec=True
-    xspec_version = 12.10.1
-    xspec_lib_dirs = ${ASCDS_LIB}
-    xspec_include_dirs = ${ASCDS_LIB}/../include
+    xspec_version = 12.12.0
+    xspec_lib_dirs = ${ASCDS_INSTALL}/lib
+    xspec_include_dirs = ${ASCDS_INSTALL}/include
 
 .. note::
-   Due to the way that the setup and install process works, environment
-   variables need to be expanded by hand. So, if your ``ASCDS_LIB`` is set to
-   ``/data/user/conda/envs/sherpaciao/lib`` then you need to expand a line like
-   ``fftw-include_dirs=${ASCDS_LIB}/../include``
-   to ``fftw-include_dirs=/data/user/conda/envs/sherpaciao/lib/../include``
-   in the list above.
+   The XSPEC version may include the patch level, such as ``12.12.0e``,
+   and this can be included in the configuration file.
 
 To avoid accidentially commiting the modified ``setup.cfg`` into git,
 the file can be marked as "assumed unchanged".
@@ -181,14 +208,9 @@ the file can be marked as "assumed unchanged".
 
     git update-index --assume-unchanged setup.cfg
 
-After these steps, the conda enviroment (here called ``sherpaciao``)
-can be activated and Sherpa can be build from source.
+After these steps, Sherpa can be built from source::
 
-::
-
-    conda activate sherpaciao
-    python setup.py develop
-
+    pip install .
 
 .. warning::
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -222,6 +222,14 @@ After these steps, Sherpa can be built from source::
 
    That is, the variable is set to a space, not the empty string.
 
+.. warning::
+
+   There is a subtle difference in the region-library code when built
+   for CIAO or for Sherpa, even when using the above options. The CIAO
+   version supports using FITS and ASCII region files, rather than
+   only ASCII region files that standalone Sherpa supports. Please
+   `create an issue <https://github.com/sherpa/sherpa/issues>`_ if
+   FITS region support is needed with standalone Sherpa.
 
 Update the Zenodo citation information
 --------------------------------------

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -84,6 +84,7 @@ sed -i "s|#region=local|region=local|" $cfg
 sed -i "s|#region-include_dirs=build/include|region-include_dirs=${CONDA_PREFIX}/include|" $cfg
 sed -i "s|#region-lib-dirs=build/lib|region-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i "s|#region-libraries=region|region-libraries=region ascdm|" $cfg
+sed -i "s|#region-use-cxc-parser=False|region-use-cxc-parser=True|" $cfg
 
 sed -i "s|#wcs=local|wcs=local|" $cfg
 # Historically the setup file has used the wrong form here

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -1,0 +1,103 @@
+#!/bin/sh
+#
+# Update the Sherpa configuration file (setup.cfg) to use the
+# CIAO conda installation.
+#
+
+# Check we have the CIAO installation available.
+#
+ciaover > /dev/null
+if [ $? -ne 0 ]; then
+    echo "ERROR: CIAO does not appear to have been activated";
+    exit 1;
+fi
+
+if [ "x$ASCDS_INSTALL" = "x" ]; then
+    echo "ERROR: The ASCDS_INSTALL environment variable is not set";
+    exit 1;
+fi
+
+if [ ! -d $ASCDS_INSTALL ]; then
+    echo "ERROR: ASCDS_INSTALL does not point to a directory";
+    exit 1;
+fi
+
+# Check we have the conda version, and not the ciao-install version.
+#
+if [ "x$CONDA_PREFIX" = "x" ]; then
+    echo "ERROR: CIAO was not installed with conda."
+    exit 1;
+fi
+
+# Sanity check
+#
+if [ "$CONDA_PREFIX" != "$ASCDS_INSTALL" ]; then
+    echo "ERROR: somehow CONDA_PREFIX and ASDCS_INSTALL are not the same"
+    exit 1;
+fi
+
+# Extract the XSPEC version from the conda packaging metadata;
+# hopefully the formatting and structure remain consistent.
+#
+xspec_version=`conda list xspec-modelsonly --json | grep version | awk '{print $2;}' - | tr -d \"`
+if [ "x$xspec_version" = "x" ]; then
+    echo "ERROR: Unable to find out XSPEC version from"
+    conda list xspec-modelsonly --json
+    exit 1;
+fi
+
+echo "Found XSPEC version: $xspec_version"
+
+# Are we in the right directory
+#
+cfg=setup.cfg
+if [ ! -f $cfg ]; then
+    echo "ERROR: Unable to find $cfg";
+    exit 1;
+fi
+
+# Check the file has not been changed (this could be relaxed but
+# try this approach first).
+#
+git diff --exit-code $cfg > /dev/null
+if [ $? -ne 0 ]; then
+    echo "ERROR: $cfg has already been changed."
+    exit 1;
+fi
+
+# Apply the changes line-by-line
+#
+echo "Updating $cfg"
+
+# This change will hopefully be made to the Sherpa distribution
+# so it can be removed from here.
+#
+sed -i "s|bdist_wheel = sherpa_config bdist_wheel|bdist_wheel = sherpa_config xspec_config bdist_wheel|" $cfg
+
+sed -i "s|#install_dir=build|install_dir=${CONDA_PREFIX}|" $cfg
+sed -i "s|#configure=None|configure=None|" $cfg
+
+sed -i "s|#disable-group=True|disable-group=True|" $cfg
+sed -i "s|#disable-stk=True|disable-stk=True|" $cfg
+
+sed -i "s|#region=local|region=local|" $cfg
+sed -i "s|#region-include_dirs=build/include|region-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i "s|#region-lib-dirs=build/lib|region-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i "s|#region-libraries=region|region-libraries=region ascdm|" $cfg
+
+sed -i "s|#wcs=local|wcs=local|" $cfg
+# Historically the setup file has used the wrong form here
+# so support both 'include-dirs' and 'include_dirs'.
+sed -i "s|#wcs-include.dirs=build/include|wcs-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i "s|#wcs-lib-dirs=build/lib|wcs-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i "s|#wcs-libraries=wcs|wcs-libraries=wcs|" $cfg
+
+sed -i "s|#fftw=local|fftw=local|" $cfg
+sed -i "s|#fftw-include_dirs=build/include|fftw-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i "s|#fftw-lib-dirs=build/lib|fftw-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i "s|#fftw-libraries=fftw3|fftw-libraries=fftw3|" $cfg
+
+sed -i "s|#with-xspec=True|with-xspec=True|" $cfg
+sed -i "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|g" $cfg
+sed -i "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|g" $cfg
+sed -i "s|#xspec_version = .*|xspec_version = ${xspec_version}|g" $cfg

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -99,6 +99,6 @@ sed -i "s|#fftw-lib-dirs=build/lib|fftw-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i "s|#fftw-libraries=fftw3|fftw-libraries=fftw3|" $cfg
 
 sed -i "s|#with-xspec=True|with-xspec=True|" $cfg
-sed -i "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|g" $cfg
-sed -i "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|g" $cfg
-sed -i "s|#xspec_version = .*|xspec_version = ${xspec_version}|g" $cfg
+sed -i "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg


### PR DESCRIPTION
# Summary

Update the "build with CIAO" documentation to match the CIAO 4.14 conda instructions and automate the process.

# Details

Adds the `scripts/use_ciao_config` script that automates the setting of the `setup.cfg` file for users of CIAO installed with conda, and update the documentation to match.

Note that this is how I found issue #1452 and changes to that could influence this, but they can be handled separately.