### PR TITLE
do not change the XSPEC configuration when Sherpa is being built

### DIFF
--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -117,17 +117,12 @@ class xspec_config(Command):
         pass
 
     def run(self):
+        if not self.with_xspec:
+            return
+
         package = 'sherpa.astro.xspec'
         dist_packages = self.distribution.packages
         dist_data = self.distribution.package_data
-
-        if not self.with_xspec:
-            if package in dist_packages:
-                dist_packages.remove(package)
-            if package in dist_data:
-                del dist_data[package]
-
-            return
 
         if package not in dist_packages:
             dist_packages.append(package)

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -120,16 +120,6 @@ class xspec_config(Command):
         if not self.with_xspec:
             return
 
-        package = 'sherpa.astro.xspec'
-        dist_packages = self.distribution.packages
-        dist_data = self.distribution.package_data
-
-        if package not in dist_packages:
-            dist_packages.append(package)
-
-        if package not in dist_data:
-            dist_data[package] = ['tests/test_*.py']
-
         ld1, inc1, l1 = build_lib_arrays(self, 'xspec')
         ld2, inc2, l2 = build_lib_arrays(self, 'cfitsio')
         ld3, inc3, l3 = build_lib_arrays(self, 'ccfits')


### PR DESCRIPTION
# Summary

Minor simplification to the XSPEC configuration code.

# Details

I've long wondered about this code, and have removed it in #1329, but https://github.com/sherpa/sherpa/pull/1458#pullrequestreview-962108820 made me think about it again. Naively I imagine that removing the package from the build instructions is "not the right thing to do", but I admit to not having a good-enough understanding of the package ecosystem to know. So this is an attempt to see what happens.

I then removed the "adding the package" change in #1329 so added it here too.