### PR TITLE
Add basic tests of data validation

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2853,6 +2853,34 @@ def test_pha_related_field_can_not_be_a_sequence_wrong_size(label, vals):
     setattr(data, label, vals)
 
 
+
+def test_pha_mask_size_must_match_ungrouped():
+    """Check if the mask can be set to the wrong length: data not grouped"""
+
+    chans = np.arange(1, 9)
+    counts = np.ones(8)
+    data = DataPHA("mask", chans, counts)
+    data.grouping = [1, -1, -1, 1, -1, -1, 1, 1]
+    assert not data.grouped
+
+    # does not raise an error
+    data.mask = [1, 0, 1]
+
+
+def test_pha_mask_size_must_match_grouped():
+    """Check if the mask can be set to the wrong length: data grouped"""
+
+    chans = np.arange(1, 9)
+    counts = np.ones(8)
+    data = DataPHA("mask", chans, counts)
+    data.grouping = [1, -1, -1, 1, -1, -1, 1, 1]
+    data.grouped = True
+
+    # The length is chosen to match the un-grouped data.
+    # does not raise an error
+    data.mask = [1, 0, 1, 1, 0, 1, 0, 0]
+
+
 @pytest.mark.parametrize("funcname", ["eval_model", "eval_model_to_fit"])
 def test_pha_eval_model_checks_dimensionality_pha(funcname):
     """Does eval_model check the model dimensionality?"""

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2607,6 +2607,22 @@ def test_invalid_independent_axis(data_args):
 
 
 @pytest.mark.parametrize("data_args",
+                         [ARF_ARGS, RMF_ARGS, IMG_ARGS, IMGINT_ARGS])
+def test_invalid_independent_axis_component(data_args):
+    """What happens if we use mis-matched sizes?
+
+    We remove one entry from the second component,
+    """
+
+    data_class, args = data_args
+    data = data_class(*args)
+    indep = list(data.indep)
+    indep[1] = indep[1][:-1]
+    # At the moment this does not error out
+    data.indep = tuple(indep)
+
+
+@pytest.mark.parametrize("data_args",
                          [ARF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
 def test_set_independent_axis_to_none(data_args):
     """What happens if we clear the independent axis?"""

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2745,3 +2745,21 @@ def test_set_independent_axis_to_none_pha_channel():
     data.channel = None
     assert len(data.indep) == 1
     assert data.indep[0] is None
+
+
+# Should we remove support for the error columns for DataARF/DataRMF?
+#
+@pytest.mark.parametrize("data_args",
+                         [ARF_ARGS, RMF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
+@pytest.mark.parametrize("column", ["staterror", "syserror"])
+def test_set_error_axis_wrong_length(data_args, column):
+    """What happens if the column is set to the wrong length?"""
+
+    data_class, args = data_args
+    data = data_class(*args)
+
+    col = getattr(data, column)
+    assert col is None
+
+    # does not raise an error
+    setattr(data, column, [1, 2])

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3066,3 +3066,85 @@ def test_pha_apply_grouping_empty():
     orig = [2, 5]
     ans = pha.apply_grouping(orig)
     assert ans == pytest.approx(orig)
+
+
+def test_pha_change_independent_element():
+    """Special case PHA as the handling is more-complex than the
+    general data cases.
+    """
+
+    chans = np.arange(1, 10)
+    counts = np.ones(len(chans))
+    pha = DataPHA("change", chans, counts)
+
+    assert len(pha.indep) == 1
+    assert pha.indep[0][1] == 2
+
+    # change the second element of the first component
+    pha.indep[0][1] = -100
+
+    expected = chans.copy()
+    expected[1] = -100
+    assert len(pha.indep) == 1
+    assert pha.indep[0] == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("field", ["y", "dep", "counts"])
+def test_pha_change_dependent_element(field):
+    """Special case PHA as the handling is more-complex than the
+    general data cases.
+    """
+
+    chans = np.arange(1, 10)
+    counts = np.arange(11, 20)
+    pha = DataPHA("change", chans, counts)
+
+    attr = getattr(pha, field)
+    assert attr[1] == 12
+
+    # change the second element of the first component
+    attr[1] = 100
+
+    expected = counts.copy()
+    expected[1] = 100
+    assert attr == pytest.approx(expected)
+
+    # explicitly check pha.y just to make sure we really are changing the
+    # object
+    assert pha.y == pytest.approx(expected)
+
+
+def test_pha_do_we_copy_the_independent_axis():
+    """Special case PHA as the handling is more-complex than the
+    general data cases.
+
+    This is a regression test.
+    """
+
+    chans = np.arange(1, 10)
+    counts = np.ones(len(chans))
+    pha = DataPHA("change", chans, counts)
+
+    assert pha.indep[0] == pytest.approx(chans)
+
+    # what happens if we change the chans array?
+    chans[1] = -100
+    assert pha.indep[0] == pytest.approx(chans)
+
+
+def test_pha_do_we_copy_the_dependent_axis():
+    """Special case PHA as the handling is more-complex than the
+    general data cases.
+
+    This is a regression test.
+    """
+
+    chans = np.arange(1, 10)
+    counts = np.ones(len(chans))
+    pha = DataPHA("change", chans, counts)
+
+    assert pha.y == pytest.approx(counts)
+
+    # what happens if we change the counts array?
+    counts[1] = 20
+    assert pha.y == pytest.approx(counts)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2624,6 +2624,38 @@ def test_invalid_independent_axis_component(data_args):
 
 @pytest.mark.parametrize("data_args",
                          [ARF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
+def test_invalid_dependent_axis(data_args):
+    """What happens if the dependent axis does not match the independent axis?
+
+    We do not include DataRMF as it's not clear what the dependent axis is
+    here.
+    """
+
+    data_class, args = data_args
+    data = data_class(*args)
+    # This currently does not fail
+    data.y = data.y[:-2]
+
+
+@pytest.mark.parametrize("data_class,args",
+                         [(DataARF, (ELO, EHI, np.ones(10))),
+                          (DataPHA, (CHANS, np.ones(10))),
+                          (DataIMG, (X0, X1, np.ones(34))),
+                          (DataIMGInt, (X0, X1, X0 + 1, X1 + 1, np.ones(2))),
+                          ])
+def test_make_invalid_dependent_axis(data_class, args):
+    """What happens if call constructor with invalid independent axis?
+
+    We do not include DataRMF as it's not clear what the dependent axis is
+    here.
+    """
+
+    # This does not raise an error
+    data_class("wrong", *args)
+
+
+@pytest.mark.parametrize("data_args",
+                         [ARF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
 def test_set_independent_axis_to_none(data_args):
     """What happens if we clear the independent axis?"""
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3034,3 +3034,35 @@ def test_data_empty_get_x_2d(data_class, args, index):
     getfunc = getattr(data, f"get_{index}")
     # XFAIL: for Data2DInt there's a TypeError about adding None to None
     assert getfunc() is None
+
+
+#@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS)
+@pytest.mark.parametrize("data_class,args",
+                         [pytest.param(DataPHA, [None] * 2, marks=pytest.mark.xfail),
+                          (DataIMG, [None] * 3),
+                          (DataIMGInt, [None] * 5)])
+def test_data_empty_apply_filter(data_class, args):
+    """What does apply_filter do when the data set is empty?
+
+    We could error out or just return the supplied argument, so
+    this is a regression test
+    """
+
+    data = data_class("empty", *args)
+    orig = [2, 5]
+    ans = data.apply_filter(orig)
+    # XFAIL for DataPHA get a TypeError from calling len(None)
+    assert ans == pytest.approx(orig)
+
+
+def test_pha_apply_grouping_empty():
+    """What does apply_grouping do when the data set is empty?
+
+    We could error out or just return the supplied argument, so
+    this is a regression test
+    """
+
+    pha = DataPHA("example", None, None)
+    orig = [2, 5]
+    ans = pha.apply_grouping(orig)
+    assert ans == pytest.approx(orig)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -796,7 +796,7 @@ def test_ungroup():
     '''
     session = Session()
     testdata = DataPHA('testdata', np.arange(50, dtype=float) + 1.,
-                       np.zeros(50), bin_lo=1, bin_hi=10)
+                       np.zeros(50))
     session.set_data(1, testdata)
     session.ungroup(1)
     session.group_bins(1, 5)
@@ -819,11 +819,9 @@ def test_unsubtract():
     '''
     session = Session()
     testdata = DataPHA('testdata', np.arange(50, dtype=float) + 1.,
-                       np.zeros(50),
-                       bin_lo=1, bin_hi=10)
+                       np.zeros(50))
     testbkg = DataPHA('testbkg', np.arange(50, dtype=float) + .5,
-                      np.zeros(50),
-                      bin_lo=1, bin_hi=10)
+                      np.zeros(50))
     session.set_data(1, testdata)
     session.set_bkg(1, testbkg)
     session.unsubtract(1)
@@ -2763,3 +2761,87 @@ def test_set_error_axis_wrong_length(data_args, column):
 
     # does not raise an error
     setattr(data, column, [1, 2])
+
+
+@pytest.mark.parametrize("related", ["y", "counts"])
+def test_pha_dependent_field_can_not_be_a_scalar(related):
+    """This is to contrast with test_pha_related_fields_can_not_be_a_scalar.
+
+    This is tested elsewhere but leave here to point out that the related
+    fields are not all handled the same.
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+    # does not raise an error
+    setattr(data, related, 2)
+
+
+@pytest.mark.parametrize("vals", [[4], (2, 3, 4, 5)])
+def test_pha_bin_field_must_match_initialization(vals):
+    """The bin_lo/hi must match when creating the object"""
+
+    data_class, args = PHA_ARGS
+    # this does not raise an error
+    data_class(*args, bin_lo=[1, 2, 3], bin_hi=vals)
+
+
+@pytest.mark.parametrize("vals", [[4], (2, 3, 4, 5)])
+def test_pha_bin_field_must_match_after(vals):
+    """The bin_lo/hi must match when creating the object"""
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+    data.bin_hi = [4, 5, 6]
+    # this does not raise an error
+    data.bin_lo = vals
+
+
+@pytest.mark.parametrize("field", ["bin_lo", "bin_hi"])
+@pytest.mark.parametrize("vals", [True, 0, np.asarray(1)])
+def test_pha_bin_field_can_not_be_a_scalar(field, vals):
+    """The bin_lo/hi fields can not be a scalar.
+
+    Note that these fields are different to sys/staterror.
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+    # this does not raise an error
+    setattr(data, field, vals)
+
+
+@pytest.mark.parametrize("field", ["bin_lo", "bin_hi"])
+@pytest.mark.parametrize("vals", [[1, 1], np.ones(10)])
+def test_pha_bin_field_can_not_be_a_sequence_wrong_size(field, vals):
+    """The bin_lo/hi fields can not be a scalar.
+
+    Note that these fields are different to sys/staterror.
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+    # this does not raise an error
+    setattr(data, field, vals)
+
+
+@pytest.mark.parametrize("related", ["staterror", "syserror", "grouping", "quality"])
+@pytest.mark.parametrize("vals", [True, 0, np.asarray(1)])
+def test_pha_related_field_can_not_be_a_scalar(related, vals):
+    """The related fields (staterror/syserror/grouping/quality) can not be a scalar."""
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+    # this does not raise an error
+    setattr(data, related, vals)
+
+
+@pytest.mark.parametrize("label", ["staterror", "syserror", "grouping", "quality"])
+@pytest.mark.parametrize("vals", [[1, 1], np.ones(10)])
+def test_pha_related_field_can_not_be_a_sequence_wrong_size(label, vals):
+    """Check we error out if column=label has the wrong size: sequence"""
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+    # this does not raise an error
+    setattr(data, label, vals)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2742,6 +2742,26 @@ def test_make_invalid_dependent_axis(data_class, args):
     data_class("wrong", *args)
 
 
+def test_pha_fails_when_bin_lo_is_invalid():
+    """What happens when bin_lo has a different size to the data?
+
+    This is to test the order of calls in the __init__ method.
+    """
+
+    # this does not fail
+    DataPHA("something", CHANS, ONES, bin_lo=[1, 3])
+
+
+def test_pha_fails_when_bin_hi_is_invalid():
+    """What happens when bin_hi has a different size to the data?
+
+    This is to test the order of calls in the __init__ method.
+    """
+
+    # this does not fail
+    DataPHA("something", CHANS, ONES, bin_hi=[1, 3])
+
+
 @pytest.mark.parametrize("data_args",
                          [ARF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
 def test_set_independent_axis_to_none(data_args):

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2579,6 +2579,24 @@ def test_set_counts_sets_y_axis():
     assert d.y == pytest.approx(counts2)
 
 
+@pytest.mark.parametrize("vals", [10, [10, 10, 10], (10, 10, 10)])
+def test_pha_can_set_dep(vals):
+    """Ensure we can call set_dep with a scalar or sequence for DataPHA"""
+
+    chans = np.arange(1, 4)
+    counts = chans[::-1]
+    data = DataPHA("simple", chans, counts)
+
+    assert data.get_dep() == pytest.approx(counts)
+
+    data.set_dep(vals)
+
+    expected = 10 * np.ones(3)
+    assert data.get_dep() == pytest.approx(expected)
+    assert data.counts == pytest.approx(expected)
+    assert data.y == pytest.approx(expected)
+
+
 # We don't really care if the arguments don't make much sense, at least
 # not until we add validation code which will mean these need fixing up.
 #

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2592,6 +2592,21 @@ IMG_ARGS = DataIMG, ("img", X0, X1, IMG_ONES)
 IMGINT_ARGS = DataIMGInt, ("imgint", X0, X1, X0 + 1, X1 + 1, IMG_ONES)
 
 @pytest.mark.parametrize("data_args",
+                         [ARF_ARGS, RMF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
+def test_invalid_independent_axis(data_args):
+    """What happens if we use the wrong number of independent axes?
+
+    We just duplicate the current axes.
+    """
+
+    data_class, args = data_args
+    data = data_class(*args)
+    indep = data.indep
+    with pytest.raises(TypeError):
+        data.indep = tuple(list(indep) * 2)
+
+
+@pytest.mark.parametrize("data_args",
                          [ARF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
 def test_set_independent_axis_to_none(data_args):
     """What happens if we clear the independent axis?"""

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2857,3 +2857,118 @@ def test_pha_eval_model_checks_dimensionality_pha(funcname):
     func = getattr(data, funcname)
     with pytest.raises(TypeError):
         func(model)
+
+
+def test_datapha_create_not_ndarray():
+    """If sent non nd-array fields, does __init__ convert them?
+
+    This is a regression test.
+    """
+
+    d = DataPHA('x', [1, 2, 3], (4, 5, 6),
+                staterror=(8, 7, 6), syserror=[2, 3, 4],
+                grouping=(1, 1, -1), quality=(0, 0, 0),
+                backscal=[2, 3, 4], areascal=(0.1, 0.2, 0.9))
+
+    assert isinstance(d.indep, tuple)
+    assert len(d.indep) == 1
+    assert isinstance(d.indep[0], np.ndarray)
+
+    assert isinstance(d.channel, np.ndarray)
+    assert isinstance(d.y, np.ndarray)
+    assert isinstance(d.counts, np.ndarray)
+    assert isinstance(d.staterror, tuple)
+    assert isinstance(d.syserror, list)
+
+    assert isinstance(d.grouping, tuple)
+    assert isinstance(d.quality, tuple)
+
+    assert isinstance(d.areascal, tuple)
+    assert isinstance(d.backscal, list)
+
+
+@pytest.mark.parametrize("field", ["staterror", "syserror",
+                                   "grouping", "quality",
+                                   "areascal", "backscal"])
+def test_datapha_set_not_ndarray(field):
+    """What happens if the field is set to a non-ndarray after creation?
+
+    This is a regression test.
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+
+    setattr(data, field, tuple([1] * len(data.y)))
+    got = getattr(data, field)
+
+    assert isinstance(got, tuple)
+
+
+def test_datapha_mask_set_not_ndarray():
+    """What happens if the mask field is set to a non-ndarray after creation?
+
+    This is a regression test.
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+
+    data.mask = tuple([1] * len(data.y))
+
+    assert isinstance(data.mask, np.ndarray)
+
+
+def test_dataimg_create_not_ndarray():
+    """If sent non nd-array fields, does __init__ convert them?
+
+    This is a regression test.
+    """
+
+    x1, x0 = np.mgrid[2:5, 3:5]
+    shape = x0.shape
+    x0 = list(x0.flatten())
+    x1 = tuple(x1.flatten())
+    listval = [1] * len(x0)
+    tupleval = tuple(listval)
+    d = DataIMG('x', x0, x1, listval, shape=shape,
+                staterror=tupleval, syserror=listval)
+
+    assert isinstance(d.indep, tuple)
+    assert len(d.indep) == 2
+    assert isinstance(d.indep[0], np.ndarray)
+    assert isinstance(d.indep[1], np.ndarray)
+
+    assert isinstance(d.y, np.ndarray)
+    assert isinstance(d.staterror, tuple)
+    assert isinstance(d.syserror, list)
+
+
+@pytest.mark.parametrize("field", ["staterror", "syserror"])
+def test_dataimg_set_not_ndarray(field):
+    """What happens if the field is set to a non-ndarray after creation?
+
+    This is a regression test.
+    """
+
+    data_class, args = IMG_ARGS
+    data = data_class(*args)
+
+    setattr(data, field, tuple([1] * len(data.y)))
+    got = getattr(data, field)
+
+    assert isinstance(got, tuple)
+
+
+def test_dataimg_mask_set_not_ndarray():
+    """What happens if the mask field is set to a non-ndarray after creation?
+
+    This is a regression test.
+    """
+
+    data_class, args = IMG_ARGS
+    data = data_class(*args)
+
+    data.mask = tuple([1] * len(data.y))
+
+    assert isinstance(data.mask, np.ndarray)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2871,6 +2871,71 @@ def test_pha_related_field_can_not_be_a_sequence_wrong_size(label, vals):
     setattr(data, label, vals)
 
 
+def test_pha_independent_axis_can_not_be_a_set():
+    """Check we error out if x is a set
+
+    This is an attempt to see what happens if a user sends in a
+    "surprising" value. We don't want to check too many of these
+    cases, but having a few checks can be useful.
+
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+
+    # this does not raise an error
+    data.set_indep(({"abc", False, 23.4}, ))
+
+
+def test_pha_independent_axis_can_not_be_a_set_sequence():
+    """Check we error out if x is a set
+
+    This is an attempt to see what happens if a user sends in a
+    "surprising" value. We don't want to check too many of these
+    cases, but having a few checks can be useful.
+
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+
+    # this does not raise an error
+    data.set_indep(([{"abc", False, 23.4}] * 3, ))
+
+
+@pytest.mark.parametrize("field", ["y", "counts", "staterror", "syserror", "grouping", "quality"])
+def test_pha_related_field_can_not_be_a_set(field):
+    """Check we error out if y/counts/... is a set
+
+    This is an attempt to see what happens if a user sends in a
+    "surprising" value. We don't want to check too many of these
+    cases, but having a few checks can be useful.
+
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+
+    # this does not fail
+    setattr(data, field, {"abc", False, 23.4})
+
+
+@pytest.mark.parametrize("field", ["y", "counts", "staterror", "syserror", "grouping", "quality"])
+def test_pha_related_field_can_not_be_a_set_sequence(field):
+    """Check we error out if y/counts/... is a sequence of sets
+
+    This is an attempt to see what happens if a user sends in a
+    "surprising" value. We don't want to check too many of these
+    cases, but having a few checks can be useful.
+
+    """
+
+    data_class, args = PHA_ARGS
+    data = data_class(*args)
+
+    # this does not fail
+    setattr(data, field, [{"abc", False, 23.4}] * 3)
+
 
 def test_pha_mask_size_must_match_ungrouped():
     """Check if the mask can be set to the wrong length: data not grouped"""

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -27,6 +27,7 @@ import pytest
 from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import DataARF, DataPHA, DataRMF, DataIMG, DataIMGInt
 from sherpa.astro.instrument import create_arf, create_delta_rmf
+from sherpa.models.basic import Gauss2D
 from sherpa.utils import parse_expr
 from sherpa.utils.err import DataErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
@@ -2845,3 +2846,14 @@ def test_pha_related_field_can_not_be_a_sequence_wrong_size(label, vals):
     data = data_class(*args)
     # this does not raise an error
     setattr(data, label, vals)
+
+
+@pytest.mark.parametrize("funcname", ["eval_model", "eval_model_to_fit"])
+def test_pha_eval_model_checks_dimensionality_pha(funcname):
+    """Does eval_model check the model dimensionality?"""
+
+    data = DataPHA('tmp', np.arange(3), np.arange(3))
+    model = Gauss2D()
+    func = getattr(data, funcname)
+    with pytest.raises(TypeError):
+        func(model)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1697,18 +1697,14 @@ def test_pha_quality_bad_filter_remove(make_test_pha):
     assert pha.get_filter() == "2:4"
 
 
-@pytest.mark.xfail
-@pytest.mark.parametrize("label", ["grouping", "quality"])
-@pytest.mark.parametrize("vals", [True, [1, 1], np.ones(10)])
-def test_pha_column_size(label, vals, make_test_pha):
-    """Check we error out if column=label has the wrong size"""
+@pytest.mark.parametrize("field", ["grouping", "quality"])
+def test_pha_change_xxx_non_integer_value(field, make_test_pha):
+    """What happens if send grouping/quality values that can not be converted to an array?"""
 
     pha = make_test_pha
-    with pytest.raises(DataErr) as de:
-        # This does not throw an error
-        setattr(pha, label, vals)
-
-    assert str(de.value) == f"size mismatch between channel and {label}"
+    invalid = [None, "x", {}, set()]
+    # This does not error out
+    setattr(pha, field, invalid)
 
 
 @pytest.mark.xfail
@@ -2156,6 +2152,20 @@ def test_grouped_pha_set_related_invalid_size(related, make_grouped_pha):
     #
     # this does not error out
     setattr(pha, related, [2, 3])
+
+
+@pytest.mark.parametrize("column", ["staterror", "syserror",
+                                    "y", "counts",
+                                    "backscal", "areascal",
+                                    "grouping", "quality"])
+def test_pha_check_related_fields_correct_size(column, make_grouped_pha):
+    """Can we set the value to a 2-element array?"""
+
+    d = DataPHA('example', None, None)
+    setattr(d, column, np.asarray([2, 10, 3]))
+
+    # This does not error out
+    d.indep = (np.asarray([2, 3, 4, 5]), )
 
 
 @pytest.mark.parametrize("label", ["filter", "grouping"])

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2730,6 +2730,40 @@ def test_img_world_get_world(path, make_test_image_world):
     assert b == pytest.approx(WORLD_X1)
 
 
+def test_img_sky_can_filter(make_test_image_sky):
+    """Check we can filter the image using physical coordinates"""
+    data = make_test_image_sky
+    assert data.coord == "logical"
+    assert data.mask
+    assert data.get_filter() == ""
+
+    data.set_coord("physical")
+    assert data.coord == "physical"
+    assert data.mask
+    assert data.get_filter() == ""
+
+    data.notice2d("rect(2009,-5006,2011,-5000)", ignore=True)
+    assert data.mask == pytest.approx([1, 1, 1, 1, 1, 0])
+    assert data.get_filter() == "Field()&!Rectangle(2009,-5006,2011,-5000)"
+
+
+def test_img_sky_can_filter_change_coords(make_test_image_sky):
+    """What happens to a filter after changing coordinates?
+
+    This is a regression test.
+    """
+    data = make_test_image_sky
+
+    data.set_coord("physical")
+    data.notice2d("rect(2009,-5006,2011,-5000)", ignore=True)
+
+    data.set_coord("image")
+    assert data.coord == "logical"
+    # Note that the mask/filter does not get cleared
+    assert data.mask == pytest.approx([1, 1, 1, 1, 1, 0])
+    assert data.get_filter() == "Field()&!Rectangle(2009,-5006,2011,-5000)"
+
+
 def test_arf_checks_energy_length():
     """Just check we error out"""
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -22,6 +22,7 @@
 
 import logging
 import pickle
+import re
 import warnings
 
 import numpy as np
@@ -2157,6 +2158,259 @@ def test_grouped_pha_set_related_invalid_size(related, make_grouped_pha):
     setattr(pha, related, [2, 3])
 
 
+@pytest.mark.parametrize("label", ["filter", "grouping"])
+def test_pha_no_group_apply_xxx_invalid_size(label, make_test_pha):
+    """Check apply_filter/grouping tests the data length: no quality/group
+
+    Issue #1439 points out that quality handling creates different results.
+
+    """
+    pha = make_test_pha
+
+    func = getattr(pha, f"apply_{label}")
+    # this does not error out
+    func([1, 2])
+
+
+@pytest.mark.parametrize("vals", [pytest.param([1], marks=pytest.mark.xfail), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_no_group_filtered_apply_filter_invalid_size(vals, make_test_pha):
+    """Check apply_filter tests the data length: no quality/group, filtered
+
+    This behaves differently to the apply_grouping case
+    """
+
+    pha = make_test_pha
+    pha.ignore(hi=2)
+
+    # safety check to make sure we've excluded points
+    assert not np.all(pha.mask)
+    assert np.any(pha.mask)
+
+    # This should error out, but it only does so for the > 1 element sequence,
+    # and this is not a "friendly" error message
+    #
+    with pytest.raises(ValueError):
+        pha.apply_filter(vals)
+
+
+@pytest.mark.parametrize("vals", [[1], [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_no_group_filtered_apply_grouping_invalid_size(vals, make_test_pha):
+    """Check apply_grouping tests the data length: no quality/group, filtered
+
+    This behaves differently to the apply_filter case
+    """
+
+    pha = make_test_pha
+    pha.ignore(hi=2)
+
+    # This should error out, but it does not.
+    pha.apply_grouping(vals)
+
+
+@pytest.mark.parametrize("label", ["filter", "grouping"])
+@pytest.mark.parametrize("vals", [[1], (2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_zero_quality_apply_xxx_invalid_size(label, vals, make_test_pha):
+    """Check apply_filter/grouping tests the data length: quality set to 0
+
+    We can not use make_grouped_pha and then set the quality array to
+    0's as that does not remove the quality setting (see issue #1427)
+    so we replicate most of make_grouped_pha with make_test_pha.
+
+    """
+    pha = make_test_pha
+    pha.grouping = [1, -1, -1, 1]
+    pha.quality = [0] * 4
+    pha.group()
+
+    func = getattr(pha, f"apply_{label}")
+    with pytest.raises(TypeError) as err:
+        func(vals)
+
+    assert re.match("^input array sizes do not match, data: [128] vs group: 4$",
+                    str(err.value))
+
+
+@pytest.mark.parametrize("vals", [(2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_zero_quality_filtered_apply_filter_invalid_size(vals, make_test_pha):
+    """Check apply_filter tests the data length: quality set to 0, filtered"""
+
+    pha = make_test_pha
+    pha.grouping = [1, -1, -1, 1]
+    pha.quality = [0] * 4
+    pha.group()
+
+    pha.ignore(hi=2)
+
+    # safety check to make sure we've excluded points
+    assert not np.all(pha.mask)
+    assert np.any(pha.mask)
+
+    with pytest.raises(ValueError) as err:
+        pha.apply_filter(vals)
+
+    # The error strong may depend on the NumPy version.
+    #
+    assert str(err.value).startswith("NumPy boolean array indexing ")
+
+
+@pytest.mark.parametrize("vals", [[1], (2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_zero_quality_filtered_apply_grouping_invalid_size(vals, make_test_pha):
+    """Check apply_grouping tests the data length: quality set to 0, filtered"""
+
+    pha = make_test_pha
+    pha.grouping = [1, -1, -1, 1]
+    pha.quality = [0] * 4
+    pha.group()
+
+    pha.ignore(hi=2)
+
+    with pytest.raises(TypeError) as err:
+        pha.apply_grouping(vals)
+
+    assert re.match("^input array sizes do not match, data: [128] vs group: 4$",
+                    str(err.value))
+
+
+@pytest.mark.parametrize("vals", [(2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_quality_apply_filter_invalid_size(vals, make_grouped_pha):
+    """Check apply_filter tests the data length: with quality set"""
+
+    pha = make_grouped_pha
+
+    with pytest.raises(ValueError) as err:
+        pha.apply_filter(vals)
+
+    # The error strong may depend on the NumPy version.
+    #
+    assert str(err.value).startswith("NumPy boolean array indexing ")
+
+
+@pytest.mark.parametrize("vals", [(2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_quality_filtered_apply_filter_invalid_size(vals, make_grouped_pha):
+    """Check apply_filter tests the data length: with quality set, filtered"""
+
+    pha = make_grouped_pha
+    pha.ignore(hi=1)
+
+    # safety check to make sure we've excluded points
+    assert pha.mask == pytest.approx([False, True])
+    assert pha.get_mask() == pytest.approx([False, False, False, True])
+
+    with pytest.raises(IndexError) as err:
+        pha.apply_filter(vals)
+
+    # The error strong may depend on the NumPy version.
+    #
+    assert str(err.value).startswith("boolean index did not match indexed array ")
+
+
+@pytest.mark.parametrize("vals", [pytest.param([42], marks=pytest.mark.xfail), [10, 20, 35, 42, 55]])
+def test_pha_quality_filtered_apply_filter_match_filter(vals, make_grouped_pha):
+    """What happens if the array has the correct size?"""
+
+    pha = make_grouped_pha
+    pha.ignore(hi=1)
+
+    # XFAIL: when the array matches the filtered data there's a problem
+    # matching to the ungrouped data.
+    got = pha.apply_filter(vals)
+    assert got == pytest.approx([42])
+
+
+@pytest.mark.parametrize("vals", [[1], (2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_quality_apply_grouping_invalid_size(vals, make_grouped_pha):
+    """Check apply_grouping tests the data length: with quality set"""
+
+    pha = make_grouped_pha
+
+    with pytest.raises(DataErr) as err:
+        pha.apply_grouping(vals)
+
+    assert str(err.value) == "size mismatch between quality filter and data array"
+
+
+@pytest.mark.parametrize("vals", [[1], (2, 3), [1, 2, 3, 4, 5, 6, 7, 8]])
+def test_pha_quality_filtered_apply_grouping_invalid_size(vals, make_grouped_pha):
+    """Check apply_grouping tests the data length: with quality set, filtered"""
+
+    pha = make_grouped_pha
+    pha.ignore(hi=1)
+
+    with pytest.raises(DataErr) as err:
+        pha.apply_grouping(vals)
+
+    assert str(err.value) == "size mismatch between quality filter and data array"
+
+
+def test_pha_apply_filter_check():
+    """Check that apply_filter works as expected.
+
+    We go through a number of stages - e.g.
+
+      - no filter or group
+      - only group
+      - group and filter
+
+    """
+
+    chans = np.arange(1, 21)
+    counts = np.ones(20)
+    data = DataPHA("ex", chans, counts)
+
+    all_vals = np.arange(1, 21)
+    filt_vals = np.arange(5, 17)
+
+    expected = np.arange(1, 21)
+    got = data.apply_filter(all_vals, groupfunc=np.sum)
+    assert got == pytest.approx(expected)
+
+    grouping = np.asarray([1, -1] * 10)
+    data.grouping = grouping
+    data.quality = [0] * 20
+
+    assert not data.grouped
+    data.group()
+    assert data.grouped
+
+    expected = np.asarray([3, 7, 11, 15, 19, 23, 27, 31, 35, 39])
+    got = data.apply_filter(all_vals, groupfunc=np.sum)
+    assert got == pytest.approx(expected)
+
+    # This ignores the first two groups, channels 1-2 and 3-4,
+    # and the last two groups, channels 17-18 and 19-20.
+    # Note that channel 17 is ignored even though not explicitly
+    # asked because of the use of ignore.
+    #
+    data.ignore(hi=4)
+    data.ignore(lo=18)
+
+    expected = np.asarray([11, 15, 19, 23, 27, 31])
+    got = data.apply_filter(all_vals, groupfunc=np.sum)
+    assert got == pytest.approx(expected)
+
+    # Now the data has been filtered we can check what happens when
+    # the input argument has less channels in.
+    #
+    got = data.apply_filter(filt_vals, groupfunc=np.sum)
+    assert got == pytest.approx(expected)
+
+    # Remove the grouping
+    #
+    data.ungroup()
+    assert not data.grouped
+
+    # Note that we still send in vals=arange(5, 17)
+    #
+    expected = filt_vals.copy()
+    got = data.apply_filter(filt_vals, groupfunc=np.sum)
+    assert got == pytest.approx(expected)
+
+    # We can send in the full array too
+    got = data.apply_filter(all_vals, groupfunc=np.sum)
+    assert got == pytest.approx(expected)
+
+
+
 @requires_fits
 @requires_data
 def test_xmmrgs_notice(make_data_path):
@@ -3392,3 +3646,32 @@ def test_1380_pickle(make_data_path):
     #
     assert img._orig_indep_axis[0] == "logical"
     assert img2._orig_indep_axis[0] == "logical"
+
+
+def test_image_apply_filter_invalid_size(make_test_image):
+    """Does an image error out if the filter is sent an invalid size?
+
+    Test related to issue #1439 which is an issue with the DataPHA class.
+    """
+
+    data = make_test_image
+
+    # this does not raise an error
+    data.apply_filter([1, 2])
+
+
+def test_image_filtered_apply_filter_invalid_size(make_test_image):
+    """Does an image error out if the filter is sent an invalid size after a filter?"""
+
+    data = make_test_image
+
+    # "Fake" a filter (this is a perfectly-valid way to set up a filter,
+    # at least at the time this code was written).
+    #
+    data.mask = np.ones(data.y.size, dtype=bool)
+    data.mask[0] = False
+
+    with pytest.raises(DataErr) as de:
+        data.apply_filter([1, 2])
+
+    assert str(de.value) == 'size mismatch between mask and data array'

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021
+#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -67,7 +67,7 @@ def check_sourceplot_energy(sp, factor=0):
 
     assert sp.title == 'Source Model of '
 
-    bins = np.arange(0.1, 10.1, 0.1)
+    bins = 0.1 + 0.1 * np.arange(11)
     assert sp.xlo == pytest.approx(bins[:-1])
     assert sp.xhi == pytest.approx(bins[1:])
 
@@ -76,29 +76,7 @@ def check_sourceplot_energy(sp, factor=0):
     #
     yexp = np.asarray([9998.300959, 9997.9935414, 9997.63869638,
                        9997.23070803, 9996.76346026, 9996.2304594, 9995.62486769,
-                       9994.9395488, 9994.16712626, 9993.30005567, 9992.33071112,
-                       9991.25148615, 9990.05490914, 9988.73377265, 9987.28127577,
-                       9985.69117819, 9983.95796409, 9982.07701351, 9980.04477839,
-                       9977.85895997, 9975.51868378, 9973.02466824, 9970.37938236,
-                       9967.58718801, 9964.65446216, 9961.58969431, 9958.40355487,
-                       9955.10893021, 9951.72092088, 9948.25679985, 9944.73592864,
-                       9941.17962987, 9937.6110159, 9934.05477423, 9930.53691143,
-                       9927.08445867, 9923.7251427, 9920.48702778, 9917.39813433,
-                       9914.48604166, 9911.77748224, 9909.29793588, 9907.07123238,
-                       9905.11917118, 9903.4611666, 9902.11392658, 9901.09117249,
-                       9900.40340655, 9900.05773225, 9900.05773225, 9900.40340655,
-                       9901.09117249, 9902.11392658, 9903.4611666, 9905.11917118,
-                       9907.07123238, 9909.29793588, 9911.77748224, 9914.48604166,
-                       9917.39813433, 9920.48702778, 9923.7251427, 9927.08445867,
-                       9930.53691143, 9934.05477423, 9937.6110159, 9941.17962987,
-                       9944.73592864, 9948.25679985, 9951.72092088, 9955.10893021,
-                       9958.40355487, 9961.58969431, 9964.65446216, 9967.58718801,
-                       9970.37938236, 9973.02466824, 9975.51868378, 9977.85895997,
-                       9980.04477839, 9982.07701351, 9983.95796409, 9985.69117819,
-                       9987.28127577, 9988.73377265, 9990.05490914, 9991.25148615,
-                       9992.33071112, 9993.30005567, 9994.16712626, 9994.9395488,
-                       9995.62486769, 9996.2304594, 9996.76346026, 9997.23070803,
-                       9997.63869638, 9997.9935414, 9998.300959, 9998.5662520])
+                       9994.9395488, 9994.16712626, 9993.30005567])
 
     if factor == 1:
         yexp *= 0.1
@@ -136,7 +114,7 @@ def check_sourceplot_wavelength(sp, factor=0):
 
     # Use the code from DataPHA to convert from keV to Angstroms.
     #
-    ebins = np.arange(0.1, 10.1, 0.1)
+    ebins = 0.1 + 0.1 * np.arange(11)
     lbins = hc / ebins
     assert sp.xlo == pytest.approx(lbins[:-1])
     assert sp.xhi == pytest.approx(lbins[1:])
@@ -148,36 +126,7 @@ def check_sourceplot_wavelength(sp, factor=0):
     #
     yexp = np.asarray([10000., 10000., 10000., 10000., 10000., 10000.,
                        9999.99999864, 9999.99949354, 9999.97224156,
-                       9999.55447151, 9996.86451659, 9987.51382359,
-                       9966.695068 , 9933.27750675, 9891.33791156,
-                       9847.93710785, 9809.78226046, 9781.16179805,
-                       9763.58920097, 9756.46908383, 9758.02782873,
-                       9766.08494609, 9778.54263095, 9793.6274431,
-                       9809.96473056, 9826.55998249, 9842.73898966,
-                       9858.07743665, 9872.33534744, 9885.40252063,
-                       9897.25609947, 9907.92910978, 9917.48798344,
-                       9926.01701814, 9933.60797703, 9940.3533812,
-                       9946.34238774, 9951.65843565, 9956.37807112,
-                       9960.57053782, 9964.29784539, 9967.61512156,
-                       9970.57111803, 9973.20878565, 9975.56586528,
-                       9977.67546184, 9979.56658298, 9981.26463295,
-                       9982.79185821, 9984.16774487, 9985.40937017,
-                       9986.5317114, 9987.54791625, 9988.46953851,
-                       9989.30674326, 9990.06848503, 9990.76266241,
-                       9991.39625226, 9991.97542597, 9992.50565038,
-                       9992.99177532, 9993.43810959, 9993.84848703,
-                       9994.22632392, 9994.57466896, 9994.89624683,
-                       9995.19349616, 9995.46860277, 9995.72352864,
-                       9995.96003731, 9996.17971622, 9996.3839962,
-                       9996.57416871, 9996.75140095, 9996.9167492,
-                       9997.07117061, 9997.21553359, 9997.35062702,
-                       9997.47716842, 9997.59581118, 9997.70715101,
-                       9997.81173162, 9997.9100499 , 9998.00256036,
-                       9998.0896793 , 9998.17178835, 9998.24923778,
-                       9998.32234937, 9998.39141906, 9998.45671928,
-                       9998.51850107, 9998.57699596, 9998.63241771,
-                       9998.68496386, 9998.73481709, 9998.78214653,
-                       9998.82710888, 9998.86984944, 9998.91050307])
+                       9999.55447151])
 
     if factor == 1:
         yexp *= (lbins[:-1] - lbins[1:])
@@ -187,12 +136,19 @@ def check_sourceplot_wavelength(sp, factor=0):
     assert sp.y == pytest.approx(yexp)
 
 
-def test_sourceplot(caplog):
+@pytest.fixture
+def make_basic_datapha():
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    chans = np.arange(10)
+    los = 0.1 + 0.1 * chans
+    his = 0.1 + los
+    return DataPHA('', chans, np.ones(10),
+                   bin_lo=los, bin_hi=his)
+
+
+def test_sourceplot(caplog, make_basic_datapha):
+
+    data = make_basic_datapha
     data.units = "energy"
     assert data.rate
     assert data.plot_fac == 0
@@ -216,13 +172,10 @@ def test_sourceplot(caplog):
     check_sourceplot_energy(sp)
 
 
-def test_sourceplot_counts(caplog):
+def test_sourceplot_counts(caplog, make_basic_datapha):
     """test_sourceplot but when rate=False is chosen"""
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    data = make_basic_datapha
     data.units = "energy"
     data.rate = False
 
@@ -246,13 +199,10 @@ def test_sourceplot_counts(caplog):
 
 
 @pytest.mark.parametrize("factor", [1, 2])
-def test_sourceplot_facn(factor, caplog):
+def test_sourceplot_facn(factor, caplog, make_basic_datapha):
     """Change plot factor for test_sourceplot"""
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    data = make_basic_datapha
     data.units = "energy"
     data.plot_fac = factor
     assert data.rate
@@ -276,13 +226,10 @@ def test_sourceplot_facn(factor, caplog):
     check_sourceplot_energy(sp, factor=factor)
 
 
-def test_sourceplot_channels(caplog):
+def test_sourceplot_channels(caplog, make_basic_datapha):
     """Although we ask for channels we get energy units"""
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    data = make_basic_datapha
     data.units = "channel"
 
     # use a model that is "okay" to use with keV bins
@@ -309,13 +256,10 @@ def test_sourceplot_channels(caplog):
     check_sourceplot_energy(sp)
 
 
-def test_sourceplot_wavelength(caplog):
+def test_sourceplot_wavelength(caplog, make_basic_datapha):
     """Check we get wavelength units"""
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    data = make_basic_datapha
     data.units = "wave"
 
     # Note that the model evaluation in done in Angstroms
@@ -338,13 +282,10 @@ def test_sourceplot_wavelength(caplog):
 
 
 @pytest.mark.parametrize("factor", [1, 2])
-def test_sourceplot_wavelength_facn(factor, caplog):
+def test_sourceplot_wavelength_facn(factor, caplog, make_basic_datapha):
     """Change plot factor for test_sourceplot_wavelength"""
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    data = make_basic_datapha
     data.units = "wavelength"
     data.plot_fac = factor
     assert data.rate
@@ -366,13 +307,10 @@ def test_sourceplot_wavelength_facn(factor, caplog):
     check_sourceplot_wavelength(sp, factor=factor)
 
 
-def test_sourceplot_wavelength_counts(caplog):
+def test_sourceplot_wavelength_counts(caplog, make_basic_datapha):
     """test_sourceplot_wavelength but when rate=False is chosen"""
 
-    bins = np.arange(0.1, 10.1, 0.1)
-    data = DataPHA('', np.arange(10), np.ones(10),
-                   bin_lo=bins[:-1].copy(),
-                   bin_hi=bins[1:].copy())
+    data = make_basic_datapha
     data.units = "wave"
     data.rate = False
 

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015, 2016, 2018, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -22,14 +23,10 @@
 # may be better placed in tests of the sherpa.astro.io module, once that
 # becomes possible
 
-import logging
-
 from sherpa.utils.testing import requires_data, requires_fits
 from sherpa.astro import ui
 from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import ARF1D, RMF1D
-
-logger = logging.getLogger("sherpa")
 
 
 FILE_NAME = 'acisf01575_001N001_r0085_pha3.fits'

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -2010,3 +2010,183 @@ def test_model_dimensionality_check_is_not_triggered_plot_model(clean_astro_ui):
         ui.plot_model()
 
     assert str(err.value) == "Data and model dimensionality do not match: 1D and 2D"
+
+
+def simple_data1dint(idval):
+    """Create a simple dataset for the #1444 checks.
+
+    Usw Data1DInt rather than Data1D as the fact it's integrated
+    gives a chance to check the model evaluation.
+    """
+
+    xlo = np.asarray([1, 3, 7])
+    xhi = np.asarray([2, 7, 9])
+    y = np.asarray([5, 17, 7])
+
+    ui.load_arrays(idval, xlo, xhi, y, ui.Data1DInt)
+    ui.set_source(idval, ui.const1d.mdl)
+
+    mdl.c0 = 100
+
+
+def simple_dataimg(idval):
+    """Create a simple dataset for the #1444 checks.
+
+    We want to use DataIMG and not Data2D to ensure we have
+    notice2d.
+    """
+
+    x1, x0 = np.mgrid[1:4, 1:5]
+    y = x1 + 10 * x0
+    ui.load_arrays(idval, x0.flatten(), x1.flatten(), y.flatten(),
+                   x0.shape, ui.DataIMG)
+
+    ui.set_source(idval, ui.polynom2d.mdl)
+    mdl.c = 100
+    mdl.cx1 = 10
+    mdl.cy1 = 1
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_1d_data_1d(idval, clean_astro_ui):
+    """Check issue #1444 for a 1D data set: calc_data_sum
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_data1dint(idval)
+    assert ui.calc_data_sum(id=idval) == pytest.approx(29)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_1d_data_2d(idval, clean_astro_ui):
+    """Check issue #1444 for a 1D data set: calc_data_sum2d
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_data1dint(idval)
+    with pytest.raises(AttributeError) as exc:
+        ui.calc_data_sum2d(id=idval)
+
+    assert str(exc.value) == "'Data1DInt' object has no attribute 'notice2d'"
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_1d_model_1d(idval, clean_astro_ui):
+    """Check issue #1444 for a 1D data set: calc_model_sum
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_data1dint(idval)
+    assert ui.calc_model_sum(id=idval) == pytest.approx(700)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_1d_model_2d(idval, clean_astro_ui):
+    """Check issue #1444 for a 1D data set: calc_model_sum2d
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_data1dint(idval)
+    with pytest.raises(AttributeError) as exc:
+        ui.calc_model_sum2d(id=idval)
+
+    assert str(exc.value) == "'Data1DInt' object has no attribute 'notice2d'"
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_1d_source_1d(idval, clean_astro_ui):
+    """Check issue #1444 for a 1D data set: calc_source_sum
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_data1dint(idval)
+    # TODO: what is calc_source_sum calculating here?
+    assert ui.calc_source_sum(id=idval) == pytest.approx(300)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_1d_source_2d(idval, clean_astro_ui):
+    """Check issue #1444 for a 1D data set: calc_source_sum2d
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_data1dint(idval)
+    with pytest.raises(AttributeError) as exc:
+        ui.calc_source_sum2d(id=idval)
+
+    assert str(exc.value) == "'Data1DInt' object has no attribute 'notice2d'"
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_2d_data_1d(idval, clean_astro_ui):
+    """Check issue #1444 for a 2D data set: calc_data_sum
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_dataimg(idval)
+    assert ui.calc_data_sum(id=idval) == pytest.approx(324)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_2d_data_2d(idval, clean_astro_ui):
+    """Check issue #1444 for a 2D data set: calc_data_sum2d
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_dataimg(idval)
+    assert ui.calc_data_sum2d(id=idval) == pytest.approx(324)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_2d_model_1d(idval, clean_astro_ui):
+    """Check issue #1444 for a 2D data set: calc_model_sum
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_dataimg(idval)
+    assert ui.calc_model_sum(id=idval) == pytest.approx(1524)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_2d_model_2d(idval, clean_astro_ui):
+    """Check issue #1444 for a 2D data set: calc_model_sum2d
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_dataimg(idval)
+    assert ui.calc_model_sum2d(id=idval) == pytest.approx(1524)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_2d_source_1d(idval, clean_astro_ui):
+    """Check issue #1444 for a 2D data set: calc_source_sum
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_dataimg(idval)
+
+    # trigger an assertion that was added as part of #756
+    with pytest.raises(AssertionError):
+        ui.calc_source_sum(id=idval)
+
+
+@pytest.mark.parametrize("idval", [None, 1, 9, "foo"])
+def test_1444_2d_source_2d(idval, clean_astro_ui):
+    """Check issue #1444 for a 2D data set: calc_source_sum2d
+
+    This is a regression test, in that it just tests the existing behavior.
+    """
+
+    simple_dataimg(idval)
+    assert ui.calc_source_sum2d(id=idval) == pytest.approx(1524)

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1776,23 +1776,32 @@ def test_pha_column_set_none(label, vals, clean_astro_ui):
     assert getfunc() is None
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("label", ["grouping", "quality"])
-@pytest.mark.parametrize("vals",
-                         [True, False, [1, 2, 3], np.ones(20)])
-def test_pha_column_has_correct_size(label, vals, clean_astro_ui):
-    """Check that the label column is the right size.
+@pytest.mark.parametrize("vals", [True, False])
+def test_pha_column_has_correct_size_scalar(label, vals, clean_astro_ui):
+    """Check that the label column is the right size: scalar
 
     This is related to issue #1160.
     """
 
     ui.load_arrays(1, [1, 2, 3, 4, 5], [5, 4, 2, 3, 7], ui.DataPHA)
 
-    with pytest.raises(DataErr) as de:
-        # This does not throw an error
-        getattr(ui, f"set_{label}")(vals)
+    # This does not throw an error
+    getattr(ui, f"set_{label}")(vals)
 
-    assert str(de.value) == f"size mismatch between channel and {label}"
+
+@pytest.mark.parametrize("label", ["grouping", "quality"])
+@pytest.mark.parametrize("vals", [[1, 2, 3], np.ones(20)])
+def test_pha_column_has_correct_size_sequence(label, vals, clean_astro_ui):
+    """Check that the label column is the right size: sequence
+
+    This is related to issue #1160.
+    """
+
+    ui.load_arrays(1, [1, 2, 3, 4, 5], [5, 4, 2, 3, 7], ui.DataPHA)
+
+    # This does not throw an error
+    getattr(ui, f"set_{label}")(vals)
 
 
 @pytest.mark.parametrize("label", ["grouping", "quality"])

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -18,6 +18,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import re
+
 import numpy as np
 import pytest
 
@@ -531,20 +533,28 @@ def test_calc_data_sum_no_range_2d(data_class):
 
 
 @pytest.mark.parametrize("data_class", ["1d", "1dint",
-                                        "pha", "grp", "qual",
-                                        "2d", "2dint"])
+                                        "pha", "grp", "qual"])
 def test_calc_data_sum2d_no_range_1d(data_class):
-    """What happens when data is not an IMG class
-
-    Note that this includes 2d/2dint classes as they all fail.
-
-    """
+    """What happens when data is not an IMG class: 1D"""
 
     data = make_data(data_class)
     with pytest.raises(AttributeError) as err:
         utils.calc_data_sum2d(data)
 
-    assert str(err.value).endswith(" object has no attribute 'notice2d'")
+    assert re.match("^'Data.*' object has no attribute 'notice2d'",
+                    str(err.value))
+
+
+@pytest.mark.parametrize("data_class", ["2d", "2dint"])
+def test_calc_data_sum2d_no_range_2d_but_not_img(data_class):
+    """What happens when data is not an IMG class: 2D"""
+
+    data = make_data(data_class)
+    with pytest.raises(AttributeError) as err:
+        utils.calc_data_sum2d(data)
+
+    assert re.match("^'Data.*' object has no attribute 'notice2d'",
+                    str(err.value))
 
 
 @pytest.mark.parametrize("data_class", ["img", "imgint"])

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,9 +30,9 @@ from sherpa.models.basic import Box1D, Const1D, Gauss1D, \
 from sherpa.models.parameter import Parameter
 from sherpa.instrument import PSFModel
 from sherpa.data import Data1D, Data1DInt
-import sherpa.astro.ui as ui
+from sherpa.astro import ui
 
-import sherpa.utils
+from sherpa.utils import linear_interp
 from sherpa.utils.err import ModelErr
 
 from sherpa.models.regrid import ModelDomainRegridder1D, EvaluationSpace1D, \
@@ -767,7 +767,7 @@ def _test_regrid1d_int(rtol,
 @pytest.mark.parametrize("eincr", [True])
 @pytest.mark.parametrize("rincr", [True, False])
 @pytest.mark.parametrize("margs", [(5e-5, None),
-                                   (0.011, sherpa.utils.linear_interp)])
+                                   (0.011, linear_interp)])
 def test_regrid1d_interpolation(eincr, rincr, margs, setup_1d):
 
     tol, method = margs

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1279,6 +1279,21 @@ def test_data_apply_filter_invalid_size(data):
     data.apply_filter([1, 2])
 
 
+@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS)
+def test_data_apply_filter_empty(data_class, args):
+    """There's no data so how can we filter?
+
+    We could error out or just return the supplied argument, so
+    this is a regression test
+    """
+
+    data = data_class("empty", *args)
+
+    orig = [1, 2]
+    ans = data.apply_filter(orig)
+    assert ans == pytest.approx(orig)
+
+
 @pytest.mark.parametrize("lo,hi,emsg", [("1:20", None, 'lower'), (None, "2", 'upper'), ("0.5", "7", 'lower')])
 @pytest.mark.parametrize("ignore", [False, True])
 def test_data1d_notice_errors_out_on_string_range(lo, hi, emsg, ignore):

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1715,6 +1715,90 @@ def test_data2dint_attribute_is_none(attribute, make_data2dint):
     assert attr is None
 
 
+@pytest.mark.parametrize("data", (Data, ) + DATA_1D_CLASSES, indirect=True)
+def test_reduce_axis_size_1d(data):
+    """What happens if we reduce the independent axis?"""
+
+    nindep = len(data.indep)
+    for indep in data.indep:
+        assert len(indep) == 10
+
+    for attr in ["dep", "staterror", "syserror"]:
+        aval = getattr(data, attr)
+        assert len(aval) == 10
+
+    # Sanity checks.
+    #
+    for a, b in zip(data.indep, data.get_indep()):
+        assert numpy.all(a == b)
+
+    # Let's make the independent axis smaller.
+    #
+    smaller = []
+    for indep in data.indep:
+        smaller.append(indep[1:-1])
+
+    data.indep = tuple(smaller)
+
+    # Check what has changed.
+    #
+    assert len(data.indep) == nindep
+    for indep in data.indep:
+        assert len(indep) == 8
+
+    # Note that the other values have not changed.
+    #
+    for attr in ["dep", "staterror", "syserror"]:
+        aval = getattr(data, attr)
+        assert len(aval) == 10
+
+
+@pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
+def test_reduce_axis_size_2d(data):
+    """What happens if we reduce the independent axis?
+
+    There is a shape attribute which could be changed, or
+    maybe should be changed.
+    """
+
+    nindep = len(data.indep)
+    for indep in data.indep:
+        assert len(indep) == 100
+
+    for attr in ["dep", "staterror", "syserror"]:
+        aval = getattr(data, attr)
+        assert len(aval) == 100
+
+    assert data.shape == (10, 10)
+
+    # Sanity checks.
+    #
+    for a, b in zip(data.indep, data.get_indep()):
+        assert numpy.all(a == b)
+
+    # Let's make the independent axis smaller.
+    #
+    smaller = []
+    for indep in data.indep:
+        smaller.append(indep[1:-1])
+
+    data.indep = tuple(smaller)
+
+    # Check what has changed.
+    #
+    assert len(data.indep) == nindep
+    for indep in data.indep:
+        assert len(indep) == 98
+
+    # Note that the other values have not changed.
+    #
+    assert data.shape == (10, 10)
+
+    for attr in ["dep", "staterror", "syserror"]:
+        aval = getattr(data, attr)
+        assert len(aval) == 100
+
+
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
 def test_set_independent_axis_to_none(data):
     """What happens if we clear the independent axis?

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1800,6 +1800,18 @@ def test_reduce_axis_size_2d(data):
 
 
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+def test_invalid_independent_axis(data):
+    """What happens if we use the wrong number of independent axes?
+
+    We just duplicate the current axes.
+    """
+
+    indep = data.indep
+    with pytest.raises(TypeError):
+        data.indep = tuple(list(indep) * 2)
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
 def test_set_independent_axis_to_none(data):
     """What happens if we clear the independent axis?
 

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1715,6 +1715,29 @@ def test_data2dint_attribute_is_none(attribute, make_data2dint):
     assert attr is None
 
 
+# We do not include the base Data in this list because the
+# notice/ignore call does not match the 1D cases.
+#
+@pytest.mark.parametrize("data", DATA_1D_CLASSES, indirect=True)
+def test_is_mask_reset(data):
+    """What happens to the mask attribute after the independent axis is changed?"""
+
+    # Pick a value somewhere within the independent axis
+    assert data.mask is True
+    data.ignore(None, 4)
+    assert isinstance(data.mask, numpy.ndarray)
+    omask = data.mask.copy()
+
+    # Change the independent axis, but to something of the same
+    # length.
+    indep = [x + 100 for x in data.indep]
+    data.indep = tuple(indep)
+
+    # This is a regression test as there is an argument that the mask
+    # should be cleared.
+    assert data.mask == pytest.approx(omask)
+
+
 @pytest.mark.parametrize("data", (Data, ) + DATA_1D_CLASSES, indirect=True)
 def test_reduce_axis_size_1d(data):
     """What happens if we reduce the independent axis?"""

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -2116,3 +2116,107 @@ def test_data_eval_model_checks_dimensionality_2d(data, funcname):
     with pytest.raises(TypeError):
         # XFAIL: Data2D does not raise an error
         func(model)
+
+
+def test_data1d_create_not_ndarray():
+    """If sent non nd-array fields, does __init__ convert them?
+
+    This is a regression test.
+    """
+
+    d = Data1D('x', [1, 2, 3], (4, 5, 6),
+               staterror=(8, 7, 6), syserror=[2, 3, 4])
+
+    assert isinstance(d.indep, tuple)
+    assert len(d.indep) == 1
+    assert isinstance(d.indep[0], numpy.ndarray)
+
+    assert isinstance(d.y, numpy.ndarray)
+    assert isinstance(d.staterror, tuple)
+    assert isinstance(d.syserror, list)
+
+
+def test_data1dint_create_not_ndarray():
+    """If sent non nd-array fields, does __init__ convert them?
+
+    This is a regression test.
+    """
+
+    d = Data1DInt('x', [2, 3, 4], (2.5, 4.5, 4.8), (4, 5, 6),
+               staterror=(8, 7, 6), syserror=[2, 3, 4])
+
+    assert isinstance(d.indep, tuple)
+    assert len(d.indep) == 2
+    assert isinstance(d.indep[0], numpy.ndarray)
+    assert isinstance(d.indep[1], numpy.ndarray)
+
+    assert isinstance(d.y, numpy.ndarray)
+    assert isinstance(d.staterror, tuple)
+    assert isinstance(d.syserror, list)
+
+
+def test_data2d_create_not_ndarray():
+    """If sent non nd-array fields, does __init__ convert them?
+
+    This is a regression test.
+    """
+
+    d = Data2D('x', [2, 3, 4], (15, 16, 17), (4, 5, 6),
+               staterror=(8, 7, 6), syserror=[2, 3, 4])
+
+    assert isinstance(d.indep, tuple)
+    assert len(d.indep) == 2
+    assert isinstance(d.indep[0], numpy.ndarray)
+    assert isinstance(d.indep[1], numpy.ndarray)
+
+    assert isinstance(d.y, numpy.ndarray)
+    assert isinstance(d.staterror, tuple)
+    assert isinstance(d.syserror, list)
+
+
+def test_data2dint_create_not_ndarray():
+    """If sent non nd-array fields, does __init__ convert them?
+
+    This is a regression test.
+    """
+
+    d = Data2DInt('x', [2, 3, 4], (15, 16, 17),
+                  (2.5, 4.5, 4.8), (16, 17, 18), (4, 5, 6),
+                  staterror=(8, 7, 6), syserror=[2, 3, 4])
+
+    assert isinstance(d.indep, tuple)
+    assert len(d.indep) == 4
+    assert isinstance(d.indep[0], numpy.ndarray)
+    assert isinstance(d.indep[1], numpy.ndarray)
+    assert isinstance(d.indep[2], numpy.ndarray)
+    assert isinstance(d.indep[3], numpy.ndarray)
+
+    assert isinstance(d.y, numpy.ndarray)
+    assert isinstance(d.staterror, tuple)
+    assert isinstance(d.syserror, list)
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+@pytest.mark.parametrize("field", ["staterror", "syserror"])
+def test_data_set_not_ndarray(data, field):
+    """What happens if the field is set to a non-ndarray after creation?
+
+    This is a regression test.
+    """
+
+    setattr(data, field, tuple([1] * len(data.y)))
+    got = getattr(data, field)
+
+    assert isinstance(got, tuple)
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+def test_data_mask_set_not_ndarray(data):
+    """What happens if the mask field is set to a non-ndarray after creation?
+
+    This is a regression test.
+    """
+
+    data.mask = tuple([1] * len(data.y))
+
+    assert isinstance(data.mask, numpy.ndarray)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1237,6 +1237,17 @@ def test_data_filter_invalid_size(vals):
     assert str(de.value) == 'size mismatch between mask and data array'
 
 
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+def test_data_apply_filter_invalid_size(data):
+    """There's no filter applied but the argument is the wrong size.
+
+    Test related to issue #1439 which is an issue with the DataPHA class.
+    """
+
+    # this does not raise an error
+    data.apply_filter([1, 2])
+
+
 @pytest.mark.parametrize("lo,hi,emsg", [("1:20", None, 'lower'), (None, "2", 'upper'), ("0.5", "7", 'lower')])
 @pytest.mark.parametrize("ignore", [False, True])
 def test_data1d_notice_errors_out_on_string_range(lo, hi, emsg, ignore):

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1881,6 +1881,34 @@ def test_reduce_axis_size_2d(data):
 
 
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+@pytest.mark.parametrize("val,etype",
+                         [(1, "int"),
+                          ([1, 2, 3], "list"),
+                          (numpy.asarray([1,2, 3]), "ndarray")
+                          ])
+def test_invalid_independent_axis_not_a_tuple_set_indep(val, etype, data):
+    """The independent axis must be a tuple: set_indep"""
+
+    # There is no consistent error message to test here
+    with pytest.raises(TypeError):
+        data.set_indep(val)
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+@pytest.mark.parametrize("val,etype",
+                         [(1, "int"),
+                          ([1, 2, 3], "list"),
+                          (numpy.asarray([1,2, 3]), "ndarray")
+                          ])
+def test_invalid_independent_axis_not_a_tuple_indep(val, etype, data):
+    """The independent axis must be a tuple: .indep"""
+
+    # There is no consistent error message to test here
+    with pytest.raises(TypeError):
+        data.indep = val
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
 def test_invalid_independent_axis(data):
     """What happens if we use the wrong number of independent axes?
 

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1840,6 +1840,36 @@ def test_invalid_independent_axis_component_none(data):
 
 
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+def test_invalid_dependent_axis(data):
+    """What happens if the dependent axis does not match the independent axis?
+    """
+
+    # This currently does not fail
+    data.y = data.y[:-2]
+
+
+@pytest.mark.parametrize("data_class", ALL_DATA_CLASSES)
+def test_make_invalid_dependent_axis(data_class):
+    """What happens if call constructor with invalid independent axis?
+    """
+
+    # Take the correct arguments and reduce the independent axis by one.
+    # Use a copy of everything just in case.
+    args = []
+    for arg in INSTANCE_ARGS[data_class]:
+        if isinstance(arg, numpy.ndarray):
+            arg = arg.copy()
+
+        args.append(arg)
+
+    ypos = POS_Y_ARRAY[data_class]
+    args[ypos] = args[ypos][:-1]
+
+    # This does not raise an error
+    data_class(*args)
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
 def test_set_independent_axis_to_none(data):
     """What happens if we clear the independent axis?
 

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -2090,3 +2090,29 @@ def test_error_must_be_1d(data, column):
     err = err.reshape(2, err.size // 2)
     # does not raise an error
     setattr(data, column, err)
+
+
+#@pytest.mark.parametrize("data", DATA_1D_CLASSES, indirect=True)
+@pytest.mark.parametrize("data", (Data1D, pytest.param(Data1DInt, marks=pytest.mark.xfail)), indirect=True)
+@pytest.mark.parametrize("funcname", ["eval_model", "eval_model_to_fit"])
+def test_data_eval_model_checks_dimensionality_1d(data, funcname):
+    """Does eval_model check the model dimensionality?"""
+
+    model = Polynom2D()
+    func = getattr(data, funcname)
+    with pytest.raises(TypeError):
+        # XFAIL: Data1DInt does not raise an error
+        func(model)
+
+
+#@pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
+@pytest.mark.parametrize("data", (pytest.param(Data2D, marks=pytest.mark.xfail), Data2DInt), indirect=True)
+@pytest.mark.parametrize("funcname", ["eval_model", "eval_model_to_fit"])
+def test_data_eval_model_checks_dimensionality_2d(data, funcname):
+    """Does eval_model check the model dimensionality?"""
+
+    model = Polynom1D()
+    func = getattr(data, funcname)
+    with pytest.raises(TypeError):
+        # XFAIL: Data2D does not raise an error
+        func(model)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1713,3 +1713,21 @@ def test_data2dint_attribute_is_none(attribute, make_data2dint):
     """Check those attributes that return None"""
     attr = getattr(make_data2dint, attribute)
     assert attr is None
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+def test_set_independent_axis_to_none(data):
+    """What happens if we clear the independent axis?
+
+    It's not entirely clear what we mean by setting the independent
+    axis to None: do we need to set all components or is it sufficient
+    to use a single None. Similarly, what should the response be. We
+    currently only test the current behavior.
+
+    """
+
+    assert all(d is not None for d in data.indep)
+
+    indep = [None for d in data.indep]
+    data.set_indep(tuple(indep))
+    assert all(d is None for d in data.indep)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1811,6 +1811,34 @@ def test_invalid_independent_axis(data):
         data.indep = tuple(list(indep) * 2)
 
 
+@pytest.mark.parametrize("data", (Data1DInt, Data2D, Data2DInt), indirect=True)
+def test_invalid_independent_axis_component_size(data):
+    """What happens if we use mis-matched sizes?
+
+    It only makes sense to do this for data classes with
+    multiple components. We remove one entry from the
+    second component,
+    """
+
+    indep = list(data.indep)
+    indep[1] = indep[1][:-1]
+    # At the moment this does not error out
+    data.indep = tuple(indep)
+
+
+@pytest.mark.parametrize("data", (Data1DInt, Data2D, Data2DInt), indirect=True)
+def test_invalid_independent_axis_component_none(data):
+    """What happens if we use mis-matched sizes (by setting one to None).
+
+    See test_invalid_independent_axis_component_size.
+    """
+
+    indep = list(data.indep)
+    indep[1] = None
+    # At the moment this does not error out
+    data.indep = tuple(indep)
+
+
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
 def test_set_independent_axis_to_none(data):
     """What happens if we clear the independent axis?

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -2461,3 +2461,29 @@ def test_data1d_do_we_copy_the_dependent_axis():
     # If an element of x is changed, does the dependent axis change?
     y[1] = -20
     assert data.y == pytest.approx(y)
+
+
+def test_data1d_compare_mask_and_filter():
+    """We can use ignore/notice or change the mask to get the same result"""
+
+    x = numpy.asarray([10, 20, 25, 30, 50])
+    y = x * 10
+    data = Data1D("ex", x, y)
+
+    assert data.mask
+
+    # Use notice/ignore
+    #
+    data.notice(15, 40)
+    data.ignore(23, 27)
+    assert data.mask == pytest.approx([0, 1, 0, 1, 0])
+    assert data.get_dep(filter=True) == pytest.approx([200, 300])
+
+    data.notice()
+    assert data.mask
+
+    # Change the mask array directly
+    data.mask = [0, 1, 0, 1, 0]
+
+    assert data.mask == pytest.approx([0, 1, 0, 1, 0])
+    assert data.get_dep(filter=True) == pytest.approx([200, 300])

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -29,9 +29,55 @@ import numpy as np
 import pytest
 
 from sherpa.data import Data1D, Data2D
-from sherpa.instrument import PSFModel
-from sherpa.models.basic import Box1D, Box2D, Const1D, Gauss1D, StepLo1D
+from sherpa.instrument import Kernel, PSFModel, RadialProfileKernel
+from sherpa.models.basic import Box1D, Box2D, Const2D, Const1D, Gauss1D, Gauss2D, StepLo1D
 from sherpa.utils.err import PSFErr
+
+
+def make_none():
+    """We can use this to create no kernel"""
+
+    return None
+
+
+def make_1d_model():
+    """We want to create a new model each call.
+
+    This could be made a fixture but this is easier.
+    """
+
+    box = Box1D('box1')
+    box.xlow = 2
+    box.xhi = 5
+    return box
+
+
+def make_2d_model():
+    """We want to create a new model each call."""
+
+    box = Box2D('box2')
+    box.xlow = 2
+    box.xhi = 5
+    box.yhi = 4
+    return box
+
+
+def make_1d_data():
+    """We want to create a new object each call."""
+
+    k = np.asarray([2, 3, 5, 1, 0, 2, 1])
+    x = np.arange(k.size)
+    return Data1D('oned', x, k)
+
+
+def make_2d_data():
+    """We want to create a new object each call."""
+
+    y, x = np.mgrid[1:3, 1:4]
+    x = x.flatten()
+    y = y.flatten()
+    z = np.ones(x.size)
+    return Data2D('twod', x, y, z)
 
 
 def test_psf1d_show():
@@ -48,9 +94,9 @@ def test_psf1d_show():
     NAME = ['psfmodel']
     PARAMS = ['Param', 'Type', 'Value', 'Min', 'Max', 'Units']
     LINES = ['-----', '----', '-----', '---', '---', '-----']
-    KERNEL = ['psfmodel.kernel', 'frozen', 'my-kernel']
-    SIZE = ['psfmodel.size', 'frozen', '3', '3', '3']
-    CENTER = ['psfmodel.center', 'frozen', '1', '1', '1']
+    KERNEL = ['psfmodel.kernel', 'frozen', 'oned']
+    SIZE = ['psfmodel.size', 'frozen', '7', '7', '7']
+    CENTER = ['psfmodel.center', 'frozen', '3', '3', '3']
     RADIAL = ['psfmodel.radial', 'frozen', '0', '0', '1']
     NORM = ['psfmodel.norm', 'frozen', '1', '0', '1']
 
@@ -66,10 +112,7 @@ def test_psf1d_show():
     check(out, 3, RADIAL)
     check(out, 4, NORM)
 
-    k = np.asarray([2, 5, 3])
-    x = np.arange(k.size)
-    d = Data1D('my-kernel', x, k)
-    m.kernel = d
+    m.kernel = make_1d_data()
 
     # before a fold you don't get the size and center parameters
     out = str(m).split('\n')
@@ -101,9 +144,7 @@ def test_psf1d_show():
 def test_psf1d_model_show():
     """What happens when the kernel is a model?"""
 
-    box1 = Box1D('box1')
-    box1.xlow = 2
-    box1.xhi = 5
+    box1 = make_1d_model()
     m = PSFModel("pmodel1", box1)
 
     dfold = Data1D('fold', np.arange(10), np.zeros(10))
@@ -154,11 +195,7 @@ def test_psf2d_data_show():
 def test_psf2d_model_show():
     """What happens when the kernel is a model?"""
 
-    box2 = Box2D('box2')
-    box2.xlow = 2
-    box2.xhi = 5
-    box2.yhi = 5
-    m = PSFModel("pmodel2", box2)
+    m = PSFModel("pmodel2", make_2d_model())
 
     yy, xx = np.mgrid[1:10, 1:9]
     xx = xx.flatten()
@@ -553,3 +590,201 @@ def test_psf1d_combined_v2():
     # check that the x <= 19 values are in ascending order
     y1 = y[x <= 19]
     assert (y1[1:] > y1[:-1]).all()
+
+
+def test_psf1d_model_given_2d_dataset():
+    """Do we error out or not?
+
+    This is a regression test.
+    """
+
+    psf = PSFModel('psf', make_1d_model())
+    d = make_2d_data()
+
+    # Does this error out?
+    psf.fold(d)
+
+    smdl = StepLo1D()
+    smdl.xcut = 100
+    smdl.ampl = 10
+
+    cmdl = Const1D()
+    cmdl.c0 = -500
+
+    imdl = smdl + cmdl
+
+    # Or maybe this errors out?
+    smoothed = psf(imdl)
+    with pytest.raises(TypeError) as err:
+        smoothed(np.arange(1, 7))
+
+    # It is not at all obvious why we have 36 for the source dim.
+    #
+    assert str(err.value) == "input array sizes do not match dimensions, source size: 6 vs source dim: 36"
+
+
+def test_psf1d_data_given_2d_dataset():
+    """Do we error out or not?
+
+    This is a regression test.
+    """
+
+    psf = PSFModel('psf', make_1d_data())
+    d = make_2d_data()
+
+    # Does this error out?
+    psf.fold(d)
+
+    smdl = StepLo1D()
+    smdl.xcut = 100
+    smdl.ampl = 10
+
+    cmdl = Const1D()
+    cmdl.c0 = -500
+
+    imdl = smdl + cmdl
+
+    # Or maybe this errors out?
+    smoothed = psf(imdl)
+    with pytest.raises(TypeError) as err:
+        smoothed(np.arange(1, 7))
+
+    assert str(err.value) == "input array sizes do not match, dims_src: 2 vs dims_kern: 1"
+
+
+def test_psf2d_model_given_1d_dataset():
+    """Do we error out or not?
+
+    This is a regression test.
+    """
+
+    psf = PSFModel('psf', make_2d_model())
+    d = make_1d_data()
+
+    # Does this error out?
+    psf.fold(d)
+
+    smdl = Gauss2D()
+    smdl.ampl = 1000
+
+    cmdl = Const2D()
+    cmdl.c0 = -500
+
+    imdl = smdl + cmdl
+
+    # Or maybe this errors out?
+    smoothed = psf(imdl)
+    with pytest.raises(TypeError) as err:
+        smoothed(np.arange(1, 7))
+
+    assert str(err.value) == "function missing required argument 'x1lo' (pos 3)"
+
+
+def test_psf2d_data_given_1d_dataset():
+    """Do we error out or not?
+
+    This is a regression test.
+    """
+
+    psf = PSFModel('psf', make_2d_data())
+    d = make_1d_data()
+
+    # Does this error out?
+    psf.fold(d)
+
+    smdl = Gauss2D()
+    smdl.ampl = 1000
+
+    cmdl = Const2D()
+    cmdl.c0 = -500
+
+    imdl = smdl + cmdl
+
+    # Or maybe this errors out?
+    smoothed = psf(imdl)
+    with pytest.raises(TypeError) as err:
+        smoothed(np.arange(1, 7))
+
+    assert str(err.value) == "function missing required argument 'x1lo' (pos 3)"
+
+
+@pytest.mark.parametrize("kernel_func", [make_1d_model, make_1d_data])
+@pytest.mark.parametrize("field", ["size", "origin", "center"])
+@pytest.mark.parametrize("vals", [[2, 3], [2, 3, 4]])
+def test_psf1d_set_invalid_field(kernel_func, field, vals):
+    """What happens if we send in a 2D array?
+
+    This is a regression test (since it currently does not error out).
+    """
+
+    kernel = kernel_func()
+    m = PSFModel("p1", kernel)
+
+    setattr(m, field, vals)
+    assert getattr(m, field) == pytest.approx(vals)
+
+
+@pytest.mark.parametrize("kernel_func", [make_2d_model, make_2d_data])
+@pytest.mark.parametrize("field", ["size", "origin", "center"])
+@pytest.mark.parametrize("vals", [4, [2, 3, 4]])
+def test_psf2d_set_invalid_field(kernel_func, field, vals):
+    """What happens if we send in a 2D array?
+
+    This is a regression test (since it currently does not error out).
+    """
+
+    kernel = kernel_func()
+    m = PSFModel("p2", kernel)
+
+    setattr(m, field, vals)
+    assert getattr(m, field) == pytest.approx(vals)
+
+
+@pytest.mark.parametrize("kernel_func", [make_none, make_1d_model, make_1d_data, make_2d_model, make_2d_data])
+def test_psf_set_model_to_model(kernel_func):
+    """Can we change the model field? model
+
+    This is a regression test.
+    """
+
+    m = PSFModel(kernel=kernel_func())
+    with pytest.raises(AttributeError) as err:
+        m.model = Box1D()
+
+    assert str(err.value) == "'PSFModel' object attribute 'model' cannot be replaced with a callable attribute"
+
+
+@pytest.mark.parametrize("kernel_func", [make_none, make_1d_model, make_1d_data, make_2d_model, make_2d_data])
+def test_psf_set_model_to_bool(kernel_func):
+    """Can we change the model field? boolean
+
+    This is a regression test.
+    """
+
+    m = PSFModel(kernel=kernel_func())
+    # This does not error out
+    m.model = False
+
+
+@pytest.mark.parametrize("dshape,kshape",
+                         [pytest.param(None, None, marks=pytest.mark.xfail), (None, [1]), pytest.param([1], None, marks=pytest.mark.xfail),
+                          ([1], [1, 2]), ([1, 2], [1]),
+                          ([], [1]), ([1], []),
+                          ([1, 3, 4], ([1, 2, 3]))])
+def test_kernel_checks_arguments(dshape, kshape):
+    """Do these error out?
+
+    This is a regression test.
+    """
+
+    # XFAIL: when kshape is None a TypeError is raised from len(None)
+    Kernel(dshape, kshape)
+
+
+def test_radialprofile_is_1d():
+    """Do these error out?
+
+    This is a regression test.
+    """
+
+    RadialProfileKernel([10, 10], [4, 3])

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -98,6 +98,88 @@ def test_psf1d_show():
     check(out, 7, NORM)
 
 
+def test_psf1d_model_show():
+    """What happens when the kernel is a model?"""
+
+    box1 = Box1D('box1')
+    box1.xlow = 2
+    box1.xhi = 5
+    m = PSFModel("pmodel1", box1)
+
+    dfold = Data1D('fold', np.arange(10), np.zeros(10))
+    m.fold(dfold)
+
+    out = str(m).split("\n")
+    assert len(out) == 8
+    assert out[0] == "pmodel1"
+    assert out[1] == "   Param        Type          Value          Min          Max      Units"
+    assert out[2] == "   -----        ----          -----          ---          ---      -----"
+    assert out[3] == "   pmodel1.kernel frozen         box1"
+    assert out[4] == "   pmodel1.size frozen           10           10           10"
+    assert out[5] == "   pmodel1.center frozen            5            5            5"
+    assert out[6] == "   pmodel1.radial frozen            0            0            1           "
+    assert out[7] == "   pmodel1.norm frozen            1            0            1           "
+
+
+def test_psf2d_data_show():
+    """What happens when the kernel is a Data2D instance?"""
+
+    y, x = np.mgrid[1:4, 1:3]
+    x = x.flatten()
+    y = y.flatten()
+    z = np.ones(x.size)
+    data2 = Data2D('data2', x, y, z)
+
+    m = PSFModel("pdata2", data2)
+
+    yy, xx = np.mgrid[1:10, 1:9]
+    xx = xx.flatten()
+    yy = yy.flatten()
+    zz = np.arange(xx.size)
+    dfold = Data2D('fold', xx, yy, zz)
+    m.fold(dfold)
+
+    out = str(m).split("\n")
+    assert len(out) == 8
+    assert out[0] == "pdata2"
+    assert out[1] == "   Param        Type          Value          Min          Max      Units"
+    assert out[2] == "   -----        ----          -----          ---          ---      -----"
+    assert out[3] == "   pdata2.kernel frozen        data2"
+    assert out[4] == "   pdata2.size  frozen       (6, 6)       (6, 6)       (6, 6)"
+    assert out[5] == "   pdata2.center frozen       (3, 3)       (3, 3)       (3, 3)"
+    assert out[6] == "   pdata2.radial frozen            0            0            1           "
+    assert out[7] == "   pdata2.norm  frozen            1            0            1           "
+
+
+def test_psf2d_model_show():
+    """What happens when the kernel is a model?"""
+
+    box2 = Box2D('box2')
+    box2.xlow = 2
+    box2.xhi = 5
+    box2.yhi = 5
+    m = PSFModel("pmodel2", box2)
+
+    yy, xx = np.mgrid[1:10, 1:9]
+    xx = xx.flatten()
+    yy = yy.flatten()
+    zz = np.arange(xx.size)
+    dfold = Data2D('fold', xx, yy, zz)
+    m.fold(dfold)
+
+    print(m)
+    out = str(m).split("\n")
+    assert len(out) == 8
+    assert out[0] == "pmodel2"
+    assert out[1] == "   Param        Type          Value          Min          Max      Units"
+    assert out[2] == "   -----        ----          -----          ---          ---      -----"
+    assert out[3] == "   pmodel2.kernel frozen         box2"
+    assert out[4] == "   pmodel2.size frozen     (72, 72)     (72, 72)     (72, 72)"
+    assert out[5] == "   pmodel2.center frozen     (36, 36)     (36, 36)     (36, 36)"
+    assert out[6] == "   pmodel2.radial frozen            0            0            1           "
+    assert out[7] == "   pmodel2.norm frozen            1            0            1           "
+
+
 def test_psf1d_empty_pars():
     """What does .pars mean for an empty PSFModel?"""
 


### PR DESCRIPTION
# Summary

Ensure we test a number of corner cases related to data validation.

# Details

This is in preparation for addressing #1470 and ensures that we test a number of issues such as

- can I change the independent axis once set
- do we allow calls with an invalid array size

and a bunch of other low-level checks. Some of these may have existing coverage (e.g. from larger tests or I may have missed a similar test), but these particular tests do not take a long time to run. There is no change to behavior here.

I originally marked a number of these tests as XFAIL, with the expectation that we could just remove this marker when the fix for #1470 lands. I have since moved away from that approach (although there are some XFAIL tests added here), as I am treating the tests as regression tests (i.e. check what we currently allow) rather than a "first principles" test. This has two advantages:

- we can see easily when a behavior is changed (rather than having to note we suddenly get new XPASS tests)
- sometimes it is not at all obvious what the "correct" behavior should be (e.g. what error should actually be raised)

The main branch before this PR - with astropy, matplotlb, XSPEC 12.12.0, and ds9 installed - results in

```
============================ 6399 passed, 32 skipped, 88 xfailed, 4 xpassed in 579.23s (0:09:39) =============================
```

The 4 `xpassed` tests are tracked in #1334.


With this PR we get

```
============================ 6917 passed, 32 skipped, 91 xfailed, 4 xpassed in 590.10s (0:09:50) =============================
```

So we've gained ~500 tests (a lot of them are repeats, checking we get the same behavior with different object classes).