### PR TITLE
Install the stack and group modules within the sherpa namespace

### DIFF
--- a/helpers/build.py
+++ b/helpers/build.py
@@ -18,7 +18,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-
 from setuptools.command.build import build as _build
 from setuptools.command.build_ext import build_ext as _build_ext
 
@@ -53,12 +52,12 @@ class build_ext(_build_ext):
             sherpa_config = self.get_finalized_command('sherpa_config', True)
             if not sherpa_config.disable_group:
                 self.copy_file(sherpa_config.group_location,
-                               "group.so")
+                               "sherpa/group.so")
                 self.announce("install group extension locally")
 
             if not sherpa_config.disable_stk:
                 self.copy_file(sherpa_config.stk_location,
-                               "stk.so")
+                               "sherpa/stk.so")
                 self.announce("install stk extension locally")
 
         super().run()

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -146,7 +146,8 @@ class sherpa_config(Command):
         #
         libdir = os.path.join('lib',
                               f'python{version}',
-                              'site-packages')
+                              'site-packages',
+                              'sherpa')
         dfiles = []
         if not self.disable_group:
             configure.append('--enable-group')

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -159,12 +159,17 @@ except ImportError:
 
 groupstatus = False
 try:
-    import group as pygroup  # type: ignore
+    # Are we using the Sherpa-supplied version or the CIAO one?
+    from sherpa import group as pygroup  # type: ignore
     groupstatus = True
 except ImportError:
-    groupstatus = False
-    warning('the group module (from the CIAO tools package) is not ' +
-            'installed.\nDynamic grouping functions will not be available.')
+    try:
+        import group as pygroup
+        groupstatus = True
+    except ImportError:
+        groupstatus = False
+        warning('the group module (from the CIAO tools package) is not ' +
+                'installed.\nDynamic grouping functions will not be available.')
 
 
 __all__ = ('DataARF', 'DataRMF', 'DataPHA', 'DataIMG', 'DataIMGInt', 'DataRosatRMF')

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2015, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016, 2019, 2020, 2021, 2022
+# Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,6 +19,7 @@
 #
 
 import numpy
+
 from sherpa.utils.logging import config_logger
 from sherpa.utils.err import IOErr
 from sherpa.utils.formatting import html_table, html_from_sections
@@ -29,9 +31,14 @@ from .utils import load_error_msg, load_wrapper, model_wrapper, \
 logger = config_logger(__name__)
 
 try:
-    import stk
+    # Are we using the Sherpa-supplied version or the CIAO one?
+    from sherpa import stk
 except ImportError:
-    logger.warning("could not import stk library. CIAO stack files and syntax will be disabled")
+    try:
+        import stk
+    except:
+        logger.warning("could not import stk library. CIAO stack files and syntax will be disabled")
+
 
 # Global list of dataset ids in use
 _all_dataset_ids = {}

--- a/sherpa/astro/datastack/utils.py
+++ b/sherpa/astro/datastack/utils.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2015, 2016, 2020  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016, 2020, 2022
+# Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -29,9 +30,13 @@ logger = config_logger(__name__)
 ID_STR = '__ID'
 
 try:
-    import stk
-except:
-    logger.warning("could not import stk library. CIAO stack files and syntax will be disabled")
+    # Are we using the Sherpa-supplied version or the CIAO one?
+    from sherpa import stk
+except ImportError:
+    try:
+        import stk
+    except:
+        logger.warning("could not import stk library. CIAO stack files and syntax will be disabled")
 
 
 @public

--- a/sherpa/tests/test_stack.py
+++ b/sherpa/tests/test_stack.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -34,7 +35,11 @@ def get_name(name):
 @requires_stk
 def test_build_stack():
     """We can use @+ syntax to read from a file"""
-    import stk
+
+    try:
+        from sherpa import stk
+    except ImportError:
+        import stk
 
     names = ['a', 'a1', 'a2', 'b', 'b1', 'b2']
     expected = [get_name(n) for n in names]
@@ -49,7 +54,11 @@ def test_build_stack():
 @requires_stk
 def test_build_stack2():
     """We can use @- syntax to read from a file"""
-    import stk
+
+    try:
+        from sherpa import stk
+    except ImportError:
+        import stk
 
     names = ['a', 'a1', 'a2', '@b.lis']
 
@@ -64,7 +73,11 @@ def test_build_stack2():
 @pytest.mark.parametrize('sep', [',', ' '])
 def test_build_stack_separator(sep):
     """We can use commas/spaces to separate entries"""
-    import stk
+
+    try:
+        from sherpa import stk
+    except ImportError:
+        import stk
 
     expected = ['a', 'a1', 'a2', 'b', 'b1', 'b2']
 
@@ -81,7 +94,11 @@ def test_build_stack_lgrid():
 
     We assume rgrid, pgrid, and igrid work if this does.
     """
-    import stk
+
+    try:
+        from sherpa import stk
+    except ImportError:
+        import stk
 
     names = [10, 12, 14, 16, 18, 20]
     expected = [str(n) for n in names]

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -159,11 +159,13 @@ if HAS_PYTEST:
 
     def requires_group(test_function):
         """Decorator for test functions requiring group library"""
-        return requires_package("group library required", 'group')(test_function)
+        packages = ("sherpa.group", "group")
+        return requires_package("group library required", *packages)(test_function)
 
     def requires_stk(test_function):
         """Decorator for test functions requiring stk library"""
-        return requires_package("stk library required", 'stk')(test_function)
+        packages = ("sherpa.stk", "stk")
+        return requires_package("stk library required", *packages)(test_function)
 
     def requires_region(test_function):
         """Decorator for test functions requiring 2D region support"""


### PR DESCRIPTION
# Summary

When building the stk and group modules (the default for standalone Sherpa), ensure these files are installed within the sherpa namespace. Fix #50.

# Details

There are two changes here

1. The changes to sherpa to make it look for the `stk` and `group` modules from within `sherpa`, falling back to look for them from the top-level namespace.
2. The build changes needed to install the files within the `sherpa` namespace

These changes are both relatively simple, but those for `2` are the minimum I needed to get the code to build/make sense, and I am not 100% convinced there aren't hidden issues (so getting these to run through CI is one way to test this out). In particular, we add to the `data_files` field of the command class, but I note in #1329 that this field looks like it's deprecated (it's hard to know as that is about the configuration file whereas this is a class field, but I imagine they are both talking about the "same idea/ground truth", so are probably the same).

For part 1, we have several options. As I noted in #1545 we could install as part of `sherpa` the configuration options as metadata, so we could decide how to load these two modules from that, rather than go through the

```python
try:
    from sherpa import stk
except ImportError:
    try:
        import stk
    except:
        warning("whatever the warning is")
```

dance, but I don't think it's worth it.

Technically we could swap the order - ie try `import stk` first and only fall back to the sherpa namespace if it fails, but I think this approach is marginally safer/clearer (i.e. import the namespaced version first, as that's the one less likely to be accidentally spoofed by other code).

I've tried the following now, and they seemed okay, but I don't know enough to know what to really look for:

- looking at `sdist` (these are compiled files so technically they are not part of a sdist)
- building against CIAO to check it works there