### PR TITLE
Include ciao region patch

### DIFF
--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -81,12 +81,13 @@ def build_wcs_ext(library_dirs, include_dirs, libraries):
                  libraries=libraries,
                  depends=get_deps(['extension']))
 
-def build_region_ext(library_dirs, include_dirs, libraries):
+def build_region_ext(library_dirs, include_dirs, libraries, define_macros=None):
     return Extension('sherpa.astro.utils._region',
                  ['sherpa/astro/utils/src/_region.cc'],
                  sherpa_inc + include_dirs,
                  library_dirs=library_dirs,
                  libraries=(libraries),
+                 define_macros=define_macros,
                  depends=get_deps(['extension']))
 
 def build_xspec_ext(library_dirs, include_dirs, libraries, define_macros=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,13 @@ parentdir_prefix = sherpa-
 #region-include_dirs=build/include
 #region-lib-dirs=build/lib
 #region-libraries=region
+#
+# Should the CXC Data Model parser be used? This enables FITS region
+# files but requires the CXC Data Model code is available. If set
+# then ascdm should be added to region-libraries and ensure
+# that ascdm.h/ascdm.so are added to the region-include-dirs
+# and region-lib-dirs directories.
+#region-use-cxc-parser=False
 
 # WCS Subroutines
 # Uncomment to use a local installation

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2016, 2020, 2021
+//  Copyright (C) 2009, 2016, 2020, 2021, 2022
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -25,7 +25,6 @@
 
 extern "C" {
 #include "cxcregion.h"
-#include <string>
 }
 
 typedef struct {


### PR DESCRIPTION
# Summary

Allow the CXC Data Model library to be used to parse region files, if available. This is primarily intended for building Sherpa as part of CIAO.

# Details

The main aim is to reduce the extra code that CIAO needs to keep around to build Sherpa, which should reduce the chance of build-failures in CIAO if the region code is changed. It should also allow users to take advantage of this support when building Sherpa against conda, as discussed at https://sherpa.readthedocs.io/en/4.14.0/developer/index.html#install-from-source-in-conda - see also #1455 

The way the code works is that if the `setup.cfg` file has set the `sherpa_config.region-use-cxc-parser` value to `True` then we trigger building the `sherpa.astro.utils._region` module with the `USE_CXCDM_PARSER` define/macro, which uses the `dmRegParse` from `ascdm` rather than the parsing code from the region library. The `region-include_dirs` and `region-lib-dirs` settings can be used to indicate the location of `ascdm.h` and `libascdm.<whatever>`, but it is expected that no change is meeded, as they should be the same as `cxcregion.h` and `libregion.<whatever>`. The only value that may need changing is `region-libraries`, from `region` to `region ascdm` (at least it is needed when building Sherpa against conda/CIAO on my machine; it may not be needed when building Sherpa for CIAO).

I think setting some sort of define/macro is realistically the only way to support the ascdm version versus the region parser.

I did think about whether we could automate the detection of this case - that is, remove the need for the `region-use-cxc-parser` option - but I decided that here it's better to be explicit rather than implicit. It's also the case that the automatic-detection approach would require significantly-more work than the approach used here.

What I'm not sure about is whether this works for all builds - so ciao-install rather than conda, and macOS versus Linux. 

I'm interested if people can come up with different approaches.