### PR TITLE
Add arguments to -i in sed calls in config script

### DIFF
--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -99,4 +99,4 @@ sed -i="" "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i="" "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg
 
 # Depending on the version of sed, there might be a temporary file. Remove it if it exists.
-rm -r setup.cfg=
+rm -f setup.cfg=

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -98,5 +98,5 @@ sed -i="" "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/inclu
 sed -i="" "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i="" "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg
 
-# The notgnused version makes a temporary file. Remove it if it exists.
+# Depending on the version of sed, there might be a temporary file. Remove it if it exists.
 rm -r setup.cfg=

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -69,31 +69,34 @@ fi
 #
 echo "Updating $cfg"
 
-sed -i "s|#install_dir=build|install_dir=${CONDA_PREFIX}|" $cfg
-sed -i "s|#configure=None|configure=None|" $cfg
+sed -i="" "s|#install_dir=build|install_dir=${CONDA_PREFIX}|" $cfg
+sed -i="" "s|#configure=None|configure=None|" $cfg
 
-sed -i "s|#disable-group=True|disable-group=True|" $cfg
-sed -i "s|#disable-stk=True|disable-stk=True|" $cfg
+sed -i="" "s|#disable-group=True|disable-group=True|" $cfg
+sed -i="" "s|#disable-stk=True|disable-stk=True|" $cfg
 
-sed -i "s|#region=local|region=local|" $cfg
-sed -i "s|#region-include_dirs=build/include|region-include_dirs=${CONDA_PREFIX}/include|" $cfg
-sed -i "s|#region-lib-dirs=build/lib|region-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
-sed -i "s|#region-libraries=region|region-libraries=region ascdm|" $cfg
-sed -i "s|#region-use-cxc-parser=False|region-use-cxc-parser=True|" $cfg
+sed -i="" "s|#region=local|region=local|" $cfg
+sed -i="" "s|#region-include_dirs=build/include|region-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#region-lib-dirs=build/lib|region-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i="" "s|#region-libraries=region|region-libraries=region ascdm|" $cfg
+sed -i="" "s|#region-use-cxc-parser=False|region-use-cxc-parser=True|" $cfg
 
-sed -i "s|#wcs=local|wcs=local|" $cfg
+sed -i="" "s|#wcs=local|wcs=local|" $cfg
 # Historically the setup file has used the wrong form here
 # so support both 'include-dirs' and 'include_dirs'.
-sed -i "s|#wcs-include.dirs=build/include|wcs-include_dirs=${CONDA_PREFIX}/include|" $cfg
-sed -i "s|#wcs-lib-dirs=build/lib|wcs-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
-sed -i "s|#wcs-libraries=wcs|wcs-libraries=wcs|" $cfg
+sed -i="" "s|#wcs-include.dirs=build/include|wcs-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#wcs-lib-dirs=build/lib|wcs-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i="" "s|#wcs-libraries=wcs|wcs-libraries=wcs|" $cfg
 
-sed -i "s|#fftw=local|fftw=local|" $cfg
-sed -i "s|#fftw-include_dirs=build/include|fftw-include_dirs=${CONDA_PREFIX}/include|" $cfg
-sed -i "s|#fftw-lib-dirs=build/lib|fftw-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
-sed -i "s|#fftw-libraries=fftw3|fftw-libraries=fftw3|" $cfg
+sed -i="" "s|#fftw=local|fftw=local|" $cfg
+sed -i="" "s|#fftw-include_dirs=build/include|fftw-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#fftw-lib-dirs=build/lib|fftw-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i="" "s|#fftw-libraries=fftw3|fftw-libraries=fftw3|" $cfg
 
-sed -i "s|#with-xspec=True|with-xspec=True|" $cfg
-sed -i "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|" $cfg
-sed -i "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
-sed -i "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg
+sed -i="" "s|#with-xspec=True|with-xspec=True|" $cfg
+sed -i="" "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i="" "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg
+
+# The notgnused version makes a temporary file. Remove it if it exists.
+rm -r setup.cfg=


### PR DESCRIPTION
In BSD sed (which is the version installed on MacOS) the argument
after -i is MANDATORY. Without it, one gets error messages like

sed: 1: "setup.cfg": unterminated substitute pattern

and no substitution takes place. The underlying cause is that, on that version of sed, the first part of the substitution pattern is read as the argument for `i`, leading to a pattern that is then too short.
See https://stackoverflow.com/questions/28592043/what-is-wrong-with-my-string-substitution-using-sed-on-mac-os-x for further comments.

Now, I hope that this fix does not break that GNU/Linux use now...