### PR TITLE
tests: ensure DS9 window is closed after the tests

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -27,6 +27,7 @@ from numpy import VisibleDeprecationWarning
 
 import pytest
 
+from sherpa.utils.err import RuntimeErr
 from sherpa.utils.testing import get_datadir, set_datadir
 
 try:
@@ -595,3 +596,23 @@ def cleanup_pylab_backend():
         return
 
     plt.close(fig="all")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def cleanup_ds9_backend():
+    """Ensure that the DS9 window has closed down.
+
+    The DS9 window can be left after the tests are run. This fixture
+    attempts to close down any DS9 instance that has been started.
+
+    """
+
+    yield
+
+    # If DS9 is not available this will lead to a warning message,
+    # but there's no way to stop this. The code could import ds9_backend
+    # instead of backend but then it would have to deal with failure,
+    # and it does not seem an improvement.
+    #
+    from sherpa.image import backend
+    backend.close()


### PR DESCRIPTION
# Summary

Ensure that any DS9 process started by the Sherpa tests is closed when the tests are finished.

# Details

An alternative to this is to just install pytest-xvfb (and ensure you have Xvfb installed), but I am sure I have seen some problems with the DS9 window still being active when the Xvsb session ends (in a similar way to the problems #1497 fixes issues with matpliotlib windows).

Ensure that the DS9 imager is closed after the tests. This is a bit heavy handed as any test run - such as running the tests in one file that doesn't require DS9 - will lead to a warning message being created (as we have to try importing the relevant code), but the pytest machinery seems to hide this.

This follows the approach from #1497 for closing down matplotlib windows after the tests are run.