### PR TITLE
Add Python 3.10 Conda Builds, Drop Python 3.7 and Numpy <1.20, Switch to Pip for Conda Builds

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -39,14 +39,14 @@ jobs:
           - name: Linux Minimum Setup (Python 3.8)
             os: ubuntu-latest
             python-version: "3.8"
-            numpy-version: 1.18
+            numpy-version: "1.18"
             install-type: develop
             test-data: none
 
           - name: Linux Minimum Setup (Python 3.10)
             os: ubuntu-latest
             python-version: "3.10"
-            numpy-version: 1.21
+            numpy-version: "1.21"
             install-type: develop
             test-data: none
 
@@ -87,7 +87,7 @@ jobs:
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
             python-version: "3.8"
-            numpy-version: 1.20
+            numpy-version: "1.20"
             install-type: develop
             fits: astropy
             test-data: none

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - name: MacOS Full Build
             os: macos-latest
-            python-version: "3.8"
+            python-version: "3.10"
             install-type: develop
             fits: astropy
             test-data: submodule

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -50,6 +50,15 @@ jobs:
             install-type: develop
             test-data: none
 
+          - name: Linux Full Build (Python 3.10)
+            os: ubuntu-latest
+            python-version: "3.10"
+            install-type: develop
+            fits: astropy
+            test-data: submodule
+            matplotlib-version: 3
+            xspec-version: 12.12.1
+
           - name: Linux Full Build (Python 3.9)
             os: ubuntu-latest
             python-version: "3.9"
@@ -57,21 +66,11 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.12.1
+            xspec-version: 12.11.1
 
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest
             python-version: "3.8"
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
-            xspec-version: 12.11.1
-
-          - name: Linux Full Build (Python 3.7)
-            os: ubuntu-latest
-            python-version: "3.7"
-            numpy-version: 1.19
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -87,8 +86,8 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.7"
-            numpy-version: 1.18
+            python-version: "3.8"
+            numpy-version: 1.20
             install-type: develop
             fits: astropy
             test-data: none

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -22,7 +22,7 @@ jobs:
           - name: Linux Minimum Setup
             os: ubuntu-latest
             python-version: "3.8"
-            numpy-pkg: 'numpy>=1.18,<1.19'
+            numpy-pkg: 'numpy>=1.20,<1.21'
             install-type: develop
             test-data: none
 
@@ -45,7 +45,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.8"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
@@ -53,7 +53,7 @@ jobs:
 
           - name: Linux Build (submodule data w/o Matplotlib or Xspec)
             os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.9"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,11 +28,6 @@ stages:
   tags:
       - sherpa-macos-build
 
-macos-python3.7-conda-build:
-  <<: *template_macos_conda_build
-  variables:
-      SHERPA_PYTHON_VERSION: "3.7.*"
-
 macos-python3.8-conda-build:
   <<: *template_macos_conda_build
   variables:
@@ -43,10 +38,10 @@ macos-python3.9-conda-build:
   variables:
       SHERPA_PYTHON_VERSION: "3.9.*"
 
-linux-python3.7-conda-build:
-  <<: *template_linux_conda_build
+macos-python3.10-conda-build:
+  <<: *template_macos_conda_build
   variables:
-    SHERPA_PYTHON_VERSION: '3.7.*'
+      SHERPA_PYTHON_VERSION: "3.10.*"
 
 linux-python3.8-conda-build:
   <<: *template_linux_conda_build
@@ -58,18 +53,23 @@ linux-python3.9-conda-build:
   variables:
     SHERPA_PYTHON_VERSION: '3.9.*'
 
+linux-python3.10-conda-build:
+  <<: *template_linux_conda_build
+  variables:
+    SHERPA_PYTHON_VERSION: '3.10.*'
+
 conda:
   stage: deploy
   tags:
       - sherpa
   image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
   dependencies:
-      - linux-python3.7-conda-build
       - linux-python3.8-conda-build
       - linux-python3.9-conda-build
-      - macos-python3.7-conda-build
+      - linux-python3.10-conda-build
       - macos-python3.8-conda-build
       - macos-python3.9-conda-build
+      - macos-python3.10-conda-build
   script:
       - echo $CONDA_UPLOAD_TOKEN
       - anaconda -t $CONDA_UPLOAD_TOKEN upload -u sherpa -c dev packages/linux-64/sherpa* --force
@@ -89,11 +89,6 @@ conda:
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
       - export PATH=~/miniconda/bin:$PATH
       - conda update -qq -y --all
-      - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
-      - source activate test37
-      - pip install /main.zip
-      - sherpa_smoke -f astropy
-      - sherpa_test
       - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test38
       - pip install /main.zip
@@ -101,6 +96,11 @@ conda:
       - sherpa_test
       - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa matplotlib # How to make sure it's the correct version?
       - source activate test39
+      - pip install /main.zip
+      - sherpa_smoke -f astropy
+      - sherpa_test
+      - conda create -n test310 --yes -q -c sherpa/label/dev python=3.10 astropy sherpa matplotlib # How to make sure it's the correct version?
+      - source activate test310
       - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
@@ -113,11 +113,6 @@ conda:
     - cd /tmp
     - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip
     - conda update -qq -y --all
-    - conda create -n test37 --yes -q -c sherpa/label/dev python=3.7 astropy sherpa matplotlib # How to make sure it's the correct version?
-    - conda activate test37
-    - pip install main.zip
-    - sherpa_smoke -f astropy
-    - sherpa_test
     - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test38
     - pip install main.zip
@@ -125,6 +120,11 @@ conda:
     - sherpa_test
     - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa matplotlib # How to make sure it's the correct version?
     - conda activate test39
+    - pip install main.zip
+    - sherpa_smoke -f astropy
+    - sherpa_test
+    - conda create -n test310 --yes -q -c sherpa/label/dev python=3.10 astropy sherpa matplotlib # How to make sure it's the correct version?
+    - conda activate test310
     - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
       - export SHERPA_FULL_VERSION=$(git describe --tags --always)
       - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
       - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
-      - conda build --output-folder /tmp/packages recipes/conda
+      - conda build --python ${SHERPA_PYTHON_VERSION} --output-folder /tmp/packages recipes/conda       #Specifying Python version with "--python 3.*" is required to allow selectors like "# [py>39]" to work
       - cp -r /tmp/packages .
   artifacts:
     expire_in: "2 weeks"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,9 @@ Example: new functionality, such as
 
 **Software versions**
 
-Development should use Python 3.7 or later.
+Development should use Python 3.8 or later.
 
-Ideally, NumPy support should be 1.17 or greater, but please include a comment
+Ideally, NumPy support should be 1.20 or greater, but please include a comment
 if you need to restrict (or relax) this further.
 
 Sherpa requires a C compiler, along with related tools, to build. Additional

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.7,3.8,3.9,3.10-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.8,3.9,3.10-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -71,7 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.7, 3.8, 3.9, and (as a beta) 3.10.
+Sherpa is tested against Python versions 3.8, 3.9, and 3.10.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -80,7 +80,7 @@ Using Anaconda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.7 to 3.10. It can be installed with the `conda`
+Python 3.8 to 3.10. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c sherpa sherpa

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,7 @@ channels:
   - astropy
 
 dependencies:
-  - python=3.7
+  - python=3.8
   - numpy
   - pandoc
   - pip

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.7 to 3.10.
+and is compatible with Python versions 3.8 to 3.10.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,9 +33,9 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.7, 3.8, 3.9, or (as a beta) 3.10
+* Python 3.8, 3.9, or 3.10
 * NumPy (the exact lower limit has not been determined,
-  1.17.0 or later will work, earlier version may work)
+  1.20.0 or later will work, earlier version may work)
 * Linux or OS-X (patches to add Windows support are welcome)
 
 Sherpa can take advantage of the following Python packages
@@ -140,7 +140,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.7, 3.8, 3.9, 3.10
+* Python versions: 3.8, 3.9, 3.10
 * Python packages: ``setuptools``, ``numpy``
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these

--- a/recipes/conda/build.sh
+++ b/recipes/conda/build.sh
@@ -2,12 +2,9 @@
 sed -i.orig "s|#install_dir=build|install_dir=$PREFIX|" setup.cfg
 git update-index --assume-unchanged setup.cfg
 
-$PYTHON setup.py clean --all
-
 export PYTHON_LDFLAGS=" "
 
-$PYTHON setup.py build
-$PYTHON setup.py install
+$PYTHON -m pip install --prefix=$PREFIX -vv .
 
 # This headers are known to collide with astropy's extensions and would prevent astropy from building
 rm -f $PREFIX/include/wcs*.h

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -17,13 +17,14 @@ requirements:
   - flex
 
  host:
-  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.8.*') }}
-  - numpy 1.20
-  - setuptools
+  - python
+  - numpy 1.20.* # [py<=39]
+  - numpy 1.21.* # [py>39]
+  - setuptools <60.0.0
   - six
 
  run:
-  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.8.*') }}
+  - python
   - {{ pin_compatible('numpy') }}
   - setuptools
   - pytest

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -17,13 +17,13 @@ requirements:
   - flex
 
  host:
-  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.7.*') }}
-  - numpy 1.19.*
+  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.8.*') }}
+  - numpy 1.20
   - setuptools
   - six
 
  run:
-  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.7.*') }}
+  - python {{ environ.get('SHERPA_PYTHON_VERSION', '3.8.*') }}
   - {{ pin_compatible('numpy') }}
   - setuptools
   - pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers=
     Intended Audience :: Science/Research
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Programming Language :: C
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -25,7 +24,7 @@ classifiers=
     Topic :: Scientific/Engineering :: Physics
 
 [options]
-python_requires = ~=3.7
+python_requires = ~=3.8
 zip_safe = False
 install_requires =
     numpy

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ import sys
 # This is done before we load in any non-core modules to avoid people
 # installing software that they can not use.
 #
-if sys.version_info < (3, 7):
-    sys.stderr.write("Sherpa 4.14 (and later) requires Python 3.7 or later.\n\n")
-    sys.stderr.write("Please use Sherpa 4.13.1 if you need to use Python 3.6\n")
+if sys.version_info < (3, 8):
+    sys.stderr.write("Sherpa 4.15 (and later) requires Python 3.8 or later.\n\n")
+    sys.stderr.write("Please use Sherpa 4.14.1 if you need to use Python 3.7\n")
     sys.exit(1)
 
 # We need to import setuptools so that 'python setup.py develop'


### PR DESCRIPTION
Continuing with [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html), we can drop Python 3.7 and Numpy <1.20 support for this next release. 

This PR bumps the Conda package builds to 3.8-3.10, switches to using pip instead of setup.py for those builds, and bumps various references to these versions. 

### Notes
As noted during the Python 3.9 addition (#1192), we will need to use Numpy 1.21 for Python 3.10 (Conda does not have a compatible Numpy 1.20.* package for Python 3.10). So, we have two main options:

1. Stay with the current SHERPA_PYTHON_VERSION method and bump the numpy version for all Conda package builds to numpy 1.21 (as done in #1203).
2. Or, switch to using "--python" with a selector for determining the Numpy version (just when using the Conda recipe to build). 

Option 2 is the method that I have currently used in this PR (as it is the same we use in CIAO's Sherpa currently). This change would mean that the Conda recipe will not use the SHERPA_PYTHON_VERSION environment variable to determine the Python version to build for (and will not have the "default" Python version of our minimum supported version). If someone uses the recipe, they will just need to add `--python 3.8` to their call to `conda build ...`. The only people impacted by this change would be those who use the recipes/conda directory to build. 

Option 1 and 2 are both valid. If there is a preference either direction, I can update this accordingly. 