### PR TITLE
get_header_data is an official method of the astro.io backend

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021
+#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -42,9 +42,10 @@ except:
     warning('failed to import WCS module; WCS routines will not be ' +
             'available')
 
-__all__ = ('get_table_data', 'get_image_data', 'get_arf_data', 'get_rmf_data',
-           'get_pha_data', 'set_table_data', 'set_image_data', 'set_pha_data',
-           'get_column_data', 'get_ascii_data')
+__all__ = ('get_table_data', 'get_header_data', 'get_image_data',
+           'get_column_data', 'get_ascii_data',
+           'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'set_table_data', 'set_image_data', 'set_pha_data')
 
 
 string_types = (str, )

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2022
 #  MIT
 #
 #
@@ -25,9 +25,10 @@ imported, even if no FITS reader is installed.
 '''
 import logging
 
-__all__ = ('get_table_data', 'get_image_data', 'get_arf_data', 'get_rmf_data',
-           'get_pha_data', 'set_table_data', 'set_image_data', 'set_pha_data',
-           'get_column_data', 'get_ascii_data')
+__all__ = ('get_table_data', 'get_header_data', 'get_image_data',
+           'get_column_data', 'get_ascii_data',
+           'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'set_table_data', 'set_image_data', 'set_pha_data')
 
 
 lgr = logging.getLogger(__name__)
@@ -43,12 +44,13 @@ def get_table_data(*args, **kwargs):
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
+get_header_data = get_table_data
 get_image_data = get_table_data
+get_column_data = get_table_data
+get_ascii_data = get_table_data
 get_arf_data = get_table_data
 get_rmf_data = get_table_data
 get_pha_data = get_table_data
 set_table_data = get_table_data
 set_image_data = get_table_data
 set_pha_data = get_table_data
-get_column_data = get_table_data
-get_ascii_data = get_table_data

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -63,9 +63,10 @@ except ImportError:
     warning('failed to import WCS module; WCS routines will not be ' +
             'available')
 
-__all__ = ('get_table_data', 'get_image_data', 'get_arf_data', 'get_rmf_data',
-           'get_pha_data', 'set_table_data', 'set_image_data', 'set_pha_data',
-           'get_column_data', 'get_ascii_data')
+__all__ = ('get_table_data', 'get_header_data', 'get_image_data',
+           'get_column_data', 'get_ascii_data',
+           'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'set_table_data', 'set_image_data', 'set_pha_data')
 
 
 def _has_hdu(hdulist, name):


### PR DESCRIPTION
# Summary

An internal change to make sure that the get_header_data routine is part of the astro I/O backend API.

# Details

In #307 I added the XSPEC read_xstable_model routine, which used both

  sherpa.astro.io.backend.get_table_data
  sherpa.astro.io.backend.get_header_data

but I did not realise that the latter one was not exported by the backend. Recent changes (e.g. #1185) have improved the astro I/O backend code, unifying things, but they did not include get_header_data as an exported symbol. Since we are relying on this in the XSPEC code, we now mark this symbol as exported (so that any new backends will be expected to provide it).

The reason this was found was in testing some code when I had no I/O backend available. It is possible to get into a case when this missing symbol from dummy_backend.py caused a problem (but it's not entirely obvious to me in what condition).

Fix #1483