### PR TITLE
Change the histogram1d and 2d routines so that they do not sort the input arguments 

### DIFF
--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2117,7 +2117,7 @@ def histogram2d(x, y, x_grid, y_grid):
     See the `numpy.histogram2d` routine for a version with more options.
 
     .. versionchanged:: 4.15.0
-       The x_grid and x_grid arguments are no-longer changed (sorted)
+       The x_grid and y_grid arguments are no-longer changed (sorted)
        by this routine.
 
     Parameters

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2088,13 +2088,12 @@ def histogram1d(x, x_lo, x_hi):
     >>> xhi = edges[1:]
     >>> y = histogram1d(x, xlo, xhi)
 
-    Given a list of samples (``vals``), bin them up so that
-    they can be used as the dependent axis (the value to
-    be fitted) in a Sherpa data set:
+    Given a list of samples, bin them up so that they can be used as
+    the dependent axis (the value to be fitted) in a Sherpa data set:
 
-    >>> dataspace1d(0.1, 10, 0.1)
-    >>> (lo, hi) = get_indep()
-    >>> n = histogram1d(vals, lo, hi)
+    >>> dataspace1d(1, 10, 1)
+    >>> lo, hi = get_indep()
+    >>> n = histogram1d([2, 3, 2, 8, 5, 2], lo, hi)
     >>> set_dep(n)
 
     """

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2060,6 +2060,10 @@ def histogram1d(x, x_lo, x_hi):
 
     See the `numpy.histogram` routine for a version with more options.
 
+    .. versionchanged:: 4.15.0
+       The x_lo and x_hi arguments are no-longer changed (sorted) by
+       this routine.
+
     Parameters
     ----------
     x : sequence of numbers
@@ -2098,8 +2102,8 @@ def histogram1d(x, x_lo, x_hi):
 
     """
 
-    x_lo = numpy.asarray(x_lo)
-    x_hi = numpy.asarray(x_hi)
+    x_lo = numpy.asarray(x_lo).copy()
+    x_hi = numpy.asarray(x_hi).copy()
 
     x_lo.sort()
     x_hi.sort()
@@ -2111,6 +2115,10 @@ def histogram2d(x, y, x_grid, y_grid):
     """Create 2D histogram from a sequence of samples.
 
     See the `numpy.histogram2d` routine for a version with more options.
+
+    .. versionchanged:: 4.15.0
+       The x_grid and x_grid arguments are no-longer changed (sorted)
+       by this routine.
 
     Parameters
     ----------
@@ -2144,8 +2152,8 @@ def histogram2d(x, y, x_grid, y_grid):
     >>> set_dep(n)
 
     """
-    x_grid = numpy.asarray(x_grid)
-    y_grid = numpy.asarray(y_grid)
+    x_grid = numpy.asarray(x_grid).copy()
+    y_grid = numpy.asarray(y_grid).copy()
 
     x_grid.sort()
     y_grid.sort()

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -395,12 +395,11 @@ def test_histogram1d_sort_axis():
     gb = ghi.copy()
     n = histogram1d([2, 3, 4, 5, 6, -1, 7, 20, 8, 9], glo, ghi)
 
-    assert glo == pytest.approx(sorted(ga))
-    assert ghi == pytest.approx(sorted(ghi))
+    assert glo == pytest.approx(ga)
+    assert ghi == pytest.approx(ghi)
     assert n == pytest.approx([1, 3, 1, 2, 1])
 
 
-@pytest.mark.xfail
 def test_histogram1d_with_fixed_bins():
     """What happens when the lo/hi bins can not be copied.
 
@@ -426,7 +425,6 @@ def test_histogram1d_with_fixed_bins():
     assert n == pytest.approx([1, 3, 1, 2, 1])
 
 
-@pytest.mark.xfail
 def test_histogram2d_with_fixed_bins():
     """What happens when the lo/hi bins can not be copied.
 

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2018, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018, 2019, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -23,7 +24,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal, \
 import pytest
 
 from sherpa.utils import _utils, is_binary_file, pad_bounding_box, \
-    get_fwhm
+    get_fwhm, histogram1d, histogram2d
 from sherpa.utils.testing import requires_data
 
 
@@ -378,3 +379,52 @@ def test_get_fwhm(x, y, expected):
 
     ans = get_fwhm(y, x)
     assert ans == pytest.approx(expected)
+
+
+@pytest.mark.xfail
+def test_histogram1d_with_fixed_bins():
+    """What happens when the lo/hi bins can not be copied.
+
+    With #1477 one of the examples started to fail because the
+    get_indep arguments can not be changed. As we currently do not
+    have doctest running (and the example test would need to be
+    updated to make it testable) let's check what happens here. The
+    original example is shown below, but it has been updated to know
+    make it doctestable, so this test is a low-level test.
+
+    >>> dataspace1d(0.1, 10, 0.1)
+    >>> (lo, hi) = get_indep()
+    >>> n = histogram1d(vals, lo, hi)
+    >>> set_dep(n)
+
+    """
+
+    # Ensure we can't overwrite the grid
+    grid = numpy.asarray([1, 3, 6, 7, 9, 12])
+    grid.setflags(write=False)
+
+    n = histogram1d([2, 3, 4, 5, 6, -1, 7, 20, 8, 9], grid[:-1], grid[1:])
+    assert n == pytest.approx([1, 3, 1, 2, 1])
+
+
+@pytest.mark.xfail
+def test_histogram2d_with_fixed_bins():
+    """What happens when the lo/hi bins can not be copied.
+
+    Similar to test_histogram1d_with_fixed_bins.
+
+    """
+
+    x0 = numpy.asarray([1, 2, 3])
+    x1 = numpy.asarray([1, 2, 3, 4])
+    x0.setflags(write=False)
+    x1.setflags(write=False)
+
+    x = numpy.asarray([2, 3, 0])
+    y = numpy.asarray([3, 4, 0])
+
+    n = histogram2d(x, y, x0, x1)
+    expected = numpy.zeros((3, 4))
+    expected[1, 2] = 1
+    expected[2, 3] = 1
+    assert n == pytest.approx(expected)

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -381,6 +381,25 @@ def test_get_fwhm(x, y, expected):
     assert ans == pytest.approx(expected)
 
 
+def test_histogram1d_sort_axis():
+    """Does histogram1d change the grid arguments?
+
+    This just checks the existing behavior.
+
+    """
+
+    glo = numpy.asarray([1, 3, 6, 7, 9])
+    ghi = numpy.asarray([6, 3, 12, 7, 9])
+
+    ga = glo.copy()
+    gb = ghi.copy()
+    n = histogram1d([2, 3, 4, 5, 6, -1, 7, 20, 8, 9], glo, ghi)
+
+    assert glo == pytest.approx(sorted(ga))
+    assert ghi == pytest.approx(sorted(ghi))
+    assert n == pytest.approx([1, 3, 1, 2, 1])
+
+
 @pytest.mark.xfail
 def test_histogram1d_with_fixed_bins():
     """What happens when the lo/hi bins can not be copied.


### PR DESCRIPTION
# Summary

The histogram1d and histogram2d routines can now fail in certain circumstances (such as when given the independent axes of a dataset, as suggested in one of the examples for histogram1d). Address this by making sure they copy the input arguments before sorting them. Fix #1601 

# Details

With #1477 the output of get_dep is marked read-only, which means that the second example for histogram1d now fails. Add tests for both 1d and 2d histogram variants that check this condition, and tweak the histogram1d example to be a bit easier to follow (and, in future, test).

As noted in #1601 this is option 2. I'd prefer option 3 - that is, remove the sort calls and note that the routines are expected to be called with sorted arguments - but that requires some research.