### PR TITLE
Improve several issues when building and testing Sherpa

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -52,3 +52,9 @@ echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC} ${DOCSBUILD}"
 conda create --yes -n build python=${PYTHONVER} pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${DOCSBUILD} ${compilers}
 
 conda activate build
+
+# Force setuptools earlier than 60 - see issue #1456. At present
+# conda seems to default to a working version, but leave this in
+# to ensure it holds, or we find out once we can no-longer do this.
+#
+conda install 'setuptools < 60'

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -59,7 +59,7 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             numpy-version: 1.19
-            install-type: install
+            install-type: develop
             fits: astropy
             test-data: submodule
             matplotlib-version: 3

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -73,6 +73,9 @@ jobs:
           python3 -m venv --system-site-packages tests
           source tests/bin/activate
 
+          # Ensure we use an old-enough setuptools: see issue #1456
+          pip install 'setuptools < 60'
+
           # without this we get configure errors when building fftw and I don't know why
           # (this adds the --disable-dependency-tracking option). A google suggests it
           # could be a make vs gmake issue but we can't easily change this (and it may

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -68,6 +68,8 @@ jobs:
           NUMPYVER='numpy'
         fi
         pip install ${NUMPYVER} ${FITSBUILD} ${MATPLOTLIBVER}
+        # Ensure we use an old-enough setuptools: see issue #1456
+        pip install 'setuptools < 60'
 
     - name: Build Sherpa
       run: |

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -151,6 +151,14 @@ The full Sherpa test suite requires `pytest` and `pytest-xvfb`. These
 packages should be installed automatically for you by the test suite
 if they do not already exist.
 
+.. warning::
+
+   Sherpa includes a number of compiled extensions that use the NumPy
+   C API. Following the `advice from NumPy
+   <https://numpy.org/devdocs/reference/distutils_status_migration.html#numpy-setuptools-interaction>`_,
+   it is **strongly suggested** that `setuptools < 60` is used when
+   building Sherpa.
+
 .. note::
 
    As of the Sherpa 4.10.1 release, a Fortran compiler is no-longer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools",
+requires = ["setuptools < 60",
             "wheel",
             "oldest-supported-numpy",
             ]

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -69,11 +69,6 @@ fi
 #
 echo "Updating $cfg"
 
-# This change will hopefully be made to the Sherpa distribution
-# so it can be removed from here.
-#
-sed -i "s|bdist_wheel = sherpa_config bdist_wheel|bdist_wheel = sherpa_config xspec_config bdist_wheel|" $cfg
-
 sed -i "s|#install_dir=build|install_dir=${CONDA_PREFIX}|" $cfg
 sed -i "s|#configure=None|configure=None|" $cfg
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ build_ext = sherpa_config xspec_config build_ext
 develop = sherpa_config xspec_config develop
 install = sherpa_config xspec_config install
 test = develop test
-bdist_wheel = sherpa_config bdist_wheel
+bdist_wheel = sherpa_config xspec_config bdist_wheel
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
# Summary

Minor improvements to the build and test installation. The use of setuptools has been restricted to match the current advice from NumPy (< 60, from https://numpy.org/devdocs/reference/distutils_status_migration.html).

# Details

This has been rebased onto #1497 (well, a version of that PR) so that the tests pass.

This is a rework of #1335 and is pulled out of #1329 / #1352. The changes are

- one of the CI runs is a bit confused over develop versus install (it used install but than ran the tests, which cause the develop build to be re-build and used); I have tried to rework the CI actions to better handle things but it is not likely to be looked at for a while so this is a simple change
- restrict to `setuptools < 60` following NumPy advice (https://numpy.org/devdocs/reference/distutils_status_migration.html)
- ensure that XSPEC is configured correctly; I believe the CIAO build of Sherpa already makes this change so it will reduce the differences between them, and I have found it necessary to move to PEP 517 and related (e.g. #1329). I have no idea why this was not done a long time ago,