### PR TITLE
Make tests pass on 3.10

### DIFF
--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -903,7 +903,7 @@ def test_img_can_not_set_coord(make_test_image):
     with pytest.raises(AttributeError) as ae:
         d.coord = "physical"
 
-    assert str(ae.value) == "can't set attribute"
+    assert  "can't set attribute" in str(ae.value)
 
 
 def test_img_set_coord_invalid(make_test_image):


### PR DESCRIPTION
## Summary
One of the tests fails in Python 3.10 because the error message has been changed.

## Details
The value of an AttributeError that gets raised when a user tries to set a property that does not has a setter has been changed in Python 3.10.
Before, it was "can't set attribute", in 3.10 it became "can't set attribute <attribute name>".

I found this problem when testing #1308 and #1474 and always saw differences in behavior between my local testing (in a 3.10 environment) and our CI.

## Minimal example
Compare the following minimal examples that shows the change in error message
```
Python 3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:24:02)
[Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class A:
...
...     _f = 5
...
...     @property
...     def f(self):
...         return self._f
...
>>> a = A()
>>> a.f = 2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: can't set attribute
```
and
```
Python 3.10.1 | packaged by conda-forge | (main, Dec 22 2021, 01:39:07) [Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class A:
...
...     _f = 5
...
...     @property
...     def f(self):
...         return self._f
...
>>> a = A()
>>> a.f = 2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: can't set attribute 'f'
```