### PR TITLE
Note that we support Python 3.10

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -23,23 +23,30 @@ jobs:
         include:
           - name: MacOS Full Build
             os: macos-latest
-            python-version: 3.8
+            python-version: "3.8"
             install-type: develop
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
             xspec-version: 12.10.1s
 
-          - name: Linux Minimum Setup
+          - name: Linux Minimum Setup (Python 3.8)
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
             numpy-version: 1.18
+            install-type: develop
+            test-data: none
+
+          - name: Linux Minimum Setup (Python 3.10)
+            os: ubuntu-latest
+            python-version: "3.10"
+            numpy-version: 1.21
             install-type: develop
             test-data: none
 
           - name: Linux Full Build (Python 3.9)
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -48,7 +55,7 @@ jobs:
 
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -57,7 +64,7 @@ jobs:
 
           - name: Linux Full Build (Python 3.7)
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
             numpy-version: 1.19
             install-type: develop
             fits: astropy
@@ -67,14 +74,14 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             install-type: install
             test-data: package
             matplotlib-version: 3
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
             numpy-version: 1.18
             install-type: develop
             fits: astropy

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -17,14 +17,23 @@ jobs:
         include:
           - name: Linux Minimum Setup
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
             numpy-pkg: 'numpy>=1.18,<1.19'
             install-type: develop
             test-data: none
 
+          - name: Linux Build (w/o Xspec; Python 3.10)
+            os: ubuntu-latest
+            python-version: "3.10"
+            numpy-pkg: 'numpy'
+            install-type: install
+            test-data: package
+            fits-pkg: 'astropy'
+            matplotlib-pkg: 'matplotlib>=3,<4'
+
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package
@@ -32,7 +41,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
@@ -40,7 +49,7 @@ jobs:
 
           - name: Linux Build (submodule data w/o Matplotlib or Xspec)
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
@@ -53,7 +62,7 @@ jobs:
         submodules: 'True'
 
     - name: Pip Testing Setup - Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.7, 3.8, 3.9, and 3.10.
+Sherpa is tested against Python versions 3.7, 3.8, 3.9, and (as a beta) 3.10.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.7,3.8,3.9-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.7,3.8,3.9,3.10-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -71,7 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.7, 3.8, and 3.9.
+Sherpa is tested against Python versions 3.7, 3.8, 3.9, and 3.10.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -80,7 +80,7 @@ Using Anaconda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.7, 3.8, and 3.9. It can be installed with the `conda`
+Python 3.7 to 3.10. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c sherpa sherpa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.7, 3.8, and 3.9.
+and is compatible with Python versions 3.7 to 3.10.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,7 +27,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.7, 3.8, 3.9, or 3.10
+* Python 3.7, 3.8, 3.9, or (as a beta) 3.10
 * NumPy (the exact lower limit has not been determined,
   1.17.0 or later will work, earlier version may work)
 * Linux or OS-X (patches to add Windows support are welcome)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,7 +27,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.7, 3.8, or 3.9
+* Python 3.7, 3.8, 3.9, or 3.10
 * NumPy (the exact lower limit has not been determined,
   1.17.0 or later will work, earlier version may work)
 * Linux or OS-X (patches to add Windows support are welcome)
@@ -136,7 +136,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.7, 3.8, 3.9
+* Python versions: 3.7, 3.8, 3.9, 3.10
 * Python packages: ``setuptools``, ``numpy``
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2014, 2017, 2018, 2019, 2020, 2021, 2022
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -135,6 +135,7 @@ meta = dict(name='sherpa',
                 'Programming Language :: Python :: 3.7',
                 'Programming Language :: Python :: 3.8',
                 'Programming Language :: Python :: 3.9',
+                'Programming Language :: Python :: 3.10',
                 'Programming Language :: Python :: Implementation :: CPython',
                 'Topic :: Scientific/Engineering :: Astronomy',
                 'Topic :: Scientific/Engineering :: Physics'


### PR DESCRIPTION
# Summary

Note that Sherpa can be built using Python 3.10 and add two Python 3.10 CI test runs.

# Details

As #1316 appears to have disappeared, let's tell people we support Python 3.10. I've picked "relatively minor" CI runs (i.e. not the full build and install with XSPEC style testing) as we need to review what runs to do properly soon.