### PR TITLE
Basic support for XSPEC 12.12.1

### DIFF
--- a/.github/scripts/setup_xspec_ds9.sh
+++ b/.github/scripts/setup_xspec_ds9.sh
@@ -64,6 +64,9 @@ xspec_library_path=${xspec_root}/lib/
 xspec_include_path=${xspec_root}/include/
 
 case "${XSPECVER}" in
+  12.12.1*)
+      xspec_version_string="12.12.1"
+      ;;
   12.11.1*)
       xspec_version_string="12.11.1"
       ;;
@@ -71,7 +74,7 @@ case "${XSPECVER}" in
       xspec_version_string="12.10.1"
       ;;
   *)
-      echo "Xspec version listed currently unsuported in Travis jobs."
+      echo "Xspec version listed currently unsupported in GitHub Actions jobs."
       exit 1
       ;;
 esac

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -51,7 +51,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.11.1
+            xspec-version: 12.12.1
 
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -415,28 +415,18 @@ available.
 
    Current version: `helpers/xspec_config.py <https://github.com/sherpa/sherpa/blob/master/helpers/xspec_config.py>`_.
 
-   When adding support for XSPEC 12.11.1, the code in the ``run``
-   method was changed to include the triple ``(12, 11, 1)``::
+   When adding support for XSPEC 12.11.1, the top-level
+   ``SUPPORTED_VERSIONS`` list was changed to include the triple
+   ``(12, 11, 1)``::
 
-       for major, minor, patch in [(12, 9, 0), (12, 9, 1),
-                                   (12, 10, 0), (12, 10, 1),
-                                   (12, 11, 0), (12, 11, 1)]:
-           version = '{}.{}.{}'.format(major, minor, patch)
-           macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
-           if xspec_version >= LooseVersion(version):
-               macros += [(macro, None)]
+     SUPPORTED_VERSIONS = [(12, 9, 0), (12, 9, 1),
+                           (12, 10, 0), (12, 10, 1),
+                           (12, 11, 0), (12, 11, 1)]
 
-   and the version check to::
-
-       # Since there are patches (e.g. 12.10.0c), look for the
-       # "next highest version.
-       if xspec_version >= LooseVersion("12.11.2"):
-           self.warn("XSPEC Version is greater than 12.11.1, which is the latest supported version for Sherpa")
-
-   The define should be named ``XSPEC_<a>_<b>_<c>`` for XSPEC release
-   ``<a>.<b>.<c>`` (the XSPEC patch level is not included). This define
-   is used when compiling the XSPEC model interface, to select which
-   functions to include.
+   This list is used to select which functions to include when
+   compiling the C++ interfce code. For reference, the defines are
+   named ``XSPEC_<a>_<b>_<c>`` for each supported XSPEC release
+   ``<a>.<b>.<c>`` (the XSPEC patch level is not included).
 
    .. note:: The Sherpa build system requires that the user indicate the
 	     version of XSPEC being used, via the ``xspec_config.xspec_version``
@@ -687,7 +677,7 @@ available.
    be updated to add an entry for the ``setup.cfg`` changes in
    :ref:`build-xspec`.
 
-   The ``sherpa/astrp/xspec/__init__.py`` file also lists the supported
+   The ``sherpa/astro/xspec/__init__.py`` file also lists the supported
    XSPEC versions.
 
 Never forget to update the year of the copyright notice?

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -424,7 +424,7 @@ available.
                            (12, 11, 0), (12, 11, 1)]
 
    This list is used to select which functions to include when
-   compiling the C++ interfce code. For reference, the defines are
+   compiling the C++ interface code. For reference, the defines are
    named ``XSPEC_<a>_<b>_<c>`` for each supported XSPEC release
    ``<a>.<b>.<c>`` (the XSPEC patch level is not included).
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -290,11 +290,13 @@ To add a new command-line option:
 * and add support in ``pytest_configure``, such as registering
   a new mark.
 
+.. _developer-update-xspec:
+
 Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.12.0 down to 12.9.0. It may build against
+:term:`XSPEC` versions 12.12.1 down to 12.9.0. It may build against
 newer versions, but if it does it will not provide access to any new
 models in the release. The following sections of the `XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__
@@ -676,6 +678,17 @@ available.
       by addtive and then multiplicative models, using an alphabetical
       sorting - and to the appropriate ``inheritance-diagram`` rule.
 
+#. Documentation updates
+
+   The ``docs/indices.rst`` file should be updated to add the new version
+   to the list of supported versions, under the :term:`XSPEC` term, and
+   ``docs/developer/index.rst`` also lists the supported versions
+   (:ref:`developer-update-xspec`). The installation page ``docs/install.rst`` should
+   be updated to add an entry for the ``setup.cfg`` changes in
+   :ref:`build-xspec`.
+
+   The ``sherpa/astrp/xspec/__init__.py`` file also lists the supported
+   XSPEC versions.
 
 Never forget to update the year of the copyright notice?
 --------------------------------------------------------

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.12.0, 12.11.1, 12.11.0,
+       Sherpa can be built to use XSPEC versions 12.12.1, 12.12.0, 12.11.1, 12.11.0,
        12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, or 12.9.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -49,9 +49,7 @@ if installed:
 
 The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
-functions from the :term:`XSPEC`.
-The supported versions of XSPEC are 12.12.0, 12.11.1, 12.11.0,
-12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, and 12.9.0.
+functions from :term:`XSPEC`.
 
 Interactive display and manipulation of two-dimensional images
 is available if the :term:`DS9` image viewer and the :term:`XPA`
@@ -222,8 +220,7 @@ XSPEC
    to support changes made in XSPEC 12.10.0.
 
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC` versions 12.12.0, 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
-12.9.1, and 12.9.0. To enable XSPEC support, several changes must be
+:term:`XSPEC`. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
 
@@ -253,7 +250,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.12.0 system has been built then use::
+1. If the full XSPEC 12.12.1 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.12.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.30
+       ccfits_libraries = CCfits_2.6
+       wcslib_libraries = wcs-7.7
+
+   where the version numbers were taken from version 6.30.1 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.12.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.0
@@ -266,7 +276,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.29 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.11.1 system has been built then use::
+3. If the full XSPEC 12.11.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.1
@@ -278,7 +288,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.28 of HEASOFT.
 
-3. If the full XSPEC 12.11.0 system has been built then use::
+4. If the full XSPEC 12.11.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.0
@@ -290,7 +300,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.27 of HEASOFT.
 
-4. If the full XSPEC 12.10.1 system has been built then use::
+5. If the full XSPEC 12.10.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.1
@@ -302,7 +312,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.26.1 of HEASOFT.
 
-5. If the full XSPEC 12.10.0 system has been built then use::
+6. If the full XSPEC 12.10.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.0
@@ -312,7 +322,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
 
-6. If the full XSPEC 12.9.x system has been built then use::
+7. If the full XSPEC 12.9.x system has been built then use::
 
        with-xspec = True
        xspec_version = 12.9.1
@@ -324,7 +334,7 @@ match the contents of the XSPEC installation.
 
    changing ``12.9.1`` to ``12.9.0`` as appropriate.
 
-7. If the model-only build of XSPEC has been installed, then
+8. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may
    not need version numbers and locations, depending on how the
    ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2017, 2018, 2020, 2021
+#  Copyright (C) 2014-2017, 2018, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -105,7 +105,7 @@ class xspec_config(Command):
                 for major, minor, patch in [(12, 9, 0), (12, 9, 1),
                                             (12, 10, 0), (12, 10, 1),
                                             (12, 11, 0), (12, 11, 1),
-                                            (12, 12, 0)]:
+                                            (12, 12, 0), (12, 12, 1)]:
                     version = '{}.{}.{}'.format(major, minor, patch)
                     macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
                     if xspec_version >= LooseVersion(version):
@@ -115,7 +115,7 @@ class xspec_config(Command):
                 # the "next highest" version (i.e. increase the
                 # "patch" value by 1).
                 #
-                if xspec_version >= LooseVersion("12.12.1"):
+                if xspec_version >= LooseVersion("12.12.2"):
                     self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
 
             extension = build_ext('xspec', ld, inc, l, define_macros=macros)

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -71,59 +71,59 @@ class xspec_config(Command):
         dist_packages = self.distribution.packages
         dist_data = self.distribution.package_data
 
-        if self.with_xspec:
-            if package not in dist_packages:
-                dist_packages.append(package)
-
-            if package not in dist_data:
-                dist_data[package] = ['tests/test_*.py']
-
-            ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
-            ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
-            ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
-            ld4, inc4, l4 = build_lib_arrays(self, 'wcslib')
-            ld5, inc5, l5 = build_lib_arrays(self, 'gfortran')
-
-            ld = clean(ld1 + ld2 + ld3 + ld4 + ld5)
-            inc = clean(inc1 + inc2 + inc3 + inc4 + inc5)
-            l = clean(l1 + l2 + l3 + l4 + l5)
-
-            xspec_raw_version = self.xspec_version
-
-            macros = []
-
-            if xspec_raw_version:
-                self.announce("Found XSPEC version: {}".format(xspec_raw_version), 2)
-                xspec_version = LooseVersion(xspec_raw_version)
-
-                if xspec_version < LooseVersion("12.9.0"):
-                    self.warn("XSPEC Version is less than 12.9.0, which is the minimal supported version for Sherpa")
-
-                # I am not sure what the naming of the XSPEC components are,
-                # but let's stick with major, minor, and patch.
-                #
-                for major, minor, patch in [(12, 9, 0), (12, 9, 1),
-                                            (12, 10, 0), (12, 10, 1),
-                                            (12, 11, 0), (12, 11, 1),
-                                            (12, 12, 0), (12, 12, 1)]:
-                    version = '{}.{}.{}'.format(major, minor, patch)
-                    macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
-                    if xspec_version >= LooseVersion(version):
-                        macros += [(macro, None)]
-
-                # Since there are patches (e.g. 12.10.0c), look for
-                # the "next highest" version (i.e. increase the
-                # "patch" value by 1).
-                #
-                if xspec_version >= LooseVersion("12.12.2"):
-                    self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
-
-            extension = build_ext('xspec', ld, inc, l, define_macros=macros)
-
-            self.distribution.ext_modules.append(extension)
-
-        else:
+        if not self.with_xspec:
             if package in dist_packages:
                 dist_packages.remove(package)
             if package in dist_data:
                 del dist_data[package]
+
+            return
+
+        if package not in dist_packages:
+            dist_packages.append(package)
+
+        if package not in dist_data:
+            dist_data[package] = ['tests/test_*.py']
+
+        ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
+        ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
+        ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
+        ld4, inc4, l4 = build_lib_arrays(self, 'wcslib')
+        ld5, inc5, l5 = build_lib_arrays(self, 'gfortran')
+
+        ld = clean(ld1 + ld2 + ld3 + ld4 + ld5)
+        inc = clean(inc1 + inc2 + inc3 + inc4 + inc5)
+        l = clean(l1 + l2 + l3 + l4 + l5)
+
+        macros = []
+        xspec_raw_version = self.xspec_version
+
+        if xspec_raw_version:
+            self.announce(f"Found XSPEC version: {xspec_raw_version}", 2)
+            xspec_version = LooseVersion(xspec_raw_version)
+
+            if xspec_version < LooseVersion("12.9.0"):
+                self.warn("XSPEC Version is less than 12.9.0, which is the minimal supported version for Sherpa")
+
+            # I am not sure what the naming of the XSPEC components are,
+            # but let's stick with major, minor, and patch.
+            #
+            for major, minor, patch in [(12, 9, 0), (12, 9, 1),
+                                        (12, 10, 0), (12, 10, 1),
+                                        (12, 11, 0), (12, 11, 1),
+                                        (12, 12, 0), (12, 12, 1)]:
+                version = f'{major}.{minor}.{patch}'
+                macro = f'XSPEC_{major}_{minor}_{patch}'
+                if xspec_version >= LooseVersion(version):
+                    macros += [(macro, None)]
+
+            # Since there are patches (e.g. 12.10.0c), look for
+            # the "next highest" version (i.e. increase the
+            # "patch" value by 1).
+            #
+            if xspec_version >= LooseVersion("12.12.2"):
+                self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
+
+        extension = build_ext('xspec', ld, inc, l, define_macros=macros)
+
+        self.distribution.ext_modules.append(extension)

--- a/scripts/check_xspec_update.py
+++ b/scripts/check_xspec_update.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -133,10 +133,14 @@ def compare_xspec_models(models, hard=True):
                 #
                 if [par.softmin, par.hardmin, par.softmax, par.hardmax] == [None] * 4:
                     for attr in ["min", "hard_min"]:
-                        assert getattr(xpar, attr) == -hugeval
+                        got = getattr(xpar, attr)
+                        if got != -hugeval:
+                            reports.append(f"par {xpar.name}.{attr} is not -hugeval but {got}")
 
                     for attr in ["max", "hard_max"]:
-                        assert getattr(xpar, attr) == hugeval
+                        got = getattr(xpar, attr)
+                        if got != hugeval:
+                            reports.append(f"par {xpar.name}.{attr} is not hugeval but {got}")
 
                     continue
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.12.0, 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
+Sherpa supports versions 12.12.1, 12.12.0, 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
 of XSPEC [1]_, and can be built against the model library or the full
 application.  There is no guarantee of support for older or newer
 versions of XSPEC.

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -316,16 +316,29 @@ extern "C" {
   xsccCall xszbabs;
 
 #ifdef XSPEC_12_9_1
-  xsf77Call ismabs_;
   xsccCall slimbbmodel;
+#endif
+
+#ifdef XSPEC_12_11_0
+  xsccCall beckerwolff;
+#endif
+
+#ifdef XSPEC_12_12_1
+  xsF77Call ismabs_;
+  xsF77Call ismdust_;
+  xsF77Call olivineabs_;
+#else
+
+#ifdef XSPEC_12_9_1
+  xsf77Call ismabs_;
 #endif
 
 #ifdef XSPEC_12_11_0
   xsf77Call ismdust_;
   xsf77Call olivineabs_;
-  xsccCall beckerwolff;
 #endif
 
+#endif // XSPEC_12_12_1
 
 // XSPEC table models; in XSPEC 12.10.1 these have been consolidated
 // into the tabint routine, but that is only available to C++, and
@@ -1386,7 +1399,12 @@ static PyMethodDef XSpecMethods[] = {
 
   XSPECMODELFCT_C_NORM(C_carbatm, 4),
   XSPECMODELFCT_C_NORM(C_hatm, 4),
+
+#ifdef XSPEC_12_12_1
+  XSPECMODELFCT_DBL(ismabs, 31),
+#else
   XSPECMODELFCT(ismabs, 31),
+#endif
 
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),
   XSPECMODELFCT_C_NORM(C_snapec, 7),
@@ -1408,9 +1426,17 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM(jet, 16),
 #endif
 
+#ifdef XSPEC_12_12_1
+  XSPECMODELFCT_DBL(ismdust, 3),
+  XSPECMODELFCT_DBL(olivineabs, 2),
+#else
 #ifdef XSPEC_12_11_0
   XSPECMODELFCT(ismdust, 3),
   XSPECMODELFCT(olivineabs, 2),
+#endif
+#endif // XSPEC_12_12_1
+
+#ifdef XSPEC_12_11_0
   XSPECMODELFCT_C(C_logconst, 1),
   XSPECMODELFCT_C(C_log10con, 1),
 #endif

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -54,6 +54,14 @@ extern "C" {
                                   const int& spectrumNumber,
                                   float* flux,
                                   float* fluxError);
+
+        typedef void (xsF77Call) (const double* energyArray,
+                                  const int& Nenergy,
+                                  const double* parameterValues,
+                                  const int& spectrumNumber,
+                                  double* flux,
+                                  double* fluxError);
+
         typedef void (xsccCall)   (const Real* energyArray,
                                    int Nenergy,
                                    const Real* parameterValues,
@@ -71,15 +79,23 @@ extern "C" {
 // available in C++ scope.
 //
 // In XSPEC 12.11.0 (the next one after 12.10.1), the tabint function
-// was moved into C scope.
+// was moved into C scope. In XSPEC 12.12.1 the signature was changed
+// to mark more arguments as const.
 //
 #ifdef XSPEC_12_10_1
 #ifdef XSPEC_12_11_0
 extern "C" {
 #endif
 
-  void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
+#ifndef XSPEC_12_12_1
+  void tabint(float* ear, int ne, float* param,
+	      int npar, const char* filenm, int ifl,
 	      const char* tabtyp, float* photar, float* photer);
+#else
+  void tabint(const float* ear, const int ne, const float* param,
+	      const int npar, const char* filenm, int ifl,
+	      const char* tabtyp, float* photar, float* photer);
+#endif
 
 #ifdef XSPEC_12_11_0
 }
@@ -663,6 +679,22 @@ static void create_output(int nbins, T &a, T &b) {
       }; // class xspecModelFctF
 
 
+      template<typename Real, typename RealArray, xsF77Call XSpecFunc>
+      class xspecModelFctFD : public xspecModelFctBase<Real, RealArray>  {
+      public:
+
+        xspecModelFctFD( PyObject* args, npy_intp NumPars, bool HasNorm )
+          : xspecModelFctBase<Real, RealArray>( args, NumPars, HasNorm ) { }
+
+        void call_xspec( RealArray& result ) {
+          XSpecFunc( &this->ear[0], this->npts, &this->pars[0], this->ifl,
+                     &result[0], &this->error[0] );
+          return;
+        }
+
+      }; // class xspecModelFctFD
+
+
       template<typename Real, typename RealArray>
       class xspecModelFctConBase {
       public:
@@ -862,6 +894,32 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args ) {
     xspecModelFctF<float, FloatArray, XSpecFunc>( args, NumPars, HasNorm );
   try {
     FloatArray result;
+    xspec_model.eval( result );
+    return result.return_new_ref();
+  } catch(const NoError& re) {
+    return NULL;
+  } catch(const ValueError& re) {
+    PyErr_SetString( PyExc_ValueError, re.what() );
+    return NULL;
+  } catch(const TypeError& re) {
+    PyErr_SetString( PyExc_TypeError, re.what() );
+    return NULL;
+  } catch(...) {
+    // Even though the XSPEC model function is Fortran, it could call
+    // C++ functions, so swallow exceptions here
+    PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+    return NULL;
+  }
+
+}
+
+template <npy_intp NumPars, bool HasNorm, xsF77Call XSpecFunc>
+PyObject* xspecmodelfct_dbl( PyObject* self, PyObject* args ) {
+
+  xspecModelFctFD<double, DoubleArray, XSpecFunc> xspec_model =
+    xspecModelFctFD<double, DoubleArray, XSpecFunc>( args, NumPars, HasNorm );
+  try {
+    DoubleArray result;
     xspec_model.eval( result );
     return result.return_new_ref();
   } catch(const NoError& re) {
@@ -1161,6 +1219,11 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds ) {
 
 #define XSPECMODELFCT(name, npars)  _XSPECFCTSPEC(name, npars, false)
 #define XSPECMODELFCT_NORM(name, npars)  _XSPECFCTSPEC(name, npars, true)
+
+// double precision
+#define XSPECMODELFCT_DBL(name, npars) \
+		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_dbl< npars, false, \
+				name##_ >))
 
 #define XSPECMODELFCT_C(name, npars) \
 		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_C< npars, false, name >))


### PR DESCRIPTION
# Summary

Allow Sherpa to be built with XSPEC 12.12.1. It does not provide access to the three new models - polconst, pollin, and polpow - added in this release of XSPEC.

# Details

The main change is to allow the code to compile against XSPEC 1212.1, since it changed the interface to the `tabint` routine (by marking a number of fields const and also exporting the definition). It also swaps over three models - `ismabs`, `ismdust`, and `olivineabs` - from FORTRAN `REAL*4` to `REAL*8` interfaces (as these have just moved in this release), which has meant some additions (as these are the first `xsF77Cal`l models we support, and this release of XSPEC doesn't provide the "wrapper functions" for these models, as confirmed to me by HEASARC).

This PR does not add support for the three new multiplicative models (`polconst`, `pollin`, and `polpow`) as they require the ability to set the XFLT values for a file, and this is not supported by Sherpa. We can add support, but this requires bumping the minimum supported version of XSPEC from 12.9.0 to something later (it's not a simple answer as to what version) and I have had a PR doing this for quite a while (e.g. the closed #1239 and the current #1396) which need to be looked at before we can do this. Even after bumping up the minimum version, which will allow us to set, query, and clear the XFLT database, we still need to do some design work to allow us to connect to the XSPEC `spectrumNumber` argument - e.g. #544 - as we don't have that as a concept for models.