### PR TITLE
Gitlab: Reduce artifact retention period

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ define-version:
   artifacts:
     reports:
       dotenv: version.env
-    expire_in: "2 weeks"
+    expire_in: "3 days"
 
 .template-conda-build: &template_conda_build
   stage: build and package

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
       - conda build --python ${SHERPA_PYTHON_VERSION} --output-folder /tmp/packages recipes/conda       #Specifying Python version with "--python 3.*" is required to allow selectors like "# [py>39]" to work
       - cp -r /tmp/packages .
   artifacts:
-    expire_in: "2 weeks"
+    expire_in: "3 days"
     paths:
         - packages/
 


### PR DESCRIPTION
GitLab will be reducing the storage amount for private repositories soon, and our sherpa mirror on GitLab has ~5gb in generated artifacts. This PR simply reduces the time from 2 weeks to 3 days, which should be satisfactory as we already do our own backup of artifacts and haven't needed that far back of retention in the first place. This is tracked under CM-559.

This PR is purely GitLab-CI focused and has no impact on the GitHub-CI.