### PR TITLE
Tests: fix a logical test error

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3896,8 +3896,8 @@ def test_set_plot_opt_explicit(cls):
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name,extraargs",
                          [("data", []), ("model", []), ("source", []),
-                          ("model_component", ["mdl"]),
-                          ("source_component", ["mdl"])
+                          ("model_component", ["m1"]),
+                          ("source_component", ["m1"])
                           ])
 def test_set_plot_opt_changes_fields(cls, name, extraargs):
     """Does "all" change all the type-specific plots?


### PR DESCRIPTION
# Summary

Fix a logical error in a plotting test.

# Details

The test should have used "m1" to reference the model component to plot, but I'd accidentally used "mdl" (as this is the local name used in the code for some reason). The problem is that we can persist model names over different test set-ups, so this was never noticed (as we don't really check the plot results in depth here).

In PR #1537 I added code to try and avoid the underlying problem - that is, model names can remain even is we have throw-away sessions - but it appears to not work here. I noticed this test issue when I was running the tests in parallel, and that obviously "hit the right spot" for running the plot tests without magically creating a component called "mdl" (a name we use a lot in the tests).

The fix is easy, I just wanted to provide some context, as it appears to be related to issue #1527.

This was only noticeable if you did something like

    pytest sherpa/astro/ui/tests/test_astro_ui_plot.py::test_set_plot_opt_changes_fields

or ran the tests in parallel with an unknown combination of the -n flag and the number of tests (e.g. it can be different with different PRs)

    pip install pytest-xdist
    pytest -n 10
