### PR TITLE
Set the language when building the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -305,7 +305,7 @@ release = sherpa_release
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
# Summary

Ensure the language setting is defined for recent versions of Sphinx

# Details

I thought I had a recent PR that made this change, but I can't find it. My guess is that this change happened in version 5.0 of Sphinx but I'm not spendnig a lot of time investigating it.