### PR TITLE
gitlab-ci: Set build num to 0 if not set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ define-version:
     - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
     - echo "SHERPA_VERSION=${SHERPA_VERSION}" >> version.env
     - echo "SHERPA_BUILD_NUMBER=${SHERPA_BUILD_NUMBER:-0}" >> version.env
+    - echo "SHERPA_BUILD_NUMBER=${SHERPA_BUILD_NUMBER:-0}"
   artifacts:
     reports:
       dotenv: version.env


### PR DESCRIPTION
The deploy stage for the first build on a new release branch just failed because the build number was not set when trying to download:

> PackagesNotFoundError: The following packages are not available from current channels:
>  \- sherpa==4.15.0[build=py*_]

For the first build on a new branch, the build number for the GitLab workflow should be 0. This is currently determined in the .gitlab-ci.yml by:
```
    - export SHERPA_FULL_VERSION=$(git describe --tags --always)
    - export SHERPA_VERSION=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[1]}'`
    - export SHERPA_BUILD_NUMBER=`echo $SHERPA_FULL_VERSION | awk '{split($0,a,"-"); print a[2]}'`
```
However, since this spot is tagged as "4.15.0" exactly, the above results in "SHERPA_BUILD_NUMBER" being blank. 

The simple fix for this is to set a default value when saving the build number:
```
    - echo "SHERPA_VERSION=${SHERPA_VERSION}" >> version.env
    - echo "SHERPA_BUILD_NUMBER=${SHERPA_BUILD_NUMBER:-0}" >> version.env
```