### PR TITLE
Ensure chi2xspecvar errors match XSPEC when 0 counts are present during background subtraction

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3531,16 +3531,7 @@ must be an integer.""")
                 else:
                     bkg_cnts = self.apply_grouping(bkg_cnts)
 
-                # TODO: shouldn't the following logic be somewhere
-                #       else more general?
-                if hasattr(staterrfunc, '__name__') and \
-                   staterrfunc.__name__ == 'calc_chi2datavar_errors' and \
-                   0.0 in bkg_cnts:
-                    mask = (numpy.asarray(bkg_cnts) != 0.0)
-                    berr = numpy.zeros(len(bkg_cnts))
-                    berr[mask] = staterrfunc(bkg_cnts[mask])
-                else:
-                    berr = staterrfunc(bkg_cnts)
+                berr = staterrfunc(bkg_cnts)
 
             # This case appears when the source dataset has an error
             # column and at least one of the background(s) do not.

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2017, 2018, 2019, 2020
-#             Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2015, 2016, 2017, 2018, 2019, 2020, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -793,8 +793,11 @@ class Chi2XspecVar(Chi2):
     bin.
 
     The calculation of the variance is the same as `Chi2DataVar`
-    except that if the number of counts in a bin is less than 1
-    then the variance for that bin is set to 1.
+    except that if the number of counts in a bin is less than 1 then
+    the variance for that bin is set to 1. Note that this does not
+    handle background subtraction, so to match XSPEC extra logic is
+    present in sherpa.astro.data.DataPHA.get_staterror to handle that
+    case.
 
     See Also
     --------

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -731,7 +731,6 @@ def test_wstat_calc_stat_info(hide_logging, make_data_path, clean_astro_ui):
     ui.get_stat_info()
 
 
-@pytest.mark.xfail(reason='y errors are not calculated correctly')
 @pytest.mark.parametrize("sexp,bexp,sscal,bscal,yexp,dyexp",
                          [(1, 1, 1, 1,
                            [0, -1, -3, 1, 3, 0, -2, 2, 0],
@@ -793,7 +792,6 @@ def test_xspecvar_zero_handling(sexp, bexp, sscal, bscal, yexp, dyexp):
     assert dy == pytest.approx(dyexp)
 
 
-@pytest.mark.xfail(reason='y errors are not calculated correctly')
 def test_xspecvar_zero_handling_variable():
     """How does XSPEC variance handle variable BACKSCAL?
 

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2007, 2015, 2016, 2018, 2020, 2021, 2022
-#       Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -732,18 +732,30 @@ def test_wstat_calc_stat_info(hide_logging, make_data_path, clean_astro_ui):
 
 
 @pytest.mark.xfail(reason='y errors are not calculated correctly')
-@pytest.mark.parametrize("bexp,yexp,dyexp",
-                         [(1,
+@pytest.mark.parametrize("sexp,bexp,sscal,bscal,yexp,dyexp",
+                         [(1, 1, 1, 1,
                            [0, -1, -3, 1, 3, 0, -2, 2, 0],
                            [1, 1, 1.73205078, 1, 1.73205078, 1.41421354, 2, 2, 2.44948983]),
-                          (10,
+                          (1, 10, 1, 1,
                            [0, -0.1, -0.3, 1, 3, 0.9, 0.7, 2.9, 2.7],
                            [0.1, 0.1, 0.173205078, 1, 1.73205078, 1.0049876, 1.01488912, 1.73493516, 1.74068952]),
-                          (0.1,
+                          (1, 0.1, 1.0, 1.0,
                            [0, -10, -30, 1, 3, -9, -29, -7, -27],
-                           [1, 10, 17.320507, 1, 1.73205078, 10.0498753, 17.3493519, 10.1488914, 17.4068947])
+                           [1, 10, 17.320507, 1, 1.73205078, 10.0498753, 17.3493519, 10.1488914, 17.4068947]),
+                          (100, 10, 0.1, 0.1,
+                           [0, -10, -30, 1, 3, -9, -29, -7, -27],
+                           [1, 10, 17.3205078, 1, 1.73205081, 10.0498758, 17.3493519, 10.1488918, 17.4068958]),
+                          (100, 10, 0.1, 0.2,
+                           [0, -5, -15, 1, 3, -4, -14, -2, -12],
+                           [1, 5, 8.66025388, 1, 1.73205081, 5.09901941, 8.7177977, 5.29150255, 8.83176103]),
+                          (100, 50, 0.1, 0.4,
+                           [0, -0.5, -1.5, 1, 3, 0.5, -0.5, 2.5, 1.5],
+                           [0.5, 0.5, 0.866025407, 1, 1.73205081, 1.11803403, 1.32287564, 1.80277564, 1.93649177]),
+                          (100, 200, 0.1, 0.2,
+                           [0, -0.25, -0.75, 1, 3, 0.75, 0.25, 2.75, 2.25],
+                           [0.25, 0.25, 0.433012703, 1, 1.73205081, 1.03077637, 1.08972471, 1.75, 1.78535711])
                           ])
-def test_xspecvar_zero_handling(bexp, yexp, dyexp):
+def test_xspecvar_zero_handling(sexp, bexp, sscal, bscal, yexp, dyexp):
     """How does XSPEC variance handle 0 in source and/or background?
 
     The values were calculated using XSPEC 12.10.1m (HEASOFT 6.26.1)
@@ -757,8 +769,12 @@ def test_xspecvar_zero_handling(bexp, yexp, dyexp):
 
     where foo.fits is a fake PHA file set up to have the channel/count
     values used below (a CSC-style PHA file was used so that source
-    and background were in the same file but a separate bgnd PHA
-    file could also have been used).
+    and background were in the same file but a separate bgnd PHA file
+    could also have been used). Remember that XSPEC plots rates and
+    not counts, so when the source exposure is not 1s, you need to
+    account for this, as the y and dy values checked in this routine
+    are in counts.
+
     """
 
     stat = Chi2XspecVar()
@@ -766,10 +782,40 @@ def test_xspecvar_zero_handling(bexp, yexp, dyexp):
     scnts = numpy.asarray([0, 0, 0, 1, 3, 1, 1, 3, 3], dtype=numpy.int16)
     bcnts = numpy.asarray([0, 1, 3, 0, 0, 1, 3, 1, 3], dtype=numpy.int16)
 
-    s = DataPHA('src', chans, scnts, exposure=1)
-    b = DataPHA('bkg', chans, bcnts, exposure=bexp)
+    s = DataPHA('src', chans, scnts, exposure=sexp, backscal=sscal)
+    b = DataPHA('bkg', chans, bcnts, exposure=bexp, backscal=bscal)
     s.set_background(b)
     s.subtract()
+
+    y, dy, other = s.to_fit(staterrfunc=stat.calc_staterror)
+    assert other is None
+    assert y == pytest.approx(yexp)
+    assert dy == pytest.approx(dyexp)
+
+
+@pytest.mark.xfail(reason='y errors are not calculated correctly')
+def test_xspecvar_zero_handling_variable():
+    """How does XSPEC variance handle variable BACKSCAL?
+
+    test_xspecvar_zero_handling checks most things, but not a
+    variable scaling (that is, some combination of AREASCAL and
+    BACKSCAL is not constant for each bin). In this case we handle
+    a single case jsut to check.
+    """
+
+    stat = Chi2XspecVar()
+    chans = numpy.arange(1, 5, dtype=numpy.int16)
+    cnts = numpy.zeros(4, dtype=numpy.int16)
+
+    sscal = numpy.asarray([0.1, 0.2, 2, 5])
+    bscal = numpy.asarray([0.1, 0.1, 4, 20])
+    s = DataPHA('src', chans, cnts, exposure=100, backscal=sscal)
+    b = DataPHA('bkg', chans, cnts, exposure=125, backscal=bscal)
+    s.set_background(b)
+    s.subtract()
+
+    yexp = numpy.asarray([0, 0, 0, 0])
+    dyexp = numpy.asarray([0.8, 1.0, 0.4, 0.2])
 
     y, dy, other = s.to_fit(staterrfunc=stat.calc_staterror)
     assert other is None

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2147,7 +2147,8 @@ class Session(NoNewAttributesAfterInit):
            data.
 
         chi2datavar
-           Chi-squared with data variance.
+           Chi-squared with data variance. If the data has 0 counts then
+           the error for that bin is 0.
 
         chi2gehrels
            Chi-squared with gehrels method [2]_. This is the default method.
@@ -2156,8 +2157,13 @@ class Session(NoNewAttributesAfterInit):
            Chi-squared with model amplitude variance.
 
         chi2xspecvar
-           Chi-squared with data variance (XSPEC-style, variance = 1.0
-           if data less than or equal to 0.0).
+           Chi-squared with data variance to match XSPEC. Errors from
+           zero-count channels (source or background) are ignored if
+           the other channel (background or source) contains counts,
+           or replaced by a minimum value (when both source or
+           background are empty). It should not be used when a model
+           is fit to the background rather than the background is
+           subtracted from the data.
 
         cstat
            A maximum likelihood function (the XSPEC implementation of


### PR DESCRIPTION
# Summary

When using the chi2xspecvar statistic for estimating PHA errors, ensure that the errors match those calculated by XSPEC when the background is subtracted and the source or background group contains 0 counts (previously the error for that bin may have been larger than XSPEC calculates).

# Details

Note that, as mentioned in #1543, this does not address the issue of what to do when fitting the background with the chi2xspecvar statistic, but that's because we don't have an equivalent in XSPEC to copy for that case.

I also hope that this is a temporary change, and we can take time to redesign the code to avoid some of the design issues, but I do not want to wait for that to wait for this to land because we have left this bug open for too long, and it is not-at-all-obvious we know what the design should be. As @hamogu has mentioned, IXPE requires combining datasets to get the errors, and that is a different, but highly-relevant, design constraint we'd need to work through.

## Problem

The chi2xspecvar statistic is meant to match XSPEC, but as pointed out in #356 it generated "too large" errors if either (or both) the source and background group contains 0 counts and the background is subtracted. This is because the code was converting 0 counts to an error of 1 and then combining this with the error from the other component to get the overall error, so for instance

```python
src_counts = 4
bkg_counts = 0
````

would then (if we assume the source and background regions have the same exposure time, backscal, and areascal values) we would get from `chi2xspecvar`

```python
src_variance = 4
bkg_variance = 1
```

and hence

```python
variance = 5
error = sqrt(5)
```

However, XSPEC just drops the 0-count channel in this case, so the "correct" error should be

```python
error = 2
```

The handling of when both source and background components have 0 counts is technically the same, it is just that we have to care about which of the components to drop, and that depends on the relative scaling values (exposure, backscal, and areascal).

## Solution

Previous attempts to fix this have looked at changing the stats code, that is the `sherpa.stats.Stat.calc_staterror` method, but this is not designed to handle source and background data, because this is only relevant for PHA data.

The approach I've taken is more restrained, in that it recognizes this is only an issue for PHA data, and so the changes are made to the `sherpa.astro.data.DataPHA.get_staterror` method. This actually makes sense, because it is in this method that we deal with the complications of background subtraction, in particular handle the scaling values we need to worry about for the "source and background are 0" case. However, it is not ideal from the sense of "mixing responsibilities", but I do not see a way to do this in any reasonable time scale (given how long #356 has remained), and I think we are going to have to look at the statistic handing if we want to handle IXPE data properly, and that will likely require quite a large, somewhat different, change so I don't think it's worth making a large design change if we are only going to have to change it again for something else.

I've validated the changes by

1.  seeing that the existing tests I added in #768 now pass when they didn't before
3. realized that those tests aren't sufficient (as they didn't really handle the different scaling regimes) by adding more cases to that test
4. realized that I needed a test with a variable scaling function, so added a test with an array for BACKSCAL

These tests are based on creating a PHA source and background dataset, load them into XSPEC, call `iplot data` and then `wdata`, and note down the last column, which is the error value. Note that if you do this the error XSPEC returns is a rate, and we are checking the counts, so you need to scale by the exposure time (I forgot this at some point and wasted time trying to understand why I was seeing differences).

I've also discussed this with the XSPEC developers who pointed me to the relevant code in XSPEC, which I've referenced in the code. One thing the XSPEC code assumes is that there's only one background, so I've made assumptions on what to do if you have multiple backgrounds (basically that we just average them).

## Notes

Other than tests, the first couple of commits are code clean ups, including removing some attempt to handle the chi2datavar routine that uses the same idea I use (i.e. the change is made to the `DataPHA.get_staterror` method rather than the lower-level statistic classes). However, it is not clear what the code is meant to be doing because

1. we don't have the problem with 0 counts that the code seems to think we do
2. it only triggered if the user was dong something unusual (i.e. they had passed in the low-level method rather than the `chi2datavar` object)

This may in part be because of changes in #153 - which meant that it can handle 0-count bins - but it really is not obvious what the code was meant to be doing and it wasn't being triggered in our tests,

As noted in the commit for 05b4faa93055aa57b84ea331c0bd4ac626b0acce we only trigger this behavior if the user is using "chi2xsecvar", with the check

```python
if staterrfunc == Chi2XspecVar.calc_staterror ...
```

Technically we could say something like

```python
if staterrfunc in [Chi2XspecVar.calc_staterror, sherpa.stats._statfcts.calc_chi2xspecvar_errors  ] ...
```  

as a user could call it with the low-level method, but I elected not to do this as it is not "meant" to be how the method is called.

## Examples

Here is one of the test examples (all channels have 0 counts and we have a variable BACKSCAL)

```
sherpa-4.14.0> data.subtracted
True

sherpa-4.14.0> print(data.counts)
[0. 0. 0. 0.]

sherpa-4.14.0> print(data.get_background().counts)
[0. 0. 0. 0.]

sherpa-4.14.0> print(data.exposure, data.backscal)
100.0 [0.1 0.2 2.  5. ]

sherpa-4.14.0> print(data.get_background().exposure, data.get_background().backscal)
125.0 [ 0.1  0.1  4.  20. ]

sherpa-4.14.0> data.get_staterror()

sherpa-4.14.0> data.get_staterror(staterrfunc=_session._stats["chi2datavar"].calc_staterror)
array([0., 0., 0., 0.])

sherpa-4.14.0> data.get_staterror(staterrfunc=_session._stats["chi2xspecvar"].calc_staterror)
array([1.28062485, 1.88679623, 1.07703296, 1.0198039 ])
```

So the xspecvar statistic returns 1 for each bin in CIAO 4.14. With this PR we get the errors:

```
>>> ui.get_data().get_staterror(staterrfunc=Chi2XspecVar().calc_staterror)
array([0.8, 1. , 0.4, 0.2])
```

I was too lazy to create a fake response so I could just call `set_stat("chi2xspecvar")` and then `calc_stat()` to show the difference, but it would have done (as this is the way users are going to see the differences).

## Worked example

The `sherpa-test-data/sherpatest/qso.pi` file has no grouping, so we can pick a small range where there's some zero's (e.g. 5-6 keV):

```
xspec

		XSPEC version: 12.12.1
	Build Date/Time: Thu Apr 28 18:10:42 2022

XSPEC12>data qso.pi

1 spectrum  in use
 
Spectral Data File: qso.pi  Spectrum 1
Net count rate (cts/s) for Spectrum:1  1.227e-01 +/- 2.040e-03 (99.2 % total)
 Assigned to Data Group 1 and Plot Group 1
  Noticed Channels:  1-1024
  Telescope: CHANDRA Instrument: ACIS  Channel Type: PI
  Exposure Time: 2.98e+04 sec
 Using fit statistic: chi
 Using Background File                qso_bkg.pi
  Background Exposure Time: 2.98e+04 sec
 Using Response (RMF) File            qso.wrmf for Source 1
 Using Auxiliary Response (ARF) File  qso.warf

XSPEC12>ignore 1-342,412-1024
   342 channels (1,342) ignored in spectrum #     1
   613 channels (412,1024) ignored in spectrum #     1

XSPEC12>mo po

Input parameter value, delta, min, bot, top, and max values for ...
              1       0.01(      0.01)         -3         -2          9         10
1:powerlaw:PhoIndex>1.7
              1       0.01(      0.01)          0          0      1e+20      1e+24
2:powerlaw:norm>3e-4

========================================================================
Model powerlaw<1> Source No.: 1   Active/On
Model Model Component  Parameter  Unit     Value
 par  comp
   1    1   powerlaw   PhoIndex            1.70000      +/-  0.0          
   2    1   powerlaw   norm                3.00000E-04  +/-  0.0          
________________________________________________________________________


Fit statistic  : Chi-Squared                  303.00     using 69 bins.

***Warning: Chi-square may not be valid due to bins with zero variance
            in spectrum number: 1

Test statistic : Chi-Squared                  303.00     using 69 bins.

***Warning: Chi-square may not be valid due to bins with zero variance
            in spectrum number(s): 1 

 Null hypothesis probability of 9.85e-32 with 67 degrees of freedom
 Current data and model not fit yet.
```

So, XSPEC has a chi-square of 303.00 for these bins.

With CIAO 4.14 we get

```
sherpa
-----------------------------------------------------
Welcome to Sherpa: CXC's Modeling and Fitting Package
-----------------------------------------------------
Sherpa 4.14.0

Python 3.9.12 | packaged by conda-forge | (main, Mar 24 2022, 23:25:59) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.2.0 -- An enhanced Interactive Python. Type '?' for help.

IPython profile: sherpa
Using matplotlib backend: QtAgg

sherpa-4.14.0> load_pha("qso.pi")
read ARF file qso.warf
read RMF file qso.wrmf
read ARF (background) file qso_bkg.warf
read RMF (background) file qso_bkg.wrmf
read background file qso_bkg.pi

sherpa-4.14.0> subtract()

sherpa-4.14.0> set_source(xspowerlaw.pl); pl.phoindex = 1.7; pl.norm = 3e-4

sherpa-4.14.0> set_analysis("channel"); ignore(1, 342); ignore(412, 1024)

sherpa-4.14.0> set_stat("chi2xspecvar"); calc_stat()
60.15435798809412

sherpa-4.14.0> set_stat("chi2datavar"); calc_stat()
147.85824365372247

sherpa-4.14.0> set_analysis("energy"); plot_data(alpha=0.5); plot_bkg(alpha=0.5, overplot=True)
```

Here's the image:

![sherpa](https://user-images.githubusercontent.com/224638/177605467-f06a2c9b-34a4-4cc6-8f98-c139f9e1b705.png)

The blue are background subtracted, but the background is 0 apart from a few bins (one of which is one where the source=0 but bgnd>0 so the result is negative). Anyway, this shows we have 0's to worry about (including, I think, one case where both source and background are zero).

Here's with this PR (the `chi2datavar` results are just to show that hasn't changed from CIAO 4.14, and `powlaw1d` is used rather than `xspowerlaw` as I don't have XSPEC built for this build, but I don't believe that will cause the small statistic difference I mention below):

```
python
Python 3.10.4 (main, Mar 31 2022, 08:41:55) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> load_pha("sherpa-test-data/sherpatest/qso.pi")
read ARF file sherpa-test-data/sherpatest/qso.warf
read RMF file sherpa-test-data/sherpatest/qso.wrmf
read ARF (background) file sherpa-test-data/sherpatest/qso_bkg.warf
read RMF (background) file sherpa-test-data/sherpatest/qso_bkg.wrmf
read background file sherpa-test-data/sherpatest/qso_bkg.pi
>>> subtract()
>>> set_analysis("channel"); ignore(1, 342); ignore(412, 1024)
>>> set_source(powlaw1d.pl); pl.gamma = 1.7; pl.ampl = 3e-4
>>> set_stat("chi2xspecvar"); calc_stat()
303.08668444575886
>>> set_stat("chi2datavar"); calc_stat()
147.85824365372272
>>> set_stat("chi2xspecvar")
>>> calc_stat_info()
Dataset               = 1
Statistic             = chi2xspecvar
Fit statistic value   = 303.087
Data points           = 69
Degrees of freedom    = 67
Probability [Q-value] = 9.52981e-32
Reduced statistic     = 4.52368
```

So we get a statistic of 303.087. It is not quite the 303.00 that XSPEC reports, but is significantly closer than the 60.2 we got in CIAO 4.14.