### PR TITLE
Add plot related tests

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -315,8 +315,6 @@ def test_save_data_ascii(session, kwargs, idval, tmp_path):
     outfile = tmp_path / "data.dat"
     save_ascii_file(s, kwargs, idval, outfile, s.save_data)
 
-    print(outfile.read_text())
-
     names, data = get_data(outfile, ncols=4)
     assert names == ["XLO", "XHI", "Y", "STATERROR"]
     assert len(data) == 4
@@ -430,7 +428,6 @@ def test_show_data(session, flag):
     s.show_data(outfile=out)
 
     toks = out.getvalue().split("\n")
-    print(out.getvalue())
     assert toks[0] == "Data Set: 1"
     idx = 1
     if flag:

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -601,3 +601,37 @@ def test_show_fit(session):
     assert toks[31] == ""
 
     assert len(toks) == 32
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("label", ["proj", "unc"])
+def test_get_int_xxx_recalc_false(session, label):
+    """Check we call the recalc=False path, even with no data loaded."""
+
+    s = session()
+    getfunc= getattr(s, f"get_int_{label}")
+    plotobj = getfunc(recalc=False)
+
+    name = "Uncertainty" if label == "unc" else "Projection"
+    expected = getattr(sherpa.plot, f"Interval{name}")
+    assert isinstance(plotobj, expected)
+
+    # check it's empty (only need a single field check)
+    assert plotobj.x is None
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("label", ["proj", "unc"])
+def test_get_reg_xxx_recalc_false(session, label):
+    """Check we call the recalc=False path, even with no data loaded."""
+
+    s = session()
+    getfunc= getattr(s, f"get_reg_{label}")
+    plotobj = getfunc(recalc=False)
+
+    name = "Uncertainty" if label == "unc" else "Projection"
+    expected = getattr(sherpa.plot, f"Region{name}")
+    assert isinstance(plotobj, expected)
+
+    # check it's empty (only need a single field check)
+    assert plotobj.x0 is None

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -79,21 +79,21 @@ def test_zero_division_calc_stat():
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_name_default(session):
-    s = Session()
+    s = session()
     assert s.get_iter_method_name() == "none"
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("opt", ["none", "sigmarej"])
 def test_set_iter_method_valid(session, opt):
-    s = Session()
+    s = session()
     s.set_iter_method(opt)
     assert s.get_iter_method_name() == opt
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_set_iter_method_unknown_string(session):
-    s = Session()
+    s = session()
     with pytest.raises(TypeError,
                        match="^not a method is not an iterative fitting method$"):
         s.set_iter_method("not a method")
@@ -101,7 +101,7 @@ def test_set_iter_method_unknown_string(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_set_iter_method_not_a_string(session):
-    s = Session()
+    s = session()
     with pytest.raises(ArgumentTypeErr,
                        match="^'meth' must be a string$"):
         s.set_iter_method(23)
@@ -109,13 +109,13 @@ def test_set_iter_method_not_a_string(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_opt_default(session):
-    s = Session()
+    s = session()
     assert s.get_iter_method_opt() == {}
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_opt_sigmarej(session):
-    s = Session()
+    s = session()
     s.set_iter_method("sigmarej")
     out = s.get_iter_method_opt()
 
@@ -125,7 +125,7 @@ def test_get_iter_method_opt_sigmarej(session):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_get_iter_method_opt_sigmarej_lrej(session):
-    s = Session()
+    s = session()
     s.set_iter_method("sigmarej")
     assert s.get_iter_method_opt("lrej") == pytest.approx(3)
 
@@ -133,7 +133,7 @@ def test_get_iter_method_opt_sigmarej_lrej(session):
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("opt,key", [("none", "lrej"), ("sigmarej", "fast")])
 def test_get_iter_method_opt_unknown(session, opt, key):
-    s = Session()
+    s = session()
     s.set_iter_method(opt)
     with pytest.raises(ArgumentErr,
                        match=f"^'{key}' is not a valid option for method {opt}$"):
@@ -142,7 +142,7 @@ def test_get_iter_method_opt_unknown(session, opt, key):
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_set_iter_method_opt_sigmarej_lrej(session):
-    s = Session()
+    s = session()
     s.set_iter_method("sigmarej")
     s.set_iter_method_opt("lrej", 5)
     assert s.get_iter_method_opt("lrej") == pytest.approx(5)

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -158,7 +158,10 @@ def test_id_checks_session(session, setting):
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
-@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace'])
+@pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace',
+                                     "bkg_model", "bkg_source", "bkg_resid", "bkg_ratio",
+                                     "bkg_delchi", "bkg_chisqr", "bkg_fit"
+                                     ])
 def test_id_checks_session_unexpected(session, setting):
     """These identifiers are allowed. Should they be?"""
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -4087,6 +4087,87 @@ def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
     assert axes[0].yaxis.get_scale() == yscale
 
 
+SET_CPT_ARGS = [("compsource", ui.get_source_component_plot),
+                # ("source_component", ui.get_source_component_plot),
+                ("compmodel", ui.get_model_component_plot),
+                # ("model_component", ui.get_model_component_plot)
+                ]
+
+@requires_plotting
+@pytest.mark.parametrize("plot,get", SET_CPT_ARGS)
+def test_set_ylog_foo_component_data1d(plot, get, clean_astro_ui):
+    """Check y axis after_ylog('<component type>'), Data1D data.
+
+    There has been some confusion in the code over whether this
+    works or not, so this is a regression test.
+
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [4, 7, 5])
+    ui.set_source(ui.const1d.mdl)
+    mdl.c0 = 6
+
+    plotobj = get(mdl, recalc=False)
+
+    assert not plotobj.plot_prefs["xlog"]
+    assert not plotobj.plot_prefs["ylog"]
+
+    ui.set_ylog(plot)
+
+    assert not plotobj.plot_prefs["xlog"]
+    assert plotobj.plot_prefs["ylog"]
+
+
+@requires_plotting
+@pytest.mark.parametrize("plot,get", SET_CPT_ARGS)
+def test_set_ylog_foo_component_data1dint(plot, get, clean_astro_ui):
+    """Check y axis after_ylog('<component type>'), Data1DInt data.
+
+    There has been some confusion in the code over whether this
+    works or not, so this is a regression test.
+
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [2, 2.5, 6], [4, 7, 5], ui.Data1DInt)
+    ui.set_source(ui.const1d.mdl)
+    mdl.c0 = 6
+
+    plotobj = get(mdl, recalc=False)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert not plotobj.histo_prefs["ylog"]
+
+    ui.set_ylog(plot)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert not plotobj.histo_prefs["ylog"]  # Really this should be set
+
+
+@requires_plotting
+@pytest.mark.parametrize("plot,get", SET_CPT_ARGS)
+def test_set_ylog_foo_component_datapha(plot, get, clean_astro_ui):
+    """Check y axis after_ylog('<component type>'), DataPHA data.
+
+    There has been some confusion in the code over whether this
+    works or not, so this is a regression test.
+
+    """
+
+    ui.load_arrays(1, [1, 2, 3], [4, 7, 5], ui.DataPHA)
+    ui.set_source(ui.const1d.mdl)
+    mdl.c0 = 6
+
+    plotobj = get(mdl, recalc=False)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert not plotobj.histo_prefs["ylog"]
+
+    ui.set_ylog(plot)
+
+    assert not plotobj.histo_prefs["xlog"]
+    assert plotobj.histo_prefs["ylog"]
+
+
 @requires_plotting
 def test_pha_model_plot_filter_range_manual_1024(clean_astro_ui):
     """Check if issue #1024 is fixed.

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -2423,3 +2423,26 @@ def test_pha_set_filter_masked_wrong(simple_pha):
         ui.set_filter(np.asarray([True, False]))
 
     assert str(err.value) == "size mismatch between 5 and 2"
+
+
+def test_get_arf_not_pha(clean_astro_ui):
+    ui.load_arrays(1, [1, 2], [1, 2], ui.DataPHA)
+    ui.load_arrays(2, [1, 2], [1, 2])
+    with pytest.raises(ArgumentErr,
+                       match="data set 2 does not contain PHA data"):
+        ui.get_arf_plot(2)
+
+
+def test_get_arf_no_pha(clean_astro_ui):
+    ui.load_arrays(1, [1, 2], [1, 2], ui.DataPHA)
+    with pytest.raises(DataErr,
+                       match="data set '1' does not have an associated ARF"):
+        ui.get_arf_plot()
+
+
+def test_get_order_not_pha(clean_astro_ui):
+    ui.load_arrays(1, [1, 2], [1, 2], ui.DataPHA)
+    ui.load_arrays(2, [1, 2], [1, 2])
+    with pytest.raises(ArgumentErr,
+                       match="data set 2 does not contain PHA data"):
+        ui.get_order_plot(2)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021
+#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -497,8 +497,10 @@ def test_source_component_arbitrary_grid(session):
         ui.set_source(regrid_model)
 
         ui.plot_source_component(regrid_model)
-        assert (ui._compsrcplot.x == x).all()
-        assert ui._compsrcplot.y == pytest.approx(yy)
+
+        splot = ui.get_source_component_plot(regrid_model, recalc=False)
+        assert (splot.x == x).all()
+        assert splot.y == pytest.approx(yy)
 
     x = [1, 2, 3]
     y = [1, 2, 3]
@@ -530,10 +532,10 @@ def test_plot_model_arbitrary_grid_integrated(session):
         ui.set_model(regrid_model)
         ui.plot_model()
 
-        # should this use ui.get_model_plot()?
-        assert ui._modelhistplot.xlo == pytest.approx(x[0])
-        assert ui._modelhistplot.xhi == pytest.approx(x[1])
-        assert ui._modelhistplot.y == pytest.approx(yy)
+        mplot = ui.get_model_plot(recalc=False)
+        assert mplot.xlo == pytest.approx(x[0])
+        assert mplot.xhi == pytest.approx(x[1])
+        assert mplot.y == pytest.approx(yy)
 
     tmp = numpy.arange(1, 5, 1)
     x = tmp[:-1], tmp[1:]
@@ -575,10 +577,10 @@ def test_source_component_arbitrary_grid_int(session):
     regrid_model = model.regrid(*re_x)
     ui.plot_source_component(regrid_model)
 
-    # should this use ui.get_source_component_plot()?
-    assert ui._compsrchistplot.xlo == pytest.approx(x[0])
-    assert ui._compsrchistplot.xhi == pytest.approx(x[1])
-    assert ui._compsrchistplot.y == pytest.approx([0.0, 0.0, 0.0])
+    splot = ui.get_source_component_plot(regrid_model, recalc=False)
+    assert splot.xlo == pytest.approx(x[0])
+    assert splot.xhi == pytest.approx(x[1])
+    assert splot.y == pytest.approx([0.0, 0.0, 0.0])
 
 
 def test_numpy_histogram_density_vs_normed(clean_astro_ui):

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -274,7 +274,7 @@ def test_paramprompt():
     # raised, and the text, but then we don't get to test the
     # behaviour of the paramprompt code.
     #
-    with patch("sys.stdin", StringIO(u"2.1")):
+    with patch("sys.stdin", StringIO("2.1")):
         s.set_model('const1d.mx')
 
     assert s.list_model_ids() == [1]
@@ -284,7 +284,7 @@ def test_paramprompt():
     mx = s.get_model_component('mx')
     assert mx.c0.val == pytest.approx(2.1)
 
-    with patch("sys.stdin", StringIO(u"2.1e-3 , 2.0e-3, 1.2e-2")):
+    with patch("sys.stdin", StringIO("2.1e-3 , 2.0e-3, 1.2e-2")):
         s.set_model('x', 'const1d.my')
 
     assert set(s.list_model_ids()) == set([1, 'x'])
@@ -296,7 +296,7 @@ def test_paramprompt():
     assert my.c0.min == pytest.approx(2.0e-3)
     assert my.c0.max == pytest.approx(1.2e-2)
 
-    with patch("sys.stdin", StringIO(u"2.1e-3 ,, 1.2e-2")):
+    with patch("sys.stdin", StringIO("2.1e-3 ,, 1.2e-2")):
         s.set_model(2, 'const1d.mz')
 
     assert set(s.list_model_ids()) == set([1, 2, 'x'])
@@ -308,7 +308,7 @@ def test_paramprompt():
     assert mz.c0.min == pytest.approx(- parameter.hugeval)
     assert mz.c0.max == pytest.approx(1.2e-2)
 
-    with patch("sys.stdin", StringIO(u"-12.1,-12.1")):
+    with patch("sys.stdin", StringIO("-12.1,-12.1")):
         s.set_model('const1d.f1')
 
     assert set(s.list_model_ids()) == set([1, 2, 'x'])
@@ -320,7 +320,7 @@ def test_paramprompt():
     assert f1.c0.min == pytest.approx(-12.1)
     assert f1.c0.max == pytest.approx(parameter.hugeval)
 
-    with patch("sys.stdin", StringIO(u" ,-12.1")):
+    with patch("sys.stdin", StringIO(" ,-12.1")):
         s.set_model('const1d.f2')
 
     # stop checking list_model_ids
@@ -332,7 +332,7 @@ def test_paramprompt():
     assert f2.c0.min == pytest.approx(-12.1)
     assert f2.c0.max == pytest.approx(parameter.hugeval)
 
-    with patch("sys.stdin", StringIO(u" ,")):
+    with patch("sys.stdin", StringIO(" ,")):
         s.set_model('const1d.f3')
 
     f3 = s.get_model_component('f3')
@@ -340,7 +340,7 @@ def test_paramprompt():
     assert f3.c0.min == pytest.approx(- parameter.hugeval)
     assert f3.c0.max == pytest.approx(parameter.hugeval)
 
-    with patch("sys.stdin", StringIO(u" ,, ")):
+    with patch("sys.stdin", StringIO(" ,, ")):
         s.set_model('const1d.f4')
 
     f4 = s.get_model_component('f4')

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -227,10 +227,10 @@ def change_fit(idval):
     change_model(idval)
 
 
-def check_example(xlabel='x'):
+def check_example(idval, xlabel='x'):
     """Check that the data plot has not changed"""
 
-    dplot = ui._session._dataplot
+    dplot = ui.get_data_plot(id=idval, recalc=False)
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -243,13 +243,13 @@ def check_example(xlabel='x'):
     assert dplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_example_changed(xlabel='x'):
+def check_example_changed(idval, xlabel='x'):
     """Check that the data plot has changed
 
     Assumes change_example has been called
     """
 
-    dplot = ui._session._dataplot
+    dplot = ui.get_data_plot(id=idval, recalc=False)
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -274,45 +274,44 @@ def check_model_plot(plot, title='Model', xlabel='x', modelval=35):
     assert plot.yerr is None
 
 
-def check_model(xlabel='x'):
+def check_model(idval, xlabel='x'):
     """Check that the model plot has not changed"""
 
-    check_model_plot(ui._session._modelplot,
-                     title='Model', xlabel=xlabel)
+    mplot = ui.get_model_plot(id=idval, recalc=False)
+    check_model_plot(mplot, title='Model', xlabel=xlabel)
 
 
-def check_model_changed(xlabel='x'):
+def check_model_changed(idval, xlabel='x'):
     """Check that the model plot has changed
 
     Assumes change_model has been called
     """
 
-    check_model_plot(ui._session._modelplot,
-                     title='Model', xlabel=xlabel,
-                     modelval=41)
+    mplot = ui.get_model_plot(id=idval, recalc=False)
+    check_model_plot(mplot, title='Model', xlabel=xlabel, modelval=41)
 
 
-def check_source():
+def check_source(idval):
     """Check that the source plot has not changed"""
 
-    check_model_plot(ui._session._sourceplot,
-                     title='Source')
+    splot = ui.get_source_plot(id=idval, recalc=False)
+    check_model_plot(splot, title='Source')
 
 
-def check_source_changed():
+def check_source_changed(idval):
     """Check that the source plot has changed
 
     Assumes change_model has been called
     """
 
-    check_model_plot(ui._session._sourceplot,
-                     title='Source', modelval=41)
+    splot = ui.get_source_plot(id=idval, recalc=False)
+    check_model_plot(splot, title='Source', modelval=41)
 
 
-def check_resid(title='Residuals for example'):
+def check_resid(idval, title='Residuals for example'):
     """Check that the resid plot has not changed"""
 
-    rplot = ui._session._residplot
+    rplot = ui.get_resid_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -322,13 +321,13 @@ def check_resid(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_resid_changed(title='Residuals for example'):
+def check_resid_changed(idval, title='Residuals for example'):
     """Check that the resid plot has changed
 
     Assumes that change_model has been called
     """
 
-    rplot = ui._session._residplot
+    rplot = ui.get_resid_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -338,13 +337,13 @@ def check_resid_changed(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_resid_changed2(title='Residuals for example'):
+def check_resid_changed2(idval, title='Residuals for example'):
     """Check that the resid plot has changed
 
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._residplot
+    rplot = ui.get_resid_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -354,10 +353,10 @@ def check_resid_changed2(title='Residuals for example'):
     assert rplot.yerr == pytest.approx(calc_errors(_data_y2))
 
 
-def check_ratio(title='Ratio of Data to Model for example'):
+def check_ratio(idval, title='Ratio of Data to Model for example'):
     """Check that the ratio plot has not changed"""
 
-    rplot = ui._session._ratioplot
+    rplot = ui.get_ratio_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -368,13 +367,13 @@ def check_ratio(title='Ratio of Data to Model for example'):
     assert rplot.yerr == pytest.approx(dy)
 
 
-def check_ratio_changed():
+def check_ratio_changed(idval):
     """Check that the ratio plot has changed
 
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._ratioplot
+    rplot = ui.get_ratio_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == 'Ratio of Data to Model for example'
@@ -385,13 +384,13 @@ def check_ratio_changed():
     assert rplot.yerr == pytest.approx(dy)
 
 
-def check_ratio_changed2(title='Ratio of Data to Model for example'):
+def check_ratio_changed2(idval, title='Ratio of Data to Model for example'):
     """Check that the ratio plot has changed
 
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._ratioplot
+    rplot = ui.get_ratio_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -402,10 +401,10 @@ def check_ratio_changed2(title='Ratio of Data to Model for example'):
     assert rplot.yerr == pytest.approx(dy)
 
 
-def check_delchi(title='Sigma Residuals for example'):
+def check_delchi(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has not changed"""
 
-    rplot = ui._session._delchiplot
+    rplot = ui.get_delchi_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -418,13 +417,13 @@ def check_delchi(title='Sigma Residuals for example'):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_y])
 
 
-def check_delchi_changed(title='Sigma Residuals for example'):
+def check_delchi_changed(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has changed
 
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._delchiplot
+    rplot = ui.get_delchi_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -437,13 +436,13 @@ def check_delchi_changed(title='Sigma Residuals for example'):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_x])
 
 
-def check_delchi_changed2(title='Sigma Residuals for example'):
+def check_delchi_changed2(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has changed
 
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui._session._delchiplot
+    rplot = ui.get_delchi_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -456,10 +455,10 @@ def check_delchi_changed2(title='Sigma Residuals for example'):
     assert rplot.yerr == pytest.approx([1.0 for y in _data_x])
 
 
-def check_chisqr():
+def check_chisqr(idval):
     """Check that the chisqr plot has not changed"""
 
-    rplot = ui._session._chisqrplot
+    rplot = ui.get_chisqr_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -472,13 +471,13 @@ def check_chisqr():
     assert rplot.yerr is None
 
 
-def check_chisqr_changed():
+def check_chisqr_changed(idval):
     """Check that the chisqr plot has changed
 
     Assumes that change_example has been called
     """
 
-    rplot = ui._session._chisqrplot
+    rplot = ui.get_chisqr_plot(id=idval, recalc=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -491,78 +490,78 @@ def check_chisqr_changed():
     assert rplot.yerr is None
 
 
-def check_fit():
+def check_fit(idval):
     """Check that the fit plot has not changed"""
 
-    check_example()
-    check_model()
+    check_example(idval)
+    check_model(idval)
 
 
-def check_fit_changed():
+def check_fit_changed(idval):
     """Check that the fit plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed()
-    check_model_changed()
+    check_example_changed(idval)
+    check_model_changed(idval)
 
 
-def check_fit_resid():
+def check_fit_resid(idval):
     """Check that the fit + resid plot has not changed"""
 
-    check_example(xlabel='')
-    check_model(xlabel='')
-    check_resid(title='')
+    check_example(idval, xlabel='')
+    check_model(idval, xlabel='')
+    check_resid(idval, title='')
 
 
-def check_fit_resid_changed():
+def check_fit_resid_changed(idval):
     """Check that the fit + resid plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed(xlabel='')
-    check_model_changed(xlabel='')
-    check_resid_changed2(title='')
+    check_example_changed(idval, xlabel='')
+    check_model_changed(idval, xlabel='')
+    check_resid_changed2(idval, title='')
 
 
-def check_fit_ratio():
+def check_fit_ratio(idval):
     """Check that the fit + ratio plot has not changed"""
 
-    check_example(xlabel='')
-    check_model(xlabel='')
-    check_ratio(title='')
+    check_example(idval, xlabel='')
+    check_model(idval, xlabel='')
+    check_ratio(idval, title='')
 
 
-def check_fit_ratio_changed():
+def check_fit_ratio_changed(idval):
     """Check that the fit + ratio plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed(xlabel='')
-    check_model_changed(xlabel='')
-    check_ratio_changed2(title='')
+    check_example_changed(idval, xlabel='')
+    check_model_changed(idval, xlabel='')
+    check_ratio_changed2(idval, title='')
 
 
-def check_fit_delchi():
+def check_fit_delchi(idval):
     """Check that the fit + delchi plot has not changed"""
 
-    check_example(xlabel='')
-    check_model(xlabel='')
-    check_delchi(title='')
+    check_example(idval, xlabel='')
+    check_model(idval, xlabel='')
+    check_delchi(idval, title='')
 
 
-def check_fit_delchi_changed():
+def check_fit_delchi_changed(idval):
     """Check that the fit + delchi plot has changed
 
     Assumes that change_fit has been called
     """
 
-    check_example_changed(xlabel='')
-    check_model_changed(xlabel='')
-    check_delchi_changed2(title='')
+    check_example_changed(idval, xlabel='')
+    check_model_changed(idval, xlabel='')
+    check_delchi_changed2(idval, title='')
 
 
 _plot_all = [
@@ -628,7 +627,7 @@ def test_plot_xxx(idval, pfunc, checkfunc, clean_ui):
     else:
         pfunc(idval)
 
-    checkfunc()
+    checkfunc(idval)
 
 
 @requires_plotting
@@ -672,7 +671,7 @@ def test_plot_xxx_replot(idval, plotfunc, changefunc, checkfunc, clean_ui):
     else:
         plotfunc(idval, replot=True)
 
-    checkfunc()
+    checkfunc(idval)
 
 
 @requires_plotting
@@ -719,31 +718,31 @@ def test_plot_xxx_change(idval, plotfunc, changefunc, checkfunc, clean_ui):
     else:
         plotfunc(idval)
 
-    checkfunc()
+    checkfunc(idval)
 
 
-_dplot = (ui.get_data_plot_prefs, "_dataplot", ui.plot_data)
-_mplot = (ui.get_model_plot_prefs, "_modelplot", ui.plot_model)
+_dplot = (ui.get_data_plot_prefs, ui.get_data_plot, ui.plot_data)
+_mplot = (ui.get_model_plot_prefs, ui.get_model_plot, ui.plot_model)
 
 
 @requires_plotting
-@pytest.mark.parametrize("getprefs,attr,plotfunc",
+@pytest.mark.parametrize("getprefs,getplot,plotfunc",
                          [_dplot, _mplot])
-def test_prefs_change_session_objects(getprefs, attr, plotfunc, clean_ui):
+def test_prefs_change_session_objects(getprefs, getplot, plotfunc, clean_ui):
     """Is a plot-preference change also reflected in the session object?
 
     This is intended to test an assumption that will be used in the
     plot_fit_xxx routines rather than of an explicit user-visible
     behavior. The test may be "obvious behavior" given how
     get_data_plot_prefs works, but DJB wanted to ensure this
-    behavior/assumption was tested.
+    behavior/assumption was tested. The setup has changed since
+    the test was written.
     """
 
-    # This has to be retrieved here, rather than passed in in the
-    # parametrize list, as the ui._session object is changed by
-    # the clean_ui fixture.
+    # This used to access the plot object directly, but is now
+    # using an accessor function.
     #
-    session = getattr(ui._session, attr)
+    session = getplot(recalc=False)
 
     # All but the last assert are just to check things are behaving
     # as expected (and stuck into one routine rather than have a
@@ -775,13 +774,13 @@ def test_prefs_change_session_objects(getprefs, attr, plotfunc, clean_ui):
 def test_prefs_change_session_objects_fit(clean_ui):
     """Is plot-preference change reflected in the fitplot session object?
 
-    This is test_prefs_change_session_objects but for the _fitplot
-    attribute. This test encodes the current behavior - so we can see
+    This is test_prefs_change_session_objects but for the fit plot
+    object. This test encodes the current behavior - so we can see
     if things change in the future - rather than being a statement
     about what we expect/want to happen.
     """
 
-    plotobj = ui._session._fitplot
+    plotobj = ui.get_fit_plot(recalc=False)
     assert plotobj.dataplot is None
     assert plotobj.modelplot is None
 
@@ -802,19 +801,19 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # We have already checked this in previous tests, but
     # just in case
     #
-    assert ui._session._dataplot.plot_prefs['xlog']
-    assert ui._session._modelplot.plot_prefs['ylog']
+    assert ui.get_data_plot(id=12, recalc=False).plot_prefs['xlog']
+    assert ui.get_model_plot(id=12, recalc=False).plot_prefs['ylog']
 
     # Now check that the fit plot has picked up these changes;
     # the simplest way is to check that the data/model plots
     # are now referencing the underlying _data/_model plot
     # attributes. An alternative would be to check that
     # plotobj.dataplot.plot_prefs['xlog'] is True
-    # which is less restrictive, but for not check the
+    # which is less restrictive, but for now check the
     # equality
     #
-    assert plotobj.dataplot is ui._session._dataplot
-    assert plotobj.modelplot is ui._session._modelplot
+    assert plotobj.dataplot is ui.get_data_plot(id=12, recalc=False)
+    assert plotobj.modelplot is ui.get_model_plot(id=12, recalc=False)
 
 
 @pytest.mark.parametrize("plotfunc", [ui.plot_cdf, ui.plot_pdf])
@@ -992,23 +991,18 @@ def test_get_kernel_plot_recalc(session):
 
 
 @requires_plotting
-@pytest.mark.parametrize("plotobj,plotfunc",
-                         [("_residplot", ui.plot_resid),
-                          ("_delchiplot", ui.plot_delchi)
+@pytest.mark.parametrize("getplot,plotfunc",
+                         [(ui.get_resid_plot, ui.plot_resid),
+                          (ui.get_delchi_plot, ui.plot_delchi)
                           ])
-def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
+def test_plot_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?
 
     Note that plot_chisqr is not included in support for ignoring
     ylog (since the data should be positive in this case).
     """
 
-    # access it this way to ensure have access to the actual
-    # object used by the session object in this test (as the
-    # clean call done by the clean_ui fixture will reset the
-    # plot objects).
-    #
-    prefs = getattr(ui._session, plotobj).plot_prefs
+    prefs = getplot(recalc=False).plot_prefs
 
     setup_example(None)
 
@@ -1024,20 +1018,15 @@ def test_plot_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
 
 
 @requires_plotting
-@pytest.mark.parametrize("plotobj,plotfunc",
-                         [("_residplot", ui.plot_fit_resid),
-                          ("_delchiplot", ui.plot_fit_delchi)
+@pytest.mark.parametrize("getplot,plotfunc",
+                         [(ui.get_resid_plot, ui.plot_fit_resid),
+                          (ui.get_delchi_plot, ui.plot_fit_delchi)
                           ])
-def test_plot_fit_resid_ignores_ylog(plotobj, plotfunc, clean_ui):
+def test_plot_fit_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?"""
 
-    # access it this way to ensure have access to the actual
-    # object used by the session object in this test (as the
-    # clean call done by the clean_ui fixture will reset the
-    # plot objects).
-    #
-    rprefs = getattr(ui._session, plotobj).plot_prefs
-    dprefs = ui._session._dataplot.plot_prefs
+    rprefs = getplot(recalc=False).plot_prefs
+    dprefs = ui.get_data_plot(recalc=False).plot_prefs
 
     setup_example(None)
 


### PR DESCRIPTION
# Summary

Add more tests to cover corner case scenarios (mostly plotting related).

# Details

This is pulled out of #1516 and adds coverage for corner cases. Note that some of these are not needed with the main branch but could be relevant if we change things in the future (such as #1516), but some areas are definitely new (e.g. they show some issues discussed in #1530).

As we have a number of plot-related changes coming in, it is useful to have these corner cases covered sooner rather than later.