### PR TITLE
tests: remove work-around for #1334 from #1336

### DIFF
--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -845,7 +845,6 @@ class ReNormalizerModel1DInt(CompositeModel, ArithmeticModel):
 
 # TODO: more tests when regridding the models
 
-@pytest.mark.xfail  # see #1334
 def test_regrid1d_works_with_convolution_style():
     """This doesn't really test more than the previous
     model-evaluation tests.

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -679,7 +679,7 @@ def test_create_expr_mask_size_error(mask):
 
 @pytest.mark.parametrize("val,expected",
                          [(numpy.int16(3), "3"),
-                          pytest.param(numpy.float32(3), "3.0", marks=pytest.mark.xfail)  # see #1334
+                          (numpy.float32(3), "3.0")
                           ])
 def test_create_expr_singleton(val, expected):
     """Simple test of create_expr with no mask."""


### PR DESCRIPTION
# Summary

Remove a test work around for our CI tests failing (issue #1334)

# Details

In #1334 we noted that on CI runs some builds would fail. It was never obvious why, so we marked them xfail in #1336. Remove this setting. It looks like we can do this now (as I don't know why the problem occurred I don't know if it's some particular version of OTS we use that caused problems., or maybe some of the build changes like #1329, or some combination, or ...).