### PR TITLE
Data test minor cleanup

### DIFF
--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1276,10 +1276,16 @@ def test_write_pha_missing_column(column, is_ascii, tmp_path):
     At the moment we write out the file.
     """
 
-    chans = np.arange(1, 4, dtype=np.int32)
-    counts = np.arange(1, 4, dtype=np.int32)
+    if column == "channel":
+        chans = None
+        counts = np.arange(1, 4, dtype=np.int32)
+    elif column == "counts":
+        chans = np.arange(1, 4, dtype=np.int32)
+        counts = None
+    else:
+        assert False, "unknown column"
+
     pha = DataPHA("tmp", chans, counts)
-    setattr(pha, column, None)
 
     tmpfile = tmp_path / 'test.out'
     assert not tmpfile.exists()

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -571,7 +571,7 @@ def test_calc_data_sum2d_no_range_2d(data_class):
 
 
 # XFAIL: We can not use DataIMGInt here because of issue #1379
-@pytest.mark.parametrize("data_class", ["img", pytest.param("imgnit", marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("data_class", ["img", pytest.param("imgint", marks=pytest.mark.xfail)])
 def test_calc_data_sum2d_filtered_2d(data_class):
     """Call calc_data_sum2d(data, region)"""
 
@@ -580,6 +580,7 @@ def test_calc_data_sum2d_filtered_2d(data_class):
     assert np.iterable(data.mask)
     omask = data.mask.copy()
     orig = data.get_dep(filter=True).copy()
+    # XFAIL: DataIMGInt returns 7, not 16
     assert utils.calc_data_sum2d(data, "rect(0, 0, 2, 3)") == 16
     assert data.mask == pytest.approx(omask)
     assert data.get_dep(filter=True) == pytest.approx(orig)

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -344,7 +344,7 @@ def setup_err_estimate_multi_ids(strings=False):
     and was evaluated and passed through sherpa.utils.poisson_noise
     to create the datasets.
 
-    Since we can have strnig or integer ids we allow either,
+    Since we can have string or integer ids we allow either,
     but do not try to mix them.
 
     """


### PR DESCRIPTION
# Summary

Minor test clean-ups.

# Details

This is part of my work on #1470 but they are really unrelated to that wirk, they are just test clean-ups. The main changes are that I have finally removed the `create_arf/delta_rmf` functions from the test file as they are now available in `sherpa.astro.instrument` (these routines were originally written for the tests and than got moved over to the instrument code but the test was never updated), and I fixed up a failing test (added in #1440) to still be failing, but to fail properly rather than due to a typo in the test itself.

One of the tests has to create a `DataPHA` instance that has a different number of elements to the original object. This is currently easy, as you can change the fields such as `counts` and `channels`, at will. However, if we ever implement #1470 then this may not be possible, so wthe test now explicitly creates a new `DataPHA` instance (this is `test_stats_calc_stat_wstat_diffbins` in `sherpa/stats/tests/test_stats_unit.py`). Both approaches currently work, but the new version should be valid however we implement #1470.