### PR TITLE
Minor grouping cleanup

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2926,6 +2926,32 @@ must be an integer.""")
         self.quality_filter = qual_flags
 
     def _dynamic_group(self, group_func, *args, **kwargs):
+        """Group the data using the given function and arguments.
+
+        In order to support the grouping module being optional this
+        routine will error out if it is not loaded (each time it is
+        called). To support Sherpa 4.14.0 and earlier group_func can
+        be a callable, but it is expected to be a string which is the
+        name of the callable from the "group" module (which in this
+        module has been renamed to pygroup if it exists). It also allows
+        the user the capability of sending in a callable that they have
+        written without the need for the group library.
+
+        If group_func is a callable then it must return the grouping
+        and quality arrays for the new scheme.
+
+        """
+
+        if not callable(group_func):
+            if not groupstatus:
+                raise ImportErr('importfailed', 'group', 'dynamic grouping')
+
+            # The assumption is that the symbol exists so it is
+            # not worth catching the AttributeError if it does not,
+            # because that's a programming error and would have been
+            # caught in testing.
+            #
+            group_func = getattr(pygroup, group_func)
 
         keys = list(kwargs.keys())[:]
         for key in keys:
@@ -2949,18 +2975,6 @@ must be an integer.""")
 
         # warning('grouping flags have changed, noticing all bins')
 
-    # Have to move this check here; as formerly written, reference
-    # to pygroup functions happened *before* checking groupstatus,
-    # in _dynamic_group.  So we did not return the intended error
-    # message; rather, a NameError was raised stating that pygroup
-    # did not exist in global scope (not too clear to the user).
-    #
-    # The groupstatus check thus has to be done in *each* of the following
-    # group functions.
-
-    # # Dynamic grouping functions now automatically impose the
-    # # same grouping conditions on *all* associated background data sets.
-    # # CIAO 4.5 bug fix, 05/01/2012
     def group_bins(self, num, tabStops=None):
         """Group into a fixed number of bins.
 
@@ -2999,9 +3013,7 @@ must be an integer.""")
         the quality value for these channels will be set to 2.
 
         """
-        if not groupstatus:
-            raise ImportErr('importfailed', 'group', 'dynamic grouping')
-        self._dynamic_group(pygroup.grpNumBins, len(self.channel), num,
+        self._dynamic_group("grpNumBins", len(self.channel), num,
                             tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
@@ -3043,9 +3055,7 @@ must be an integer.""")
         for these channels will be set to 2.
 
         """
-        if not groupstatus:
-            raise ImportErr('importfailed', 'group', 'dynamic grouping')
-        self._dynamic_group(pygroup.grpBinWidth, len(self.channel), val,
+        self._dynamic_group("grpBinWidth", len(self.channel), val,
                             tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
@@ -3091,9 +3101,7 @@ must be an integer.""")
         quality value for these channels will be set to 2.
 
         """
-        if not groupstatus:
-            raise ImportErr('importfailed', 'group', 'dynamic grouping')
-        self._dynamic_group(pygroup.grpNumCounts, self.counts, num,
+        self._dynamic_group("grpNumCounts", self.counts, num,
                             maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
@@ -3146,9 +3154,7 @@ must be an integer.""")
         quality value for these channels will be set to 2.
 
         """
-        if not groupstatus:
-            raise ImportErr('importfailed', 'group', 'dynamic grouping')
-        self._dynamic_group(pygroup.grpSnr, self.counts, snr,
+        self._dynamic_group("grpSnr", self.counts, snr,
                             maxLength=maxLength, tabStops=tabStops,
                             errorCol=errorCol)
         for bkg_id in self.background_ids:
@@ -3199,9 +3205,7 @@ must be an integer.""")
         quality value for these channels will be set to 2.
 
         """
-        if not groupstatus:
-            raise ImportErr('importfailed', 'group', 'dynamic grouping')
-        self._dynamic_group(pygroup.grpAdaptive, self.counts, minimum,
+        self._dynamic_group("grpAdaptive", self.counts, minimum,
                             maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
@@ -3259,9 +3263,7 @@ must be an integer.""")
         quality value for these channels will be set to 2.
 
         """
-        if not groupstatus:
-            raise ImportErr('importfailed', 'group', 'dynamic grouping')
-        self._dynamic_group(pygroup.grpAdaptiveSnr, self.counts, minimum,
+        self._dynamic_group("grpAdaptiveSnr", self.counts, minimum,
                             maxLength=maxLength, tabStops=tabStops,
                             errorCol=errorCol)
         for bkg_id in self.background_ids:

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2018, 2019, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2018, 2019, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,7 +22,8 @@ import numpy
 
 import pytest
 
-from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group, requires_xspec
 
 from sherpa.models import Polynom1D, SimulFitModel
 from sherpa.models.basic import Gauss1D
@@ -33,6 +35,7 @@ from sherpa.astro import ui
 
 
 @requires_data
+@requires_group
 @requires_fits
 @requires_xspec
 def test_ARFModelPHA(make_data_path, clean_astro_ui):

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021
+#  Copyright (C) 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -31,7 +31,7 @@ import pytest
 from sherpa.astro import ui
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_plotting, requires_xspec
+    requires_group, requires_plotting, requires_xspec
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, FitErr, \
     IdentifierErr, IOErr, ModelErr
 import sherpa.astro.utils
@@ -2395,6 +2395,7 @@ def test_sample_flux_pha_bkg_no_source(idval, make_data_path, clean_astro_ui,
 
 @requires_data
 @requires_fits
+@requires_group
 @requires_xspec
 @pytest.mark.parametrize("idval", [1, 2])
 def test_sample_flux_pha_bkg(idval, make_data_path, clean_astro_ui,

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018, 2020, 2021
+#  Copyright (C) 2007, 2015, 2016, 2018, 2020, 2021, 2022
 #       Smithsonian Astrophysical Observatory
 #
 #
@@ -37,7 +37,7 @@ from sherpa.stats import Cash, CStat, WStat, LeastSq, UserStat, \
     Chi2Gehrels, Chi2ConstVar, Chi2ModVar, Chi2XspecVar, Chi2DataVar
 from sherpa.utils.err import StatErr
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec
+    requires_group, requires_xspec
 
 logger = logging.getLogger("sherpa")
 
@@ -397,6 +397,7 @@ def compare_results(expected, got, tol=1e-6):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2xspecvar_stat(hide_logging, reset_xspec, setup_group):
@@ -418,6 +419,7 @@ def test_chi2xspecvar_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2modvar_stat(hide_logging, reset_xspec, setup_group):
@@ -439,6 +441,7 @@ def test_chi2modvar_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2constvar_stat(hide_logging, reset_xspec, setup_group):
@@ -460,6 +463,7 @@ def test_chi2constvar_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_chi2gehrels_stat(hide_logging, reset_xspec, setup_group):
@@ -481,6 +485,7 @@ def test_chi2gehrels_stat(hide_logging, reset_xspec, setup_group):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 def test_leastsq_stat(hide_logging, reset_xspec, setup_group):
@@ -545,6 +550,7 @@ def test_cash_stat(stat, hide_logging, reset_xspec, setup):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 @pytest.mark.parametrize('stat', [MyChiWithBkg, MyChiNoBkg])
@@ -590,6 +596,7 @@ def test_mycash(stat, hide_logging, reset_xspec, setup_bkg):
 
 
 @requires_fits
+@requires_group
 @requires_xspec
 @requires_data
 @pytest.mark.parametrize('stat', [MyChiWithBkg, MyChiNoBkg])

--- a/sherpa/ui/tests/test_plot_pvalue.py
+++ b/sherpa/ui/tests/test_plot_pvalue.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,13 +30,14 @@ import pytest
 
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, \
-    requires_xspec, requires_fits
+    requires_xspec, requires_fits, requires_group
 
 from sherpa.astro import ui
 from sherpa.models.basic import Gauss2D
 
 
 @requires_xspec
+@requires_group
 @requires_fits
 @requires_data
 def test_plot_pvalue(make_data_path, clean_astro_ui, hide_logging):


### PR DESCRIPTION
# Summary

Minor internal change to how the group routines work for PHA objects.

# Details

This builds on #1453 (which just cleans up the grouping tests, and is the first commit).

Rather than have code like

    def group_a(self, ....):
        if not do_grouping:
            raise-an-error
        self._dynamic_group(pygroup.a, ..)

    def group_b(self, ....):
        if not do_grouping:
            raise-an-error
        self._dynamic_group(pygroup.b, ..)

we move the check for whether the group code has been loaded into `_dynamic_group`. To avoid the errors from trying to access `pygroup.a`, `pygroup.b`, ... we change `_dynamic_group` so that it is sent the name of the callable, rather than the callable itself. This means that in `_dynamic_group` we now need something like `func = getattr(pygroup, name)`.

To avoid possible regressions with any user code that has been calling `_dynamic_group` , and because I think it may still be useful to send a callable to `_dynamic_group`, we still allow the old calling convention.

One thing to note is that the group module is renamed on import - i.e. there's a line like `import group as pygroup` - since we have too much code that uses `group` as a symbol. Which is wy we talk about `pygrgroup.grpRandomMethod` rather than `group.grpRandomMethod`.

I have also removed a few comments which have been left over from the pre-git days of Sherpa and which no-longer add value to the code.