### PR TITLE
GitLab: Add version info to deploy test, update test OS, and allow interrupt.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,41 @@
+#Allow all jobs in the pipeline to be canceled automatically if a newer pipeline
+# is kicked off on the same branch before the first run is complete.
+# Important if multiple PRs are merged to a branch in succession.
+# We disable this below for the deploy job (which disables this for
+# all jobs after "deploy")
+default:
+  interruptible: true
+
 stages:
+  - version
   - build and package
   - deploy
   - test deploy
 
+#See this doc for GitLab's reccomendation for passing env variables between jobs:
+# https://docs.gitlab.com/ee/ci/variables/index.html#pass-an-environment-variable-to-another-job
+define-version:
+  stage: version
+  image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
+  tags:
+    - sherpa
+  script:
+    - export SHERPA_FULL_VERSION=$(git describe --tags --always)
+    - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
+    - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
+    - echo "SHERPA_VERSION=${SHERPA_VERSION}" >> version.env
+    - echo "SHERPA_BUILD_NUMBER=${SHERPA_BUILD_NUMBER}" >> version.env
+  artifacts:
+    reports:
+      dotenv: version.env
+    expire_in: "2 weeks"
+
 .template-conda-build: &template_conda_build
   stage: build and package
+  dependencies:
+    - define-version
   script:
-      - export SHERPA_FULL_VERSION=$(git describe --tags --always)
-      - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
-      - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
-      - conda build --python ${SHERPA_PYTHON_VERSION} --output-folder /tmp/packages recipes/conda       #Specifying Python version with "--python 3.*" is required to allow selectors like "# [py>39]" to work
+      - conda build --output-folder /tmp/packages recipes/conda
       - cp -r /tmp/packages .
   artifacts:
     expire_in: "2 weeks"
@@ -21,7 +47,6 @@ stages:
   image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
   tags:
     - sherpa
-
 
 .template-macos-conda-build: &template_macos_conda_build
   <<: *template_conda_build
@@ -63,6 +88,7 @@ conda:
   tags:
       - sherpa
   image: registry.gitlab.com/cxc/sherpa/sherpa-docker-build:main
+  interruptible: false
   dependencies:
       - linux-python3.8-conda-build
       - linux-python3.9-conda-build
@@ -78,6 +104,8 @@ conda:
 .template-linux-test: &template-linux-test
   stage: test deploy
   image: centos:7
+  dependencies:
+    - define-version
   variables:
       PAGER: 'less'
   before_script:
@@ -87,20 +115,21 @@ conda:
       - curl -LO -k http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
       - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip # Hack, gitlab can't checkout the submodule from github
       - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
-      - export PATH=~/miniconda/bin:$PATH
+      - source ~/miniconda/etc/profile.d/conda.sh
+      - conda activate
       - conda update -qq -y --all
-      - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
-      - source activate test38
+      - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa==${SHERPA_VERSION}=py*_${SHERPA_BUILD_NUMBER} matplotlib
+      - conda activate test38
       - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
-      - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa matplotlib # How to make sure it's the correct version?
-      - source activate test39
+      - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa==${SHERPA_VERSION}=py*_${SHERPA_BUILD_NUMBER} matplotlib
+      - conda activate test39
       - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
-      - conda create -n test310 --yes -q -c sherpa/label/dev python=3.10 astropy sherpa matplotlib # How to make sure it's the correct version?
-      - source activate test310
+      - conda create -n test310 --yes -q -c sherpa/label/dev python=3.10 astropy sherpa==${SHERPA_VERSION}=py*_${SHERPA_BUILD_NUMBER} matplotlib
+      - conda activate test310
       - pip install /main.zip
       - sherpa_smoke -f astropy
       - sherpa_test
@@ -109,21 +138,23 @@ conda:
   tags:
     - sherpa-macos-build
   stage: test deploy
+  dependencies:
+    - define-version
   script:
     - cd /tmp
     - curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip
     - conda update -qq -y --all
-    - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa matplotlib # How to make sure it's the correct version?
+    - conda create -n test38 --yes -q -c sherpa/label/dev python=3.8 astropy sherpa==${SHERPA_VERSION}=py*_${SHERPA_BUILD_NUMBER} matplotlib
     - conda activate test38
     - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test
-    - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa matplotlib # How to make sure it's the correct version?
+    - conda create -n test39 --yes -q -c sherpa/label/dev python=3.9 astropy sherpa==${SHERPA_VERSION}=py*_${SHERPA_BUILD_NUMBER} matplotlib
     - conda activate test39
     - pip install main.zip
     - sherpa_smoke -f astropy
     - sherpa_test
-    - conda create -n test310 --yes -q -c sherpa/label/dev python=3.10 astropy sherpa matplotlib # How to make sure it's the correct version?
+    - conda create -n test310 --yes -q -c sherpa/label/dev python=3.10 astropy sherpa==${SHERPA_VERSION}=py*_${SHERPA_BUILD_NUMBER} matplotlib
     - conda activate test310
     - pip install main.zip
     - sherpa_smoke -f astropy
@@ -133,31 +164,25 @@ centos7-test:
   <<: *template-linux-test
   image: centos:7
 
-ubuntu14-test:
-  <<: *template-linux-test
-  image: ubuntu:14.04
-  before_script:
-      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
-
-ubuntu16-test:
-  <<: *template-linux-test
-  image: ubuntu:16.04
-  before_script:
-      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
-
 ubuntu18-test:
   <<: *template-linux-test
   image: ubuntu:18.04
   before_script:
       - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
 
-fedora29-test:
+ubuntu20-test:
   <<: *template-linux-test
-  image: fedora:29
+  image: ubuntu:20.04
+  before_script:
+      - apt-get update && apt-get install -y -q bzip2 curl libxext6 libsm6 libxrender1 less
 
-fedora30-test:
+fedora34-test:
   <<: *template-linux-test
-  image: fedora:30
+  image: fedora:34
+
+fedora35-test:
+  <<: *template-linux-test
+  image: fedora:35
 
 macos-10.13-test:
   <<: *template-macos-test


### PR DESCRIPTION
In this PR, the following updates were made to the GitLab workflow:

-  Added a step to save the version information so that we always test the same version of Sherpa that we built
    - In more recent versions of GitLab, we can save environment information to be shared between jobs. This allows us to store the Sherpa version info to make sure we run the download tests for the same version we built. This prevents us from just downloading the latest available, which causes the wrong Sherpa package to be tested under some circumstances (eg. a second pipeline runs deploy before a previous deployment test starts downloading sherpa or when between releases).
- Updated the OS support for the automated tests:
    - Updated the OS versions tested to drop some of the older platforms that are EOL or to pick up newer versions. *The exact versions here are up for debate (just proposing some options to get the ball rolling).*
- Switched the way to use Conda on Linux from adding Conda to the path to sourcing Conda
- Set the default for "interruptible" to true (until the "conda" job in the "deploy" stage). 
    - With this set to true, we allow GitLab to cancel a pipeline if it is made redundant (eg. if another pipeline runs on the same branch). This should help reduce the number of pipelines especially around releases (which have occasionally knocked out a machine if they are too bogged down). 
    - Once a pipeline reaches the deploy stage (where "interruptible" is set to false), the pipeline can no longer be interrupted. This is done to avoid partial deployments which is one of the recommendations from GitLab [here](https://docs.gitlab.com/ee/ci/yaml/#interruptible).