### PR TITLE
XSPEC minimum version is now 12.12.0

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -296,7 +296,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.12.1 down to 12.10.1. It may build against
+:term:`XSPEC` versions 12.12.1 down to 12.12.0. It may build against
 newer versions, but if it does it will not provide access to any new
 models in the release. The following sections of the `XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__
@@ -419,9 +419,7 @@ available.
    ``SUPPORTED_VERSIONS`` list was changed to include the triple
    ``(12, 12, 1)``::
 
-     SUPPORTED_VERSIONS = [(12, 10, 1),
-                           (12, 11, 0), (12, 11, 1),
-                           (12, 12, 0), (12, 12, 1)]
+     SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1)]
 
    This list is used to select which functions to include when
    compiling the C++ interface code. For reference, the defines are
@@ -526,6 +524,9 @@ available.
    to ``True``. Another option is the "scale" parameter, which is
    labelled with a ``*`` prefix, and these are treated as normal
    parameter values.
+
+   .. note:: The examples below may refer to XSPEC versions we
+	     no-longer support.
 
    a. ``sherpa/astro/xspec/src/_xspec.cc``
 
@@ -650,6 +651,10 @@ available.
 	is specified as a string using the ``__function__`` attribute. The
 	:py:class:`sherpa.astro.xspec.utils.ModelMeta` metaclass performs
 	a runtime check to ensure that the model can be used.
+
+        For example (from when XSPEC 12.9.0 was still supported):
+
+            __function__ = "C_apec" if equal_or_greater_than("12.9.1") else "xsaped"
 
    c. ``sherpa/astro/xspec/tests/test_xspec.py``
 

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,4 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.12.1, 12.12.0, 12.11.1,
-       12.11.0, and 12.10.1 (patch level `a` or later).
+       Sherpa can be built to use XSPEC versions 12.12.1 and 12.12.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -224,7 +224,7 @@ made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
 
     with-xspec = False
-    xspec_version = 12.10.1
+    xspec_version = 12.12.0
     xspec_lib_dirs = None
     xspec_include_dirs = None
     xspec_libraries = XSFunctions XSUtil XS
@@ -275,43 +275,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.29 of HEASOFT and
    may need updating with a newer release.
 
-3. If the full XSPEC 12.11.1 system has been built then use::
-
-       with-xspec = True
-       xspec_version = 12.11.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.28
-       ccfits_libraries = CCfits_2.5
-       wcslib_libraries = wcs-5.19.1
-
-   where the version numbers were taken from version 6.28 of HEASOFT.
-
-4. If the full XSPEC 12.11.0 system has been built then use::
-
-       with-xspec = True
-       xspec_version = 12.11.0
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.27
-       ccfits_libraries = CCfits_2.5
-       wcslib_libraries = wcs-5.19.1
-
-   where the version numbers were taken from version 6.27 of HEASOFT.
-
-5. If the full XSPEC 12.10.1 system has been built then use::
-
-       with-xspec = True
-       xspec_version = 12.10.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.26
-       ccfits_libraries = CCfits_2.5
-       wcslib_libraries = wcs-5.19.1
-
-   where the version numbers were taken from version 6.26.1 of HEASOFT.
-
-6. If the model-only build of XSPEC - created with the
+3. If the model-only build of XSPEC - created with the
    ``--enable-xs-models-only`` flag when building HEASOFT - has been
    installed, then the configuration is similar, but the library names
    may not need version numbers and locations, depending on how the

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -28,9 +28,7 @@ from .extensions import build_ext
 # major, minor, and micro. We drop the patch level - e.g.
 # "c" in "12.12.0c" as that is not helpful to track here.
 #
-SUPPORTED_VERSIONS = [(12, 10, 1),
-                      (12, 11, 0), (12, 11, 1),
-                      (12, 12, 0), (12, 12, 1)]
+SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1)]
 
 
 # We could use packaging.versions.Version here, but for our needs we
@@ -80,7 +78,7 @@ class xspec_config(Command):
     description = "Configure XSPEC Models external module (optional) "
     user_options = [
                     ('with-xspec', None, "Whether sherpa must build the XSPEC module (default False)"),
-                    ('xspec-version', None, "the XSPEC version (default 12.10.1)"),
+                    ('xspec-version', None, "the XSPEC version (default 12.12.0)"),
                     ('xspec-lib-dirs', None, "Where the xspec libraries are located, if with-xspec is True"),
                     ('xspec-libraries', None, "Name of the libraries that should be linked for xspec"),
                     ('cfitsio-lib-dirs', None, "Where the cfitsio libraries are located, if with-xspec is True"),
@@ -95,7 +93,7 @@ class xspec_config(Command):
 
     def initialize_options(self):
         self.with_xspec = False
-        self.xspec_version = '12.10.1'
+        self.xspec_version = '12.12.0'
         self.xspec_include_dirs = ''
         self.xspec_lib_dirs = ''
         # This is set up for how CIAO builds XSPEC; other users may require more libraries

--- a/setup.cfg
+++ b/setup.cfg
@@ -217,8 +217,8 @@ source-dir = docs
 #
 # If you are using a full XSPEC build, then it may be necessary to add
 # the correct version numbers to the cfitsio, CCfits, and wcs
-# libraries used in the build. For XSPEC 12.11.1 (HEAsoft 6.28)
-# this means using CCfits_2.5, wcs-5.19.1, and hdsp_6.28.
+# libraries used in the build. For XSPEC 12.12.1 (HEAsoft 6.30.1)
+# this means using CCfits_2.6, wcs-7.7, and hdsp_6.30.
 #
 # If you are using the models-only XSPEC build, then the cfitsio_lib_dirs,
 # ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if
@@ -227,10 +227,10 @@ source-dir = docs
 #
 # The gfortran_lib_dirs should be set if needed.
 #
-#xspec_version = 12.10.1
+#xspec_version = 12.12.0
 #xspec_lib_dirs = None
 #xspec_include_dirs = None
-#xspec_libraries = XSFunctions XSUtil XS hdsp_6.26  # change 6.26 to the correct version
+#xspec_libraries = XSFunctions XSUtil XS hdsp_6.30  # change 6.30 to the correct version
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio
 #ccfits_lib_dirs = None

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -5318,7 +5318,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     """
 
-    __function__ = "spin"
+    __function__ = "C_spin"
 
     def __init__(self, name='kerrdisk'):
         self.lineE = XSParameter(name, 'lineE', 6.4, 0.1, 100., 0.1, 100, units='keV', frozen=True)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,10 +20,9 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.12.1, 12.12.0, 12.11.1, 12.11.0, and 12.10.1 of
-XSPEC [1]_, and can be built against the model library or the full
-application.  There is no guarantee of support for older or newer
-versions of XSPEC.
+Sherpa supports versions 12.12.1 and 12.12.0 of XSPEC [1]_, and can be
+built against the model library or the full application.  There is no
+guarantee of support for older or newer versions of XSPEC.
 
 To be able to use most routines from this module, the HEADAS environment
 variable must be set. The `get_xsversion` function can be used to return the
@@ -108,7 +107,7 @@ from sherpa.astro.utils import get_xspec_position
 # Note that utils also imports _xspec so it will error out if it is
 # not available.
 #
-from .utils import ModelMeta, version_at_least, equal_or_greater_than
+from .utils import ModelMeta
 from . import _xspec
 
 
@@ -296,8 +295,8 @@ def set_xsabund(abundance):
      - 'wilm', from [7]_, except for elements not listed which
        are given zero abundance
      - 'lodd', from [8]_
-     - 'lpgp', from [9]_ (photospheric, requires XSPEC 12.12.0 or later)
-     - 'lpgs', from [9]_ (proto-solar, requires XSPEC 12.12.0 or later)
+     - 'lpgp', from [9]_ (photospheric)
+     - 'lpgs', from [9]_ (proto-solar)
 
     The values for these tables are given at [1]_.
 
@@ -1769,7 +1768,6 @@ class XSagnsed(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
-@version_at_least("12.11.0")
 class XSagnslim(XSAdditiveModel):
     """The XSPEC agnslim model: AGN super-Eddington accretion model
 
@@ -1827,10 +1825,6 @@ class XSagnslim(XSAdditiveModel):
     See Also
     --------
     XSagnsed, XSqsosed
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -1914,7 +1908,7 @@ class XSapec(XSAdditiveModel):
     .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelApec.html
 
     """
-    __function__ = "C_apec" if equal_or_greater_than("12.9.1") else "xsaped"
+    __function__ = "C_apec"
 
     def __init__(self, name='apec'):
         self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64.0, units='keV')
@@ -1960,7 +1954,7 @@ class XSbapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_bapec" if equal_or_greater_than("12.9.1") else "xsbape"
+    __function__ = "C_bapec"
 
     def __init__(self, name='bapec'):
         self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
@@ -2489,7 +2483,7 @@ class XSbvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_bvapec" if equal_or_greater_than("12.9.1") else "xsbvpe"
+    __function__ = "C_bvapec"
 
     def __init__(self, name='bvapec'):
         self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
@@ -2668,7 +2662,7 @@ class XSbvvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_bvvapec" if equal_or_greater_than("12.9.1") else "xsbvvp"
+    __function__ = "C_bvvapec"
 
     def __init__(self, name='bvvapec'):
         self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
@@ -4094,7 +4088,7 @@ class XSdiskline(XSAdditiveModel):
 
     """
 
-    __function__ = "C_diskline" if equal_or_greater_than("12.10.1") else "xsdili"
+    __function__ = "C_diskline"
 
     def __init__(self, name='diskline'):
         self.LineE = XSParameter(name, 'LineE', 6.7, 0., 100., 0.0, 100, units='keV')
@@ -4650,7 +4644,7 @@ class XSgaussian(XSAdditiveModel):
 
     """
 
-    __function__ = "C_gaussianLine" if equal_or_greater_than("12.9.1") else "xsgaul"
+    __function__ = "C_gaussianLine"
 
     def __init__(self, name='gaussian'):
         self.LineE = XSParameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
@@ -4894,7 +4888,6 @@ class XSgrbcomp(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.kTs, self.gamma, self.kTe, self.tau, self.beta, self.fbflag, self.log_A, self.z, self.a_boost, self.norm))
 
 
-@version_at_least("12.12.0")
 class XSgrbjet(XSAdditiveModel):
     """The XSPEC grbjet model: Two-phase Comptonization model of soft thermal seed photons for GRB prompt emission
 
@@ -4939,10 +4932,6 @@ class XSgrbjet(XSAdditiveModel):
     See Also
     --------
     XSgrbcomp, XSgrbm
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.12.0 or later.
 
     References
     ----------
@@ -5263,7 +5252,7 @@ class XSkerrd(XSAdditiveModel):
 
     """
 
-    __function__ = "C_kerrd" if equal_or_greater_than("12.10.0") else "C_kerrdisk"
+    __function__ = "C_kerrd"
 
     def __init__(self, name='kerrd'):
         self.distance = XSParameter(name, 'distance', 1., 0.01, 1000., 0.01, 1000, units='kpc', frozen=True)
@@ -5560,7 +5549,7 @@ class XSlaor(XSAdditiveModel):
 
     """
 
-    __function__ = "C_laor" if equal_or_greater_than("12.10.1") else "C_xslaor"
+    __function__ = "C_laor"
 
     def __init__(self, name='laor'):
         self.lineE = XSParameter(name, 'lineE', 6.4, 0., 100., 0.0, 100, units='keV')
@@ -5668,7 +5657,7 @@ class XSlogpar(XSAdditiveModel):
 
     """
 
-    __function__ = "C_logpar" if equal_or_greater_than("12.10.1") else "logpar"
+    __function__ = "C_logpar"
 
     def __init__(self, name='logpar'):
         self.alpha = XSParameter(name, 'alpha', 1.5, 0., 4., 0.0, 4)
@@ -5707,7 +5696,7 @@ class XSlorentz(XSAdditiveModel):
 
     """
 
-    __function__ = "C_lorentzianLine" if equal_or_greater_than("12.9.1") else "xslorz"
+    __function__ = "C_lorentzianLine"
 
     def __init__(self, name='lorentz'):
         self.LineE = XSParameter(name, 'LineE', 6.5, 0., 1.e6, 0.0, 1e6, units='keV')
@@ -5752,7 +5741,7 @@ class XSmeka(XSAdditiveModel):
 
     """
 
-    __function__ = "C_meka" if equal_or_greater_than("12.9.1") else "xsmeka"
+    __function__ = "C_meka"
 
     def __init__(self, name='meka'):
         self.kT = XSParameter(name, 'kT', 1., 1.e-3, 1.e2, 1e-3, 1e2, units='keV')
@@ -5799,7 +5788,7 @@ class XSmekal(XSAdditiveModel):
 
     """
 
-    __function__ = "C_mekal" if equal_or_greater_than("12.9.1") else "xsmekl"
+    __function__ = "C_mekal"
 
     def __init__(self, name='mekal'):
         self.kT = XSParameter(name, 'kT', 1., 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -7008,7 +6997,7 @@ class XSraymond(XSAdditiveModel):
 
     """
 
-    __function__ = "C_raysmith" if equal_or_greater_than("12.9.1") else "xsrays"
+    __function__ = "C_raysmith"
 
     def __init__(self, name='raymond'):
         self.kT = XSParameter(name, 'kT', 1., 0.008, 64.0, 0.008, 64, units='keV')
@@ -7633,7 +7622,7 @@ class XSvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vapec" if equal_or_greater_than("12.9.1") else "xsvape"
+    __function__ = "C_vapec"
 
     def __init__(self, name='vapec'):
         self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
@@ -7999,7 +7988,7 @@ class XSvmeka(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vmeka" if equal_or_greater_than("12.9.1") else "xsvmek"
+    __function__ = "C_vmeka"
 
     def __init__(self, name='vmeka'):
         self.kT = XSParameter(name, 'kT', 1., 1.e-3, 1.e2, 1e-3, 100, units='keV')
@@ -8058,7 +8047,7 @@ class XSvmekal(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vmekal" if equal_or_greater_than("12.9.1") else "xsvmkl"
+    __function__ = "C_vmekal"
 
     def __init__(self, name='vmekal'):
         self.kT = XSParameter(name, 'kT', 1., 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -8401,7 +8390,7 @@ class XSvraymond(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vraysmith" if equal_or_greater_than("12.9.1") else "xsvrys"
+    __function__ = "C_vraysmith"
 
     def __init__(self, name='vraymond'):
         self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 79.9, 0.0808, 79.9, units='keV')
@@ -8637,7 +8626,7 @@ class XSvvapec(XSAdditiveModel):
 
     """
 
-    __function__ = "C_vvapec" if equal_or_greater_than("12.9.1") else "xsvvap"
+    __function__ = "C_vvapec"
 
     def __init__(self, name='vvapec'):
         self.kT = XSParameter(name, 'kT', 6.5, 0.0808, 68.447, 0.0808, 68.447, units='keV')
@@ -9236,7 +9225,6 @@ class XSvvtapec(XSAdditiveModel):
                                  (self.kT, self.kTi, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.norm))
 
 
-@version_at_least("12.12.0")
 class XSvvwdem(XSAdditiveModel):
     """The XSPEC vvwdem model: plasma emission, multi-temperature with power-law distribution of emission measure.
 
@@ -9268,10 +9256,6 @@ class XSvvwdem(XSAdditiveModel):
     See Also
     --------
     XSvwdem, XSwdem
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.12.0 or later.
 
     References
     ----------
@@ -9330,7 +9314,6 @@ class XSvvwdem(XSAdditiveModel):
                                               self.redshift, self.switch, self.norm))
 
 
-@version_at_least("12.12.0")
 class XSvwdem(XSAdditiveModel):
     """The XSPEC vwdem model: plasma emission, multi-temperature with power-law distribution of emission measure.
 
@@ -9361,10 +9344,6 @@ class XSvwdem(XSAdditiveModel):
     See Also
     --------
     XSvvwdem, XSwdem
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.12.0 or later.
 
     References
     ----------
@@ -9404,7 +9383,6 @@ class XSvwdem(XSAdditiveModel):
                                               self.redshift, self.switch, self.norm))
 
 
-@version_at_least("12.12.0")
 class XSwdem(XSAdditiveModel):
     """The XSPEC wdem model: plasma emission, multi-temperature with power-law distribution of emission measure.
 
@@ -9435,10 +9413,6 @@ class XSwdem(XSAdditiveModel):
     See Also
     --------
     XSapec, XSmekal, XSvwdem, XSvvdem
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.12.0 or later.
 
     References
     ----------
@@ -9703,7 +9677,6 @@ class XSzgauss(XSAdditiveModel):
         param_apply_limits(pos, self.LineE, **kwargs)
 
 
-@version_at_least("12.11.0")
 class XSzkerrbb(XSAdditiveModel):
     """The XSPEC zkerrbb model: multi-temperature blackbody model for thin accretion disk around a Kerr black hole.
 
@@ -9755,10 +9728,6 @@ class XSzkerrbb(XSAdditiveModel):
     See Also
     --------
     XSkerrbb
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -10446,7 +10415,6 @@ class XSismabs(XSMultiplicativeModel):
                                         self.Fe, self.redshift))
 
 
-@version_at_least("12.11.0")
 class XSismdust(XSMultiplicativeModel):
     """The XSPEC ismdust model: Extinction due to a power-law distribution of dust grains.
 
@@ -10464,10 +10432,6 @@ class XSismdust(XSMultiplicativeModel):
     See Also
     --------
     XSolivineabs
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -10488,7 +10452,6 @@ class XSismdust(XSMultiplicativeModel):
                                         self.redshift))
 
 
-@version_at_least("12.11.0")
 class XSlogconst(XSMultiplicativeModel):
     """The XSPEC logconst model: Constant in log units.
 
@@ -10502,10 +10465,6 @@ class XSlogconst(XSMultiplicativeModel):
     See Also
     --------
     XSconstant, XSlog10con
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -10521,7 +10480,6 @@ class XSlogconst(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.logfact, ))
 
 
-@version_at_least("12.11.0")
 class XSlog10con(XSMultiplicativeModel):
     """The XSPEC log10con model: Constant in base 10 log units.
 
@@ -10535,10 +10493,6 @@ class XSlog10con(XSMultiplicativeModel):
     See Also
     --------
     XSconstant, XSlogconst
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -10633,7 +10587,6 @@ class XSnotch(XSMultiplicativeModel):
         param_apply_limits(pos, self.LineE, **kwargs)
 
 
-@version_at_least("12.11.0")
 class XSolivineabs(XSMultiplicativeModel):
     """The XSPEC olivineabs model: Absorption due to olivine.
 
@@ -10649,10 +10602,6 @@ class XSolivineabs(XSMultiplicativeModel):
     See Also
     --------
     XSismdust
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -11983,7 +11932,6 @@ class XSzphabs(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.redshift))
 
 
-@version_at_least("12.12.0")
 class XSzxipab(XSMultiplicativeModel):
     """The XSPEC zxipab model: power-law distribution of ionized absorbers.
 
@@ -12003,10 +11951,6 @@ class XSzxipab(XSMultiplicativeModel):
     See Also
     --------
     XSpwab
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.12.0 or later.
 
     References
     ----------
@@ -13250,7 +13194,6 @@ class XSsimpl(XSConvolutionKernel):
                                                   ))
 
 
-@version_at_least("12.11.0")
 class XSthcomp(XSConvolutionKernel):
     """The XSPEC thcomp convolution model: Thermally comptonized continuum.
 
@@ -13288,8 +13231,6 @@ class XSthcomp(XSConvolutionKernel):
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
-
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------
@@ -13553,7 +13494,6 @@ class XSzmshift(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, (self.Redshift,))
 
 
-@version_at_least("12.11.0")
 class XSbwcycl(XSAdditiveModel):
     """The XSPEC bwcycl model: Becker-Wolff self-consistent cyclotron line model.
 
@@ -13597,10 +13537,6 @@ class XSbwcycl(XSAdditiveModel):
         component (fix it to one).
     norm
         The normalization of the model (fix it to one).
-
-    Notes
-    -----
-    This model is only available when used with XSPEC 12.11.0 or later.
 
     References
     ----------

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -101,13 +101,8 @@
 // functionMap.h but that requires using the XSPEC build location
 // rather than install location.
 //
-#ifdef XSPEC_12_12_0
 #include "XSFunctions/Utilities/xsFortran.h"
 #include "XSFunctions/funcWrappers.h"
-#else
-#include "xsFortran.h"
-#include "funcWrappers.h"
-#endif
 
 // TODO: is this defined in an XSPEC header file?
 #define ABUND_SIZE (30) // number of elements in Solar Abundance table
@@ -117,9 +112,7 @@ extern "C" {
   xsf77Call agnsed_;
   xsf77Call qsosed_;
 
-#ifdef XSPEC_12_11_0
   xsf77Call agnslim_;
-#endif
 
   xsf77Call xsblbd_;
   xsf77Call xsbbrd_;
@@ -228,23 +221,16 @@ extern "C" {
 
   xsccCall slimbbmodel;
 
-#ifdef XSPEC_12_11_0
   xsccCall beckerwolff;
-#endif
 
 #ifdef XSPEC_12_12_1
   xsF77Call ismabs_;
   xsF77Call ismdust_;
   xsF77Call olivineabs_;
 #else
-
   xsf77Call ismabs_;
-
-#ifdef XSPEC_12_11_0
   xsf77Call ismdust_;
   xsf77Call olivineabs_;
-#endif
-
 #endif // XSPEC_12_12_1
 
 // XSPEC convolution models
@@ -254,15 +240,10 @@ extern "C" {
 
   xsf77Call kyconv_;
 
-#ifdef XSPEC_12_11_0
   xsf77Call thcompf_;
-#endif
 
-// XSPEC 12.12.0 changes
-#ifdef XSPEC_12_12_0
   xsccCall xsgrbjet;
   xsf77Call zxipab_;
-#endif
 
 }
 
@@ -846,9 +827,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( agnsed, 16 ),
   XSPECMODELFCT_NORM( qsosed, 7 ),
 
-#ifdef XSPEC_12_11_0
   XSPECMODELFCT_NORM( agnslim, 15 ),
-#endif
 
   XSPECMODELFCT_C_NORM( C_apec, 4 ),
   XSPECMODELFCT_C_NORM( C_bapec, 5 ),
@@ -895,9 +874,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM( xsgrbm, 4 ),
   XSPECMODELFCT_C_NORM( C_kerrbb, 10 ),
 
-#ifdef XSPEC_12_11_0
   XSPECMODELFCT_C_NORM( C_zkerrbb, 10 ),
-#endif
 
   XSPECMODELFCT_C_NORM( C_kerrd, 8 ),
   XSPECMODELFCT_NORM( spin, 10 ),
@@ -1054,13 +1031,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_vvpshock, 35 ),
   XSPECMODELFCT_C_NORM( C_vvsedov, 35 ),
 
-#ifdef XSPEC_12_11_0
   // We do not have a direct interface to the c_func routines, so
   // take advantage of the fact XSPEC provides multiple APIs
   // and use the C one.
   // XSPECMODELFCT_C_NORM( c_beckerwolff, 13 ),
   XSPECMODELFCT_C_NORM( beckerwolff, 13 ),
-#endif
 
   //multiplicative
   XSPECMODELFCT( xsphei, 3 ),
@@ -1094,9 +1069,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_zashift, 1),
   XSPECMODELFCT_CON(C_zmshift, 1),
 
-#ifdef XSPEC_12_11_0
   XSPECMODELFCT_CON_F77(thcompf, 4),
-#endif
 
   // Models from 12.9.1
   //
@@ -1138,25 +1111,19 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_DBL(ismdust, 3),
   XSPECMODELFCT_DBL(olivineabs, 2),
 #else
-#ifdef XSPEC_12_11_0
   XSPECMODELFCT(ismdust, 3),
   XSPECMODELFCT(olivineabs, 2),
-#endif
 #endif // XSPEC_12_12_1
 
-#ifdef XSPEC_12_11_0
   XSPECMODELFCT_C(C_logconst, 1),
   XSPECMODELFCT_C(C_log10con, 1),
-#endif
 
-#ifdef XSPEC_12_12_0
   XSPECMODELFCT_C_NORM( xsgrbjet, 14 ),  // follow xsgrbcomp and drop the leading c_
   XSPECMODELFCT_C_NORM( C_vvwDem, 37 ),
   XSPECMODELFCT_C_NORM( C_vwDem, 21 ),
   XSPECMODELFCT_C_NORM( C_wDem, 8 ),
 
   XSPECMODELFCT(zxipab, 5),
-#endif
 
   { NULL, NULL, 0, NULL }
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -98,153 +98,15 @@
 // TODO:: switch to C++ FuntionUtility interface rather than use xsFortran.h
 //
 // funcWrappers: C_<model> are declared here; the other models are defined in
-// functionMap.h but that requires using the XSPEC build location
-// rather than install location.
+// functionMap.h
 //
-#include "XSFunctions/Utilities/xsFortran.h"
-#include "XSFunctions/funcWrappers.h"
+#include <XSFunctions/Utilities/xsFortran.h>
+#include <XSFunctions/funcWrappers.h>
+#include <XSFunctions/functionMap.h>
 
 // TODO: is this defined in an XSPEC header file?
 #define ABUND_SIZE (30) // number of elements in Solar Abundance table
 
-extern "C" {
-
-  xsf77Call agnsed_;
-  xsf77Call qsosed_;
-
-  xsf77Call agnslim_;
-
-  xsf77Call xsblbd_;
-  xsf77Call xsbbrd_;
-  xsf77Call xsbmc_;
-  xsf77Call xsbrms_;
-
-  xsf77Call cemekl_;
-  xsf77Call compbb_;
-  xsf77Call compls_;
-  xsf77Call compst_;
-  xsf77Call xstitg_;
-  xsf77Call disk_;
-  xsf77Call diskir_;
-  xsf77Call xsdskb_;
-  xsf77Call diskm_;
-  xsf77Call disko_;
-  xsf77Call diskpbb_;
-  xsf77Call xsdiskpn_;
-  xsf77Call xsxpdec_;
-  xsf77Call ezdiskbb_;
-
-  xsf77Call grad_;
-
-  xsccCall xsgrbcomp;
-
-  xsf77Call jet_;
-
-  xsf77Call xsgrbm_;
-
-  xsf77Call kyrline_;
-
-  xsf77Call nsa_;
-  xsf77Call nsagrav_;
-  xsf77Call nsatmos_;
-
-  xsf77Call xspegp_;
-  xsf77Call xsp1tr_;
-  xsf77Call xsposm_;
-
-  xsf77Call xredge_;
-  xsf77Call xsrefsch_;
-  xsf77Call srcut_;
-  xsf77Call sresc_;
-  xsf77Call ssa_;
-  xsf77Call xsstep_;
-
-  xsf77Call xsbrmv_;
-
-  xsf77Call xszbod_;
-  xsf77Call xszbrm_;
-
-  xsf77Call xscnst_;
-  xsf77Call xscabs_;
-  xsf77Call xscycl_;
-  xsf77Call xsdust_;
-  xsf77Call xsedge_;
-  xsf77Call xsabsc_;
-  xsf77Call xsexp_;
-  xsf77Call xshecu_;
-  xsf77Call xshrfl_;
-  xsf77Call xsntch_;
-  xsf77Call xsabsp_;
-  xsf77Call xsphab_;
-  xsf77Call xsplab_;
-  xsf77Call xscred_;
-  xsf77Call xssmdg_;
-  xsf77Call xsspln_;
-  xsf77Call xssssi_;
-
-  xsf77Call xsred_;
-  xsf77Call xsabsv_;
-  xsf77Call xsvphb_;
-  xsf77Call xsabsw_;
-  xsf77Call xswnab_;
-  xsf77Call xsxirf_;
-  xsf77Call mszdst_;
-  xsf77Call xszedg_;
-  xsf77Call xszhcu_;
-  xsf77Call xszabp_;
-  xsf77Call xszphb_;
-
-  xsf77Call xszcrd_;
-  xsf77Call msldst_;
-  xsf77Call xszvab_;
-  xsf77Call xszvfe_;
-  xsf77Call xszvph_;
-  xsf77Call xszabs_;
-  xsf77Call xszwnb_;
-
-  xsf77Call zigm_;
-
-  xsf77Call eplogpar_;
-  xsf77Call optxagn_;
-  xsf77Call optxagnf_;
-  xsf77Call pexmon_;
-
-// additive
-  xsccCall xscompmag;
-  xsccCall xscomptb;
-
-//multiplicative
-  xsf77Call xsphei_;
-  xsf77Call xslyman_;
-  xsccCall xszbabs;
-
-  xsccCall slimbbmodel;
-
-  xsccCall beckerwolff;
-
-#ifdef XSPEC_12_12_1
-  xsF77Call ismabs_;
-  xsF77Call ismdust_;
-  xsF77Call olivineabs_;
-#else
-  xsf77Call ismabs_;
-  xsf77Call ismdust_;
-  xsf77Call olivineabs_;
-#endif // XSPEC_12_12_1
-
-// XSPEC convolution models
-//
-
-  xsf77Call rgsxsrc_;
-
-  xsf77Call kyconv_;
-
-  xsf77Call thcompf_;
-
-  xsccCall xsgrbjet;
-  xsf77Call zxipab_;
-
-}
 
 // The XSPEC initialization used to be done lazily - that is, only
 // when the first routine from XSPEC was about to be called - but

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -141,7 +141,6 @@ extern "C" {
   xsf77Call jet_;
 
   xsf77Call xsgrbm_;
-  xsf77Call spin_;
 
   xsf77Call kyrline_;
 
@@ -877,7 +876,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM( C_zkerrbb, 10 ),
 
   XSPECMODELFCT_C_NORM( C_kerrd, 8 ),
-  XSPECMODELFCT_NORM( spin, 10 ),
+  XSPECMODELFCT_C_NORM( C_spin, 10 ),
 
   XSPECMODELFCT_NORM( kyrline, 12 ),
 

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -34,69 +34,19 @@
 
 #include "sherpa/fcmp.hh"
 
-// We should be able to just include funcType.h but our XSPEC conda
-// builds, at least for testing/12.11.1, do not include this file,
-// so we just include what we need.
+#include <XSFunctions/Utilities/funcType.h>
+#include <XSFunctions/Utilities/xsFortran.h>
+
+// The table interface is defined in XSPEC 12.12.1 in xsFortran.h
+// (and uses const parameters) but it is not defined in 12.12.0.
 //
-// #ifdef XSPEC_12_12_0
-// #include "XSFunctions/Utilities/funcType.h"
-// #else
-// #include "funcType.h"
-// #endif
-
-#include "xsTypes.h"   // get Real typedef
-
-extern "C" {
-
-        typedef void (xsf77Call) (const float* energyArray,
-                                  const int& Nenergy,
-                                  const float* parameterValues,
-                                  const int& spectrumNumber,
-                                  float* flux,
-                                  float* fluxError);
-
-        typedef void (xsF77Call) (const double* energyArray,
-                                  const int& Nenergy,
-                                  const double* parameterValues,
-                                  const int& spectrumNumber,
-                                  double* flux,
-                                  double* fluxError);
-
-        typedef void (xsccCall)   (const Real* energyArray,
-                                   int Nenergy,
-                                   const Real* parameterValues,
-                                   int spectrumNumber,
-                                   Real* flux,
-                                   Real* fluxError,
-                                   const char* initString);
-}
-
-// Prior to XSPEC 12.10.1, the table models were split into different
-// functions. These functions are defined in _xspec.cc.
-//
-// In 12.10.1 they were consolidated into a single function, tabint,
-// and so the declaration was moved here. The function was only
-// available in C++ scope.
-//
-// In XSPEC 12.11.0 (the next one after 12.10.1), the tabint function
-// was moved into C scope. In XSPEC 12.12.1 the signature was changed
-// to mark more arguments as const.
-//
-#ifdef XSPEC_12_11_0
-extern "C" {
-#endif
-
 #ifndef XSPEC_12_12_1
+extern "C" {
+
   void tabint(float* ear, int ne, float* param,
 	      int npar, const char* filenm, int ifl,
 	      const char* tabtyp, float* photar, float* photer);
-#else
-  void tabint(const float* ear, const int ne, const float* param,
-	      const int npar, const char* filenm, int ifl,
-	      const char* tabtyp, float* photar, float* photer);
-#endif
 
-#ifdef XSPEC_12_11_0
 }
 #endif
 


### PR DESCRIPTION
# Summary

Bump the minimum supported XSPEC version to version 12.12.0. 

# Details

Bump the XSPEC minimum to 12.12.0. This is based on #1396 which bumps the minimum version to 12.10.1. This main advantages of moving to XSPEC 12.12.0 are done in a follow-up PR: #1615 There are two small changes here

- we no-longer need to declare the model typedefs (from funcType.h) model names (from functionMap.h) (with earlier releases of XSPEC these were not importable for various reasons)
- we can switch a model to use the model.dat-defined function (it should have been versioned but for whatever reason had not been)

The main aims of this PR are

1. simplify the code (e.g. removing conditional compilation blocks, in particular the table-interpolation code)
2. simplify the code from having the XSPEC headers present
3. allow for future work (#1615)