### PR TITLE
RTD: include the DataOgipResponse class in the documentation

### DIFF
--- a/docs/data/astrodata.rst
+++ b/docs/data/astrodata.rst
@@ -7,19 +7,20 @@ The sherpa.astro.data module
 .. automodule:: sherpa.astro.data
 
    .. rubric:: Classes
-               
+
    .. autosummary::
       :toctree: api
 
-      DataPHA
+      DataOgipResponse
       DataARF
       DataRMF
+      DataRosatRMF
+      DataPHA
       DataIMG
       DataIMGInt
-      DataRosatRMF
-   
+
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: DataPHA DataARF DataRMF DataIMG DataIMGInt DataRosatRMF
+.. inheritance-diagram:: DataOgipResponse DataARF DataRMF DataRosatRMF DataPHA DataIMG DataIMGInt
    :parts: 1


### PR DESCRIPTION
# Summary

Add a missing class (`DataOgipResponse`) to the documentation.