### PR TITLE
Fix error in #1521 - do not skip all tests

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -666,7 +666,7 @@ def add_sherpa_test_data_dir(doctest_namespace):
     #
     path = get_datadir()
     if path is None:
-        pytest.skip("sherpa-test-data not found")
+        return None
 
     if not path.endswith('/'):
         path += '/'

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pytest>=5.0,!=5.2.3
 pytest-xvfb
+pytest-doctestplus


### PR DESCRIPTION
## Summary
In PR #1521 I introduced a bug that led to all tests being skipped if the sherpa-test-data is not present. This PR fixes that bug.

## Details
The intend in #1521 was to skip only doctests, not regular tests, but the scope of the pytest fixture function that contained the `pytest.skip` statement was global.