### PR TITLE
Remove model instances from the global symbol table when clean is called

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -162,12 +162,9 @@ def test_does_clean_remove_model_identifiers(session):
 
     s.clean()
 
-    for store in [globals(), locals()]:
+    for store in [globals(), locals(), sys.modules["__main__"].__dict__]:
         assert "mdl1" not in store
         assert "mdl2" not in store
-
-    assert "mdl1" in sys.modules["__main__"].__dict__
-    assert "mdl2" in sys.modules["__main__"].__dict__
 
 
 def test_astro_does_clean_remove_model_identifiers():
@@ -185,12 +182,9 @@ def test_astro_does_clean_remove_model_identifiers():
 
     s.clean()
 
-    for store in [globals(), locals()]:
+    for store in [globals(), locals(), sys.modules["__main__"].__dict__]:
         assert "mdl1" not in store
         assert "mdl2" not in store
-
-    assert "mdl1" in sys.modules["__main__"].__dict__
-    assert "mdl2" in sys.modules["__main__"].__dict__
 
 
 @pytest.mark.parametrize("label", ["arf", "rmf"])

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -24,6 +24,7 @@
 from io import StringIO
 import logging
 import os
+import sys
 
 import numpy
 
@@ -40,6 +41,156 @@ from sherpa.ui.utils import Session
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, IdentifierErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("as_string", [True, False])
+def test_model_identifiers_set_globally(session, as_string):
+    """Check we create a global symbol for the models.
+
+    See also the same test in
+      sherpa/astro/ui/tests/test_astro_ui_import.py
+      sherpa/astro/ui/tests/test_astro_ui_unit.py
+
+    There shouldn't be anything do in the astro class that changes the
+    behavior here, but run tests on both just in case.
+
+    """
+
+    # The "global" symbol table depends on what has been run before. We
+    # could try and make sure that we are "clean", but this makes checking
+    # what this test is doing hard to do, so we remove the symbols just
+    # in case.
+    #
+    for name in ["mdl1", "mdl2"]:
+        try:
+            del sys.modules["__main__"].__dict__[name]
+        except KeyError:
+            pass
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10, 1)
+
+    for store in [globals(), locals(), sys.modules["__main__"].__dict__]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    if as_string:
+        s.set_source("const1d.mdl1 + gauss1d.mdl2")
+    else:
+        # Unlike 'from sherpa[.astro].ui import *', the models are not
+        # added to the global symbol table, so this can not use
+        #
+        #     s.set_source(const1d.mdl1 + gauss1d.mdl2)
+        #
+        # so the create_model_component call is used instead.
+        #
+        s.create_model_component("const1d", "mdl1")
+        s.create_model_component("gauss1d", "mdl2")
+
+    for store in [globals(), locals()]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    assert "mdl1" in sys.modules["__main__"].__dict__
+    assert "mdl2" in sys.modules["__main__"].__dict__
+
+    assert isinstance(sys.modules["__main__"].__dict__["mdl1"],
+                      sherpa.models.basic.Const1D)
+    assert isinstance(sys.modules["__main__"].__dict__["mdl2"],
+                      sherpa.models.basic.Gauss1D)
+
+    s.clean()
+
+
+def test_astro_model_identifiers_set_globally():
+    """Check we create a global symbol for the background/pileup models."""
+
+    # The "global" symbol table depends on what has been run before. We
+    # could try and make sure that we are "clean", but this makes checking
+    # what this test is doing hard to do, so we remove the symbols just
+    # in case.
+    #
+    for name in ["mdl1", "mdl2"]:
+        try:
+            del sys.modules["__main__"].__dict__[name]
+        except KeyError:
+            pass
+
+    s = AstroSession()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10, 1, dstype=DataPHA)
+
+    # Technically gauss1d is not a pileup model but it is accepted.
+    #
+    s.set_bkg_source("const1d.mdl1")
+    s.set_pileup_model("gauss1d.mdl2")
+
+    for store in [globals(), locals()]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    assert "mdl1" in sys.modules["__main__"].__dict__
+    assert "mdl2" in sys.modules["__main__"].__dict__
+
+    assert isinstance(sys.modules["__main__"].__dict__["mdl1"],
+                      sherpa.models.basic.Const1D)
+    assert isinstance(sys.modules["__main__"].__dict__["mdl2"],
+                      sherpa.models.basic.Gauss1D)
+
+    s.clean()
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_does_clean_remove_model_identifiers(session):
+    """Check whether clean() will remove model identifiers.
+
+    There shouldn't be anything do in the astro class that changes the
+    behavior here, but run tests on both just in case.
+
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10, 1)
+
+    s.create_model_component("const1d", "mdl1")
+    s.create_model_component("gauss1d", "mdl2")
+
+    s.clean()
+
+    for store in [globals(), locals()]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    assert "mdl1" in sys.modules["__main__"].__dict__
+    assert "mdl2" in sys.modules["__main__"].__dict__
+
+
+def test_astro_does_clean_remove_model_identifiers():
+    """Check a few astro-related symbols."""
+
+    s = AstroSession()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10, 1, dstype=DataPHA)
+
+    # Technically gauss1d is not a pileup model but it is accepted.
+    #
+    s.set_bkg_source("const1d.mdl1")
+    s.set_pileup_model("gauss1d.mdl2")
+
+    s.clean()
+
+    for store in [globals(), locals()]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    assert "mdl1" in sys.modules["__main__"].__dict__
+    assert "mdl2" in sys.modules["__main__"].__dict__
 
 
 @pytest.mark.parametrize("label", ["arf", "rmf"])

--- a/sherpa/astro/ui/tests/test_astro_ui_import.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_import.py
@@ -1,0 +1,148 @@
+#
+#  Copyright (C) 2022
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""While frowned-upon in polite Python society, many Sherpa users
+will be using the
+
+    from sherpa.astro.ui import *
+
+form, either drectly or indirectly (when using the sherpa application
+in CIAO). So this adds some basic tests of this behavior, as there are
+a few "interesting" things to review.
+
+"""
+
+import sys
+
+import pytest
+
+from sherpa.astro.ui import *
+from sherpa.astro.ui.utils import Session
+import sherpa.models.basic
+from sherpa.ui.utils import ModelWrapper
+
+
+# Select models from sherpa.models.basic and sherpa.astro.models
+#
+MODEL_NAMES = ["const1d", "gauss2d", "lorentz1d"]
+
+
+def test_secret_session_is_created():
+    """This is a regression test.
+
+    The sherpa.ui module does not export _session but astro does.
+    """
+
+    assert isinstance(_session, Session)
+
+
+@pytest.mark.parametrize("model", MODEL_NAMES)
+def test_model_is_known(model):
+    """Check we have loaded some models"""
+
+    assert model in list_models()
+
+
+@pytest.mark.parametrize("model", MODEL_NAMES)
+def test_model_is_defined(model):
+    """Check we have loaded some models"""
+
+    assert model in globals()
+
+    sym = globals()[model]
+    assert isinstance(sym, ModelWrapper)
+
+
+@pytest.mark.parametrize("as_string", [True, False])
+def test_model_identifiers_set_globally(as_string):
+    """Check we create a global symbol for the models.
+
+    See also the same test in
+      sherpa/astro/ui/tests/test_astro_session.py
+      sherpa/astro/ui/tests/test_astro_ui_unit.py
+
+    """
+
+    # The "global" symbol table depends on what has been run before. We
+    # could try and make sure that we are "clean", but this makes checking
+    # what this test is doing hard to do, so we remove the symbols just
+    # in case.
+    #
+    for name in ["mdl1", "mdl2"]:
+        try:
+            del sys.modules["__main__"].__dict__[name]
+        except KeyError:
+            pass
+
+    dataspace1d(1, 10, 1)
+
+    for store in [globals(), locals(), sys.modules["__main__"].__dict__]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    if as_string:
+        set_source("const1d.mdl1 + gauss1d.mdl2")
+    else:
+        set_source(const1d.mdl1 + gauss1d.mdl2)
+
+    for store in [globals(), locals()]:
+        assert "mdl1" not in store
+        assert "mdl2" not in store
+
+    assert "mdl1" in sys.modules["__main__"].__dict__
+    assert "mdl2" in sys.modules["__main__"].__dict__
+
+    assert isinstance(sys.modules["__main__"].__dict__["mdl1"],
+                      sherpa.models.basic.Const1D)
+    assert isinstance(sys.modules["__main__"].__dict__["mdl2"],
+                      sherpa.models.basic.Gauss1D)
+
+    clean()
+
+
+def test_delete_model_removes_global_identifier():
+    """Check we create a global symbol for the models."""
+
+    create_model_component("const1d", "mdl1")
+    create_model_component("gauss1d", "mdl2")
+
+    assert "mdl1" in sys.modules["__main__"].__dict__
+    assert "mdl2" in sys.modules["__main__"].__dict__
+
+    delete_model_component("mdl1")
+    delete_model_component("mdl2")
+
+    assert "mdl1" not in sys.modules["__main__"].__dict__
+    assert "mdl2" not in sys.modules["__main__"].__dict__
+
+
+def test_what_happens_if_the_same_identifier_is_reused():
+    """Regression test.
+
+    It's not obvious what we want to do here.
+    """
+
+    # This could error out or set the "first" name as the winner, or
+    # the "last", or something else. Test the current behavior.
+    #
+    combined = gauss1d.bob + const1d.bob
+    assert isinstance(bob, sherpa.models.basic.Const1D)
+
+    delete_model_component("bob")

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -125,24 +125,6 @@ class Session(sherpa.ui.utils.Session):
         super().__setstate__(state)
 
     def clean(self):
-        """Clear out the current Sherpa session.
-
-        The `clean` function removes all data sets and model
-        assignments, and restores the default settings for the
-        optimisation and fit statistic.
-
-        See Also
-        --------
-        save : Save the current Sherpa session to a file.
-        restore : Load in a Sherpa session from a file.
-        save_all : Save the Sherpa session as an ASCII file.
-
-        Examples
-        --------
-
-        >>> clean()
-
-        """
         self._pileup_models = {}
         self._background_models = {}
         self._background_sources = {}
@@ -223,6 +205,8 @@ class Session(sherpa.ui.utils.Session):
         self._plot_type_names['bkgresid'] = 'bkg_resid'
         self._plot_type_names['bkgdelchi'] = 'bkg_delchi'
         self._plot_type_names['bkgchisqr'] = 'bkg_chisqr'
+
+    clean.__doc__ = sherpa.ui.utils.Session.clean.__doc__
 
     # Add ability to save attributes sepcific to the astro package.
     # Save XSPEC module settings that need to be restored.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -208,7 +208,7 @@ class Session(sherpa.ui.utils.Session):
 
     clean.__doc__ = sherpa.ui.utils.Session.clean.__doc__
 
-    # Add ability to save attributes sepcific to the astro package.
+    # Add ability to save attributes specific to the astro package.
     # Save XSPEC module settings that need to be restored.
     def save(self, filename='sherpa.save', clobber=False):
         """Save the current Sherpa session to a file.

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -663,6 +663,9 @@ def test_paramprompt_single_parameter_works(caplog):
     assert mdl.c0.min < -3e38
     assert mdl.c0.max > 3e38
 
+    # remove the bob symbol from the global table
+    s.clean()
+
 
 def test_paramprompt_single_parameter_min_works(caplog):
 
@@ -681,6 +684,9 @@ def test_paramprompt_single_parameter_min_works(caplog):
     assert mdl.c0.val == pytest.approx(1)
     assert mdl.c0.min == pytest.approx(-100)
     assert mdl.c0.max > 3e38
+
+    # remove the bob symbol from the global table
+    s.clean()
 
 
 def test_paramprompt_single_parameter_max_works(caplog):
@@ -701,6 +707,9 @@ def test_paramprompt_single_parameter_max_works(caplog):
     assert mdl.c0.min < -3e38
     assert mdl.c0.max == pytest.approx(100)
 
+    # remove the bob symbol from the global table
+    s.clean()
+
 
 def test_paramprompt_single_parameter_combo_works(caplog):
 
@@ -719,6 +728,9 @@ def test_paramprompt_single_parameter_combo_works(caplog):
     assert mdl.c0.val == pytest.approx(-2)
     assert mdl.c0.min == pytest.approx(-10)
     assert mdl.c0.max == pytest.approx(10)
+
+    # remove the bob symbol from the global table
+    s.clean()
 
 
 def test_paramprompt_single_parameter_check_invalid(caplog):
@@ -744,6 +756,9 @@ def test_paramprompt_single_parameter_check_invalid(caplog):
     assert mdl.c0.min < -3e38
     assert mdl.c0.max > 3e38
 
+    # remove the bob symbol from the global table
+    s.clean()
+
 
 def test_paramprompt_single_parameter_check_invalid_min(caplog):
 
@@ -768,6 +783,9 @@ def test_paramprompt_single_parameter_check_invalid_min(caplog):
     assert mdl.c0.min == pytest.approx(-200)
     assert mdl.c0.max > 3e38
 
+    # remove the bob symbol from the global table
+    s.clean()
+
 
 def test_paramprompt_single_parameter_check_invalid_max(caplog):
 
@@ -791,6 +809,9 @@ def test_paramprompt_single_parameter_check_invalid_max(caplog):
     assert mdl.c0.val == pytest.approx(-200)
     assert mdl.c0.min < -3e38
     assert mdl.c0.max == pytest.approx(-2)
+
+    # remove the bob symbol from the global table
+    s.clean()
 
 
 def test_paramprompt_single_parameter_check_invalid_max_out_of_bound(caplog):
@@ -822,6 +843,9 @@ def test_paramprompt_single_parameter_check_invalid_max_out_of_bound(caplog):
     assert mdl.c0.min < -3e38
     assert mdl.c0.max == pytest.approx(-200)
 
+    # remove the bob symbol from the global table
+    s.clean()
+
 
 def test_paramprompt_single_parameter_check_too_many_commas(caplog):
     """Check we tell users there was a problem"""
@@ -846,6 +870,9 @@ def test_paramprompt_single_parameter_check_too_many_commas(caplog):
     assert mdl.c0.val == pytest.approx(12)
     assert mdl.c0.min < -3e38
     assert mdl.c0.max > 3e38
+
+    # remove the bob symbol from the global table
+    s.clean()
 
 
 def test_add_user_pars_modelname_not_a_string():
@@ -876,6 +903,9 @@ def test_add_user_pars_modelname_not_a_model2():
         s.add_user_pars('foo', ['x'])
 
     assert str(exc.value) == "'foo' must be a user model"
+
+    # remove the foo symbol from the global table
+    s.clean()
 
 
 def test_paramprompt_multi_parameter(caplog):
@@ -912,6 +942,9 @@ def test_paramprompt_multi_parameter(caplog):
     assert cpt2.ampl.min == pytest.approx(-5)
     assert cpt2.ampl.max == pytest.approx(0)
 
+    # remove the bob and fred symbols from the global table
+    s.clean()
+
 
 def test_paramprompt_eof(caplog):
     """What happens when we end early?"""
@@ -947,6 +980,9 @@ def test_paramprompt_eof(caplog):
     assert cpt2.ampl.val == pytest.approx(1)
     assert cpt2.ampl.min < -3e38
     assert cpt2.ampl.max > 3e38
+
+    # remove the bob and fred symbols from the global table
+    s.clean()
 
 
 def test_delete_model_component_invalid_argument():
@@ -990,6 +1026,9 @@ def test_delete_model_component_warning(caplog):
     assert msg == "the model component 'gauss1d.mdl2' is found in model 1 and cannot be deleted"
 
     assert s.list_model_components() == ['mdl', 'mdl2']
+
+    # remove the mdl1 and mdl2 symbols from the global table
+    s.clean()
 
 
 def test_issue_16():

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -957,20 +957,18 @@ def test_delete_model_component_invalid_argument():
 
     tst = s.create_model_component('gauss1d', 'gmdl')
 
-    with pytest.raises(ArgumentTypeErr) as te:
+    with pytest.raises(ArgumentTypeErr,
+                       match="'name' must be a string"):
         s.delete_model_component(tst)
-
-    assert str(te.value) == "'name' must be a string"
 
 
 def test_delete_model_component_not_a_component():
-    """Check correct error message for non-exitant model"""
+    """Check correct error message for non-existant model"""
 
     s = Session()
-    with pytest.raises(IdentifierErr) as te:
+    with pytest.raises(IdentifierErr,
+                       match="model component 'tst' does not exist"):
         s.delete_model_component('tst')
-
-    assert str(te.value) == "model component 'tst' does not exist"
 
 
 def test_delete_model_component_warning(caplog):

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -999,7 +999,7 @@ def test_delete_model_component_invalid_argument():
 
 
 def test_delete_model_component_not_a_component():
-    """Check correct error message for non-existant model"""
+    """Check correct error message for non-existent model"""
 
     s = Session()
     with pytest.raises(IdentifierErr,


### PR DESCRIPTION
# Summary

Ensure that models are removed when `clean()` is called.

# Details

The summary is what's of interest to the user, but it's devoid of context for why I wrote this.

The Session code will add model symbols to various symbol tables which we haven't explicitly tested. So add some tests. This is related to issue #1527. For instance

```python
mdl = const1d.foo + gauss1d.bar
```

will create `foo` and `bar` symbols in a "global" namespace (technically it appears to be in `sys.modules["__main__"]` and `sys.modules["builtin"]`), so we check that these are created. There are plenty of implicit tests of this, but I wanted some explicit checks, and also to see what happens if you try to remove these symbols.  There's also a few checks just to check we set up the symbol correctly when using `from sherpa.astro.ui import *` - again nothing that we haven't got implicit tests for, I believe, but some explicit tests don't hurt (and they check things a little differently to the implicit tests).

As part of the investigation into #1527 I realized that while `delete_model_component` was removing the label from the "global" symbol table, calls to `clean` were not. So we now do. This is potentially dangerous, as the user may have re-assigned the symbol to some other value, or that the user may have replaced the logic for creating the global label. To handle the latter case, we only do anything if the hook to set up the global label has not been changed, and for the latter I note that we could check that the symbol is a model before deleting it, but I have not implemented this. The changes to the behavior of `clean`, followed by adding `clean` to a number of tests in `sherpa/ui/tests/test_session.py`, mean that we"fix" #1527. @hamogu had noted we could come up with fixture that cleaned up the global symbol table between each test (or could be requested to do so), but I didn't go that way as there are times we find out things from our system when we don't clean up everything (a la finding #1527), but it's not a huge preference.

Fortunately many of the commands that create model components - such as `load_psf` and `load_conv` - record the change in the variable that is used to identify those labels to remove. I had originally worried about these calls and things like `set_bkg_model`, but they are handled for us. Thanks original designers of this bit of code.

I had originally thought that these symbols would be included in `locals()` and/or `globals()`, but it turns out they aren't - we just change the `__main__` and `builtins` modules. We check all four in the tests so we will notice any future changes.

# Example

In CIAO 4.14 we have

```
sherpa-4.14.0> set_source(gauss1d.mdl)

sherpa-4.14.0> list_model_components()
['mdl']

sherpa-4.14.0> mdl.fwhm
<Parameter 'fwhm' of model 'mdl'>

sherpa-4.14.0> clean()

sherpa-4.14.0> list_model_components()
[]

sherpa-4.14.0> mdl.fwhm
<Parameter 'fwhm' of model 'mdl'>
```

We now have

```
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> set_source(gauss1d.mdl)
>>> list_model_components()
['mdl']
>>> mdl.fwhm
<Parameter 'fwhm' of model 'mdl'>
>>> clean()
>>> list_model_components()
[]
>>> mdl.fwhm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'mdl' is not defined
```