### PR TITLE
Bump the ci-pip-arch workflow to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: (github.repository == 'sherpa/sherpa' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'CI arch')))
 
     strategy:


### PR DESCRIPTION
It looks like we will begin seeing issues during the brownout period until we update: https://github.com/actions/virtual-environments/issues/6002