### PR TITLE
allow user to use minuit if they install it

### DIFF
--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2020, 2021
+#  Copyright (C) 2007, 2015, 2018, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -812,69 +812,18 @@ class NelderMead(OptMethod):
         OptMethod.__init__(self, name, neldermead)
 
 
-###############################################################################
+try:
+    from iminuit import Minuit
+    from sherpa.optmethods.myminuit import myminuit
 
-# # from sherpa.optmethods.fminpowell import *
-# # from sherpa.optmethods.nmpfit import *
+    tmp = list(__all__)
+    tmp.append('Minuit')
+    __all__ = tuple(tmp)
 
-# # from sherpa.optmethods.odrpack import odrpack
-# # from sherpa.optmethods.stogo import stogo
-# # from sherpa.optmethods.chokkan import chokkanlbfgs
-# # from sherpa.optmethods.odr import odrf77
+    class Minuit(OptMethod):
+        r"""https://iminuit.readthedocs.io/en/stable/"""
+        def __init__(self, name='minuit'):
+            OptMethod.__init__(self, name, myminuit)
 
-# # def myall( targ, arg ):
-# #     fubar = list( targ )
-# #     fubar.append( arg )
-# #     return tuple( fubar )
-
-# # __all__ = myall( __all__, 'Bobyqa' )
-# # __all__ = myall( __all__, 'Chokkan' )
-# # __all__ = myall( __all__, 'cppLevMar' )
-# # __all__ = myall( __all__, 'Dif_Evo' )
-# # __all__ = myall( __all__, 'MarLev' )
-# # __all__ = myall( __all__, 'MyMinim' )
-# # __all__ = myall( __all__, 'Nelder_Mead' )
-# # __all__ = myall( __all__, 'NMPFIT' )
-# # __all__ = myall( __all__, 'Newuoa' )
-# # __all__ = myall( __all__, 'Odr' )
-# # __all__ = myall( __all__, 'OdrPack' )
-# # __all__ = myall( __all__, 'PortChi' )
-# # __all__ = myall( __all__, 'PortFct' )
-# # __all__ = myall( __all__, 'ScipyPowell' )
-# # __all__ = myall( __all__, 'StoGo' )
-
-# # class Chokkan(OptMethod):
-# #     def __init__(self, name='chokkan'):
-# #         OptMethod.__init__(self, name, chokkanlbfgs)
-
-# # class cppLevMar(OptMethod):
-
-# #    def __init__(self, name='clevmar'):
-# # 	OptMethod.__init__(self, name, optfcts.lmdif_cpp)
-
-# # class MyMinim(OptMethod):
-
-# #     def __init__(self, name='simplex'):
-# # 	OptMethod.__init__(self, name, minim)
-
-# # class NMPFIT(OptMethod):
-# #     def __init__(self, name='pytools_nmpfit'):
-# #         OptMethod.__init__(self, name, nmpfit.pytools_nmpfit)
-
-# # class OdrPack(OptMethod):
-# #     def __init__(self, name='odrpack'):
-# #         OptMethod.__init__(self, name, odrpack)
-
-# # class Odr(OptMethod):
-# #     def __init__(self, name='odr'):
-# #         OptMethod.__init__(self, name, odrf77)
-
-# # class ScipyPowell(OptMethod):
-# #     def __init__(self, name='scipypowell'):
-# #         OptMethod.__init__(self, name, my_fmin_powell)
-
-# # class StoGo(OptMethod):
-# #     def __init__(self, name='stogo'):
-# # 	OptMethod.__init__(self, name, stogo)
-
-###############################################################################
+except ImportError:
+    pass

--- a/sherpa/optmethods/myminuit.py
+++ b/sherpa/optmethods/myminuit.py
@@ -1,0 +1,80 @@
+#
+# https://github.com/scikit-hep/iminuit
+#
+import numpy
+from iminuit import Minuit
+from sherpa.optmethods.optfcts import EPSILON, _check_args, _get_saofit_msg
+from sherpa.models.parameter import hugeval
+
+__all__ = ('myminuit',)
+
+
+def myminuit(fcn, x0, xmin, xmax, tol=EPSILON, maxfev=None, leastsqr=True,
+             migrad=True, verbose=0):
+    """if migrad == False then use Minuit simplex optimization"""
+
+    def stat_cb0(pars):
+        return fcn(pars)[0]
+
+    x0, xmin, xmax = _check_args(x0, xmin, xmax)
+
+    bounds = []
+    x_tmp = None
+    y_tmp = None
+    myhugeval = hugeval / 10.0
+    for xxx, yyy in zip(xmin, xmax):
+        x_tmp = xxx
+        # +/- inf to preven iminuit from transforming
+        if xxx < - myhugeval:
+            x_tmp = - numpy.inf
+        y_tmp = yyy
+        if yyy > myhugeval:
+            y_tmp = numpy.inf
+        bounds.append((x_tmp, y_tmp))
+
+    midnight =  Minuit(stat_cb0, numpy.asarray(x0))
+    midnight.limits = bounds
+    midnight.errors = tol
+    midnight.print_level = verbose
+    if leastsqr:
+        midnight.errordef = Minuit.LEAST_SQUARES
+    else:
+        midnight.errordef = Minuit.LIKELIHOOD
+
+    if migrad:
+        if maxfev is None:
+            maxfev = 128 * len(x0)
+        midnight.migrad(ncall=maxfev)
+    else:
+        if maxfev is None:
+            maxfev = 512 * len(x0)
+        midnight.simplex(ncall=maxfev)
+
+    nfev = midnight.nfcn
+    fval = midnight.fval
+    # x = numpy.asarray([ val for val in midnight.values ])
+    x = midnight.values
+    
+    if midnight.valid:
+        status, msg = _get_saofit_msg(maxfev, 0)
+        if midnight.accurate:
+            pass
+        else:
+            msg += ", but uncertainties are unrealiable."
+    else:
+        fmin = midnight.fmin
+        status, msg = _get_saofit_msg(maxfev, 4)
+        if fmin.has_reached_call_limit:
+            status, msg = _get_saofit_msg(maxfev, 3)
+        if fmin.is_above_max_edm:
+            msg += " Estimated distance to minimum too large."
+
+    npar = len(x)
+    if midnight.covariance is not None:
+        covar = midnight.covariance
+        rv = (status, x, fval, msg, {'nfev': nfev,
+                                     'covar': covar, 'info': 1})
+    else:
+        rv = (status, x, fval, msg, {'nfev': nfev, 'info': 1})
+
+    return rv

--- a/sherpa/optmethods/tests/test_iminuit.py
+++ b/sherpa/optmethods/tests/test_iminuit.py
@@ -1,0 +1,612 @@
+#
+#  Copyright (C) 2022  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+import numpy
+
+from sherpa.utils.testing import requires_iminuit
+from sherpa.optmethods import _tstoptfct
+
+try:
+    from sherpa.optmethods.myminuit import myminuit
+except ImportError:
+    pass
+
+def init(name, npar):
+    x0, _, _, fmin = _tstoptfct.init(name, npar)
+    # make sure minuit does not transform
+    xmin = npar * [-numpy.inf]
+    xmax = npar * [numpy.inf]
+    return x0, xmin, xmax, fmin
+
+def tst_opt(fct, migrad, npar, reltol=1.0e-3, abstol=1.0e-3):
+    """The central function for all the optimization test
+    1) Out of the 35 tests from:
+    J. MORE', B. GARBOW & K. HILLSTROM,
+    "Algorithm 566: Fortran Subroutines for Testing Unconstrained
+    Optimization Software.", ACM TOMS, VOL. 7, PAGES 14-41 AND 136-140, 1981
+    xfail: lmdif(6), minim(5), neldermead(3), moncar(2)
+    2) The remaining random 32 'global' func tests:
+    xfail: minim(14), montecarlo(0), neldermead(10)
+    """
+    x0, xmin, xmax, fmin = init(fct.__name__, npar)
+    status, x, fval, msg, xtra = myminuit(fct, x0, xmin, xmax, migrad=migrad)
+    assert fval == pytest.approx(fmin, rel=reltol, abs=abstol)
+
+
+###############################################################################
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(True, marks=pytest.mark.xfail)])
+def test_rosenbrock(migrad, npar=4):
+    tst_opt(_tstoptfct.rosenbrock, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_freudensteinroth(migrad, npar=4):
+    tst_opt(_tstoptfct.freudenstein_roth, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_powell_badly_scaled(migrad, npar=2):
+    tst_opt(_tstoptfct.powell_badly_scaled, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_brown_badly_scaled(migrad, npar=2):
+    tst_opt(_tstoptfct.brown_badly_scaled, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_beale(migrad, npar=2):
+    tst_opt(_tstoptfct.beale, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_jennrich_sampson(migrad, npar=2):
+    tst_opt(_tstoptfct.jennrich_sampson, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_helical_valley(migrad, npar=3):
+    tst_opt(_tstoptfct.helical_valley, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_bard(migrad, npar=3):
+    tst_opt(_tstoptfct.bard, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, False])
+def test_gaussian(migrad, npar=3):
+    tst_opt(_tstoptfct.gaussian, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_meyer(migrad, npar=3):
+    tst_opt(_tstoptfct.meyer, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_gulf_research_development(migrad, npar=3):
+    tst_opt(_tstoptfct.gulf_research_development, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_box3d(migrad, npar=3):
+    tst_opt(_tstoptfct.box3d, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_powell_singular(migrad, npar=4):
+    tst_opt(_tstoptfct.powell_singular, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_wood(migrad, npar=4):
+    tst_opt(_tstoptfct.wood, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_kowalik_osborne(migrad, npar=4):
+    tst_opt(_tstoptfct.kowalik_osborne, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_brown_dennis(migrad, npar=4):
+    tst_opt(_tstoptfct.brown_dennis, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_osborne1(migrad, npar=5):
+    tst_opt(_tstoptfct.osborne1, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_biggs(migrad, npar=6):
+    tst_opt(_tstoptfct.biggs, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_osborne2(migrad, npar=11):
+    tst_opt(_tstoptfct.osborne2, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_watson(migrad, npar=6):
+    tst_opt(_tstoptfct.watson, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_extended_rosenbrock(migrad, npar=12):
+    tst_opt(_tstoptfct.rosenbrock, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_extended_powell_singular(migrad, npar=8):
+    tst_opt(_tstoptfct.powell_singular, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_penaltyI(migrad, npar=4):
+    tst_opt(_tstoptfct.penaltyI, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_penaltyII(migrad, npar=4):
+    tst_opt(_tstoptfct.penaltyII, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_variably_dimensioned(migrad, npar=6):
+    tst_opt(_tstoptfct.variably_dimensioned, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_trigonometric(migrad, npar=4):
+    tst_opt(_tstoptfct.trigonometric, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_brown_almost_linear(migrad, npar=3):
+    tst_opt(_tstoptfct.brown_almost_linear, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_discrete_boundary(migrad, npar=4):
+    tst_opt(_tstoptfct.discrete_boundary, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_discrete_integral(migrad, npar=4):
+    tst_opt(_tstoptfct.discrete_integral, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_broyden_tridiagonal(migrad, npar=4):
+    tst_opt(_tstoptfct.broyden_tridiagonal, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_broyden_banded(migrad, npar=4):
+    tst_opt(_tstoptfct.broyden_banded, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_linear_fullrank(migrad, npar=4):
+    tst_opt(_tstoptfct.linear_fullrank, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_linear_fullrank1(migrad, npar=4):
+    tst_opt(_tstoptfct.linear_fullrank1, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_linear_fullrank0cols0rows0(migrad, npar=4):
+    tst_opt(_tstoptfct.linear_fullrank0cols0rows, migrad, npar)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [True, pytest.param(False, marks=pytest.mark.xfail)])
+def test_linear_chebyquad(migrad, npar=9):
+    tst_opt(_tstoptfct.chebyquad, migrad, npar)
+
+# ###############################################################################
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Ackley(migrad, npar=4):
+    tst_opt(_tstoptfct.Ackley, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Booth(migrad, npar=6):
+    tst_opt(_tstoptfct.Booth, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Bohachevsky1(migrad, npar=2):
+    tst_opt(_tstoptfct.Bohachevsky1, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Bohachevsky2(migrad, npar=2):
+    tst_opt(_tstoptfct.Bohachevsky2, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Bohachevsky3(migrad, npar=2):
+    tst_opt(_tstoptfct.Bohachevsky3, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Branin(migrad, npar=2):
+    tst_opt(_tstoptfct.Branin, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Branin2(migrad, npar=2):
+    tst_opt(_tstoptfct.Branin2, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Chichinadze(migrad, npar=2):
+    tst_opt(_tstoptfct.Chichinadze, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Cola(migrad, npar=17):
+    tst_opt(_tstoptfct.Cola, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Colville(migrad, npar=4):
+    tst_opt(_tstoptfct.Colville, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_dcs(migrad, npar=5):
+    tst_opt(_tstoptfct.dcs, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_decanom(migrad, npar=2):
+    tst_opt(_tstoptfct.decanom, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_dodecal(migrad, npar=3):
+    tst_opt(_tstoptfct.dodecal, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_DixonPrice(migrad, npar=5):
+    tst_opt(_tstoptfct.DixonPrice, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Easom(migrad, npar=5):
+    tst_opt(_tstoptfct.Easom, migrad, npar, False)
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_factor(migrad, npar=5):
+    tst_opt(_tstoptfct.factor, migrad, npar, False)
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Func1(migrad, npar=2):
+    tst_opt(_tstoptfct.Func1, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Griewank(migrad, npar=2):
+    tst_opt(_tstoptfct.Griewank, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Hansen(migrad, npar=2):
+    tst_opt(_tstoptfct.Hansen, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Hartman6(migrad, npar=6):
+    tst_opt(_tstoptfct.Hartman6, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Himmelblau(migrad, npar=2):
+    tst_opt(_tstoptfct.Himmelblau, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Holzman1(migrad, npar=3):
+    tst_opt(_tstoptfct.Holzman1, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Holzman2(migrad, npar=3):
+    tst_opt(_tstoptfct.Holzman2, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Judge(migrad, npar=3):
+    tst_opt(_tstoptfct.Judge, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Levy(migrad, npar=4):
+    tst_opt(_tstoptfct.Levy, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_McCormick(migrad, npar=2):
+    tst_opt(_tstoptfct.McCormick, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_McKinnon(migrad, npar=2):
+    tst_opt(_tstoptfct.McKinnon, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Michalewicz(migrad, npar=2):
+    tst_opt(_tstoptfct.Michalewicz, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Paviani(migrad, npar=10):
+    tst_opt(_tstoptfct.Paviani, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Rastrigin(migrad, npar=4):
+    tst_opt(_tstoptfct.Rastrigin, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_seqp(migrad, npar=2):
+    tst_opt(_tstoptfct.seqp, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Shekel5(migrad, npar=4):
+    tst_opt(_tstoptfct.Shekel5, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Shekel7(migrad, npar=4):
+    tst_opt(_tstoptfct.Shekel7, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Shekel10(migrad, npar=4):
+    tst_opt(_tstoptfct.Shekel10, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_ShekelModified(migrad, npar=2):
+    tst_opt(_tstoptfct.ShekelModified, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Shubert(migrad, npar=2):
+    tst_opt(_tstoptfct.Shubert, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_SixHumpCamel(migrad, npar=2):
+    tst_opt(_tstoptfct.SixHumpCamel, migrad, npar, False)
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Trecanni(migrad, npar=2):
+    tst_opt(_tstoptfct.Trecanni, migrad, npar, False)
+
+
+@requires_iminuit
+@pytest.mark.parametrize("migrad",
+                         [pytest.param(True, marks=pytest.mark.xfail),
+                          pytest.param(False, marks=pytest.mark.xfail)])
+def test_Trefethen4(migrad, npar=2):
+    tst_opt(_tstoptfct.Trefethen4, migrad, npar, False)

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -188,6 +188,9 @@ if HAS_PYTEST:
     def requires_xspec(test_function):
         return requires_package("xspec required", "sherpa.astro.xspec")(test_function)
 
+    def requires_iminuit(test_function):
+        return requires_package("iminuit required", "iminuit")(test_function)
+
 else:
 
     def wrapped():
@@ -213,6 +216,8 @@ else:
     requires_ds9 = make_fake()
 
     requires_xspec = make_fake()
+
+    requires_iminuit = make_fake()
 
     def requires_package(*args):
         return make_fake()


### PR DESCRIPTION
If ```iminuit``` is not available:
```bash
(testing-PR) [dtn@devel12 optionalMinuit]$ pip uninstall iminuit
Found existing installation: iminuit 2.9.0
Uninstalling iminuit-2.9.0:
  Would remove:
    /export/miniconda/envs/testing-PR/lib/python3.9/site-packages/iminuit-2.9.0.dist-info/*
    /export/miniconda/envs/testing-PR/lib/python3.9/site-packages/iminuit/*
Proceed (Y/n)? Y
  Successfully uninstalled iminuit-2.9.0
```
then we waste ~ .23secs

```Python
(testing-PR) [dtn@devel12 optionalMinuit]$ pytest sherpa/optmethods/tests/test_iminuit.py
============================= test session starts ==============================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /export/optionalMinuit, configfile: pytest.ini
collected 148 items                                                            

sherpa/optmethods/tests/test_iminuit.py ssssssssssssssssssssssssssssssss [ 21%]
ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 70%]
ssssssssssssssssssssssssssssssssssssssssssss                             [100%]

=========================== short test summary info ============================
SKIPPED [2] sherpa/optmethods/tests/test_iminuit.py:53: iminuit required

...
SKIPPED [2] sherpa/optmethods/tests/test_iminuit.py:607: iminuit required
============================= 148 skipped in 0.23s =============================
```
However if ```iminuit``` is installed via:
```bash
(testing-PR) [dtn@devel12 optionalMinuit]$ pip install iminuit
Collecting iminuit
  Using cached iminuit-2.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (335 kB)
Requirement already satisfied: numpy in /export/miniconda/envs/testing-PR/lib/python3.9/site-packages (from iminuit) (1.21.2)
Installing collected packages: iminuit
Successfully installed iminuit-2.9.0
```
then
```Python
(testing-PR) [dtn@devel12 optionalMinuit]$ pytest sherpa/optmethods/tests/test_iminuit.py
============================= test session starts ==============================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /export/optionalMinuit, configfile: pytest.ini
collected 148 items                                                            

sherpa/optmethods/tests/test_iminuit.py .Xxx.x.xXx.x.x.x..xx.xxx.xXx.x.x [ 21%]
.x.X.x.x.x.x.x.x.x.xxx.x.x.x.x.x.x.x.xxxXXxxXxxxXxxxxxxxXxxxxxXxXxxxxxxx [ 70%]
xxxxxxXxxxXxxxxxXxxxXxxxxxXxxxxxxxxxxxxxXxxx                             [100%]

================= 30 passed, 101 xfailed, 17 xpassed in 1.99s ==================
```