### PR TITLE
Add UI type annotations

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -180,12 +180,18 @@ def test_id_checks_session(session, setting):
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
-@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace',
+@pytest.mark.parametrize("setting", ["cdf", "energy", "lr", "photon", "pdf", "scatter", "trace",
                                      "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio",
                                      "bkg_delchi", "bkg_chisqr", "bkg_fit"
                                      ])
 def test_id_checks_session_unexpected(session, setting):
-    """These identifiers are allowed. Should they be?"""
+    """These identifiers are allowed. Should they be?
+
+    This test has morphed to be a test of "expected" labels that are
+    allowed, so the test name is a bit of a mis-nomer, but is left as
+    is.
+
+    """
 
     s = session()
     s.load_arrays(setting, [1, 2], [1, 2])
@@ -198,7 +204,6 @@ def test_id_checks_session_unexpected(session, setting):
 @pytest.mark.parametrize("setting", ['arf', 'bkg', 'bkgchisqr', 'bkgdelchi', 'bkgfit',
                                      'bkgmodel', 'bkgratio', 'bkgresid', 'bkgsource',
                                      'order',
-                                     # "energy", "photon",  these are currently both valid for astro
                                      "astrocompsource", "astrocompmodel", "astrodata",
                                      "astrosource", "astromodel"])
 def test_id_checks_astro_session(session, success, setting):

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -315,8 +315,6 @@ def test_save_data_ascii(session, kwargs, idval, tmp_path):
     outfile = tmp_path / "data.dat"
     save_ascii_file(s, kwargs, idval, outfile, s.save_data)
 
-    print(outfile.read_text())
-
     names, data = get_data(outfile, ncols=4)
     assert names == ["XLO", "XHI", "Y", "STATERROR"]
     assert len(data) == 4
@@ -430,7 +428,6 @@ def test_show_data(session, flag):
     s.show_data(outfile=out)
 
     toks = out.getvalue().split("\n")
-    print(out.getvalue())
     assert toks[0] == "Data Set: 1"
     idx = 1
     if flag:

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -168,6 +168,7 @@ def test_set_iter_method_opt_sigmarej_lrej(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("setting", ['chisqr', 'compmodel', 'compsource', 'data',
+                                     "model_component", "source_component",
                                      'delchi', 'fit', 'kernel', 'model',
                                      'psf', 'ratio', 'resid', 'source'])
 def test_id_checks_session(session, setting):
@@ -181,8 +182,6 @@ def test_id_checks_session(session, setting):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("setting", ["cdf", "energy", "lr", "photon", "pdf", "scatter", "trace",
-                                     "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio",
-                                     "bkg_delchi", "bkg_chisqr", "bkg_fit"
                                      ])
 def test_id_checks_session_unexpected(session, setting):
     """These identifiers are allowed. Should they be?
@@ -201,11 +200,15 @@ def test_id_checks_session_unexpected(session, setting):
 
 @pytest.mark.parametrize("session,success",
                          [(Session, True), (AstroSession, False)])
-@pytest.mark.parametrize("setting", ['arf', 'bkg', 'bkgchisqr', 'bkgdelchi', 'bkgfit',
-                                     'bkgmodel', 'bkgratio', 'bkgresid', 'bkgsource',
-                                     'order',
-                                     "astrocompsource", "astrocompmodel", "astrodata",
-                                     "astrosource", "astromodel"])
+@pytest.mark.parametrize("setting", ['arf', 'bkg',
+                                     "bkg_chisqr", "bkg_delchi", "bkg_fit",
+                                     "bkg_model", "bkg_ratio", "bkg_resid", "bkg_source",
+                                     "order",
+                                     "bkgmodel", "bkgsource", "bkgresid", "bkgratio",
+                                     "bkgdelchi", "bkgchisqr", "bkgfit",
+                                     "astrocompmodel", "astrocompsource", "astrodata",
+                                     "astrosource", "astromodel"
+                                     ])
 def test_id_checks_astro_session(session, success, setting):
     """Do some common identifiers fail for astro but not default?"""
 

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -601,3 +601,37 @@ def test_show_fit(session):
     assert toks[31] == ""
 
     assert len(toks) == 32
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("label", ["proj", "unc"])
+def test_get_int_xxx_recalc_false(session, label):
+    """Check we call the recalc=False path, even with no data loaded."""
+
+    s = session()
+    getfunc= getattr(s, f"get_int_{label}")
+    plotobj = getfunc(recalc=False)
+
+    name = "Uncertainty" if label == "unc" else "Projection"
+    expected = getattr(sherpa.plot, f"Interval{name}")
+    assert isinstance(plotobj, expected)
+
+    # check it's empty (only need a single field check)
+    assert plotobj.x is None
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("label", ["proj", "unc"])
+def test_get_reg_xxx_recalc_false(session, label):
+    """Check we call the recalc=False path, even with no data loaded."""
+
+    s = session()
+    getfunc= getattr(s, f"get_reg_{label}")
+    plotobj = getfunc(recalc=False)
+
+    name = "Uncertainty" if label == "unc" else "Projection"
+    expected = getattr(sherpa.plot, f"Region{name}")
+    assert isinstance(plotobj, expected)
+
+    # check it's empty (only need a single field check)
+    assert plotobj.x0 is None

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -79,21 +79,21 @@ def test_zero_division_calc_stat():
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_name_default(session):
-    s = Session()
+    s = session()
     assert s.get_iter_method_name() == "none"
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("opt", ["none", "sigmarej"])
 def test_set_iter_method_valid(session, opt):
-    s = Session()
+    s = session()
     s.set_iter_method(opt)
     assert s.get_iter_method_name() == opt
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_set_iter_method_unknown_string(session):
-    s = Session()
+    s = session()
     with pytest.raises(TypeError,
                        match="^not a method is not an iterative fitting method$"):
         s.set_iter_method("not a method")
@@ -101,7 +101,7 @@ def test_set_iter_method_unknown_string(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_set_iter_method_not_a_string(session):
-    s = Session()
+    s = session()
     with pytest.raises(ArgumentTypeErr,
                        match="^'meth' must be a string$"):
         s.set_iter_method(23)
@@ -109,13 +109,13 @@ def test_set_iter_method_not_a_string(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_opt_default(session):
-    s = Session()
+    s = session()
     assert s.get_iter_method_opt() == {}
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_opt_sigmarej(session):
-    s = Session()
+    s = session()
     s.set_iter_method("sigmarej")
     out = s.get_iter_method_opt()
 
@@ -125,7 +125,7 @@ def test_get_iter_method_opt_sigmarej(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_opt_sigmarej_lrej(session):
-    s = Session()
+    s = session()
     s.set_iter_method("sigmarej")
     assert s.get_iter_method_opt("lrej") == pytest.approx(3)
 
@@ -133,7 +133,7 @@ def test_get_iter_method_opt_sigmarej_lrej(session):
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("opt,key", [("none", "lrej"), ("sigmarej", "fast")])
 def test_get_iter_method_opt_unknown(session, opt, key):
-    s = Session()
+    s = session()
     s.set_iter_method(opt)
     with pytest.raises(ArgumentErr,
                        match=f"^'{key}' is not a valid option for method {opt}$"):
@@ -142,7 +142,7 @@ def test_get_iter_method_opt_unknown(session, opt, key):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_set_iter_method_opt_sigmarej_lrej(session):
-    s = Session()
+    s = session()
     s.set_iter_method("sigmarej")
     s.set_iter_method_opt("lrej", 5)
     assert s.get_iter_method_opt("lrej") == pytest.approx(5)

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -158,7 +158,10 @@ def test_id_checks_session(session, setting):
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
-@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace'])
+@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace',
+                                     "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio",
+                                     "bkg_delchi", "bkg_chisqr", "bkg_fit"
+                                     ])
 def test_id_checks_session_unexpected(session, setting):
     """These identifiers are allowed. Should they be?"""
 

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -37,7 +37,7 @@ from sherpa.io import get_ascii_data
 from sherpa.models import Const1D
 import sherpa.models.basic
 from sherpa.ui.utils import Session
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, IdentifierErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, IdentifierErr, PlotErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 
@@ -1950,3 +1950,58 @@ def test_fit_checks_kwarg(session, msg):
 
     with pytest.raises(TypeError, match=msg):
         s.fit(unknown_argument=True)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("alias,original",
+                         [("compsource", "source_component"),
+                          ("compmodel", "model_component")])
+def test_plot_alias_warning(session, alias, original, caplog):
+    """Check we get a deprecated warning from using a plot alias.
+
+    Support for aliases is intended to be short-term, but ensure
+    they are tested. This is only relevant for the set_xlog/...
+    family of commands.
+    """
+
+    s = session()
+    assert len(caplog.record_tuples) == 0
+    s.set_xlog(alias)
+    assert len(caplog.record_tuples) == 1
+
+    loc, lvl, msg = caplog.record_tuples[0]
+    assert loc == "sherpa.ui.utils"
+    assert lvl == logging.WARNING
+    assert msg == f"The argument '{alias}' is deprecated and '{original}' should be used instead"
+
+
+@pytest.mark.parametrize("session,success", [(Session, False), (AstroSession, True)])
+@pytest.mark.parametrize("key", ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"])
+def test_astro_plot_alias_warning(session, success, key, caplog):
+    """Check we get a deprecated warning from using a plot alias.
+
+    Support for aliases is intended to be short-term, but ensure
+    they are tested. This is only relevant for the set_xlog/...
+    family of commands.
+    """
+
+    alias = f"bkg{key}"
+    original = f"bkg_{key}"
+
+    s = session()
+    assert len(caplog.record_tuples) == 0
+
+    if success:
+        s.set_xlog(alias)
+        assert len(caplog.record_tuples) == 1
+
+        loc, lvl, msg = caplog.record_tuples[0]
+        assert loc == "sherpa.ui.utils"
+        assert lvl == logging.WARNING
+        assert msg == f"The argument '{alias}' is deprecated and '{original}' should be used instead"
+
+    else:
+        # Check this errors out (i.e. is not an alias).
+        #
+        with pytest.raises(PlotErr, match=rf"^Plot type '{alias}' not found in \[.*\]$"):
+            s.set_xlog(alias)

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -4087,6 +4087,87 @@ def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
     assert axes[0].yaxis.get_scale() == yscale
 
 
+SET_CPT_ARGS = [("compsource", ui.get_source_component_plot),
+                # ("source_component", ui.get_source_component_plot),
+                ("compmodel", ui.get_model_component_plot),
+                # ("model_component", ui.get_model_component_plot)
+                ]
+
+@requires_plotting
+@pytest.mark.parametrize("plot,get", SET_CPT_ARGS)
+def test_set_ylog_foo_component_data1d(plot, get, clean_astro_ui):
+    """Check y axis after_ylog('<component type>'), Data1D data.
+
+    There has been some confusion in the code over whether this
+    works or not, so this is a regression test.
+
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [4, 7, 5])
+    ui.set_source(ui.const1d.mdl)
+    mdl.c0 = 6
+
+    plotobj = get(mdl, recalc=False)
+
+    assert not plotobj.plot_prefs["xlog"]
+    assert not plotobj.plot_prefs["ylog"]
+
+    ui.set_ylog(plot)
+
+    assert not plotobj.plot_prefs["xlog"]
+    assert plotobj.plot_prefs["ylog"]
+
+
+@requires_plotting
+@pytest.mark.parametrize("plot,get", SET_CPT_ARGS)
+def test_set_ylog_foo_component_data1dint(plot, get, clean_astro_ui):
+    """Check y axis after_ylog('<component type>'), Data1DInt data.
+
+    There has been some confusion in the code over whether this
+    works or not, so this is a regression test.
+
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [2, 2.5, 6], [4, 7, 5], ui.Data1DInt)
+    ui.set_source(ui.const1d.mdl)
+    mdl.c0 = 6
+
+    plotobj = get(mdl, recalc=False)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert not plotobj.histo_prefs["ylog"]
+
+    ui.set_ylog(plot)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert not plotobj.histo_prefs["ylog"]  # Really this should be set
+
+
+@requires_plotting
+@pytest.mark.parametrize("plot,get", SET_CPT_ARGS)
+def test_set_ylog_foo_component_datapha(plot, get, clean_astro_ui):
+    """Check y axis after_ylog('<component type>'), DataPHA data.
+
+    There has been some confusion in the code over whether this
+    works or not, so this is a regression test.
+
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [4, 7, 5], ui.DataPHA)
+    ui.set_source(ui.const1d.mdl)
+    mdl.c0 = 6
+
+    plotobj = get(mdl, recalc=False)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert not plotobj.histo_prefs["ylog"]
+
+    ui.set_ylog(plot)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert plotobj.histo_prefs["ylog"]
+
+
 @requires_plotting
 def test_pha_model_plot_filter_range_manual_1024(clean_astro_ui):
     """Check if issue #1024 is fixed.

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3777,10 +3777,16 @@ def test_set_opt_not_string(cls, name):
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name", ["notdata",  "fit-allthe-things", " fi", "fi",
-                                  "source_component", "model_component",
+                                  # Comment-out those names which are currently aliases;
+                                  # that is, they can be used in a call but are expected
+                                  # to change to being unsupported at some point in the
+                                  # future, at which point they can be added to the test.
+                                  #
+                                  # "compsource", "compmodel"
                                   "astrodata", "astrosource", "astromodel",
                                   "flux",
-                                  "bkg_model", "bkg_source", "bkg_fit", "bkg_resid", "bkg_ratio", "bkg_chisqr", "bkg_delchi"])
+                                  # "bkgmodel", "bkgsource", "bkgfit", "bkgresid", "bkgratio", "bkgchisqr", "bkgdelchi"
+                                  ])
 def test_set_opt_invalid(cls, name):
     """Check we error out if called with an invalid option.
 
@@ -3788,6 +3794,7 @@ def test_set_opt_invalid(cls, name):
     has not really been documented, so just test some possible names
     which do not work. This is a regression test, so values may be
     added or removed over time.
+
     """
 
     s = cls()
@@ -3805,6 +3812,7 @@ def test_set_opt_invalid(cls, name):
                                   "source", "model",
                                   "resid", "ratio", "delchi", "chisqr",
                                   "fit",
+                                  "model_component", "source_component",
                                   "compmodel", "compsource"])
 def test_set_opt_valid(cls, name):
     """What names are accepted for set_xlog/ylog/...?
@@ -3823,7 +3831,9 @@ def test_set_opt_valid(cls, name):
     s.set_ylinear(name)
 
 
-@pytest.mark.parametrize("name", ["bkg", "bkgfit", "bkgresid", "bkgratio", "bkgdelchi",
+@pytest.mark.parametrize("name", ["bkg",
+                                  "bkg_fit", "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio", "bkg_delchi", "bkg_chisqr",
+                                  "bkgfit", "bkgmodel", "bkgsource", "bkgresid", "bkgratio", "bkgdelchi", "bkgchisqr",  # temporary
                                   "order", "energy", "photon"])
 def test_set_opt_valid_astro(name):
     """What names are accepted for set_xlog/ylog/...? Astro Session only
@@ -4088,9 +4098,9 @@ def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
 
 
 SET_CPT_ARGS = [("compsource", ui.get_source_component_plot),
-                # ("source_component", ui.get_source_component_plot),
+                ("source_component", ui.get_source_component_plot),
                 ("compmodel", ui.get_model_component_plot),
-                # ("model_component", ui.get_model_component_plot)
+                ("model_component", ui.get_model_component_plot)
                 ]
 
 @requires_plotting

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3786,6 +3786,7 @@ def test_set_opt_not_string(cls, name):
                                   "astrodata", "astrosource", "astromodel",
                                   "flux",
                                   # "bkgmodel", "bkgsource", "bkgfit", "bkgresid", "bkgratio", "bkgchisqr", "bkgdelchi"
+                                  "energy", "photon"
                                   ])
 def test_set_opt_invalid(cls, name):
     """Check we error out if called with an invalid option.
@@ -3834,7 +3835,7 @@ def test_set_opt_valid(cls, name):
 @pytest.mark.parametrize("name", ["bkg",
                                   "bkg_fit", "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio", "bkg_delchi", "bkg_chisqr",
                                   "bkgfit", "bkgmodel", "bkgsource", "bkgresid", "bkgratio", "bkgdelchi", "bkgchisqr",  # temporary
-                                  "order", "energy", "photon"])
+                                  "order"])
 def test_set_opt_valid_astro(name):
     """What names are accepted for set_xlog/ylog/...? Astro Session only
     """

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3896,8 +3896,8 @@ def test_set_plot_opt_explicit(cls):
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name,extraargs",
                          [("data", []), ("model", []), ("source", []),
-                          pytest.param("model_component", ["mdl"], marks=pytest.mark.xfail),
-                          pytest.param("source_component", ["mdl"], marks=pytest.mark.xfail)
+                          ("model_component", ["mdl"]),
+                          ("source_component", ["mdl"])
                           ])
 def test_set_plot_opt_changes_fields(cls, name, extraargs):
     """Does "all" change all the type-specific plots?
@@ -4192,7 +4192,7 @@ def test_set_ylog_foo_component_data1dint(plot, get, clean_astro_ui):
     ui.set_ylog(plot)
 
     assert not plotobj.histo_prefs["xlog"]
-    assert not plotobj.histo_prefs["ylog"]  # Really this should be set
+    assert plotobj.histo_prefs["ylog"]
 
 
 @requires_plotting

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -2423,3 +2423,26 @@ def test_pha_set_filter_masked_wrong(simple_pha):
         ui.set_filter(np.asarray([True, False]))
 
     assert str(err.value) == "size mismatch between 5 and 2"
+
+
+def test_get_arf_not_pha(clean_astro_ui):
+    ui.load_arrays(1, [1, 2], [1, 2], ui.DataPHA)
+    ui.load_arrays(2, [1, 2], [1, 2])
+    with pytest.raises(ArgumentErr,
+                       match="data set 2 does not contain PHA data"):
+        ui.get_arf_plot(2)
+
+
+def test_get_arf_no_pha(clean_astro_ui):
+    ui.load_arrays(1, [1, 2], [1, 2], ui.DataPHA)
+    with pytest.raises(DataErr,
+                       match="data set '1' does not have an associated ARF"):
+        ui.get_arf_plot()
+
+
+def test_get_order_not_pha(clean_astro_ui):
+    ui.load_arrays(1, [1, 2], [1, 2], ui.DataPHA)
+    ui.load_arrays(2, [1, 2], [1, 2])
+    with pytest.raises(ArgumentErr,
+                       match="data set 2 does not contain PHA data"):
+        ui.get_order_plot(2)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -147,24 +147,12 @@ class Session(sherpa.ui.utils.Session):
         self._background_models = {}
         self._background_sources = {}
 
-        self._dataphaplot = sherpa.astro.plot.DataPHAPlot()
-        self._astrosourceplot = sherpa.astro.plot.SourcePlot()
-        self._astrocompsrcplot = sherpa.astro.plot.ComponentSourcePlot()
-        self._astrocompmdlplot = sherpa.astro.plot.ComponentModelPlot()
-        self._modelhisto = sherpa.astro.plot.ModelHistogram()
-        self._bkgmodelhisto = sherpa.astro.plot.BkgModelHistogram()
-
-        # self._bkgdataplot = sherpa.astro.plot.DataPHAPlot()
-        self._bkgdataplot = sherpa.astro.plot.BkgDataPlot()
+        # The fit-model for PHA data does not get stored in a field
+        # (it is created whenever needed), so we should do the same
+        # for this case.
+        #
         self._bkgmodelplot = sherpa.astro.plot.BkgModelPHAHistogram()
-        self._bkgfitplot = sherpa.astro.plot.BkgFitPlot()
-        self._bkgchisqrplot = sherpa.astro.plot.BkgChisqrPlot()
-        self._bkgdelchiplot = sherpa.astro.plot.BkgDelchiPlot()
-        self._bkgresidplot = sherpa.astro.plot.BkgResidPlot()
-        self._bkgratioplot = sherpa.astro.plot.BkgRatioPlot()
-        self._bkgsourceplot = sherpa.astro.plot.BkgSourcePlot()
-        self._arfplot = sherpa.astro.plot.ARFPlot()
-        self._orderplot = sherpa.astro.plot.OrderPlot()
+
         self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
         self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
 
@@ -189,21 +177,25 @@ class Session(sherpa.ui.utils.Session):
         # The keys are used by the set_xlog/... calls to identify what
         # plot objects are changed by a given set_xxx(label) call.
         #
-        self._plot_types["data"].append(self._dataphaplot)
-        self._plot_types["model"].append(self._modelhisto)
-        self._plot_types["model_component"].append(self._astrocompmdlplot)
-        self._plot_types["source"].append(self._astrosourceplot)
-        self._plot_types["source_component"].append(self._astrocompsrcplot)
-        self._plot_types["arf"] = [self._arfplot]
-        self._plot_types["bkg"] = [self._bkgdataplot]
-        self._plot_types["bkg_model"] = [self._bkgmodelhisto]
-        self._plot_types["bkg_fit"] = [self._bkgfitplot]
-        self._plot_types["bkg_source"] = [self._bkgsourceplot]
-        self._plot_types["bkg_ratio"] = [self._bkgratioplot]
-        self._plot_types["bkg_resid"] = [self._bkgresidplot]
-        self._plot_types["bkg_delchi"] = [self._bkgdelchiplot]
-        self._plot_types["bkg_chisqr"] = [self._bkgchisqrplot]
-        self._plot_types["order"] = [self._orderplot]
+        self._plot_types["data"].append(sherpa.astro.plot.DataPHAPlot())
+        self._plot_types["model"].append(sherpa.astro.plot.ModelHistogram())
+        self._plot_types["model_component"].append(sherpa.astro.plot.ComponentModelPlot())
+        self._plot_types["source"].append(sherpa.astro.plot.SourcePlot())
+        self._plot_types["source_component"].append(sherpa.astro.plot.ComponentSourcePlot())
+        self._plot_types["arf"] = [sherpa.astro.plot.ARFPlot()]
+        self._plot_types["order"] = [sherpa.astro.plot.OrderPlot()]
+
+        # The bkg* plot types are special in that their "base" type
+        # is DataPHA; they are not used with Data1D/Data1DInt objects.
+        #
+        self._plot_types["bkg"] = [sherpa.astro.plot.BkgDataPlot()]
+        self._plot_types["bkg_model"] = [sherpa.astro.plot.BkgModelHistogram()]
+        self._plot_types["bkg_fit"] = [sherpa.astro.plot.BkgFitPlot()]
+        self._plot_types["bkg_source"] = [sherpa.astro.plot.BkgSourcePlot()]
+        self._plot_types["bkg_ratio"] = [sherpa.astro.plot.BkgRatioPlot()]
+        self._plot_types["bkg_resid"] = [sherpa.astro.plot.BkgResidPlot()]
+        self._plot_types["bkg_delchi"] = [sherpa.astro.plot.BkgDelchiPlot()]
+        self._plot_types["bkg_chisqr"] = [sherpa.astro.plot.BkgChisqrPlot()]
 
         # Set up temporary aliases
         #

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -189,22 +189,22 @@ class Session(sherpa.ui.utils.Session):
         # The keys are used by the set_xlog/... calls to identify what
         # plot objects are changed by a given set_xxx(label) call.
         #
-        self._plot_types['order'] = [self._orderplot]
+        self._plot_types["order"] = [self._orderplot]
         self._plot_types["source_component"].append(self._astrocompsrcplot)
         self._plot_types["model_component"].append(self._astrocompmdlplot)
 
-        self._plot_types['data'].append(self._dataphaplot)
-        self._plot_types['source'].append(self._astrosourceplot)
-        self._plot_types['model'].append(self._modelhisto)
-        self._plot_types['arf'] = [self._arfplot]
-        self._plot_types['bkg'] = [self._bkgdataplot]
-        self._plot_types['bkg_model'] = [self._bkgmodelhisto]
-        self._plot_types['bkg_fit'] = [self._bkgfitplot]
-        self._plot_types['bkg_source'] = [self._bkgsourceplot]
-        self._plot_types['bkg_ratio'] = [self._bkgratioplot]
-        self._plot_types['bkg_resid'] = [self._bkgresidplot]
-        self._plot_types['bkg_delchi'] = [self._bkgdelchiplot]
-        self._plot_types['bkg_chisqr'] = [self._bkgchisqrplot]
+        self._plot_types["data"].append(self._dataphaplot)
+        self._plot_types["source"].append(self._astrosourceplot)
+        self._plot_types["model"].append(self._modelhisto)
+        self._plot_types["arf"] = [self._arfplot]
+        self._plot_types["bkg"] = [self._bkgdataplot]
+        self._plot_types["bkg_model"] = [self._bkgmodelhisto]
+        self._plot_types["bkg_fit"] = [self._bkgfitplot]
+        self._plot_types["bkg_source"] = [self._bkgsourceplot]
+        self._plot_types["bkg_ratio"] = [self._bkgratioplot]
+        self._plot_types["bkg_resid"] = [self._bkgresidplot]
+        self._plot_types["bkg_delchi"] = [self._bkgdelchiplot]
+        self._plot_types["bkg_chisqr"] = [self._bkgchisqrplot]
 
         # Set up temporary aliases
         #
@@ -214,24 +214,24 @@ class Session(sherpa.ui.utils.Session):
         # The keys of _plot_type_names are used to define the
         # labels that can be used in plot() calls.
         #
-        self._plot_type_names['order'] = 'order'
-        # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
-        # self._plot_type_names['photon'] = 'photon'
-        self._plot_type_names['astrocompsource'] = 'source_component'
-        self._plot_type_names['astrocompmodel'] = 'model_componentl'
+        self._plot_type_names["order"] = "order"
+        # self._plot_type_names["energy"] = "energy"  - how to do energy/flux plots?
+        # self._plot_type_names["photon"] = "photon"
+        self._plot_type_names["astrocompsource"] = "source_component"
+        self._plot_type_names["astrocompmodel"] = "model_componentl"  # NOTE: typo here
 
-        self._plot_type_names['astrodata'] = 'data'
-        self._plot_type_names['astrosource'] = 'source'  # is this meaningful anymore
-        self._plot_type_names['astromodel'] = 'model'  # is this meaningful anymore
-        self._plot_type_names['arf'] = 'arf'
-        self._plot_type_names['bkg'] = 'bkg'
-        self._plot_type_names['bkgmodel'] = 'bkg_model'
-        self._plot_type_names['bkgfit'] = 'bkg_fit'
-        self._plot_type_names['bkgsource'] = 'bkg_source'
-        self._plot_type_names['bkgratio'] = 'bkg_ratio'
-        self._plot_type_names['bkgresid'] = 'bkg_resid'
-        self._plot_type_names['bkgdelchi'] = 'bkg_delchi'
-        self._plot_type_names['bkgchisqr'] = 'bkg_chisqr'
+        self._plot_type_names["astrodata"] = "data"
+        self._plot_type_names["astrosource"] = "source"  # is this meaningful anymore
+        self._plot_type_names["astromodel"] = "model"  # is this meaningful anymore
+        self._plot_type_names["arf"] = "arf"
+        self._plot_type_names["bkg"] = "bkg"
+        self._plot_type_names["bkgmodel"] = "bkg_model"
+        self._plot_type_names["bkgfit"] = "bkg_fit"
+        self._plot_type_names["bkgsource"] = "bkg_source"
+        self._plot_type_names["bkgratio"] = "bkg_ratio"
+        self._plot_type_names["bkgresid"] = "bkg_resid"
+        self._plot_type_names["bkgdelchi"] = "bkg_delchi"
+        self._plot_type_names["bkgchisqr"] = "bkg_chisqr"
 
     # Add ability to save attributes sepcific to the astro package.
     # Save XSPEC module settings that need to be restored.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -50,6 +50,38 @@ info = logging.getLogger(__name__).info
 __all__ = ('Session',)
 
 
+def get_pha_background(data, idval, bkg_id):
+    """Given a PHA data set, return the associated background.
+
+    Parameters
+    ----------
+    data : sherpa.astro.data.DataPHA instance
+    id : int or str
+        The identifier (only used for an error message).
+    bkg_id : int
+        The background identifier
+
+    Returns
+    -------
+    bkg : sherpa.astro.data.DataPHA instance
+
+    Raises
+    ------
+    IdentifierErr
+        If there is no bkg_id background component in data.
+
+    """
+
+    assert idval is not None  # make sure id has been set
+    bkg = data.get_background(bkg_id)
+    if bkg is None:
+        raise IdentifierErr("getitem", "background data set",
+                            bkg_id,
+                            f"in PHA data set {idval} has not been set")
+
+    return bkg
+
+
 class Session(sherpa.ui.utils.Session):
 
     ###########################################################################
@@ -6309,14 +6341,10 @@ class Session(sherpa.ui.utils.Session):
         >>> bg = get_bkg('flare', 2)
 
         """
+        id = self._fix_id(id)
         data = self._get_pha_data(id)
-        bkg = data.get_background(bkg_id)
-        if bkg is None:
-            raise IdentifierErr('getitem', 'background data set',
-                                data._fix_background_id(bkg_id),
-                                'in PHA data set %s has not been set' %
-                                str(self._fix_id(id)))
-        return bkg
+        bkg_id = data._fix_background_id(bkg_id)
+        return get_pha_background(data, id, bkg_id)
 
     def set_bkg(self, id, bkg=None, bkg_id=None):
         """Set the background for a PHA data set.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -190,8 +190,6 @@ class Session(sherpa.ui.utils.Session):
         # plot objects are changed by a given set_xxx(label) call.
         #
         self._plot_types['order'] = [self._orderplot]
-        self._plot_types['energy'] = [self._energyfluxplot]
-        self._plot_types['photon'] = [self._photonfluxplot]
         self._plot_types["source_component"].append(self._astrocompsrcplot)
         self._plot_types["model_component"].append(self._astrocompmdlplot)
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -192,21 +192,26 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['order'] = [self._orderplot]
         self._plot_types['energy'] = [self._energyfluxplot]
         self._plot_types['photon'] = [self._photonfluxplot]
-        self._plot_types['compsource'].append(self._astrocompsrcplot)
-        self._plot_types['compmodel'].append(self._astrocompmdlplot)
+        self._plot_types["source_component"].append(self._astrocompsrcplot)
+        self._plot_types["model_component"].append(self._astrocompmdlplot)
 
         self._plot_types['data'].append(self._dataphaplot)
         self._plot_types['source'].append(self._astrosourceplot)
         self._plot_types['model'].append(self._modelhisto)
         self._plot_types['arf'] = [self._arfplot]
         self._plot_types['bkg'] = [self._bkgdataplot]
-        self._plot_types['bkgmodel'] = [self._bkgmodelhisto]
-        self._plot_types['bkgfit'] = [self._bkgfitplot]
-        self._plot_types['bkgsource'] = [self._bkgsourceplot]
-        self._plot_types['bkgratio'] = [self._bkgratioplot]
-        self._plot_types['bkgresid'] = [self._bkgresidplot]
-        self._plot_types['bkgdelchi'] = [self._bkgdelchiplot]
-        self._plot_types['bkgchisqr'] = [self._bkgchisqrplot]
+        self._plot_types['bkg_model'] = [self._bkgmodelhisto]
+        self._plot_types['bkg_fit'] = [self._bkgfitplot]
+        self._plot_types['bkg_source'] = [self._bkgsourceplot]
+        self._plot_types['bkg_ratio'] = [self._bkgratioplot]
+        self._plot_types['bkg_resid'] = [self._bkgresidplot]
+        self._plot_types['bkg_delchi'] = [self._bkgdelchiplot]
+        self._plot_types['bkg_chisqr'] = [self._bkgchisqrplot]
+
+        # Set up temporary aliases
+        #
+        for key in ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"]:
+            self._plot_types_alias[f"bkg{key}"] = f"bkg_{key}"
 
         # The keys of _plot_type_names are used to define the
         # labels that can be used in plot() calls.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -186,6 +186,9 @@ class Session(sherpa.ui.utils.Session):
 
         self._pyblocxs = sherpa.astro.sim.MCMC()
 
+        # The keys are used by the set_xlog/... calls to identify what
+        # plot objects are changed by a given set_xxx(label) call.
+        #
         self._plot_types['order'] = [self._orderplot]
         self._plot_types['energy'] = [self._energyfluxplot]
         self._plot_types['photon'] = [self._photonfluxplot]
@@ -205,6 +208,9 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['bkgdelchi'] = [self._bkgdelchiplot]
         self._plot_types['bkgchisqr'] = [self._bkgchisqrplot]
 
+        # The keys of _plot_type_names are used to define the
+        # labels that can be used in plot() calls.
+        #
         self._plot_type_names['order'] = 'order'
         # self._plot_type_names['energy'] = 'energy'  - how to do energy/flux plots?
         # self._plot_type_names['photon'] = 'photon'

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -18,6 +18,18 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+
+# We have many redefinitions of id, min, max so exclude them for the
+# whole file, rather than per-routine.
+#
+# pylint: disable=redefined-builtin
+# pylint: disable=redefined-argument-from-local
+
 import logging
 import os
 import sys
@@ -82,6 +94,8 @@ def get_pha_background(data, idval, bkg_id):
 
 
 class Session(sherpa.ui.utils.Session):
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-public-methods
 
     ###########################################################################
     # Standard methods
@@ -348,6 +362,8 @@ class Session(sherpa.ui.utils.Session):
                 self._xspec_state = None
 
     def _get_show_data(self, id=None):
+
+        # pylint: disable=too-many-branches
         if id is None:
             ids = self.list_data_ids()
         else:
@@ -951,6 +967,8 @@ class Session(sherpa.ui.utils.Session):
         self.set_data(id, self.unpack_arrays(*args))
 
     # DOC-TODO: should unpack_ascii be merged into this?
+    #
+    # pylint: disable-next=no-self-use
     def unpack_table(self, filename, ncols=2, colkeys=None, dstype=Data1D):
         """Unpack a FITS binary file into a data structure.
 
@@ -1141,6 +1159,8 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: I am going to ignore the crates support here as
     # it is somewhat meaningless, since the crate could
     # have been read from a FITS binary table.
+    #
+    # pylint: disable-next=no-self-use
     def unpack_ascii(self, filename, ncols=2, colkeys=None,
                      dstype=Data1D, sep=' ', comment='#'):
         """Unpack an ASCII file into a data structure.
@@ -1627,6 +1647,7 @@ class Session(sherpa.ui.utils.Session):
         datasets = self.unpack_data(filename, *args, **kwargs)
         self._load_data(id, datasets)
 
+    # pylint: disable-next=no-self-use
     def unpack_image(self, arg, coord='logical',
                      dstype=sherpa.astro.data.DataIMG):
         """Create an image data structure.
@@ -1740,6 +1761,8 @@ class Session(sherpa.ui.utils.Session):
         self.set_data(id, self.unpack_image(arg, coord, dstype))
 
     # DOC-TODO: what does this return when given a PHA2 file?
+    #
+    # pylint: disable-next=no-self-use
     def unpack_pha(self, arg, use_errors=False):
         """Create a PHA data structure.
 
@@ -1792,6 +1815,8 @@ class Session(sherpa.ui.utils.Session):
         return sherpa.astro.io.read_pha(arg, use_errors)
 
     # DOC-TODO: what does this return when given a PHA2 file?
+    #
+    # pylint: disable-next=no-self-use
     def unpack_bkg(self, arg, use_errors=False):
         """Create a PHA data structure for a background data set.
 
@@ -5523,6 +5548,7 @@ class Session(sherpa.ui.utils.Session):
         if data.units == 'channel':
             data._set_initial_quantity()
 
+    # pylint: disable-next=no-self-use
     def unpack_arf(self, arg):
         """Create an ARF data structure.
 
@@ -5995,6 +6021,7 @@ class Session(sherpa.ui.utils.Session):
         if data.units == 'channel':
             data._set_initial_quantity()
 
+    # pylint: disable-next=no-self-use
     def unpack_rmf(self, arg):
         """Create a RMF data structure.
 
@@ -8790,6 +8817,8 @@ class Session(sherpa.ui.utils.Session):
         ...          grouping=grp, quality=qual, grouped=True)
         >>> save_pha('sim', 'sim.pi')
         """
+
+        # pylint: disable=too-many-branches,too-many-statements
         id = self._fix_id(id)
 
         if id in self._data:
@@ -9768,6 +9797,7 @@ class Session(sherpa.ui.utils.Session):
         """
 
         try:
+            # pylint: disable=import-outside-toplevel
             from sherpa.astro import xspec
         except ImportError as exc:
             # TODO: what is the best error to raise here?
@@ -13659,6 +13689,7 @@ class Session(sherpa.ui.utils.Session):
     def eqwidth(self, src, combo, id=None, lo=None, hi=None, bkg_id=None,
                 error=False, params=None, otherids=(), niter=1000,
                 covar_matrix=None):
+        # pylint: disable=too-many-statements
         """Calculate the equivalent width of an emission or absorption line.
 
         The equivalent width [1]_ is calculated in the selected units

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -30,9 +30,12 @@
 # pylint: disable=redefined-builtin
 # pylint: disable=redefined-argument-from-local
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
+from typing import Optional, Tuple, Union
 import warnings
 
 import numpy
@@ -56,6 +59,10 @@ from sherpa.astro import fake
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info
+
+# How best to share these aliases?
+OptionalIdType = Union[None, int, str]
+PlotObject = Union[sherpa.plot.Plot, sherpa.plot.Histogram]
 
 
 __all__ = ('Session',)
@@ -101,7 +108,7 @@ class Session(sherpa.ui.utils.Session):
     # Standard methods
     ###########################################################################
 
-    def __init__(self):
+    def __init__(self) -> None:
 
         self.clean()
         super().__init__()
@@ -361,7 +368,7 @@ class Session(sherpa.ui.utils.Session):
                 sherpa.astro.xspec.set_xsstate(self._xspec_state)
                 self._xspec_state = None
 
-    def _get_show_data(self, id=None):
+    def _get_show_data(self, id: OptionalIdType = None) -> str:
 
         # pylint: disable=too-many-branches
         if id is None:
@@ -418,7 +425,7 @@ class Session(sherpa.ui.utils.Session):
 
         return data_str
 
-    def _get_show_bkg(self, id=None, bkg_id=None):
+    def _get_show_bkg(self, id: OptionalIdType = None, bkg_id: Optional[int] = None) -> str:
         if id is None:
             ids = self.list_data_ids()
         else:
@@ -457,7 +464,7 @@ class Session(sherpa.ui.utils.Session):
 
         return data_str
 
-    def _get_show_bkg_model(self, id=None, bkg_id=None):
+    def _get_show_bkg_model(self, id: OptionalIdType = None, bkg_id: Optional[int] = None) -> str:
         if id is None:
             ids = self.list_data_ids()
         else:
@@ -478,7 +485,7 @@ class Session(sherpa.ui.utils.Session):
 
         return model_str
 
-    def _get_show_bkg_source(self, id=None, bkg_id=None):
+    def _get_show_bkg_source(self, id: OptionalIdType = None, bkg_id: Optional[int] = None) -> str:
         if id is None:
             ids = self.list_data_ids()
         else:
@@ -10358,7 +10365,9 @@ class Session(sherpa.ui.utils.Session):
     # Plotting
     ###########################################################################
 
-    def _get_plotobj(self, plottype, *, id=None, recalc=False):
+    def _get_plotobj(self, plottype: str, *,
+                     id: Union[None, int, str] = None,
+                     recalc: bool = False) -> Tuple[PlotObject, Optional[sherpa.data.Data]]:
         """Select the plot object for the given plottype.
 
         The current mechanism to chose a specific type of object
@@ -14672,6 +14681,7 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: no reason can't k-correct wavelength range,
     # but need to work out how to identify the units
+    #
     def calc_kcorr(self, z, obslo, obshi, restlo=None, resthi=None,
                    id=None, bkg_id=None):
         """Calculate the K correction for a model.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -211,27 +211,15 @@ class Session(sherpa.ui.utils.Session):
         for key in ["model", "fit", "source", "ratio", "resid", "delchi", "chisqr"]:
             self._plot_types_alias[f"bkg{key}"] = f"bkg_{key}"
 
-        # The keys of _plot_type_names are used to define the
-        # labels that can be used in plot() calls.
+        # These are left-over from earlier, when they may have meant
+        # something different but no-longer do. It is probably
+        # time to remoove them.
         #
-        self._plot_type_names["order"] = "order"
-        # self._plot_type_names["energy"] = "energy"  - how to do energy/flux plots?
-        # self._plot_type_names["photon"] = "photon"
-        self._plot_type_names["astrocompsource"] = "source_component"
-        self._plot_type_names["astrocompmodel"] = "model_componentl"  # NOTE: typo here
-
-        self._plot_type_names["astrodata"] = "data"
-        self._plot_type_names["astrosource"] = "source"  # is this meaningful anymore
-        self._plot_type_names["astromodel"] = "model"  # is this meaningful anymore
-        self._plot_type_names["arf"] = "arf"
-        self._plot_type_names["bkg"] = "bkg"
-        self._plot_type_names["bkgmodel"] = "bkg_model"
-        self._plot_type_names["bkgfit"] = "bkg_fit"
-        self._plot_type_names["bkgsource"] = "bkg_source"
-        self._plot_type_names["bkgratio"] = "bkg_ratio"
-        self._plot_type_names["bkgresid"] = "bkg_resid"
-        self._plot_type_names["bkgdelchi"] = "bkg_delchi"
-        self._plot_type_names["bkgchisqr"] = "bkg_chisqr"
+        self._plot_types_alias["astrocompsource"] = "source_component"
+        self._plot_types_alias["astrocompmodel"] = "model_componentl"  # NOTE typo here
+        self._plot_types_alias["astrodata"] = "data"
+        self._plot_types_alias["astrosource"] = "source"
+        self._plot_types_alias["astromodel"] = "model"
 
     # Add ability to save attributes sepcific to the astro package.
     # Save XSPEC module settings that need to be restored.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10433,16 +10433,17 @@ class Session(sherpa.ui.utils.Session):
             data = None
 
         plotobj = self._get_plotobj("source", data=data)
-        if recalc:
-            args = [data, self.get_source(id)]
-            kwargs = {}
+        if not recalc:
+            return plotobj
 
-            if isinstance(data, sherpa.astro.data.DataPHA):
-                kwargs["lo"] = lo
-                kwargs["hi"] = hi
+        args = [data, self.get_source(id)]
+        kwargs = {}
 
-            plotobj.prepare(*args, **kwargs)
+        if isinstance(data, sherpa.astro.data.DataPHA):
+            kwargs["lo"] = lo
+            kwargs["hi"] = hi
 
+        plotobj.prepare(*args, **kwargs)
         return plotobj
 
     def get_fit_plot(self, id=None, recalc=True):
@@ -10558,17 +10559,18 @@ class Session(sherpa.ui.utils.Session):
             return super().get_model_component_plot(id, model=model, recalc=recalc)
 
         plotobj = self._get_plotobj("model_component", data=data)
-        if recalc:
-            if not has_pha_response(model):
-                try:
-                    rsp = self.get_response(id)  # TODO: bkg_id?
-                    model = rsp(model)
-                except DataErr:
-                    # no response
-                    pass
+        if not recalc:
+            return plotobj
 
-            plotobj.prepare(data, model, self.get_stat())
+        if not has_pha_response(model):
+            try:
+                rsp = self.get_response(id)  # TODO: bkg_id?
+                model = rsp(model)
+            except DataErr:
+                # no response
+                pass
 
+        plotobj.prepare(data, model, self.get_stat())
         return plotobj
 
     def get_source_component_plot(self, id, model=None, recalc=True):
@@ -10662,9 +10664,11 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("order")
-        if recalc:
-            plotobj.prepare(self._get_pha_data(id),
-                            self.get_model(id), orders=orders)
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self._get_pha_data(id),
+                        self.get_model(id), orders=orders)
         return plotobj
 
     def get_arf_plot(self, id=None, resp_id=None, recalc=True):
@@ -10868,10 +10872,12 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg_model")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_bkg_model(id, bkg_id),
-                            self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_bkg_model(id, bkg_id),
+                        self.get_stat())
         return plotobj
 
     def get_bkg_plot(self, id=None, bkg_id=None, recalc=True):
@@ -10933,9 +10939,11 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_stat())
         return plotobj
 
     def get_bkg_source_plot(self, id=None, lo=None, hi=None,
@@ -11024,10 +11032,12 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg_source")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_bkg_source(id, bkg_id),
-                            lo=lo, hi=hi)
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_bkg_source(id, bkg_id),
+                        lo=lo, hi=hi)
         return plotobj
 
     def get_bkg_resid_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11081,10 +11091,12 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg_resid")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_bkg_model(id, bkg_id),
-                            self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_bkg_model(id, bkg_id),
+                        self.get_stat())
         return plotobj
 
     def get_bkg_ratio_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11138,10 +11150,12 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg_ratio")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_bkg_model(id, bkg_id),
-                            self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_bkg_model(id, bkg_id),
+                        self.get_stat())
         return plotobj
 
     def get_bkg_delchi_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11196,10 +11210,12 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg_delchi")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_bkg_model(id, bkg_id),
-                            self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_bkg_model(id, bkg_id),
+                        self.get_stat())
         return plotobj
 
     def get_bkg_chisqr_plot(self, id=None, bkg_id=None, recalc=True):
@@ -11254,10 +11270,12 @@ class Session(sherpa.ui.utils.Session):
         """
 
         plotobj = self._get_plotobj("bkg_chisqr")
-        if recalc:
-            plotobj.prepare(self.get_bkg(id, bkg_id),
-                            self.get_bkg_model(id, bkg_id),
-                            self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_bkg(id, bkg_id),
+                        self.get_bkg_model(id, bkg_id),
+                        self.get_stat())
         return plotobj
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -18,6 +18,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+
 import logging
 
 import numpy
@@ -350,6 +356,7 @@ def _flux(data, lo, hi, src, eflux=False, srcflux=False):
         assert mask is not None
 
         # no bin found
+        # pylint: disable=invalid-unary-operand-type
         if numpy.all(~mask):
             return 0.0
 

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -25,10 +25,11 @@ import numpy
 from sherpa.utils import get_position, filter_bins
 from sherpa.utils.err import IOErr, DataErr
 
+from sherpa.astro import hc, charge_e
+
 from ._utils import arf_fold, do_group, expand_grouped_mask, \
     filter_resp, is_in, resp_init, rmf_fold, shrink_effarea
 from ._pileup import apply_pileup
-from sherpa.astro import hc, charge_e
 
 
 __all__ = ['arf_fold', 'rmf_fold', 'do_group', 'apply_pileup',
@@ -247,7 +248,7 @@ def range_overlap_1dint(axislist, lo, hi):
     # as that makes code below easier.
     #
     if density:
-        assert lo >= axmin and lo < axmax
+        assert axmin <= lo < axmax
 
     lo = max(lo, axmin)
     hi = min(hi, axmax)
@@ -368,7 +369,7 @@ def _flux(data, lo, hi, src, eflux=False, srcflux=False):
     # same (which is set by bounds_check when a density is requested).
     #
     if lo is not None and dim == 2 and lo == hi:
-        assert scale.sum() == 1, 'programmer error: sum={}'.format(scale.sum())
+        assert scale.sum() == 1, f"programmer error: sum={scale.sum()}"
         y /= numpy.abs(axislist[1] - axislist[0])
 
     flux = (scale * y).sum()
@@ -973,12 +974,12 @@ def calc_kcorr(data, model, z, obslo, obshi, restlo=None, resthi=None):
         z = numpy.asarray(z)
 
     if 0 != sum(z[z < 0]):
-        raise IOErr('z<=0')
+        raise IOErr("z<=0")
 
     if obslo <= 0 or restlo <= 0 or obshi <= obslo or resthi <= restlo:
-        raise IOErr('erange')
+        raise IOErr("erange")
 
-    if hasattr(data, 'get_response'):
+    if hasattr(data, "get_response"):
         arf, rmf = data.get_response()
         elo = data.bin_lo
         ehi = data.bin_hi
@@ -992,22 +993,22 @@ def calc_kcorr(data, model, z, obslo, obshi, restlo=None, resthi=None):
         elo, ehi = data.get_indep()
 
     if elo is None or ehi is None:
-        raise DataErr('noenergybins', data.name)
+        raise DataErr("noenergybins", data.name)
 
     emin = elo[0]
     emax = ehi[-1]
 
     if restlo < emin or resthi > emax:
-        raise IOErr('energoverlap', emin, emax, 'rest-frame',
-                    restlo, resthi, '')
+        raise IOErr("energoverlap", emin, emax, "rest-frame",
+                    restlo, resthi, "")
 
     if obslo * (1.0 + z.min()) < emin:
-        raise IOErr('energoverlap', emin, emax, 'observed-frame',
-                    restlo, resthi, "at a redshift of %f" % z.min())
+        raise IOErr("energoverlap", emin, emax, "observed-frame",
+                    restlo, resthi, f"at a redshift of {z.min()}")
 
     if obshi * (1.0 + z.max()) > emax:
-        raise IOErr('energoverlap', emin, emax, 'rest-frame',
-                    restlo, resthi, "at a redshift of %f" % z.min())
+        raise IOErr("energoverlap", emin, emax, "rest-frame",
+                    restlo, resthi, f"at a redshift of {z.min()}")
 
     zplus1 = z + 1.0
     flux_rest = _flux(data, restlo, resthi, model, eflux=True)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -982,6 +982,14 @@ class Data(NoNewAttributesAfterInit, BaseData):
         kwargs['ignore'] = True
         self.notice(*args, **kwargs)
 
+    def get_filter_expr(self):
+        # Could probably come up with something relevant here
+        raise NotImplementedError("get_filter_expr is not over-ridden")
+
+    def get_filter(self):
+        # Could probably come up with something relevant here
+        raise NotImplementedError("get_filter is not over-ridden")
+
     def eval_model(self, modelfunc):
         return modelfunc(*self.get_indep())
 

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -60,6 +61,9 @@ class Image(NoNewAttributesAfterInit):
 
     def __init__(self):
         NoNewAttributesAfterInit.__init__(self)
+
+    def prepare_image(self, *args, **kwargs):
+        raise NotImplementedError("The prepare_image method has not been over-ridden")
 
     def close():
         """Stop the image viewer."""

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -17,6 +17,10 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
+# pylint: disable=too-many-lines
 
 import logging
 
@@ -835,6 +839,7 @@ class Polynom1D(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, pars)
 
     def guess(self, dep, *args, **kwargs):
+        # pylint: disable=too-many-locals
         xmin = args[0].min()
         xmax = args[0].max()
         ymin = dep.min()
@@ -1673,6 +1678,7 @@ class NormGauss2D(RegriddableModel2D):
 
 
 class Polynom2D(RegriddableModel2D):
+    # pylint: disable=too-many-instance-attributes
     """Two-dimensional polynomial function.
 
     The maximum order of the polynomial is 2.
@@ -1734,6 +1740,7 @@ class Polynom2D(RegriddableModel2D):
         self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
+        # pylint: disable=too-many-locals
         x0min = args[0].min()
         x0max = args[0].max()
         x1min = args[1].min()

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -317,6 +317,10 @@ sherpa.models.basic.Scale1D and sherpa.models.basic.Scale2D)::
 
 """
 
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
+# pylint: disable=too-many-lines
+# pylint: disable=redefined-builtin
 
 import functools
 import logging
@@ -1587,6 +1591,8 @@ def modelcomponents_to_list(model):
 
 
 def html_model(mdl):
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-locals
     """Construct the HTML to display the model."""
 
     # Note that as this is a specialized table we do not use

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2017, 2020, 2021
+#  Copyright (C) 2007, 2017, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -192,6 +192,9 @@ in a fit then `reset` will change them back to the values before a
 fit.
 
 """
+
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
 
 import logging
 import numpy

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#  Copyright (C) 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -27,6 +27,9 @@ data - e.g. a larger grid, since the convolution will account
 for signal outside the data range - and then be regridded to
 match the desired grid.
 """
+
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
 
 import logging
 import warnings

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2019, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -16,6 +17,9 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
 
 import operator
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -315,6 +315,10 @@ class Plot(NoNewAttributesAfterInit):
         kwargs['overplot'] = True
         self.plot(*args, **kwargs)
 
+    def prepare(self, *args, **kwargs):
+        """Add the necessary data to plot."""
+        raise NotImplementedError("The prepare method has not been over-ridden")
+
 
 class Contour(NoNewAttributesAfterInit):
     "Base class for contour plots"
@@ -347,6 +351,10 @@ class Contour(NoNewAttributesAfterInit):
     def overcontour(self, *args, **kwargs):
         kwargs['overcontour'] = True
         self.contour(*args, **kwargs)
+
+    def prepare(self, *args, **kwargs):
+        """Add the necessary data to plot."""
+        raise NotImplementedError("The prepare method has not been over-ridden")
 
 
 class Point(NoNewAttributesAfterInit):
@@ -457,6 +465,10 @@ class Histogram(NoNewAttributesAfterInit):
     def overplot(self, *args, **kwargs):
         kwargs['overplot'] = True
         self.plot(*args, **kwargs)
+
+    def prepare(self, *args, **kwargs):
+        """Add the necessary data to plot."""
+        raise NotImplementedError("The prepare method has not been over-ridden")
 
 
 class HistogramPlot(Histogram):

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021
+#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -497,8 +497,10 @@ def test_source_component_arbitrary_grid(session):
         ui.set_source(regrid_model)
 
         ui.plot_source_component(regrid_model)
-        assert (ui._compsrcplot.x == x).all()
-        assert ui._compsrcplot.y == pytest.approx(yy)
+
+        splot = ui.get_source_component_plot(regrid_model, recalc=False)
+        assert (splot.x == x).all()
+        assert splot.y == pytest.approx(yy)
 
     x = [1, 2, 3]
     y = [1, 2, 3]
@@ -530,10 +532,10 @@ def test_plot_model_arbitrary_grid_integrated(session):
         ui.set_model(regrid_model)
         ui.plot_model()
 
-        # should this use ui.get_model_plot()?
-        assert ui._modelhistplot.xlo == pytest.approx(x[0])
-        assert ui._modelhistplot.xhi == pytest.approx(x[1])
-        assert ui._modelhistplot.y == pytest.approx(yy)
+        mplot = ui.get_model_plot(recalc=False)
+        assert mplot.xlo == pytest.approx(x[0])
+        assert mplot.xhi == pytest.approx(x[1])
+        assert mplot.y == pytest.approx(yy)
 
     tmp = numpy.arange(1, 5, 1)
     x = tmp[:-1], tmp[1:]
@@ -575,10 +577,10 @@ def test_source_component_arbitrary_grid_int(session):
     regrid_model = model.regrid(*re_x)
     ui.plot_source_component(regrid_model)
 
-    # should this use ui.get_source_component_plot()?
-    assert ui._compsrchistplot.xlo == pytest.approx(x[0])
-    assert ui._compsrchistplot.xhi == pytest.approx(x[1])
-    assert ui._compsrchistplot.y == pytest.approx([0.0, 0.0, 0.0])
+    splot = ui.get_source_component_plot(regrid_model, recalc=False)
+    assert splot.xlo == pytest.approx(x[0])
+    assert splot.xhi == pytest.approx(x[1])
+    assert splot.y == pytest.approx([0.0, 0.0, 0.0])
 
 
 def test_numpy_histogram_density_vs_normed(clean_astro_ui):

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1027,8 +1027,8 @@ def test_issue_16():
 
 
 @pytest.mark.parametrize("value", ["data", "model", "source", "fit", "resid", "ratio",
-                                   "delchi", "chisqr", "psf", "kernel", "compsource",
-                                   "compmodel", "source_component", "model_component",])
+                                   "delchi", "chisqr", "psf", "kernel",
+                                   "source_component", "model_component",])
 def test_set_default_id_check_invalid(value):
     """Check we error out with an invalid id.
 

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -274,7 +274,7 @@ def test_paramprompt():
     # raised, and the text, but then we don't get to test the
     # behaviour of the paramprompt code.
     #
-    with patch("sys.stdin", StringIO(u"2.1")):
+    with patch("sys.stdin", StringIO("2.1")):
         s.set_model('const1d.mx')
 
     assert s.list_model_ids() == [1]
@@ -284,7 +284,7 @@ def test_paramprompt():
     mx = s.get_model_component('mx')
     assert mx.c0.val == pytest.approx(2.1)
 
-    with patch("sys.stdin", StringIO(u"2.1e-3 , 2.0e-3, 1.2e-2")):
+    with patch("sys.stdin", StringIO("2.1e-3 , 2.0e-3, 1.2e-2")):
         s.set_model('x', 'const1d.my')
 
     assert set(s.list_model_ids()) == set([1, 'x'])
@@ -296,7 +296,7 @@ def test_paramprompt():
     assert my.c0.min == pytest.approx(2.0e-3)
     assert my.c0.max == pytest.approx(1.2e-2)
 
-    with patch("sys.stdin", StringIO(u"2.1e-3 ,, 1.2e-2")):
+    with patch("sys.stdin", StringIO("2.1e-3 ,, 1.2e-2")):
         s.set_model(2, 'const1d.mz')
 
     assert set(s.list_model_ids()) == set([1, 2, 'x'])
@@ -308,7 +308,7 @@ def test_paramprompt():
     assert mz.c0.min == pytest.approx(- parameter.hugeval)
     assert mz.c0.max == pytest.approx(1.2e-2)
 
-    with patch("sys.stdin", StringIO(u"-12.1,-12.1")):
+    with patch("sys.stdin", StringIO("-12.1,-12.1")):
         s.set_model('const1d.f1')
 
     assert set(s.list_model_ids()) == set([1, 2, 'x'])
@@ -320,7 +320,7 @@ def test_paramprompt():
     assert f1.c0.min == pytest.approx(-12.1)
     assert f1.c0.max == pytest.approx(parameter.hugeval)
 
-    with patch("sys.stdin", StringIO(u" ,-12.1")):
+    with patch("sys.stdin", StringIO(" ,-12.1")):
         s.set_model('const1d.f2')
 
     # stop checking list_model_ids
@@ -332,7 +332,7 @@ def test_paramprompt():
     assert f2.c0.min == pytest.approx(-12.1)
     assert f2.c0.max == pytest.approx(parameter.hugeval)
 
-    with patch("sys.stdin", StringIO(u" ,")):
+    with patch("sys.stdin", StringIO(" ,")):
         s.set_model('const1d.f3')
 
     f3 = s.get_model_component('f3')
@@ -340,7 +340,7 @@ def test_paramprompt():
     assert f3.c0.min == pytest.approx(- parameter.hugeval)
     assert f3.c0.max == pytest.approx(parameter.hugeval)
 
-    with patch("sys.stdin", StringIO(u" ,, ")):
+    with patch("sys.stdin", StringIO(" ,, ")):
         s.set_model('const1d.f4')
 
     f4 = s.get_model_component('f4')

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -40,7 +40,7 @@ from sherpa.data import Data1D, Data1DInt, Data2D
 from sherpa.models import basic
 import sherpa.plot
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
+from sherpa.utils.err import ArgumentTypeErr, IdentifierErr, PlotErr
 from sherpa.utils.testing import requires_plotting, requires_pylab
 
 
@@ -1054,11 +1054,9 @@ def test_plot_contour_error_out_invalid(plottype, session):
 
     s = session()
     func = getattr(s, plottype)
-    with pytest.raises(ArgumentErr) as exc:
+    msg = r"Plot type 'fooflan flim flam' not found in \[.*\]"
+    with pytest.raises(PlotErr, match=msg):
         func("fooflan flim flam")
-
-    emsg = "'fooflan flim flam' is not a valid plot type"
-    assert str(exc.value) == emsg
 
 
 @requires_pylab

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -227,10 +227,10 @@ def change_fit(idval):
     change_model(idval)
 
 
-def check_example(xlabel='x'):
+def check_example(idval, xlabel='x'):
     """Check that the data plot has not changed"""
 
-    dplot = ui._session._dataplot
+    dplot = ui.get_data_plot(id=idval, recalc=False)
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -243,13 +243,13 @@ def check_example(xlabel='x'):
     assert dplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_example_changed(xlabel='x'):
+def check_example_changed(idval, xlabel='x'):
     """Check that the data plot has changed
 
     Assumes change_example has been called
     """
 
-    dplot = ui._session._dataplot
+    dplot = ui.get_data_plot(id=idval, recalc=False)
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -274,45 +274,44 @@ def check_model_plot(plot, title='Model', xlabel='x', modelval=35):
     assert plot.yerr is None
 
 
-def check_model(xlabel='x'):
+def check_model(idval, xlabel='x'):
     """Check that the model plot has not changed"""
 
-    check_model_plot(ui._session._modelplot,
-                     title='Model', xlabel=xlabel)
+    mplot = ui.get_model_plot(id=idval, recalc=False)
+    check_model_plot(mplot, title='Model', xlabel=xlabel)
 
 
-def check_model_changed(xlabel='x'):
+def check_model_changed(idval, xlabel='x'):
     """Check that the model plot has changed
 
     Assumes change_model has been called
     """
 
-    check_model_plot(ui._session._modelplot,
-                     title='Model', xlabel=xlabel,
-                     modelval=41)
+    mplot = ui.get_model_plot(id=idval, recalc=False)
+    check_model_plot(mplot, title='Model', xlabel=xlabel, modelval=41)
 
 
-def check_source():
+def check_source(idval):
     """Check that the source plot has not changed"""
 
-    check_model_plot(ui._session._sourceplot,
-                     title='Source')
+    splot = ui.get_source_plot(id=idval, recalc=False)
+    check_model_plot(splot, title='Source')
 
 
-def check_source_changed():
+def check_source_changed(idval):
     """Check that the source plot has changed
 
     Assumes change_model has been called
     """
 
-    check_model_plot(ui._session._sourceplot,
-                     title='Source', modelval=41)
+    splot = ui.get_source_plot(id=idval, recalc=False)
+    check_model_plot(splot, title='Source', modelval=41)
 
 
-def check_resid(title='Residuals for example'):
+def check_resid(idval, title='Residuals for example'):
     """Check that the resid plot has not changed"""
 
-    rplot = ui._session._residplot
+    rplot = ui.get_resid_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -322,13 +321,13 @@ def check_resid(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_resid_changed(title='Residuals for example'):
+def check_resid_changed(idval, title='Residuals for example'):
     """Check that the resid plot has changed
 
     Assumes that change_model has been called
     """
 
-    rplot = ui._session._residplot
+    rplot = ui.get_resid_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -338,13 +337,13 @@ def check_resid_changed(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_resid_changed2(title='Residuals for example'):
+def check_resid_changed2(idval, title='Residuals for example'):
     """Check that the resid plot has changed
 
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._residplot
+    rplot = ui.get_resid_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -354,10 +353,10 @@ def check_resid_changed2(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y2))
 
 
-def check_ratio(title='Ratio of Data to Model for example'):
+def check_ratio(idval, title='Ratio of Data to Model for example'):
     """Check that the ratio plot has not changed"""
 
-    rplot = ui._session._ratioplot
+    rplot = ui.get_ratio_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -368,13 +367,13 @@ def check_ratio(title='Ratio of Data to Model for example'):
     assert rplot.yerr == pytest.approx(dy)
 
 
-def check_ratio_changed():
+def check_ratio_changed(idval):
     """Check that the ratio plot has changed
 
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._ratioplot
+    rplot = ui.get_ratio_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == 'Ratio of Data to Model for example'
@@ -385,13 +384,13 @@ def check_ratio_changed():
     assert rplot.yerr == pytest.approx(dy)
 
 
-def check_ratio_changed2(title='Ratio of Data to Model for example'):
+def check_ratio_changed2(idval, title='Ratio of Data to Model for example'):
     """Check that the ratio plot has changed
 
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._ratioplot
+    rplot = ui.get_ratio_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -402,10 +401,10 @@ def check_ratio_changed2(title='Ratio of Data to Model for example'):
     assert rplot.yerr == pytest.approx(dy)
 
 
-def check_delchi(title='Sigma Residuals for example'):
+def check_delchi(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has not changed"""
 
-    rplot = ui._session._delchiplot
+    rplot = ui.get_delchi_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -418,13 +417,13 @@ def check_delchi(title='Sigma Residuals for example'):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_y])
 
 
-def check_delchi_changed(title='Sigma Residuals for example'):
+def check_delchi_changed(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has changed
 
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._delchiplot
+    rplot = ui.get_delchi_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -437,13 +436,13 @@ def check_delchi_changed(title='Sigma Residuals for example'):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_x])
 
 
-def check_delchi_changed2(title='Sigma Residuals for example'):
+def check_delchi_changed2(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has changed
 
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._delchiplot
+    rplot = ui.get_delchi_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -456,10 +455,10 @@ def check_delchi_changed2(title='Sigma Residuals for example'):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_x])
 
 
-def check_chisqr():
+def check_chisqr(idval):
     """Check that the chisqr plot has not changed"""
 
-    rplot = ui._session._chisqrplot
+    rplot = ui.get_chisqr_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -472,13 +471,13 @@ def check_chisqr():
     assert rplot.yerr is None
 
 
-def check_chisqr_changed():
+def check_chisqr_changed(idval):
     """Check that the chisqr plot has changed
 
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._chisqrplot
+    rplot = ui.get_chisqr_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -491,78 +490,78 @@ def check_chisqr_changed():
     assert rplot.yerr is None
 
 
-def check_fit():
+def check_fit(idval):
     """Check that the fit plot has not changed"""
 
-    check_example()
-    check_model()
+    check_example(idval)
+    check_model(idval)
 
 
-def check_fit_changed():
+def check_fit_changed(idval):
     """Check that the fit plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed()
-    check_model_changed()
+    check_example_changed(idval)
+    check_model_changed(idval)
 
 
-def check_fit_resid():
+def check_fit_resid(idval):
     """Check that the fit + resid plot has not changed"""
 
-    check_example(xlabel='')
-    check_model(xlabel='')
-    check_resid(title='')
+    check_example(idval, xlabel='')
+    check_model(idval, xlabel='')
+    check_resid(idval, title='')
 
 
-def check_fit_resid_changed():
+def check_fit_resid_changed(idval):
     """Check that the fit + resid plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed(xlabel='')
-    check_model_changed(xlabel='')
-    check_resid_changed2(title='')
+    check_example_changed(idval, xlabel='')
+    check_model_changed(idval, xlabel='')
+    check_resid_changed2(idval, title='')
 
 
-def check_fit_ratio():
+def check_fit_ratio(idval):
     """Check that the fit + ratio plot has not changed"""
 
-    check_example(xlabel='')
-    check_model(xlabel='')
-    check_ratio(title='')
+    check_example(idval, xlabel='')
+    check_model(idval, xlabel='')
+    check_ratio(idval, title='')
 
 
-def check_fit_ratio_changed():
+def check_fit_ratio_changed(idval):
     """Check that the fit + ratio plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed(xlabel='')
-    check_model_changed(xlabel='')
-    check_ratio_changed2(title='')
+    check_example_changed(idval, xlabel='')
+    check_model_changed(idval, xlabel='')
+    check_ratio_changed2(idval, title='')
 
 
-def check_fit_delchi():
+def check_fit_delchi(idval):
     """Check that the fit + delchi plot has not changed"""
 
-    check_example(xlabel='')
-    check_model(xlabel='')
-    check_delchi(title='')
+    check_example(idval, xlabel='')
+    check_model(idval, xlabel='')
+    check_delchi(idval, title='')
 
 
-def check_fit_delchi_changed():
+def check_fit_delchi_changed(idval):
     """Check that the fit + delchi plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed(xlabel='')
-    check_model_changed(xlabel='')
-    check_delchi_changed2(title='')
+    check_example_changed(idval, xlabel='')
+    check_model_changed(idval, xlabel='')
+    check_delchi_changed2(idval, title='')
 
 
 _plot_all = [
@@ -628,7 +627,7 @@ def test_plot_xxx(idval, pfunc, checkfunc, clean_ui):
     else:
         pfunc(idval)
 
-    checkfunc()
+    checkfunc(idval)
 
 
 @requires_plotting
@@ -672,7 +671,7 @@ def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc, clean_ui):
     else:
         plotfunc(idval, replot=True)
 
-    checkfunc()
+    checkfunc(idval)
 
 
 @requires_plotting
@@ -719,31 +718,31 @@ def test_plot_xxx_change(idval, plotfunc, changefunc, checkfunc, clean_ui):
     else:
         plotfunc(idval)
 
-    checkfunc()
+    checkfunc(idval)
 
 
-_dplot = (ui.get_data_plot_prefs, "_dataplot", ui.plot_data)
-_mplot = (ui.get_model_plot_prefs, "_modelplot", ui.plot_model)
+_dplot = (ui.get_data_plot_prefs, ui.get_data_plot, ui.plot_data)
+_mplot = (ui.get_model_plot_prefs, ui.get_model_plot, ui.plot_model)
 
 
 @requires_plotting
-@pytest.mark.parametrize("getprefs,attr,plotfunc",
+@pytest.mark.parametrize("getprefs,getplot,plotfunc",
                          [_dplot, _mplot])
-def test_prefs_change_session_objects(getprefs, attr, plotfunc, clean_ui):
+def test_prefs_change_session_objects(getprefs, getplot, plotfunc, clean_ui):
     """Is a plot-preference change also reflected in the session object?
 
     This is intended to test an assumption that will be used in the
     plot_fit_xxx routines rather than of an explicit user-visible
     behavior. The test may be "obvious behavior" given how
     get_data_plot_prefs works, but DJB wanted to ensure this
-    behavior/assumption was tested.
+    behavior/assumption was tested. The setup has changed since
+    the test was written.
     """
 
-    # This has to be retrieved here, rather than passed in in the
-    # parametrize list, as the ui._session object is changed by
-    # the clean_ui fixture.
+    # This used to access the plot object directly, but is now
+    # using an accessor function.
     #
-    session = getattr(ui._session, attr)
+    session = getplot(recalc=False)
 
     # All but the last assert are just to check things are behaving
     # as expected (and stuck into one routine rather than have a
@@ -775,13 +774,13 @@ def test_prefs_change_session_objects(getprefs, attr, plotfunc, clean_ui):
 def test_prefs_change_session_objects_fit(clean_ui):
     """Is plot-preference change reflected in the fitplot session object?
 
-    This is test_prefs_change_session_objects but for the _fitplot
-    attribute. This test encodes the current behavior - so we can see
+    This is test_prefs_change_session_objects but for the fit plot
+    object. This test encodes the current behavior - so we can see
     if things change in the future - rather than being a statement
     about what we expect/want to happen.
     """
 
-    plotobj = ui._session._fitplot
+    plotobj = ui.get_fit_plot(recalc=False)
     assert plotobj.dataplot is None
     assert plotobj.modelplot is None
 
@@ -802,19 +801,19 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # We have already checked this in previous tests, but
     # just in case
     #
-    assert ui._session._dataplot.plot_prefs['xlog']
-    assert ui._session._modelplot.plot_prefs['ylog']
+    assert ui.get_data_plot(id=12, recalc=False).plot_prefs['xlog']
+    assert ui.get_model_plot(id=12, recalc=False).plot_prefs['ylog']
 
     # Now check that the fit plot has picked up these changes;
     # the simplest way is to check that the data/model plots
     # are now referencing the underlying _data/_model plot
     # attributes. An alternative would be to check that
     # plotobj.dataplot.plot_prefs['xlog'] is True
-    # which is less restrictive, but for not check the
+    # which is less restrictive, but for now check the
     # equality
     #
-    assert plotobj.dataplot is ui._session._dataplot
-    assert plotobj.modelplot is ui._session._modelplot
+    assert plotobj.dataplot is ui.get_data_plot(id=12, recalc=False)
+    assert plotobj.modelplot is ui.get_model_plot(id=12, recalc=False)
 
 
 @pytest.mark.parametrize("plotfunc", [ui.plot_cdf, ui.plot_pdf])
@@ -992,23 +991,18 @@ def test_get_kernel_plot_recalc(session):
 
 
 @requires_plotting
-@pytest.mark.parametrize("plotobj,plotfunc",
-                         [("_residplot", ui.plot_resid),
-                          ("_delchiplot", ui.plot_delchi)
+@pytest.mark.parametrize("getplot,plotfunc",
+                         [(ui.get_resid_plot, ui.plot_resid),
+                          (ui.get_delchi_plot, ui.plot_delchi)
                           ])
-def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
+def test_plot_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?
 
     Note that plot_chisqr is not included in support for ignoring
     ylog (since the data should be positive in this case).
     """
 
-    # access it this way to ensure have access to the actual
-    # object used by the session object in this test (as the
-    # clean call done by the clean_ui fixture will reset the
-    # plot objects).
-    #
-    prefs = getattr(ui._session, plotobj).plot_prefs
+    prefs = getplot(recalc=False).plot_prefs
 
     setup_example(None)
 
@@ -1024,20 +1018,15 @@ def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
 
 
 @requires_plotting
-@pytest.mark.parametrize("plotobj,plotfunc",
-                         [("_residplot", ui.plot_fit_resid),
-                          ("_delchiplot", ui.plot_fit_delchi)
+@pytest.mark.parametrize("getplot,plotfunc",
+                         [(ui.get_resid_plot, ui.plot_fit_resid),
+                          (ui.get_delchi_plot, ui.plot_fit_delchi)
                           ])
-def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
+def test_plot_fit_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?"""
 
-    # access it this way to ensure have access to the actual
-    # object used by the session object in this test (as the
-    # clean call done by the clean_ui fixture will reset the
-    # plot objects).
-    #
-    rprefs = getattr(ui._session, plotobj).plot_prefs
-    dprefs = ui._session._dataplot.plot_prefs
+    rprefs = getplot(recalc=False).plot_prefs
+    dprefs = ui.get_data_plot(recalc=False).plot_prefs
 
     setup_example(None)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -319,29 +319,10 @@ class Session(NoNewAttributesAfterInit):
 
         self._splitplot = sherpa.plot.SplitPlot()
         self._jointplot = sherpa.plot.JointPlot()
-        self._dataplot = sherpa.plot.DataPlot()
-        self._datahistplot = sherpa.plot.DataHistogramPlot()
-        self._modelplot = sherpa.plot.ModelPlot()
-        self._modelhistplot = sherpa.plot.ModelHistogramPlot()
-
-        self._compmdlplot = sherpa.plot.ComponentModelPlot()
-        self._compmdlhistplot = sherpa.plot.ComponentModelHistogramPlot()
-
-        self._compsrcplot = sherpa.plot.ComponentSourcePlot()
-        self._compsrchistplot = sherpa.plot.ComponentSourceHistogramPlot()
 
         # self._comptmplmdlplot = sherpa.plot.ComponentTemplateModelPlot()
         self._comptmplsrcplot = sherpa.plot.ComponentTemplateSourcePlot()
 
-        self._sourceplot = sherpa.plot.SourcePlot()
-        self._sourcehistplot = sherpa.plot.SourceHistogramPlot()
-        self._fitplot = sherpa.plot.FitPlot()
-        self._residplot = sherpa.plot.ResidPlot()
-        self._delchiplot = sherpa.plot.DelchiPlot()
-        self._chisqrplot = sherpa.plot.ChisqrPlot()
-        self._ratioplot = sherpa.plot.RatioPlot()
-        self._psfplot = sherpa.plot.PSFPlot()
-        self._kernelplot = sherpa.plot.PSFKernelPlot()
         self._lrplot = sherpa.plot.LRHistogram()
         self._pdfplot = sherpa.plot.PDFPlot()
         self._cdfplot = sherpa.plot.CDFPlot()
@@ -363,19 +344,27 @@ class Session(NoNewAttributesAfterInit):
         #
         # Note that not all plot_xxx commands use this structure.
         #
+        # The values are a list of plot objects related to this plot
+        # type. The first value is the "default" value and the second,
+        # if it exists, is the class used for Data1DInt data. For the
+        # astro class the plot types that have two values are extended
+        # to three, with the addition of a DataPHA specific
+        # class. This approach is not particularly extensible but at
+        # the moment it does not need to be anything more complex.
+        #
         self._plot_types = {
-            "data": [self._dataplot, self._datahistplot],
-            "model": [self._modelplot, self._modelhistplot],
-            "model_component": [self._compmdlplot, self._compmdlhistplot],
-            "source": [self._sourceplot, self._sourcehistplot],
-            "source_component": [self._compsrcplot, self._compsrchistplot],
-            "fit": [self._fitplot],
-            "resid": [self._residplot],
-            "ratio": [self._ratioplot],
-            "delchi": [self._delchiplot],
-            "chisqr": [self._chisqrplot],
-            "psf": [self._psfplot],
-            "kernel": [self._kernelplot]
+            "data": [sherpa.plot.DataPlot(), sherpa.plot.DataHistogramPlot()],
+            "model": [sherpa.plot.ModelPlot(), sherpa.plot.ModelHistogramPlot()],
+            "model_component": [sherpa.plot.ComponentModelPlot(), sherpa.plot.ComponentModelHistogramPlot()],
+            "source": [sherpa.plot.SourcePlot(), sherpa.plot.SourceHistogramPlot()],
+            "source_component": [sherpa.plot.ComponentSourcePlot(), sherpa.plot.ComponentSourceHistogramPlot()],
+            "fit": [sherpa.plot.FitPlot()],
+            "resid": [sherpa.plot.ResidPlot()],
+            "ratio": [sherpa.plot.RatioPlot()],
+            "delchi": [sherpa.plot.DelchiPlot()],
+            "chisqr": [sherpa.plot.ChisqrPlot()],
+            "psf": [sherpa.plot.PSFPlot()],
+            "kernel": [sherpa.plot.PSFKernelPlot()]
         }
 
         # Temporary aliases so that calls to set_xlog/.. will still succeed,

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -18,6 +18,18 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+
+# We have many redefinitions of id, min, max so exclude them for the
+# whole file, rather than per-routine.
+#
+# pylint: disable=redefined-builtin
+# pylint: disable=redefined-argument-from-local
+
 from configparser import ConfigParser
 import copy
 import copyreg as copy_reg
@@ -224,6 +236,8 @@ def _assign_model_to_main(name, model):
 #
 ###############################################################################
 class Session(NoNewAttributesAfterInit):
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-public-methods
 
     ###########################################################################
     # Standard methods
@@ -2439,6 +2453,7 @@ class Session(NoNewAttributesAfterInit):
         self._set_item(id, data, self._data, sherpa.data.Data, 'data',
                        'a data set')
 
+    # pylint: disable-next=no-self-use
     def _read_error(self, filename, *args, **kwargs):
         err = sherpa.io.get_ascii_data(filename, *args, **kwargs)[1].pop()
         return err
@@ -3674,6 +3689,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-TODO: What data types are supported here?
+    #
+    # pylint: disable-next=no-self-use
     def unpack_arrays(self, *args):
         """Create a sherpa data object from arrays of data.
 
@@ -4033,6 +4050,8 @@ class Session(NoNewAttributesAfterInit):
         sherpa.io.write_arrays(filename, args, fields, **kwargs)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
+    #
+    # pylint: disable-next=no-self-use
     def save_arrays(self, filename, args, fields=None, clobber=False, sep=' ',
                     comment='#', linebreak='\n', format='%g'):
         """Write a list of arrays to an ASCII file.
@@ -5830,6 +5849,7 @@ class Session(NoNewAttributesAfterInit):
 
     def _eval_model_expression(self, expr, typestr='model'):
         try:
+            # pylint: disable=eval-used
             return eval(expr, self._model_globals, self._model_components)
         except Exception as exc:
             raise ArgumentErr('badexpr', typestr, sys.exc_info()[1]) from exc
@@ -6715,6 +6735,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: description of template interpolation needs a lot of work.
     # @loggable()
+    #
+    # pylint: disable-next=no-self-use
     def load_template_interpolator(self, name, interpolator_class, **kwargs):
         """Set the template interpolation scheme.
 
@@ -7061,6 +7083,8 @@ class Session(NoNewAttributesAfterInit):
         self._add_model_component(newusermodel)
 
     # DOC-TODO: Improve priors documentation
+    #
+    # pylint: disable-next=no-self-use
     def load_user_stat(self, statname, calc_stat_func, calc_err_func=None,
                        priors={}):
         """Create a user-defined statistic.
@@ -9277,6 +9301,7 @@ class Session(NoNewAttributesAfterInit):
     # New "wrappers" to access estimation methods without calling
     # get_proj(), etc.
 
+    # pylint: disable-next=no-self-use
     def _check_estmethod_opt(self, estmethod, optname):
         _check_str_type(optname, "optname")
         if optname not in estmethod.config:
@@ -12260,6 +12285,7 @@ class Session(NoNewAttributesAfterInit):
         else:
             sherpa.plot.backend.end()
 
+    # pylint: disable-next=no-self-use
     def _plot(self, plotobj, **kwargs):
         """Display a plot object
 
@@ -14152,6 +14178,7 @@ class Session(NoNewAttributesAfterInit):
     # Contours
     #
 
+    # pylint: disable-next=no-self-use
     def _contour(self, plotobj, overcontour=False, **kwargs):
         """Display a plot object
 
@@ -16779,6 +16806,7 @@ class Session(NoNewAttributesAfterInit):
     # through unbound functions of the Image class--always talking to
     # the same instance of the Image backend, so OK for now
 
+    # pylint: disable-next=no-self-use
     def image_deleteframes(self):
         """Delete all the frames open in the image viewer.
 
@@ -16803,6 +16831,7 @@ class Session(NoNewAttributesAfterInit):
         """
         sherpa.image.Image.delete_frames()
 
+    # pylint: disable-next=no-self-use
     def image_open(self):
         """Start the image viewer.
 
@@ -16839,6 +16868,7 @@ class Session(NoNewAttributesAfterInit):
         """
         sherpa.image.Image.open()
 
+    # pylint: disable-next=no-self-use
     def image_close(self):
         """Close the image viewer.
 
@@ -16863,6 +16893,8 @@ class Session(NoNewAttributesAfterInit):
         sherpa.image.Image.close()
 
     # DOC-TODO: what is the "default" coordinate system
+    #
+    # pylint: disable-next=no-self-use
     def image_getregion(self, coord=''):
         """Return the region defined in the image viewer.
 
@@ -16902,6 +16934,8 @@ class Session(NoNewAttributesAfterInit):
         return sherpa.image.Image.get_region(coord)
 
     # DOC-TODO: what is the "default" coordinate system
+    #
+    # pylint: disable-next=no-self-use
     def image_setregion(self, reg, coord=''):
         """Set the region to display in the image viewer.
 
@@ -16945,6 +16979,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: check the ds9 link when it is working
     # DOC-TODO: is there a link of ds9 commands we can link to?
+    #
+    # pylint: disable-next=no-self-use
     def image_xpaget(self, arg):
         """Return the result of an XPA call to the image viewer.
 
@@ -16997,6 +17033,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: check the ds9 link when it is working
     # DOC-TODO: is there a link of ds9 commands we can link to?
+    #
+    # pylint: disable-next=no-self-use
     def image_xpaset(self, arg, data=None):
         """Return the result of an XPA call to the image viewer.
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -362,6 +362,9 @@ class Session(NoNewAttributesAfterInit):
         self._regproj = sherpa.plot.RegionProjection()
         self._regunc = sherpa.plot.RegionUncertainty()
 
+        # The keys are used by the set_xlog/... calls to identify what
+        # plot objects are changed by a given set_xxx(label) call.
+        #
         self._plot_types = {
             'data': [self._dataplot, self._datahistplot],
             'model': [self._modelplot, self._modelhistplot],
@@ -377,6 +380,11 @@ class Session(NoNewAttributesAfterInit):
             'compmodel': [self._compmdlplot]
         }
 
+        # The keys define the labels that can be used in calls to
+        # plot(), and the values map to the get_<value>_plot call used
+        # to create the particular plot entry. The keys are also used
+        # to determine the set of forbidden identifiers.
+        #
         self._plot_type_names = {
             'data': 'data',
             'model': 'model',
@@ -394,6 +402,8 @@ class Session(NoNewAttributesAfterInit):
             'compmodel': 'model_component',
         }
 
+        # This isn't actually used at the moment.
+        #
         self._contour_types = {
             'data': self._datacontour,
             'model': self._modelcontour,
@@ -405,6 +415,11 @@ class Session(NoNewAttributesAfterInit):
             'kernel': self._kernelcontour
         }
 
+        # The keys define the labels that can be used in calls to
+        # contour(), and the values map to the get_<value>_contour
+        # call used to create the particular contour entry. The keys
+        # are also used to determine the set of forbidden identifiers.
+        #
         self._contour_type_names = {
             'data': 'data',
             'model': 'model',
@@ -416,6 +431,10 @@ class Session(NoNewAttributesAfterInit):
             'kernel': 'kernel',
         }
 
+        # This is used by the get_<key>_image calls to access the
+        # relevant image class. The keys are not included in any
+        # check of valid identifiers.
+        #
         self._image_types = {
             'data': sherpa.image.DataImage(),
             'model': sherpa.image.ModelImage(),

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1367,6 +1367,16 @@ class Session(NoNewAttributesAfterInit):
 
         return plottype in self._contour_types
 
+    def _get_contourobj(self, plottype):
+        """Select the contour object for the given plottype."""
+
+        return self._contour_types[plottype]
+
+    def _get_imageobj(self, plottype):
+        """Select the image object for the given plottype."""
+
+        return self._image_types[plottype]
+
     def _get_item(self, id, itemdict, itemdesc, errdesc):
         id = self._fix_id(id)
         item = itemdict.get(id)
@@ -11601,7 +11611,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["data"]
+        plotobj = self._get_contourobj("data")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_stat())
         return plotobj
@@ -11699,7 +11709,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["model"]
+        plotobj = self._get_contourobj("model")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11747,7 +11757,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["source"]
+        plotobj = self._get_contourobj("source")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
         return plotobj
@@ -11849,7 +11859,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["fit"]
+        plotobj = self._get_contourobj("fit")
 
         if recalc:
             dataobj = self.get_data_contour(id, recalc=recalc)
@@ -11902,7 +11912,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["resid"]
+        plotobj = self._get_contourobj("resid")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11951,7 +11961,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["ratio"]
+        plotobj = self._get_contourobj("ratio")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11995,7 +12005,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["psf"]
+        plotobj = self._get_contourobj("psf")
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
@@ -12040,7 +12050,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._contour_types["kernel"]
+        plotobj = self._get_contourobj("kernel")
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
@@ -15627,7 +15637,7 @@ class Session(NoNewAttributesAfterInit):
         (150, 175)
 
         """
-        imageobj = self._image_types['data']
+        imageobj = self._get_imageobj("data")
         data = self.get_data(id)
         imageobj.prepare_image(data)
         return imageobj
@@ -15675,7 +15685,7 @@ class Session(NoNewAttributesAfterInit):
         >>> resid = dinfo.y - minfo.y
 
         """
-        imageobj = self._image_types['model']
+        imageobj = self._get_imageobj("model")
         data = self.get_data(id)
         model = self.get_model(id)
         imageobj.prepare_image(data, model)
@@ -15724,7 +15734,7 @@ class Session(NoNewAttributesAfterInit):
         (150, 175)
 
         """
-        imageobj = self._image_types['source']
+        imageobj = self._get_imageobj("source")
         data = self.get_data(id)
         source = self.get_source(id)
         imageobj.prepare_image(data, source)
@@ -15791,7 +15801,7 @@ class Session(NoNewAttributesAfterInit):
         model = self._add_convolution_models(id, self.get_data(id),
                                              model, is_source)
 
-        imageobj = self._image_types['model_component']
+        imageobj = self._get_imageobj("model_component")
         data = self.get_data(id)
         imageobj.prepare_image(data, model)
         return imageobj
@@ -15851,7 +15861,7 @@ class Session(NoNewAttributesAfterInit):
             id, model = model, id
         model = self._check_model(model)
 
-        imageobj = self._image_types['source_component']
+        imageobj = self._get_imageobj("source_component")
         data = self.get_data(id)
         imageobj.prepare_image(data, model)
         return imageobj
@@ -15893,7 +15903,7 @@ class Session(NoNewAttributesAfterInit):
         >>> rinfo = get_ratio_image()
 
         """
-        imageobj = self._image_types['ratio']
+        imageobj = self._get_imageobj("ratio")
         data = self.get_data(id)
         model = self.get_model(id)
         imageobj.prepare_image(data, model)
@@ -15936,7 +15946,7 @@ class Session(NoNewAttributesAfterInit):
         >>> rinfo = get_resid_image()
 
         """
-        imageobj = self._image_types['resid']
+        imageobj = self._get_imageobj("resid")
         data = self.get_data(id)
         model = self.get_model(id)
         imageobj.prepare_image(data, model)
@@ -15976,7 +15986,7 @@ class Session(NoNewAttributesAfterInit):
         (175, 200)
 
         """
-        imageobj = self._image_types['psf']
+        imageobj = self._get_imageobj("psf")
         psf = self.get_psf(id)
         data = self.get_data(id)
         imageobj.prepare_image(psf, data)
@@ -16016,7 +16026,7 @@ class Session(NoNewAttributesAfterInit):
         (51, 51)
 
         """
-        imageobj = self._image_types['kernel']
+        imageobj = self._get_imageobj("kernel")
         psf = self.get_psf(id)
         data = self.get_data(id)
         imageobj.prepare_image(psf, data)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -348,15 +348,6 @@ class Session(NoNewAttributesAfterInit):
         self._traceplot = sherpa.plot.TracePlot()
         self._scatterplot = sherpa.plot.ScatterPlot()
 
-        self._datacontour = sherpa.plot.DataContour()
-        self._modelcontour = sherpa.plot.ModelContour()
-        self._sourcecontour = sherpa.plot.SourceContour()
-        self._fitcontour = sherpa.plot.FitContour()
-        self._residcontour = sherpa.plot.ResidContour()
-        self._ratiocontour = sherpa.plot.RatioContour()
-        self._psfcontour = sherpa.plot.PSFContour()
-        self._kernelcontour = sherpa.plot.PSFKernelContour()
-
         self._intproj = sherpa.plot.IntervalProjection()
         self._intunc = sherpa.plot.IntervalUncertainty()
         self._regproj = sherpa.plot.RegionProjection()
@@ -402,38 +393,32 @@ class Session(NoNewAttributesAfterInit):
             'compmodel': 'model_component',
         }
 
-        # This isn't actually used at the moment.
+        # This is used by the get_<key>_contour calls to access the
+        # relevant contour class. The keys define the labels that can be
+        # used in calls to contour(), and are also used to determine
+        # the set of forbidden identifiers.
         #
         self._contour_types = {
-            'data': self._datacontour,
-            'model': self._modelcontour,
-            'source': self._sourcecontour,
-            'fit': self._fitcontour,
-            'resid': self._residcontour,
-            'ratio': self._ratiocontour,
-            'psf': self._psfcontour,
-            'kernel': self._kernelcontour
+            "data": sherpa.plot.DataContour(),
+            "model": sherpa.plot.ModelContour(),
+            "source": sherpa.plot.SourceContour(),
+            "fit": sherpa.plot.FitContour(),
+            "resid": sherpa.plot.ResidContour(),
+            "ratio": sherpa.plot.RatioContour(),
+            "psf": sherpa.plot.PSFContour(),
+            "kernel": sherpa.plot.PSFKernelContour()
         }
 
-        # The keys define the labels that can be used in calls to
-        # contour(), and the values map to the get_<value>_contour
-        # call used to create the particular contour entry. The keys
-        # are also used to determine the set of forbidden identifiers.
+        # This is a temporary structure, and will be removed once
+        # the plot code has been updated.
         #
-        self._contour_type_names = {
-            'data': 'data',
-            'model': 'model',
-            'source': 'source',
-            'fit': 'fit',
-            'resid': 'resid',
-            'ratio': 'ratio',
-            'psf': 'psf',
-            'kernel': 'kernel',
-        }
+        self._contour_type_names = {k: k for k in self._contour_types.keys()}
 
         # This is used by the get_<key>_image calls to access the
-        # relevant image class. The keys are not included in any
-        # check of valid identifiers.
+        # relevant image class. The keys are not included in any check
+        # of valid identifiers, unlike _plot_types and _contour_types,
+        # as there is no image() call that acts like plot() or
+        # contour().
         #
         self._image_types = {
             'data': sherpa.image.DataImage(),
@@ -1348,7 +1333,7 @@ class Session(NoNewAttributesAfterInit):
         if not self._valid_id(id):
             raise ArgumentTypeErr('intstr')
 
-        badkeys = self._plot_type_names.keys() | self._contour_type_names.keys()
+        badkeys = self._plot_type_names.keys() | self._contour_types.keys()
         if id in badkeys:
             raise IdentifierErr('badid', id)
 
@@ -11588,7 +11573,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._datacontour
+        plotobj = self._contour_types["data"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_stat())
         return plotobj
@@ -11686,7 +11671,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._modelcontour
+        plotobj = self._contour_types["model"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11734,7 +11719,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._sourcecontour
+        plotobj = self._contour_types["source"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
         return plotobj
@@ -11836,11 +11821,11 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._fitcontour
+        plotobj = self._contour_types["fit"]
 
-        dataobj = self.get_data_contour(id, recalc=recalc)
-        modelobj = self.get_model_contour(id, recalc=recalc)
         if recalc:
+            dataobj = self.get_data_contour(id, recalc=recalc)
+            modelobj = self.get_model_contour(id, recalc=recalc)
             plotobj.prepare(dataobj, modelobj)
 
         return plotobj
@@ -11889,7 +11874,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._residcontour
+        plotobj = self._contour_types["resid"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11938,7 +11923,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._ratiocontour
+        plotobj = self._contour_types["ratio"]
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
@@ -11982,7 +11967,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._psfcontour
+        plotobj = self._contour_types["psf"]
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
@@ -12027,7 +12012,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._kernelcontour
+        plotobj = self._contour_types["kernel"]
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10791,8 +10791,10 @@ class Session(NoNewAttributesAfterInit):
             data = None
 
         plotobj = self._get_plotobj("data", data=data)
-        if recalc:
-            plotobj.prepare(data, self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(data, self.get_stat())
         return plotobj
 
     # DOC-TODO: discussion of preferences needs better handling
@@ -10955,9 +10957,10 @@ class Session(NoNewAttributesAfterInit):
             data = None
 
         plotobj = self._get_plotobj("model", data=data)
-        if recalc:
-            plotobj.prepare(data, self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(data, self.get_model(id), self.get_stat())
         return plotobj
 
     # also in sherpa.astro.utils (does not copy this docstring)
@@ -11028,9 +11031,10 @@ class Session(NoNewAttributesAfterInit):
             data = None
 
         plotobj = self._get_plotobj("source", data=data)
-        if recalc:
-            plotobj.prepare(data, self.get_source(id), self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(data, self.get_source(id), self.get_stat())
         return plotobj
 
     def get_model_component_plot(self, id, model=None, recalc=True):
@@ -11103,9 +11107,10 @@ class Session(NoNewAttributesAfterInit):
             data = None
 
         plotobj = self._get_plotobj("model_component", data=data)
-        if recalc:
-            plotobj.prepare(data, model, self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(data, model, self.get_stat())
         return plotobj
 
     def get_source_component_plot(self, id, model=None, recalc=True):
@@ -11183,9 +11188,10 @@ class Session(NoNewAttributesAfterInit):
         else:
             plotobj = self._get_plotobj("source_component", data=data)
 
-        if recalc:
-            plotobj.prepare(data, model, self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(data, model, self.get_stat())
         return plotobj
 
     def get_model_plot_prefs(self, id=None):
@@ -11304,13 +11310,12 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("fit")
+        if not recalc:
+            return plotobj
 
         dataobj = self.get_data_plot(id, recalc=recalc)
         modelobj = self.get_model_plot(id, recalc=recalc)
-
-        if recalc:
-            plotobj.prepare(dataobj, modelobj)
-
+        plotobj.prepare(dataobj, modelobj)
         return plotobj
 
     def get_resid_plot(self, id=None, recalc=True):
@@ -11369,9 +11374,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("resid")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_delchi_plot(self, id=None, recalc=True):
@@ -11431,9 +11437,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("delchi")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_chisqr_plot(self, id=None, recalc=True):
@@ -11493,9 +11500,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("chisqr")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_ratio_plot(self, id=None, recalc=True):
@@ -11555,9 +11563,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("ratio")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_data_contour(self, id=None, recalc=True):
@@ -11604,8 +11613,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("data")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_data(id), self.get_stat())
         return plotobj
 
     def get_data_contour_prefs(self):
@@ -11702,8 +11713,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("model")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_source_contour(self, id=None, recalc=True):
@@ -11750,8 +11763,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("source")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
         return plotobj
 
     def get_model_contour_prefs(self):
@@ -11852,12 +11867,12 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("fit")
+        if not recalc:
+            return plotobj
 
-        if recalc:
-            dataobj = self.get_data_contour(id, recalc=recalc)
-            modelobj = self.get_model_contour(id, recalc=recalc)
-            plotobj.prepare(dataobj, modelobj)
-
+        dataobj = self.get_data_contour(id, recalc=recalc)
+        modelobj = self.get_model_contour(id, recalc=recalc)
+        plotobj.prepare(dataobj, modelobj)
         return plotobj
 
     def get_resid_contour(self, id=None, recalc=True):
@@ -11905,8 +11920,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("resid")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_ratio_contour(self, id=None, recalc=True):
@@ -11954,8 +11971,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("ratio")
-        if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
         return plotobj
 
     def get_psf_contour(self, id=None, recalc=True):
@@ -11998,8 +12017,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("psf")
-        if recalc:
-            plotobj.prepare(self.get_psf(id), self.get_data(id))
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
 
     def get_kernel_contour(self, id=None, recalc=True):
@@ -12043,8 +12064,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_contourobj("kernel")
-        if recalc:
-            plotobj.prepare(self.get_psf(id), self.get_data(id))
+        if not recalc:
+            return plotobj
+
+        plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
 
     def get_psf_plot(self, id=None, recalc=True):
@@ -12086,9 +12109,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("psf")
-        if recalc:
-            plotobj.prepare(self.get_psf(id), self.get_data(id))
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
 
     def get_kernel_plot(self, id=None, recalc=True):
@@ -12130,9 +12154,10 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._get_plotobj("kernel")
-        if recalc:
-            plotobj.prepare(self.get_psf(id), self.get_data(id))
+        if not recalc:
+            return plotobj
 
+        plotobj.prepare(self.get_psf(id), self.get_data(id))
         return plotobj
 
     #
@@ -14702,15 +14727,16 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._intproj
-        if recalc:
-            par = self._check_par(par)
-            if otherids is None:
-                otherids = ()
-            ids, fit = self._get_fit(id, otherids)
-            plotobj.prepare(min=min, max=max, nloop=nloop, delv=delv,
-                            fac=fac, log=log, numcores=numcores)
-            plotobj.calc(fit, par, self._methods)
+        if not recalc:
+            return plotobj
 
+        par = self._check_par(par)
+        if otherids is None:
+            otherids = ()
+        ids, fit = self._get_fit(id, otherids)
+        plotobj.prepare(min=min, max=max, nloop=nloop, delv=delv,
+                        fac=fac, log=log, numcores=numcores)
+        plotobj.calc(fit, par, self._methods)
         return plotobj
 
     # DOC-NOTE: Check that this works (since get_int_proj may not) when
@@ -14810,16 +14836,17 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._intunc
-        if recalc:
-            par = self._check_par(par)
-            if otherids is None:
-                otherids = ()
-            ids, fit = self._get_fit(id, otherids)
-            plotobj.prepare(min=min, max=max, nloop=nloop, delv=delv,
-                            fac=fac, log=sherpa.utils.bool_cast(log),
-                            numcores=numcores)
-            plotobj.calc(fit, par)
+        if not recalc:
+            return plotobj
 
+        par = self._check_par(par)
+        if otherids is None:
+            otherids = ()
+        ids, fit = self._get_fit(id, otherids)
+        plotobj.prepare(min=min, max=max, nloop=nloop, delv=delv,
+                        fac=fac, log=sherpa.utils.bool_cast(log),
+                        numcores=numcores)
+        plotobj.calc(fit, par)
         return plotobj
 
     def get_reg_proj(self, par0=None, par1=None, id=None, otherids=None,
@@ -14934,18 +14961,19 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._regproj
-        if recalc:
-            par0 = self._check_par(par0, 'par0')
-            par1 = self._check_par(par1, 'par1')
-            if otherids is None:
-                otherids = ()
-            ids, fit = self._get_fit(id, otherids)
-            plotobj.prepare(fast=fast, min=min, max=max,
-                            nloop=nloop, delv=delv, fac=fac,
-                            log=log, sigma=sigma, levels=levels,
-                            numcores=numcores)
-            plotobj.calc(fit, par0, par1, self._methods)
+        if not recalc:
+            return plotobj
 
+        par0 = self._check_par(par0, 'par0')
+        par1 = self._check_par(par1, 'par1')
+        if otherids is None:
+            otherids = ()
+        ids, fit = self._get_fit(id, otherids)
+        plotobj.prepare(fast=fast, min=min, max=max,
+                        nloop=nloop, delv=delv, fac=fac,
+                        log=log, sigma=sigma, levels=levels,
+                        numcores=numcores)
+        plotobj.calc(fit, par0, par1, self._methods)
         return plotobj
 
     def get_reg_unc(self, par0=None, par1=None, id=None, otherids=None,
@@ -15060,19 +15088,20 @@ class Session(NoNewAttributesAfterInit):
         """
 
         plotobj = self._regunc
-        if recalc:
-            par0 = self._check_par(par0, 'par0')
-            par1 = self._check_par(par1, 'par1')
+        if not recalc:
+            return plotobj
 
-            if otherids is None:
-                otherids = ()
-            ids, fit = self._get_fit(id, otherids)
-            plotobj.prepare(min=min, max=max,
-                            nloop=nloop, delv=delv, fac=fac,
-                            log=log, sigma=sigma, levels=levels,
-                            numcores=numcores)
-            plotobj.calc(fit, par0, par1)
+        par0 = self._check_par(par0, 'par0')
+        par1 = self._check_par(par1, 'par1')
 
+        if otherids is None:
+            otherids = ()
+        ids, fit = self._get_fit(id, otherids)
+        plotobj.prepare(min=min, max=max,
+                        nloop=nloop, delv=delv, fac=fac,
+                        log=log, sigma=sigma, levels=levels,
+                        numcores=numcores)
+        plotobj.calc(fit, par0, par1)
         return plotobj
 
     # DOC-NOTE: I am not convinced I have fac described correctly

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -366,16 +366,16 @@ class Session(NoNewAttributesAfterInit):
         self._plot_types = {
             "data": [self._dataplot, self._datahistplot],
             "model": [self._modelplot, self._modelhistplot],
+            "model_component": [self._compmdlplot, self._compmdlhistplot],
             "source": [self._sourceplot, self._sourcehistplot],
+            "source_component": [self._compsrcplot, self._compsrchistplot],
             "fit": [self._fitplot],
             "resid": [self._residplot],
             "ratio": [self._ratioplot],
             "delchi": [self._delchiplot],
             "chisqr": [self._chisqrplot],
             "psf": [self._psfplot],
-            "kernel": [self._kernelplot],
-            "source_component": [self._compsrcplot],
-            "model_component": [self._compmdlplot]
+            "kernel": [self._kernelplot]
         }
 
         # Temporary aliases so that calls to set_xlog/.. will still succeed,
@@ -1366,6 +1366,23 @@ class Session(NoNewAttributesAfterInit):
         """Is this a valid contour type?"""
 
         return plottype in self._contour_types
+
+    def _get_plotobj(self, plottype, data=None):
+        """Select the plot object for the given plottype.
+
+        The current mechanism to chose a specific type of object
+        is not particularly extensible.
+        """
+
+        # The assumption is that only those plottype values which have
+        # separate support for Data1D and Data1DInt plots will have
+        # the data argument set.
+        #
+        pos = 0
+        if data is not None and isinstance(data, sherpa.data.Data1DInt):
+            pos = 1
+
+        return self._plot_types[plottype][pos]
 
     def _get_contourobj(self, plottype):
         """Select the contour object for the given plottype."""
@@ -10777,20 +10794,16 @@ class Session(NoNewAttributesAfterInit):
         # changed type since get_data_plot was last called.
         #
         try:
-            is_int = isinstance(self.get_data(id), sherpa.data.Data1DInt)
+            data = self.get_data(id)
         except IdentifierErr as ie:
             if recalc:
                 raise ie
 
-            is_int = False
+            data = None
 
-        if is_int:
-            plotobj = self._datahistplot
-        else:
-            plotobj = self._dataplot
-
+        plotobj = self._get_plotobj("data", data=data)
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_stat())
+            plotobj.prepare(data, self.get_stat())
         return plotobj
 
     # DOC-TODO: discussion of preferences needs better handling
@@ -10945,19 +10958,16 @@ class Session(NoNewAttributesAfterInit):
         """
 
         try:
-            d = self.get_data(id)
+            data = self.get_data(id)
         except IdentifierErr as ie:
             if recalc:
                 raise ie
-            d = None
 
-        if isinstance(d, sherpa.data.Data1DInt):
-            plotobj = self._modelhistplot
-        else:
-            plotobj = self._modelplot
+            data = None
 
+        plotobj = self._get_plotobj("model", data=data)
         if recalc:
-            plotobj.prepare(d, self.get_model(id), self.get_stat())
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -11021,19 +11031,16 @@ class Session(NoNewAttributesAfterInit):
                                 " You should use get_model_plot instead.")
 
         try:
-            d = self.get_data(id)
+            data = self.get_data(id)
         except IdentifierErr as ie:
             if recalc:
                 raise ie
-            d = None
 
-        if isinstance(d, sherpa.data.Data1DInt):
-            plotobj = self._sourcehistplot
-        else:
-            plotobj = self._sourceplot
+            data = None
 
+        plotobj = self._get_plotobj("source", data=data)
         if recalc:
-            plotobj.prepare(d, self.get_source(id), self.get_stat())
+            plotobj.prepare(data, self.get_source(id), self.get_stat())
 
         return plotobj
 
@@ -11099,23 +11106,19 @@ class Session(NoNewAttributesAfterInit):
         model = self._check_model(model)
 
         try:
-            d = self.get_data(id)
+            data = self.get_data(id)
         except IdentifierErr as ie:
             if recalc:
                 raise ie
-            d = None
 
-        if isinstance(d, sherpa.data.Data1DInt):
-            plotobj = self._compmdlhistplot
-        else:
-            plotobj = self._compmdlplot
+            data = None
 
+        plotobj = self._get_plotobj("model_component", data=data)
         if recalc:
-            plotobj.prepare(d, model, self.get_stat())
+            plotobj.prepare(data, model, self.get_stat())
 
         return plotobj
 
-    # sherpa.astro.utils version copies this docstring
     def get_source_component_plot(self, id, model=None, recalc=True):
         """Return the data used by plot_source_component.
 
@@ -11178,21 +11181,21 @@ class Session(NoNewAttributesAfterInit):
         model = self._check_model(model)
 
         try:
-            d = self.get_data(id)
+            data = self.get_data(id)
         except IdentifierErr as ie:
             if recalc:
                 raise ie
-            d = None
 
+            data = None
+
+        # This does not match other plots
         if isinstance(model, sherpa.models.TemplateModel):
             plotobj = self._comptmplsrcplot
-        elif isinstance(d, sherpa.data.Data1DInt):
-            plotobj = self._compsrchistplot
         else:
-            plotobj = self._compsrcplot
+            plotobj = self._get_plotobj("source_component", data=data)
 
         if recalc:
-            plotobj.prepare(d, model, self.get_stat())
+            plotobj.prepare(data, model, self.get_stat())
 
         return plotobj
 
@@ -11311,7 +11314,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._fitplot
+        plotobj = self._get_plotobj("fit")
 
         dataobj = self.get_data_plot(id, recalc=recalc)
         modelobj = self.get_model_plot(id, recalc=recalc)
@@ -11376,7 +11379,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._residplot
+        plotobj = self._get_plotobj("resid")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
@@ -11438,7 +11441,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._delchiplot
+        plotobj = self._get_plotobj("delchi")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
@@ -11500,7 +11503,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._chisqrplot
+        plotobj = self._get_plotobj("chisqr")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
@@ -11562,7 +11565,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._ratioplot
+        plotobj = self._get_plotobj("ratio")
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
@@ -12093,7 +12096,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._psfplot
+        plotobj = self._get_plotobj("psf")
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
 
@@ -12137,7 +12140,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._kernelplot
+        plotobj = self._get_plotobj("kernel")
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
 
@@ -12651,7 +12654,7 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    # DOC-NOTE: also in sherpa.astro.utils
+    # DOC-NOTE:
     #  - we include a description of the DataPHA handling here
     #    even though its only relevant to sherpa.astro.ui
     #
@@ -12735,8 +12738,8 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    # DOC-NOTE: also in sherpa.astro.utils, for now copies this text
-    #           but does the astro version support a bkg_id parameter?
+    # DOC-NOTE: should the astro version support a bkg_id parameter?
+    #           (at the moment it re-uses this routine)
     def plot_source_component(self, id, model=None, replot=False,
                               overplot=False, clearwindow=True, **kwargs):
         """Plot a component of the source expression for a data set.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -429,15 +429,15 @@ class Session(NoNewAttributesAfterInit):
         # contour().
         #
         self._image_types = {
-            'data': sherpa.image.DataImage(),
-            'model': sherpa.image.ModelImage(),
-            'source': sherpa.image.SourceImage(),
-            'ratio': sherpa.image.RatioImage(),
-            'resid': sherpa.image.ResidImage(),
-            'psf': sherpa.image.PSFImage(),
-            'kernel': sherpa.image.PSFKernelImage(),
-            'model_component': sherpa.image.ComponentModelImage(),
-            'source_component': sherpa.image.ComponentSourceImage()
+            "data": sherpa.image.DataImage(),
+            "model": sherpa.image.ModelImage(),
+            "source": sherpa.image.SourceImage(),
+            "ratio": sherpa.image.RatioImage(),
+            "resid": sherpa.image.ResidImage(),
+            "psf": sherpa.image.PSFImage(),
+            "kernel": sherpa.image.PSFKernelImage(),
+            "model_component": sherpa.image.ComponentModelImage(),
+            "source_component": sherpa.image.ComponentSourceImage()
         }
 
     def save(self, filename='sherpa.save', clobber=False):
@@ -12139,15 +12139,15 @@ class Session(NoNewAttributesAfterInit):
     # Line plots
     #
 
-    def _multi_plot(self, args, plotmeth='plot', **kwargs):
+    def _multi_plot(self, args, plotmeth="plot", **kwargs):
         if len(args) == 0:
-            raise ArgumentTypeErr('plotargs')
+            raise ArgumentTypeErr("plotargs")
 
-        if plotmeth not in ['plot', 'contour']:
-            raise ArgumentErr("Unsupported plotmeth={}".format(plotmeth))
+        if plotmeth not in ["plot", "contour"]:
+            raise ArgumentErr(f"Unsupported plotmeth={plotmeth}")
 
         plots = []
-        allowed_types = getattr(self, '_{}_type_names'.format(plotmeth))
+        allowed_types = getattr(self, f"_{plotmeth}_type_names")
         args = list(args)
 
         while args:
@@ -12158,7 +12158,7 @@ class Session(NoNewAttributesAfterInit):
             try:
                 plotname = allowed_types[plottype]
             except KeyError:
-                raise ArgumentErr('badplottype', plottype) from None
+                raise ArgumentErr("badplottype", plottype) from None
 
             # Collect the arguments for the get_<>_plot/contour
             # call. Loop through until we hit a supported
@@ -12171,7 +12171,7 @@ class Session(NoNewAttributesAfterInit):
 
                 getargs.append(args.pop(0))
 
-            funcname = 'get_{}_{}'.format(plotname, plotmeth)
+            funcname = f"get_{plotname}_{plotmeth}"
             getfunc = getattr(self, funcname)
 
             # Need to make sure we have a copy of each plot
@@ -12181,7 +12181,7 @@ class Session(NoNewAttributesAfterInit):
             plots.append(copy.deepcopy(getfunc(*getargs)))
 
         if len(plots) == 1:
-            plotmeth = getattr(self, '_' + plotmeth)
+            plotmeth = getattr(self, f"_{plotmeth}")
             plotmeth(plots[0], **kwargs)
             return
 
@@ -12189,7 +12189,7 @@ class Session(NoNewAttributesAfterInit):
         ncols = int((len(plots) + 1) / 2.0)
         sp = self._splitplot
         sp.reset(nrows, ncols)
-        plotmeth = getattr(sp, 'add' + plotmeth)
+        plotmeth = getattr(sp, f"add{plotmeth}")
 
         try:
             sherpa.plot.backend.begin()

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1145,8 +1145,7 @@ def bool_cast(val):
 
 
 def export_method(meth, name=None, modname=None):
-    """
-    Given a bound instance method, return a simple function that wraps
+    """Given a bound instance method, return a simple function that wraps
     it.  The only difference between the interface of the original
     method and the generated function is that the latter doesn't
     include 'self' in its argument list.  This means that when the
@@ -1163,6 +1162,11 @@ def export_method(meth, name=None, modname=None):
     be a string and will be used as the module name for the generated
     function.  Note that the caller is responsible for assigning the
     returned function to an appropriate name in the calling scope.
+
+    Annotations are copied over if available. With all the changes in
+    annotation support in Python 3.10 it is not at all obvious if this
+    is sufficient or will work with the currently-supported Python
+    verions.
 
     """
 
@@ -1215,6 +1219,13 @@ def export_method(meth, name=None, modname=None):
                             new_meth.__name__, defaults,
                             new_meth.__closure__)
     new_meth.__doc__ = doc
+
+    # Can we support annotations? There are changes in Python 3.10,
+    # but for now just do the simplest thing in the hope it works.
+    #
+    annotations = getattr(meth, "__annotations__", None)
+    if annotations is not None:
+        new_meth.__annotations__ = annotations
 
     return new_meth
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -18,6 +18,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# pylint: disable=line-too-long
+# pylint: disable=invalid-name
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+
 """
 Objects and utilities used by multiple Sherpa subpackages
 """
@@ -1198,6 +1204,7 @@ def export_method(meth, name=None, modname=None):
         g["__name__"] = modname
 
     fdef = f"def {name}({argspec}):  return {old_name}({argspec})"
+    # pylint: disable=exec-used
     exec(fdef, g)
 
     # Create another new function from the one we just made, this time
@@ -3233,6 +3240,8 @@ def neville2d(xinterp, yinterp, x, y, fval):
 
 class NumDeriv:
 
+    # pylint: disable=too-few-public-methods
+
     def __init__(self, func, fval0):
         self.nfev, self.func = func_counter(func)
         self.fval_0 = fval0
@@ -3275,6 +3284,8 @@ class NumDerivCentralOrdinary(NumDeriv):
 
     """
 
+    # pylint: disable=too-few-public-methods
+
     # TODO: can we remove this as it is the only class that allows
     # fval0 to be optional?
     #
@@ -3289,6 +3300,7 @@ class NumDerivCentralOrdinary(NumDeriv):
 
 class NumDerivFowardPartial(NumDeriv):
 
+    # pylint: disable=too-few-public-methods
 
     def __call__(self, x, h, *args):
 
@@ -3352,6 +3364,7 @@ class NumDerivCentralPartial(NumDeriv):
         h ~ r^1/4
     """
 
+    # pylint: disable=too-few-public-methods
 
     def __call__(self, x, h, *args):
 
@@ -3397,6 +3410,8 @@ class NumDerivCentralPartial(NumDeriv):
 
 class NoRichardsonExtrapolation:
 
+    # pylint: disable=too-few-public-methods
+
     def __init__(self, sequence, verbose=False):
         self.sequence = sequence
         self.verbose = verbose
@@ -3419,6 +3434,7 @@ class RichardsonExtrapolation(NoRichardsonExtrapolation):
     2. Richardson, L. F. (1927). \" The deferred approach to the limit \".
     Philosophical Transactions of the Royal Society of London, Series A 226:"""
 
+    # pylint: disable=too-few-public-methods
 
     def __call__(self, x, t, tol, maxiter, h, *args):
 
@@ -3662,6 +3678,8 @@ class OutOfBoundErr:
 class QuadEquaRealRoot:
     """ solve for the real roots of the quadratic equation:
     a * x^2 + b * x + c = 0"""
+
+    # pylint: disable=too-few-public-methods
 
     def __call__(self, a, b, c):
 


### PR DESCRIPTION
An example of adding type annotations to try out #1501. What is interesting (in this particular work) is what "interfaces" we end up relying on. There are a number of cases where we basically want to say "we return an object that follows this interface" but our current setup isn't designed like this (we don't really use metaclasses to create protocols/interfaces, instead rely on just straight subclasses. Does this suggest that we might want to use a more metaclass approach, or is it worth not breaking things that aren't broken.

I have been using `mypy` to validate this, (I have now tried with `mypy` using python 3.10 and 3.7). However, even with a number of methods annotated I am not convinced this has correctly caught the best type annotations. I expect that there can be some places where annotating a new method/module may cause a number of related changes to existing annotations. There's also some functionality in 3.10 (or later) that may be helpful (eg type guards), that we could think about requiring type_extensions.

One interesting thing to think about from this work, as it deals with the ui layer, is that we have routines like

    def set_model(id, model=None):

(dropping the `self` argument for exposition) which can actually be used as

    set_model(a_model)
    set_model(idval, a_model)

that is, even though the first argument is labelled `id` it is actually somewhat amorphous in its meaning: if only one argument is given it actually means the `model` argument and the default `id` is used, but if two positional arguments are given then the first argument is the `id`. I decided I didn't want to deal with that in my first play around.

This is based on #1524 #1516 #1513 - currently only the last commit is actually part of this PR
 
I will note that `sherpa/ui/uitils.py` will not validate via `mypy` but that's mnot my fault as it is an existing bit of code and it is rather low-level so I don't feel like worrying about it just yet:

```
% mypy sherpa/ui/utils.py 
sherpa/ui/utils.py:185: error: Argument 1 to "constructor" has incompatible type "Callable[[Any, Any], Any]"; expected "Callable[[Union[Tuple[Callable[..., Any], Tuple[Any, ...]], Tuple[Callable[..., Any], Tuple[Any, ...], Optional[Any]]]], Any]"
Found 1 error in 1 file (checked 1 source file)
```