### PR TITLE
Bring "no-implicit-function-declaration" instructions back for MacOS

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -401,6 +401,11 @@ C++ compilers to use if not found by ``setup.py``.
      export PYTHON_LDFLAGS=' '
 
    That is, the variable is set to a space, not the empty string.
+   For the clang compiler (which Apple confusingly aliases to ``gcc``) you
+   also need to set::
+
+       export CFLAGS='-Wno-implicit-function-declaration'
+
 
 A standard installation
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This partially addresses Sherpa still requires `-Wno-implicit-function-declaration` on current main #1467, but it woudl be even better
if the C-code did not require this flag, I guess.