### PR TITLE
Tests: ensure a test is built with a clean UI session

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -393,7 +393,7 @@ def test_save_filter_ignored(bid, tmp_path):
                            "model 1 has not been set"),
                           (ui.save_delchi,  IdentifierErr,
                            "model 1 has not been set")])
-def test_save_xxx_nodata(func, etype, emsg, tmp_path):
+def test_save_xxx_nodata(func, etype, emsg, tmp_path, clean_astro_ui):
     """Does save_xxx error out if there's no data to save? DataPHA
     """
 


### PR DESCRIPTION
# Summary

Fix several tests that could fail when run in parallel.

# Details

The problem here is that the test, as written, needs a "clean" environment - created by the `clean_astro_ui` fixture, but had not been written as such. In this particular case we need the source/model expression not to be set. This turns out to not cause a problem when the tests are run sequentially, e.g. with `pytest` or `python setup.py test`, because it turns out that they are run in such a clean environment. However, when ran in parallel - via the `-n ...` option after installing `pytest-xdist` - we can be in a situation where the source expression has been set by a previous test, causing the test to fail.

This was pulled out of #1458 