### PR TITLE
CI bump to Python 3.10 for macOS

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -25,9 +25,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS Full Build
+          - name: MacOS Full Build (Python 3.10)
             os: macos-latest
-            python-version: "3.8"
+            python-version: "3.10"
             install-type: develop
             fits: astropy
             test-data: submodule


### PR DESCRIPTION
This is to test out https://discuss.python.org/t/pip-install-e-on-macos-suddenly-builds-for-universal2-by-default/16890/18 and is not intended for merging

I didn't update the XSPEC version as I don't know what versions are available on the mac channel.
