### PR TITLE
Consolidate plot and set_xlog handling

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -169,6 +169,7 @@ def test_set_iter_method_opt_sigmarej_lrej(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("setting", ['chisqr', 'compmodel', 'compsource', 'data',
+                                     "model_component", "source_component",
                                      'delchi', 'fit', 'kernel', 'model',
                                      'psf', 'ratio', 'resid', 'source'])
 def test_id_checks_session(session, setting):
@@ -181,10 +182,7 @@ def test_id_checks_session(session, setting):
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
-@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace',
-                                     "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio",
-                                     "bkg_delchi", "bkg_chisqr", "bkg_fit"
-                                     ])
+@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace'])
 def test_id_checks_session_unexpected(session, setting):
     """These identifiers are allowed. Should they be?"""
 
@@ -198,8 +196,9 @@ def test_id_checks_session_unexpected(session, setting):
                          [(Session, True), (AstroSession, False)])
 @pytest.mark.parametrize("setting", ['arf', 'bkg', 'bkgchisqr', 'bkgdelchi', 'bkgfit',
                                      'bkgmodel', 'bkgratio', 'bkgresid', 'bkgsource',
+                                     "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio",
+                                     "bkg_delchi", "bkg_chisqr", "bkg_fit",
                                      'order',
-                                     # "energy", "photon",  these are currently both valid for astro
                                      "astrocompsource", "astrocompmodel", "astrodata",
                                      "astrosource", "astromodel"])
 def test_id_checks_astro_session(session, success, setting):
@@ -330,10 +329,7 @@ def test_astro_plot_bkg_xxx(label):
     mdl = s.create_model_component("const1d", "mdl")
     s.set_bkg_source(mdl)
 
-    plot = f"bkg_{label}"
-    with pytest.raises(ArgumentErr,
-                       match=f"^'{plot}' is not a valid plot type$"):
-        s.plot(plot)
+    s.plot(f"bkg_{label}")
 
 
 def save_ascii_file(s, kwargs, idval, outfile, savefunc, syserr=False):

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3885,8 +3885,8 @@ def test_set_plot_opt_explicit(cls):
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name,extraargs",
                          [("data", []), ("model", []), ("source", []),
-                          pytest.param("model_component", ["mdl"], marks=pytest.mark.xfail),
-                          pytest.param("source_component", ["mdl"], marks=pytest.mark.xfail)
+                          ("model_component", ["mdl"]),
+                          ("source_component", ["mdl"])
                           ])
 def test_set_plot_opt_changes_fields(cls, name, extraargs):
     """Does "all" change all the type-specific plots?
@@ -4140,7 +4140,7 @@ def test_set_ylog_foo_component_data1dint(plot, get, clean_astro_ui):
     ui.set_ylog(plot)
 
     assert not plotobj.histo_prefs["xlog"]
-    assert not plotobj.histo_prefs["ylog"]  # Really this should be set
+    assert plotobj.histo_prefs["ylog"]
 
 
 @requires_plotting

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3824,7 +3824,7 @@ def test_set_opt_valid(cls, name):
 
 
 @pytest.mark.parametrize("name", ["bkg", "bkgfit", "bkgresid", "bkgratio", "bkgdelchi",
-                                  "order", "energy", "photon"])
+                                  "order"])
 def test_set_opt_valid_astro(name):
     """What names are accepted for set_xlog/ylog/...? Astro Session only
     """

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3783,7 +3783,7 @@ def test_set_opt_not_string(cls, name):
                                   # future, at which point they can be added to the test.
                                   #
                                   # "compsource", "compmodel"
-                                  "astrodata", "astrosource", "astromodel",
+                                  # "astrodata", "astrosource", "astromodel",
                                   "flux",
                                   # "bkgmodel", "bkgsource", "bkgfit", "bkgresid", "bkgratio", "bkgchisqr", "bkgdelchi"
                                   ])
@@ -3834,6 +3834,7 @@ def test_set_opt_valid(cls, name):
 @pytest.mark.parametrize("name", ["bkg",
                                   "bkg_fit", "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio", "bkg_delchi", "bkg_chisqr",
                                   "bkgfit", "bkgmodel", "bkgsource", "bkgresid", "bkgratio", "bkgdelchi", "bkgchisqr",  # temporary
+                                  "astrodata", "astrosource", "astromodel",
                                   "order"])
 def test_set_opt_valid_astro(name):
     """What names are accepted for set_xlog/ylog/...? Astro Session only

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3777,10 +3777,16 @@ def test_set_opt_not_string(cls, name):
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name", ["notdata",  "fit-allthe-things", " fi", "fi",
-                                  "source_component", "model_component",
+                                  # Comment-out those names which are currently aliases;
+                                  # that is, they can be used in a call but are expected
+                                  # to change to being unsupported at some point in the
+                                  # future, at which point they can be added to the test.
+                                  #
+                                  # "compsource", "compmodel"
                                   "astrodata", "astrosource", "astromodel",
                                   "flux",
-                                  "bkg_model", "bkg_source", "bkg_fit", "bkg_resid", "bkg_ratio", "bkg_chisqr", "bkg_delchi"])
+                                  # "bkgmodel", "bkgsource", "bkgfit", "bkgresid", "bkgratio", "bkgchisqr", "bkgdelchi"
+                                  ])
 def test_set_opt_invalid(cls, name):
     """Check we error out if called with an invalid option.
 
@@ -3788,6 +3794,7 @@ def test_set_opt_invalid(cls, name):
     has not really been documented, so just test some possible names
     which do not work. This is a regression test, so values may be
     added or removed over time.
+
     """
 
     s = cls()
@@ -3805,6 +3812,7 @@ def test_set_opt_invalid(cls, name):
                                   "source", "model",
                                   "resid", "ratio", "delchi", "chisqr",
                                   "fit",
+                                  "model_component", "source_component",
                                   "compmodel", "compsource"])
 def test_set_opt_valid(cls, name):
     """What names are accepted for set_xlog/ylog/...?
@@ -3823,7 +3831,9 @@ def test_set_opt_valid(cls, name):
     s.set_ylinear(name)
 
 
-@pytest.mark.parametrize("name", ["bkg", "bkgfit", "bkgresid", "bkgratio", "bkgdelchi",
+@pytest.mark.parametrize("name", ["bkg",
+                                  "bkg_fit", "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio", "bkg_delchi", "bkg_chisqr",
+                                  "bkgfit", "bkgmodel", "bkgsource", "bkgresid", "bkgratio", "bkgdelchi", "bkgchisqr",  # temporary
                                   "order"])
 def test_set_opt_valid_astro(name):
     """What names are accepted for set_xlog/ylog/...? Astro Session only
@@ -4088,9 +4098,9 @@ def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
 
 
 SET_CPT_ARGS = [("compsource", ui.get_source_component_plot),
-                # ("source_component", ui.get_source_component_plot),
+                ("source_component", ui.get_source_component_plot),
                 ("compmodel", ui.get_model_component_plot),
-                # ("model_component", ui.get_model_component_plot)
+                ("model_component", ui.get_model_component_plot)
                 ]
 
 @requires_plotting

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10321,15 +10321,16 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
 
     def get_data_plot(self, id=None, recalc=True):
-        try:
-            d = self.get_data(id)
-        except IdentifierErr:
-            return super().get_data_plot(id, recalc=recalc)
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(data, sherpa.astro.data.DataPHA):
             plotobj = self._dataphaplot
             if recalc:
-                plotobj.prepare(d, self.get_stat())
+                plotobj.prepare(data, self.get_stat())
+
             return plotobj
 
         return super().get_data_plot(id, recalc=recalc)
@@ -10337,15 +10338,16 @@ class Session(sherpa.ui.utils.Session):
     get_data_plot.__doc__ = sherpa.ui.utils.Session.get_data_plot.__doc__
 
     def get_model_plot(self, id=None, recalc=True):
-        try:
-            d = self.get_data(id)
-        except IdentifierErr:
-            return super().get_model_plot(id, recalc=recalc)
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(data, sherpa.astro.data.DataPHA):
             plotobj = self._modelhisto
             if recalc:
-                plotobj.prepare(d, self.get_model(id), self.get_stat())
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
             return plotobj
 
         return super().get_model_plot(id, recalc=recalc)
@@ -10428,17 +10430,16 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(data, sherpa.astro.data.DataPHA):
             plotobj = self._astrosourceplot
             if recalc:
-                plotobj.prepare(d, self.get_source(id), lo=lo, hi=hi)
+                plotobj.prepare(data, self.get_source(id), lo=lo, hi=hi)
+
             return plotobj
 
         return super().get_source_plot(id, recalc=recalc)
@@ -10449,8 +10450,8 @@ class Session(sherpa.ui.utils.Session):
         if not recalc:
             return plotobj
 
-        d = self.get_data(id)
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        data = self.get_data(id)
+        if isinstance(data, sherpa.astro.data.DataPHA):
 
             dataobj = self.get_data_plot(id, recalc=recalc)
 
@@ -10463,7 +10464,7 @@ class Session(sherpa.ui.utils.Session):
             # no way to get it by API (apart from get_fit_plot).
             #
             modelobj = sherpa.astro.plot.ModelPHAHistogram()
-            modelobj.prepare(d, self.get_model(id),
+            modelobj.prepare(data, self.get_model(id),
                              self.get_stat())
 
             plotobj.prepare(dataobj, modelobj)
@@ -10545,14 +10546,12 @@ class Session(sherpa.ui.utils.Session):
             id, model = model, id
         model = self._check_model(model)
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(data, sherpa.astro.data.DataPHA):
             plotobj = self._astrocompmdlplot
             if recalc:
                 if not has_pha_response(model):
@@ -10563,7 +10562,8 @@ class Session(sherpa.ui.utils.Session):
                         # no response
                         pass
 
-                plotobj.prepare(d, model, self.get_stat())
+                plotobj.prepare(data, model, self.get_stat())
+
             return plotobj
 
         return super().get_model_component_plot(id, model=model, recalc=recalc)
@@ -10574,17 +10574,16 @@ class Session(sherpa.ui.utils.Session):
             id, model = model, id
         model = self._check_model(model)
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(data, sherpa.astro.data.DataPHA):
             plotobj = self._astrocompsrcplot
             if recalc:
-                plotobj.prepare(d, model, self.get_stat())
+                plotobj.prepare(data, model, self.get_stat())
+
             return plotobj
 
         return super().get_source_component_plot(id, model=model, recalc=recalc)
@@ -10656,6 +10655,7 @@ class Session(sherpa.ui.utils.Session):
         if recalc:
             plotobj.prepare(self._get_pha_data(id),
                             self.get_model(id), orders=orders)
+
         return plotobj
 
     def get_arf_plot(self, id=None, resp_id=None, recalc=True):
@@ -10862,6 +10862,7 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
+
         return plotobj
 
     def get_bkg_plot(self, id=None, bkg_id=None, recalc=True):
@@ -10926,6 +10927,7 @@ class Session(sherpa.ui.utils.Session):
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_stat())
+
         return plotobj
 
     def get_bkg_source_plot(self, id=None, lo=None, hi=None,
@@ -11018,6 +11020,7 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_source(id, bkg_id),
                             lo=lo, hi=hi)
+
         return plotobj
 
     def get_bkg_resid_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11075,6 +11078,7 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
+
         return plotobj
 
     def get_bkg_ratio_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11132,6 +11136,7 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
+
         return plotobj
 
     def get_bkg_delchi_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11190,6 +11195,7 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
+
         return plotobj
 
     def get_bkg_chisqr_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11248,6 +11254,7 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
+
         return plotobj
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
@@ -11404,13 +11411,16 @@ class Session(sherpa.ui.utils.Session):
         ...                          id=1, otherids=(2, 3, 4))
 
         """
+
+        plotobj = self._energyfluxplot
         if recalc:
-            self._prepare_energy_flux_plot(self._energyfluxplot, lo, hi, id=id,
+            self._prepare_energy_flux_plot(plotobj, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
-        return self._energyfluxplot
+
+        return plotobj
 
     def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
                              correlated=False, numcores=None, bkg_id=None,
@@ -11539,13 +11549,16 @@ class Session(sherpa.ui.utils.Session):
         ...                          id=1, otherids=(2, 3, 4))
 
         """
+
+        plotobj = self._photonfluxplot
         if recalc:
-            self._prepare_photon_flux_plot(self._photonfluxplot, lo, hi, id=id,
+            self._prepare_photon_flux_plot(plotobj, lo, hi, id=id,
                                            num=num, bins=bins, correlated=correlated,
                                            scales=scales, model=model,
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
-        return self._photonfluxplot
+
+        return plotobj
 
     def plot_arf(self, id=None, resp_id=None, replot=False, overplot=False,
                  clearwindow=True, **kwargs):
@@ -11685,8 +11698,8 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        d = self.get_data(id)
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        data = self.get_data(id)
+        if isinstance(data, sherpa.astro.data.DataPHA):
             # Note: lo/hi arguments mean we can not just rely on superclass
             plotobj = self.get_source_plot(id, lo=lo, hi=hi, recalc=not replot)
             self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -147,24 +147,11 @@ class Session(sherpa.ui.utils.Session):
         self._background_models = {}
         self._background_sources = {}
 
-        self._dataphaplot = sherpa.astro.plot.DataPHAPlot()
-        self._astrosourceplot = sherpa.astro.plot.SourcePlot()
-        self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
-        self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
-        self._modelhisto = sherpa.astro.plot.ModelHistogram()
-        self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
-
-        # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
-        self._bkgdataplot = sherpa.astro.plot.BkgDataPlot()
+        # The fit-model for PHA data does not get stored in a field
+        # (it is created whenever needed), so we should probably do
+        # the same for this case.
+        #
         self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
-        self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
-        self._bkgchisqrplot = sherpa.astro.plot.BkgChisqrPlot()
-        self._bkgdelchiplot = sherpa.astro.plot.BkgDelchiPlot()
-        self._bkgresidplot = sherpa.astro.plot.BkgResidPlot()
-        self._bkgratioplot = sherpa.astro.plot.BkgRatioPlot()
-        self._bkgsourceplot = sherpa.astro.plot.BkgSourcePlot()
-        self._arfplot = sherpa.astro.plot.ARFPlot()
-        self._orderplot = sherpa.astro.plot.OrderPlot()
 
         self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
         self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
@@ -189,24 +176,34 @@ class Session(sherpa.ui.utils.Session):
 
         # The keys are used by the set_xlog/... calls to identify what
         # plot objects are changed by a given set_xxx(label) call.
+        # They are also used by code - normally get_<key>_plot - to
+        # identify what plot objects to return.
         #
-        self._plot_types['data'].append(self._dataphaplot)
-        self._plot_types['model'].append(self._modelhisto)
-        self._plot_types['model_component'].append(self._astrocompmdlplot)
-        self._plot_types['source'].append(self._astrosourceplot)
-        self._plot_types['source_component'].append(self._astrocompsrcplot)
+        # This extends the parent behavior to
+        #
+        # a) add a DataPHA specific class for plots like "data" that
+        #    already have a Data1DInt-specific plot class;
+        #
+        # b) and plots that are only relevant for PHA data, so they
+        #    only have a PHA-specific class (e.g. "bkg").
+        #
+        self._plot_types['data'].append(sherpa.astro.plot.DataPHAPlot())
+        self._plot_types['model'].append(sherpa.astro.plot.ModelHistogram())
+        self._plot_types["model_component"].append(sherpa.astro.plot.ComponentModelPlot())
+        self._plot_types['source'].append(sherpa.astro.plot.SourcePlot())
+        self._plot_types["source_component"].append(sherpa.astro.plot.ComponentSourcePlot())
 
-        self._plot_types['arf'] = [self._arfplot]
-        self._plot_types['order'] = [self._orderplot]
+        self._plot_types['arf'] = [sherpa.astro.plot.ARFPlot()]
+        self._plot_types['order'] = [sherpa.astro.plot.OrderPlot()]
 
-        self._plot_types['bkg'] = [self._bkgdataplot]
-        self._plot_types['bkg_model'] = [self._bkgmodelhisto]
-        self._plot_types['bkg_fit'] = [self._bkgfitplot]
-        self._plot_types['bkg_source'] = [self._bkgsourceplot]
-        self._plot_types['bkg_ratio'] = [self._bkgratioplot]
-        self._plot_types['bkg_resid'] = [self._bkgresidplot]
-        self._plot_types['bkg_delchi'] = [self._bkgdelchiplot]
-        self._plot_types['bkg_chisqr'] = [self._bkgchisqrplot]
+        self._plot_types['bkg'] = [sherpa.astro.plot.BkgDataPlot()]
+        self._plot_types['bkg_model'] = [sherpa.astro.plot.BkgModelHistogram()]
+        self._plot_types['bkg_fit'] = [sherpa.astro.plot.BkgFitPlot()]
+        self._plot_types['bkg_source'] = [sherpa.astro.plot.BkgSourcePlot()]
+        self._plot_types['bkg_ratio'] = [sherpa.astro.plot.BkgRatioPlot()]
+        self._plot_types['bkg_resid'] = [sherpa.astro.plot.BkgResidPlot()]
+        self._plot_types['bkg_delchi'] = [sherpa.astro.plot.BkgDelchiPlot()]
+        self._plot_types['bkg_chisqr'] = [sherpa.astro.plot.BkgChisqrPlot()]
 
         # Set up aliases (bkgxxx to bkg_xxx).
         #
@@ -10333,7 +10330,7 @@ class Session(sherpa.ui.utils.Session):
             data = self._get_data(id)
 
         if isinstance(data, sherpa.astro.data.DataPHA):
-            plotobj = self._dataphaplot
+            plotobj = self._plot_types["data"][2]
             if recalc:
                 plotobj.prepare(data, self.get_stat())
 
@@ -10350,7 +10347,7 @@ class Session(sherpa.ui.utils.Session):
             data = self._get_data(id)
 
         if isinstance(data, sherpa.astro.data.DataPHA):
-            plotobj = self._modelhisto
+            plotobj = self._plot_types["model"][2]
             if recalc:
                 plotobj.prepare(data, self.get_model(id), self.get_stat())
 
@@ -10442,7 +10439,7 @@ class Session(sherpa.ui.utils.Session):
             data = self._get_data(id)
 
         if isinstance(data, sherpa.astro.data.DataPHA):
-            plotobj = self._astrosourceplot
+            plotobj = self._plot_types["source"][2]
             if recalc:
                 plotobj.prepare(data, self.get_source(id), lo=lo, hi=hi)
 
@@ -10452,7 +10449,7 @@ class Session(sherpa.ui.utils.Session):
 
     def get_fit_plot(self, id=None, recalc=True):
 
-        plotobj = self._fitplot
+        plotobj = self._plot_types["fit"][0]
         if not recalc:
             return plotobj
 
@@ -10558,7 +10555,7 @@ class Session(sherpa.ui.utils.Session):
             data = self._get_data(id)
 
         if isinstance(data, sherpa.astro.data.DataPHA):
-            plotobj = self._astrocompmdlplot
+            plotobj = self._plot_types["model_component"][2]
             if recalc:
                 if not has_pha_response(model):
                     try:
@@ -10586,7 +10583,7 @@ class Session(sherpa.ui.utils.Session):
             data = self._get_data(id)
 
         if isinstance(data, sherpa.astro.data.DataPHA):
-            plotobj = self._astrocompsrcplot
+            plotobj = self._plot_types["source_component"][2]
             if recalc:
                 plotobj.prepare(data, model, self.get_stat())
 
@@ -10657,7 +10654,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._orderplot
+        plotobj = self._plot_types["order"][0]
         if recalc:
             plotobj.prepare(self._get_pha_data(id),
                             self.get_model(id), orders=orders)
@@ -10712,7 +10709,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._arfplot
+        plotobj = self._plot_types["arf"][0]
         if not recalc:
             return plotobj
 
@@ -10797,7 +10794,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgfitplot
+        plotobj = self._plot_types["bkg_fit"][0]
         if not recalc:
             return plotobj
 
@@ -10863,7 +10860,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgmodelhisto
+        plotobj = self._plot_types["bkg_model"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -10929,7 +10926,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgdataplot
+        plotobj = self._plot_types["bkg"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_stat())
@@ -11021,7 +11018,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgsourceplot
+        plotobj = self._plot_types["bkg_source"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_source(id, bkg_id),
@@ -11079,7 +11076,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgresidplot
+        plotobj = self._plot_types["bkg_resid"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11137,7 +11134,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgratioplot
+        plotobj = self._plot_types["bkg_ratio"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11196,7 +11193,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgdelchiplot
+        plotobj = self._plot_types["bkg_delchi"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),
@@ -11255,7 +11252,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        plotobj = self._bkgchisqrplot
+        plotobj = self._plot_types["bkg_chisqr"][0]
         if recalc:
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_bkg_model(id, bkg_id),

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -165,6 +165,7 @@ class Session(sherpa.ui.utils.Session):
         self._bkgsourceplot = sherpa.astro.plot.BkgSourcePlot()
         self._arfplot = sherpa.astro.plot.ARFPlot()
         self._orderplot = sherpa.astro.plot.OrderPlot()
+
         self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
         self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
 
@@ -189,16 +190,15 @@ class Session(sherpa.ui.utils.Session):
         # The keys are used by the set_xlog/... calls to identify what
         # plot objects are changed by a given set_xxx(label) call.
         #
-        self._plot_types['order'] = [self._orderplot]
-        self._plot_types['energy'] = [self._energyfluxplot]
-        self._plot_types['photon'] = [self._photonfluxplot]
-        self._plot_types['compsource'].append(self._astrocompsrcplot)
-        self._plot_types['compmodel'].append(self._astrocompmdlplot)
-
         self._plot_types['data'].append(self._dataphaplot)
-        self._plot_types['source'].append(self._astrosourceplot)
         self._plot_types['model'].append(self._modelhisto)
+        self._plot_types['compmodel'].append(self._astrocompmdlplot)
+        self._plot_types['source'].append(self._astrosourceplot)
+        self._plot_types['compsource'].append(self._astrocompsrcplot)
+
         self._plot_types['arf'] = [self._arfplot]
+        self._plot_types['order'] = [self._orderplot]
+
         self._plot_types['bkg'] = [self._bkgdataplot]
         self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
         self._plot_types['bkgfit'] = [self._bkgfitplot]

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -186,6 +186,9 @@ class Session(sherpa.ui.utils.Session):
 
         self._pyblocxs = sherpa.astro.sim.MCMC()
 
+        # The keys are used by the set_xlog/... calls to identify what
+        # plot objects are changed by a given set_xxx(label) call.
+        #
         self._plot_types['order'] = [self._orderplot]
         self._plot_types['energy'] = [self._energyfluxplot]
         self._plot_types['photon'] = [self._photonfluxplot]
@@ -205,11 +208,14 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['bkgdelchi'] = [self._bkgdelchiplot]
         self._plot_types['bkgchisqr'] = [self._bkgchisqrplot]
 
+        # The keys of _plot_type_names are used to define the
+        # labels that can be used in plot() calls.
+        #
         self._plot_type_names['order'] = 'order'
         # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
         # self._plot_type_names['photon'] = 'photon'
         self._plot_type_names['astrocompsource'] = 'source_component'
-        self._plot_type_names['astrocompmodel'] = 'model_componentl'
+        self._plot_type_names['astrocompmodel'] = 'model_componentl'  # NOTE: typo here
 
         self._plot_type_names['astrodata'] = 'data'
         self._plot_type_names['astrosource'] = 'source'  # is this meaningful anymore

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -192,28 +192,31 @@ class Session(sherpa.ui.utils.Session):
         #
         self._plot_types['data'].append(self._dataphaplot)
         self._plot_types['model'].append(self._modelhisto)
-        self._plot_types['compmodel'].append(self._astrocompmdlplot)
+        self._plot_types['model_component'].append(self._astrocompmdlplot)
         self._plot_types['source'].append(self._astrosourceplot)
-        self._plot_types['compsource'].append(self._astrocompsrcplot)
+        self._plot_types['source_component'].append(self._astrocompsrcplot)
 
         self._plot_types['arf'] = [self._arfplot]
         self._plot_types['order'] = [self._orderplot]
 
         self._plot_types['bkg'] = [self._bkgdataplot]
-        self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
-        self._plot_types['bkgfit'] = [self._bkgfitplot]
-        self._plot_types['bkgsource'] = [self._bkgsourceplot]
-        self._plot_types['bkgratio'] = [self._bkgratioplot]
-        self._plot_types['bkgresid'] = [self._bkgresidplot]
-        self._plot_types['bkgdelchi'] = [self._bkgdelchiplot]
-        self._plot_types['bkgchisqr'] = [self._bkgchisqrplot]
+        self._plot_types['bkg_model'] = [self._bkgmodelhisto]
+        self._plot_types['bkg_fit'] = [self._bkgfitplot]
+        self._plot_types['bkg_source'] = [self._bkgsourceplot]
+        self._plot_types['bkg_ratio'] = [self._bkgratioplot]
+        self._plot_types['bkg_resid'] = [self._bkgresidplot]
+        self._plot_types['bkg_delchi'] = [self._bkgdelchiplot]
+        self._plot_types['bkg_chisqr'] = [self._bkgchisqrplot]
+
+        # Set up aliases (bkgxxx to bkg_xxx).
+        #
+        for key in ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"]:
+            self._plot_types_alias[f"bkg{key}"] = f"bkg_{key}"
 
         # The keys of _plot_type_names are used to define the
         # labels that can be used in plot() calls.
         #
         self._plot_type_names['order'] = 'order'
-        # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
-        # self._plot_type_names['photon'] = 'photon'
         self._plot_type_names['astrocompsource'] = 'source_component'
         self._plot_type_names['astrocompmodel'] = 'model_componentl'  # NOTE: typo here
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -210,28 +210,15 @@ class Session(sherpa.ui.utils.Session):
         for key in ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"]:
             self._plot_types_alias[f"bkg{key}"] = f"bkg_{key}"
 
-        # The keys of _plot_type_names are used to define the
-        # labels that can be used in plot() calls.
+        # These are left-over from earlier, when they may have meant
+        # something different but no-longer do. It is probably
+        # time to remove them.
         #
-        self._plot_type_names['arf'] = 'arf'
-        self._plot_type_names['order'] = 'order'
-
-        # Set up the background commands (bkg_xxx) as well as the
-        # aliases (bkgxxx).
-        #
-        self._plot_type_names['bkg'] = 'bkg'
-        for key in ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"]:
-            label = f"bkg_{key}"
-            self._plot_type_names[label] = label
-            self._plot_type_names[f"bkg{key}"] = label
-
-        # Are these meaningful or worth keeping?
-        #
-        self._plot_type_names['astrodata'] = 'data'
-        self._plot_type_names['astrosource'] = 'source'
-        self._plot_type_names['astromodel'] = 'model'
-        self._plot_type_names['astrocompsource'] = 'source_component'
-        self._plot_type_names['astrocompmodel'] = 'model_componentl'  # NOTE: typo here
+        self._plot_types_alias["astrocompsource"] = "source_component"
+        self._plot_types_alias["astrocompmodel"] = "model_componentl"  # NOTE typo here
+        self._plot_types_alias["astrodata"] = "data"
+        self._plot_types_alias["astrosource"] = "source"
+        self._plot_types_alias["astromodel"] = "model"
 
     # Add ability to save attributes sepcific to the astro package.
     # Save XSPEC module settings that need to be restored.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -216,22 +216,25 @@ class Session(sherpa.ui.utils.Session):
         # The keys of _plot_type_names are used to define the
         # labels that can be used in plot() calls.
         #
+        self._plot_type_names['arf'] = 'arf'
         self._plot_type_names['order'] = 'order'
+
+        # Set up the background commands (bkg_xxx) as well as the
+        # aliases (bkgxxx).
+        #
+        self._plot_type_names['bkg'] = 'bkg'
+        for key in ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"]:
+            label = f"bkg_{key}"
+            self._plot_type_names[label] = label
+            self._plot_type_names[f"bkg{key}"] = label
+
+        # Are these meaningful or worth keeping?
+        #
+        self._plot_type_names['astrodata'] = 'data'
+        self._plot_type_names['astrosource'] = 'source'
+        self._plot_type_names['astromodel'] = 'model'
         self._plot_type_names['astrocompsource'] = 'source_component'
         self._plot_type_names['astrocompmodel'] = 'model_componentl'  # NOTE: typo here
-
-        self._plot_type_names['astrodata'] = 'data'
-        self._plot_type_names['astrosource'] = 'source'  # is this meaningful anymore
-        self._plot_type_names['astromodel'] = 'model'  # is this meaningful anymore
-        self._plot_type_names['arf'] = 'arf'
-        self._plot_type_names['bkg'] = 'bkg'
-        self._plot_type_names['bkgmodel'] = 'bkg_model'
-        self._plot_type_names['bkgfit'] = 'bkg_fit'
-        self._plot_type_names['bkgsource'] = 'bkg_source'
-        self._plot_type_names['bkgratio'] = 'bkg_ratio'
-        self._plot_type_names['bkgresid'] = 'bkg_resid'
-        self._plot_type_names['bkgdelchi'] = 'bkg_delchi'
-        self._plot_type_names['bkgchisqr'] = 'bkg_chisqr'
 
     # Add ability to save attributes sepcific to the astro package.
     # Save XSPEC module settings that need to be restored.

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -40,7 +40,7 @@ from sherpa.data import Data1D, Data1DInt, Data2D
 from sherpa.models import basic
 import sherpa.plot
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
+from sherpa.utils.err import ArgumentTypeErr, IdentifierErr, PlotErr
 from sherpa.utils.testing import requires_plotting, requires_pylab
 
 
@@ -1054,11 +1054,9 @@ def test_plot_contour_error_out_invalid(plottype, session):
 
     s = session()
     func = getattr(s, plottype)
-    with pytest.raises(ArgumentErr) as exc:
+    with pytest.raises(PlotErr,
+                       match="Plot type 'fooflan flim flam' not found in"):
         func("fooflan flim flam")
-
-    emsg = "'fooflan flim flam' is not a valid plot type"
-    assert str(exc.value) == emsg
 
 
 @requires_pylab

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -348,15 +348,6 @@ class Session(NoNewAttributesAfterInit):
         self._traceplot = sherpa.plot.TracePlot()
         self._scatterplot = sherpa.plot.ScatterPlot()
 
-        self._datacontour = sherpa.plot.DataContour()
-        self._modelcontour = sherpa.plot.ModelContour()
-        self._sourcecontour = sherpa.plot.SourceContour()
-        self._fitcontour = sherpa.plot.FitContour()
-        self._residcontour = sherpa.plot.ResidContour()
-        self._ratiocontour = sherpa.plot.RatioContour()
-        self._psfcontour = sherpa.plot.PSFContour()
-        self._kernelcontour = sherpa.plot.PSFKernelContour()
-
         self._intproj = sherpa.plot.IntervalProjection()
         self._intunc = sherpa.plot.IntervalUncertainty()
         self._regproj = sherpa.plot.RegionProjection()
@@ -413,25 +404,23 @@ class Session(NoNewAttributesAfterInit):
         self._plot_type_names['compsource'] = 'source_component'
         self._plot_type_names['compmodel'] = 'model_component'
 
-        # This is only used to set up _contour_type_names, so the
-        # values are currently unused. This is because set_xlog/...
-        # do not change the contour displays.
+        # This is used by the get_<key>_contour calls to access the
+        # relevant contour class.
         #
         self._contour_types = {
-            'data': self._datacontour,
-            'model': self._modelcontour,
-            'source': self._sourcecontour,
-            'fit': self._fitcontour,
-            'resid': self._residcontour,
-            'ratio': self._ratiocontour,
-            'psf': self._psfcontour,
-            'kernel': self._kernelcontour
+            "data": sherpa.plot.DataContour(),
+            "model": sherpa.plot.ModelContour(),
+            "source": sherpa.plot.SourceContour(),
+            "fit": sherpa.plot.FitContour(),
+            "resid": sherpa.plot.ResidContour(),
+            "ratio": sherpa.plot.RatioContour(),
+            "psf": sherpa.plot.PSFContour(),
+            "kernel": sherpa.plot.PSFKernelContour()
         }
 
         # The keys define the labels that can be used in calls to
-        # contour(), and the values map to the get_<value>_contour
-        # call used to create the particular contour entry. The keys
-        # are also used to determine the set of forbidden identifiers.
+        # contour(). The keys are also used to determine the set of
+        # forbidden identifiers.
         #
         self._contour_type_names = {k: k for k in self._contour_types.keys()}
 
@@ -11668,9 +11657,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._datacontour
+        plotobj = self._contour_types["data"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_stat())
+
         return plotobj
 
     def get_data_contour_prefs(self):
@@ -11766,9 +11756,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._modelcontour
+        plotobj = self._contour_types["model"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+
         return plotobj
 
     def get_source_contour(self, id=None, recalc=True):
@@ -11814,9 +11805,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._sourcecontour
+        plotobj = self._contour_types["source"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
+
         return plotobj
 
     def get_model_contour_prefs(self):
@@ -11916,7 +11908,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._fitcontour
+        plotobj = self._contour_types["fit"]
         if recalc:
             dataobj = self.get_data_contour(id, recalc=recalc)
             modelobj = self.get_model_contour(id, recalc=recalc)
@@ -11968,9 +11960,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._residcontour
+        plotobj = self._contour_types["resid"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+
         return plotobj
 
     def get_ratio_contour(self, id=None, recalc=True):
@@ -12017,9 +12010,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._ratiocontour
+        plotobj = self._contour_types["ratio"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+
         return plotobj
 
     def get_psf_contour(self, id=None, recalc=True):
@@ -12061,9 +12055,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._psfcontour
+        plotobj = self._contour_types["psf"]
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
+
         return plotobj
 
     def get_kernel_contour(self, id=None, recalc=True):
@@ -12106,9 +12101,10 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._kernelcontour
+        plotobj = self._contour_types["kernel"]
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
+
         return plotobj
 
     def get_psf_plot(self, id=None, recalc=True):

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -373,16 +373,16 @@ class Session(NoNewAttributesAfterInit):
         self._plot_types = {
             'data': [self._dataplot, self._datahistplot],
             'model': [self._modelplot, self._modelhistplot],
+            'compmodel': [self._compmdlplot, self._compmdlhistplot],
             'source': [self._sourceplot, self._sourcehistplot],
+            'compsource': [self._compsrcplot, self._compsrchistplot],
             'fit': [self._fitplot],
             'resid': [self._residplot],
             'ratio': [self._ratioplot],
             'delchi': [self._delchiplot],
             'chisqr': [self._chisqrplot],
             'psf': [self._psfplot],
-            'kernel': [self._kernelplot],
-            'compsource': [self._compsrcplot, self._compsrchistplot],
-            'compmodel': [self._compmdlplot, self._compmdlhistplot]
+            'kernel': [self._kernelplot]
         }
 
         # The keys define the labels that can be used in calls to

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -362,6 +362,14 @@ class Session(NoNewAttributesAfterInit):
         self._regproj = sherpa.plot.RegionProjection()
         self._regunc = sherpa.plot.RegionUncertainty()
 
+        # The keys are used by the set_xlog/... calls to identify what
+        # plot objects are changed by a given set_xxx(label) call.
+        #
+        # Note that the get_data_plot()/... calls do not use this data
+        # to get the required plotobj; they just access the data
+        # directly. This means this mapping must be updated when a new
+        # plot class is added to a particular plot type.
+        #
         self._plot_types = {
             'data': [self._dataplot, self._datahistplot],
             'model': [self._modelplot, self._modelhistplot],
@@ -377,23 +385,24 @@ class Session(NoNewAttributesAfterInit):
             'compmodel': [self._compmdlplot, self._compmdlhistplot]
         }
 
-        self._plot_type_names = {
-            'data': 'data',
-            'model': 'model',
-            'source': 'source',
-            'fit': 'fit',
-            'resid': 'resid',
-            'ratio': 'ratio',
-            'delchi': 'delchi',
-            'chisqr': 'chisqr',
-            'psf': 'psf',
-            'kernel': 'kernel',
-            'source_component': 'source_component',
-            'model_component': 'model_component',
-            'compsource': 'source_component',
-            'compmodel': 'model_component',
-        }
+        # The keys define the labels that can be used in calls to
+        # plot(), and the values map to the get_<value>_plot call used
+        # to create the particular plot entry. The keys are also used
+        # to determine the set of forbidden identifiers.
+        #
+        self._plot_type_names = {k: k for k in self._plot_types.keys()}
+        self._plot_type_names['source_component'] = 'source_component'
+        self._plot_type_names['model_component'] = 'model_component'
 
+        # Now over-ride the compsource/model labels.
+        #
+        self._plot_type_names['compsource'] = 'source_component'
+        self._plot_type_names['compmodel'] = 'model_component'
+
+        # This is only used to set up _contour_type_names, so the
+        # values are currently unused. This is because set_xlog/...
+        # do not change the contour displays.
+        #
         self._contour_types = {
             'data': self._datacontour,
             'model': self._modelcontour,
@@ -405,17 +414,21 @@ class Session(NoNewAttributesAfterInit):
             'kernel': self._kernelcontour
         }
 
-        self._contour_type_names = {
-            'data': 'data',
-            'model': 'model',
-            'source': 'source',
-            'fit': 'fit',
-            'resid': 'resid',
-            'ratio': 'ratio',
-            'psf': 'psf',
-            'kernel': 'kernel',
-        }
+        # The keys define the labels that can be used in calls to
+        # contour(), and the values map to the get_<value>_contour
+        # call used to create the particular contour entry. The keys
+        # are also used to determine the set of forbidden identifiers.
+        #
+        self._contour_type_names = {k: k for k in self._contour_types.keys()}
 
+        # This is used by the get_<key>_image calls to access the
+        # relevant image class. The keys are not included in any check
+        # of valid identifiers. unlike the plot and contour cases, as
+        # there is
+        #
+        # - no image() call that acts like plot() or contour();
+        # - and no set_xlog/... like call to change the image displays.
+        #
         self._image_types = {
             'data': sherpa.image.DataImage(),
             'model': sherpa.image.ModelImage(),

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -334,10 +334,15 @@ class Session(NoNewAttributesAfterInit):
         self._regproj = sherpa.plot.RegionProjection()
         self._regunc = sherpa.plot.RegionUncertainty()
 
-        # The keys are used by the set_xlog/... calls to identify what
-        # plot objects are changed by a given set_xxx(label) call. It
-        # is also used by the get_<key>_plot calls to access the
-        # relevant contour class.
+        # The keys of _plot_types are used to define:
+        # a) the mapping from get_<key>_plot to the plot objects
+        #    (that is, there must be a matching get_<key>_plot method)
+        # b) valid arguments for the plot() call
+        # c) the arguments that set_xlog/... accept
+        # d) a set of names that can not be used as a dataset identifier
+        #    (because of point b); see also _contour_types
+        #
+        # Note that not all plot_xxx commands use this structure.
         #
         # Unlike the contour case, we have different plot classes to
         # handle different types of plot. There are either plot types
@@ -372,30 +377,15 @@ class Session(NoNewAttributesAfterInit):
         # name. These keys are also used, along with _plot_type_names,
         # to determine the set of forbidden identifiers.
         #
-        # We could use _plot_type_names to identify this mapping,
-        # by identifying those cases when the key does not equal the
-        # value, but _plot_type_names is also used for the plot()
-        # command, and so has other labels that are currently not
-        # supported by set_xlog/...
-        #
         self._plot_types_alias = {
             "compsource": "source_component",
             "compmodel": "model_component"
         }
 
-        # The keys define the labels that can be used in calls to
-        # plot(). The keys are also used to determine the set of
-        # forbidden identifiers.
-        #
-        self._plot_type_names = {k: k for k in self._plot_types.keys()}
-
-        # Now over-ride the compsource/model labels.
-        #
-        self._plot_type_names['compsource'] = 'source_component'
-        self._plot_type_names['compmodel'] = 'model_component'
-
         # This is used by the get_<key>_contour calls to access the
-        # relevant contour class.
+        # relevant contour class. The keys define the labels that can be
+        # used in calls to contour(), and are also used to determine
+        # the set of forbidden identifiers.
         #
         self._contour_types = {
             "data": sherpa.plot.DataContour(),
@@ -407,12 +397,6 @@ class Session(NoNewAttributesAfterInit):
             "psf": sherpa.plot.PSFContour(),
             "kernel": sherpa.plot.PSFKernelContour()
         }
-
-        # The keys define the labels that can be used in calls to
-        # contour(). The keys are also used to determine the set of
-        # forbidden identifiers.
-        #
-        self._contour_type_names = {k: k for k in self._contour_types.keys()}
 
         # This is used by the get_<key>_image calls to access the
         # relevant image class. The keys are not included in any check
@@ -1388,8 +1372,7 @@ class Session(NoNewAttributesAfterInit):
         """Is this a valid plot type (including aliases)?"""
 
         return plottype in self._plot_types or \
-            plottype in self._plot_types_alias or \
-            plottype in self._plot_type_names
+            plottype in self._plot_types_alias
 
     def _get_contourtype(self, plottype):
         """Return the name to refer to a given contour type."""

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2254,14 +2254,13 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        instance
-           An instance of a sherpa.Data.Data-derived class.
+        instance : sherpa.data.Data
+           The data instance.
 
         Raises
         ------
         sherpa.utils.err.IdentifierErr
-           If no model expression has been set for the data set
-           (with `set_model` or `set_source`).
+           No data has been loaded for this data set.
 
         See Also
         --------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2303,8 +2303,29 @@ class Session(NoNewAttributesAfterInit):
         """
         return self._get_item(id, self._data, 'data set', 'has not been set')
 
+    def _get_data(self, id):
+        """Return a data set or None.
+
+        The same as get_data except that it returns None if the
+        dataset does not exist.
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The data set. If not given then the default
+           identifier is used, as returned by `get_default_id`.
+
+        Returns
+        -------
+        instance : sherpa.data.Data or None
+
+        """
+
+        return self._data.get(self._fix_id(id))
+
     # DOC-TODO: terrible synopsis
     def set_data(self, id, data=None):
+
         """Set a data set.
 
         Parameters
@@ -10749,21 +10770,18 @@ class Session(NoNewAttributesAfterInit):
         # answer should be if recalc=False and the dataset has
         # changed type since get_data_plot was last called.
         #
-        try:
-            is_int = isinstance(self.get_data(id), sherpa.data.Data1DInt)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-            is_int = False
-
-        if is_int:
+        if isinstance(data, sherpa.data.Data1DInt):
             plotobj = self._datahistplot
         else:
             plotobj = self._dataplot
 
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_stat())
+            plotobj.prepare(data, self.get_stat())
         return plotobj
 
     # DOC-TODO: discussion of preferences needs better handling
@@ -10917,20 +10935,18 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.data.Data1DInt):
+        if isinstance(data, sherpa.data.Data1DInt):
             plotobj = self._modelhistplot
         else:
             plotobj = self._modelplot
 
         if recalc:
-            plotobj.prepare(d, self.get_model(id), self.get_stat())
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -10993,20 +11009,18 @@ class Session(NoNewAttributesAfterInit):
                                 "\n is set for dataset {}.".format(id) +
                                 " You should use get_model_plot instead.")
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.data.Data1DInt):
+        if isinstance(data, sherpa.data.Data1DInt):
             plotobj = self._sourcehistplot
         else:
             plotobj = self._sourceplot
 
         if recalc:
-            plotobj.prepare(d, self.get_source(id), self.get_stat())
+            plotobj.prepare(data, self.get_source(id), self.get_stat())
 
         return plotobj
 
@@ -11071,20 +11085,18 @@ class Session(NoNewAttributesAfterInit):
             id, model = model, id
         model = self._check_model(model)
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
-        if isinstance(d, sherpa.data.Data1DInt):
+        if isinstance(data, sherpa.data.Data1DInt):
             plotobj = self._compmdlhistplot
         else:
             plotobj = self._compmdlplot
 
         if recalc:
-            plotobj.prepare(d, model, self.get_stat())
+            plotobj.prepare(data, model, self.get_stat())
 
         return plotobj
 
@@ -11150,22 +11162,20 @@ class Session(NoNewAttributesAfterInit):
             id, model = model, id
         model = self._check_model(model)
 
-        try:
-            d = self.get_data(id)
-        except IdentifierErr as ie:
-            if recalc:
-                raise ie
-            d = None
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
 
         if isinstance(model, sherpa.models.TemplateModel):
             plotobj = self._comptmplsrcplot
-        elif isinstance(d, sherpa.data.Data1DInt):
+        elif isinstance(data, sherpa.data.Data1DInt):
             plotobj = self._compsrchistplot
         else:
             plotobj = self._compsrcplot
 
         if recalc:
-            plotobj.prepare(d, model, self.get_stat())
+            plotobj.prepare(data, model, self.get_stat())
 
         return plotobj
 
@@ -11286,10 +11296,9 @@ class Session(NoNewAttributesAfterInit):
 
         plotobj = self._fitplot
 
-        dataobj = self.get_data_plot(id, recalc=recalc)
-        modelobj = self.get_model_plot(id, recalc=recalc)
-
         if recalc:
+            dataobj = self.get_data_plot(id, recalc=recalc)
+            modelobj = self.get_model_plot(id, recalc=recalc)
             plotobj.prepare(dataobj, modelobj)
 
         return plotobj
@@ -11833,10 +11842,9 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._fitcontour
-
-        dataobj = self.get_data_contour(id, recalc=recalc)
-        modelobj = self.get_model_contour(id, recalc=recalc)
         if recalc:
+            dataobj = self.get_data_contour(id, recalc=recalc)
+            modelobj = self.get_model_contour(id, recalc=recalc)
             plotobj.prepare(dataobj, modelobj)
 
         return plotobj

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -373,8 +373,8 @@ class Session(NoNewAttributesAfterInit):
             'chisqr': [self._chisqrplot],
             'psf': [self._psfplot],
             'kernel': [self._kernelplot],
-            'compsource': [self._compsrcplot],
-            'compmodel': [self._compmdlplot]
+            'compsource': [self._compsrcplot, self._compsrchistplot],
+            'compmodel': [self._compmdlplot, self._compmdlhistplot]
         }
 
         self._plot_type_names = {

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12491,6 +12491,11 @@ class Session(NoNewAttributesAfterInit):
         identifier is given for a plot type, the default identifier -
         as returned by `get_default_id` - is used.
 
+        .. versionchanged:: 4.15.0
+           A number of labels, such as "bkgfit", are marked as
+           deprecated and using them will cause a warning message to
+           be displayed, indicating the new label to use.
+
         .. versionchanged:: 4.12.2
            Keyword arguments, such as alpha and ylog, can be sent to
            each plot.
@@ -12498,7 +12503,7 @@ class Session(NoNewAttributesAfterInit):
         Raises
         ------
         sherpa.utils.err.ArgumentErr
-           The data set does not support the requested plot type.
+           The label is invalid.
 
         See Also
         ---------
@@ -12514,9 +12519,9 @@ class Session(NoNewAttributesAfterInit):
         The supported plot types depend on the data set type, and
         include the following list. There are also individual
         functions, with ``plot_`` prepended to the plot type, such as
-        `plot_data` (the ``bkg`` variants use a prefix of
-        ``plot_bkg_``). There are also several multiple-plot commands,
-        such as `plot_fit_ratio`, `plot_fit_resid`, and `plot_fit_delchi`.
+        `plot_data`. There are also several multiple-plot commands,
+        such as `plot_fit_ratio`, `plot_fit_resid`, and
+        `plot_fit_delchi`.
 
         ``arf``
            The ARF for the data set (only for `DataPHA` data sets).
@@ -12524,30 +12529,30 @@ class Session(NoNewAttributesAfterInit):
         ``bkg``
            The background.
 
-        ``bkgchisqr``
+        ``bkg_chisqr``
            The chi-squared statistic calculated for each bin when
            fitting the background.
 
-        ``bkgdelchi``
+        ``bkg_delchi``
            The residuals for each bin, calculated as (data-model)
            divided by the error, for the background.
 
-        ``bkgfit``
+        ``bkg_fit``
            The data (as points) and the convolved model (as a line),
            for the background data set.
 
-        ``bkgmodel``
+        ``bkg_model``
            The convolved background model.
 
-        ``bkgratio``
+        ``bkg_ratio``
            The residuals for each bin, calculated as data/model,
            for the background data set.
 
-        ``bkgresid``
+        ``bkg_resid``
            The residuals for each bin, calculated as (data-model),
            for the background data set.
 
-        ``bkgsource``
+        ``bkg_source``
            The un-convolved background model.
 
         ``chisqr``
@@ -12569,6 +12574,12 @@ class Session(NoNewAttributesAfterInit):
         ``model``
            The convolved model.
 
+        ``model_component``
+           Part of the full model expression (convolved).
+
+        ``order``
+          Plot the model for a selected response
+
         ``psf``
            The unfiltered PSF kernel associated with the data set.
 
@@ -12580,6 +12591,9 @@ class Session(NoNewAttributesAfterInit):
 
         ``source``
            The un-convolved model.
+
+        ``source_component``
+           Part of the full model expression (un-convolved).
 
         The plots can be specialized for a particular data type,
         such as the `set_analysis` command controlling the units
@@ -12630,10 +12644,10 @@ class Session(NoNewAttributesAfterInit):
 
         >>> plot("data", "model", ylog=True)
 
-        Plot the backgrounds for dataset 1 using the 'up' and 'down'
+        Plot the backgrounds for dataset 1 using the "up" and "down"
         components (in this case the background identifier):
 
-        >>> plot('bkg', 1, 'up', 'bkg', 1, 'down')
+        >>> plot("bkg", 1, "up", "bkg", 1, "down")
 
         """
         self._multi_plot(args, **kwargs)


### PR DESCRIPTION
# Summary

Use the same labels for the plot and set_xlog/set_ylog/set_xlinear/set_ylinear functions. As a result, a number of names can no-longer be used as an identifier for a dataset (bkg_chisqr, bkg_delchi, bkg_fit, bkg_model, bkg_ratio, bkg_resid, bkg_source). A number of labels are now considered deprecated and their use will trigger a warning message, displaying the label that should be used. The "energy" and "photon" labels can no-longer be used with the set_x/yxxx functions: instead the get_energy_flux_hist and get_photon_flux_hist calls can be used, such as `get_energy_flux_hist(recalc=False).histo_prefs["ylog"] = True`.

# Details

## Background

This replaces #1089 and #1175. One of the discussion issues on #1175 was a comment I'd made about some code being in a transitional state that would be finished off in a later commit: this addresses this by making the image, contour, and plot commands all use the `_<label>_type` dictionary, and to try and unify the meaning of this (between the plot/contour and set_xlog/... set of commands). The image() command is a little bit different, and set_xlog/.. only is only relevant for the plot commands, so we don't have a clean design for what these structures represent (in the sense of "what do the keys mean"), so having a unified design is a bit hard here. The data-specific plot support added in #906 (or, rather, the more-obviously-designed support for data-specific plots, as there was always some level of support for this) is another reason why there's difference between plots, contours, and images.

Overall this has the same "shape" as the previous attempts, but it has teased out the differences between how set_xlog/... and the plot commands work, and unifies them. It is also less expressive than previous attempts, in that it doesn't try to do much follow-on work to take advantage of the plot changes, as it turns out to be not-quite as effective in reducing the code base as I'd hoped.

In the following I describe the changes made to the code, skipping the intermediate steps. I have added fairly extensive notes to the main commits to describe the per-commit changes so you can follow those, and made sure each "important" step ran through CI to show it works.

The first actual code change (the third commit) is technically a separate bug fix for the handling of calls to `source_component` and `model_component` when using `Data1DInt` data, but it is not a significant-enough fix to be pulled out to a separate commit and it fits in well with the changes in this PR (i.e. it needs to be done to make this PR make sense anyway).

## The original code

The first commit of Sherpa to git is https://github.com/sherpa/sherpa/commit/9ccf0e72acb9f85fdd20a8feea16ea774e1288b3 and contains the Sesion `_plot_types` and `_contour_types` dictionaries, with keys being labels like `"data"` and `"compsource"`, and the values are the plot objects stored as fields, such as `self._dataplot`. The `get_data_plot` call was implemented as

```python
        self._prepare_plotobj(id, self._dataplot)
        return self._dataplot
```

and the `_prepare_plotobj` call started with (this is the sherpa/ui version; the sherpa/astro/ui version had it's own copy rather than falling through to this logic):

```python
    def _prepare_plotobj(self, id, plotobj, model=None):
        id = self._fix_id(id)
        if isinstance(plotobj, sherpa.plot.FitPlot):
            plotobj.prepare(self._prepare_plotobj(id, self._dataplot),
                            self._prepare_plotobj(id, self._modelplot))
        elif isinstance(plotobj, sherpa.plot.FitContour):
            plotobj.prepare(self._prepare_plotobj(id, self._datacontour),
                            self._prepare_plotobj(id, self._modelcontour))
        else:
            if(isinstance(plotobj, sherpa.plot.PSFPlot) or
               isinstance(plotobj, sherpa.plot.PSFContour) or
               isinstance(plotobj, sherpa.plot.PSFKernelPlot) or 
               isinstance(plotobj, sherpa.plot.PSFKernelContour)):
                plotobj.prepare(self.get_psf(id), self.get_data(id))
...
```

A similar scheme was used for contours (you can see that `_prepare_plotobj` deals with both plot and contour classes) and images (this had a separate `_prepare_imageobj` call), although there was no `_image_types` structure. The astro session code over-rode the `_prepare_plotobj` call.

## Recent changes

In trying to fix plot issues I found that I could never work out what was being done, as it ended up going through `_prepare_plotobj` and this hid subtle (or not-so-subtle) issues.

In #906 (Oct 2020) I re-worked the plot and contour code so that access to the `plotobj` is now controlled by the relevant `get_xxx_plot` or `get_xxx_contour` call, rather than going via `_prepare_plotobj`. This lead to `get_data_plot` becoming

```python
        plotobj = self._dataplot
        if recalc:
            plotobj.prepare(self.get_data(id), self.get_stat())
        return plotobj
```

although this is a simple case. We have more-complex code - in particular, as pointed out below, the above code has changed, but the point is that it is now in the relevant call rather than hidden away in code that can't be easily over-ridden. This PR added the `_plot_type_names` and `_contour_type_names` dictionaries which I now want to remove, as I have a better understanding of how the various pieces fit together.

in #1177 (June 2021) I added changes to the image code to copy the #906 changes **and** to extend the logic, so that we do not access fields directly from the session object but do so via an "API" (in this case the API is just a dictionary). I note that the image and contour cases are easier than the plot case as we don't have any extra logic: we always use a particular class for a particular image/contour call. In the plot case we care about the data type (Data1DInt or DataPHA) and there are other places where we appear to care about the model type (this is an area I note below as needing more follow-up, e.g. #1530 but it is not to be fixed here).

The `get_data_plot` code (for the ui case) has changed to become (this was the main branch at one point of the recent development of the PR):

https://github.com/sherpa/sherpa/blob/feffe3565e329162b1dff81e34d6e3a64ab3fe9b/sherpa/ui/utils.py#L10693-L10713

## Changes in this PR

The basic idea of this PR is to follow #1177 and remove the direct access to fields like `self._dataplot` and access them from a dictionary. This would be for both the plot and contour commands. There main initial complication is that the obvious thing to do - which is re-use the existing `_plot_types` and `_component_types` dictionaries - ends up causing issues with the `set_xlog`/../`set_ylinear` set of commands. This is because the keys of `_plot_types` and `_component_types` are used to indicate the set of valid dataset identifiers and what labels are valid as "plot/contour" names in the `plot()` and `contour()` calls. I note that the contour code does not care about the `set_xlog`/... family of commands but it does about the second plot, and that the image code in #1177 didn't have to worry about either case (although I note that we could add an `image` command in #1517 but that is irrelevant here).
 
So, there is some work needed to be done to rationalize the `set_xlog`/... and `plot()` commands so that they use the same labels and underlying data structures. This leads to changes to the set of valid identifiers: at the moment we allow old and new names but the idea is that the old names are deprecated and will be removed in a future release. The user is noted by a screen message whenever they use an old name.

So, the idea is that we now have in `sherpa.ui.utils.Session`

```python
        self._plot_types = {
            'data': [sherpa.plot.DataPlot(), sherpa.plot.DataHistogramPlot()],
            'model': [sherpa.plot.ModelPlot(), sherpa.plot.ModelHistogramPlot()],
            'model_component': [sherpa.plot.ComponentModelPlot(), sherpa.plot.ComponentModelHistogramPlot()],
            'source': [sherpa.plot.SourcePlot(), sherpa.plot.SourceHistogramPlot()],
            'source_component': [sherpa.plot.ComponentSourcePlot(), sherpa.plot.ComponentSourceHistogramPlot()],
            'fit': [sherpa.plot.FitPlot()],
            'resid': [sherpa.plot.ResidPlot()],
            'ratio': [sherpa.plot.RatioPlot()],
            'delchi': [sherpa.plot.DelchiPlot()],
            'chisqr': [sherpa.plot.ChisqrPlot()],
            'psf': [sherpa.plot.PSFPlot()],
            'kernel': [sherpa.plot.PSFKernelPlot()]
        }
```

and we access the data with

```python
    def get_data_plot(self, id=None, recalc=True):
...
        # Allow an answer to be returned if recalc is False and no
        # data has been loaded. However, it's not obvious what the
        # answer should be if recalc=False and the dataset has
        # changed type since get_data_plot was last called.
        #
        if recalc:
            data = self.get_data(id)
        else:
            data = self._get_data(id)

        # This uses the implicit conversion of bool to 0 or 1.
        #
        idx = isinstance(data, sherpa.data.Data1DInt)
        plotobj = self._plot_types["data"][idx]
        if recalc:
            plotobj.prepare(data, self.get_stat())

        return plotobj
```

For the `sherpa.astro.ui.utils.Session` class this gets augmented with

```python
        self._plot_types['data'].append(sherpa.astro.plot.DataPHAPlot())

...

    def get_data_plot(self, id=None, recalc=True):
        if recalc:
            data = self.get_data(id)
        else:
            data = self._get_data(id)

        if isinstance(data, sherpa.astro.data.DataPHA):
            plotobj = self._plot_types["data"][2]
            if recalc:
                plotobj.prepare(data, self.get_stat())

            return plotobj

        return super().get_data_plot(id, recalc=recalc)
```

The logic for matching the data class to the plot object is intentionally low-tech: it's just a set of `isinstance` calls and we assume that those plots that care about this have the `_plot_types` dictionary set up correctly (that is, the value is a list with 2 or 3 elements in the correct order, depending on which module you are in). I had tried fancier approaches but they didn't make the code simpler, and would make it harder to extend in the future (e.g. for #347).

**NOTES**

1. not all plot types care about the data they are sent (perhaps they should, to better catch things like trying to plot a `DataIMG` dataset, but that's a separate issue and it also depends on what we want to do with #347); in this case the `get_xxx_plot` call is simpler and doesn't need to be over-ridden in the astro module;

2. the `fit` and `bkg_fit` plots complicate things since, for PHA data, the model part of the plot behaves differently to a `model` plot (the fit version groups the model, the model version shows ungrouped data) and the way that this is done is subtly-different between the `fit` and `bkg_fit` versions - I do not try to address this here;

3. the `source` plot has some strange behavior with template models, and this behavior depends on whether you are using PHA data or not - I do not try to address this here but instead raised issue #1530 to track it.

## Interaction with `set_xlog` et al and `plot`

The set_xlog/ylog/xlinear/ylinear commands are affected by these changes because there is an undocumented relationship between dictionary keys and the labels you can use with these commands. This PR attempts to clarify and clean this up. These commands take an optional string (defaulting to `"all"`). When it is not `"all"` it must match a key from either the `_plot_types` dictionary, or the `_plot_types_alias` dictionary (new in this PR). The idea is that the `_plot_types` key must match a corresponding `get_<key>_plot` method, which makes it easier to see what the relationship is between

```python
set_xlog("data")
set_ylinear("resid")
set_xlog("model_component")
```

This last call is new in this PR. Previously you would have had to know to say

```python
set_xlog("compmodel")
```

The code now labels these "special" labels as an alias, so that they still work but the user is warned to change their code, and we can hopefully remove them at some point in the future. We do not use the python deprecation warning system because users of the UI layer are unlikely to see these messages (since they helpfully get hidden by default), so we use the warning logger. The new behavior is:
```
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> set_xlog("compsource")
WARNING: The argument 'compsource' is deprecated and 'source_component' should be used instead
>>> set_xlog("compmodel")
WARNING: The argument 'compmodel' is deprecated and 'model_component' should be used instead
>>> set_xlog("compmodel")
WARNING: The argument 'compmodel' is deprecated and 'model_component' should be used instead
>>> set_xlog("astrodata")
WARNING: The argument 'astrodata' is deprecated and 'data' should be used instead
>>> set_xlog("astromodel")
WARNING: The argument 'astromodel' is deprecated and 'model' should be used instead
>>> set_xlog("bkgfit")
WARNING: The argument 'bkgfit' is deprecated and 'bkg_fit' should be used instead
 ```

I honestly don't know what commands like "astrodata" meant - I think it was a way you could change only the PHA plot command, but this was never documented and thanks to changes I've made to the plotting code they no-longer have a meaning.

Since the `plot` command now uses the same labels, we get the same behavior - e.g.

```
>>> plot("compsource", mdl)
WARNING: The argument 'compsource' is deprecated and 'source_component' should be used instead
```

**NOTE**

- the message gets repeated, rather than only shown once; we could add an internal cache so that the message is only displayed once per session (well, per "clean" call)

Related changes because of this are

1. the `plot` command now takes the "new" labels, so `plot("bkg_fit")` mean "do the plot_bkg_fit plot" when before you needed to know that `plot("bkgfit")` was the magic
4. the old names are still supported (with the warning message)
5. the old code did support some of these aliases, in particular you used to be able to say `plot("model_component")` as well as the "secret" `plot("compsource")`. I'm not sure if this is from something I did in earlier plot changes or was something that was always there. This has not been changed, but I just wanted to point it out
6. the identifiers that are marked as "forbidden" - that is the strings you can not use as the `id` argument in calls, is actually based around the labels that the `plot` and `contour` calls accepts; this makes sense, as you need to know when parsing `plot(arg1, arg2, arg3, ...)` whether `arg2` is an identifier or a new plot. This means that changes to the values that `set_xlog` take changes this. So we have some changes.

As an example of the last point, in CIAO 4.14:

```
sherpa-4.14.0> set_default_id("astrodata")
IdentifierErr: identifier 'astrodata' is a reserved word

sherpa-4.14.0> set_default_id("data")
IdentifierErr: identifier 'data' is a reserved word

sherpa-4.14.0> set_default_id("bkgfit")
IdentifierErr: identifier 'bkgfit' is a reserved word

sherpa-4.14.0> set_default_id("bkg_fit")

sherpa-4.14.0> set_default_id("compsource")
IdentifierErr: identifier 'compsource' is a reserved word

sherpa-4.14.0> set_default_id("source_component")
IdentifierErr: identifier 'source_component' is a reserved word

sherpa-4.14.0> set_default_id("energy")

sherpa-4.14.0> set_default_id("flux")

```

The current behavior is to make both the aliases and the actual commands be reserved:

```
>>> import sys
>>> sys.tracebacklimit = 0
>>> set_default_id("data")
sherpa.utils.err.IdentifierErr: identifier 'data' is a reserved word
>>> set_default_id("astrodata")
sherpa.utils.err.IdentifierErr: identifier 'astrodata' is a reserved word
>>> set_default_id("bkgfit")
sherpa.utils.err.IdentifierErr: identifier 'bkgfit' is a reserved word
>>> set_default_id("bkg_fit")
sherpa.utils.err.IdentifierErr: identifier 'bkg_fit' is a reserved word
>>> set_default_id("compsource")
sherpa.utils.err.IdentifierErr: identifier 'compsource' is a reserved word
>>> set_default_id("source_component")
sherpa.utils.err.IdentifierErr: identifier 'source_component' is a reserved word
>>> set_default_id("energy")
>>> set_default_id("flux")
>>> 
```

It turns out that it should only be the new bkg_xxx labels that are added to the set of invalid labels - that is bkg_chisqr, bkg_delchi, bkg_fit, bkg_model, bkg_ratio, bkg_resid, bkg_source.

## Consequences

One consequence of these changes is that we now have a consistent set of names that are used

- by the set_xlog/... family of commands;
- plot() and contour() to refer to the plot/contour to display;
- and to determine what labels are not allowed to be used as a dataset identifier (because of the confusion with the plot/contour calls if they are used).

## Some special plot commands: energy and photon

Note: these are only present in the astro version.

As part of this clean up, the `"energy"` and `"photon"` labels have been removed from the `_plot_types` dictionary, which means they can no longer be used with `set_xlog`/..., as shown below. This is a regression in functionality, but the meaning of these labels is unclear, and the `plot_energy_flux`/`plot_photon_flux` commands are a bit different to the other calls.

```
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> import sys
>>> sys.tracebacklimit = 0
>>> set_xlog("energy")
sherpa.utils.err.PlotErr: Plot type 'energy' not found in ['data', 'model', 'source', 'fit', 'resid', 'ratio', 'delchi', 'chisqr', 'psf', 'kernel', 'source_component', 'model_component', 'order', 'arf', 'bkg', 'bkg_model', 'bkg_fit', 'bkg_source', 'bkg_ratio', 'bkg_resid', 'bkg_delchi', 'bkg_chisqr']
```

I note that we do not document the behavior of "energy" and "photon", so it is not like we are changing behavior we told users they could rely on.

This is most-likely to cause a problem for users who have been using the `"all"` label - e.g. `set_ylog()` or `set_ylog("all")` - without knowing it.

To change these plot preferences users will have to call the relevant `get` call and change the setting manually:

```python
get_energy_flux_hist(recalc=False).histo_prefs["ylog"] = True
```

This is rather ungainly, but I don't see it as a remotely-high-priority to fix.

## Some special plot commands: pdf, cdf, trace, scatter, pvalue 

There are other plot_xxx calls that do not use the `_plot_types` dictionary - e.g. plot_pdf  - that are present in both versions (unlike energy/photon which are only in the astro session). These calls generally require multiple arguments to call - rather than something like `plot_data(2)` or `plot("data", 2)` - and so it is no clear how best to go forward with these.

This means that there are several "plot objects" that are still left as direct attributes of the Session class. However, this is always likely the case because we have things like `self._splitplot` which is used for setting up multiple plots, and `self._intproj` which is used by the `int_proj` command, that are not directly related to `plot` or `set_xlog`.

## Left over fields of the Session class

I will mention two that are left in that are used by the `plot` code, for reference and because they have been mentioned above:

1. `self._comptmplsrcplot = sherpa.plot.ComponentTemplateSourcePlot()`

I do not understand what the template plot code is meant to be doing. It looks half-finished to me. This PR changes (I believe) how the template model display works for DataPHA data as I think the logic has now changed. We don't have tests to check this. We also do not seem to handle the source and model cases the same for the template models (ie there's no `ComponentTemplateModelPlot`). I really don't want to worry about this code in this PR as I believe it can be looked at after this has been merged. I argue that the logic of what is going on is more-obvious after this PR.

Since writing this I created #1530 as I feel it's not something to address in this PR

2. `self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()`

PHA plots behave "strangely" in calls to `plot_fit` and `plot_bkg_fit` which took me a long time to understand, even after looking at the code. We want the model to be displayed using the grouped data here, whereas `plot_model` and `plot_bkg_model` display the data ungrouped. This has caused me no-end of pain, and it would be nice to have a "better" way of doing this, but this is existing functionality and this PR is not the place to try and address this.

Saying that, we do have a difference to how `plot_fit` and `plot_bkg_fit` do things - the former generates the plot object each time whereas the latter uses the `self._bkgmodelplot`. I think we should remove this (so make `plot_bkg_fit` behave like `plot_fit`), but I haven't made that change yet.

For reference, the `plot_fit` code is (here using the `main` branch at the time of writing)

https://github.com/sherpa/sherpa/blob/feffe3565e329162b1dff81e34d6e3a64ab3fe9b/sherpa/astro/ui/utils.py#L10440-L10468

and `plot_bkg_fit` uses

https://github.com/sherpa/sherpa/blob/feffe3565e329162b1dff81e34d6e3a64ab3fe9b/sherpa/astro/ui/utils.py#L10788-L10803 

which shows the different behavior in how the `modelobj` variable is set.