### PR TITLE
Minor UI tweaks

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -232,9 +232,6 @@ def get_data(path, **kwargs):
 def test_save_model_ascii(session, kwargs, idval, tmp_path):
     """Can we use save_model?"""
 
-    if session == Session and idval is None:
-        pytest.xfail()
-
     s = session()
     outfile = tmp_path / "model.dat"
     save_ascii_file(s, kwargs, idval, outfile, s.save_model)
@@ -252,9 +249,6 @@ def test_save_model_ascii(session, kwargs, idval, tmp_path):
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
 def test_save_source_ascii(session, kwargs, idval, tmp_path):
     """Can we use save_source?"""
-
-    if session == Session and idval is None:
-        pytest.xfail()
 
     s = session()
     outfile = tmp_path / "source.dat"
@@ -274,9 +268,6 @@ def test_save_source_ascii(session, kwargs, idval, tmp_path):
 def test_save_resid_ascii(session, kwargs, idval, tmp_path):
     """Can we use save_resid?"""
 
-    if session == Session and idval is None:
-        pytest.xfail()
-
     s = session()
     outfile = tmp_path / "resid.dat"
     save_ascii_file(s, kwargs, idval, outfile, s.save_resid)
@@ -294,9 +285,6 @@ def test_save_resid_ascii(session, kwargs, idval, tmp_path):
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
 def test_save_delchi_ascii(session, kwargs, idval, tmp_path):
     """Can we use save_delchi?"""
-
-    if session == Session and idval is None:
-        pytest.xfail()
 
     s = session()
     outfile = tmp_path / "resid.dat"

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -24,10 +24,12 @@ import pytest
 
 from sherpa.astro.data import DataPHA
 from sherpa.astro.ui.utils import Session as AstroSession
-from sherpa.data import Data1D
+from sherpa.data import Data1D, Data1DInt
+from sherpa.io import get_ascii_data
 from sherpa.models import Const1D
+import sherpa.models.basic
 from sherpa.ui.utils import Session
-from sherpa.utils.err import IdentifierErr
+from sherpa.utils.err import DataErr, IdentifierErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 
@@ -79,10 +81,9 @@ def test_id_checks_session(session, setting):
     """Do some common identifiers fail?"""
 
     s = session()
-    with pytest.raises(IdentifierErr) as ie:
+    with pytest.raises(IdentifierErr,
+                       match=f"identifier '{setting}' is a reserved word"):
         s.load_arrays(setting, [1, 2], [1, 2])
-
-    assert str(ie.value) == f"identifier '{setting}' is a reserved word"
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
@@ -113,7 +114,236 @@ def test_id_checks_astro_session(session, success, setting):
         d = s.get_data(setting)
         assert isinstance(d, Data1D)
     else:
-        with pytest.raises(IdentifierErr) as ie:
+        with pytest.raises(IdentifierErr,
+                           match=f"identifier '{setting}' is a reserved word"):
             s.load_arrays(setting, [1, 2], [1, 2])
 
-        assert str(ie.value) == f"identifier '{setting}' is a reserved word"
+
+def save_ascii_file(s, kwargs, idval, outfile, savefunc, syserr=False):
+    """create data and save a file based on it"""
+
+    s._add_model_types(sherpa.models.basic)
+
+    cpt = s.create_model_component("const1d", "cpt")
+    cpt.integrate = True
+    cpt.c0 = 2
+
+    # Select bin edges that lead to integer for the middle values,
+    # along with the model per-bin values (2 * width).
+    #
+    s.load_arrays(idval, [1, 3, 5], [3, 5, 9], [3, 4, 5], Data1DInt)
+    dy = [1, 2, 6]
+
+    errfunc = s.set_syserror if syserr else s.set_staterror
+
+    if idval is None:
+        errfunc(dy)
+        s.set_source(cpt)
+        savefunc(str(outfile), **kwargs)
+    else:
+        errfunc(idval, dy)
+        s.set_staterror(idval, dy)
+        s.set_source(idval, cpt)
+        savefunc(idval, str(outfile), **kwargs)
+
+
+def get_data(path, **kwargs):
+    """wrapper routine to handle path conversion and dropping last argument."""
+
+    ans = get_ascii_data(str(path), **kwargs)
+    return ans[0], ans[1]
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_model_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_model?"""
+
+    if session == Session and idval is None:
+        pytest.xfail()
+
+    s = session()
+    outfile = tmp_path / "model.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_model)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "MODEL"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([2, 4, 7])
+    assert data[1] == pytest.approx([4, 4, 8])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_source_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_source?"""
+
+    if session == Session and idval is None:
+        pytest.xfail()
+
+    s = session()
+    outfile = tmp_path / "source.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_source)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "SOURCE"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([2, 4, 7])
+    assert data[1] == pytest.approx([4, 4, 8])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_resid_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_resid?"""
+
+    if session == Session and idval is None:
+        pytest.xfail()
+
+    s = session()
+    outfile = tmp_path / "resid.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_resid)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "RESID"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([2, 4, 7])
+    assert data[1] == pytest.approx([-1, 0, -3])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_delchi_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_delchi?"""
+
+    if session == Session and idval is None:
+        pytest.xfail()
+
+    s = session()
+    outfile = tmp_path / "resid.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_delchi)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "DELCHI"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([2, 4, 7])
+    assert data[1] == pytest.approx([-1, 0, -0.5])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_data_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_data?"""
+
+    s = session()
+    outfile = tmp_path / "data.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_data)
+
+    print(outfile.read_text())
+
+    names, data = get_data(outfile, ncols=4)
+    assert names == ["XLO", "XHI", "Y", "STATERROR"]
+    assert len(data) == 4
+    assert data[0] == pytest.approx([1, 3, 5])
+    assert data[1] == pytest.approx([3, 5, 9])
+    assert data[2] == pytest.approx([3, 4, 5])
+    assert data[3] == pytest.approx([1, 2, 6])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_staterror_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_staterror?
+
+    The output of this looks wrong (just showing the XLO values not
+    XMID or XLO,XHI) but treat as a regression test. See #1526.
+
+    """
+
+    s = session()
+    outfile = tmp_path / "errs.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_staterror)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "STAT_ERR"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([1, 3, 5])
+    assert data[1] == pytest.approx([1, 2, 6])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_syserror_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_syserror?
+
+    The output of this looks wrong (just showing the XLO values not
+    XMID or XLO,XHI) but treat as a regression test. See #1526.
+
+    """
+
+    s = session()
+    outfile = tmp_path / "errs.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_syserror, syserr=True)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "SYS_ERR"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([1, 3, 5])
+    assert data[1] == pytest.approx([1, 2, 6])
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_syserror_no_data_ascii(session, kwargs, idval, tmp_path):
+    """Check save_syserror needs a systematic-error column."""
+
+    s = session()
+    outfile = tmp_path / "errs.dat"
+
+    mid = 1 if idval is None else idval
+    with pytest.raises(DataErr,
+                       match=f"^data set '{mid}' does not specify systematic errors$"):
+        save_ascii_file(s, kwargs, idval, outfile, s.save_syserror)
+
+
+@requires_fits  # only for AstroSession, but not worth being clever
+@pytest.mark.parametrize("session,kwargs",
+                         [(Session, {}), (AstroSession, {"ascii": True})])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_save_error_ascii(session, kwargs, idval, tmp_path):
+    """Can we use save_error?
+
+    This does not bother testing the various combinations of
+    statistical and systematic errors as this is assumed tested
+    elsewhere.
+
+    The output of this looks wrong (just showing the XLO values not
+    XMID or XLO,XHI) but treat as a regression test.
+
+    """
+
+    s = session()
+    outfile = tmp_path / "errs.dat"
+    save_ascii_file(s, kwargs, idval, outfile, s.save_error)
+
+    names, data = get_data(outfile, ncols=2)
+    assert names == ["X", "ERR"]
+    assert len(data) == 2
+    assert data[0] == pytest.approx([1, 3, 5])
+    assert data[1] == pytest.approx([1, 2, 6])

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -99,7 +99,7 @@ def test_set_iter_method_unknown_string(session):
 def test_set_iter_method_not_a_string(session):
     s = Session()
     with pytest.raises(ArgumentTypeErr,
-                       match="^'23' must be a string$"):
+                       match="^'meth' must be a string$"):
         s.set_iter_method(23)
 
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -28,7 +28,7 @@ import numpy
 import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, \
     create_non_delta_rmf, has_pha_response
-from sherpa.ui.utils import _check_type, _check_str_type
+from sherpa.ui.utils import _check_type, _check_str_type, _is_str
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
     send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
@@ -45,9 +45,6 @@ from sherpa.astro.data import DataPHA
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info
-
-
-string_types = (str, )
 
 
 __all__ = ('Session',)
@@ -8872,7 +8869,7 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
     def load_psf(self, modelname, filename_or_model, *args, **kwargs):
         kernel = filename_or_model
-        if isinstance(filename_or_model, string_types):
+        if _is_str(filename_or_model):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
             except:
@@ -9261,7 +9258,7 @@ class Session(sherpa.ui.utils.Session):
         """
         if model is None:
             id, model = model, id
-        if isinstance(model, string_types):
+        if _is_str(model):
             model = self._eval_model_expression(model)
         self._set_item(id, model, self._pileup_models, sherpa.models.Model,
                        'model', 'a model object or model expression string')
@@ -9458,7 +9455,7 @@ class Session(sherpa.ui.utils.Session):
         id = self._fix_id(id)
         bkg_id = self._fix_background_id(id, bkg_id)
 
-        if isinstance(model, string_types):
+        if _is_str(model):
             model = self._eval_model_expression(model)
         _check_type(model, sherpa.models.Model, 'model',
                     'a model object or model expression string')
@@ -9580,7 +9577,7 @@ class Session(sherpa.ui.utils.Session):
         id = self._fix_id(id)
         bkg_id = self._fix_background_id(id, bkg_id)
 
-        if isinstance(model, string_types):
+        if _is_str(model):
             model = self._eval_model_expression(model)
         _check_type(model, sherpa.models.Model, 'model',
                     'a model object or model expression string')
@@ -14805,7 +14802,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if isinstance(outfile, string_types):
+        if _is_str(outfile):
             if os.path.isfile(outfile):
                 if sherpa.utils.bool_cast(clobber):
                     os.remove(outfile)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -28,7 +28,7 @@ import numpy
 import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, \
     create_non_delta_rmf, has_pha_response
-from sherpa.ui.utils import _check_type
+from sherpa.ui.utils import _check_type, _check_str_type
 from sherpa.utils import SherpaInt, SherpaFloat, sao_arange, \
     send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
@@ -3828,7 +3828,7 @@ class Session(sherpa.ui.utils.Session):
     def _save_type(self, objtype, id, filename, bkg_id=None, **kwargs):
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         d = self.get_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4353,7 +4353,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         id = self._fix_id(id)
 
         if bkg_id is not None:
@@ -4458,7 +4458,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         d = self.get_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4548,7 +4548,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         d = self.get_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4645,7 +4645,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         d = self.get_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4730,7 +4730,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         d = self._get_pha_data(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4808,7 +4808,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         id = self._fix_id(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4893,7 +4893,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         id = self._fix_id(id)
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
@@ -4971,7 +4971,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
 
         sherpa.astro.io.write_image(filename, self.get_data(id),
                                     ascii=ascii, clobber=clobber)
@@ -5041,7 +5041,7 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
         id = self._fix_id(id)
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
 
         sherpa.astro.io.write_table(filename, self.get_data(id),
                                     ascii=ascii, clobber=clobber)
@@ -5121,7 +5121,7 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, 'filename')
         if bkg_id is not None:
             d = self.get_bkg(id, bkg_id)
         else:
@@ -6533,8 +6533,8 @@ class Session(sherpa.ui.utils.Session):
         if quantity is None:
             id, quantity = quantity, id
 
-        _check_type(quantity, string_types, 'quantity', 'a string')
-        _check_type(type, string_types, 'type', 'a string')
+        _check_str_type(quantity, "quantity")
+        _check_str_type(type, "type")
 
         ids = self.list_data_ids()
         if id is not None:
@@ -6660,7 +6660,7 @@ class Session(sherpa.ui.utils.Session):
         if coord is None:
             id, coord = coord, id
 
-        _check_type(coord, string_types, 'coord', 'a string')
+        _check_str_type(coord, "coord")
 
         ids = self.list_data_ids()
         if id is not None:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -59,7 +59,7 @@ class Session(sherpa.ui.utils.Session):
     def __init__(self):
 
         self.clean()
-        sherpa.ui.utils.Session.__init__(self)
+        super().__init__()
 
     ###########################################################################
     # High-level utilities
@@ -122,7 +122,7 @@ class Session(sherpa.ui.utils.Session):
             self.__dict__['_background_sources'] = state.pop(
                 '_background_models')
 
-        sherpa.ui.utils.Session.__setstate__(self, state)
+        super().__setstate__(state)
 
     def clean(self):
         """Clear out the current Sherpa session.
@@ -182,7 +182,7 @@ class Session(sherpa.ui.utils.Session):
         #
         self._xspec_state = None
 
-        sherpa.ui.utils.Session.clean(self)
+        super().clean()
 
         self._pyblocxs = sherpa.astro.sim.MCMC()
 
@@ -275,7 +275,8 @@ class Session(sherpa.ui.utils.Session):
             self._xspec_state = sherpa.astro.xspec.get_xsstate()
         else:
             self._xspec_state = None
-        sherpa.ui.utils.Session.save(self, filename, clobber)
+
+        super().save(filename, clobber)
 
     def restore(self, filename='sherpa.save'):
         """Load in a Sherpa session from a file.
@@ -321,7 +322,7 @@ class Session(sherpa.ui.utils.Session):
         >>> restore('/data/m31/setup.sherpa')
 
         """
-        sherpa.ui.utils.Session.restore(self, filename)
+        super().restore(filename)
         if hasattr(sherpa.astro, "xspec"):
             if self._xspec_state is not None:
                 sherpa.astro.xspec.set_xsstate(self._xspec_state)
@@ -6773,7 +6774,8 @@ class Session(sherpa.ui.utils.Session):
 
         if lo is not None or hi is not None:
             self._notice_warning()
-        sherpa.ui.utils.Session.notice(self, lo, hi, **kwargs)
+
+        super().notice(lo, hi, **kwargs)
 
     notice.__doc__ = sherpa.ui.utils.Session.notice.__doc__
 
@@ -6781,7 +6783,8 @@ class Session(sherpa.ui.utils.Session):
 
         if lo is not None or hi is not None:
             self._notice_warning()
-        sherpa.ui.utils.Session.ignore(self, lo, hi, **kwargs)
+
+        super().ignore(lo, hi, **kwargs)
 
     ignore.__doc__ = sherpa.ui.utils.Session.ignore.__doc__
 
@@ -8958,7 +8961,7 @@ class Session(sherpa.ui.utils.Session):
         >>> set_full_model("src", smodel)
 
         """
-        sherpa.ui.utils.Session.set_full_model(self, id, model)
+        super().set_full_model(id, model)
 
         if model is None:
             id, model = model, id

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -134,7 +134,7 @@ def test_set_iter_method_type_not_string():
     with pytest.raises(ArgumentTypeErr) as te:
         ui.set_iter_method(23)
 
-    assert str(te.value) == "'23' must be a string"
+    assert str(te.value) == "'meth' must be a string"
 
 
 def test_set_iter_method_type_not_enumeration():

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -69,6 +69,14 @@ def _check_type(arg, argtype, argname, argdesc, nottype=None):
         raise ArgumentTypeErr('badarg', argname, argdesc)
 
 
+def _check_str_type(arg: str, argname: str) -> None:
+    """Ensure that arg (with name argname) is a string"""
+    if isinstance(arg, string_types):
+        return
+
+    raise ArgumentTypeErr('badarg', argname, "a string")
+
+
 def _is_integer(val):
     return isinstance(val, (int, numpy.integer))
 
@@ -143,7 +151,7 @@ class ModelWrapper(NoNewAttributesAfterInit):
         NoNewAttributesAfterInit.__init__(self)
 
     def __call__(self, name):
-        _check_type(name, string_types, 'name', 'a string')
+        _check_str_type(name, "name")
 
         m = self._session._get_model_component(name)
         if (m is not None) and isinstance(m, self.modeltype):
@@ -463,7 +471,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, "filename")
         clobber = sherpa.utils.bool_cast(clobber)
 
         if os.path.isfile(filename) and not clobber:
@@ -519,7 +527,7 @@ class Session(NoNewAttributesAfterInit):
         >>> restore('/data/m31/setup.sherpa')
 
         """
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, "filename")
 
         fin = open(filename, 'rb')
         try:
@@ -1501,7 +1509,8 @@ class Session(NoNewAttributesAfterInit):
         """
         if name is None:
             return self._current_method
-        _check_type(name, string_types, 'name', 'a string')
+
+        _check_str_type(name, "name")
         return self._get_method_by_name(name)
 
     # DOC-TODO: is this guaranteed to be the same as get_method().name
@@ -1616,8 +1625,8 @@ class Session(NoNewAttributesAfterInit):
                         'a method name or object')
         self._current_method = meth
 
-    def _check_method_opt(self, optname):
-        _check_type(optname, string_types, 'optname', 'a string')
+    def _check_method_opt(self, optname: str) -> None:
+        _check_str_type(optname, "optname")
         if optname not in self._current_method.config:
             raise ArgumentErr('badopt', optname, self.get_method_name())
 
@@ -1777,7 +1786,7 @@ class Session(NoNewAttributesAfterInit):
         if optname is None:
             return itermethod_opts
 
-        _check_type(optname, string_types, 'optname', 'a string')
+        _check_str_type(optname, "optname")
         if optname not in itermethod_opts:
             raise ArgumentErr(
                 'badopt', optname, self._current_itermethod['name'])
@@ -1900,13 +1909,12 @@ class Session(NoNewAttributesAfterInit):
         >>> set_iter_method('none')
 
         """
-        if not isinstance(meth, string_types):
-            raise ArgumentTypeErr('badarg', meth, 'a string')
+        _check_str_type(meth, meth)
 
-        if meth in self._itermethods:
-            self._current_itermethod = self._itermethods[meth]
-        else:
+        if meth not in self._itermethods:
             raise TypeError(f'{meth} is not an iterative fitting method')
+
+        self._current_itermethod = self._itermethods[meth]
 
     def set_iter_method_opt(self, optname, val):
         """Set an option for the iterative-fitting scheme.
@@ -1968,11 +1976,12 @@ class Session(NoNewAttributesAfterInit):
         >>> fit()
 
         """
-        _check_type(optname, string_types, 'optname', 'a string')
+        _check_str_type(optname, "optname")
         if (optname not in self._current_itermethod or
                 optname == 'name'):
             raise ArgumentErr(
                 'badopt', optname, self._current_itermethod['name'])
+
         self._current_itermethod[optname] = val
 
     ###########################################################################
@@ -2063,7 +2072,8 @@ class Session(NoNewAttributesAfterInit):
         """
         if name is None:
             return self._current_stat
-        _check_type(name, string_types, 'name', 'a string')
+
+        _check_str_type(name, "name")
         return self._get_stat_by_name(name)
 
     def get_stat_name(self):
@@ -3553,7 +3563,7 @@ class Session(NoNewAttributesAfterInit):
 
     @staticmethod
     def _read_data(readfunc, filename, *args, **kwargs):
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, "filename")
         return readfunc(filename, *args, **kwargs)
 
     # DOC-NOTE: also in sherpa.astro.utils
@@ -3874,7 +3884,7 @@ class Session(NoNewAttributesAfterInit):
         if filename is None:
             id, filename = filename, id
 
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, "filename")
 
         d = self.get_data(id)
 
@@ -3970,7 +3980,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         clobber = sherpa.utils.bool_cast(clobber)
-        _check_type(filename, string_types, 'filename', 'a string')
+        _check_str_type(filename, "filename")
         sherpa.io.write_arrays(filename, args, fields, sep, comment, clobber,
                                linebreak, format)
 
@@ -4342,7 +4352,8 @@ class Session(NoNewAttributesAfterInit):
         clobber = sherpa.utils.bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+
+        _check_str_type(filename, "filename")
         sherpa.io.write_data(filename, self.get_data(id), fields, sep,
                              comment, clobber, linebreak, format)
 
@@ -4409,7 +4420,8 @@ class Session(NoNewAttributesAfterInit):
         clobber = sherpa.utils.bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+
+        _check_str_type(filename, "filename")
         d = self.get_data(id)
         id = self._fix_id(id)
         if d.mask is False:
@@ -4494,7 +4506,8 @@ class Session(NoNewAttributesAfterInit):
         clobber = sherpa.utils.bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+
+        _check_str_type(filename, "filename")
         x = self.get_data(id).get_indep(filter=False)[0]
         err = self.get_staterror(id, filter=False)
         self.save_arrays(filename, [x, err], fields=['X', 'STAT_ERR'],
@@ -4571,7 +4584,8 @@ class Session(NoNewAttributesAfterInit):
         clobber = sherpa.utils.bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+
+        _check_str_type(filename, "filename")
         x = self.get_data(id).get_indep(filter=False)[0]
         err = self.get_syserror(id, filter=False)
         self.save_arrays(filename, [x, err], fields=['X', 'SYS_ERR'],
@@ -4655,7 +4669,8 @@ class Session(NoNewAttributesAfterInit):
         clobber = sherpa.utils.bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
-        _check_type(filename, string_types, 'filename', 'a string')
+
+        _check_str_type(filename, "filename")
         x = self.get_data(id).get_indep(filter=False)[0]
         err = self.get_error(id, filter=False)
         self.save_arrays(filename, [x, err], fields=['X', 'ERR'],
@@ -5479,7 +5494,7 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(name, sherpa.models.Model):
             return name
 
-        _check_type(name, string_types, 'name', 'a string')
+        _check_str_type(name, "name")
         return self._get_model_component(name, require=True)
 
     def create_model_component(self, typename=None, name=None):
@@ -5553,8 +5568,8 @@ class Session(NoNewAttributesAfterInit):
         if isinstance(typename, sherpa.models.Model) and name is None:
             return typename
 
-        _check_type(typename, string_types, 'typename', 'a string')
-        _check_type(name, string_types, 'name', 'a string')
+        _check_str_type(typename, "typename")
+        _check_str_type(name, "name")
 
         typename = typename.lower()
         cls = self._model_types.get(typename)
@@ -5662,7 +5677,7 @@ class Session(NoNewAttributesAfterInit):
         >>> delete_model_component('pl')
 
         """
-        _check_type(name, string_types, 'name', 'a string')
+        _check_str_type(name, "name")
         mod = self._model_components.pop(name, None)
         if mod is None:
             raise IdentifierErr('nomodelcmpt', name)
@@ -6874,7 +6889,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        _check_type(modelname, string_types, 'model name', 'a string')
+        _check_str_type(modelname, "model name")
 
         usermodel = self._get_model_component(modelname)
         if (usermodel is None or
@@ -9142,7 +9157,7 @@ class Session(NoNewAttributesAfterInit):
     # get_proj(), etc.
 
     def _check_estmethod_opt(self, estmethod, optname):
-        _check_type(optname, string_types, 'optname', 'a string')
+        _check_str_type(optname, "optname")
         if optname not in estmethod.config:
             raise ArgumentErr('badopt', optname, estmethod.name)
 
@@ -12100,7 +12115,7 @@ class Session(NoNewAttributesAfterInit):
 
         while args:
             plottype = args.pop(0)
-            _check_type(plottype, string_types, 'plottype', 'a string')
+            _check_str_type(plottype, "plottype")
             plottype = plottype.lower()
 
             try:
@@ -12177,7 +12192,7 @@ class Session(NoNewAttributesAfterInit):
 
     def _set_plot_item(self, plottype, item, value):
 
-        _check_type(plottype, string_types, 'plottype', 'a string')
+        _check_str_type(plottype, 'plottype')
         keys = list(self._plot_types.keys())
 
         plottype = plottype.strip().lower()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1909,7 +1909,7 @@ class Session(NoNewAttributesAfterInit):
         >>> set_iter_method('none')
 
         """
-        _check_str_type(meth, meth)
+        _check_str_type(meth, "meth")
 
         if meth not in self._itermethods:
             raise TypeError(f'{meth} is not an iterative fitting method')

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -61,10 +61,11 @@ _builtin_symbols_ = tuple(BUILTINS.__dict__.keys())
 ###############################################################################
 
 
-def _check_type(arg, argtype, argname, argdesc, nottype=None):
-    if ((not isinstance(arg, argtype)) or
-            ((nottype is not None) and isinstance(arg, nottype))):
-        raise ArgumentTypeErr('badarg', argname, argdesc)
+def _check_type(arg, argtype, argname, argdesc):
+    if isinstance(arg, argtype):
+        return
+
+    raise ArgumentTypeErr('badarg', argname, argdesc)
 
 
 def _check_str_type(arg: str, argname: str) -> None:

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12160,6 +12160,8 @@ class Session(NoNewAttributesAfterInit):
             sherpa.plot.backend.end()
 
     def _set_plot_item(self, plottype, item, value):
+
+        _check_type(plottype, string_types, 'plottype', 'a string')
         keys = list(self._plot_types.keys())
 
         plottype = plottype.strip().lower()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -3851,6 +3851,9 @@ class Session(NoNewAttributesAfterInit):
     def _save_type(self, objtype, id, filename, **kwargs):
         if filename is None:
             id, filename = filename, id
+
+        _check_type(filename, string_types, 'filename', 'a string')
+
         d = self.get_data(id)
 
         args = None
@@ -4021,7 +4024,6 @@ class Session(NoNewAttributesAfterInit):
 
         """
         clobber = sherpa.utils.bool_cast(clobber)
-        _check_type(filename, string_types, 'filename', 'a string')
         self._save_type('source', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
@@ -4098,7 +4100,6 @@ class Session(NoNewAttributesAfterInit):
 
         """
         clobber = sherpa.utils.bool_cast(clobber)
-        _check_type(filename, string_types, 'filename', 'a string')
         self._save_type('model', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
@@ -4169,7 +4170,6 @@ class Session(NoNewAttributesAfterInit):
 
         """
         clobber = sherpa.utils.bool_cast(clobber)
-        _check_type(filename, string_types, 'filename', 'a string')
         self._save_type('resid', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
@@ -4240,7 +4240,6 @@ class Session(NoNewAttributesAfterInit):
 
         """
         clobber = sherpa.utils.bool_cast(clobber)
-        _check_type(filename, string_types, 'filename', 'a string')
         self._save_type('delchi', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -48,8 +48,6 @@ numpy.set_printoptions(threshold=int(config.get('verbosity',
                                                 'arraylength',
                                                 fallback=1000000)))
 
-string_types = (str, )
-
 __all__ = ('ModelWrapper', 'Session')
 
 BUILTINS = sys.modules["builtins"]
@@ -71,7 +69,7 @@ def _check_type(arg, argtype, argname, argdesc, nottype=None):
 
 def _check_str_type(arg: str, argname: str) -> None:
     """Ensure that arg (with name argname) is a string"""
-    if isinstance(arg, string_types):
+    if _is_str(arg):
         return
 
     raise ArgumentTypeErr('badarg', argname, "a string")
@@ -79,6 +77,10 @@ def _check_str_type(arg: str, argname: str) -> None:
 
 def _is_integer(val):
     return isinstance(val, (int, numpy.integer))
+
+
+def _is_str(val):
+    return isinstance(val, (str, ))
 
 
 def _is_subclass(t1, t2):
@@ -1280,7 +1282,7 @@ class Session(NoNewAttributesAfterInit):
 
         This does not treat None as a valid identifier.
         """
-        return (_is_integer(id) or isinstance(id, string_types))
+        return (_is_integer(id) or _is_str(id))
 
     def _fix_id(self, id):
         """Validate the dataset id.
@@ -1618,7 +1620,7 @@ class Session(NoNewAttributesAfterInit):
         >>> set_method('neldermead')
 
         """
-        if isinstance(meth, string_types):
+        if _is_str(meth):
             meth = self._get_method_by_name(meth)
         else:
             _check_type(meth, sherpa.optmethods.OptMethod, 'meth',
@@ -2192,7 +2194,7 @@ class Session(NoNewAttributesAfterInit):
         >>> set_stat('cash')
 
         """
-        if isinstance(stat, string_types):
+        if _is_str(stat):
             stat = self._get_stat_by_name(stat)
         else:
             _check_type(stat, sherpa.stats.Stat, 'stat',
@@ -5993,7 +5995,7 @@ class Session(NoNewAttributesAfterInit):
         """
         if model is None:
             id, model = model, id
-        if isinstance(model, string_types):
+        if _is_str(model):
             model = self._eval_model_expression(model)
 
         self._set_item(id, model, self._models, sherpa.models.Model, 'model',
@@ -6119,7 +6121,7 @@ class Session(NoNewAttributesAfterInit):
         """
         if model is None:
             id, model = model, id
-        if isinstance(model, string_types):
+        if _is_str(model):
             model = self._eval_model_expression(model)
 
         self._set_item(id, model, self._sources, sherpa.models.Model,
@@ -6177,7 +6179,7 @@ class Session(NoNewAttributesAfterInit):
         self._sources.pop(id, None)
 
     def _check_model(self, model):
-        if isinstance(model, string_types):
+        if _is_str(model):
             model = self._eval_model_expression(model)
         _check_type(model, sherpa.models.Model, 'model',
                     'a model object or model expression string')
@@ -7084,7 +7086,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         kernel = filename_or_model
-        if isinstance(filename_or_model, string_types):
+        if _is_str(filename_or_model):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
             except:
@@ -7148,7 +7150,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         kernel = filename_or_model
-        if isinstance(filename_or_model, string_types):
+        if _is_str(filename_or_model):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
             except:
@@ -7275,7 +7277,7 @@ class Session(NoNewAttributesAfterInit):
             id, psf, = psf, id
         id = self._fix_id(id)
 
-        if isinstance(psf, string_types):
+        if _is_str(psf):
             psf = self._eval_model_expression(psf)
 
         self._set_item(id, psf, self._psf, sherpa.instrument.PSFModel, 'psf',
@@ -7414,7 +7416,7 @@ class Session(NoNewAttributesAfterInit):
     #
 
     def _check_par(self, par, argname='par'):
-        if isinstance(par, string_types):
+        if _is_str(par):
             par = self._eval_model_expression(par, 'parameter')
         _check_type(par, sherpa.models.Parameter, argname,
                     'a parameter object or parameter expression string')
@@ -7573,7 +7575,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         for par in list(args):
-            if isinstance(par, string_types):
+            if _is_str(par):
                 par = self._eval_model_expression(par, 'parameter or model')
 
             try:
@@ -7636,7 +7638,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         for par in list(args):
-            if isinstance(par, string_types):
+            if _is_str(par):
                 par = self._eval_model_expression(par, 'parameter or model')
 
             try:
@@ -7714,7 +7716,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         par = self._check_par(par)
-        if isinstance(val, string_types):
+        if _is_str(val):
             val = self._eval_model_expression(val, 'parameter link')
         par.link = val
 


### PR DESCRIPTION
# Summary

Add validation to the set_xlog/ylog/xlinear/ylinear calls to ensure the argument is a string. Fiix an issue where the save_model, save_source, save_resid, and save_delchi commands from sherpa.ui (but not sherpa.astro.ui) would error out if not given an explicit identifier. Also minor code cleanups to the session/ui code.

# Details

The "headline change" is the set_xlog (and other routines) now explicitly check the argument is a string. However, by code this is a small change. The bugfix is also a small change (and makes sherpa.ui.utils behave more-like sherpa.astro.ui.utils). There have been a few style changes, moving code around and simplifying things slightly. 

I found the bug because I had added tests to check code that was changed in this PR but that coverage claimed was un-checked. Imagine my surprise when it pointed out an actual bug (I claim that as it is only in the sherpa.ui version of the functions it is not a major fix). I also came across issue #1526 but that is a change in behavior rather than an outright bug, so I have not attempted to address this here.

Before this change

```
>>> from sherpa.astro.ui import *
>>> set_xlog(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in set_xlog
  File "/home/dburke/miniconda3/envs/ciao414/lib/python3.9/site-packages/sherpa/ui/utils.py", line 12168, in set_xlog
    self._set_plot_item(plottype, 'xlog', True)
  File "/home/dburke/miniconda3/envs/ciao414/lib/python3.9/site-packages/sherpa/ui/utils.py", line 12115, in _set_plot_item
    plottype = plottype.strip().lower()
AttributeError: 'bool' object has no attribute 'strip'
```

we now get

```
>>> set_xlog(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in set_xlog
  File "/home/dburke/sherpa/sherpa-master/sherpa/ui/utils.py", line 12319, in set_xlog
    self._set_plot_item(plottype, 'xlog', True)
  File "/home/dburke/sherpa/sherpa-master/sherpa/ui/utils.py", line 12223, in _set_plot_item
    _check_str_type(plottype, 'plottype')
  File "/home/dburke/sherpa/sherpa-master/sherpa/ui/utils.py", line 77, in _check_str_type
    raise ArgumentTypeErr('badarg', argname, "a string")
sherpa.utils.err.ArgumentTypeErr: 'plottype' must be a string
```

The save_model/... change is that the code used to (this is from a CIAO 4.14 build):

```
>>> from sherpa import ui
>>> ui.load_arrays(1, [1, 2], [2, 3])
>>> ui.set_source(ui.const1d.mdl)
>>> ui.save_model("x.dat", clobber=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in save_model
  File "/home/dburke/miniconda3/envs/ciao414/lib/python3.9/site-packages/sherpa/ui/utils.py", line 4131, in save_model
    _check_type(filename, string_types, 'filename', 'a string')
  File "/home/dburke/miniconda3/envs/ciao414/lib/python3.9/site-packages/sherpa/ui/utils.py", line 72, in _check_type
    _argument_type_error(argname, argdesc)
  File "/home/dburke/miniconda3/envs/ciao414/lib/python3.9/site-packages/sherpa/ui/utils.py", line 66, in _argument_type_error
    raise ArgumentTypeErr('badarg', argname, argdesc)
sherpa.utils.err.ArgumentTypeErr: 'filename' must be a string
```

and it now works (and is tested to work)

```
>>> from sherpa import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_arrays(1, [1, 2], [2, 3])
>>> ui.set_source(ui.const1d.mdl)
>>> ui.save_model("x.dat", clobber=True)
>>> quit()
% cat x.dat
#X MODEL
1 1
2 1
```

Note that if I had used `from sherpa.astro import ui` then I would have been able to call `save_model` without an identifier; it is only for the sherpa.ui version (which is why our testing had not found it)