### PR TITLE
Allow testing of the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,6 +157,7 @@ extensions = [
     # notebooks
     'nbsphinx',
     'sphinx_rtd_theme',
+    'pytest_doctestplus.sphinx.doctestplus',
 ]
 # Imported from sphinx_astropy so we don't have to maintain the list
 # of servers

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,52 @@
+#
+#  Copyright (C) 2022
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+'''Pytest fixtures for running doctests
+
+Pytest looks for conftest.py files that define fixtures only in the
+directory tree that is being tested. When we run doctests in the
+documentation only, it will therefore not find that fixtures that are
+defined in sherpa/conftest.py, thus this file copies over the fixtures we
+need.
+'''
+import pytest
+from sherpa.utils.testing import get_datadir
+
+@pytest.fixture(autouse=True)
+def add_sherpa_test_data_dir(doctest_namespace):
+    '''Define `data_dir` for doctests
+
+    We make this an autouse=True fixture, because that means that
+    the variable `data_dir` is available in every file that we may
+    want to test without any special markup to that file. There is a
+    risk that this is too magical and could confuse developers
+    in the future, but it seems more important that this keeps any
+    extra markup out of those files and keep them clean.
+    '''
+    # We could error out here, but we only want the tests that
+    # use it to fail.
+    #
+    path = get_datadir()
+    if path is None:
+        pytest.skip("sherpa-test-data not found")
+
+    if not path.endswith('/'):
+        path += '/'
+
+    doctest_namespace["data_dir"] = path

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -98,6 +98,44 @@ run allows us to generate a coverage report after that::
 The report is in ``report/index.html``, which links to individual
 files and shows exactly which lines were excuted while running the tests.
 
+Run doctests locally
+--------------------
+If `doctestplus <https://pypi.org/project/pytest-doctestplus/>` is installed
+(and it probably is because it's part of
+`sphinx-astropy <https://pypi.org/project/sphinx-astropy/>`,
+which is required to build the documentation locally), you can
+run the examples in the documentation or in the doctrings of individual
+functions, for example:
+
+   pytest --doctest-plus sherpa/astro/data.py
+   pytest --doctest-plus sherpa/data.py
+   pytest --doctest-rst docs/quick.rst
+   pytest --doctest-rst docs/evaluation/combine.rst
+
+This guarantees that the examples actually work and don't have typos or outdated
+parameters, which might confuse a user.
+
+Running `pytest --doctest-plus` or `pytest --doctest-rst` (without extra parameters)
+will run all usual tests and also the doctests on all files not specifically
+excluded in `pytest.ini`.
+If you fix examples to pass these tests, remove them from the exclusion list in
+`pytest.ini`! The goal is to eventually pass on all files.
+
+.. note::
+   The doctests are not run as part of the CI process.
+   The plan is to add them in once we have more experience with the system.
+
+Some doctests (in the documentation or in the docstrings of individual
+functions) load data files. Those datafiles can be found in the
+`sherpa-test-data <https://github.com/sherpa/sherpa-test-data>` directory
+as explained in the description of the :ref:`development build <developer-build>`.
+There is a `conftest.py` file in the `sherpa/docs` directory and in the `sherpa/sherpa`
+directory that sets up a
+pytest fixture to define a variable called `data_dir` which points to this directory.
+That way, we do not need to clutter the example with long filename, but the
+`sherpa-test-data` directory has to be present as a submodule to successfully pass all
+doctests.
+
 
 How do I ...
 ============
@@ -745,6 +783,7 @@ with:
 A regularly-gridded 2D dataset can be created, but note that the
 arguments must be flattened:
 
+  >>> import numpy as np
   >>> x1, x0 = np.mgrid[20:30:2, 5:20:2]
   >>> shp = x0.shape
   >>> y = np.sqrt((x0 - 10)**2 + (x1 - 31)**2)
@@ -891,12 +930,16 @@ raised. The aim is to provide some context in the message, such as::
   >>> x = np.asarray([1, 2, 3])
   >>> y = np.asarray([1, 2])
   >>> data = Data1D('example', x, y)
+  Traceback (most recent call last):
+  ...
   sherpa.utils.err.DataErr: size mismatch between independent axis and y: 3 vs 2
 
 and::
 
   >>> data = Data1D('example', x, x + 10)
   >>> data.apply_filter(y)
+  Traceback (most recent call last):
+  ...
   sherpa.utils.err.DataErr: size mismatch between data and array: 3 vs 2
 
 For `~sherpa.astro.data.DataPHA` objects, where some length checks
@@ -1088,7 +1131,7 @@ The :py:meth:`sherpa.ui.utils.Session.plot` and
 plots to be created by specifying the plot type as a list of
 argumemts. For example::
 
-    >>> s.plot('data', 'model', 'data', 2, 'model', 2)
+    >>> s.plot('data', 'model', 'data', 2, 'model', 2)  # doctest: +SKIP
 
 will create four plots, in a two-by-two grid, showing the
 data and model values for the default dataset and the
@@ -1145,11 +1188,11 @@ We can view the model plot object::
     >>> print(plot)
     xlo    = [2,3,5,7,8]
     xhi    = [3,5,6,8,9]
-    y      = [ 8.5,20. ,11.5,13.5,14.5]
+    y      = [ 6.,12., 6., 6., 6.]
     xlabel = x
     ylabel = y
     title  = Model
-    histo_prefs = {'yerrorbars': False, 'ecolor': None, ... , 'linecolor': None}
+    histo_prefs = {'xerrorbars': False, 'yerrorbars': False, ..., 'linecolor': None}
 
 
 .. _dataimg_coords:
@@ -1196,6 +1239,7 @@ transform, then they can just be set when creating the
 `~sherpa.astro.data.DataIMG.coord` attribute set to
 ``logical``.
 
+  >>> from sherpa.astro.data import DataIMG
   >>> x0 = np.asarray([1000, 1200, 2000])
   >>> x1 = np.asarray([-500, 500, -500])
   >>> y = np.asarray([10, 200, 30])

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -103,9 +103,25 @@ Run doctests locally
 If `doctestplus <https://pypi.org/project/pytest-doctestplus/>` is installed
 (and it probably is because it's part of
 `sphinx-astropy <https://pypi.org/project/sphinx-astropy/>`,
-which is required to build the documentation locally), you can
-run the examples in the documentation or in the doctrings of individual
-functions, for example:
+which is required to build the documentation locally),
+examples in the documentation are run automatically.
+This serves two purposes:
+
+  - It ensure that the examples we give execute and give the expected output.
+    It is confusing to a user to see an example in the documentation that does not
+    work because it contains bugs to calls functions that have been removed from sherpa.
+  - This also acts as an additional tests.
+
+However, many examples were written because doctestplus was used with Sherpa and do not execute
+as written (e.g. they need implicit set-up that's not spelled out),
+so a number of rst files are explicitly excluded from that run in `pyests.ini`.
+When an rst file is fixed to work top-to-bottom, it should be removed from the
+blacklist in `pytest.ini`.
+
+doctestplus can also run the examples in the doctrings of individual
+functions, but again many files are still blacklisted for this functionality in
+`pytest.ini`.
+During development, you can run doctestplus on individual files like so::
 
    pytest --doctest-plus sherpa/astro/data.py
    pytest --doctest-plus sherpa/data.py
@@ -115,15 +131,8 @@ functions, for example:
 This guarantees that the examples actually work and don't have typos or outdated
 parameters, which might confuse a user.
 
-Running `pytest --doctest-plus` or `pytest --doctest-rst` (without extra parameters)
-will run all usual tests and also the doctests on all files not specifically
-excluded in `pytest.ini`.
 If you fix examples to pass these tests, remove them from the exclusion list in
 `pytest.ini`! The goal is to eventually pass on all files.
-
-.. note::
-   The doctests are not run as part of the CI process.
-   The plan is to add them in once we have more experience with the system.
 
 Some doctests (in the documentation or in the docstrings of individual
 functions) load data files. Those datafiles can be found in the
@@ -132,7 +141,7 @@ as explained in the description of the :ref:`development build <developer-build>
 There is a `conftest.py` file in the `sherpa/docs` directory and in the `sherpa/sherpa`
 directory that sets up a
 pytest fixture to define a variable called `data_dir` which points to this directory.
-That way, we do not need to clutter the example with long filename, but the
+That way, we do not need to clutter the example with long directory names, but the
 `sherpa-test-data` directory has to be present as a submodule to successfully pass all
 doctests.
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -107,29 +107,21 @@ which is required to build the documentation locally),
 examples in the documentation are run automatically.
 This serves two purposes:
 
-  - It ensure that the examples we give execute and give the expected output.
-    It is confusing to a user to see an example in the documentation that does not
-    work because it contains bugs to calls functions that have been removed from sherpa.
-  - This also acts as an additional tests.
+  - it ensure that the examples we give are actually correct and match the code,
+  - and it acts as additional tests of the Sherpa code base.
 
-However, many examples were written because doctestplus was used with Sherpa and do not execute
-as written (e.g. they need implicit set-up that's not spelled out),
-so a number of rst files are explicitly excluded from that run in `pyests.ini`.
-When an rst file is fixed to work top-to-bottom, it should be removed from the
-blacklist in `pytest.ini`.
+The `doctest_norecursedirs` setting in the `pytests.ini` file is used to exclude files which can not be
+tested. This is generally because the examples were written before doctestplus support was added, and so
+they need to be re-worked, or there is too much extra set-up required that would make the examples
+hard-to follow. The file should be removed from this list when it has been updated to allow testing with doctestplus.
 
-doctestplus can also run the examples in the doctrings of individual
-functions, but again many files are still blacklisted for this functionality in
-`pytest.ini`.
-During development, you can run doctestplus on individual files like so::
+During development, you can run doctestplus on individual files like so (the option to use depends on whether it is a Python or reStructuredText file)::
 
    pytest --doctest-plus sherpa/astro/data.py
    pytest --doctest-plus sherpa/data.py
    pytest --doctest-rst docs/quick.rst
    pytest --doctest-rst docs/evaluation/combine.rst
 
-This guarantees that the examples actually work and don't have typos or outdated
-parameters, which might confuse a user.
 
 If you fix examples to pass these tests, remove them from the exclusion list in
 `pytest.ini`! The goal is to eventually pass on all files.

--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -110,9 +110,9 @@ True
 {}
 >>> print(m([1, 2, 3, 4, 5, 6]))
 [0. 1. 1. 1. 0. 0.]
->>> print(m._cache)
+>>> print(m._cache)  # doctest: +SKIP
 {b'<random byte string>': array([0., 1., 1., 1., 0., 0.])}
->>> print(m._queue)
+>>> print(m._queue)  # doctest: +SKIP
 [b'<random byte string>']
 
 Fit and the startup method

--- a/docs/evaluation/combine.rst
+++ b/docs/evaluation/combine.rst
@@ -198,7 +198,7 @@ combination of the ``lhs`` and ``rhs`` attributes)::
     >>> sim_model.parts
     (<Gauss1D model instance 'sim1'>, <Gauss1D model instance 'sim2'>)
     >>> for cpt in sim_model.parts:
-       ...:     print(cpt)
+    ...     print(cpt)
     sim1
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
@@ -306,8 +306,8 @@ values)::
     >>> mplot.prepare(d, mdl)
     >>> fplot.prepare(dplot, mplot)
     >>> fplot.plot()
-    >>> plt.plot(x, ystart, label='Start')
-    >>> plt.legend(loc=2)
+    >>> out = plt.plot(x, ystart, label='Start')
+    >>> out = plt.legend(loc=2)
 
 .. image:: ../_static/models/combine/model_combine.png
 
@@ -334,10 +334,10 @@ These can be used to query - as shown below - or change the model
 values:
    
     >>> for p in mdl.pars:
-       ...:     if p.link is None:
-       ...:         print("{:10s} -> {:.3f}".format(p.fullname, p.val))
-       ...:     else:
-       ...:         print("{:10s} -> link to {}".format(p.fullname, p.link.name))
+    ...     if p.link is None:
+    ...         print("{:10s} -> {:.3f}".format(p.fullname, p.val))
+    ...     else:
+    ...         print("{:10s} -> link to {}".format(p.fullname, p.link.name))
     g1.fwhm    -> 0.516
     g1.pos     -> 0.004
     g1.ampl    -> 0.985

--- a/docs/evaluation/convolution.rst
+++ b/docs/evaluation/convolution.rst
@@ -69,6 +69,7 @@ In this example we want to convolve a model by the "kernel"
 :py:class:`sherpa.data.Data1D` instance to store the
 data, and then pass it to :py:class:`sherpa.instrument.PSFModel`:
 
+    >>> import numpy as np
     >>> from sherpa.data import Data1D
     >>> from sherpa.instrument import PSFModel
     >>> k = np.asarray([5, 10, 3, 2])
@@ -92,26 +93,26 @@ since it has sharp edges and so the convolution is more obvious).
     >>> point.xlow = 9.5
     >>> point.xhi = 10.5
     >>> print(point)
-    point
+    pt
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       point.xlow   thawed          9.5 -3.40282e+38  3.40282e+38
-       point.xhi    thawed         10.5 -3.40282e+38  3.40282e+38
-       point.ampl   thawed            1           -1            1
+       pt.xlow      thawed          9.5 -3.40282e+38  3.40282e+38
+       pt.xhi       thawed         10.5 -3.40282e+38  3.40282e+38
+       pt.ampl      thawed            1           -1            1
 
 The convolution case is created by applying the `psf1` model
 to the `point` model (the :ref:`2D example <convolution-psf2d-convolve>`
 below shows an example of applying a kernel to a
 composite model):
 
-    >>> convolved = psf1(pt)
+    >>> convolved = psf1(point)
     >>> print(convolved)
-    psfmodel(point)
+    psf1(pt)
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       point.xlow   thawed          9.5 -3.40282e+38  3.40282e+38
-       point.xhi    thawed         10.5 -3.40282e+38  3.40282e+38
-       point.ampl   thawed            1           -1            1
+       pt.xlow      thawed          9.5 -3.40282e+38  3.40282e+38
+       pt.xhi       thawed         10.5 -3.40282e+38  3.40282e+38
+       pt.ampl      thawed            1           -1            1
 
 .. _convolution-1d-fold:
 
@@ -154,14 +155,14 @@ kernel. The parameters of the convolution kernel (in this case
 ``psf1``) can be changed to control the behavior.
 
     >>> print(psf1)
-    psfmodel
+    psf1
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       psfmodel.kernel frozen       kdata1
-       psfmodel.size frozen            4            4            4
-       psfmodel.center frozen            2            2            2
-       psfmodel.radial frozen            0            0            1
-       psfmodel.norm frozen            1            0            1
+       psf1.kernel  frozen       kdata1
+       psf1.size    frozen            4            4            4
+       psf1.center  frozen            2            2            2
+       psf1.radial  frozen            0            0            1
+       psf1.norm    frozen            1            0            1
 
 .. note::
 
@@ -200,7 +201,7 @@ the steps needed in the
     >>> k = np.asarray([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
     >>> yg, xg = np.mgrid[:3, :3]
     >>> kernel = Data2D('kdata', xg.flatten(), yg.flatten(), k.flatten(),
-                        shape=k.shape)
+    ...                 shape=k.shape)
     >>> psf = PSFModel(kernel=kernel)
     >>> print(psf)
     psfmodel
@@ -236,12 +237,13 @@ the sum of a single pixel and a line of pixels, using
        pt.xhi       thawed          2.5 -3.40282e+38  3.40282e+38
        pt.ylow      thawed          2.5 -3.40282e+38  3.40282e+38
        pt.yhi       thawed          3.5 -3.40282e+38  3.40282e+38
-       pt.ampl      thawed           10 -3.40282e+38  3.40282e+38
+       pt.ampl      thawed            8 -3.40282e+38  3.40282e+38
        box.xlow     thawed            4 -3.40282e+38  3.40282e+38
        box.xhi      thawed           10 -3.40282e+38  3.40282e+38
        box.ylow     thawed          6.5 -3.40282e+38  3.40282e+38
        box.yhi      thawed          7.5 -3.40282e+38  3.40282e+38
        box.ampl     thawed           10 -3.40282e+38  3.40282e+38
+
 
 .. note::
 
@@ -270,7 +272,7 @@ This can be a single model or - as in this case - a composite one::
        pt.xhi       thawed          2.5 -3.40282e+38  3.40282e+38
        pt.ylow      thawed          2.5 -3.40282e+38  3.40282e+38
        pt.yhi       thawed          3.5 -3.40282e+38  3.40282e+38
-       pt.ampl      thawed           10 -3.40282e+38  3.40282e+38
+       pt.ampl      thawed            8 -3.40282e+38  3.40282e+38
        box.xlow     thawed            4 -3.40282e+38  3.40282e+38
        box.xhi      thawed           10 -3.40282e+38  3.40282e+38
        box.ylow     thawed          6.5 -3.40282e+38  3.40282e+38
@@ -292,7 +294,7 @@ component that is not affected by the PSF::
        pt.xhi       thawed          2.5 -3.40282e+38  3.40282e+38
        pt.ylow      thawed          2.5 -3.40282e+38  3.40282e+38
        pt.yhi       thawed          3.5 -3.40282e+38  3.40282e+38
-       pt.ampl      thawed           10 -3.40282e+38  3.40282e+38
+       pt.ampl      thawed            8 -3.40282e+38  3.40282e+38
        box.xlow     thawed            4 -3.40282e+38  3.40282e+38
        box.xhi      thawed           10 -3.40282e+38  3.40282e+38
        box.ylow     thawed          6.5 -3.40282e+38  3.40282e+38
@@ -383,9 +385,9 @@ comparing the signal in the unconvolved and convolved images, which
 are (to numerical precision) the same:
 
     >>> m1.sum()
-    60.0
+    58.0
     >>> m2.sum()
-    60.0
+    58.0
 
 The use of a fourier transform means that low-level signal will be
 found in many pixels which would expect to be 0. For example,

--- a/docs/evaluation/examples.rst
+++ b/docs/evaluation/examples.rst
@@ -13,7 +13,7 @@ Examples
    method (or introduces the concept)?
 
 The following examples show the different ways that a model can
-be evaluted, for a range of situations. The
+be evaluated, for a range of situations. The
 :ref:`direct method <model_evaluate_example_oned_direct>` is
 often sufficient, but for more complex cases it can be useful to
 :ref:`ask a data object to evaluate the
@@ -113,7 +113,7 @@ the model on the grid defined by the data set, so it is the same
 as calling the model directly with these values::
 
     >>> twod.eval_model(mdl) == mdl(x0, x1)
-    array([ True,  True,  True,  True], dtype=bool)
+    array([ True,  True,  True,  True])
 
 The :py:meth:`~sherpa.data.Data.eval_model_to_fit` method
 will apply any filter associated with the data before
@@ -169,13 +169,20 @@ interrogate the object.
 ::
 
    >>> from sherpa.astro.io import read_pha
-   >>> pha = read_pha('9774.pi')
-   read ARF file 9774.arf
-   read RMF file 9774.rmf
-   read background file 9774_bg.pi
+   >>> pha = read_pha( data_dir + '9774.pi')
 
 We can see that the ARF, RMF, and a background dataset have
-automatically been loaded for us. They can be loaded manually - with
+automatically been loaded for us.
+
+::
+
+   read ARF file .../9774.arf
+   read RMF file .../9774.rmf
+   read background file .../9774_bg.pi
+
+
+
+Instead, ARF and RMF could be loaded manually - with
 :py:func:`sherpa.astro.io.read_arf`, :py:func:`sherpa.astro.io.read_rmf`,
 and :py:func:`sherpa.astro.io.read_pha` -
 and set with :py:meth:`~sherpa.astro.data.DataPHA.set_arf`,
@@ -184,13 +191,13 @@ and set with :py:meth:`~sherpa.astro.data.DataPHA.set_arf`,
 methods of the :py:class:`~sherpa.astro.data.DataPHA` class::
 
    >>> pha
-   <DataPHA data set instance '9774.pi'>
+   <DataPHA data set instance '.../9774.pi'>
    >>> pha.get_background()
-   <DataPHA data set instance '9774_bg.pi'>
+   <DataPHA data set instance '.../9774_bg.pi'>
    >>> pha.get_arf()
-   <DataARF data set instance '9774.arf'>
+   <DataARF data set instance '.../9774.arf'>
    >>> pha.get_rmf()
-   <DataRMF data set instance '9774.rmf'>
+   <DataRMF data set instance '.../9774.rmf'>
 
 This is a Chandra imaging-mode ACIS observation, as shown
 by header keywords defined by :term:`OGIP`, and so it has
@@ -259,10 +266,11 @@ show the "raw" data (you can see that each group has at least
    >>> gchans = pha.apply_filter(chans, pha._middle)
    >>> gchans.size
    143
+   >>> import matplotlib.pyplot as plt
    >>> plt.clf()
-   >>> plt.plot(gchans, counts, 'o')
-   >>> plt.xlabel('Channel')
-   >>> plt.ylabel('Counts')
+   >>> lines = plt.plot(gchans, counts, 'o')
+   >>> xlabel = plt.xlabel('Channel')
+   >>> ylabel = plt.ylabel('Counts')
 
 .. image:: ../_static/evaluation/pha_data_manual.png
 
@@ -284,7 +292,7 @@ show they match::
    >>> x = pha.apply_filter(x, pha._middle)
    >>> y = pha.get_y(filter=True)
    >>> dplot.plot(xlog=True, ylog=True)
-   >>> plt.plot(x, y)
+   >>> lines = plt.plot(x, y)
 
 .. image:: ../_static/evaluation/pha_data_compare.png
 
@@ -295,6 +303,7 @@ to wavelength will create a plot in Angstroms::
    >>> pha.set_analysis('wave')
    >>> pha.get_x().max()
    1544.0122577477066
+   >>> from sherpa.plot import DataPlot
    >>> wplot = DataPlot()
    >>> wplot.prepare(pha)
    >>> wplot.plot(linestyle='solid', xlog=True, ylog=True)
@@ -331,7 +340,7 @@ powerlaw (:py:class:`~sherpa.models.basic.PowLaw1D`)::
    (phabs * powlaw1d)
       Param        Type          Value          Min          Max      Units
       -----        ----          -----          ---          ---      -----
-      phabs.nH     thawed          0.2            0       100000 10^22 atoms / cm^2
+      phabs.nH     thawed          0.2            0        1e+06 10^22 atoms / cm^2
       powlaw1d.gamma thawed          1.7          -10           10
       powlaw1d.ref frozen            1 -3.40282e+38  3.40282e+38
       powlaw1d.ampl thawed            1            0  3.40282e+38
@@ -342,15 +351,16 @@ for use. As the data is binned we call the models - here the
 commbined model labelled "Absorbed" and just the powerlaw
 component labelled "Unabsorbed" - with both low and high edges::
 
+   >>> import numpy as np
    >>> egrid = np.arange(0.1, 10, 0.01)
    >>> elo, ehi = egrid[:-1], egrid[1:]
    >>> emid = (elo + ehi) / 2
    >>> plt.clf()
-   >>> plt.plot(emid, mdl(elo, ehi), label='Absorbed')
-   >>> plt.plot(emid, pl(elo, ehi), ':', label='Unabsorbed')
+   >>> lines = plt.plot(emid, mdl(elo, ehi), label='Absorbed')
+   >>> lines = plt.plot(emid, pl(elo, ehi), ':', label='Unabsorbed')
    >>> plt.xscale('log')
-   >>> plt.ylim(0, 0.01)
-   >>> plt.legend()
+   >>> ylim = plt.ylim(0, 0.01)
+   >>> legend = plt.legend()
 
 The Y axis has been restricted because the absorption is quite severe
 at low energies!
@@ -372,7 +382,7 @@ called ``full``, which includes the corrections::
    apply_rmf(apply_arf((75141.227687398 * (phabs * powlaw1d))))
       Param        Type          Value          Min          Max      Units
       -----        ----          -----          ---          ---      -----
-      phabs.nH     thawed          0.2            0       100000 10^22 atoms / cm^2
+      phabs.nH     thawed          0.2            0        1e+06 10^22 atoms / cm^2
       powlaw1d.gamma thawed          1.7          -10           10
       powlaw1d.ref frozen            1 -3.40282e+38  3.40282e+38
       powlaw1d.ampl thawed            1            0  3.40282e+38
@@ -393,7 +403,7 @@ such as ``PowLaw1D``.
    like
 
    >>> from sherpa.astro.instrument import RSPModelPHA
-   >>> full = RSPModelPHA(arf, rmf, pha, pha.exposure * mdl)
+   >>> full = RSPModelPHA(arf, rmf, pha, pha.exposure * mdl)  # doctest: +SKIP
 
    Note that the exposure time is not automatically included for you as it
    is with ``Response1D``.
@@ -416,9 +426,9 @@ The evaluated model can therefore be displayed with a
 call such as::
 
    >>> plt.clf()
-   >>> plt.plot(pha.channel, full(pha.channel))
-   >>> plt.xlabel('Channel')
-   >>> plt.ylabel('Counts')
+   >>> lines = plt.plot(pha.channel, full(pha.channel))
+   >>> xlabel = plt.xlabel('Channel')
+   >>> ylabel = plt.ylabel('Counts')
 
 The reason for the ridiculously-large count range is because
 the powerlaw amplitude has not been changed from its
@@ -467,9 +477,9 @@ attribute to get the exposure time)::
    >>> x2 = pha.get_x()
    >>> xmid = pha.apply_filter(x2, pha._middle)
    >>> plt.clf()
-   >>> plt.plot(xmid, y2 / (xhi - xlo) / pha.exposure)
-   >>> plt.xlabel('Energy (keV)')
-   >>> plt.ylabel('Counts/sec/keV')
+   >>> lines = plt.plot(xmid, y2 / (xhi - xlo) / pha.exposure)
+   >>> xlabel = plt.xlabel('Energy (keV)')
+   >>> ylable = plt.ylabel('Counts/sec/keV')
 
 .. image:: ../_static/evaluation/pha_eval_model_to_fit.png
 
@@ -508,9 +518,9 @@ consider)::
    Probability [Q-value] = 0.995322
    Reduced statistic     = 0.716768
    Change in statistic   = 3.34091e+11
-      phabs.nH       0.0129625    +/- 0.00727019
-      powlaw1d.gamma   1.78432      +/- 0.0459786
-      powlaw1d.ampl   7.17014e-05  +/- 2.48751e-06
+      phabs.nH       0.0129623    +/- 0.00727297
+      powlaw1d.gamma   1.78432      +/- 0.0459881
+      powlaw1d.ampl   7.17014e-05  +/- 2.48851e-06
 
 We can see the amplitude has changed from 1 to :math:`\sim 10^{-4}`,
 which should make the predicted counts a lot more believable!

--- a/docs/evaluation/integrate.rst
+++ b/docs/evaluation/integrate.rst
@@ -76,12 +76,8 @@ each bin::
     >>> y
     array([-22.5,   2.5,  27.5,  52.5])
 
-Thanks to the easy functonal form chosen for this example,
-it is easy to confirm that these are the values of the
-integrated model::
-  
-    >>> (y[:-1] + y[1:]) * 5 / 2.0
-    array([-22.5,   2.5,  27.5,  52.5])
+and indeed the resulting value match the analytical integration of the
+function.
 
 Turning off the ``integrate`` flag for this model shows that it
 uses the low-edge of the bin when evaluating the model::

--- a/docs/evaluation/regrid.rst
+++ b/docs/evaluation/regrid.rst
@@ -107,10 +107,15 @@ style of grid, and will raise a :py:class:`~sherpa.utils.err.ModelErr`
 error::
 
    >>> rmdl(x[:-1], x[1:])
-   ModelErr: A non-integrated grid is required for model evaluation
+   Traceback (most recent call last):
+   ...
+   sherpa.utils.err.ModelErr: A non-integrated grid is required for model evaluation
+
 
    >>> imdl(x)
-   ModelErr: A non-overlapping integrated grid is required for model evaluation,
+   Traceback (most recent call last):
+   ...
+   sherpa.utils.err.ModelErr: A non-overlapping integrated grid is required for model evaluation,
    e.g. [0.1,0.2],[0.2,0.3]
 
 

--- a/docs/evaluation/simulate.rst
+++ b/docs/evaluation/simulate.rst
@@ -65,8 +65,8 @@ and counts empty, because these will be filled in by the simulation::
   >>> from sherpa.astro.data import DataPHA
   >>> from sherpa.astro.io import read_arf, read_rmf, read_pha
   >>> data = DataPHA(name='any', channel=None, counts=None, exposure=10000.)
-  >>> data.set_arf(read_arf('9774.arf'))
-  >>> data.set_rmf(read_rmf('9774.rmf'))
+  >>> data.set_arf(read_arf(data_dir + '9774.arf'))
+  >>> data.set_rmf(read_rmf(data_dir + '9774.rmf'))
 
 Alternatively, one could read in a PHA file (``data =
 read_pha('9774_bg.pi')``). In this case, the response and backgrounds
@@ -136,7 +136,7 @@ complex models which may include such components as the instrumental
 backgound (which should not be folded through the ARF) or arbitary
 other components::
 
-  >>> fake_pha(data, model=inst_bkg + my_arf(my_rmf(srcmodel)), is_source=False)
+  >>> fake_pha(data, model=inst_bkg + my_arf(my_rmf(srcmodel)), is_source=False)  # doctest: +SKIP
 
 .. image:: ../_static/evaluation/fake_pha.png
 
@@ -156,7 +156,7 @@ One way to include background is to sample it from a
 loaded into the dataset before running the simluation and, if not done
 before, the scale of the background scaling has to be set::
 
-  >>> data.set_background(read_pha('9774_bg.pi'))
+  >>> data.set_background(read_pha('sherpa-test-data/sherpatest/9774_bg.pi'))
   >>> data.backscal = 9.6e-06
   >>> fake_pha(data, srcmdl, add_bkgs=True)
 

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -53,7 +53,7 @@ The following data - where ``x`` is the independent axis and
     >>> err_true = 0.2
     >>> y = ampl_true * np.exp(-0.5 * (x - pos_true)**2 / sigma_true**2)
     >>> y += np.random.normal(0., err_true, x.shape)
-    >>> plt.plot(x, y, 'ko');
+    >>> out = plt.plot(x, y, 'ko')
 
 .. image:: _static/quick/data1d.png
 
@@ -220,14 +220,15 @@ so we start with it (the optimiser can be changed and the data re-fit):
     >>> from sherpa.optmethods import LevMar
     >>> opt = LevMar()
     >>> print(opt)
-    name    = levmar
-    ftol    = 1.19209289551e-07
-    xtol    = 1.19209289551e-07
-    gtol    = 1.19209289551e-07
-    maxfev  = None
-    epsfcn  = 1.19209289551e-07
-    factor  = 100.0
-    verbose = 0
+    name     = levmar
+    ftol     = 1.1920928955078125e-07
+    xtol     = 1.1920928955078125e-07
+    gtol     = 1.1920928955078125e-07
+    maxfev   = None
+    epsfcn   = 1.1920928955078125e-07
+    factor   = 100.0
+    numcores = 1
+    verbose  = 0
 
 .. _quick-gauss1d-fit:
     
@@ -319,9 +320,9 @@ As the model can be
 :doc:`evaluated directly <evaluation/index>`,
 this plot can also be created manually::
 
-   >>> plt.plot(d.x, d.y, 'ko', label='Data')
-   >>> plt.plot(d.x, g(d.x), linewidth=2, label='Gaussian')
-   >>> plt.legend(loc=2);
+   >>> out = plt.plot(d.x, d.y, 'ko', label='Data')
+   >>> out = plt.plot(d.x, g(d.x), linewidth=2, label='Gaussian')
+   >>> out = plt.legend(loc=2);
 
 .. image:: _static/quick/data1d_gauss_fit.png
 
@@ -479,7 +480,7 @@ The default error estimation routine is
 
     >>> from sherpa.estmethods import Confidence
     >>> gefit.estmethod = Confidence()
-    >>> print(gefit.estmethod)
+    >>> print(gefit.estmethod)  # doctest: +IGNORE_OUTPUT
     name         = confidence
     sigma        = 1
     eps          = 0.01
@@ -495,6 +496,10 @@ The default error estimation routine is
     verbose      = False
     openinterval = False
 
+..
+   Comment: IGNORE_OUTPUT is neccessary because numcores will have
+   different value, depending on the machine that runs the doctest.
+
 Running the error analysis can take time, for particularly complex
 models. The default behavior is to use all the available CPU cores
 on the machine, but this can be changed with the ``numcores``
@@ -502,6 +507,9 @@ attribute. Note that a message is displayed to the screen when each
 bound is calculated, to indicate progress::
   
     >>> errors = gefit.est_errors()
+
+And this is the output::
+
     gerr.fwhm lower bound:	-0.0326327
     gerr.fwhm upper bound:	0.0332578
     gerr.pos lower bound:	-0.0140981
@@ -548,9 +556,9 @@ ranges::
     >>> dvals = zip(errors.parnames, errors.parvals, errors.parmins,
     ... errors.parmaxes)
     >>> pvals = {d[0]: {'val': d[1], 'min': d[2], 'max': d[3]}
-                 for d in dvals}
+    ...          for d in dvals}
     >>> pvals['gerr.pos']
-    {'min': -0.014098074065578947, 'max': 0.014098074065578947, 'val': 1.2743015983545292}
+    {'val': 1.2743015983545225, 'min': -0.01409807406557051, 'max': 0.01409807406557051}
              
 .. todo::
 
@@ -605,7 +613,7 @@ This can take some time, depending on the complexity of the model and
 number of steps requested. The resulting data looks like::
    
    >>> iproj.plot()
-   >>> plt.axhline(geres.statval + 9, linestyle='dotted');
+   >>> out = plt.axhline(geres.statval + 9, linestyle='dotted');
 
 .. image:: _static/quick/data1d_pos_iproj.png
 
@@ -673,14 +681,14 @@ contours)::
     >>> x0.resize(ny, nx)
     >>> x1.resize(ny, nx)
     >>> y.resize(ny, nx)
-    >>> plt.imshow(y, origin='lower', cmap='viridis_r', aspect='auto',
-    ...            extent=(x0.min(), x0.max(), x1.min(), x1.max()))
-    >>> plt.colorbar()
-    >>> plt.xlabel(rproj.xlabel)
-    >>> plt.ylabel(rproj.ylabel)
+    >>> out = plt.imshow(y, origin='lower', cmap='viridis_r', aspect='auto',
+    ...                  extent=(x0.min(), x0.max(), x1.min(), x1.max()))
+    >>> out = plt.colorbar()
+    >>> out = plt.xlabel(rproj.xlabel)
+    >>> out = plt.ylabel(rproj.ylabel)
     >>> cs = plt.contour(x0, x1, y, levels=lvls)
     >>> lbls = [(v, r"${}\sigma$".format(i+1)) for i, v in enumerate(lvls)]
-    >>> plt.clabel(cs, lvls, fmt=dict(lbls));
+    >>> out = plt.clabel(cs, lvls, fmt=dict(lbls));
 
 .. image:: _static/quick/data1d_pos_fwhm_rproj_manual.png
 
@@ -759,8 +767,7 @@ To reduce the number of parameters being fit, the ``frozen`` attribute
 can be set::
 
     >>> for n in ['cx1', 'cy1', 'cx2y1', 'cx1y2', 'cx2y2']:
-       ...:     getattr(p2, n).frozen = True
-       ...:
+    ...     getattr(p2, n).frozen = True
     >>> print(p2)
     p2
        Param        Type          Value          Min          Max      Units
@@ -837,12 +844,12 @@ and then displaying it::
     ...                  ticks=[0, 20000, 40000])
     ...     plt.title(title)
     ...
-    >>> plt.figure(figsize=(8, 3))
-    >>> plt.subplot(1, 3, 1);
+    >>> out = plt.figure(figsize=(8, 3))
+    >>> out = plt.subplot(1, 3, 1);
     >>> pimg(y, "Data")
-    >>> plt.subplot(1, 3, 2)
+    >>> out = plt.subplot(1, 3, 2)
     >>> pimg(m2, "Model")
-    >>> plt.subplot(1, 3, 3)
+    >>> out = plt.subplot(1, 3, 3)
     >>> pimg(y - m2, "Residual")
 
 .. image:: _static/quick/data2d_residuals.png
@@ -890,8 +897,8 @@ for the signal::
 There is **no** requirement that the data sets have a common grid,
 as can be seen in a raw view of the data::
 
-    >>> plt.plot(x1, y1)
-    >>> plt.plot(x2, y2)
+    >>> out = plt.plot(x1, y1)
+    >>> out = plt.plot(x2, y2)
    
 .. image:: _static/quick/quick_simulfit_data.png
 
@@ -972,12 +979,12 @@ The data can then be viewed (in this case a separate grid
 is used, but the
 :ref:`data objects could be used to define the grid <evaluation_data>`)::
 
-    >>> plt.plot(x1, y1, label='Data 1')
-    >>> plt.plot(x2, y2, label='Data 2')
+    >>> out = plt.plot(x1, y1, label='Data 1')
+    >>> out = plt.plot(x2, y2, label='Data 2')
     >>> x = np.arange(4000, 5000, 10)
-    >>> plt.plot(x, (fpoly + flor)(x), linestyle='dotted', label='Fit 1')
-    >>> plt.plot(x, fpoly(x), linestyle='dotted', label='Fit 2')
-    >>> plt.legend();
+    >>> out = plt.plot(x, (fpoly + flor)(x), linestyle='dotted', label='Fit 1')
+    >>> out = plt.plot(x, fpoly(x), linestyle='dotted', label='Fit 2')
+    >>> out = plt.legend()
 
 .. image:: _static/quick/quick_simulfit_fit.png
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,54 @@
 [pytest]
 addopts = -rs --ignore=setup.py --ignore=test_requirements.txt
 norecursedirs = .git build dist tmp* .eggs
+text_file_format = rst
+doctest_plus = enabled
+doctest_plus_atol = 1e-4
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    ELLIPSIS
+    FLOAT_CMP
+doctest_norecursedirs =
+    extern
+    sherpa-test-data
+    scripts
+    # Blacklist everything and then remove from this list when it's ready
+    docs/_examples
+    docs/code
+    docs/data
+    docs/developer
+    docs/examples
+    docs/extra
+    docs/fit
+    docs/install.rst
+    docs/mcmc
+    docs/model_classes
+    docs/models
+    docs/optimisers
+    docs/overview
+    docs/plots
+    docs/statistics
+    docs/ui
+    sherpa/__init__.py
+    sherpa/astro
+    sherpa/conftest.py
+    sherpa/estmethods
+    sherpa/fit.py
+    sherpa/image
+    sherpa/include
+    sherpa/io.py
+    sherpa/models
+    sherpa/optmethods
+    sherpa/plot
+    sherpa/sim
+    sherpa/static
+    sherpa/stats
+    sherpa/tests
+    sherpa/ui
+    sherpa/utils
+
+doctest_subpackage_requires =
+    sherpa/astro/io/crates_backend.py = pycrates
+    sherpa/astro/io/pyfits_backend.py = astropy
+    sherpa/plot/pylab_backend.py = matplotlib
+

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -96,25 +96,25 @@ References
 Examples
 --------
 
-Read in a 2D dataset from the file 'clus.fits' and then filter it to
+Read in a 2D dataset from the file 'image2.fits' and then filter it to
 only use those pixels that lie within 45 units from the physical
 coordinate 3150,4515:
 
 >>> from sherpa.astro.io import read_image
->>> img = read_image('clus.fits')
+>>> img = read_image(data_dir + 'image2.fits')
 >>> img.set_coord('physical')
 >>> img.notice2d('circle(3150,4515,45)')
 
-Read in a PHA dataset from the file 'src.pi', subtract the background,
+Read in a PHA dataset from the file '3c273.pi', subtract the background,
 filter to only use the data 0.5 to 7 keV, and re-group the data within
 this range to have at least 20 counts per group:
 
 >>> from sherpa.astro.io import read_pha
->>> pha = read_pha('src.pi')
+>>> pha = read_pha(data_3c273 + '3c273.pi')
 >>> pha.subtract()
 >>> pha.set_analysis('energy')
 >>> pha.notice(0.5, 7)
->>> pha.group_counts(20, tabStops=~pha.mask)
+>>> pha.group_counts(20)
 
 """
 
@@ -2096,6 +2096,8 @@ must be an integer.""")
         Examples
         --------
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.set_analysis('energy')
 
         >>> pha.set_analysis('wave', type='counts', factor=1)
@@ -2151,6 +2153,9 @@ must be an integer.""")
         Examples
         --------
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
+        >>> pha.set_analysis("wave")
         >>> is_wave = pha.get_analysis() == 'wavelength'
 
         """
@@ -2488,6 +2493,8 @@ must be an integer.""")
         Examples
         --------
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.ungroup()
         >>> pha.units = 'channel'
         >>> clo, chi = pha._get_ebins()
@@ -2516,7 +2523,7 @@ must be an integer.""")
         >>> pha.units = 'wave'
         >>> wlo, whi = pha._get_ebins()
         >>> (wlo == glo).all()
-
+        True
         """
         group = bool_cast(group)
 
@@ -2599,8 +2606,10 @@ must be an integer.""")
         Examples
         --------
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.units = 'energy'
-        >>> elo, eho = pha._get_indep()
+        >>> elo, ehi = pha._get_indep()
         >>> elo.shape
         (1090,)
         >>> pha.channel.shape
@@ -2613,7 +2622,7 @@ must be an integer.""")
         True
 
         >>> pha.units = 'wave'
-        >>> wlo, who = pha._get_indep()
+        >>> wlo, whi = pha._get_indep()
         >>> wlo[0:4]
         array([112.71289825, 103.32015848,  95.37245534,  88.56013348])
         >>> whi[0:4]
@@ -3014,8 +3023,10 @@ must be an integer.""")
         Examples
         --------
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.get_backscal()
-        7.8504301607718007e-06
+        2.5264364698914e-06
 
         """
         if self.backscal is None:
@@ -3053,6 +3064,8 @@ must be an integer.""")
         Examples
         --------
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.get_areascal()
         1.0
 
@@ -3099,14 +3112,16 @@ must be an integer.""")
         Group and filter the counts array with no filter and then
         with a filter:
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.grouped
         True
         >>> pha.notice()
-        >>> pha.apply_filter(pha.counts)
-        array([17., 15., 16., 15., ...
+        >>> print(pha.apply_filter(pha.counts))
+        [17.  15.  16.  15. ...
         >>> pha.notice(0.5, 7)
-        >>> pha.apply_filter(pha.counts)
-        array([15., 16., 15., 18., ...
+        >>> print(pha.apply_filter(pha.counts))
+        [15.  16.  15.  18.  ...
 
         As the previous example but with no grouping:
 
@@ -3265,6 +3280,8 @@ must be an integer.""")
         been filtered so using get_dep with the filter argument set to
         True is generally preferred to using this method):
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> gcounts = pha.apply_grouping(pha.counts)
 
         The grouping for an unfiltered PHA data set with 1024 channels
@@ -3278,14 +3295,16 @@ must be an integer.""")
         True
         >>> len(pha.channel)
         1024
-        >>> pha.apply_grouping(np.ones(1024))
-        array([ 17.,   4.,  11.,   ...
-        >>> pha.apply_grouping(np.arange(1, 1025), pha._min)
-        array([  1.,  18.,  22.,  ...
-        >>> pha.apply_grouping(np.arange(1, 1025), pha._max)
-        array([  17.,   21.,   32.,   ...
-        >>> pha.apply_grouping(np.arange(1, 1025), pha._middle)
-        array([  9. ,  19.5,  27. ,  ...
+        >>> import numpy as np
+        >>> dvals = np.arange(1, 1025)
+        >>> print(pha.apply_grouping(np.ones(1024)))
+        [ 17.   4.  11.  ...
+        >>> print(pha.apply_grouping(dvals, pha._min))
+        [  1.  18.  22.  ...
+        >>> print(pha.apply_grouping(dvals, pha._max))
+        [  17.   21.   32.   ...
+        >>> print(pha.apply_grouping(dvals, pha._middle))
+        [  9.   19.5  27.   ...
 
         The grouped data is not filtered (unless ignore_bad has been
         used):
@@ -3752,14 +3771,16 @@ must be an integer.""")
         Calculate the background counts, per channel, scaled to match
         the source:
 
-        >>> bcounts = src.sum_background_data()
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
+        >>> bcounts = pha.sum_background_data()
 
         Calculate the scaling factor that you need to multiply the
         background data to match the source data. In this case the
         background data has been replaced by the value 1 (rather than
         the per-channel values used with the default argument):
 
-        >>> bscale = src.sum_background_data(lambda k, d: 1)
+        >>> bscale = pha.sum_background_data(lambda k, d: 1)
 
         """
 
@@ -3894,14 +3915,17 @@ must be an integer.""")
         Examples
         --------
 
-        >>> dy = dset.get_staterror()
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi', use_errors=True)
+        >>> dy = pha.get_staterror()
 
         Ensure that there is no pre-defined statistical-error column
         and then use the Chi2DataVar statistic to calculate the errors:
 
-        >>> stat = sherpa.stats.Chi2DataVar()
-        >>> dset.set_staterror(None)
-        >>> dy = dset.get_staterror(staterrfunc=stat.calc_staterror)
+        >>> from sherpa.stats import Chi2DataVar
+        >>> stat = Chi2DataVar()
+        >>> pha.staterror = None
+        >>> dy = pha.get_staterror(staterrfunc=stat.calc_staterror)
 
         """
 
@@ -4377,6 +4401,8 @@ must be an integer.""")
         --------
         For a Chandra non-grating dataset which has been grouped:
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.set_analysis('energy')
         >>> pha.notice(0.5, 7)
         >>> pha.get_filter(format='%.4f')
@@ -4400,19 +4426,19 @@ must be an integer.""")
         is grouped or not (unless the groups align with the filter
         edges):
 
-        >>> d.ungroup()
-        >>> d.notice()
-        >>> d.notice(0.5, 7)
-        >>> d.get_filter(format='%.3f')
+        >>> pha.ungroup()
+        >>> pha.notice()
+        >>> pha.notice(0.5, 7)
+        >>> pha.get_filter(format='%.3f')
         '0.496:7.008'
-        >>> d.group()
-        >>> d.get_filter(format='%.3f')
+        >>> pha.group()
+        >>> pha.get_filter(format='%.3f')
         '0.467:9.870'
 
-        >>> d.notice()
-        >>> d.notice(0.5, 6)
-        >>> d.ignore(2.1, 2.2)
-        >>> d.get_filter(format='%.2f', delim='-')
+        >>> pha.notice()
+        >>> pha.notice(0.5, 6)
+        >>> pha.ignore(2.1, 2.2)
+        >>> pha.get_filter(format='%.2f', delim='-')
         '0.47-2.09,2.28-6.57'
 
         """
@@ -4560,6 +4586,9 @@ must be an integer.""")
         --------
         So, for an ungrouped PHA file with 1024 channels:
 
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
+        >>> pha.ungroup()
         >>> pha.units = 'channel'
         >>> pha.get_filter()
         '1:1024'
@@ -4567,6 +4596,7 @@ must be an integer.""")
         >>> pha.get_filter()
         '20:200'
         >>> pha.notice(300, 500)
+        >>> pha.get_filter()
         '20:200,300:500'
 
         Calling `notice` with no arguments removes all the filters:
@@ -4586,6 +4616,7 @@ must be an integer.""")
         range will not always match the requested range because each
         channel has a finite width in these spaces:
 
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.grouped
         True
         >>> pha.get_analysis()

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -666,7 +666,7 @@ def add_sherpa_test_data_dir(doctest_namespace):
     #
     path = get_datadir()
     if path is None:
-        pytest.skip("sherpa-test-data not found")
+        return None
 
     if not path.endswith('/'):
         path += '/'

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -647,3 +647,28 @@ def cleanup_ds9_backend():
     #
     from sherpa.image import backend
     backend.close()
+
+@pytest.fixture(autouse=True)
+def add_sherpa_test_data_dir(doctest_namespace):
+    '''Define `data_dir` for doctests
+
+    We make this an autouse=True fixture, because that means that
+    the variable `data_dir` is available in every file that we may
+    want to test without any special markup to that file. There is a
+    risk that this is too magical and could confuse developers
+    in the future, but it seems more important that this keeps any
+    extra markup out of those files and keep them clean.
+    '''
+    doctest_namespace["data_3c273"] = 'sherpa/astro/datastack/tests/data/'
+
+    # We could error out here, but we only want the tests that
+    # use it to fail.
+    #
+    path = get_datadir()
+    if path is None:
+        pytest.skip("sherpa-test-data not found")
+
+    if not path.endswith('/'):
+        path += '/'
+
+    doctest_namespace["data_dir"] = path

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -107,6 +107,9 @@ Create a data set representing the independent axis (``x``) and
 dependent axis (``y``) then filter to select only those values between
 500-520 and 530-700:
 
+>>> import numpy as np
+>>> x = np.arange(1000)
+>>> y = np.random.normal(size=1000)
 >>> d1 = Data1D('example', x, y)
 >>> d1.notice(500, 700)
 >>> d1.ignore(520, 530)
@@ -723,7 +726,7 @@ class Filter():
         array([False,  True,  True,  False, False])
         >>> f.notice([None, 1.5], [3.5, None], (xlo, xhi), integrated=True)
         >>> f.mask
-        array([True,  True,  True,  False, False])
+        array([ True,  True,  True, False, False])
 
         """
 
@@ -1648,6 +1651,7 @@ class Data1D(Data):
         Examples
         --------
 
+        >>> import numpy as np
         >>> x = np.asarray([1, 2, 3, 5, 6])
         >>> y = np.ones(5)
         >>> d = Data1D('example', x, y)
@@ -1689,9 +1693,15 @@ class Data1D(Data):
         Examples
         --------
 
+        >>> d = Data1D('example', [1., 2., 3., 5., 6., 7.], [0, .4, .5, .6, .7, .8])
+        >>> d.notice(1., 6.)
+        >>> d.ignore(2.5, 4.)
         >>> d.get_filter_expr()
         '1.0000-2.0000,5.0000-6.0000 x'
 
+        Note that the expression lists the valid data points. While we ignore
+        only the range 2.5-4.0, there is no data point between 4. and 5., so
+        the second part of the valid range is 5.0 to 6.0.
         """
         return self.get_filter(delim='-') + ' ' + self.get_xlabel()
 
@@ -1751,6 +1761,7 @@ class Data1D(Data):
         Examples
         --------
 
+        >>> import numpy as np
         >>> x = np.arange(0.4, 2.6, 0.2)
         >>> y = np.ones_like(x)
         >>> d = Data1D('example', x, y)
@@ -1866,6 +1877,7 @@ class Data1DInt(Data1D):
         Examples
         --------
 
+        >>> import numpy as np
         >>> xlo = np.asarray([1, 2, 3, 5, 6])
         >>> xhi = xlo + 1
         >>> y = np.ones(5)
@@ -1936,6 +1948,7 @@ class Data1DInt(Data1D):
         Examples
         --------
 
+        >>> import numpy as np
         >>> edges = np.arange(0.4, 2.6, 0.2)
         >>> xlo, xhi = edges[:-1], edges[1:]
         >>> y = np.ones_like(xlo)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pytest>=5.0,!=5.2.3
 pytest-xvfb
+pytest-doctestplus


### PR DESCRIPTION
# Summary

Allow doctests to run in Sherpa

# Details

This is a redo of #1521, which we pulled before a release. It adds the ability to run doctests in py and rst files. Those tests will run automatically, if doctestplus is installed (not on CI in the current setup) and the file is not explicitly balcklisted for doctestplus. This PR fixes up a few files as examples. Common problems that prevent doctestplus to run a file are 
(from the common, trivial on the top, to the rare, but worthy of fixing at the bottom):

    formatting of code
    numpy not imported
    slightly different formatting of of the output
    example contains typos
    example uses variable that are not defined
    example uses functionality that's buggy or outdated.

The far goal is to run doctests for all rst files and all embedded examples of the docs (https://github.com/sherpa/sherpa/issues/816). This would ensure that the examples we give execute at all, and, where we have expected output to compare to, also act as an additional tests. We have about 1000 doctests embedded in our rst docs, so running all those automatically is a significant enhancement in itself.