### PR TITLE
Minor cleanup of the data and instrument code

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1990,18 +1990,20 @@ must be an integer.""")
         filter = bool_cast(filter)
         self.notice_response(False)
         arf, rmf = self.get_response()
-        newarf = None
 
-        if arf is not None and rmf is not None:
-            specresp = arf.get_dep()
-            elo, ehi = arf.get_indep()
-            lo, hi = self._get_ebins(group=False)
+        # Should we allow an ARF-only analysis?
+        if arf is None or rmf is None:
+            return None
 
-            newarf = interpolate(lo, elo, specresp)
-            newarf[newarf <= 0] = 1.
+        specresp = arf.get_dep()
+        elo, ehi = arf.get_indep()
+        lo, hi = self._get_ebins(group=False)
 
-            if filter:
-                newarf = self.apply_filter(newarf, self._middle)
+        newarf = interpolate(lo, elo, specresp)
+        newarf[newarf <= 0] = 1.
+
+        if filter:
+            newarf = self.apply_filter(newarf, self._middle)
 
         return newarf
 
@@ -2034,14 +2036,12 @@ must be an integer.""")
         from sherpa.astro import instrument
 
         if pileup_model is not None:
-            resp = instrument.PileupResponse1D(self, pileup_model)
-        elif len(self._responses) > 1:
-            resp = instrument.MultipleResponse1D(self)
-        else:
-            resp = instrument.Response1D(self)
+            return instrument.PileupResponse1D(self, pileup_model)
 
-        return resp
+        if len(self._responses) > 1:
+            return instrument.MultipleResponse1D(self)
 
+        return instrument.Response1D(self)
 
     def _get_ebins(self, response_id=None, group=True):
         """Return the low and high edges of the independent axis.
@@ -2283,7 +2283,6 @@ must be an integer.""")
         # the group).
         #
         mid = numpy.floor(mid)
-
         val = numpy.asarray(val).astype(numpy.int_) - 1
         try:
             return mid[val]

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3270,11 +3270,9 @@ must be an integer.""")
             bkg.group_adapt_snr(minimum, maxLength=maxLength,
                                 tabStops=tabStops, errorCol=errorCol)
 
-    def eval_model(self, modelfunc):
-        return modelfunc(*self.get_indep(filter=False))
-
     def eval_model_to_fit(self, modelfunc):
-        return self.apply_filter(modelfunc(*self.get_indep(filter=True)))
+        model = super().eval_model_to_fit(modelfunc)
+        return self.apply_filter(model)
 
     def sum_background_data(self,
                             get_bdata_func=(lambda key, bkg: bkg.counts)):

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3398,26 +3398,26 @@ must be an integer.""")
             dep = self.apply_filter(dep)
         return dep
 
-    def set_dep(self, val):
-        # QUS: should this "invert" the areascaling to val
-        #      to get the stored values?
-        #
-        #      Otherwise, when areascal /= 1
-        #            y1 = d.get_dep()
-        #            d.set_dep(y1)
-        #            y2 = d.get_dep()
-        #            y1 != y2
-        #
-        # Or perhaps it removes the areascal value in this case?
-        # We already have this split in the API when background data
-        # is available and is subtracted.
-        #
-        if numpy.iterable(val):
-            dep = numpy.asarray(val, SherpaFloat)
-        else:
-            val = SherpaFloat(val)
-            dep = numpy.array([val] * len(self.get_indep()[0]))
-        self.counts = dep
+    # The code used to re-define set_dep, but the only difference
+    # from the parent class was that it set the counts attribute and
+    # not the y attribute. These are now the same so it is no-longer
+    # needed.
+    #
+    # There was the following comment in the code which we keep here:
+    #
+    # QUS: should this "invert" the areascaling to val
+    #      to get the stored values?
+    #
+    #      Otherwise, when areascal /= 1
+    #            y1 = d.get_dep()
+    #            d.set_dep(y1)
+    #            y2 = d.get_dep()
+    #            y1 != y2
+    #
+    # Or perhaps it removes the areascal value in this case?
+    # We already have this split in the API when background data
+    # is available and is subtracted.
+    #
 
     def get_staterror(self, filter=False, staterrfunc=None):
         """Return the statistical error.

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1559,12 +1559,13 @@ must be an integer.""")
     def _set_response_ids(self, ids):
         if not numpy.iterable(ids):
             raise DataErr('idsnotarray', 'response', str(ids))
+
         keys = self._responses.keys()
         for id in ids:
             if id not in keys:
                 raise DataErr('badids', str(id), 'response', str(keys))
-        ids = list(ids)
-        self._response_ids = ids
+
+        self._response_ids = list(ids)
 
     response_ids = property(_get_response_ids, _set_response_ids,
                             doc=('IDs of defined instrument responses ' +
@@ -1576,12 +1577,13 @@ must be an integer.""")
     def _set_background_ids(self, ids):
         if not numpy.iterable(ids):
             raise DataErr('idsnotarray', 'background', str(ids))
+
         keys = self._backgrounds.keys()
         for id in ids:
             if id not in keys:
                 raise DataErr('badids', str(id), 'background', str(keys))
-        ids = list(ids)
-        self._background_ids = ids
+
+        self._background_ids = list(ids)
 
     background_ids = property(_get_background_ids, _set_background_ids,
                               doc='IDs of defined background data sets')
@@ -1765,9 +1767,10 @@ must be an integer.""")
         return self.units
 
     def _fix_response_id(self, id):
-        if id is None:
-            id = self.primary_response_id
-        return id
+        if id is not None:
+            return id
+
+        return self.primary_response_id
 
     def get_response(self, id=None):
         """Return the response component.
@@ -1829,6 +1832,7 @@ must be an integer.""")
         ids = self.response_ids[:]
         if id not in ids:
             ids.append(id)
+
         self.response_ids = ids
 
         # To support simulated data (e.g. issue #1209) we over-write
@@ -1987,7 +1991,6 @@ must be an integer.""")
            component).
 
         """
-        filter = bool_cast(filter)
         self.notice_response(False)
         arf, rmf = self.get_response()
 
@@ -2002,7 +2005,7 @@ must be an integer.""")
         newarf = interpolate(lo, elo, specresp)
         newarf[newarf <= 0] = 1.
 
-        if filter:
+        if bool_cast(filter):
             newarf = self.apply_filter(newarf, self._middle)
 
         return newarf
@@ -2305,6 +2308,7 @@ must be an integer.""")
                 vals = tiny
         else:
             vals[vals == 0.0] = tiny
+
         vals = hc / vals
         return vals
 
@@ -2312,9 +2316,10 @@ must be an integer.""")
     """The identifier for the background component when not set."""
 
     def _fix_background_id(self, id):
-        if id is None:
-            id = self.default_background_id
-        return id
+        if id is not None:
+            return id
+
+        return self.default_background_id
 
     def get_background(self, id=None):
         """Return the background component.
@@ -2554,8 +2559,9 @@ must be an integer.""")
 
         """
         if numpy.isscalar(scale) and scale <= 0.0:
-            scale = 1.0
-        elif numpy.iterable(scale):
+            return 1.0
+
+        if numpy.iterable(scale):
             scale = numpy.asarray(scale, dtype=SherpaFloat)
             if group:
                 if filter:
@@ -2564,6 +2570,7 @@ must be an integer.""")
                     scale = self.apply_grouping(scale, self._middle)
 
             scale[scale <= 0.0] = 1.0
+
         return scale
 
     def get_backscal(self, group=True, filter=False):
@@ -3377,7 +3384,6 @@ must be an integer.""")
         # return self.counts - self.sum_background_data()
 
         dep = self.counts
-        filter = bool_cast(filter)
 
         # The area scaling is not applied to the data, since it
         # should be being applied to the model via the *PHA
@@ -3392,8 +3398,9 @@ must be an integer.""")
                 raise DataErr("subtractlength")
             dep = dep - bkg
 
-        if filter:
+        if bool_cast(filter):
             dep = self.apply_filter(dep)
+
         return dep
 
     # The code used to re-define set_dep, but the only difference
@@ -3614,11 +3621,11 @@ must be an integer.""")
         There is no scaling by the AREASCAL setting.
         """
         syserr = self.syserror
-        filter = bool_cast(filter)
-        if filter:
+        if bool_cast(filter):
             syserr = self.apply_filter(syserr, self._sum_sq)
         else:
             syserr = self.apply_grouping(syserr, self._sum_sq)
+
         return syserr
 
     def get_x(self, filter=False, response_id=None):
@@ -3634,6 +3641,7 @@ must be an integer.""")
             xlabel += ' (Angstrom)'
         # elif self.units == 'channel' and self.grouped:
         #     xlabel = 'Group Number'
+
         return xlabel
 
     def _set_initial_quantity(self):
@@ -3743,8 +3751,7 @@ must be an integer.""")
         return self._fix_y_units(err, filter, response_id)
 
     def get_xerr(self, filter=False, response_id=None):
-        filter = bool_cast(filter)
-        if filter:
+        if bool_cast(filter):
             # If we apply a filter, make sure that
             # ebins are ungrouped before applying
             # the filter.
@@ -3883,6 +3890,7 @@ must be an integer.""")
         chans = self.get_noticed_channels()
         if self.mask is False or len(chans) == 0:
             return 'No noticed channels'
+
         return create_expr(chans, format='%i')
 
     def get_filter(self, group=True, format='%.12f', delim=':'):

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -425,9 +425,15 @@ class DataSpaceND():
         return self.indep
 
 
+# NOTE:
+#
+# Although this is labelled as supporting N-D datasets, the
+# implementation assumes that the data has been flattened to 1D arrays
+# - in particular the notice method. It is likely that we can document
+# this - i.e. that the mask is going to be 1D.
+#
 class Filter():
-    """
-    A class for representing filters of N-Dimentional datasets.
+    """A class for representing filters of N-Dimensional datasets.
     """
     def __init__(self):
         self._mask = True
@@ -444,31 +450,43 @@ class Filter():
 
     @mask.setter
     def mask(self, val):
-        if (val is True) or (val is False):
-            self._mask = val
-        # if val is of type np.bool_ and True, it failed the previous test because
-        # "is True" compares with Python "True" singelton.
-        # Yet, we do not want to allow arbitrary values that evaluate as True.
+        # Special case the numpy.ma.nomask setting (which evaluates to False
+        # but is not a bool).
+        #
+        if val is None:
+            raise DataErr('ismask')
+
+        elif not numpy.isscalar(val):
+            # We could catch an error if the value can not be converted,
+            # but wat values can not be converted to a bool?
+            self._mask = numpy.asarray(val, bool)
+
         elif val is numpy.ma.nomask:
             self._mask = True
-        elif numpy.isscalar(val) and isinstance(val, numpy.bool_):
+
+        elif (val is True) or (val is False):
+            self._mask = val
+
+        elif isinstance(val, numpy.bool_):
             self._mask = bool(val)
-        elif (val is None) or numpy.isscalar(val):
-            raise DataErr('ismask')
+
         else:
-            self._mask = numpy.asarray(val, numpy.bool_)
+            # Note that setting mask to 2.0 will fail, but an array
+            # of 2.0's will get converted to booleans.
+            #
+            raise DataErr('ismask')
 
     def apply(self, array):
         """Apply this filter to an array
 
         Parameters
         ----------
-        array : array_like
+        array : array_like or None
             Array to be filtered
 
         Returns
         -------
-        array_like : filtered array
+        array_like : ndarray or None
 
         Raises
         ------
@@ -488,10 +506,12 @@ class Filter():
         if self.mask is False:
             raise DataErr('notmask')
 
+        # Ensure we always return a ndarray.
+        #
+        array = numpy.asarray(array)
         if self.mask is True:
             return array
 
-        array = numpy.asarray(array)
         if array.shape != self.mask.shape:
             raise DataErr('mismatch', 'mask', 'data array')
         return array[self.mask]

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -835,15 +835,14 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         """
         y = self.get_dep(filter)
+        if yfunc is None:
+            return y
 
-        if yfunc is not None:
-            if filter:
-                yfunc = self.eval_model_to_fit(yfunc)
-            else:
-                yfunc = self.eval_model(yfunc)
-            y = (y, yfunc)
-
-        return y
+        if filter:
+            y2 = self.eval_model_to_fit(yfunc)
+        else:
+            y2 = self.eval_model(yfunc)
+        return (y, y2)
 
     def get_staterror(self, filter=False, staterrfunc=None):
         """Return the statistical error on the dependent axis of a data set.
@@ -1185,12 +1184,11 @@ class Data1D(Data):
 
         """
         y = self.get_dep(filter)
+        if yfunc is None:
+            return y
 
-        if yfunc is not None:
-            model_evaluation = yfunc(*self.get_evaluation_indep(filter, yfunc, use_evaluation_space))
-            y = y, model_evaluation
-
-        return y
+        model_evaluation = yfunc(*self.get_evaluation_indep(filter, yfunc, use_evaluation_space))
+        return (y, model_evaluation)
 
     def get_bounding_mask(self):
         mask = self.mask
@@ -1320,8 +1318,8 @@ class Data1D(Data):
         data_space = self._data_space.get(filter)
         if use_evaluation_space:
             return data_space.for_model(model).grid
-        else:
-            return data_space.grid
+
+        return data_space.grid
 
     def notice(self, xlo=None, xhi=None, ignore=False):
         """Notice or ignore the given range.

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -966,8 +966,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
                                 self.get_syserror(filter))
 
     def get_yerr(self, filter=False, staterrfunc=None):
-        """
-        Return errors in dependent axis in N-D view of dependent variable
+        """Return errors in dependent axis in N-D view of dependent variable
 
         Parameters
         ----------
@@ -981,8 +980,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         return self.get_error(filter, staterrfunc)
 
     def get_ylabel(self, yfunc=None):
-        """
-        Return label for dependent axis in N-D view of dependent variable"
+        """Return label for dependent axis in N-D view of dependent variable
 
         Parameters
         ----------

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -435,7 +435,7 @@ class PSFModel(Model):
         self.model = None
         self.data_space = None
         self.psf_space = None
-        Model.__init__(self, name)
+        super().__init__(name)
 
     def _get_center(self):
         if self._center is not None:
@@ -724,30 +724,31 @@ class PSFModel(Model):
 
         We only check the resolution in one dimention and assume they are the same
         """
-        if hasattr(self.kernel, "sky"):
-            # This corresponds to the case when the kernel is actually a psf image, not just a model.
+        if not hasattr(self.kernel, "sky"):
+            return self.SAME_RESOLUTION
 
-            try:
-                psf_pixel_size = self.kernel.sky.cdelt
-            except AttributeError:
-                # If the kernel does not have a pixel size, issue a warning and keep going
-                warnings.warn("PSF Image does not have a pixel size. Sherpa will assume "
-                              "the pixel size is the same as the data")
-                return self.SAME_RESOLUTION
+        # This corresponds to the case when the kernel is actually a psf image, not just a model.
+        try:
+            psf_pixel_size = self.kernel.sky.cdelt
+        except AttributeError:
+            # If the kernel does not have a pixel size, issue a warning and keep going
+            warnings.warn("PSF Image does not have a pixel size. Sherpa will assume "
+                          "the pixel size is the same as the data")
+            return self.SAME_RESOLUTION
 
-            try:
-                data_pixel_size = data.sky.cdelt
-            except AttributeError:
-                warnings.warn("Data Image does not have a pixel size. Sherpa will assume "
-                              "the pixel size is the same as the PSF")
-                return self.SAME_RESOLUTION
+        try:
+            data_pixel_size = data.sky.cdelt
+        except AttributeError:
+            warnings.warn("Data Image does not have a pixel size. Sherpa will assume "
+                          "the pixel size is the same as the PSF")
+            return self.SAME_RESOLUTION
 
-            if numpy.allclose(psf_pixel_size, data_pixel_size):
-                return self.SAME_RESOLUTION
-            if psf_pixel_size[0] < data_pixel_size[0]:
-                return self.BETTER_RESOLUTION
-            if psf_pixel_size[0] > data_pixel_size[0]:
-                return self.WORSE_RESOLUTION
+        if numpy.allclose(psf_pixel_size, data_pixel_size):
+            return self.SAME_RESOLUTION
+        if psf_pixel_size[0] < data_pixel_size[0]:
+            return self.BETTER_RESOLUTION
+        if psf_pixel_size[0] > data_pixel_size[0]:
+            return self.WORSE_RESOLUTION
 
         return self.SAME_RESOLUTION
 
@@ -779,4 +780,4 @@ class PSFSpace2D(EvaluationSpace2D):
         x = numpy.arange(x_start, x_range_end, step_x)
         y = numpy.arange(y_start, y_range_end, step_y)
         self.data_2_psf_pixel_size_ratio = (step_x, step_y)
-        super(PSFSpace2D, self).__init__(x, y)
+        super().__init__(x, y)


### PR DESCRIPTION
# Summary

Minor code clean up of the data and instrument classes.

# Details

This is part of the preparation work for #1470 but these commits do not change the behavior of Sherpa. There are a number of lint-style changes - e.g. change

```python
if foo:
    return bar
elif foofoo:
    return barbar
else:
    return barbarbar
```

to

```python
if foo:
    return bar

if foofoo:
    return barbar

return barbarbar
```

or

```python
if foo is not None:
    foo = do-something-to-foo
return foo
```

to

```python
if foo is None:
    return None

return do-something-to-foo
```

as I find these make it clearer what the logic is (and, in the latter case, the `do-something-to-foo` part may consist of multiple parts. A number of changes to use `super()` rather than explicitly label the super-class, have also been made.

There are two "larger" changes 

- the removal of the `DataPHA.set_dep` method, which is now possible because of #1442 (where the channel/independent axis and counts/depenent axis were aliased rather than carrying around the same data).
- removal of the `DataPHA.eval_model` method since it does the same as the super-class, and using it in the `DataPHA.eval_model_to_fit` method rather than repeating the logic.

The changes to `sherpa/instrument.py` are more extensive, but it's mainly re-arranging information so that it's clearer to me. and hopefully other readers, what is going on.