### PR TITLE
Improve filtering/grouping behavior

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1612,20 +1612,29 @@ class DataPHA(Data1D):
         if val and self.grouping is None:
             raise DataErr('nogrouping', self.name)
 
-        if self._grouped == val:
+        # Short cut if the grouping isn't changing.
+        #
+        # This could be dangerous, as there may be times we
+        # would want to generate things, but it is believed
+        # that we have identified all these changes, such
+        # as changing the grouping field.
+        #
+        if val == self._grouped:
             return
 
-        # As the grouping status is being changed, we need to reset the mask
-        # to be correct size, while still noticing groups within the filter
-        #
-        if numpy.iterable(self.mask):
-            old_filter = self.get_filter(group=val)
+        if not numpy.iterable(self.mask):
             self._grouped = val
-            self.ignore()
-            for vals in parse_expr(old_filter):
-                self.notice(*vals)
+            return
 
+        # As the grouping has changed AND there's a partial filter
+        # then it is important to re-apply the filter so that the mask
+        # matches the new grouping scheme.
+        #
+        old_filter = self.get_filter()
         self._grouped = val
+        self.ignore()
+        for vals in parse_expr(old_filter):
+            self.notice(*vals)
 
     grouped = property(_get_grouped, _set_grouped,
                        doc='Are the data grouped?')
@@ -3393,22 +3402,9 @@ must be an integer.""")
             if kwargs[key] is None:
                 kwargs.pop(key)
 
-        old_filter = self.get_filter(group=False)
-        do_notice = numpy.iterable(self.mask)
-
         self.grouping, self.quality = group_func(*args, **kwargs)
         self.group()
         self._original_groups = False
-
-        if do_notice:
-            # self.group() above has cleared the filter if applicable
-            # No, that just sets a flag.  So manually clear filter
-            # here
-            self.ignore()
-            for vals in parse_expr(old_filter):
-                self.notice(*vals)
-
-        # warning('grouping flags have changed, noticing all bins')
 
     def group_bins(self, num, tabStops=None):
         """Group into a fixed number of bins.

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1913,9 +1913,14 @@ must be an integer.""")
 
         A group is indicated by a sequence of flag values starting
         with ``1`` and then ``-1`` for all the channels in the group,
-        following [OGIP_92_007]_.  The grouping array must match the number of
-        channels and it will be converted to an integer type if
-        necessary.
+        following [OGIP_92_007]_.  The grouping array must match the
+        number of channels and it will be converted to an integer type
+        if necessary.
+
+        .. versionchanged:: 4.15.1
+           The filter is now re-calculated when the grouping is
+           changed. It is suggested that the filter be checked with
+           `get_filter` to check it is still sensible.
 
         Returns
         -------
@@ -1939,7 +1944,30 @@ must be an integer.""")
             except TypeError:
                 raise DataErr("notanintarray") from None
 
+        # If this is called within __init__ then we do not want to
+        # recreate the filter expression. If the mask is either True
+        # or False then we do not want to recreate filter (as a mask
+        # of True will get converted to [True] * nbins which then
+        # breaks downstream processing, as it looks like notice/ignore
+        # has already been called).
+        #
+        ofilter = None
+        if self._NoNewAttributesAfterInit__initialized and numpy.iterable(self.mask):
+            ofilter = self.get_filter()
+
         self._set_related("grouping", val)
+
+        if ofilter is not None:
+            # If the data has been filtered then we want to re-create
+            # the filter (which is needed because the mask size may
+            # have changed).  This is not ideal, since the actual
+            # filter is not necessarily the requested filter (thanks
+            # to the width of a group), so this could end up selecting
+            # a surprising range.
+            #
+            self.ignore()
+            for vals in parse_expr(ofilter):
+                self.notice(*vals)
 
     @property
     def quality(self):
@@ -1973,6 +2001,11 @@ must be an integer.""")
             except TypeError:
                 raise DataErr("notanintarray") from None
 
+        # If the quality changes, should we re-create the filter as we
+        # do with grouping? No, because the quality array is currently
+        # not automatically applied. Although perhaps we should reset
+        # quality_filter?
+        #
         self._set_related("quality", val)
 
     @property

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1525,7 +1525,6 @@ def test_pha_grouping_changed_no_filter_1160(make_test_pha):
     assert d4 == pytest.approx([1, 2, 3])
 
 
-@pytest.mark.xfail
 def test_pha_grouping_changed_filter_1160(make_test_pha):
     """What happens when the grouping is changed?
 
@@ -1548,8 +1547,6 @@ def test_pha_grouping_changed_filter_1160(make_test_pha):
     d3 = pha.get_dep(filter=True)
     assert d3 == pytest.approx([2, 0, 3])
 
-    # This currently raises a DataErr due to
-    # 'size mismatch between mask and data array'
     pha.grouping = [1, 1, -1, 1]
     d4 = pha.get_dep(filter=True)
     assert d4 == pytest.approx([2, 3])
@@ -1581,7 +1578,6 @@ def test_pha_grouping_changed_1160_grped_no_filter(make_grouped_pha):
     assert pha.get_filter() == ofilter
 
 
-@pytest.mark.xfail
 def test_pha_grouping_changed_1160_grped_with_filter(make_grouped_pha):
     """Test based on work on #1160
 
@@ -1610,15 +1606,16 @@ def test_pha_grouping_changed_1160_grped_with_filter(make_grouped_pha):
     assert pha.get_dep(filter=False) == pytest.approx([1, 2, 0, 3, 12])
     assert pha.get_dep(filter=True) == pytest.approx([3])
 
-    # Change the grouping
+    # Change the grouping; it would be nice if it could have
+    # recognized the requested range was > 1 and <= 5 but the current
+    # code does not support this.
+    #
     pha.grouping = [1] * 5
 
     assert pha.get_dep(filter=False) == pytest.approx([1, 2, 0, 3, 12])
+    assert pha.get_dep(filter=True) == pytest.approx([3])
 
-    # This fails with DataErr: size mismatch between mask and data array: 2 vs 4
-    assert pha.get_dep(filter=True) == pytest.approx([2, 0, 3])
-
-    assert pha.get_filter() == "2:4"
+    assert pha.get_filter() == "4"
 
 
 def test_pha_grouping_changed_1160_ungrped_with_filter(make_grouped_pha):
@@ -1655,7 +1652,6 @@ def test_pha_grouping_changed_1160_ungrped_with_filter(make_grouped_pha):
     assert pha.get_filter() == "4"
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_1160(make_data_path):
@@ -1683,7 +1679,6 @@ def test_1160(make_data_path):
 
     pha.grouping = [1] * 1024
     assert pha.get_dep(filter=False).shape == (1024, )
-    # This fails with a DataErr: size mismatch between mask and data array
     assert pha.get_dep(filter=True).shape == (418, )
     assert pha.mask.shape == (1024, )
     assert pha.mask.sum() == 418

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -194,7 +194,6 @@ def test_spatial_filter_errors_out_invalid_id(func):
         func(ids)
 
 
-@pytest.mark.xfail
 @requires_data
 @requires_fits
 def test_1160_original(make_data_path, clean_astro_ui, caplog):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -7553,6 +7553,11 @@ class Session(sherpa.ui.utils.Session):
         with ``1`` and then ``-1`` for all the channels in the group,
         following [1]_.
 
+        .. versionchanged:: 4.15.1
+           The filter is now re-calculated to match the new grouping
+           scheme. It is suggested that the filter be checked with
+           `get_filter` to check it is still sensible.
+
         Parameters
         ----------
         id : int or str, optional

--- a/sherpa/astro/utils/src/_utils.cc
+++ b/sherpa/astro/utils/src/_utils.cc
@@ -348,7 +348,7 @@ namespace sherpa { namespace astro { namespace utils {
       return NULL;
     }
 
-    // Use TypeError for the size=0 checks as this is what historically been
+    // Use TypeError for the size=0 checks as this is what has historically been
     // used for this check (when only mask_size was checked).
     //
     npy_intp mask_size = mask.get_size();
@@ -381,7 +381,7 @@ namespace sherpa { namespace astro { namespace utils {
     //     res[ii] = mask[jj]
     // is insignificant.
     //
-    if( mask[jj] )
+    if( mask[0] )
       res[0] = true;
 
     for( npy_intp ii = 1; ii < group_size; ++ii ) {
@@ -617,7 +617,7 @@ static PyMethodDef UtilsFcts[] = {
 	      "--------\n\n"
 	      ">>> mask = [True, False, False, True]\n"
 	      ">>> group = [1, -1, 1, 1, -1, 1, -1, -1]\n"
-	      ">>> expand_grouped_data(mask, group)\n"
+	      ">>> expand_grouped_mask(mask, group)\n"
 	      "[True, True, False, False, False, True, True, True]\n\n"
               ">>> expand_grouped_mask([True, False], [1, 1])\n"
               "[True, False]\n"

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -596,56 +596,63 @@ def test_expand_grouped_mask_mask_is_empty(group):
 
 @pytest.mark.parametrize("mask", [[True], [False], [True, False]])
 def test_expand_grouped_mask_group_is_empty(mask):
-    """This should probably be an error"""
+    """Check we get an error"""
 
-    out = expand_grouped_mask(mask, [])
-    assert len(out) == 0
+    with pytest.raises(TypeError) as err:
+        expand_grouped_mask(mask, [])
+
+    assert str(err.value) == "group array has no elements"
 
 
 @pytest.mark.parametrize("val", [None, 0, 1, "x"])  # mask is converted to bool so a string/None are accepted
 @pytest.mark.parametrize("group", [[1], [1, -1], [1] * 10, []])
 def test_expand_grouped_mask_mask_is_scalar(val, group):
-    """What happens if mask is a scalar.
+    """Check we get an error"""
 
-    This is an edge case. It should probably error out but at the
-    moment it does not.
-    """
+    with pytest.raises(ValueError) as err:
+        expand_grouped_mask(val, group)
 
-    answer = expand_grouped_mask(val, group)
-    assert len(answer) == len(group)
+    assert str(err.value) == "mask array must be 1D"
 
 
 @pytest.mark.parametrize("val", [0, 1])  # group is converted to int so string/None fail, unlike mask
 @pytest.mark.parametrize("mask", [[True], [False], [True] * 5])
 def test_expand_grouped_mask_group_is_scalar(val, mask):
-    """What happens if group is a scalar.
+    """What happens if group is a scalar."""
 
-    This is an edge case. It should probably error out but at the
-    moment it does not.
-    """
+    with pytest.raises(ValueError) as err:
+        expand_grouped_mask(mask, val)
 
-    # The return value is hard to test, so we just check if it runs or not
-    expand_grouped_mask(mask, val)
+    assert str(err.value) == "group array must be 1D"
 
 
 @pytest.mark.parametrize("group", [[1, 1, 1], [1, -1, 1, -1, 1, -1], [1, -1, -1, -1, -1, 1, 1, 1]])
 def test_expand_grouped_mask_mask_is_to_small(group):
-    """What happens if the group and mask do not match? mask too small.
+    """What happens if the group and mask do not match? mask too small."""
 
-    This should probably be an error but it currently is not.
-    """
+    with pytest.raises(ValueError) as err:
+        expand_grouped_mask([True, False], group)
 
-    expand_grouped_mask([True, False], group)
+    assert str(err.value) == "More groups than mask elements"
 
 
 @pytest.mark.parametrize("group", [[1, 1], [1, 1, 1, 1], [1, -1, -1, 1, -1, -1, 1, -1, -1]])
 def test_expand_grouped_mask_mask_is_to_large(group):
-    """What happens if the group and mask do not match? mask too large.
+    """What happens if the group and mask do not match? mask too large."""
 
-    This should probably be an error but it currently is not.
-    """
+    with pytest.raises(ValueError) as err:
+        expand_grouped_mask([True] * 5, group)
 
-    expand_grouped_mask([True] * 5, group)
+    assert str(err.value) == "More mask elements than groups"
+
+
+def test_expand_grouped_mask_ingalid_group():
+    """What happens if the first element of groups is negative?"""
+
+    with pytest.raises(ValueError) as err:
+        expand_grouped_mask([True, False], [-1, 1])
+
+    assert str(err.value) == "The first element of group is negative"
 
 
 @pytest.mark.parametrize("mask,group,expected",

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2007, 2016, 2017, 2020  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2007, 2016, 2017, 2020, 2022
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -39,7 +40,7 @@ typedef int (*converter)( PyObject*, void* );
 #define CONVERTME(arg) ((converter) sherpa::convert_to_contig_array<arg>)
 
 #define SHERPAMOD(name, fctlist) \
-static struct PyModuleDef module##name = {\
+static struct PyModuleDef module##name = { \
 PyModuleDef_HEAD_INIT, \
 #name, \
 NULL, \
@@ -52,8 +53,25 @@ PyMODINIT_FUNC PyInit_##name(void) { \
   return PyModule_Create(&module##name); \
 }
 
+#define SHERPAMODDOC(name, fctlist, doc) \
+static struct PyModuleDef module##name = { \
+PyModuleDef_HEAD_INIT, \
+#name, \
+PyDoc_STR(doc), \
+-1, \
+fctlist \
+}; \
+\
+PyMODINIT_FUNC PyInit_##name(void) { \
+  import_array(); \
+  return PyModule_Create(&module##name); \
+}
+
 #define FCTSPEC(name, func) \
  { (char*)#name, (PyCFunction)func, METH_VARARGS, NULL }
+
+#define FCTSPECDOC(name, func, doc) \
+  { (char*)#name, (PyCFunction)func, METH_VARARGS, PyDoc_STR(doc) }
 
 
 #endif /* __sherpa_extension_hh__ */


### PR DESCRIPTION
# Summary

Changing the grouping array of a PHA dataset (with set_grouping from the UI layer or by setting the grouping attribute of a DataPHA object) will now re-create the filter, to fix #1160. It is suggested that the filter expression (e.g. as returned by the get_filter routine for uses of the UI layer) is checked to ensure the result is still sensible.

The low-level grouping code has been updated to add data validation to check when it is called improperly.

# Details

The next PR following this is #1637 

## 1160 fix

The user-relevant change is to fix #1160 - which is that grouping the data can mess up the existing filter. This has been addressed by re-filtering the data after a change to the grouping, which ensures that the DataPHA  mask is correctly set up. One consequence of this work is that the resulting filter may be significantly different than before the grouping, since we do not record the intended filter but the result of the filter when applied to the currently-grouped data (see a discussion in #1655). We can help users out by reporting the filter (in the same way we now do for notice/ignore calls) which is done in #1637 as a follow-up PR. An alternative approach would be to clear the filter whenever the grouping changes, but I don't think that will really help as, unless we have something like #1637 users don't know what's happened to the data: we could warn the user the filter has changed but I think that it's not particularly helpful (but this is very-much an opinion and not a fact, others  may disagree here). 

## validation

The sherpa.astro.utils.expand_grouped_mask routine is written in C++ and provided by the sherpa.astro.utils._utils.expand_grouped_mask routine. We add

- documentation
- data validation
  - arguments are 1D arrays
  - arguments are not empty
  - arguments have the correct size (thanks to the way the routine works it's ever-so-slightly-tricky to check)
 
I know @hamogu will claim this (grouping) could be done in Python rather than C++ but I'm not willing to make that change yet (if we were to do that we'd want to check a number of routines, not just remove them one-by-one, in particular with an eye on performance). Technically these changes are not needed, as it doesn't lead to any changes to the code that calls expand_grouped_mask. However, in investigating #1160 I did hit some cases where this validation would have pointed out there was a problem with my proposed solution (rather than just silently creating the wrong answer), so I think it's worth it.

There is a question over whether we should allow the arguments to both be empty (in which case the return would be empty), but I don't believe that's a useful case for us.

This is obviously related to the data-validation work - #1470 / #1477 - but it's technically different and can be looked at separately (and in fact they have been closed now, but not when this was originally written).

---

# Example

## Issues with filtering

In the following we can see that as we regroup things the original filter gets "diluted", in particular we lose the gap between 0.9 and 1 keV. Thanks to the way we do filtering there's no real way to stop this, but at least with #1637 you would at least be able to see this change "directly".

```
In [4]: load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi

In [5]: notice(0.5, 0.9)
dataset 1: 0.00146:14.9504 -> 0.4672:0.949 Energy (keV)

In [6]: notice(1, 2)
dataset 1: 0.4672:0.949 -> 0.4672:0.949,0.9928:2.0294 Energy (keV)

In [7]: notice(2.3, 6)
dataset 1: 0.4672:0.949,0.9928:2.0294 -> 0.4672:0.949,0.9928:2.0294,2.2776:6.57 Energy (keV)

In [8]: group_counts(5)

In [9]: get_filter()
Out[9]: '0.467200011015:0.963599979877,0.992799997330:2.043999910355,2.263000011444:6.613800048828'

In [10]: group_counts(7)

In [11]: get_filter()
Out[11]: '0.467200011015:0.963599979877,0.978200018406:2.043999910355,2.248399972916:6.745200157166'

In [12]: group_counts(20)

In [13]: get_filter()
Out[13]: '0.437999993563:2.087800025940,2.219199895859:6.759799957275'
```

## 1160 fix

The 4.15.0 build does

```
sherpa In [1]: load_pha("3c273.pi")
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi

sherpa In [2]: notice(0.5, 7)
dataset 1: 0.00146:14.9504 -> 0.4672:9.8696 Energy (keV)

sherpa In [3]: get_dep(filter=True).shape
Out[3]: (42,)

sherpa In [4]: set_grouping(np.ones(1024))

sherpa In [5]: get_dep(filter=True).shape
DataErr: size mismatch between mask and data array: 46 vs 1024

sherpa In [6]: get_filter()
Out[6]: '0.043800000101:0.657000005245,0.700800001621:0.715399980545,0.817600011826:0.846800029278,8.526399612427:8.541000366211,8.643199920654:8.730799674988,8.760000228882:8.847599983215,8.891400337219:8.964400291443,9.095800399780:9.125000000000,9.227199554443:9.256400108337,9.694399833679:9.781999588013,9.811200141907:9.825799942017,9.928000450134:10.015600204468,10.044799804688:10.132399559021,10.161600112915:10.249199867249,10.278400421143:10.366000175476,10.512000083923:10.599599838257,10.803999900818:10.818599700928,10.979200363159:10.993800163269,11.154399871826:11.168999671936'
```

whereas this PR does

```
In [1]: from sherpa.astro.ui import *

In [2]: load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi

In [3]: notice(0.5, 7)
dataset 1: 0.00146:14.9504 -> 0.4672:9.8696 Energy (keV)

In [4]: get_dep(filter=True).shape
Out[4]: (42,)

In [5]: set_grouping([1] * 1024)

In [6]: get_dep(filter=True).shape
Out[6]: (644,)

In [7]: get_filter()
Out[7]: '0.467200011015:9.869600296021'
```
