### PR TITLE
Avoid occasional test errors from Tcl_AsyncDelete

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -559,7 +559,7 @@ def old_numpy_printing():
 PLOT_BACKENDS = [dummy_backend]
 if pylab_backend is not None:
 
-    # over-ride the matplotlib backend from TkAgg to Agg to try
+    # override the matplotlib backend from TkAgg to Agg to try
     # and avoid errors from multiprocessing thanks to the error
     # "Tcl_AsyncDelete: async handler deleted by the wrong thread"
     # See issue #1590.

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -558,6 +558,15 @@ def old_numpy_printing():
 
 PLOT_BACKENDS = [dummy_backend]
 if pylab_backend is not None:
+
+    # over-ride the matplotlib backend from TkAgg to Agg to try
+    # and avoid errors from multiprocessing thanks to the error
+    # "Tcl_AsyncDelete: async handler deleted by the wrong thread"
+    # See issue #1590.
+    #
+    import matplotlib
+    matplotlib.use("agg")
+
     PLOT_BACKENDS.append(pylab_backend)
 
 


### PR DESCRIPTION
# Summary

Switch the matplotlib tests to use the Agg backend to avoid possible Tcl_AsyncDelete errors (issue #1509)

# Details

From a number of internet searches, it seems like the

    Tcl_AsyncDelete: async handler deleted by the wrong thread

error "caused" by matplotlib, as it defaults to the TkAgg backend. If we switch to the Agg backend does this fix the problem? It's hard to be sure, as the test errors were are not reproducible, but I have used this with #1477 and it seems to have stopped the problem.

Note that we currently don't actually test the matplotlib output so there should be no problem in the tests.

Fix #1509.