### PR TITLE
BUILD update setup.cfg based on the conda environment

### DIFF
--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -36,13 +36,34 @@ if [ "$CONDA_PREFIX" != "$ASCDS_INSTALL" ]; then
     exit 1;
 fi
 
+# What conda-like system are we using?
+#
+function find_conda_exe {
+    local name
+    local output
+    output=""
+    for name in conda mamba micromamba ; do
+	if command -v $name >/dev/null 2>&1; then
+	    output=$name
+	    break
+	fi
+    done
+    echo "$output"
+}
+
+EXE=$(find_conda_exe)
+if [ "$EXE" = "" ]; then
+    echo "ERROR: unable to find conda, mamba, or micromamba"
+    exit 1
+fi
+
 # Extract the XSPEC version from the conda packaging metadata;
 # hopefully the formatting and structure remain consistent.
 #
-xspec_version=`conda list xspec-modelsonly --json | grep version | awk '{print $2;}' - | tr -d \"`
+xspec_version=`$EXE list xspec-modelsonly --json | grep version | awk '{print $2;}' - | tr -d \"`
 if [ "x$xspec_version" = "x" ]; then
     echo "ERROR: Unable to find out XSPEC version from"
-    conda list xspec-modelsonly --json
+    $EXE list xspec-modelsonly --json
     exit 1;
 fi
 

--- a/scripts/use_conda_config
+++ b/scripts/use_conda_config
@@ -76,13 +76,13 @@ echo "Updating $cfg"
 
 if [ "x$fftw_version" != "x" ]; then
     sed -i="" "s|#fftw=local|fftw=local|" $cfg
-    sed -i="" "s|#fftw-include_dirs=build/include|fftw-include_dirs=${CONDA_PREFIX}/include|" $cfg
-    sed -i="" "s|#fftw-lib-dirs=build/lib|fftw-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
-    sed -i="" "s|#fftw-libraries=fftw3|fftw-libraries=fftw3|" $cfg
+    sed -i="" "s|#fftw_include_dirs=build/include|fftw_include_dirs=${CONDA_PREFIX}/include|" $cfg
+    sed -i="" "s|#fftw_lib-dirs=build/lib|fftw_lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+    sed -i="" "s|#fftw_libraries=fftw3|fftw_libraries=fftw3|" $cfg
 fi
 
 if [ "x$xspec_version" != "x" ]; then
-    sed -i="" "s|#with-xspec=True|with-xspec=True|" $cfg
+    sed -i="" "s|#with_xspec=True|with_xspec=True|" $cfg
     sed -i="" "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|" $cfg
     sed -i="" "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
     sed -i="" "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg

--- a/scripts/use_conda_config
+++ b/scripts/use_conda_config
@@ -14,18 +14,42 @@ if [ "x$CONDA_PREFIX" = "x" ]; then
     exit 1;
 fi
 
-fftw_version=`conda list fftw --json | grep version | awk '{print $2;}' - | tr -d \"`
+# What conda-like system are we using?
+#
+function find_conda_exe {
+    local name
+    local output
+    output=""
+    for name in conda mamba micromamba ; do
+	if command -v $name >/dev/null 2>&1; then
+	    output=$name
+	    break
+	fi
+    done
+    echo "$output"
+}
+
+EXE=$(find_conda_exe)
+if [ "$EXE" = "" ]; then
+    echo "ERROR: unable to find conda, mamba, or micromamba"
+    exit 1
+fi
+
+fftw_version=`$EXE list fftw --json | grep version | awk '{print $2;}' - | tr -d \"`
 if [ "x$fftw_version" != "x" ]; then
     echo "Found FFTW version: $fftw_version";
 fi
 
-xspec_version=`conda list xspec-modelsonly --json | grep version | awk '{print $2;}' - | tr -d \"`
+xspec_version=`$EXE list xspec-modelsonly --json | grep version | awk '{print $2;}' - | tr -d \"`
 if [ "x$xspec_version" != "x" ]; then
     echo "Found XSPEC version: $xspec_version";
 fi
 
 if [ "x" = "x$fftw_version" ] && [ "x" = "x$xspec_version" ]; then
-    echo "Did not find FFTW or xspec-modelsonly; no conda change needed";
+    echo "Did not find FFTW or xspec-modelsonly; no change needed";
+    # Treat this as an error because we assume one of the packages has
+    # been installed, otherwise why call this script?
+    #
     exit 1;
 fi
 

--- a/scripts/use_conda_config
+++ b/scripts/use_conda_config
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Update the Sherpa configuration file (setup.cfg) to use the
+# current conda installation:
+#
+#   - use fftw if installed
+#   - use xspec-modelsonly if installed
+#
+
+# Check we have a conda environment
+#
+if [ "x$CONDA_PREFIX" = "x" ]; then
+    echo "ERROR: has conda been initialized?"
+    exit 1;
+fi
+
+fftw_version=`conda list fftw --json | grep version | awk '{print $2;}' - | tr -d \"`
+if [ "x$fftw_version" != "x" ]; then
+    echo "Found FFTW version: $fftw_version";
+fi
+
+xspec_version=`conda list xspec-modelsonly --json | grep version | awk '{print $2;}' - | tr -d \"`
+if [ "x$xspec_version" != "x" ]; then
+    echo "Found XSPEC version: $xspec_version";
+fi
+
+if [ "x" = "x$fftw_version" ] && [ "x" = "x$xspec_version" ]; then
+    echo "Did not find FFTW or xspec-modelsonly; no conda change needed";
+    exit 1;
+fi
+
+# Are we in the right directory
+#
+cfg=setup.cfg
+if [ ! -f $cfg ]; then
+    echo "ERROR: Unable to find $cfg";
+    exit 1;
+fi
+
+# Check the file has not been changed (this could be relaxed but
+# try this approach first).
+#
+git diff --exit-code $cfg > /dev/null
+if [ $? -ne 0 ]; then
+    echo "ERROR: $cfg has already been changed."
+    exit 1;
+fi
+
+# Apply the changes line-by-line
+#
+echo "Updating $cfg"
+
+if [ "x$fftw_version" != "x" ]; then
+    sed -i="" "s|#fftw=local|fftw=local|" $cfg
+    sed -i="" "s|#fftw-include_dirs=build/include|fftw-include_dirs=${CONDA_PREFIX}/include|" $cfg
+    sed -i="" "s|#fftw-lib-dirs=build/lib|fftw-lib-dirs=${CONDA_PREFIX}/lib|" $cfg
+    sed -i="" "s|#fftw-libraries=fftw3|fftw-libraries=fftw3|" $cfg
+fi
+
+if [ "x$xspec_version" != "x" ]; then
+    sed -i="" "s|#with-xspec=True|with-xspec=True|" $cfg
+    sed -i="" "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|" $cfg
+    sed -i="" "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
+    sed -i="" "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg
+fi
+
+# Depending on the version of sed, there might be a temporary file. Remove it if it exists.
+rm -f setup.cfg=


### PR DESCRIPTION
This is not needed if we take #2484

# Summary

Add the scripts/use_conda_config script to allow easier configuration when using conda-like environments and update scropts/use_ciao_config to support mamba or micromamba instead of conda.

# Details

The `scripts/use_conda_config` script will change the setup.cfg file to build against conda-provided packages:

- fftw
- xspec-modelsonly

The idea is to make it easy to make these changes (it's something I often do). Is it worth keeping?

There is duplicated logic with `scripts/use_ciao_config` but they are technically separate (you could imagine re-writing `use_ciao_config` to call this first and then post-process the output for the CIAO-specific logic) but I'm not sure it's worth it (unless we re-write these scripts in Python).

# Example

```
% ./scripts/use_conda_config 
Found FFTW version: 3.3.10
Found XSPEC version: 12.12.0
Updating setup.cfg
(sherpa-main) dburke@dburke-Precision-5530:~/sherpa/sherpa-main$ git diff setup.cfg
diff --git a/setup.cfg b/setup.cfg
index df19e1df..329c1011 100644
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,15 +36,15 @@ parentdir_prefix = sherpa-
 
 # FFTW Library
 # Uncomment to use a local installation
-#fftw=local
+fftw=local
 
 # If fftw=local uncomment the following lines and
 # change the default location of libraries and the name
 # of the library to be linked (usually fftw3)
 # (include multiple values by separating them with spaces)
-#fftw-include_dirs=build/include
-#fftw-lib-dirs=build/lib
-#fftw-libraries=fftw3
+fftw-include_dirs=/home/dburke/miniconda3/envs/sherpa-main/include
+fftw-lib-dirs=/home/dburke/miniconda3/envs/sherpa-main/lib
+fftw-libraries=fftw3

 # Region Library
 # Uncomment to use a local installation
@@ -82,7 +82,7 @@ source-dir = docs
 # XSPEC Models
 [xspec_config]
 # Uncomment (set to True) to build XSPEC extension
-#with-xspec=True
+with-xspec=True
 
 # If with-xspec is True, make sure to point Sherpa to right
 # XSPEC-related libraries and to indicate the XSPEC version.
@@ -111,9 +111,9 @@ source-dir = docs
 #
 # The gfortran_lib_dirs should be set if needed.
 #
-#xspec_version = 12.9.0
-#xspec_lib_dirs = None
-#xspec_include_dirs = None
+xspec_version = 12.12.0
+xspec_lib_dirs=/home/dburke/miniconda3/envs/sherpa-main/lib
+xspec_include_dirs=/home/dburke/miniconda3/envs/sherpa-main/include
 #xspec_libraries = XSFunctions XSModel XSUtil XS
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio
 ```