### PR TITLE
report the change in the filter because of calls to notice and ignore

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -1,0 +1,196 @@
+#
+#  Copyright (C) 2021
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Astro-specific tests of the image functionality for Session
+
+Notes
+-----
+A number of tests send data to an external DS9 process (which will be
+started if needed) and then check the values displayed by the process.
+These tests are highly-likely to fail if the tests are run in
+parallel, such as with
+
+    pytest -n auto
+
+as there is no support in our DS9 interface to either create a new DS9
+instance per worker, or to "lock" a DS9 so that the tests can be run
+in serial.
+
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.ui.utils import Session as AstroSession
+
+from sherpa.astro.data import DataIMG
+
+from sherpa.utils.err import ArgumentTypeErr
+from sherpa.utils.testing import requires_ds9
+
+
+def example_data():
+    """Create an example data set.
+
+    It's not entirely clear whether this is a valid object, as we do
+    not clearly describe what the units of the intependent axis are
+    meant, or allowed, to be: e.g.  must they by logical units with
+    any coord system added via WCS, or can they be anything, as used
+    here? This means that some of the results (e.g. the filters used)
+    may need to be updated if we ever resolve this.
+
+    """
+
+    x1, x0 = np.mgrid[-4:5, 6:15]
+
+    shp = x1.shape
+
+    x0 = x0.flatten()
+    x1 = x1.flatten()
+    y = 100 / (1 + np.sqrt((x0 - 11)**2 + (x1 + 2)**2))
+
+    return DataIMG('example', x0, x1, y, shape=shp)
+
+
+@requires_ds9
+@pytest.mark.parametrize("idval", [None, "foo"])
+@pytest.mark.parametrize("funcname", ["notice", "ignore"])
+def test_image_xxx2d_not_sent_an_image(funcname, idval):
+    """Check we error out
+
+    This test takes a surprising amount of time as we don't
+    error out before setting up DS9, so we try to reduce the
+    number of parameters.
+
+    If we address #1583 the funcname parameter can be removed, as we
+    would expect the image_data call to fail.
+
+    """
+
+    idarg = 1 if idval is None else idval
+    s = AstroSession()
+    s.load_arrays(idarg, [1, 2, 3], [1, 2, 3])
+
+    # Should this fail? see #1583
+    if idval is None:
+        s.image_data()
+    else:
+        s.image_data(idval)
+
+    func = getattr(s, f"{funcname}2d_image")
+    with pytest.raises(ArgumentTypeErr,
+                       match="^'img' must be a image data set$"):
+        if idval is None:
+            func()
+        else:
+            func(idval)
+
+
+@requires_ds9
+@pytest.mark.parametrize("funcname", ["notice", "ignore"])
+def test_xxx2d_image_no_region(funcname):
+    """What happens when no region has been supplied?"""
+
+    s = AstroSession()
+
+    # This is a bit awkward as we have to send a region to
+    # DS9 with XPA so we can check we can read it back
+    # with notice2d_image.
+    #
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    func = getattr(s, f"{funcname}2d_image")
+    with pytest.raises(ValueError,
+                       match="^unable to parse region string: ''$"):
+        func()
+
+
+def send_filters_to_ds9():
+    """Filters used by test_xxx2d_image"""
+
+    from sherpa.image import backend
+    backend.xpaset("regions", data="circle(10,0,3)")
+    backend.xpaset("regions", data="box(8,4,8,6,30)")
+
+
+FILTER_NTOT = 81
+FILTER_NSET = 47
+FILTER_A = "Circle(10,0,3)"
+FILTER_B = "RotBox(8,4,8,6,30)"
+
+
+@requires_ds9
+def test_notice2d_image():
+    """A valid region"""
+
+    s = AstroSession()
+
+    # This is a bit awkward as we have to send a region to
+    # DS9 with XPA so we can check we can read it back
+    # with notice2d_image.
+    #
+    s.set_data(example_data())
+    s.image_data()
+
+    d = s.get_data()
+    assert s.get_filter() == ""
+    assert d.mask is True
+
+    send_filters_to_ds9()
+
+    s.notice2d_image()
+    assert s.get_filter() == f"{FILTER_A}|{FILTER_B}"
+
+    assert len(d.mask) == FILTER_NTOT
+    assert d.mask.sum() == FILTER_NSET
+
+
+@requires_ds9
+def test_ignore2d_image():
+    """A valid region
+
+    Unlike test_notice2d_image this uses an explicit
+    dataset identifier.
+    """
+
+    s = AstroSession()
+
+    # This is a bit awkward as we have to send a region to
+    # DS9 with XPA so we can check we can read it back
+    # with notice2d_image.
+    #
+    s.set_data("ex", example_data())
+    s.image_data("ex")
+
+    d = s.get_data("ex")
+    assert s.get_filter("ex") == ""
+    assert d.mask is True
+
+    send_filters_to_ds9()
+
+    s.ignore2d_image("ex")
+    assert s.get_filter("ex") == f"Field()&!{FILTER_A}&!{FILTER_B}"
+
+    # 47 is from test_notice2d_image
+    assert len(d.mask) == FILTER_NTOT
+    assert d.mask.sum() == (FILTER_NTOT - FILTER_NSET)

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2022
 #  Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1227,9 +1227,9 @@ def test_grouped_pha_all_bad_response_bg_warning(elo, ehi, nbins, fstr, bkg_id,
     assert name == 'sherpa.ui.utils'
     assert lvl == logging.INFO
     if bkg_id is None:
-        assert msg == f"check: 0.00146:14.9504 -> {fstr} Energy (keV)"
+        assert msg == f"dataset check: 0.00146:14.9504 -> {fstr} Energy (keV)"
     else:
-        assert msg == f"check:1: no data (unchanged)"
+        assert msg == f"dataset check: background 1: no data (unchanged)"
 
 
 @pytest.mark.parametrize('dtype', [ui.Data1D, ui.Data1DInt, ui.DataPHA,

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+#  Copyright (C) 2012, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1183,12 +1183,17 @@ def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xlo, e
 
 @requires_fits
 @requires_data
-@pytest.mark.parametrize("elo,ehi,nbins",
-                         [(None, 5, 41), (1, None, 33), (1, 5, 28)])
+@pytest.mark.parametrize("elo,ehi,nbins,fstr",
+                         [(None, 5, 41, "0.00146:5.0224"),
+                          (1, None, 33, "0.9928:14.9504"),
+                          (1, 5, 28, "0.9928:5.0224")])
 @pytest.mark.parametrize("bkg_id", [None, 1])
-def test_grouped_pha_all_bad_response_bg_warning(elo, ehi, nbins, bkg_id,
+def test_grouped_pha_all_bad_response_bg_warning(elo, ehi, nbins, fstr, bkg_id,
                                                  caplog, make_data_path, clean_astro_ui):
-    """Check we get the warning messages with background filtering"""
+    """Check we get the warning messages with background filtering
+
+    We also get information from the notice_bad call.
+    """
 
     ui.load_pha('check', make_data_path('3c273.pi'))
 
@@ -1210,12 +1215,21 @@ def test_grouped_pha_all_bad_response_bg_warning(elo, ehi, nbins, bkg_id,
         assert nback == 0
 
     # did we get a warning message from the background?
-    assert len(caplog.records) == 1
+    assert len(caplog.records) == 2
     name, lvl, msg = caplog.record_tuples[0]
     assert name == 'sherpa.astro.data'
     assert lvl == logging.INFO
     assert msg.startswith('Skipping dataset ')
     assert msg.endswith('/3c273_bg.pi: mask excludes all data')
+
+    # Check the filter output
+    name, lvl, msg = caplog.record_tuples[1]
+    assert name == 'sherpa.ui.utils'
+    assert lvl == logging.INFO
+    if bkg_id is None:
+        assert msg == f"check: 0.00146:14.9504 -> {fstr} Energy (keV)"
+    else:
+        assert msg == f"check:1: no data (unchanged)"
 
 
 @pytest.mark.parametrize('dtype', [ui.Data1D, ui.Data1DInt, ui.DataPHA,

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1938,7 +1938,7 @@ def test_image_filter_coord_change_same(make_data_path, clean_astro_ui, caplog):
     r = caplog.record_tuples[0]
     assert r[0] == "sherpa.ui.utils"
     assert r[1] == logging.INFO
-    assert r[2] == "foo: Field() -> Rectangle(4000,4200,4100,4300)"
+    assert r[2] == "dataset foo: Field() -> Rectangle(4000,4200,4100,4300)"
 
 
 @requires_fits
@@ -1987,7 +1987,7 @@ def test_image_filter_coord_change(make_data_path, clean_astro_ui, caplog):
     r = caplog.record_tuples[0]
     assert r[0] == "sherpa.ui.utils"
     assert r[1] == logging.INFO
-    assert r[2] == "foo: Field() -> Rectangle(4000,4200,4100,4300)"
+    assert r[2] == "dataset foo: Field() -> Rectangle(4000,4200,4100,4300)"
 
     r = caplog.record_tuples[1]
     assert r[0] == "sherpa.astro.data"
@@ -2032,7 +2032,7 @@ def test_image_filter_coord_change_same_negate(make_data_path, clean_astro_ui, c
     r = caplog.record_tuples[0]
     assert r[0] == "sherpa.ui.utils"
     assert r[1] == logging.INFO
-    assert r[2] == "foo: Field() -> Field()&!Rectangle(4000,4200,4100,4300)"
+    assert r[2] == "dataset foo: Field() -> Field()&!Rectangle(4000,4200,4100,4300)"
 
 
 @requires_fits
@@ -2076,7 +2076,7 @@ def test_image_filter_coord_change_negate(make_data_path, clean_astro_ui, caplog
     r = caplog.record_tuples[0]
     assert r[0] == "sherpa.ui.utils"
     assert r[1] == logging.INFO
-    assert r[2] == "foo: Field() -> Field()&!Rectangle(4000,4200,4100,4300)"
+    assert r[2] == "dataset foo: Field() -> Field()&!Rectangle(4000,4200,4100,4300)"
 
     r = caplog.record_tuples[1]
     assert r[0] == "sherpa.astro.data"

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -116,7 +116,7 @@ def test_filter_notice_bad_361(make_data_path, caplog):
     lname, lvl, msg = caplog.record_tuples[5]
     assert lname == 'sherpa.ui.utils'
     assert lvl == logging.INFO
-    assert msg == '1: 0.0073:14.9504 -> 0.4964:8.0592 Energy (keV)'
+    assert msg == 'dataset 1: 0.0073:14.9504 -> 0.4964:8.0592 Energy (keV)'
 
     lname, lvl, msg = caplog.record_tuples[6]
     assert lname == 'sherpa.astro.data'
@@ -127,7 +127,7 @@ def test_filter_notice_bad_361(make_data_path, caplog):
     lname, lvl, msg = caplog.record_tuples[7]
     assert lname == 'sherpa.ui.utils'
     assert lvl == logging.INFO
-    assert msg == '1: 0.4964:8.0592 -> 0.0073:14.9504 Energy (keV)'
+    assert msg == 'dataset 1: 0.4964:8.0592 -> 0.0073:14.9504 Energy (keV)'
 
     s1 = ui.calc_stat()
     assert s1 == pytest.approx(stats['bad'])
@@ -298,7 +298,7 @@ def test_notice_string_data1d(session, expr, result, caplog):
     expected = "-100:100" if result is None else result
     assert s.get_data().get_filter(format='%d') == expected
 
-    expected = "1: -100:100 "
+    expected = "dataset 1: -100:100 "
     if result is None:
         expected += "x (unchanged)"
     elif result == "":
@@ -342,7 +342,7 @@ def test_notice_string_data1dint(session, expr, result, caplog):
     expected = "-100:100" if result is None else result
     assert s.get_data().get_filter(format='%d') == expected
 
-    expected = "1: -100:100 "
+    expected = "dataset 1: -100:100 "
     if result is None:
         expected += "x (unchanged)"
     elif result == "":
@@ -384,7 +384,7 @@ def test_notice_string_datapha(expr, result, caplog):
     expected = "1:19" if result is None else result
     assert s.get_data().get_filter(format='%d') == expected
 
-    expected = "1: 1:19 "
+    expected = "dataset 1: 1:19 "
     if result is None:
         expected += "Channel (unchanged)"
     elif result == "":
@@ -415,7 +415,7 @@ def test_notice_reporting_data1d(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: -100:100 x (unchanged)"
+    assert msg == "dataset 1: -100:100 x (unchanged)"
 
     s.notice(lo=2.5)
     assert len(caplog.record_tuples) == 2
@@ -423,7 +423,7 @@ def test_notice_reporting_data1d(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: -100:100 -> 3:100 x"
+    assert msg == "dataset 1: -100:100 -> 3:100 x"
 
     s.ignore(6, 15)
     assert len(caplog.record_tuples) == 3
@@ -431,7 +431,7 @@ def test_notice_reporting_data1d(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 3:100 -> 3:5,100 x"
+    assert msg == "dataset 1: 3:100 -> 3:5,100 x"
 
     s.notice_id(1, 12.5, 15)
     assert len(caplog.record_tuples) == 4
@@ -439,7 +439,7 @@ def test_notice_reporting_data1d(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 3:5,100 -> 3:5,13:100 x"
+    assert msg == "dataset 1: 3:5,100 -> 3:5,13:100 x"
 
     s.ignore_id(1)
     assert len(caplog.record_tuples) == 5
@@ -447,7 +447,7 @@ def test_notice_reporting_data1d(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 3:5,13:100 x -> no data"
+    assert msg == "dataset 1: 3:5,13:100 x -> no data"
 
     s.ignore()
     assert len(caplog.record_tuples) == 6
@@ -455,7 +455,7 @@ def test_notice_reporting_data1d(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: no data (unchanged)"
+    assert msg == "dataset 1: no data (unchanged)"
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
@@ -476,7 +476,7 @@ def test_notice_reporting_data1dint(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: -100:100 -> 2:100 x"
+    assert msg == "dataset 1: -100:100 -> 2:100 x"
 
     s.ignore(6, 15)
     assert len(caplog.record_tuples) == 2
@@ -484,7 +484,7 @@ def test_notice_reporting_data1dint(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 2:100 -> 2:4,99:100 x"
+    assert msg == "dataset 1: 2:100 -> 2:4,99:100 x"
 
     s.notice_id(1, 12.5, 15)
     assert len(caplog.record_tuples) == 3
@@ -492,7 +492,7 @@ def test_notice_reporting_data1dint(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 2:4,99:100 -> 2:4,12:100 x"
+    assert msg == "dataset 1: 2:4,99:100 -> 2:4,12:100 x"
 
     s.ignore_id(1)
     assert len(caplog.record_tuples) == 4
@@ -500,7 +500,7 @@ def test_notice_reporting_data1dint(session, caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 2:4,12:100 x -> no data"
+    assert msg == "dataset 1: 2:4,12:100 x -> no data"
 
 
 def test_notice_reporting_datapha(caplog):
@@ -519,7 +519,7 @@ def test_notice_reporting_datapha(caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 1:19 -> 3:19 Channel"
+    assert msg == "dataset 1: 1:19 -> 3:19 Channel"
 
     s.ignore(6, 15)
     assert len(caplog.record_tuples) == 2
@@ -527,7 +527,7 @@ def test_notice_reporting_datapha(caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 3:19 -> 3:5,16:19 Channel"
+    assert msg == "dataset 1: 3:19 -> 3:5,16:19 Channel"
 
     s.notice_id(1, 13, 15)
     assert len(caplog.record_tuples) == 3
@@ -535,7 +535,7 @@ def test_notice_reporting_datapha(caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 3:5,16:19 -> 3:5,13:19 Channel"
+    assert msg == "dataset 1: 3:5,16:19 -> 3:5,13:19 Channel"
 
     s.ignore_id(1)
     assert len(caplog.record_tuples) == 4
@@ -543,7 +543,7 @@ def test_notice_reporting_datapha(caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: 3:5,13:19 -> No noticed bins Channel"
+    assert msg == "dataset 1: 3:5,13:19 -> No noticed bins Channel"
 
     s.ignore()
     assert len(caplog.record_tuples) == 5
@@ -551,7 +551,7 @@ def test_notice_reporting_datapha(caplog):
     loc, lvl, msg = caplog.record_tuples[-1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: No noticed bins Channel (unchanged)"
+    assert msg == "dataset 1: No noticed bins Channel (unchanged)"
 
 
 def test_notice2d_reporting(caplog):
@@ -577,7 +577,7 @@ def test_notice2d_reporting(caplog):
     loc, lvl, msg = caplog.record_tuples[0]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: Field() -> Circle(3,15,5)"
+    assert msg == "dataset 1: Field() -> Circle(3,15,5)"
 
     s.notice2d_id(1, "rect(4, 12, 7, 14)")
     assert len(caplog.record_tuples) == 2
@@ -585,7 +585,7 @@ def test_notice2d_reporting(caplog):
     loc, lvl, msg = caplog.record_tuples[1]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: Circle(3,15,5) -> Circle(3,15,5)|Rectangle(4,12,7,14)"
+    assert msg == "dataset 1: Circle(3,15,5) -> Circle(3,15,5)|Rectangle(4,12,7,14)"
 
     # I was trying to remove all the filters, but this doesn't seem to
     # do it. Maybe the region logic is not able to recognize that this
@@ -597,4 +597,4 @@ def test_notice2d_reporting(caplog):
     loc, lvl, msg = caplog.record_tuples[2]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
-    assert msg == "1: Circle(3,15,5)|Rectangle(4,12,7,14) -> Circle(3,15,5)&!Rectangle(-5,-5,25,25)|Rectangle(4,12,7,14)&!Rectangle(-5,-5,25,25)"
+    assert msg == "dataset 1: Circle(3,15,5)|Rectangle(4,12,7,14) -> Circle(3,15,5)&!Rectangle(-5,-5,25,25)|Rectangle(4,12,7,14)&!Rectangle(-5,-5,25,25)"

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -515,11 +515,11 @@ def test_notice_reporting_datapha(caplog):
 
     s.ignore_id(1)
     assert len(caplog.record_tuples) == 4
-    clc_filter(caplog, "dataset 1: 3:5,13:19 -> No noticed bins Channel")
+    clc_filter(caplog, "dataset 1: 3:5,13:19 Channel -> no data")
 
     s.ignore()
     assert len(caplog.record_tuples) == 5
-    clc_filter(caplog, "dataset 1: No noticed bins Channel (unchanged)")
+    clc_filter(caplog, "dataset 1: no data (unchanged)")
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -57,22 +57,36 @@ def _get_image_filter(data):
     means no data has been selected for the former, but all data is
     selected in the latter. For the logging of the filters this makes
     things awkward, so we over-ride the image case and replace an empty
-    string with "Field()".
+    string with "Field()". See also issue #1430 which points out that
+    the empty string can also mean "all data has been ignored".
 
     Parameters
     ----------
     data : sherpa.astro.data.DataIMG instance
 
+    Returns
+    -------
+    msg : str
+        The filter expression. An empty string means all data has been
+        ignored, to match the 1D case.
+
     """
+
+    # We can not rely on get_filter as it returns the empty string to
+    # indicate both "all data is selected" and "add data is
+    # ignored". So we add in a check on the mask tri-state (a boolean
+    # or a ndarray).
+    #
+    if data.mask is True:
+        return "Field()"
+
+    if data.mask is False:
+        return ""  # follow the 1D case and use "" to mean no data
 
     # Unlike sherpa.ui.utils._get_filter, there is no known "the
     # get_filter call can raise an exception" case to handle.
     #
-    out = data.get_filter()
-    if out == "":
-        return "Field()"
-
-    return out
+    return data.get_filter()
 
 
 class Session(sherpa.ui.utils.Session):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -54,9 +54,9 @@ def _get_image_filter(data):
     """When reporting filters, we need to handle images separately.
 
     There is a disconnect between 1D and 2D filters as an empty string
-    means no data has been seected for the former, but all data is
+    means no data has been selected for the former, but all data is
     selected in the latter. For the logging of the filters this makes
-    things awkward, so we over-ride the image case and replace an mpty
+    things awkward, so we over-ride the image case and replace an empty
     string with "Field()".
 
     Parameters

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -65,6 +65,9 @@ def _get_image_filter(data):
 
     """
 
+    # Unlike sherpa.ui.utils._get_filter, there is no known "the
+    # get_filter call can raise an exception" case to handle.
+    #
     out = data.get_filter()
     if out == "":
         return "Field()"
@@ -6732,18 +6735,19 @@ class Session(sherpa.ui.utils.Session):
 
         """
         idval = self._fix_id(id)
+        idstr = f"dataset {idval}"
         if bkg_id is None:
             data = self._get_pha_data(idval)
         else:
             data = self.get_bkg(idval, bkg_id)
+            idstr += f": background {bkg_id}"
 
         ofilter = data.get_filter(delim=':', format='%g')
         data.ignore_bad()
         nfilter = data.get_filter(delim=':', format='%g')
 
-        sherpa.ui.utils.report_filter_change(idval, ofilter, nfilter,
-                                             data.get_xlabel(),
-                                             bkg_id=bkg_id)
+        sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter,
+                                             data.get_xlabel())
 
     def _notice_warning(self):
         quantities = numpy.asarray([data.get_analysis()
@@ -6918,8 +6922,9 @@ class Session(sherpa.ui.utils.Session):
             ofilter = _get_image_filter(d)
             d.notice2d(val, False)
             nfilter = _get_image_filter(d)
-            sherpa.ui.utils.report_filter_change(idval, ofilter, nfilter,
-                                                 xlabel=None)
+
+            idstr = f"dataset {idval}"
+            sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
     def ignore2d(self, val=None):
         """Exclude a spatial region from all data sets.
@@ -6986,8 +6991,9 @@ class Session(sherpa.ui.utils.Session):
             ofilter = _get_image_filter(d)
             d.notice2d(val, True)
             nfilter = _get_image_filter(d)
-            sherpa.ui.utils.report_filter_change(idval, ofilter, nfilter,
-                                                 xlabel=None)
+
+            idstr = f"dataset {idval}"
+            sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
     def notice2d_id(self, ids, val=None):
         """Include a spatial region of a data set.
@@ -7063,8 +7069,9 @@ class Session(sherpa.ui.utils.Session):
             ofilter = _get_image_filter(d)
             d.notice2d(val, False)
             nfilter = _get_image_filter(d)
-            sherpa.ui.utils.report_filter_change(idval, ofilter, nfilter,
-                                                 xlabel=None)
+
+            idstr = f"dataset {idval}"
+            sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
     def ignore2d_id(self, ids, val=None):
         """Exclude a spatial region from a data set.
@@ -7135,8 +7142,9 @@ class Session(sherpa.ui.utils.Session):
             ofilter = _get_image_filter(d)
             d.notice2d(val, True)
             nfilter = _get_image_filter(d)
-            sherpa.ui.utils.report_filter_change(idval, ofilter, nfilter,
-                                                 xlabel=None)
+
+            idstr = f"dataset {idval}"
+            sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
     def notice2d_image(self, ids=None):
         """Include pixels using the region defined in the image viewer.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -151,7 +151,7 @@ def report_filter_change(idval, ofilter, nfilter,
     to the get_filter call, but I list them so we have consistent
     code. Ideally this would be encapsulated in the Data class, so we
     let the object define the best arguments to use, but it's not
-    guaranteed to work well so we are trynig this explicit approach.
+    guaranteed to work well so we are trying this explicit approach.
 
     A filter expression of "" (the empty string) is taken to mean all
     data has been removed, and converted to something more readable

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -223,7 +223,7 @@ def report_filter_change(idstr, ofilter, nfilter, xlabel=None):
     else:
         ostr += f"{ofilter}"
         if ofilter == nfilter:
-            ostr += f" {xlabel} (unchanged)"
+            ostr += f"{label} (unchanged)"
         else:
             ostr += f" -> {nfilter}{label}"
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -134,9 +134,23 @@ def _get_filter(data):
     # See #1430 for a discussion on why we have different behavior
     # when all the data is excluded: it should be unified.
     #
+    # We follow the approach used for the DataIMG case be relying on
+    # the mask attribute to determine what the output should
+    # be. Unfortunately this is only helpful for the "all data
+    # excluded" case, as we do not have the equivalent of "Field()" to
+    # indicate "use all the data", and we can not remove the DataErr
+    # exception check from get_filter, just in case.
+    #
+    if data.mask is False:
+        return ""
+
     try:
         return data.get_filter(delim=':', format='%g')
     except DataErr as exc:
+        # It may be possible that this happens - e.g. that data.mask
+        # is a ndarray of all False vaues - but it is not 100%
+        # obvious.  This is left in just in case.
+        #
         if str(exc) == "mask excludes all data":
             return ""
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -159,11 +159,9 @@ def report_filter_change(idval, ofilter, nfilter,
 
     """
 
-    ostr = f"{idval}:"
+    ostr = f"dataset {idval}: "
     if bkg_id is not None:
-        ostr += f"{bkg_id}:"
-
-    ostr += " "
+        ostr += f"background {bkg_id}: "
 
     # Make it easy to handle labels being optional
     if xlabel is None:


### PR DESCRIPTION
# Summary

When a `notice` or `ignore` call - including the variants like `notice_id` and `ignore2d` - then the change in the filter is reported to the screen (for users of the ui layer). This is to help users understand what a filter has actually done, as there are times when it may be surprising (in particular with grouped PHA data). The output can be hidden by using the `sherpa.utils.logging.SherpaVerbosity` context manager:

    >>> with SherpaVerbosity("WARN"):
    ...     notice(0.5, 8)

# Details

This is the initial response to #1558 as it is the simplest thing to do. There may be more changes we would like to make - such as enhancing the `FitResults` structure - but that can be done at a later time, as this is hopefully going to provide significant benefit.

Two issues to be aware of:

1. for the `DataIMG` case, the empty string means either "all data", and we handle this by replacing it by `Field()`, or "no data", and we leave this as "" as this is the convention used for the 1D case. See also issue #1560 
2. the filer for background PHA datasets is only shown when explicitly selected - i.e. the `bkg_id` parameter is set. Technically we could show the range when the background is not being subtracted (i.e. even when the user is filtering the "source"), but let's leave that for a potential update, once we understand how well this works.

The implementation is reasonably simple, but there is some annoying repetition in the astro 2d case as we do not pass through an ignore keyword. We should look at improving this in a later PR but I didn't want to change the API of the `notice2d` family of calls in this PR (see #1586). One place I have tried to be careful with is that the logic for `notice`/`ignore` is now to do something like

    ostr = data.get_filter(...)
    data.do-the-filter()
    nstr = data.get_filter(...)
    output_the_old_and_new_filter(ostr, nstr)

but if the `get_filter` call fails then we may not end up doing the filter. Technically the only way to get a failure is if something very wrong has happened, but we have at least two cases where it can happen and (knowing the filter code, there could be other odd cases out there):

1. using `ignore_bad` can leave us in a strange state where some things still work and I don't know what is going on, but let's not break this
2. if a user happens to have used Data2D or Data2DInt then we suffer from #1587 and strange things could happen (in this case it might be helpful to the user to error out as they are likely to get wring results, but again let's not break things needlessly)

In looking at the code I noticed (again) that we do not reliably handle the "add-data-is-filtered" case - e.g. see #1430 :

1. for 1D data we use the empty string, but for `DataIMG` filters the empty string means **both** "all data is noticed" and "all data is ignored"
3. some times we get a `"No noticed bins"` string instead of the empty string (for `DataPHA`), but I have worked around this by checking for `data.mask is False`
4. I don't know if it's still the case, but there have been cases where a filter that removes all data results in an error (there are times this makes sense, but probablly not when just reporting things, but I can't remember the details just now).

We also have some unresolved differences between `get_filter` and `get_filter_expr`, and in whether this output can be handled by the low-level `parse_expr` code (which assumes we use `a:b` to indicate a range, in part because `-` is complicated to read when you have negative coordinates)
 
Edge case: we allow a string to be sent to `notice` and family, which then gets interpreted as a set of filters. This means that we get a line of output after each call, as shown below. Handling this to only create one line would be significantly-more work than I have to put into this PR:

```
>>> ignore()
dataset 1: 15:30 x -> no data
>>> notice("8:12, 18:22")
dataset 1: no data -> 10 x
dataset 1: 10 -> 10,20 x
```

ie it would be nice to just have a single output saying `dataset 1: no data -> 10,20 x`, but that's complicated. Similarly we could try and combine the output from multiple datasets when they are the same, but I don't think it's worth it.

# Examples

## PHA

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: for i in range(1, 5):
   ...:     load_pha(i, f"sherpa-test-data/sherpatest/obs{i}.pi")
   ...: 
read ARF file sherpa-test-data/sherpatest/obs1.arf
read RMF file sherpa-test-data/sherpatest/obs1.rmf
read background file sherpa-test-data/sherpatest/obs1_bg.pi
read ARF file sherpa-test-data/sherpatest/obs2.arf
read RMF file sherpa-test-data/sherpatest/obs2.rmf
read background file sherpa-test-data/sherpatest/obs2_bg.pi
read ARF file sherpa-test-data/sherpatest/obs3.arf
read RMF file sherpa-test-data/sherpatest/obs3.rmf
read background file sherpa-test-data/sherpatest/obs3_bg.pi
read ARF file sherpa-test-data/sherpatest/obs4.arf
read RMF file sherpa-test-data/sherpatest/obs4.rmf
read background file sherpa-test-data/sherpatest/obs4_bg.pi

In [3]: notice(0.5, 7)
dataset 1: 0.00146:14.9504 -> 0.4964:7.008 Energy (keV)
dataset 2: 0.00146:14.9504 -> 0.4964:7.008 Energy (keV)
dataset 3: 0.00146:14.9504 -> 0.4964:7.008 Energy (keV)
dataset 4: 0.00146:14.9504 -> 0.4964:7.008 Energy (keV)

In [4]: notice()
dataset 1: 0.4964:7.008 -> 0.00146:14.9504 Energy (keV)
dataset 2: 0.4964:7.008 -> 0.00146:14.9504 Energy (keV)
dataset 3: 0.4964:7.008 -> 0.00146:14.9504 Energy (keV)
dataset 4: 0.4964:7.008 -> 0.00146:14.9504 Energy (keV)

In [5]: for i in range(1, 5):
   ...:     group_counts(i, 5)
   ...: 

In [6]: notice()
dataset 1: 0.00146:14.9504 Energy (keV) (unchanged)
dataset 2: 0.00146:14.9504 Energy (keV) (unchanged)
dataset 3: 0.00146:14.9504 Energy (keV) (unchanged)
dataset 4: 0.00146:14.9504 Energy (keV) (unchanged)

In [7]: notice(0.5, 7)
dataset 1: 0.00146:14.9504 -> 0.00146:9.0374 Energy (keV)
dataset 2: 0.00146:14.9504 Energy (keV) (unchanged)
dataset 3: 0.00146:14.9504 -> 0.4818:13.2422 Energy (keV)
dataset 4: 0.00146:14.9504 Energy (keV) (unchanged)

In [8]: ignore_id(2, hi=0.8)
dataset 2: 0.00146:14.9504 -> 0.8906:14.9504 Energy (keV)
```

## PHA (background)

I am just being explicit (checking against the underlying `DataPHA` objects) to check it all makes sense.

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi

In [3]: notice(0.5, 7)
dataset 1: 0.00146:14.9504 -> 0.4672:9.8696 Energy (keV)

In [4]: get_data().get_filter()
Out[4]: '0.467200011015:9.869600296021'

In [5]: get_bkg().get_filter()
Out[5]: '0.467200011015:9.869600296021'

In [6]: notice(bkg_id=1)  # note that this filter is applied to the existing filter (which is why we are clearing it)
dataset 1: background 1: 0.4672:9.8696 -> 0.00146:14.9504 Energy (keV)

In [7]: get_data().get_filter()
Out[7]: '0.467200011015:9.869600296021'

In [8]: get_bkg().get_filter()
Out[8]: '0.001460000058:14.950400352478'

In [9]: notice(0.3, 8, bkg_id=1)
dataset 1: background 1: 0.00146:14.9504 -> 0.2482:9.8696 Energy (keV)

In [10]: get_data().get_filter()
Out[10]: '0.467200011015:9.869600296021'

In [11]: get_bkg().get_filter()
Out[11]: '0.248199999332:9.869600296021'

In [12]: group_counts(1, 3, bkg_id=1)

In [13]: get_data().get_filter()
Out[13]: '0.467200011015:9.869600296021'

In [14]: get_bkg().get_filter()
Out[14]: '0.001460000058:9.942600250244'

In [15]: notice(bkg_id=1)
dataset 1: background 1: 0.00146:9.9426 -> 0.00146:14.9504 Energy (keV)

In [16]: notice(0.3, 8, bkg_id=1)
dataset 1: background 1: 0.00146:14.9504 -> 0.00146:8.176 Energy (keV)

In [17]: notice(bkg_id=1)
dataset 1: background 1: 0.00146:8.176 -> 0.00146:14.9504 Energy (keV)

In [18]: notice(0.5, 7, bkg_id=1)
dataset 1: background 1: 0.00146:14.9504 -> 0.3066:7.2416 Energy (keV)

In [19]: get_data().get_filter()
Out[19]: '0.467200011015:9.869600296021'

In [20]: get_bkg().get_filter()
Out[20]: '0.306600004435:7.241600036621'
```

## image

The output of "Field()" in line 3 is a hack, since get_filter() returns "" which is taken to mean everything, rather than nothing as it does for the 1D case (although note that it also uses "" to indicate all data is ignored):

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_image("bob", "sherpa-test-data/sherpatest/acisf08478_000N001_r0043_regevt3_srcimg.fits")

In [3]: notice2d("circle(100, 100, 10)")
dataset bob: Field() -> Circle(100,100,10) 

In [4]: notice2d("rect(0, 0, 200, 20)")
dataset bob: Circle(100,100,10) -> Circle(100,100,10)|Rectangle(0,0,200,20) 

In [5]: notice2d("rect(0, 0, 200, 200)")
dataset bob: Circle(100,100,10)|Rectangle(0,0,200,20) -> Circle(100,100,10)|Rectangle(0,0,200,20)|Rectangle(0,0,200,200) 
```

## Image with all or no data

```
In [6]: notice2d()
dataset 1: Circle(4324.5,3827.5,430) -> Field()

In [7]: notice2d()
dataset 1: Field() (unchanged)

In [8]: ignore2d()
dataset 1: Field() -> no data

In [9]: ignore2d()
dataset 1: no data (unchanged)

```

## PHA filtering out all data

What happens when all the data is filtered out - part 1:

```
In [2]: load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi

In [3]: get_filter()
Out[3]: '0.001460000058:14.950400352478'

In [4]: notice(0.5, 7)
dataset 1: 0.00146:14.9504 -> 0.4672:9.8696 Energy (keV)

In [5]: ignore(lo=2)
dataset 1: 0.4672:9.8696 -> 0.467:-1.9418 Energy (keV)

In [6]: ignore(hi=3)
dataset 1: 0.4672:1.9418 Energy (keV) -> no data

In [7]: get_filter()
Out[7]: ''

In [8]: notice(2, 3)
dataset 1: no data  -> 1.9418:3.0806 Energy (keV)

In [9]: notice()
dataset 1: 1.9418:3.0806 -> 0.00146:14.9504 Energy (keV)
```

Part 2: however, because of oddities (eg #1430) we can get different output which I have now fixed (it used to say "No noticed bins Energy (keV)" rather than "no data"):

```
In [10]: ignore()
dataset 1: 0.00146:14.9504 Energy (keV) -> no data

In [11]: ignore()
dataset 1: no data (unchanged)

In [12]: notice(2,3)
dataset 1: no data -> 1.9418:3.0806 Energy (keV)
```

## Data1D basic checks

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_arrays(1, [1, 2, 3, 4, 10, 20, 25, 30], [1, 2, 3, 4, 5, 6, 7, 8])

In [3]: notice(lo=5)
dataset 1: 1:30 -> 10:30 x

In [4]: notice(lo=2, hi=24)
dataset 1: 10:30 -> 2:30 x

In [5]: ignore(3, 5)
dataset 1: 2:30 -> 2,10:30 x
```

## Data1D filtering out all data

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_arrays(1, [1, 2, 3, 4, 10, 20, 25, 30], [1, 2, 3, 4, 5, 6, 7, 8])

In [3]: notice()
dataset 1: 1:30 x (unchanged)

In [4]: ignore()
dataset 1: 1:30 x -> no data

In [5]: ignore()
dataset 1: no data (unchanged)

In [6]: notice(lo=5)
dataset 1: no data -> 10:30 x
```

## Data1DInt filtering out all data

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_arrays(1, [1, 2, 5], [2, 4, 6], [1, 2, 10], Data1DInt)

In [3]: notice()
dataset 1: 1:6 x (unchanged)

In [4]: ignore()
dataset 1: 1:6 x -> no data
```

## DataPHA with ignore_bad

Calling `ignore_bad` does not always change the `get_filter` output (at least not at the moment), as as we use this to determine what to display it may seem like `ignore_bad` is always going to look ike

```
>>> ignore_bad()
dataset 1: 0.00146:14.9504 Energy (keV) (unchanged)
```

which might make it a bit confusing. However, as `ignore_bad` resets the filter it turns out to be useful (along with the existing `WARING` message which has not been changed in this PR):

```
>>> notice(0.5, 8)
dataset 1: 0.00146:14.9504 -> 0.4672:9.8696 Energy (keV)
>>> ignore_bad()
WARNING: filtering grouped data with quality flags, previous filters deleted
dataset 1: 0.4672:9.8696 -> 0.00146:14.9504 Energy (keV)
```