### PR TITLE
Cleanup template code

### DIFF
--- a/docs/model_classes/template.rst
+++ b/docs/model_classes/template.rst
@@ -7,7 +7,7 @@ The sherpa.models.template module
 .. automodule:: sherpa.models.template
 
    .. rubric:: Classes
-               
+
    .. autosummary::
       :toctree: api
 
@@ -15,11 +15,18 @@ The sherpa.models.template module
       InterpolatingTemplateModel
       KNNInterpolator
       Template
-   
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      add_interpolator
+      create_template_model
+      reset_interpolators
+
 Class Inheritance Diagram
 =========================
 
 .. inheritance-diagram:: TemplateModel InterpolatingTemplateModel KNNInterpolator Template
    :parts: 1
-
-

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,7 +37,9 @@ doctest_norecursedirs =
     sherpa/image
     sherpa/include
     sherpa/io.py
-    sherpa/models
+    sherpa/models/model.py
+    sherpa/models/parameter.py
+    sherpa/models/regrid.py
     sherpa/optmethods
     sherpa/plot
     sherpa/sim

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -360,14 +360,14 @@ class TemplateModel(ArithmeticModel):
     def __init__(self, name='templatemodel', pars=(), parvals=None,
                  templates=None):
 
-        # TODO: this should probably error out if given no parameters
-        # or templates.
-        #
         self.parvals = parvals if parvals is not None else []
         self.templates = templates if templates is not None else []
 
         if len(self.parvals) != len(self.templates):
             raise ModelErr("Number of parameter values and templates do not match")
+
+        if len(self.parvals) == 0:
+            raise ModelErr("parvals is empty or not set")
 
         self.index = {}
 

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -86,8 +86,13 @@ from .parameter import Parameter
 from .model import ArithmeticModel, modelCacher1d
 from .basic import TableModel
 
-__all__ = ('create_template_model', 'TemplateModel', 'KNNInterpolator',
-           'Template')
+__all__ = ('TemplateModel', 'InterpolatingTemplateModel',
+           'KNNInterpolator', 'Template', 'add_interpolator',
+           'create_template_model', 'reset_interpolators')
+
+
+# This is reset by reset_interpolators below.
+interpolators = {}
 
 
 def create_template_model(modelname, names, parvals, templates,
@@ -419,6 +424,41 @@ class TemplateModel(ArithmeticModel):
         return table_model(x0, x1, *args, **kwargs)
 
 
-interpolators = {
-    'default': (Template, {'k': 2, 'order': 2})
-}
+def reset_interpolators():
+    """Reset the list of interpolators to the default.
+
+    If the list does not exist then recreate it.
+
+    See Also
+    --------
+    add_interpolator
+
+    """
+
+    d = globals()
+    d["interpolators"] = {
+        'default': (Template, {'k': 2, 'order': 2})
+    }
+
+
+def add_interpolator(name, interpolator, **kwargs):
+    """Add the interpolator to the list.
+
+    Parameters
+    ----------
+    name : str
+    interpolator
+       An interpolator class.
+    **kwargs
+       The arguments for the interpolator.
+
+    See Also
+    --------
+    reset_interpolators
+
+    """
+
+    interpolators[name] = (interpolator, kwargs)
+
+
+reset_interpolators()

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2019, 2020, 2021, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,6 +18,65 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# pylint: disable=invalid-name
+
+"""Use data as model templates.
+
+Allow models to be created from data, where the model data,
+represented as a `sherpa.models.basic.TableModel`, can be associated
+with a set of parameters. The `TemplateModel` class only supports
+access to the parameter values, but the `InterpolatingTemplateModel`
+class adds interpolation of the parameter values (although this is
+class should not be used directly, and the `KNNInterpolator` class
+used instead).
+
+Examples
+========
+
+A set of three templates are set for the "scale" parameter with values
+of 5, 17, and 25. All templates have the same independent axis (of [5,
+15, 40]) and the scale=5 value is [1, 2, 3], the scale=17 is [3, 7,
+4], and scale=25 is [10, 15, 0].
+
+>>> import numpy as np
+>>> from sherpa.models.template import create_template_model
+>>> from sherpa.models.basic import TableModel
+>>> parnames = ["scale"]
+>>> parvals = np.asarray([[5], [17], [25]])
+>>> m1 = TableModel("m1")
+>>> m2 = TableModel("m2")
+>>> m3 = TableModel("m3")
+>>> m1.load([5, 15, 40], [1, 2, 3])
+>>> m2.load([5, 15, 40], [3, 7, 4])
+>>> m3.load([5, 15, 40], [10, 15, 0])
+>>> tmps = [m1, m2, m3]
+>>> mdl = create_template_model("model", parnames, parvals, tmps)
+
+The model defaults to the first parameter value:
+
+>>> print(mdl)
+model
+   Param        Type          Value          Min          Max      Units
+   -----        ----          -----          ---          ---      -----
+   model.scale  thawed            5            5           25
+
+>>> mdl([5, 15, 40])
+array([1., 2., 3.])
+
+If the parameter is changed then the templates are weighted:
+
+>>> mdl.scale = 16
+>>> mdl([5, 15, 40])
+array([3.7, 7.8, 3.6])
+
+As the templates were set up with an x array, the model can be
+interpolated onto a different grid:
+
+>>> mdl([10, 20, 30])
+array([5.75, 6.96, 5.28])
+
+"""
+
 import operator
 
 import numpy
@@ -32,81 +92,177 @@ __all__ = ('create_template_model', 'TemplateModel', 'KNNInterpolator',
 
 def create_template_model(modelname, names, parvals, templates,
                           template_interpolator_name='default'):
+    """Create a TemplateModel model class from template input.
+
+    Parameters
+    ----------
+    modelname : str
+        The name of the template model.
+    names : sequence of str
+        The order of the parameters.
+    parvals : ndarray
+        The parameter values, organised as a 2D ndarray of shape
+        (nelem, npars), where nelem is the number of parameter values
+        and npars the number of parameters (which must match the names
+        parameter).
+    templates : sequence of TemplateModel instances
+        The spectrum at a specific parameter vector, corresponding to
+        a row in ``parvals``.
+    template_interpolator_name : str or None, optional
+        The interpolator name. If None then there is no interpolation
+        between templates.
+
+    Returns
+    -------
+    model
+
     """
-    Create a TemplateModel model class from template input
 
+    if parvals.ndim != 2:
+        raise ValueError(f"parvals must be 2D, sent {parvals.ndim}D")
 
-    `modelname`  - name of the template model.
+    # It is not obvious why we have the data transposed, but leave as
+    # is for now.
+    #
+    if parvals.shape[1] != len(names):
+        raise ValueError(f"number of parvals and names do not match: {parvals.shape[1]} vs {len(names)}")
 
-    `names`      - list of strings that define the order of the
-                   named parameters.
-
-    `parvals`    - 2-D ndarray of parameter vectors, index corresponds
-                   to the spectrum in `templates`. The parameter grid.
-
-    `templates`  - list of TableModel objects that contain a spectrum
-                   at a specific parameter vector (corresponds to a row
-                   in `parvals`).
-
-    `template_interpolator_name` - name of the template interpolator, or None
-                   for disabling interpolation *between* templates.
-                   See load_template_model for more information.
-
-    """
     # Create a list of parameters from input
     pars = []
-    for ii, name in enumerate(names):
-        minimum = min(parvals[:, ii])
-        maximum = max(parvals[:, ii])
-        initial = parvals[:, ii][0]
+    for name, parval in zip(names, parvals.T):
+        minimum = min(parval)
+        maximum = max(parval)
         # Initial parameter value is always first parameter value listed
-        par = Parameter(modelname, name, initial,
-                        minimum, maximum,
-                        minimum, maximum)
+        par = Parameter(modelname, name, parval[0],
+                        min=minimum, max=maximum,
+                        hard_min=minimum, hard_max=maximum)
         pars.append(par)
 
     # Create the templates table from input
     tm = TemplateModel(modelname, pars, parvals, templates)
-    if template_interpolator_name is not None:
-        if template_interpolator_name in interpolators:
-            interp = interpolators[template_interpolator_name]
-            args = interp[1]
-            args['template_model'] = tm
-            args['name'] = modelname
-            return interp[0](**args)
-    else:
+    if template_interpolator_name is None:
         return tm
 
+    try:
+        func, args = interpolators[template_interpolator_name]
+    except KeyError:
+        raise ModelErr(f"Unknown template_interpolator_name={template_interpolator_name}") from None
 
+    # Do not add keys to the stored dictionary
+    args = args.copy()
+    args['template_model'] = tm
+    args['name'] = modelname
+    return func(**args)
+
+
+# Should this provide direct access to query to better match
+# TemplateModel.  Or should we not export the parvals attribute, as we
+# don't want to copy that interface?
+#
 class InterpolatingTemplateModel(ArithmeticModel):
+    """Allow parameter interpolation for a TemplateModel.
+
+    This class should not be used directly.
+
+    Parameters
+    ----------
+    name : str
+        The name of the model
+    template_model : TemplateModel instance
+        The templates to use.
+
+    See Also
+    --------
+    TemplateModel, KNNInterpolator
+
+    """
+
     def __init__(self, name, template_model):
         self.template_model = template_model
+        self.parvals = template_model.parvals
+
+        # The parameters are copied over from parvals, so we need to
+        # add them to the object, as the parent class does not do this.
+        #
         for par in template_model.pars:
             self.__dict__[par.name] = par
-            self.parvals = template_model.parvals
+
         ArithmeticModel.__init__(self, name, template_model.pars)
 
     def fold(self, data):
-        for template in self.template_model.templates:
-            template.fold(data)
+        """Ensure the templates match the data filtering.
+
+        Parameters
+        ----------
+        data : sherpa.data.Data instance
+
+        """
+        self.template_model.fold(data)
 
     @modelCacher1d
     def calc(self, p, x0, x1=None, *args, **kwargs):
         interpolated_template = self.interpolate(p, x0)
         return interpolated_template(x0, x1, *args, **kwargs)
 
+    def interpolate(self, point, x_out):
+        """Calculate the model combination for the given parameter values.
+
+        If the given point matches a template than that is used, otherwise
+        weight the templates in some manner.
+
+        Parameters
+        ----------
+        point : sequence of float
+            The parameter values to use. This must match the size and
+            ordering of the parameters of the model.
+        x_out : sequence of float
+            The x values to use for the model evaluation.
+
+        Returns
+        -------
+        model : TableModel instance
+            The model to use.
+
+        """
+
+        raise NotImplementedError
+
 
 class KNNInterpolator(InterpolatingTemplateModel):
+    """Use K-nearest neighbors interpolation for parameters.
+
+    Select the template to use based on the K-nearest neighbors
+    algorithm
+    https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm
+
+    Parameters
+    ----------
+    name : str
+        The name of the model
+    template_model : TemplateModel instance
+        The templates to use.
+    k : int or None, optional
+        The k to use.
+    order : int, optional
+        The order to use.
+
+    See Also
+    --------
+    TemplateModel
+
+    """
     def __init__(self, name, template_model, k=None, order=2):
         self._distances = {}
         if k is None:
-            self.k = 2*template_model.parvals[0].size
+            # TODO: what happens if no params? What is .size meant to be?
+            self.k = 2 * template_model.parvals[0].size
         else:
             self.k = k
         self.order = order
         InterpolatingTemplateModel.__init__(self, name, template_model)
 
     def _calc_distances(self, point):
+        """What are the distances for the given set of parameters?"""
         self._distances = {}
         for i, t_point in enumerate(self.template_model.parvals):
             self._distances[i] = numpy.linalg.norm(point - t_point, self.order)
@@ -116,59 +272,143 @@ class KNNInterpolator(InterpolatingTemplateModel):
         self._calc_distances(point)
         if self._distances[0][1] == 0:
             return self.template_model.templates[self._distances[0][0]]
+
         k_distances = self._distances[:self.k]
         weights = [(idx, 1/numpy.array(distance)) for idx, distance in k_distances]
-        sum_weights = sum([1/weight for idx, weight in k_distances])
         y_out = numpy.zeros(len(x_out))
         for idx, weight in weights:
             y_out += self.template_model.templates[idx].calc((weight,), x_out)
+
+        sum_weights = sum(1 / weight for (idx, weight) in k_distances)
         y_out /= sum_weights
         tm = TableModel('interpolated')
         tm.load(x_out, y_out)
         return tm
 
 
+# Why do we have this class?
+#
 class Template(KNNInterpolator):
-    def __init__(self, *args, **kwargs):
-        KNNInterpolator.__init__(self, *args, **kwargs)
+    """The Template class.
+
+    See Also
+    --------
+    KNNInterpolator
+
+    """
+
+    pass
 
 
 class TemplateModel(ArithmeticModel):
+    """Combine TableModel instances.
+
+    Parameters
+    ----------
+    name : str
+        The name of the model
+    pars : sequence of sherpa.models.parameter.Parameter
+        The parameters.
+    parvals : sequence of sequence of float
+        The parameter values for each template.
+    templates : sequence of TableModel
+        The template for each element of parvals.
+
+    See Also
+    --------
+    TemplateModel, KNNInterpolator
+
+    """
 
     def __init__(self, name='templatemodel', pars=(), parvals=None,
                  templates=None):
+
+        # TODO: this should probably error out if given no parameters
+        # or templates.
+        #
         self.parvals = parvals if parvals is not None else []
         self.templates = templates if templates is not None else []
+
+        if len(self.parvals) != len(self.templates):
+            raise ModelErr("Number of parameter values and templates do not match")
+
         self.index = {}
 
+        # The parameters are copied over from parvals, so we need to
+        # add them to the object, as the parent class does not do this.
+        #
         for par in pars:
             self.__dict__[par.name] = par
 
-        for ii, parval in enumerate(parvals):
+        npars = len(pars)
+        for ii, parval in enumerate(self.parvals):
+            ngot = len(parval)
+            if ngot != npars:
+                raise ModelErr(f"parvals[{ii}] has length {ngot}, expected {npars}")
+
             self.index[tuple(parval)] = templates[ii]
 
         ArithmeticModel.__init__(self, name, pars)
         self.is_discrete = True
 
     def fold(self, data):
+        """Ensure the templates match the data filtering.
+
+        Parameters
+        ----------
+        data : sherpa.data.Data instance
+
+        """
         for template in self.templates:
             template.fold(data)
 
     def get_x(self):
+        """Return the x (independent) axis for the selected template.
+
+        Returns
+        -------
+        x : sequence of float
+
+        """
         p = tuple(par.val for par in self.pars)
         template = self.query(p)
         return template.get_x()
 
     def get_y(self):
+        """Return the y (dependent) axis for the selected template.
+
+        Returns
+        -------
+        y : sequence of float
+
+        """
         p = tuple(par.val for par in self.pars)
         template = self.query(p)
         return template.get_y()
 
     def query(self, p):
+        """Return the template for a given set of parameters.
+
+        Parameters
+        ----------
+        p : sequence of float
+            The parameter values to use. This must match the size and
+            ordering of the parameters of the model.
+
+        Returns
+        -------
+        model : TableModel instance
+
+        Raises
+        ------
+        ModelErr
+            There is no template that matches the given set of parameters.
+
+        """
         try:
             return self.index[tuple(p)]
         except KeyError:
-            raise ModelErr("Interpolation of template parameters was disabled for this model, but parameter values not in the template library have been requested. Please use gridsearch method and make sure the sequence option is consistent with the template library")
+            raise ModelErr("Interpolation of template parameters was disabled for this model, but parameter values not in the template library have been requested. Please use gridsearch method and make sure the sequence option is consistent with the template library") from None
 
     @modelCacher1d
     def calc(self, p, x0, x1=None, *args, **kwargs):

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -104,7 +104,7 @@ def test_grid_search_with_discrete_template_parvals(run_thread, clean_ui):
 
 
 @pytest.fixture
-def setUp(reset_seed):
+def setUp():
     x = numpy.linspace(0.1, 5, 50)
 
     num = 4
@@ -120,14 +120,14 @@ def setUp(reset_seed):
     # Since we randomize the parameters use for the gaussian models,
     # use a fixed seed.
     #
-    numpy.random.seed(94272045)
+    rng = numpy.random.default_rng(9427205)
 
     templates = []
     for ii in range(ntemplates):
         t = TableModel()
-        g1.fwhm = numpy.random.uniform(0.5, 2.0)
-        g1.pos = numpy.random.uniform(1.0, 4.5)
-        g1.ampl = numpy.random.uniform(1.0, 50.)
+        g1.fwhm = rng.uniform(0.5, 2.0)
+        g1.pos = rng.uniform(1.0, 4.5)
+        g1.ampl = rng.uniform(1.0, 50.)
         t.load(coords, g1(coords))
         templates.append(t)
 
@@ -142,4 +142,7 @@ def test_template_model_evaluation(setUp):
     # a regression test and so the predicted values may change).
     #
     y = model([0.55, 1.25, 3.65, 4.95])
-    assert y == pytest.approx([0.13578952, 2.77359801, 8.66001796, 0.04257855])
+    assert y == pytest.approx([0.006695045904199339,
+                               0.33558934132320956,
+                               5.274350209830429,
+                               0.024472491880120843])

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2018, 2021, 2022
+#  Copyright (C) 2011, 2015, 2016, 2018, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -104,7 +104,7 @@ def test_grid_search_with_discrete_template_parvals(run_thread, clean_ui):
 
 
 @pytest.fixture
-def setUp():
+def setUp(reset_seed):
     x = numpy.linspace(0.1, 5, 50)
 
     num = 4
@@ -116,6 +116,12 @@ def setUp():
     grid = numpy.asarray(list(map(numpy.ravel, grid))).T
     coords = numpy.linspace(0.01, 6, 100)
     names = [f"p{i}" for i in range(num)]
+
+    # Since we randomize the parameters use for the gaussian models,
+    # use a fixed seed.
+    #
+    numpy.random.seed(94272045)
+
     templates = []
     for ii in range(ntemplates):
         t = TableModel()
@@ -132,5 +138,8 @@ def test_template_model_evaluation(setUp):
     x, model = setUp
     model.thawedpars = [0, 1, 0, 1]
 
-    # We want to evaluate the model, but do not check the result
-    model(x)
+    # Evaluate on a very-restricted grid and check the result (this is
+    # a regression test and so the predicted values may change).
+    #
+    y = model([0.55, 1.25, 3.65, 4.95])
+    assert y == pytest.approx([0.13578952, 2.77359801, 8.66001796, 0.04257855])

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,28 +18,57 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-# At present this only contains a very basic test for fix 309.
-
 import os
 
+import numpy as np
+
+import pytest
+
+from sherpa.astro.ui.utils import Session as AstroSession
+from sherpa.data import Data1D
+from sherpa.models.basic import TableModel, Gauss1D
+from sherpa.models.parameter import Parameter
+from sherpa.models.template import Template, TemplateModel, \
+    create_template_model
 from sherpa.ui.utils import Session
-from sherpa.utils.testing import requires_data
+from sherpa.utils.err import ModelErr
+from sherpa.utils.testing import has_package_from_list, requires_data
+
+
+@pytest.fixture
+def skip_if_no_io(request):
+    """For tests with a session fixture that need to be skipped if
+    the I/O backend is not present ONLY for AstroSession.
+    """
+
+    if request.getfixturevalue("session") == Session:
+        return
+
+    # This requires knowledge of requires_fits, but we don't make it
+    # possible to access this so we hard code the knowledge here. If
+    # we ever get another I/O backend we need to revisit this.
+    #
+    if has_package_from_list("astropy.io.fits", "pycrates"):
+        return
+
+    pytest.skip(reason="FITS backend required")
 
 
 @requires_data
-def test_309(make_data_path):
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_309(session, make_data_path, skip_if_no_io):
 
     idval = 'bug309'
 
     # have values near unity for the data
     ynorm = 1e9
 
-    session = Session()
+    s = session()
 
     dname = make_data_path('load_template_with_interpolation-bb_data.dat')
 
-    session.load_data(idval, dname)
-    session.get_data(idval).y *= ynorm
+    s.load_data(idval, dname)
+    s.get_data(idval).y *= ynorm
 
     indexname = 'bb_index.dat'
     datadir = make_data_path('')
@@ -47,13 +77,428 @@ def test_309(make_data_path):
     basedir = os.getcwd()
     os.chdir(datadir)
     try:
-        session.load_template_model('bbtemp', indexname)
+        s.load_template_model('bbtemp', indexname)
     finally:
         os.chdir(basedir)
 
-    bbtemp = session.get_model_component('bbtemp')
-    session.set_source(idval, bbtemp * ynorm)
+    bbtemp = s.get_model_component('bbtemp')
+    s.set_source(idval, bbtemp * ynorm)
 
-    session.set_method('gridsearch')
-    session.set_method_opt('sequence', None)
-    session.fit(idval)
+    s.set_method('gridsearch')
+    s.set_method_opt('sequence', None)
+    s.fit(idval)
+
+
+def test_create_template_model_parnames_does_not_match():
+    """What happens if we send in too many parnames?"""
+
+    templates = [TableModel("foo")]
+    parvals = np.asarray([[2.3]])
+    with pytest.raises(IndexError,
+                       match="index 1 is out of bounds"):
+        create_template_model("foo", ["a", "b"], parvals, templates)
+
+
+def test_create_template_model_parvals_not_2d():
+    """What happens if we send parvals not 2D"""
+
+    # These arguments do not really make sense. They are enough to
+    # check the code.
+    #
+    templates = [TableModel("foo")]
+    parvals = np.asarray([2.3])
+    with pytest.raises(IndexError,
+                       match="too many indices for array"):
+        create_template_model("foo", ["a"], parvals, templates)
+
+
+def test_create_template_model_parvals_wrong_size():
+    """What happens if we send parvals not the right size"""
+
+    # These arguments do not really make sense. They are enough to
+    # check the code.
+    #
+    templates = [TableModel("foo")]
+    parvals = np.arange(12).reshape(3, 4)
+    with pytest.raises(IndexError,
+                       match="list index out of range"):
+        create_template_model("foo", ["a"], parvals, templates)
+
+
+def test_create_template_model_unknown_interpolator():
+    """What happens if we send an unknown interpolator?"""
+
+    # These arguments do not really make sense. They are enough to
+    # check the code.
+    #
+    templates = [TableModel("foo"), TableModel("bar")]
+    parvals = np.asarray([[12], [13]])
+    tmpl = create_template_model("foo", ["a"], parvals, templates,
+                                 template_interpolator_name="made_up")
+    assert tmpl is None  # check current behavior, even if "not good"TM
+
+
+def test_templatemodel_wrong_number_of_pars():
+    """Check we error out"""
+
+    templates = [TableModel("foo"), TableModel("bar")]
+    with pytest.raises(TypeError,
+                       match="'NoneType' object is not iterable"):
+        TemplateModel(templates=templates)
+
+
+def test_templatemodel_wrong_parvals_element():
+    """Check we error out"""
+
+    templates = [TableModel("foo"), TableModel("bar")]
+    pars = [Parameter("fooy", "x", 1), Parameter("fooy", "y", 2)]
+    parvals = [[2, 3], [1], [4, 5, 54]]
+    with pytest.raises(IndexError,
+                       match="list index out of range"):
+        TemplateModel(pars=pars, parvals=parvals,
+                      templates=templates)
+
+
+def test_templatemodel_no_arguments():
+    """What happens if we have no parameters?"""
+
+    # This is really a failure of validation as this is an internal error
+    with pytest.raises(TypeError,
+                       match="'NoneType' object is not iterable"):
+        TemplateModel("empty")
+
+
+def test_templatemodel_pars_no_templates():
+    """What happens if we have pars but no templates"""
+
+    pars = [Parameter("empty", "bob", 12)]
+
+    # This is really a failure of validation as this is an internal error
+    with pytest.raises(TypeError,
+                       match="'NoneType' object is not iterable"):
+        empty = TemplateModel("empty", pars=pars)
+
+
+def test_templatemodel_templates_not_tablemodel():
+    """What happens if we send in templates that are not TableModels?"""
+
+    templates = [Gauss1D("m1"), Gauss1D("m2")]
+    woop = create_template_model("woop", ["woop"], np.asarray([[5], [10]]),
+                                 templates)
+
+    with pytest.raises(AttributeError,
+                       match="'Gauss1D' object has no attribute 'fold'"):
+        woop.fold(Data1D("x", [1, 2, 3], [1, 2, 3]))
+
+    # Not sure why this actually fails. Ideally the error would be clearer,
+    # but really this should have been caught at object creation.
+    #
+    with pytest.raises(TypeError,
+                       match="1D model evaluation input array sizes do not match, xlo: 3 vs xhi: 1"):
+        woop([1, 2, 3])
+
+
+def setup_basic(iname=None, no_x=False):
+    """Can we get a TemplateModel set up?"""
+
+    x = np.arange(1, 5)
+    xdata = None if no_x else x
+
+    templates = []
+    for scale, name in enumerate(["m1", "m2", "m3"], 1):
+        template = TableModel(name)
+        template.load(xdata, x * scale)
+        templates.append(template)
+
+    return create_template_model("bob", ["pa"], np.asarray([[10], [20], [30]]),
+                                 templates, template_interpolator_name=iname)
+
+
+@pytest.mark.parametrize("iname,cls", [(None, TemplateModel), ("default", Template)])
+def test_templatemodel_basic_returns_class(iname, cls):
+    """Check we can get the correct class"""
+
+    assert isinstance(setup_basic(iname), cls)
+
+
+@pytest.mark.parametrize("iname", [None, "default"])
+def test_templatemodel_basic_show(iname):
+    """Check we can get a reasonable show value"""
+
+    tmpl = setup_basic(iname)
+    out = str(tmpl).split("\n")
+    assert out[0] == "bob"
+    assert out[1].startswith("   Param  ")
+    assert out[2].startswith("   -----  ")
+    assert out[3].startswith("   bob.pa ")
+    assert len(out) == 4
+
+
+@pytest.mark.parametrize("iname", [None, "default"])
+def test_templatemodel_basic_has_pars(iname):
+    """Check we can get expected parameters"""
+
+    tmpl = setup_basic(iname)
+    assert len(tmpl.pars) == 1
+
+    par = tmpl.pars[0]
+    assert isinstance(par, Parameter)
+    assert par.name == "pa"
+    assert par.fullname == "bob.pa"
+    assert not par.frozen
+    assert par.val == pytest.approx(10)
+    assert par.min == pytest.approx(10)
+    assert par.max == pytest.approx(30)
+
+
+@pytest.mark.parametrize("iname", [None, pytest.param("default", marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("pval,pname", [(10, "m1"), (20, "m2"), (30, "m3")])
+def test_templatemodel_basic_can_query(iname, pval, pname):
+    """Check we can query
+
+    This does not work it interpolation is selected, but perhaps it
+    should, which is why the test is marked xfail.
+
+    """
+
+    tmpl = setup_basic(iname)
+    tbl = tmpl.query([pval])
+    assert isinstance(tbl, TableModel)
+    assert tbl.name == pname
+
+
+@pytest.mark.parametrize("iname", [None, "default"])
+@pytest.mark.parametrize("pval", [10, 20, 30])
+def test_templatemodel_basic_can_evaluate(iname, pval):
+    """Check we can evaluate the model for the parameter values."""
+
+    tmpl = setup_basic(iname)
+
+    # We know that the scaling is pval / 10 * [1, 2, 3, 4]
+    #
+    x = np.arange(1, 5)
+    expected = x * pval / 10
+
+    tmpl.pa = pval
+    assert tmpl(x) == pytest.approx(expected)
+
+
+def test_templatemodel_basic_can_evaluate_not_at_par_none():
+    """There is no interpolation."""
+
+    tmpl = setup_basic(None)
+    x = np.arange(1, 5)
+    tmpl.pa = 17.5
+
+    with pytest.raises(ModelErr,
+                       match="^Interpolation of template parameters was disabled for this model, "):
+        tmpl(x)
+
+
+def test_templatemodel_basic_can_evaluate_not_at_par_default():
+    """There is interpolation within a parameter"""
+
+    tmpl = setup_basic("default")
+    x = np.arange(1, 5)
+    tmpl.pa = 17.5
+
+    # This is linear scaling, so it "should" be easy;
+    #   pa = 10  -> 1, 2, 3, 4
+    #   pa = 20  -> 2, 4, 6, 8
+    #
+    expected = 1.75 * x
+    assert tmpl(x) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("iname", [None, "default"])
+@pytest.mark.parametrize("pval", [10, 20, 30])
+def test_templatemodel_basic_can_interpolate_x(iname, pval):
+    """Check we can evaluate the model for the parameter values withinterpolating x"""
+
+    tmpl = setup_basic(iname)
+
+    # We know that the scaling is pval / 10 * x when x is in the range
+    # 1-4, so let's see how the interpolation does.
+    #
+    x = np.asarray([1.4, 2.5, 2.8, 3.9])
+    expected = x * pval / 10
+
+    tmpl.pa = pval
+    assert tmpl(x) == pytest.approx(expected)
+
+
+def test_templatemodel_basic_can_evaluate_not_at_par_default_interpolate_x():
+    """There is interpolation within a parameter and within x"""
+
+    tmpl = setup_basic("default")
+    x = np.arange(1, 5)
+    tmpl.pa = 23.5
+
+    # We need to assume the interpolation both between the parameter
+    # values and then within x works.
+    #
+    x = np.asarray([1.4, 2.5, 2.8, 3.9])
+    expected = x * 2.35
+    assert tmpl(x) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("iname", [None, "default"])
+def test_templatemodel_basic_fold(iname):
+    """We can fold the dataset and use this correctly"""
+
+    tmpl = setup_basic(iname, no_x=True)
+
+    data = Data1D("orig", [1, 2, 3, 4], [1] * 4)
+    data.ignore(xlo=3, xhi=3)
+
+    # check we have a subset
+    assert data.mask == pytest.approx([1, 1, 0, 1])
+
+    tmpl.fold(data)
+
+    # Pick a known template so we can handle both iname=None and default
+    tmpl.pa = 20
+
+    assert data.eval_model_to_fit(tmpl) == pytest.approx([2, 4, 8])
+    assert data.eval_model(tmpl) == pytest.approx([2, 4, 6, 8])
+
+
+def weighted(xs):
+    """Sum up the weight values."""
+    w = sum(x[0] for x in xs)
+    return sum(x[0] * x[1] for x in xs) / w
+
+
+# k=1 means nearest match
+# k=2 means linear interpolation
+# k=3 means weighted nearest 3 matches
+#
+# It is unclear what the code will do when values are equidistant, so
+# these tests may need to check for "a or b" rather than just a, but
+# wait until that becomes a problem before worrying about it.
+#
+@pytest.mark.parametrize("order", [1, 2, 3])
+@pytest.mark.parametrize("k,pval,expected",
+                         [(1, 11, 5),
+                          (1, 15, 5),
+                          (1, 27, 20),
+                          (1, 31, 20),
+                          (1, 39, 40),
+
+                          (2, 11, weighted([(0.9, 5), (0.1, 15)])),
+                          (2, 15, weighted([(0.5, 5), (0.5, 15)])),
+                          (2, 27, weighted([(0.3, 15), (0.7, 20)])),
+                          (2, 31, weighted([(0.9, 20), (0.1, 40)])),
+                          (2, 39, weighted([(0.1, 20), (0.9, 40)])),
+
+                          # Weights are 1/<distance>
+                          (3, 11, weighted([(1/1, 5), (1/9, 15), (1/19, 20)])),
+                          (3, 15, weighted([(1/5, 5), (1/5, 15), (1/15, 20)])),
+                          (3, 27, weighted([(1/7, 15), (1/3, 20), (1/13, 40)])),
+                          (3, 31, weighted([(1/11, 15), (1/1, 20), (1/9, 40)])),
+                          (3, 39, weighted([(1/9, 20), (1/1, 40), (1/11, 44)])),
+                          ])
+def test_interpolate_par1(order, k, pval, expected):
+    """Check KNNInterpolator/Template distance calculation: 1 par
+
+    The idea is that we use a "constant" model so we can know what
+    the interpolated value should be.
+
+    I was surprised that order=1, 2, 3 all gave the same results,
+    but we only have one parameter so there's no real "power"
+    for the order value to address.
+
+    """
+
+    x = np.asarray([2, 4, 6])
+    templates = []
+    for scale, name in zip([5, 15, 20, 40, 44], ["m1", "m2", "m3", "m4", "m5"]):
+        template = TableModel(name)
+        template.load(x, np.ones_like(x) * scale)
+        templates.append(template)
+
+    tmpl = create_template_model("bob", ["pa"], np.asarray([[10], [20], [30], [40], [50]]),
+                                 templates)
+    assert isinstance(tmpl, Template)
+    assert tmpl.k == 2
+    assert tmpl.order == 2
+
+    # The x axis values don't really matter here, but keep them inside
+    # the original x=2, 4, 6 setting. A single value could be used,
+    # but include 2 just in case.
+    #
+    tmpl.order = order
+    tmpl.k = k
+    tmpl.pa = pval
+    assert tmpl([3, 5]) == pytest.approx([expected, expected])
+
+
+def check3(p1, p2, p3):
+    """What do we expect the answer to be?"""
+    x = np.asarray([2, 4, 6])
+    return p1 * x * x + p2 * x + p3
+
+
+@pytest.mark.parametrize("order,k,pval1,pval2,pval3,expected",
+                         # First checks are linear interpolation along
+                         # p3 axis at points where we have p1 and p2.
+                         #
+                         [(1, 2, 2, 3, 25, check3(2, 3, 25)),
+                          (2, 2, 2, 3, 25, check3(2, 3, 25)),
+                          (3, 2, 2, 3, 25, check3(2, 3, 25)),
+                          (1, 2, 0.5, 1, 15, check3(0.5, 1, 15)),
+                          (2, 2, 0.5, 1, 15, check3(0.5, 1, 15)),
+                          (3, 2, 0.5, 1, 15, check3(0.5, 1, 15)),
+
+                          # Actual vaues are [39, 57, 81]
+                          # Why does the order setting not matter?
+                          #
+                          (1, 2, 0.75, 4.5, 27, [41, 58, 81]),
+                          (2, 2, 0.75, 4.5, 27, [41, 58, 81]),
+                          (3, 2, 0.75, 4.5, 27, [41, 58, 81])
+                          ])
+def test_interpolate_par3(order, k, pval1, pval2, pval3, expected):
+    """Check KNNInterpolator/Template distance calculation: 3 pars
+
+    The underlying model is
+
+        y(p1, p2, p3) = p1 x^2 + p2 x + p3
+
+    """
+
+    x = np.asarray([2, 4, 6])
+    templates = []
+
+    # Here we use the same parameter values for the models
+    # and the parameter values, unlike the test_interpolate_par1
+    # case, where we had different scaling.
+    #
+    pvals1 = [0.5, 1, 1.5, 2, 2.5]
+    pvals2 = [1, 2, 3, 4, 5]
+    pvals3 = [10, 20, 30, 40, 50]
+
+    pvals = []
+    for p3 in pvals3:
+        for p2 in pvals2:
+            for p1 in pvals1:
+                template = TableModel()
+                template.load(x, p1 * x * x + p2 * x + p3)
+                templates.append(template)
+                pvals.append([p1, p2, p3])
+
+    pvals = np.asarray(pvals)
+    tmpl = create_template_model("bob", ["pa", "pb", "pc"], pvals,
+                                 templates)
+    assert isinstance(tmpl, Template)
+    assert tmpl.k == 2
+    assert tmpl.order == 2
+
+    # To simplify comparison, we use the actual x array rather than
+    # add on more interpolation.
+    #
+    tmpl.order = order
+    tmpl.k = k
+    tmpl.pa = pval1
+    tmpl.pb = pval2
+    tmpl.pc = pval3
+    assert tmpl(x) == pytest.approx(expected)

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2022
+#  Copyright (C) 2016, 2018, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -527,3 +527,28 @@ def test_interpolate_par3(order, k, pval1, pval2, pval3, expected):
     tmpl.pb = pval2
     tmpl.pc = pval3
     assert tmpl(x) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("pa,expected",
+                         [(1, [4.8, 6, 7.6, 8.2, 10]),
+                          (1.5, [10.4, 11, 16.466667, 18.516667, 24.66667]),
+                          (2, [16, 16, 25.333333, 28.83333, 39.33333])])
+def test_template_with_different_independent_axes(pa, expected):
+    """Check we can have different x values."""
+
+    t1 = TableModel("m1")
+    t1.load([10, 20, 30], [4, 6, 8])
+
+    t2 = TableModel("m2")
+    t2.load([12, 20, 32], [16, 16, 30])
+
+    templates = [t1, t2]
+
+    mdl = create_template_model("bob", ["pa"], np.asarray([[1], [2]]),
+                                templates)
+
+    # Evaluate in the grid 14, 20, 28, 31, 40
+    #
+    mdl.pa = pa
+    got = mdl([14, 20, 28, 31, 40])
+    assert got == pytest.approx(expected)

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -163,45 +163,18 @@ def test_templatemodel_wrong_parvals_element():
 def test_templatemodel_no_arguments():
     """What happens if we have no parameters?"""
 
-    # We should probably error out, but we currently do not.
-    #
-    empty = TemplateModel("empty")
-    assert len(empty.pars) == 0
-
-    out = str(empty).split("\n")
-    assert out[0] == "empty"
-    assert out[1].startswith("   Param ")
-    assert out[2].startswith("   ----- ")
-    assert len(out) == 3
-
-    # What can evaluating the model do? Oh, this is an interesting error.
-    #
     with pytest.raises(ModelErr,
-                       match="^Interpolation of template parameters "):
-        empty([1, 2, 3])
+                       match="^parvals is empty or not set"):
+        empty = TemplateModel("empty")
 
 
 def test_templatemodel_pars_no_templates():
     """What happens if we have pars but no templates"""
 
-    # We should probably error out, but we currently do not.
-    #
     pars = [Parameter("empty", "bob", 12)]
-    empty = TemplateModel("empty", pars=pars)
-    assert len(empty.pars) == 1
-
-    out = str(empty).split("\n")
-    assert out[0] == "empty"
-    assert out[1].startswith("   Param ")
-    assert out[2].startswith("   ----- ")
-    assert out[3].startswith("   empty.bob ")
-    assert len(out) == 4
-
-    # What can evaluating the model do? Oh, this is an interesting error.
-    #
     with pytest.raises(ModelErr,
-                       match="^Interpolation of template parameters "):
-        empty([1, 2, 3])
+                       match="^parvals is empty or not set"):
+        TemplateModel("empty", pars=pars)
 
 
 def test_templatemodel_templates_not_tablemodel():
@@ -281,7 +254,7 @@ def test_templatemodel_basic_has_pars(iname):
 def test_templatemodel_basic_can_query(iname, pval, pname):
     """Check we can query
 
-    This does not work it interpolation is selected, but perhaps it
+    This does not work if interpolation is selected, but perhaps it
     should, which is why the test is marked xfail.
 
     """

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -34,7 +34,8 @@ from sherpa import get_config
 import sherpa.all
 from sherpa.models.basic import TableModel
 from sherpa.models.model import Model
-from sherpa.models.template import create_template_model
+from sherpa.models.template import add_interpolator, create_template_model, \
+    reset_interpolators
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
@@ -835,6 +836,8 @@ class Session(NoNewAttributesAfterInit):
         self._current_stat = self._stats['chi2gehrels']
         # Add simplex as alias to neldermead
         self._methods['simplex'] = self._methods['neldermead']
+
+        reset_interpolators()
 
         self._data = {}
         self._psf = {}
@@ -7220,8 +7223,7 @@ class Session(NoNewAttributesAfterInit):
         >>> load_template_interpolator('myint', KNNInterpolator, k=4, order=3)
 
         """
-        sherpa.models.template.interpolators[
-            name] = (interpolator_class, kwargs)
+        add_interpolator(name, interpolator_class, **kwargs)
 
     def load_table_model(self, modelname, filename, ncols=2, colkeys=None,
                          dstype=sherpa.data.Data1D, sep=' ', comment='#',


### PR DESCRIPTION
# Summary

Improve the documentation and testing of the template-model code. There is no significant change in behavior, but some use cases will generate more-appropriate errors than they used to.

# Details

I was looking at the template code to help answer a user ticket and noticed some style issues. Since I originally wrote this I've removed some of the code clean up (from the utils code) since this is likely to conflict with  #1638 and I desperately want to avoid the same issue I've had the last few years when integrating long-lived PRs thanks to conflicts. Unfortunately, I know there are some conflicts as #1638 adds tests for some validation checks that the template code does and I don't want to add the tests here too, and the code in this part is definitely going to be a pain to rebase. I've added some tests, but more are needed to check out the KNN behavior. This has now been dealt with as #1662 has been merged (taken out of #1638) but I've left this text in as a reminder.

There are some questions I had when reviewing the code that I feel better about answering (e.g. "why can we not just the contained object's fold method") with the tests I've added. This mainly resolves around whether we should add validation to the classes (i.e. checking the inputs make sense).

## Questions include

Should we allow an empty (no template) template model? Currently yes but it's pointless, so probably going to get zapped.

Why do we have `Template` and `KNNInterpolator` - the latter is just a renamed version of the former?

Should `InterpolatingTemplateModel` extend `TemplateModel` or treat it as container? We currently do the latter (which is not a common approach within Sherpa). In and of itself this is not necessarily a bad thing, but we do add an attribute and a method (`.parvals` and `.fold`) that make it look like we are extending the `TemplateModel` behavior (or, rather, that if we did just make it a superclass then we wouldn't need to set up). This may just be done with documentation or a comment in the code.

There's a number of "abstract" methods we don't over-rise in `TemplateModel` or `InterpolatingTemplateModel`. Should we?

Two methods are flagged by pylnit as `W1113: Keyword argument before variable positional arguments list in the definition of calc function (keyword-arg-before-vararg)` - these are both the `calc` method. Should we try and fix this?

I don't understand what creating a `KNNInterpolator` (or `Template`) with no `k` set is meant to do. It obviously picks a value, but exactly what this value is meant to be is unclear as the documentation does not explain what the fields it is using are meant to be (ie what exactly is being used) and there are no tests of this functionality. Actually, I now have some idea...
