### PR TITLE
Tests: ensure matplotlib windows are closed after all tests are run

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -572,3 +572,26 @@ def override_plot_backend(request):
     if changed:
         sherpa.plot.backend = old
         sherpa.astro.plot.backend = old
+
+
+@pytest.fixture(autouse=True, scope="session")
+def cleanup_pylab_backend():
+    """Ensure that the pylab backend has closed down all windows.
+
+    This is related to https://github.com/The-Compiler/pytest-xvfb/issues/11
+    and the idea is to ensure that all matplotlib windows are closed at the
+    end of the tests.
+    """
+
+    yield
+
+    # Technically the system could have matplotlib installed but not
+    # selected. However, this is not easily checked, so just check
+    # if we can install matplotlib and, of so, close down any wnidows.
+    #
+    try:
+        from matplotlib import pyplot as plt
+    except ImportError:
+        return
+
+    plt.close(fig="all")

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -587,7 +587,7 @@ def cleanup_pylab_backend():
 
     # Technically the system could have matplotlib installed but not
     # selected. However, this is not easily checked, so just check
-    # if we can install matplotlib and, of so, close down any wnidows.
+    # if we can install matplotlib and, if so, close down any windows.
     #
     try:
         from matplotlib import pyplot as plt


### PR DESCRIPTION
# Summary

Ensure that our tests can run on CI cleanly.

# Details

There are times our tests suffer from

https://github.com/The-Compiler/pytest-xvfb/issues/11

That is, the tests run but because smoething still has a window
open then the xvfb server falls over, causing the tests to appear
to fail, when they haven't. Following the discussion in this issue
this commit adds a session-scoped fixture that ensures that any
matplotlib windows are closed before the tests end.