### PR TITLE
Remove deprecated distutils.version.LooseVersion

### DIFF
--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -99,7 +99,7 @@ jobs:
       if: matrix.test-data == 'submodule'
       run: |
         pip install -r test_requirements.txt
-        pip install pytest-cov 
+        pip install pytest-cov
 
         pytest --cov=sherpa --cov-report=xml
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -415,28 +415,18 @@ available.
 
    Current version: `helpers/xspec_config.py <https://github.com/sherpa/sherpa/blob/master/helpers/xspec_config.py>`_.
 
-   When adding support for XSPEC 12.11.1, the code in the ``run``
-   method was changed to include the triple ``(12, 11, 1)``::
+   When adding support for XSPEC 12.11.1, the top-level
+   ``SUPPORTED_VERSIONS`` list was changed to include the triple
+   ``(12, 11, 1)``::
 
-       for major, minor, patch in [(12, 9, 0), (12, 9, 1),
-                                   (12, 10, 0), (12, 10, 1),
-                                   (12, 11, 0), (12, 11, 1)]:
-           version = '{}.{}.{}'.format(major, minor, patch)
-           macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
-           if xspec_version >= LooseVersion(version):
-               macros += [(macro, None)]
+     SUPPORTED_VERSIONS = [(12, 9, 0), (12, 9, 1),
+                           (12, 10, 0), (12, 10, 1),
+                           (12, 11, 0), (12, 11, 1)]
 
-   and the version check to::
-
-       # Since there are patches (e.g. 12.10.0c), look for the
-       # "next highest version.
-       if xspec_version >= LooseVersion("12.11.2"):
-           self.warn("XSPEC Version is greater than 12.11.1, which is the latest supported version for Sherpa")
-
-   The define should be named ``XSPEC_<a>_<b>_<c>`` for XSPEC release
-   ``<a>.<b>.<c>`` (the XSPEC patch level is not included). This define
-   is used when compiling the XSPEC model interface, to select which
-   functions to include.
+   This list is used to select which functions to include when
+   compiling the C++ interfce code. For reference, the defines are
+   named ``XSPEC_<a>_<b>_<c>`` for each supported XSPEC release
+   ``<a>.<b>.<c>`` (the XSPEC patch level is not included).
 
    .. note:: The Sherpa build system requires that the user indicate the
 	     version of XSPEC being used, via the ``xspec_config.xspec_version``
@@ -687,7 +677,7 @@ available.
    be updated to add an entry for the ``setup.cfg`` changes in
    :ref:`build-xspec`.
 
-   The ``sherpa/astrp/xspec/__init__.py`` file also lists the supported
+   The ``sherpa/astro/xspec/__init__.py`` file also lists the supported
    XSPEC versions.
 
 Never forget to update the year of the copyright notice?

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -424,7 +424,7 @@ available.
                            (12, 11, 0), (12, 11, 1)]
 
    This list is used to select which functions to include when
-   compiling the C++ interfce code. For reference, the defines are
+   compiling the C++ interface code. For reference, the defines are
    named ``XSPEC_<a>_<b>_<c>`` for each supported XSPEC release
    ``<a>.<b>.<c>`` (the XSPEC patch level is not included).
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -290,11 +290,13 @@ To add a new command-line option:
 * and add support in ``pytest_configure``, such as registering
   a new mark.
 
+.. _developer-update-xspec:
+
 Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.12.0 down to 12.9.0. It may build against
+:term:`XSPEC` versions 12.12.1 down to 12.9.0. It may build against
 newer versions, but if it does it will not provide access to any new
 models in the release. The following sections of the `XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__
@@ -676,6 +678,17 @@ available.
       by addtive and then multiplicative models, using an alphabetical
       sorting - and to the appropriate ``inheritance-diagram`` rule.
 
+#. Documentation updates
+
+   The ``docs/indices.rst`` file should be updated to add the new version
+   to the list of supported versions, under the :term:`XSPEC` term, and
+   ``docs/developer/index.rst`` also lists the supported versions
+   (:ref:`developer-update-xspec`). The installation page ``docs/install.rst`` should
+   be updated to add an entry for the ``setup.cfg`` changes in
+   :ref:`build-xspec`.
+
+   The ``sherpa/astrp/xspec/__init__.py`` file also lists the supported
+   XSPEC versions.
 
 Never forget to update the year of the copyright notice?
 --------------------------------------------------------

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.12.0, 12.11.1, 12.11.0,
+       Sherpa can be built to use XSPEC versions 12.12.1, 12.12.0, 12.11.1, 12.11.0,
        12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, or 12.9.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -49,9 +49,7 @@ if installed:
 
 The Sherpa build can be configured to create the
 :py:mod:`sherpa.astro.xspec` module, which provides the models and utility
-functions from the :term:`XSPEC`.
-The supported versions of XSPEC are 12.12.0, 12.11.1, 12.11.0,
-12.10.1 (patch level `a` or later), 12.10.0, 12.9.1, and 12.9.0.
+functions from :term:`XSPEC`.
 
 Interactive display and manipulation of two-dimensional images
 is available if the :term:`DS9` image viewer and the :term:`XPA`
@@ -222,8 +220,7 @@ XSPEC
    to support changes made in XSPEC 12.10.0.
 
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC` versions 12.12.0, 12.11.1, 12.11.0, 12.10.1 (patch level `a` or later), 12.10.0,
-12.9.1, and 12.9.0. To enable XSPEC support, several changes must be
+:term:`XSPEC`. To enable XSPEC support, several changes must be
 made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
 
@@ -253,7 +250,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.12.0 system has been built then use::
+1. If the full XSPEC 12.12.1 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.12.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.30
+       ccfits_libraries = CCfits_2.6
+       wcslib_libraries = wcs-7.7
+
+   where the version numbers were taken from version 6.30.1 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.12.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.0
@@ -266,7 +276,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.29 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.11.1 system has been built then use::
+3. If the full XSPEC 12.11.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.1
@@ -278,7 +288,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.28 of HEASOFT.
 
-3. If the full XSPEC 12.11.0 system has been built then use::
+4. If the full XSPEC 12.11.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.11.0
@@ -290,7 +300,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.27 of HEASOFT.
 
-4. If the full XSPEC 12.10.1 system has been built then use::
+5. If the full XSPEC 12.10.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.1
@@ -302,7 +312,7 @@ match the contents of the XSPEC installation.
 
    where the version numbers were taken from version 6.26.1 of HEASOFT.
 
-5. If the full XSPEC 12.10.0 system has been built then use::
+6. If the full XSPEC 12.10.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.10.0
@@ -312,7 +322,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.5
        wcslib_libraries = wcs-5.16
 
-6. If the full XSPEC 12.9.x system has been built then use::
+7. If the full XSPEC 12.9.x system has been built then use::
 
        with-xspec = True
        xspec_version = 12.9.1
@@ -324,7 +334,7 @@ match the contents of the XSPEC installation.
 
    changing ``12.9.1`` to ``12.9.0`` as appropriate.
 
-7. If the model-only build of XSPEC has been installed, then
+8. If the model-only build of XSPEC has been installed, then
    the configuration is similar, but the library names may
    not need version numbers and locations, depending on how the
    ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2017, 2018, 2020, 2021
+#  Copyright (C) 2014-2017, 2018, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -105,7 +105,7 @@ class xspec_config(Command):
                 for major, minor, patch in [(12, 9, 0), (12, 9, 1),
                                             (12, 10, 0), (12, 10, 1),
                                             (12, 11, 0), (12, 11, 1),
-                                            (12, 12, 0)]:
+                                            (12, 12, 0), (12, 12, 1)]:
                     version = '{}.{}.{}'.format(major, minor, patch)
                     macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
                     if xspec_version >= LooseVersion(version):
@@ -115,7 +115,7 @@ class xspec_config(Command):
                 # the "next highest" version (i.e. increase the
                 # "patch" value by 1).
                 #
-                if xspec_version >= LooseVersion("12.12.1"):
+                if xspec_version >= LooseVersion("12.12.2"):
                     self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
 
             extension = build_ext('xspec', ld, inc, l, define_macros=macros)

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -71,59 +71,59 @@ class xspec_config(Command):
         dist_packages = self.distribution.packages
         dist_data = self.distribution.package_data
 
-        if self.with_xspec:
-            if package not in dist_packages:
-                dist_packages.append(package)
-
-            if package not in dist_data:
-                dist_data[package] = ['tests/test_*.py']
-
-            ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
-            ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
-            ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
-            ld4, inc4, l4 = build_lib_arrays(self, 'wcslib')
-            ld5, inc5, l5 = build_lib_arrays(self, 'gfortran')
-
-            ld = clean(ld1 + ld2 + ld3 + ld4 + ld5)
-            inc = clean(inc1 + inc2 + inc3 + inc4 + inc5)
-            l = clean(l1 + l2 + l3 + l4 + l5)
-
-            xspec_raw_version = self.xspec_version
-
-            macros = []
-
-            if xspec_raw_version:
-                self.announce("Found XSPEC version: {}".format(xspec_raw_version), 2)
-                xspec_version = LooseVersion(xspec_raw_version)
-
-                if xspec_version < LooseVersion("12.9.0"):
-                    self.warn("XSPEC Version is less than 12.9.0, which is the minimal supported version for Sherpa")
-
-                # I am not sure what the naming of the XSPEC components are,
-                # but let's stick with major, minor, and patch.
-                #
-                for major, minor, patch in [(12, 9, 0), (12, 9, 1),
-                                            (12, 10, 0), (12, 10, 1),
-                                            (12, 11, 0), (12, 11, 1),
-                                            (12, 12, 0), (12, 12, 1)]:
-                    version = '{}.{}.{}'.format(major, minor, patch)
-                    macro = 'XSPEC_{}_{}_{}'.format(major, minor, patch)
-                    if xspec_version >= LooseVersion(version):
-                        macros += [(macro, None)]
-
-                # Since there are patches (e.g. 12.10.0c), look for
-                # the "next highest" version (i.e. increase the
-                # "patch" value by 1).
-                #
-                if xspec_version >= LooseVersion("12.12.2"):
-                    self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
-
-            extension = build_ext('xspec', ld, inc, l, define_macros=macros)
-
-            self.distribution.ext_modules.append(extension)
-
-        else:
+        if not self.with_xspec:
             if package in dist_packages:
                 dist_packages.remove(package)
             if package in dist_data:
                 del dist_data[package]
+
+            return
+
+        if package not in dist_packages:
+            dist_packages.append(package)
+
+        if package not in dist_data:
+            dist_data[package] = ['tests/test_*.py']
+
+        ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
+        ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
+        ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')
+        ld4, inc4, l4 = build_lib_arrays(self, 'wcslib')
+        ld5, inc5, l5 = build_lib_arrays(self, 'gfortran')
+
+        ld = clean(ld1 + ld2 + ld3 + ld4 + ld5)
+        inc = clean(inc1 + inc2 + inc3 + inc4 + inc5)
+        l = clean(l1 + l2 + l3 + l4 + l5)
+
+        macros = []
+        xspec_raw_version = self.xspec_version
+
+        if xspec_raw_version:
+            self.announce(f"Found XSPEC version: {xspec_raw_version}", 2)
+            xspec_version = LooseVersion(xspec_raw_version)
+
+            if xspec_version < LooseVersion("12.9.0"):
+                self.warn("XSPEC Version is less than 12.9.0, which is the minimal supported version for Sherpa")
+
+            # I am not sure what the naming of the XSPEC components are,
+            # but let's stick with major, minor, and patch.
+            #
+            for major, minor, patch in [(12, 9, 0), (12, 9, 1),
+                                        (12, 10, 0), (12, 10, 1),
+                                        (12, 11, 0), (12, 11, 1),
+                                        (12, 12, 0), (12, 12, 1)]:
+                version = f'{major}.{minor}.{patch}'
+                macro = f'XSPEC_{major}_{minor}_{patch}'
+                if xspec_version >= LooseVersion(version):
+                    macros += [(macro, None)]
+
+            # Since there are patches (e.g. 12.10.0c), look for
+            # the "next highest" version (i.e. increase the
+            # "patch" value by 1).
+            #
+            if xspec_version >= LooseVersion("12.12.2"):
+                self.warn("XSPEC Version is greater than 12.12.0, which is the latest supported version for Sherpa")
+
+        extension = build_ext('xspec', ld, inc, l, define_macros=macros)
+
+        self.distribution.ext_modules.append(extension)

--- a/scripts/check_xspec_update.py
+++ b/scripts/check_xspec_update.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -133,10 +133,14 @@ def compare_xspec_models(models, hard=True):
                 #
                 if [par.softmin, par.hardmin, par.softmax, par.hardmax] == [None] * 4:
                     for attr in ["min", "hard_min"]:
-                        assert getattr(xpar, attr) == -hugeval
+                        got = getattr(xpar, attr)
+                        if got != -hugeval:
+                            reports.append(f"par {xpar.name}.{attr} is not -hugeval but {got}")
 
                     for attr in ["max", "hard_max"]:
-                        assert getattr(xpar, attr) == hugeval
+                        got = getattr(xpar, attr)
+                        if got != hugeval:
+                            reports.append(f"par {xpar.name}.{attr} is not hugeval but {got}")
 
                     continue
 

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ try:
     from numpy.distutils import core
 
 except ImportError:
-    import sys
-
     print((
         "You need to install NUMPY in order to build Sherpa\n"
         "Other dependencies will be automatically installed\n"

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.12.0, 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
+Sherpa supports versions 12.12.1, 12.12.0, 12.11.1, 12.11.0, 12.10.1, 12.10.0, 12.9.1, and 12.9.0
 of XSPEC [1]_, and can be built against the model library or the full
 application.  There is no guarantee of support for older or newer
 versions of XSPEC.

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -316,16 +316,29 @@ extern "C" {
   xsccCall xszbabs;
 
 #ifdef XSPEC_12_9_1
-  xsf77Call ismabs_;
   xsccCall slimbbmodel;
+#endif
+
+#ifdef XSPEC_12_11_0
+  xsccCall beckerwolff;
+#endif
+
+#ifdef XSPEC_12_12_1
+  xsF77Call ismabs_;
+  xsF77Call ismdust_;
+  xsF77Call olivineabs_;
+#else
+
+#ifdef XSPEC_12_9_1
+  xsf77Call ismabs_;
 #endif
 
 #ifdef XSPEC_12_11_0
   xsf77Call ismdust_;
   xsf77Call olivineabs_;
-  xsccCall beckerwolff;
 #endif
 
+#endif // XSPEC_12_12_1
 
 // XSPEC table models; in XSPEC 12.10.1 these have been consolidated
 // into the tabint routine, but that is only available to C++, and
@@ -1386,7 +1399,12 @@ static PyMethodDef XSpecMethods[] = {
 
   XSPECMODELFCT_C_NORM(C_carbatm, 4),
   XSPECMODELFCT_C_NORM(C_hatm, 4),
+
+#ifdef XSPEC_12_12_1
+  XSPECMODELFCT_DBL(ismabs, 31),
+#else
   XSPECMODELFCT(ismabs, 31),
+#endif
 
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),
   XSPECMODELFCT_C_NORM(C_snapec, 7),
@@ -1408,9 +1426,17 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM(jet, 16),
 #endif
 
+#ifdef XSPEC_12_12_1
+  XSPECMODELFCT_DBL(ismdust, 3),
+  XSPECMODELFCT_DBL(olivineabs, 2),
+#else
 #ifdef XSPEC_12_11_0
   XSPECMODELFCT(ismdust, 3),
   XSPECMODELFCT(olivineabs, 2),
+#endif
+#endif // XSPEC_12_12_1
+
+#ifdef XSPEC_12_11_0
   XSPECMODELFCT_C(C_logconst, 1),
   XSPECMODELFCT_C(C_log10con, 1),
 #endif

--- a/sherpa/astro/xspec/utils.py
+++ b/sherpa/astro/xspec/utils.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2017, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2017, 2018, 2019, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -16,13 +17,45 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from distutils.version import LooseVersion
+
+import re
 
 from . import _xspec
 
 __all__ = ['ModelMeta', 'include_if', 'version_at_least']
 
-XSPEC_VERSION = LooseVersion(_xspec.get_xsversion())
+
+def get_version(version):
+    """Strip out any XSPEC patch level.
+
+    So '12.12.0c' gets converted to '12.12.0', and then to (12, 12,
+    0). This is helpful as then it makes version comparison easier, as
+    we can rely on the standard tuple ordering.
+
+    Parameters
+    ----------
+    version : str
+        The XSPEC version string, of the form "12.12.0c", so it can
+        include the XSPEC patch level.
+
+    Returns
+    -------
+    (major, minor, micro) : tuple of int
+        The XSPEC patchlevel is ignored.
+
+    """
+
+    # XSPEC versions do not match PEP 440, so strip out the trailing
+    # text (which indicates the XSPEC patch level).
+    #
+    match = re.search(r'^(\d+)\.(\d+)\.(\d+)', version)
+    if match is None:
+        raise ValueError(f"Invalid XSPEC version string: {version}")
+
+    return (int(match[1]), int(match[2]), int(match[3]))
+
+
+XSPEC_VERSION = get_version(_xspec.get_xsversion())
 
 
 class ModelMeta(type):
@@ -64,18 +97,29 @@ class ModelMeta(type):
 
 
 def equal_or_greater_than(version_string):
+    """Compare with the version of the current xspec instance.
+
+    Parameters
+    ----------
+    version_string : str
+        The version to compare against the current XSPEC version. It
+        can include an XSPEC patch level, such as "12.12.0c", but the
+        patch level is ignored.
+
+    Returns
+    -------
+    flag : bool
+        `True` if the version of xspec is equal or greater than the
+        argument, `False` otherwise
+
+    Notes
+    -----
+    For better or worse the xspec current instance is not cached
+    across calls. It probably could be but it just seems safer not to,
+    and any overhead insists on models initialization only.
+
     """
-    Utility function that compares a version string with the version of the current xspec instance.
-
-    For better or worse the xspec current instance is not cached across calls. It probably could be but
-    it just seems safer not to, and any overhead insists on models initialization only.
-
-    The comparison is made in terms of the `distutils.version.LooseVersion` class.
-
-    :param version_string: the version against which to compare the current xspec version
-    :return: `True` if the version of xspec is equal or greater than the argument, `False` otherwise
-    """
-    return XSPEC_VERSION >= LooseVersion(version_string)
+    return XSPEC_VERSION >= get_version(version_string)
 
 
 class include_if():

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -54,6 +54,14 @@ extern "C" {
                                   const int& spectrumNumber,
                                   float* flux,
                                   float* fluxError);
+
+        typedef void (xsF77Call) (const double* energyArray,
+                                  const int& Nenergy,
+                                  const double* parameterValues,
+                                  const int& spectrumNumber,
+                                  double* flux,
+                                  double* fluxError);
+
         typedef void (xsccCall)   (const Real* energyArray,
                                    int Nenergy,
                                    const Real* parameterValues,
@@ -71,15 +79,23 @@ extern "C" {
 // available in C++ scope.
 //
 // In XSPEC 12.11.0 (the next one after 12.10.1), the tabint function
-// was moved into C scope.
+// was moved into C scope. In XSPEC 12.12.1 the signature was changed
+// to mark more arguments as const.
 //
 #ifdef XSPEC_12_10_1
 #ifdef XSPEC_12_11_0
 extern "C" {
 #endif
 
-  void tabint(float* ear, int ne, float* param, int npar, const char* filenm, int ifl,
+#ifndef XSPEC_12_12_1
+  void tabint(float* ear, int ne, float* param,
+	      int npar, const char* filenm, int ifl,
 	      const char* tabtyp, float* photar, float* photer);
+#else
+  void tabint(const float* ear, const int ne, const float* param,
+	      const int npar, const char* filenm, int ifl,
+	      const char* tabtyp, float* photar, float* photer);
+#endif
 
 #ifdef XSPEC_12_11_0
 }
@@ -663,6 +679,22 @@ static void create_output(int nbins, T &a, T &b) {
       }; // class xspecModelFctF
 
 
+      template<typename Real, typename RealArray, xsF77Call XSpecFunc>
+      class xspecModelFctFD : public xspecModelFctBase<Real, RealArray>  {
+      public:
+
+        xspecModelFctFD( PyObject* args, npy_intp NumPars, bool HasNorm )
+          : xspecModelFctBase<Real, RealArray>( args, NumPars, HasNorm ) { }
+
+        void call_xspec( RealArray& result ) {
+          XSpecFunc( &this->ear[0], this->npts, &this->pars[0], this->ifl,
+                     &result[0], &this->error[0] );
+          return;
+        }
+
+      }; // class xspecModelFctFD
+
+
       template<typename Real, typename RealArray>
       class xspecModelFctConBase {
       public:
@@ -862,6 +894,32 @@ PyObject* xspecmodelfct( PyObject* self, PyObject* args ) {
     xspecModelFctF<float, FloatArray, XSpecFunc>( args, NumPars, HasNorm );
   try {
     FloatArray result;
+    xspec_model.eval( result );
+    return result.return_new_ref();
+  } catch(const NoError& re) {
+    return NULL;
+  } catch(const ValueError& re) {
+    PyErr_SetString( PyExc_ValueError, re.what() );
+    return NULL;
+  } catch(const TypeError& re) {
+    PyErr_SetString( PyExc_TypeError, re.what() );
+    return NULL;
+  } catch(...) {
+    // Even though the XSPEC model function is Fortran, it could call
+    // C++ functions, so swallow exceptions here
+    PyErr_SetString( PyExc_ValueError, xspec_model.get_err_msg() );
+    return NULL;
+  }
+
+}
+
+template <npy_intp NumPars, bool HasNorm, xsF77Call XSpecFunc>
+PyObject* xspecmodelfct_dbl( PyObject* self, PyObject* args ) {
+
+  xspecModelFctFD<double, DoubleArray, XSpecFunc> xspec_model =
+    xspecModelFctFD<double, DoubleArray, XSpecFunc>( args, NumPars, HasNorm );
+  try {
+    DoubleArray result;
     xspec_model.eval( result );
     return result.return_new_ref();
   } catch(const NoError& re) {
@@ -1161,6 +1219,11 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds ) {
 
 #define XSPECMODELFCT(name, npars)  _XSPECFCTSPEC(name, npars, false)
 #define XSPECMODELFCT_NORM(name, npars)  _XSPECFCTSPEC(name, npars, true)
+
+// double precision
+#define XSPECMODELFCT_DBL(name, npars) \
+		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_dbl< npars, false, \
+				name##_ >))
 
 #define XSPECMODELFCT_C(name, npars) \
 		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_C< npars, false, name >))


### PR DESCRIPTION
# Summary

The distutils.version.LooseVersion class is now marked as deprecated so remove its use when building Sherpa and when importing the Sherpa XSPEC module.

# Details

This is taken from #1329 but it's simplified. It also requires #1490 as that makes changes to `xspec_config.py` which we take advantage of here (it could be done without #1490 but they change the same bit of code so one has to be done first). An earlier version of this PR required the `packaging` package to be installed, but as mentioned below that just added more complexity than it was worth, so I've re-worked it to avoid the need for it.

The suggested replacement for `distutils.version.LooseVersion` is `packaging.version.Version` but this requires  an extra package be installed both when building Sherpa and when using Sherpa. As the code to support PEP 517 (in particular the code to allow build pre-requisites to be specified) has not been looked at yet (e.g. #1329) we can't easily add the `packaging` package to the Sherpa build without a lot of work documenting it and telling the user. 

Fortunately, the version check we need does not need the full PEP 440 support provided by `Version` and can be handled with a tuple of (major, minor, micro) versions (all integers). So the code is re-written to use this. Now, full XSPEC version strings are actually not PEP 440 complaint as the trailing patch level - such as the "c" in "12.12.0c" - breaks PEP 440, but the changes started in #1490 (to strip this patch-level value) are used to ensure we have a "sensible" check.

