### PR TITLE
DS9 update from 8.2.1 to 8.3

### DIFF
--- a/.github/scripts/setup_xspec_ds9.sh
+++ b/.github/scripts/setup_xspec_ds9.sh
@@ -43,7 +43,7 @@ download () {
 
 ### DS9 and XPA
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.2.1.tar.gz
+ds9_tar=ds9.${ds9_os}.8.3.tar.gz
 xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
 
 # Fetch them

--- a/.github/scripts/setup_xspec_ds9.sh
+++ b/.github/scripts/setup_xspec_ds9.sh
@@ -19,7 +19,7 @@ echo "HEADAS=${HEADAS}"
 xspec_root=${CONDA_PREFIX}
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinhighsierra
+    ds9_os=darwinmojave
 else
     echo "* installing dev environment"
 


### PR DESCRIPTION
It looks like ds9 8.2.1 is now gone. This updates the script to grab 8.3.