### PR TITLE
Update all CI tests by +0.1 Python and numpy versions

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - name: MacOS Full Build
             os: macos-latest
-            python-version: 3.8
+            python-version: 3.9
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -32,10 +32,19 @@ jobs:
 
           - name: Linux Minimum Setup
             os: ubuntu-latest
-            python-version: 3.8
-            numpy-version: 1.18
+            python-version: 3.9
+            numpy-version: 1.19
             install-type: develop
             test-data: none
+
+          - name: Linux Full Build (Python 3.10)
+            os: ubuntu-latest
+            python-version: 3.10
+            install-type: develop
+            fits: astropy
+            test-data: submodule
+            matplotlib-version: 3
+            xspec-version: 12.11.1
 
           - name: Linux Full Build (Python 3.9)
             os: ubuntu-latest
@@ -49,16 +58,7 @@ jobs:
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest
             python-version: 3.8
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
-            xspec-version: 12.11.1
-
-          - name: Linux Full Build (Python 3.7)
-            os: ubuntu-latest
-            python-version: 3.7
-            numpy-version: 1.19
+            numpy-version: 1.20
             install-type: install
             fits: astropy
             test-data: submodule
@@ -67,15 +67,15 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: 3.10
             install-type: install
             test-data: package
             matplotlib-version: 3
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: 3.7
-            numpy-version: 1.18
+            python-version: 3.9
+            numpy-version: 1.19
             install-type: develop
             fits: astropy
             test-data: none

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -39,7 +39,7 @@ jobs:
 
           - name: Linux Full Build (Python 3.10)
             os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -58,7 +58,7 @@ jobs:
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest
             python-version: 3.8
-            numpy-version: 1.20
+            numpy-version: '1.20'
             install-type: install
             fits: astropy
             test-data: submodule
@@ -67,7 +67,7 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
             install-type: install
             test-data: package
             matplotlib-version: 3

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -24,7 +24,7 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -17,14 +17,14 @@ jobs:
         include:
           - name: Linux Minimum Setup
             os: ubuntu-latest
-            python-version: 3.8
-            numpy-pkg: 'numpy>=1.18,<1.19'
+            python-version: 3.9
+            numpy-pkg: 'numpy>=1.19'
             install-type: develop
             test-data: none
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: 3.10
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package
@@ -32,7 +32,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
@@ -40,7 +40,7 @@ jobs:
 
           - name: Linux Build (submodule data w/o Matplotlib or Xspec)
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'


### PR DESCRIPTION
I don't necessarily intend for this to get merged and certainly not before the upcoming freeze, but I think it's about time to try out if CI passes when we just update all Python and numpy versions. It's a more thorough test than me just trying if 3.10 works on just my single, local, architecture.

Once we know, we can close (or keep around, whatever seems useful).