### PR TITLE
Docs: fix up documentation of ui.set_grouping

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1787,10 +1787,72 @@ def test_pha_column_has_correct_size(label, vals, clean_astro_ui):
     """
 
     ui.load_arrays(1, [1, 2, 3, 4, 5], [5, 4, 2, 3, 7], ui.DataPHA)
-    pha = ui.get_data()
 
     with pytest.raises(DataErr) as de:
         # This does not throw an error
         getattr(ui, f"set_{label}")(vals)
 
     assert str(de.value) == f"size mismatch between channel and {label}"
+
+
+@pytest.mark.parametrize("label", ["grouping", "quality"])
+def test_pha_column_checks_pha(label, clean_astro_ui):
+    """Check we error out with a non-PHA class"""
+
+    ui.load_arrays(1, [1, 2, 3, 4, 5], [5, 4, 2, 3, 7], ui.Data1D)
+
+    with pytest.raises(ArgumentErr) as err:
+        getattr(ui, f"get_{label}")()
+
+    assert str(err.value) == "data set 1 does not contain PHA data"
+
+
+@pytest.mark.parametrize("label", ["grouping", "quality"])
+def test_pha_column_converts_to_int(label, clean_astro_ui):
+    """Check that the label column is converted to an int"""
+
+    ui.load_arrays(1, [1, 2, 3, 4, 5], [5, 4, 2, 3, 7], ui.DataPHA)
+
+    getfunc = getattr(ui, f"get_{label}")
+    setfunc = getattr(ui, f"set_{label}")
+    assert getfunc() is None
+
+    vals = [2.0, -2.0, 1.5, 1.9, 1.2]
+    setfunc(vals)
+
+    got = getfunc()
+    assert len(got) == 5
+    assert isinstance(got, np.ndarray)
+    assert issubclass(got.dtype.type, np.integer)
+    assert got == pytest.approx([2, -2, 1, 1, 1])
+
+
+def test_pha_does_set_grouping_set_grouped(clean_astro_ui):
+    """If the grouping column is set is the data automatically grouped?"""
+
+    counts = [5, 4, 2, 3, 7]
+    ui.load_arrays(1, [1, 2, 3, 4, 5], counts, ui.DataPHA)
+    pha = ui.get_data()
+
+    assert pha.grouping is None
+    assert not pha.grouped
+    assert ui.get_dep() == pytest.approx(counts)
+
+    ui.set_grouping([1, -1, 1, 1, 1])
+
+    # ui.get_dep returns somethng when grouped
+    assert pha.grouping is not None
+    assert not pha.grouped
+    assert ui.get_dep() == pytest.approx(counts)
+
+
+
+def test_pha_what_does_get_dep_return_when_grouped(clean_astro_ui):
+    """Regression test for get_dep with grouped data"""
+
+    ui.load_arrays(1, [1, 2, 3, 4, 5], [5, 4, 2, 3, 7], ui.DataPHA)
+    ui.set_grouping([1, -1, 1, -1, -1])
+    ui.group()
+
+    # Looks like it's returning sum of group / number of channels in group
+    assert ui.get_dep() == pytest.approx([4.5, 4])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -7437,8 +7437,7 @@ class Session(sherpa.ui.utils.Session):
 
         A group is indicated by a sequence of flag values starting
         with ``1`` and then ``-1`` for all the channels in the group,
-        following [1]_.  Setting the grouping column automatically
-        turns on the grouping flag for that data set.
+        following [1]_.
 
         Parameters
         ----------
@@ -7494,10 +7493,11 @@ class Session(sherpa.ui.utils.Session):
         --------
 
         Copy the grouping array from data set 2 into the default data
-        set:
+        set and ensure it is applied:
 
         >>> grp = get_grouping(2)
         >>> set_grouping(grp)
+        >>> group()
 
         Copy the grouping from data set "src1" to the source and the
         first background data set of "src2":
@@ -7505,6 +7505,7 @@ class Session(sherpa.ui.utils.Session):
         >>> grp = get_grouping("src1")
         >>> set_grouping("src2", grp)
         >>> set_grouping("src2", grp, bkg_id=1)
+        >>> group("src2")
 
         """
         if val is None:


### PR DESCRIPTION
# Summary

Fix the documentation for set_grouping to match the code.

# Details

The documentation suggested that setting the grouping column automatically set the groupng flag, but it does not. A test has
been added to check this and the documentation updated. A few other tests have been added to check the set_grouping/quality handling.

We could change the behavior to match the old documentation.