### PR TITLE
Fix CI failures from AstroPy 5.1 warning changes

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -166,9 +166,9 @@ known_warnings = {
 
             # It would be nice if we could find this out from first principles,
             # rather than only finding them from random CI runs
-            r"unclosed file <_io.BufferedReader name='/tmp/.*/data.dat'>",
-            r"unclosed file <_io.BufferedReader name='/tmp/.*/model.dat'>",
-            r"unclosed file <_io.BufferedReader name='/tmp/.*/resid.out'>",
+            r"unclosed file <_io.BufferedReader name='.*/data.dat'>",
+            r"unclosed file <_io.BufferedReader name='.*/model.dat'>",
+            r"unclosed file <_io.BufferedReader name='.*/resid.out'>",
 
             # Does this replace the versions above?
             r"unclosed file <_io.BufferedReader name='.*/aref_Cedge.fits'>",


### PR DESCRIPTION
# Summary

Allow the macOS tests to run on CI with AstroPy 5.1.

# Details

We were looking for files in /tmp/... but this is not correct, as they can be in other locations. The simple change is to remove the check for /tmp. This was identified as being related to AstroPy 5.1 by @Marie-Terrell 