### PR TITLE
Add back --python removed in #1566

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ define-version:
   dependencies:
     - define-version
   script:
-      - conda build --output-folder /tmp/packages recipes/conda
+      - conda build --python ${SHERPA_PYTHON_VERSION} --output-folder /tmp/packages recipes/conda       #Specifying Python version with "--python 3.*" is required to allow selectors like "# [py>39]" to work
       - cp -r /tmp/packages .
   artifacts:
     expire_in: "2 weeks"


### PR DESCRIPTION
The --python flag was accidentally removed in #1566. This just adds that back in.