### PR TITLE
Take advantage of XSPEC 12.12.0

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1856,8 +1856,8 @@ class Session(sherpa.ui.utils.Session):
         axis, the asymmetric errors ``elo`` and ``ehi``. ``elo`` and ``ehi``
         assumed to be positive values. They are used to calculate ``staterror`` for
         ``fit`` with ``chi2`` statistics. Note that ``set_stat`` will not
-        impact the statistics values for the fitting this type of data and 
-        ``fit`` will always use ``staterror`` in this case. ``resample_data`` 
+        impact the statistics values for the fitting this type of data and
+        ``fit`` will always use ``staterror`` in this case. ``resample_data``
         will assume ``set_stat`` setting in calculating the statistics for bootstrap
         sampling.
 
@@ -16641,7 +16641,7 @@ class Session(sherpa.ui.utils.Session):
 
         >>> show_xsabund()
         Solar Abundance Table:
-        angr  Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)
+        angr:  Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)
           H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
           C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
           Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
@@ -16665,12 +16665,10 @@ class Session(sherpa.ui.utils.Session):
             warning("XSPEC support is not available")
             return
 
-        # Very similar to the XSPEC "show abund" format, except that
-        # we do not have the "documentation" for the abundance table.
-        # This can be added but needs changes to the _xspec module.
+        # Very similar to the XSPEC "show abund" format.
         #
         lines = ["Solar Abundance Table:",
-                 f"{xspec.get_xsabund():4s}  {xspec.get_xsabund_doc()}",
+                 f"{xspec.get_xsabund():4s}:  {xspec.get_xsabund_doc()}",
                  ""]
 
         # Rely on get_xsbundances to be in order of atomic number.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -918,6 +918,81 @@ def set_xsxflt(spectrumNumber: int, xflt: dict[str, float]) -> None:
     xsstate["xfltnums"].add(spectrumNumber)
 
 
+def clear_xsdb() -> None:
+    """Clear out the XSPEC database.
+
+    .. versionadded:: 4.17.0
+
+    See Also
+    --------
+    get_xsdb, set_xsdb
+
+    Examples
+    --------
+
+    >>> clear_xsdb()
+
+    """
+    return _xspec.clear_db()
+
+
+def get_xsdb() -> dict[str, float]:
+    """Return the XSPEC database values.
+
+    .. versionadded:: 4.17.0
+
+    Returns
+    -------
+    db : dict
+        The current keywords (strings) and values (numbers) associated
+        with the XSPEC database. It may be empty.
+
+    See Also
+    --------
+    clear_xsdb, set_xsdb
+
+    Examples
+    --------
+
+    >>> get_xsdb()
+    {}
+
+    >>> set_db("inner", 0.2)
+    >>> set_db("outer", 2)
+    >>> get_db()
+    {'inner': 0.2, 'outer': 2.0}
+
+    """
+    return _xspec.get_db()
+
+
+def set_xsdb(key: str, value: float) -> None:
+    """Set a XSPEC database value.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    key : str
+        The keyword to set (it is converted to lower case).
+    value : number
+        The number to set.
+
+    See Also
+    --------
+    clear_db, get_db
+
+    Examples
+    --------
+
+    >>> set_xsdb("inner", 0.2)
+    >>> set_xsdb("outer", 2)
+    >>> get_xsdb()
+
+    """
+    _xspec.set_db(key, value)
+
+
 def get_xspath_manager() -> str:
     """Return the path to the files describing the XSPEC models.
 
@@ -1007,8 +1082,8 @@ def get_xsstate() -> dict[str, Any]:
 
     See Also
     --------
-    get_xsabund, get_xschatter, get_xscosmo, get_xsxflt, get_xsxsect,
-    get_xsxset, set_xsstate
+    get_xsabund, get_xschatter, get_xscosmo, get_xsdb, get_xsxflt,
+    get_xsxsect, get_xsxset, set_xsstate
 
     """
 
@@ -1027,6 +1102,7 @@ def get_xsstate() -> dict[str, Any]:
             "xsect": get_xsxsect(),
             "modelstrings": get_xsxset(),
             "paths": xsstate["paths"].copy(),
+            "db": get_xsdb(),
             "xflt": xflt
             }
 
@@ -1044,8 +1120,8 @@ def set_xsstate(state: dict[str, Any]) -> None:
         The current settings for the XSPEC module. This is expected to
         match the return value of ``get_xsstate``, and so uses the
         keys: 'abund', 'chatter', 'cosmo', 'xsect', 'modelstrings',
-        'xflt', and 'paths'. If a keyword is missing then that setting
-        will not be changed.
+        'xflt', 'db', and 'paths'. If a keyword is missing then that
+        setting will not be changed.
 
     See Also
     --------
@@ -1089,6 +1165,12 @@ def set_xsstate(state: dict[str, Any]) -> None:
         clear_xsxset()
         for name, value in settings.items():
             set_xsxset(name, value)
+
+    db = state.get("db", None)
+    if db is not None:
+        clear_xsdb()
+        for name, value in db.items():
+            set_xsdb(name, value)
 
     xflt = state.get("xflt", None)
     if xflt is not None:
@@ -1250,7 +1332,8 @@ __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'get_xsversion',
            'set_xsxset', 'get_xsxset', 'clear_xsxset',
            'set_xsstate', 'get_xsstate',
-           'clear_xsxflt', 'get_xsxflt', 'set_xsxflt', 'clear_xsxflt',
+           'get_xsxflt', 'set_xsxflt', 'clear_xsxflt',
+           'clear_xsdb', 'get_xsdb', 'set_xsdb', 'clear_xsdb',
            'get_xsabundances', 'set_xsabundances')
 
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -359,6 +359,39 @@ def get_xselements() -> dict[str, int]:
     return out
 
 
+# This function is not added to __all__ as it is not likely to be well
+# used.
+#
+def get_xsabundances_file() -> Path:
+    """Return the path to the abundances file used by X-Spec.
+
+    This file is used by X-Spec to determine the different
+    abundance-table settings used by set_xsabund and get_xsabund.
+
+    .. versionadded:: 4.17.0
+
+    Returns
+    -------
+    path : pathlib.Path
+        The full path to the abundances file.
+
+    See Also
+    --------
+    get_xsabund, set_xsabund
+
+    Examples
+    --------
+
+    >>> get_xsabundances_file()
+    PosixPath('/path/to/spectral/manager/abundances.dat')
+
+    """
+
+    out = Path(_xspec.get_xspath_abundance())
+    out /= Path(_xspec.get_abundance_file())
+    return out.resolve()
+
+
 def get_xschatter() -> int:
     """Return the chatter level used by X-Spec.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -143,7 +143,7 @@ def get_xsabund(element: Optional[Union[str, int]] = None,
                 ) -> Union[str, float]:
     """Return the X-Spec abundance setting or elemental abundance.
 
-    .. versionchanged 4.17.0::
+    .. versionchanged:: 4.17.0
        The element can now be specified via it's atomic number and the
        abundance table to search can be given.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -172,7 +172,7 @@ def get_xsabund(element: Optional[Union[str, int]] = None,
 
     See Also
     --------
-    get_xsabundances, set_xsabund, set_xsabundances
+    get_xsabund_doc, get_xsabundances, set_xsabund, set_xsabundances
 
     Examples
     --------
@@ -265,36 +265,50 @@ def get_xsabundances(table: Optional[str] = None
     return out
 
 
-def get_xsabund_doc(name: Optional[str] = None) -> str:
-    """Return the documentation for the abundance table.
+def get_xsabund_doc(table: str | None = None) -> str:
+    """Return the description of the X-Spec abundance table.
+
+    .. versionadded:: 4.17.0
 
     Parameters
     ----------
-    name : str or None, optional
-        If not set, use the current abundance table
+    table : str, optional
+       The abundance table to use. It accepts the same string labels
+       as `set_xsabund`. If not given the table from `get_xsabund` is
+       used.
 
     Returns
     -------
-    doc : str
-        The documentation for the table
+    desc : str
+       The description of the table.
 
     See Also
     --------
-    get_xsabund
+    get_xsabund, set_xsabund
 
     Examples
     --------
 
-    >>> get_xsabund_doc("angr")
+    Return the description of the current abundance setting, which in
+    this case is 'angr', the default value for X-Spec:
+
+    >>> get_xsabund_doc()
     'Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)'
+
+    Return the description for the 'lodd' and 'grsa' tables:
+
+    >>> get_xsabund_doc('lodd')
+    'Lodders, K. ApJ 591, 1220 (2003)'
+    >>> get_xsabund_doc('grsa')
+    'Grevesse, N. & Sauval, A. J. Space Science Reviews 85, 161 (1998)'
 
     """
 
-    aname = get_xsabund() if name is None else name
+    aname = _xspec.get_xsabund_table() if name is None else name
 
     # Remove any unwanted space characters.
     #
-    return _xspec.get_xsabund_doc(aname).strip()
+    return _xspec.get_xsabund_doc(etable).strip()
 
 
 def set_xsabundances(abundances: dict[str, float]) -> None:

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -495,6 +495,71 @@ def set_xsversion(name: VersionType, version: str) -> None:
     raise ValueError(f"name must be 'atomdb' or 'nei', not '{name}'")
 
 
+# This function is not added to __all__ as it is very specialized.
+#
+def get_xselements() -> dict[str, int]:
+    """Return the elements names and atomic numbers used by X-Spec.
+
+    .. versionadded:: 4.17.0
+
+    Returns
+    -------
+    elements : dict
+        The keys are the element names and the values the atomic
+        numbers.
+
+    See Also
+    --------
+    get_xsnelem
+
+    Examples
+    --------
+
+    >>> els = get_xselements()
+    >>> len(els)
+    30
+    >>> els['H']
+    1
+    >>> els['Zn']
+    30
+
+    """
+
+    # This could have accessed a Python dict, such as {'H': 1, 'He':
+    # 2, ..., 'Zn': 30}, which would have been a lot simpler, but this
+    # is ore future-proof, in the very-unlikely case that XSPEC adds
+    # more elements.
+    #
+    return _xspec.get_xselements()
+
+
+# This function is not added to __all__ as it is very specialized.
+#
+def get_xsnelem() -> int:
+    """Return the number of elements used by XSPEC.
+
+    .. versionadded:: 4.17.0
+
+    Returns
+    -------
+    nelem : int
+        The number of elements.
+
+    See Also
+    --------
+    get_xselements
+
+    Examples
+    --------
+
+    >>> get_xsnelem()
+    30
+
+    """
+
+    return len(get_xselements())
+
+
 def get_xsxsect() -> str:
     """Return the cross sections used by X-Spec models.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -104,6 +104,7 @@ References
 
 from contextlib import suppress
 import logging
+from pathlib import Path
 import string
 import tempfile
 from typing import Any, Optional, Union
@@ -1027,7 +1028,7 @@ def get_xspath_model() -> str:
 
     See Also
     --------
-    get_xspath_manager
+    get_xspath_manager, set_xspath_model
 
     Examples
     --------
@@ -1039,30 +1040,62 @@ def get_xspath_model() -> str:
     return _xspec.get_xspath_model()
 
 
-def set_xspath_manager(path: str) -> None:
+def set_xspath_manager(path: Union[Path, str]) -> None:
     """Set the path to the files describing the XSPEC models.
+
+    .. versionchanged:: 4.17.0
+       The argument can now be sent in as a Path object.
 
     Parameters
     ----------
-    path : str
+    path : str or Path
         The new path.
 
     See Also
     --------
-    get_xspath_manager : Return the path to the files describing the XSPEC models.
+    get_xspath_manager, set_xspath_model
 
     Examples
     --------
     >>> set_xspath_manager('/data/xspec/spectral/manager')
     """
 
-    _xspec.set_xspath_manager(path)
-    spath = get_xspath_manager()
-    if spath != path:
+    spath = str(path)
+    _xspec.set_xspath_manager(spath)
+    got = get_xspath_manager()
+    if got != spath:
         raise IOError("Unable to set the XSPEC manager path "
-                      f"to '{path}'")
+                      f"to '{spath}'")
 
-    xsstate["paths"]["manager"] = path
+    xsstate["paths"]["manager"] = spath
+
+
+def set_xspath_model(path: Union[Path, str]) -> None:
+    """Set the path to the XSPEC model data files.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    path : str or Path
+        The new path.
+
+    See Also
+    --------
+    get_xspath_model, set_xspath_manager
+
+    Examples
+    --------
+    >>> set_xspath_model('/data/xspec/spectral/modelData/')
+    """
+
+    spath = str(path)
+    _xspec.set_xspath_model(spath)
+    got = get_xspath_model()
+    if got != spath:
+        raise IOError(f"Unable to set the XSPEC model path to '{spath}'")
+
+    xsstate["paths"]["model"] = spath
 
 
 def get_xsstate() -> dict[str, Any]:
@@ -1181,6 +1214,11 @@ def set_xsstate(state: dict[str, Any]) -> None:
     paths = state.get("paths", {})
     try:
         set_xspath_manager(paths["manager"])
+    except KeyError:
+        pass
+
+    try:
+        set_xspath_model(paths["model"])
     except KeyError:
         pass
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -569,6 +569,11 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(get_db, getAllDb),
   FCTSPEC(set_db, loadDbValue),
 
+  NOARGSPEC(get_xsversion_atomdb, get_xspec_string<FunctionUtility::atomdbVersion>),
+  NOARGSPEC(get_xsversion_nei, get_xspec_string<FunctionUtility::neiVersion>),
+  FCTSPEC(set_xsversion_atomdb, set_xspec_string<FunctionUtility::atomdbVersion>),
+  FCTSPEC(set_xsversion_nei, set_xspec_string<FunctionUtility::neiVersion>),
+
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
   FCTSPEC(set_xspath_manager, set_xspec_string<FunctionUtility::managerPath>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -599,6 +599,22 @@ static PyMethodDef XSpecMethods[] = {
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
 
+  // The set commands are not wrapped yet as it's not clear how well
+  // the system handles these changes (e.g. it doesn't seem to update
+  // the stored abundances if you change one or both of the abundance
+  // settings). The cross-section file should also be accessible in a
+  // similar manner, but the XSPEC API does not provide access to this
+  // (at least for XSPEC 12.12.1).
+  //
+  // Also, abundPath is essentially managerPath, but we provide access
+  // to it as it could be changed (but not by any routine we currently
+  // provide access to).
+  //
+  NOARGSPEC(get_abundance_file, get_xspec_string<FunctionUtility::abundanceFile>),
+  NOARGSPEC(get_xspath_abundance, get_xspec_string<FunctionUtility::abundPath>),
+  // FCTSPEC(set_abundance_file, set_xspec_string<FunctionUtility::abundanceFile>),
+  // FCTSPEC(set_xspath_abundance, set_xspec_string<FunctionUtility::abundPath>),
+
   // XFLT commands
   NOARGSPEC(clear_xflt, clearXFLT),
   FCTSPEC(get_xflt, getAllXFLT),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -527,16 +527,14 @@ static PyObject* get_xspec_string( PyObject *self ) {
   return Py_BuildValue( (char*)"s", get().c_str() );
 }
 
-static PyObject* set_manager_data_path( PyObject *self, PyObject *args )
-{
-
+template <void set(const std::string& value)>
+static PyObject* set_xspec_string( PyObject *self, PyObject *args ) {
   char* path = NULL;
   if ( !PyArg_ParseTuple( args, (char*)"s", &path ) )
     return NULL;
 
-  FunctionUtility::managerPath(string(path));
+  set(string(path));
   Py_RETURN_NONE;
-
 }
 
 #define NOARGSPEC(name, func) \
@@ -573,7 +571,8 @@ static PyMethodDef XSpecMethods[] = {
 
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
-  FCTSPEC(set_xspath_manager, set_manager_data_path),
+  FCTSPEC(set_xspath_manager, set_xspec_string<FunctionUtility::managerPath>),
+  FCTSPEC(set_xspath_model, set_xspec_string<FunctionUtility::modelDataPath>),
 
   // Start model definitions
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -383,6 +383,96 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 
 }
 
+
+// XFLT functions
+//
+//      static int getNumberXFLT(int ifl);
+//      // This will throw a silent YellowAlert if map corresponding to ifl doesn't exist.
+//      static const std::map<string, Real>& getAllXFLT(int ifl);
+//      static bool inXFLT(int ifl, int i);
+//      static bool inXFLT(int ifl, string skey);
+//      static double getXFLT(int ifl, int i);
+//      static double getXFLT(int ifl, string skey);
+//      static void loadXFLT(int ifl, const std::map<string, Real>& values);
+//      static void clearXFLT();
+//
+// We use a dictionary interface - that is we set and get dictionaries
+// rather than have commands work on individual keys. That is,
+// checks like inXFLT have to be done by the user on the data returned
+// by these routines.
+//
+static PyObject* clearXFLT( PyObject *self )
+{
+  FunctionUtility::clearXFLT();
+  Py_RETURN_NONE;
+}
+
+static PyObject* getAllXFLT( PyObject *self, PyObject *args )
+{
+  int spectrumNumber = 1;
+
+  if ( !PyArg_ParseTuple( args, (char*)"i", &spectrumNumber ) )
+    return NULL;
+
+  PyObject *d = PyDict_New();
+
+  // Check that we have data, to avoid a YellowAlert when calling
+  // getAllXFLT.
+  //
+  if (FunctionUtility::getNumberXFLT(spectrumNumber) > 0) {
+    const std::map<string, Real> xflt = FunctionUtility::getAllXFLT(spectrumNumber);
+
+    for (const auto& item : xflt) {
+      PyObject *value = PyFloat_FromDouble(item.second);
+      PyDict_SetItemString(d, item.first.c_str(), value);
+      Py_DECREF(value);
+    }
+  }
+
+  return d;
+}
+
+static PyObject* loadXFLT( PyObject *self, PyObject *args )
+{
+  PyObject *xflt_dict = NULL;
+  int spectrumNumber = 1;
+
+  if ( !PyArg_ParseTuple( args, (char*)"iO!",
+			  &spectrumNumber,
+			  &PyDict_Type, &xflt_dict
+			  ) )
+    return NULL;
+
+  std::map<string, Real> xflt;
+
+  PyObject *key, *value;
+  Py_ssize_t pos = 0;
+
+  while (PyDict_Next(xflt_dict, &pos, &key, &value)) {
+
+    const char *k = PyUnicode_AsUTF8(key);
+    if (k == NULL) {
+	PyErr_SetString( PyExc_ValueError,
+			 (char*)"keys must be strings" );
+	return NULL;
+    }
+
+    double v = PyFloat_AsDouble(value);
+    if (v == -1 && PyErr_Occurred()) {
+	PyErr_SetString( PyExc_ValueError,
+			 (char*)"values must be numbers" );
+	return NULL;
+    }
+
+    xflt[k] = v;
+  }
+
+  // We do not check if xflt is empty.
+  FunctionUtility::loadXFLT(spectrumNumber, xflt);
+  Py_RETURN_NONE;
+}
+
+
 template <const std::string& get()>
 static PyObject* get_xspec_string( PyObject *self ) {
   return Py_BuildValue( (char*)"s", get().c_str() );
@@ -421,6 +511,12 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(clear_xsxset, clear_xset),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
+
+  // XFLT commands
+  NOARGSPEC(clear_xflt, clearXFLT),
+  FCTSPEC(get_xflt, getAllXFLT),
+  FCTSPEC(set_xflt, loadXFLT),
+
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
   FCTSPEC(set_xspath_manager, set_manager_data_path),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -384,6 +384,25 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 }
 
 
+static PyObject *emptyDict() { return PyDict_New(); }
+
+// This is not a generic routine (i.e. it's only for the Python type
+// dict[str, float]). Note that Real is a typedef for double, which is
+// why it can be used for both getAllXFLT and getAllDbValues.
+//
+static PyObject *mapToDict(const std::map<string, double> &map) {
+  PyObject *d = PyDict_New();
+
+  for (const auto& item : map) {
+    PyObject *value = PyFloat_FromDouble(item.second);
+    PyDict_SetItemString(d, item.first.c_str(), value);
+    Py_DECREF(value);
+  }
+
+  return d;
+}
+
+
 // XFLT functions
 //
 //      static int getNumberXFLT(int ifl);
@@ -414,22 +433,15 @@ static PyObject* getAllXFLT( PyObject *self, PyObject *args )
   if ( !PyArg_ParseTuple( args, (char*)"i", &spectrumNumber ) )
     return NULL;
 
-  PyObject *d = PyDict_New();
-
   // Check that we have data, to avoid a YellowAlert when calling
   // getAllXFLT.
   //
   if (FunctionUtility::getNumberXFLT(spectrumNumber) > 0) {
     const std::map<string, Real> xflt = FunctionUtility::getAllXFLT(spectrumNumber);
-
-    for (const auto& item : xflt) {
-      PyObject *value = PyFloat_FromDouble(item.second);
-      PyDict_SetItemString(d, item.first.c_str(), value);
-      Py_DECREF(value);
-    }
+    return mapToDict(xflt);
+  } else {
+    return emptyDict();
   }
-
-  return d;
 }
 
 static PyObject* loadXFLT( PyObject *self, PyObject *args )
@@ -469,6 +481,43 @@ static PyObject* loadXFLT( PyObject *self, PyObject *args )
 
   // We do not check if xflt is empty.
   FunctionUtility::loadXFLT(spectrumNumber, xflt);
+  Py_RETURN_NONE;
+}
+
+
+// This is easy to provide access to, but is it worth it?
+//
+//   static double getDbValue(const string keyword);
+//   static void loadDbValue(const string keyword, const double value);
+//   static void clearDb();
+//   static string getDbKeywords();
+//   static const std::map<string,double>& getAllDbValues();
+//
+// Follow the XFLT approach and just provide an access via
+// dictionaries, although in  this case we do support a way
+// to set a single value.
+//
+static PyObject* clearDb( PyObject *self )
+{
+  FunctionUtility::clearDb();
+  Py_RETURN_NONE;
+}
+
+static PyObject* getAllDb( PyObject *self )
+{
+  const std::map<string, double> db = FunctionUtility::getAllDbValues();
+  return mapToDict(db);
+}
+
+static PyObject* loadDbValue( PyObject *self, PyObject *args )
+{
+  char* key = NULL;
+  double value = 0;
+
+  if ( !PyArg_ParseTuple( args, (char*)"sd", &key, &value ) )
+    return NULL;
+
+  FunctionUtility::loadDbValue(string(key), value);
   Py_RETURN_NONE;
 }
 
@@ -516,6 +565,11 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(clear_xflt, clearXFLT),
   FCTSPEC(get_xflt, getAllXFLT),
   FCTSPEC(set_xflt, loadXFLT),
+
+  // DB commands
+  NOARGSPEC(clear_db, clearDb),
+  NOARGSPEC(get_db, getAllDb),
+  FCTSPEC(set_db, loadDbValue),
 
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -219,8 +219,8 @@ static PyObject* get_abund_doc( PyObject *self, PyObject *args )
     return NULL;
 
   std::string doc = FunctionUtility::abundDoc(std::string(name));
-
   return Py_BuildValue( (char*)"s", doc.c_str() );
+
 }
 
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -392,9 +392,10 @@ def test_checks_input_length():
 @requires_xspec
 @requires_data
 @requires_fits
-@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
-def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_path):
+@pytest.mark.parametrize('loadname', ["xstable", "table"])
+def test_xstablemodel_checks_input_length(loadname, clean_astro_ui, make_data_path):
 
+    loadfunc = getattr(ui, f"load_{loadname}_model")
     loadfunc('mdl', make_data_path('xspec-tablemodel-RCS.mod'))
     mdl = ui.get_model_component('mdl')
 
@@ -423,8 +424,11 @@ def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_pa
 @requires_xspec
 @requires_data
 @requires_fits
-@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
-def test_xspec_xstablemodel(loadfunc, clean_astro_ui, make_data_path):
+@pytest.mark.parametrize('loadname', ["xstable", "table"])
+def test_xspec_xstablemodel(loadname, clean_astro_ui, make_data_path):
+
+    loadfunc = getattr(ui, f"load_{loadname}_model")
+
     # Just test one table model; use the same scheme as
     # test_xspec_models_noncontiguous().
     #
@@ -452,8 +456,10 @@ def test_xspec_xstablemodel(loadfunc, clean_astro_ui, make_data_path):
 @requires_xspec
 @requires_data
 @requires_fits
-@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
-def test_xspec_xstablemodel_noncontiguous2(loadfunc, clean_astro_ui, make_data_path):
+@pytest.mark.parametrize('loadname', ["xstable", "table"])
+def test_xspec_xstablemodel_noncontiguous2(loadname, clean_astro_ui, make_data_path):
+
+    loadfunc = getattr(ui, f"load_{loadname}_model")
     loadfunc('tmod', make_data_path('xspec-tablemodel-RCS.mod'))
     tmod = ui.get_model_component('tmod')
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -249,6 +249,16 @@ def test_abund_default():
 
 
 @requires_xspec
+def test_get_xsabundancies_file():
+    """Minimal test of get_xsabundancies"""
+    from sherpa.astro import xspec
+
+    # We assume the file must exist if we have got this far
+    path = xspec.get_xsabundances_file()
+    assert path.is_file()
+
+
+@requires_xspec
 def test_xset_default():
     """Check the expected default setting for the xset setting.
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -504,7 +504,23 @@ def test_abund_set_dict():
     """Can we set a dict of abundances?
 
     We only set a sub-set of elements, with the rest being set to 0.
+    """
 
+    h = xspec.get_xsabund('H', 'wilm')
+    he = xspec.get_xsabund('He', 'wilm')
+    si = xspec.get_xsabund('Si', 'wilm')
+    ar = xspec.get_xsabund('Ar', 'wilm')
+    k = xspec.get_xsabund('K', 'wilm')
+    fe = xspec.get_xsabund('Fe', 'wilm')
+
+    check_abundances(h, he, si, ar, k, fe)
+
+
+# TODO: is this the correct test or did rebasing mess things up?
+#
+@requires_xspec
+def test_abund_element_named_z_todo_check_name():
+    """Can we access the elemental settings with atomic numbers?
     """
 
     from sherpa.astro import xspec
@@ -596,6 +612,95 @@ def test_abund_set_dict_invalid_value():
     # table should not have changed
     nvals = xspec.get_xsabundances()
     assert nvals == ovals
+
+
+@requires_xspec
+def test_abund_element_named():
+    """Can we access the elemental settings?
+
+    """
+
+    from sherpa.astro import xspec
+
+    h = xspec.get_xsabund('H', 'wilm')
+    he = xspec.get_xsabund('He', 'wilm')
+    si = xspec.get_xsabund('Si', 'wilm')
+    ar = xspec.get_xsabund('Ar', 'wilm')
+    k = xspec.get_xsabund('K', 'wilm')
+    fe = xspec.get_xsabund('Fe', 'wilm')
+
+    check_abundances(h, he, si, ar, k, fe)
+
+
+@requires_xspec
+def test_abund_element_named_z():
+    """Can we access the elemental settings?
+
+    """
+
+    from sherpa.astro import xspec
+
+    h = xspec.get_xsabund(1, 'wilm')
+    he = xspec.get_xsabund(2, 'wilm')
+    si = xspec.get_xsabund(14, 'wilm')
+    ar = xspec.get_xsabund(18, 'wilm')
+    k = xspec.get_xsabund(19, 'wilm')
+    fe = xspec.get_xsabund(26, 'wilm')
+
+    check_abundances(h, he, si, ar, k, fe)
+
+
+@pytest.mark.parametrize("table", [None, "angr"])
+@requires_xspec
+def test_abund_element_wrong(table):
+    """Check we error out with the wrong element name
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match="^could not find element 'H2'$"):
+        xspec.get_xsabund('H2', table)
+
+
+@pytest.mark.parametrize("table", [None, "angr"])
+@pytest.mark.parametrize("z", [0, 200])
+@requires_xspec
+def test_abund_element_wrong_z(table, z):
+    """Check we error out with the wrong element Z
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^Unsupported atomic number: {z}$"):
+        xspec.get_xsabund(z, table)
+
+
+@pytest.mark.parametrize("table", [None, "angr"])
+@requires_xspec
+def test_abund_element_wrong_type(table):
+    """Check we error out with the wrong type for the element
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(TypeError,
+                       match="^element must be None, a string, or an integer$"):
+        xspec.get_xsabund(23.4, table)
+
+
+@pytest.mark.parametrize("arg", ["He", 2])
+@requires_xspec
+def test_abund_element_named_wrong(arg):
+    """Check we error out with the wrong table name
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match="^Unknown abundance table 'foobar'$"):
+        xspec.get_xsabund(arg, 'foobar')
 
 
 @requires_xspec
@@ -712,6 +817,23 @@ def test_abund_get_dict():
 
     finally:
         xspec.set_xsabund(oval)
+
+    check_abundances(abunds['H'],
+                     abunds['He'],
+                     abunds['Si'],
+                     abunds['Ar'],
+                     abunds['K'],
+                     abunds['Fe'])
+
+
+@requires_xspec
+def test_abund_get_dict_named():
+    """Can we access the elemental settings - a named table"""
+
+    from sherpa.astro import xspec
+
+    assert xspec.get_xsabund() != 'wilm'
+    abunds = xspec.get_xsabundances('wilm')
 
     check_abundances(abunds['H'],
                      abunds['He'],

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1404,7 +1404,8 @@ def test_set_xsstate_abundances():
 @requires_data
 @requires_fits
 @requires_xspec
-def test_read_xstable_model(make_data_path):
+@pytest.mark.parametrize("usepath", [True, False])
+def test_read_xstable_model(usepath, make_data_path):
     """Limited test (only one file).
 
     Evaluation tests using this model are in
@@ -1414,7 +1415,8 @@ def test_read_xstable_model(make_data_path):
     from sherpa.astro import xspec
 
     path = make_data_path('xspec-tablemodel-RCS.mod')
-    tbl = xspec.read_xstable_model('bar', path)
+    filename = Path(path) if usepath else path
+    tbl = xspec.read_xstable_model('bar', filename)
 
     assert tbl.name == 'bar'
     assert isinstance(tbl, xspec.XSTableModel)

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -74,7 +74,6 @@ DEFAULT_COSMO = (70.0, 0.0, 0.73)
 # will not be used by an actual model so we can set it.
 #
 DEFAULT_XSET_NAME = 'SHERPA-TEST-DUMMY-NAME'
-DEFAULT_XSET_VALUE = ''
 
 # The number of elements in the abundance table
 ELEMENT_NAMES = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
@@ -195,12 +194,11 @@ def test_xset_default():
     from sherpa.astro import xspec
 
     # The test is case insensitive, but this test doesn't really
-    # test this out (since it is expected to return '' whatever
-    # the input name is).
+    # test this out.
     #
     name = DEFAULT_XSET_NAME.lower()
-    oval = xspec.get_xsxset(name)
-    assert oval == DEFAULT_XSET_VALUE
+    with pytest.raises(KeyError):
+        xspec.get_xsxset(name)
 
 
 @requires_xspec
@@ -705,25 +703,18 @@ def test_xset_change():
 
     from sherpa.astro import xspec
 
-    def getfunc():
-        return xspec.get_xsxset(DEFAULT_XSET_NAME)
+    with pytest.raises(KeyError):
+        xspec.get_xsxset(DEFAULT_XSET_NAME)
 
-    def setfunc(val):
-        xspec.set_xsxset(DEFAULT_XSET_NAME.lower(), val)
+    try:
+        xspec.set_xsxset(DEFAULT_XSET_NAME.lower(), 'dummy value')
+        got = xspec.get_xsxset(DEFAULT_XSET_NAME)
+    finally:
+        # clear out the keyword
+        xspec.set_xsxset(DEFAULT_XSET_NAME, '')
 
-    val1 = 'dummy value'
-    val2 = 'a different setting'
-    validate_xspec_setting(getfunc, setfunc, val1, val2)
-
-    # A separate part of the XSET interface is that the settings
-    # are recorded in the XSPEC state maintained by the xspec
-    # module, so check that the stored value is included in this.
-    #
-    modelvals = xspec.get_xsstate()['modelstrings']
-    assert DEFAULT_XSET_NAME in modelvals
-
-    # Is it worth changing the code so we know which to check for?
-    assert modelvals[DEFAULT_XSET_NAME] in [val1, val2]
+    with pytest.raises(KeyError):
+        xspec.get_xsxset(DEFAULT_XSET_NAME)
 
 
 @requires_xspec
@@ -902,35 +893,26 @@ def test_set_xsstate_xset():
 
     ukey = key.upper()
 
-    # There should be no value for this key (since it isn't in
-    # modelstrings by construction). Note that this access, that is
-    # via xspec.xsstate, is not guaranteed (i.e. it is an
-    # implementation detail).
+    # There should be no value for this key.
     #
-    assert key not in xspec.xsstate["modelstrings"]
-    assert xspec.get_xsxset(key) == ''
+    assert key not in xspec.get_xsxset()
+    with pytest.raises(KeyError):
+        xspec.get_xsxset(key)
 
     nstate = copy.deepcopy(ostate)
     nstate['modelstrings'][key] = val
     xspec.set_xsstate(nstate)
 
     assert xspec.get_xsxset(key) == val
-    assert ukey in xspec.xsstate["modelstrings"]
-    assert xspec.xsstate["modelstrings"][ukey] == val
+    modelstrings = xspec.get_xsxset()
+    assert ukey in modelstrings
+    assert modelstrings[ukey] == val
 
     xspec.set_xsstate(ostate)
 
-    # Unfortunately, due to there being no attempt at clearing out the
-    # XSET settings (e.g. removing existing settings before restoring
-    # the state), the following tests fail.
-    #
-    # TODO: the code should probably be updated to fix this
-    #
-    # assert xspec.get_xsxset(key) == ''
-    # assert xspec.get_xsstate() == ostate
+    with pytest.raises(KeyError):
+        assert xspec.get_xsxset(key)
 
-    xspec.set_xsxset(key, '')
-    del xspec.xsstate["modelstrings"][ukey]
     assert xspec.get_xsstate() == ostate
 
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -77,6 +77,8 @@ DEFAULT_COSMO = (70.0, 0.0, 0.73)
 DEFAULT_XSET_NAME = 'SHERPA-TEST-DUMMY-NAME'
 
 # The number of elements in the abundance table
+# (this is assumed to be unlikely to change).
+#
 ELEMENT_NAMES = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
                  'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K',
                  'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni',
@@ -174,16 +176,26 @@ def test_set_version_error(name):
 
 
 @requires_xspec
-def test_expected_elements():
-    """If this fails then something is wrong!"""
+def test_expected_number_of_elements():
+    """Check we know how many elements are needed by XSPEC.
+
+    If this changes then we need to re-do some of the test
+    code but in and of itself it is not a terrible change. It
+    is an unlikely change though!
+    """
 
     from sherpa.astro import xspec
 
-    # At the moment this just checks I can repeat the information in
-    # two places, but the aim is to change the interface to access
-    # this information from XSPEC itself, at which point it becomes a
-    # regression test.
-    #
+    assert xspec.get_xsnelem() == NELEM
+
+
+@requires_xspec
+def test_expected_elements():
+    """If this fails then something is wrong!
+    """
+
+    from sherpa.astro import xspec
+
     xselems = xspec.get_xselements()
     for idx, elem in enumerate(ELEMENT_NAMES, 1):
         assert xselems[elem] == idx

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -811,7 +811,7 @@ def test_get_xsstate_keys():
     ostate = xspec.get_xsstate()
     assert isinstance(ostate, dict)
 
-    for key in ["abund", "chatter", "cosmo", "xsect", "xflt",
+    for key in ["abund", "chatter", "cosmo", "xsect", "xflt", "db",
                 "modelstrings", "paths"]:
         assert key in ostate
 
@@ -2407,3 +2407,53 @@ def test_xflt_can_set_xsxstate():
 
     # And this is an unknown record
     assert xspec.get_xsxflt(3) == {}
+
+
+@requires_xspec
+def test_db_can_clear_all():
+    """Check clear_db() does something."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsdb("a", 23);
+    xspec.set_xsdb("b", 4.9);
+    xspec.clear_xsdb()
+
+    assert len(xspec.get_xsdb()) == 0
+
+
+@requires_xspec
+def test_db_can_set():
+    """We can set a single value."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsdb("aA", -1.2e4);
+    ans = xspec.get_xsdb()
+    assert ans["aa"] == pytest.approx(-1.2e4);
+
+    xspec.clear_xsdb()
+
+
+@requires_xspec
+def test_db_can_get():
+    """We can get the values we set.
+
+    It appears that the keys are converted to lower case.
+
+    """
+
+    from sherpa.astro import xspec
+
+    xspec.clear_xsdb()
+    xspec.set_xsdb("aA", 23)
+    xspec.set_xsdb("b", 4.9)
+    xspec.set_xsdb("CC", -1.2e-2)
+
+    out = xspec.get_xsdb()
+    assert len(out) == 3
+    assert out["aa"] == pytest.approx(23)
+    assert out["b"] == pytest.approx(4.9)
+    assert out["cc"] == pytest.approx(-1.2e-2)
+
+    xspec.clear_xsdb()

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -100,7 +100,8 @@ def test_chatter_default():
 
 
 @requires_xspec
-def test_version():
+@pytest.mark.parametrize("name", [None, "atomdb", "nei"])
+def test_version(name):
     """Can we get at the XSPEC version?
 
     There is limited testing of the return value.
@@ -108,12 +109,68 @@ def test_version():
 
     from sherpa.astro import xspec
 
-    v = xspec.get_xsversion()
+    v = xspec.get_xsversion(name)
     assert isinstance(v, (str, ))
     assert len(v) > 0
 
-    # Could check it's of the form a.b.c[optional] but leave that for
-    # now.
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["ATOMDB", "", "foo"])
+def test_version_error(name):
+    """Does this error out?
+
+    At the moment we are case sensitive when checking the name.
+
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^name must be one of None, 'atomdb', or 'nei', not '{name}'$"):
+        xspec.get_xsversion(name)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["atomdb", "nei"])
+def test_set_version(name):
+    """Can we set the XSPEC version?
+
+    This is just to check we can call the routine - we don't really do
+    much with it.
+
+    """
+
+    from sherpa.astro import xspec
+
+    old = xspec.get_xsversion(name)
+
+    # pick a value that is "realistic" but old, and should not
+    # appear with any supported XSPEC version.
+    #
+    new = '3.0.0'
+    assert old != new
+
+    try:
+        xspec.set_xsversion(name, new)
+        assert xspec.get_xsversion(name) == new
+    finally:
+        xspec.set_xsversion(name, old)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["ATOMDB", "", "foo"])
+def test_set_version_error(name):
+    """Does this error out?
+
+    At the moment we are case sensitive when checking the name.
+
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^name must be 'atomdb' or 'nei', not '{name}'$"):
+        xspec.set_xsversion(name, "1.2.3")
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -406,14 +406,35 @@ def test_abund_element():
 
 
 @requires_xspec
+def test_abund_element_z():
+    """Can we access the elemental settings with atomic number?
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xsabund()
+    try:
+        xspec.set_xsabund('wilm')
+        h = xspec.get_xsabund(1)
+        he = xspec.get_xsabund(2)
+        si = xspec.get_xsabund(14)
+        ar = xspec.get_xsabund(18)
+        k = xspec.get_xsabund(19)
+        fe = xspec.get_xsabund(26)
+
+    finally:
+        xspec.set_xsabund(oval)
+
+    check_abundances(h, he, si, ar, k, fe)
+
+
+@requires_xspec
 def test_abund_get_invalid_element(caplog):
     """Check what happens if sent the wrong element name"""
 
     from sherpa.astro import xspec
 
-    # TODO: TypeError is not the best error type here.
-    with pytest.raises(TypeError,
-                       match="^could not find element 'O3'$"):
+    with pytest.raises(ValueError, match="^could not find element 'O3'$"):
         xspec.get_xsabund("O3")
 
     assert len(caplog.records) == 0

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -24,6 +24,7 @@
 import copy
 import logging
 import os
+from pathlib import Path
 import re
 
 import pytest
@@ -526,7 +527,13 @@ def validate_xspec_setting(getfunc, setfunc, newval, altval):
     finally:
         setfunc(oval)
 
-    assert xval == nval
+    # If nval is a Path we need to convert it to a str since we
+    # (currently) do not return a Path but a str.
+    #
+    if isinstance(nval, Path):
+        assert xval == str(nval)
+    else:
+        assert xval == nval
 
     # As a sanity check ensure we are back at the starting point
     assert getfunc() == oval
@@ -764,16 +771,30 @@ def test_cosmo_change():
 
 
 @requires_xspec
-def test_path_manager_change(tmp_path):
-    """Can we change the manager-path setting?
+@pytest.mark.parametrize("name", ["manager", "model"])
+@pytest.mark.parametrize("usepath", [True, False])
+def test_path_change(name, usepath, tmp_path):
+    """Can we change the path setting?
+
+    We allow string or Path objects to be sent in, which is what the
+    usepath boolean checks. It would be nice to send in the actual
+    arguments, but that would be very complicated to set up, as it
+    involves the tmp_path setting).
+
     """
 
     from sherpa.astro import xspec
 
-    validate_xspec_setting(xspec.get_xspath_manager,
-                           xspec.set_xspath_manager,
-                           '/dev/null',
-                           str(tmp_path))
+    if usepath:
+        newval = Path('/dev/null')
+        altval = tmp_path
+    else:
+        newval = '/dev/null'
+        altval = str(tmp_path)
+
+    getfn = getattr(xspec, f"get_xspath_{name}")
+    setfn = getattr(xspec, f"set_xspath_{name}")
+    validate_xspec_setting(getfn, setfn, newval, altval)
 
 
 # Note that the XSPEC state is used in test_xspec.py, but only


### PR DESCRIPTION
Some of these changes have been moved to (in a form that isn't necessarily quite as useful as in this PR, but they don't need C++ changes so are easier to review):

- #2107
- #2109

and this commit has not been updated to reflect that yet. I have pulled out other changes to

- #2215
- #2216 

# Summary

Add support for new functionality in XSPEC provided by XSPEC 12.12.0, such as setting abundance values via atomic number or as an array, and access to the atomdb and nei version settings, XFLT keywords, and the Db database.

# Details

This is built on #1793 which switches from the xsFortran API to the FunctionUtility one. This means that we can just concentrate on new functionality here.

Start taking advantage of the features provided by XSPEC 12.12.0

- use FunctionUtility rather than the xsFortran interface (see #1225)
  - `set_xsabund` can now be sent an array of abundances, not just the name of a table or a filename
  - `get_xsabund` can now be sent the atomic number, as well as the name, and the (optional) table to search
  - `get_xsabundances` has been added, which returns all the abundances for a table as a dictionary, and `set_xsabundances` which takes a dictionary
  - `get_xsxset` now behaves like a dictionary when a keyword does not exist - it raises a `KeyError` rather than returns the empty string
  - add access to the XFLT keyword database with `clear_xsxflt`, `set_xsxflt`, and `get_xsxflt`
    - this is needed for some models, such as `smaug` and the new polarimetry models, although more work is needed to support those models (in particular the `spectrumNumber` value, as discussed in #544)
  - add access to the XSPEC "Db" database (mapping from string to double values), although it's not at all clear how users are meant to use this (or if they are), with `clear_xsdb`, `set_xsdb`, and `get_xsdb`
  - setting the model database path
  - get/set the atomdb/nei versions with `get_xsversion` and `set_xsversion` (the latter is new)
  - the XSPEC state now stores/restores more settings
  - I have added a low-level `get_xsabund_doc` call to get the "nice" name of the abundance table (e.g. `Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)` for the `angr` table)

This is all pretty "low level" stuff, so very-few users are expected to take advantage.

One change I have added is to support the use of `Path` when specifying file / directory names - rather than just using a string. The idea is that you can use either. We can also think about returning `Path` objects: in this PR a new low-level routine does this, but existing routines (which currently return `str` but could easily be changed) have not been updated.

I have added a `show_xsabund` call to the astro UI layer since I noted that XSPEC lists the actual abundances with its `show abund` call, so we now have (taking advantage of these lower-level routines):

```
>>> show_xsabund()
Solar Abundance Table:
angr:  Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)
  H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
  C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
  Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
  S : 1.620e-05  Cl: 3.160e-07  Ar: 3.630e-06  K : 1.320e-07  Ca: 2.290e-06
  Sc: 1.260e-09  Ti: 9.770e-08  V : 1.000e-08  Cr: 4.680e-07  Mn: 2.450e-07
  Fe: 4.680e-05  Co: 8.320e-08  Ni: 1.780e-06  Cu: 1.620e-08  Zn: 3.980e-08
``` 

# Issues

What are the best names / API here? I've tried to fit into the existing settings (e.g `get_xsXXX` and `set_xsXXX`) where appropriate, but have tried to make use of optional arguments and using dictionaries rather than map closely to either the `xsFortran` interface or the newer `FunctionUtilities` interface (note that there are differences between the two, e.g. the old interface, and our code, has "xset" whereas the C++ code talks about the model string database).

Unfortunately, just providing access to the XFLT database is not sufficient, we need to work out how to pass around the `spectrumNumber`/`ifl` argument to models and to map between data objects and these identifiers (see 

- #544
 
). The logic for this (or at least the initial support for this) has been pushed to 

- #1617
 
(and doesn't currently require this PR in an attempt to avoid ridiculously-long chains of PRs as they are already hard enough to handle as is).