### PR TITLE
Minor changes to the fake_pha test added in #1567

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -547,9 +547,10 @@ def test_fake_pha_issue_1209(make_data_path, clean_astro_ui, tmp_path):
     ui.set_source(3, pl)
     assert ui.calc_stat(3) == pytest.approx(stat)
 
+
 @requires_fits
 @requires_data
-def test_fake_pha_issue_1568(make_data_path, clean_astro_ui, tmp_path):
+def test_fake_pha_issue_1568(make_data_path, clean_astro_ui, reset_seed):
     """Check issue #1568.
 
     In some cases, in particular XMM/RGS we only have an RMF, but no ARF.

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -566,9 +566,10 @@ def test_fake_pha_issue_1568(make_data_path, clean_astro_ui, reset_seed):
 
     ui.fake_pha(None, arf=None, rmf=infile, exposure=1000.)
     data = ui.get_data()
-    # Even with noise, maximum should be close to 3 keV
-    assert np.isclose(data.get_x()[np.argmax(data.counts)], 2., atol=.2)
 
-    # This normalization should generate a good number of counts.
-    assert data.counts.sum() > 5000
-    assert data.counts.sum() < 10000
+    # The maximum count value should be near 2 keV, thanks to the response,
+    # and there's a reasonable number of counts. With this random seed
+    # we can check the values.
+    #
+    assert data.counts.sum() == 7968
+    assert data.get_x()[np.argmax(data.counts)] == pytest.approx(1.957132)


### PR DESCRIPTION
# Summary

Internal changes to the test added for fake_pha in #1567

# Details

Changes are

- removed `tmp_path` fixture as unused
- added `reset_seed` fixture to ensure we go back to a "randomised" seed (I see this as more use in that it makes it easier to see other tests that are affected by random-ness_
- since we have fixed the seed we can be more-explicit in the tests, rather than "is the value between these ranges"
- tweaked a comment that said we expected the peak at 3 keV when it's more-like 2 keV