### PR TITLE
Pass keyword arguments to models

### DIFF
--- a/docs/model_classes/model.rst
+++ b/docs/model_classes/model.rst
@@ -20,6 +20,7 @@ The sherpa.models.model module
       FilterModel
       MultigridSumModel
       NestedModel
+      RegriddableModel
       RegriddableModel1D
       RegriddableModel2D
       SimulFitModel
@@ -35,5 +36,5 @@ The sherpa.models.model module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: Model ArithmeticConstantModel ArithmeticFunctionModel ArithmeticModel CompositeModel BinaryOpModel FilterModel MultigridSumModel NestedModel RegriddableModel1D RegriddableModel2D SimulFitModel UnaryOpModel
+.. inheritance-diagram:: Model ArithmeticConstantModel ArithmeticFunctionModel ArithmeticModel CompositeModel BinaryOpModel FilterModel MultigridSumModel NestedModel RegriddableModel RegriddableModel1D RegriddableModel2D SimulFitModel UnaryOpModel
    :parts: 1

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 #
-#  Copyright (C) 2007, 2016, 2018, 2019, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2019, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,6 +21,7 @@
 
 import numpy
 
+from sherpa.models.basic import clean_kwargs1d, clean_kwargs2d
 from sherpa.models.parameter import Parameter, tinyval
 from sherpa.models.model import ArithmeticModel, RegriddableModel2D, RegriddableModel1D, modelCacher1d
 from sherpa.astro.utils import apply_pileup
@@ -93,6 +95,7 @@ class Atten(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
+        kwargs = clean_kwargs1d(self, kwargs)
         # atten should act like xsphabs, never integrate.
         kwargs['integrate'] = False
         return _modelfcts.atten(*args, **kwargs)
@@ -174,7 +177,7 @@ class BBody(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.bbody(*args, **kwargs)
 
 
@@ -231,7 +234,7 @@ class BBodyFreq(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.bbodyfreq(*args, **kwargs)
 
 
@@ -301,7 +304,7 @@ class Beta1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.beta1d(*args, **kwargs)
 
 
@@ -361,7 +364,7 @@ class BPL1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.bpl1d(*args, **kwargs)
 
 
@@ -426,7 +429,7 @@ class Dered(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.dered(*args, **kwargs)
 
 
@@ -477,7 +480,7 @@ class Edge(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.edge(*args, **kwargs)
 
 
@@ -542,7 +545,7 @@ class LineBroad(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.linebroad(*args, **kwargs)
 
 
@@ -610,7 +613,7 @@ class Lorentz1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.lorentz1d(*args, **kwargs)
 
 
@@ -726,7 +729,7 @@ class Voigt1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.wofz(*args, **kwargs)
 
 
@@ -813,7 +816,7 @@ class PseudoVoigt1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
 
         pars = args[0]
         xargs = args[1:]
@@ -892,7 +895,7 @@ class NormBeta1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.nbeta1d(*args, **kwargs)
 
 
@@ -939,6 +942,7 @@ class Schechter(RegriddableModel1D):
     def calc(self, *args, **kwargs):
         if not self.integrate:
             raise ModelErr('alwaysint', self.name)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.schechter(*args, **kwargs)
 
 
@@ -1030,7 +1034,7 @@ class Beta2D(RegriddableModel2D):
         param_apply_limits(rad, self.r0, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.beta2d(*args, **kwargs)
 
 
@@ -1112,7 +1116,7 @@ class DeVaucouleurs2D(RegriddableModel2D):
         param_apply_limits(rad, self.r0, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.devau(*args, **kwargs)
 
 
@@ -1198,7 +1202,7 @@ class HubbleReynolds(RegriddableModel2D):
         param_apply_limits(rad, self.r0, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.hr(*args, **kwargs)
 
 
@@ -1272,7 +1276,7 @@ class Lorentz2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.lorentz2d(*args, **kwargs)
 
 
@@ -1489,7 +1493,7 @@ class Sersic2D(RegriddableModel2D):
         param_apply_limits(rad, self.r0, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.sersic(*args, **kwargs)
 
 

--- a/sherpa/astro/models/tests/test_astro_model.py
+++ b/sherpa/astro/models/tests/test_astro_model.py
@@ -79,7 +79,6 @@ def test_create_and_evaluate(name, cls):
         assert out.shape == x.shape
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("cls", [models.Atten,
                                  models.BBody,
                                  models.BBodyFreq,
@@ -104,17 +103,16 @@ def test_send_keyword_1d(cls):
     # Not guaranteed to produce interesting results
     x = [10, 12, 13, 15]
     y1 = mdl(x)
-    # This fails
     y2 = mdl(x, not_an_argument=True)
     assert y2 == pytest.approx(y1)
 
 
-@pytest.mark.parametrize("cls", [pytest.param(models.Beta2D, marks=pytest.mark.xfail),
-                                 pytest.param(models.DeVaucouleurs2D, marks=pytest.mark.xfail),
+@pytest.mark.parametrize("cls", [models.Beta2D,
+                                 models.DeVaucouleurs2D,
                                  models.Disk2D,
-                                 pytest.param(models.HubbleReynolds, marks=pytest.mark.xfail),
-                                 pytest.param(models.Lorentz2D, marks=pytest.mark.xfail),
-                                 pytest.param(models.Sersic2D, marks=pytest.mark.xfail),
+                                 models.HubbleReynolds,
+                                 models.Lorentz2D,
+                                 models.Sersic2D,
                                  models.Shell2D])
 def test_send_keyword_2d(cls):
     """What happens if we use an un-supported keyword?"""
@@ -126,7 +124,6 @@ def test_send_keyword_2d(cls):
     x0 =  [10, 12, 13, 15]
     x1 =  [5, 7, 12, 13]
     y1 = mdl(x0, x1)
-    # This fails for most models
     y2 = mdl(x0, x1, not_an_argument=True)
     assert y2 == pytest.approx(y1)
 

--- a/sherpa/astro/models/tests/test_astro_model.py
+++ b/sherpa/astro/models/tests/test_astro_model.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -71,6 +72,58 @@ def test_create_and_evaluate():
             assert out.shape == (4, )
 
     assert count == 20
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("cls", [models.Atten,
+                                 models.BBody,
+                                 models.BBodyFreq,
+                                 models.BPL1D,
+                                 models.Beta1D,
+                                 models.Edge,
+                                 models.LineBroad,
+                                 models.Lorentz1D,
+                                 models.NormBeta1D,
+                                 models.PseudoVoigt1D,
+                                 models.Schechter,
+                                 models.Voigt1D])
+def test_send_keyword_1d(cls):
+    """What happens if we use an un-supported keyword?"""
+
+    mdl = cls()
+    mdl._use_caching = False
+
+    if cls == models.LineBroad:
+        mdl.vsini = 1e6
+
+    # Not guaranteed to produce interesting results
+    x = [10, 12, 13, 15]
+    y1 = mdl(x)
+    # This fails
+    y2 = mdl(x, not_an_argument=True)
+    assert y2 == pytest.approx(y1)
+
+
+@pytest.mark.parametrize("cls", [pytest.param(models.Beta2D, marks=pytest.mark.xfail),
+                                 pytest.param(models.DeVaucouleurs2D, marks=pytest.mark.xfail),
+                                 models.Disk2D,
+                                 pytest.param(models.HubbleReynolds, marks=pytest.mark.xfail),
+                                 pytest.param(models.Lorentz2D, marks=pytest.mark.xfail),
+                                 pytest.param(models.Sersic2D, marks=pytest.mark.xfail),
+                                 models.Shell2D])
+def test_send_keyword_2d(cls):
+    """What happens if we use an un-supported keyword?"""
+
+    mdl = cls()
+    mdl._use_caching = False
+
+    # Not guaranteed to produce interesting results
+    x0 =  [10, 12, 13, 15]
+    x1 =  [5, 7, 12, 13]
+    y1 = mdl(x0, x1)
+    # This fails for most models
+    y2 = mdl(x0, x1, not_an_argument=True)
+    assert y2 == pytest.approx(y1)
 
 
 @pytest.mark.parametrize("test_input, expected", [

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -344,7 +344,7 @@ def test_lowlevel_checks_too_many_arguments(model):
     with pytest.raises(TypeError) as exc:
         mdl._calc()
 
-    assert str(exc.value) == "function takes at least 2 arguments (0 given)"
+    assert str(exc.value) == "function missing required argument 'pars' (pos 1)"
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1608,7 +1608,7 @@ def test_xspec_model_kwarg_cached_not_needed():
     value, since it does not change the model output, but it is tricky
     to do, so we do make each call be different. This is a
     pessimisation (i.e. it potentially slows down model evaluation)
-    and could be changed in the future). It depends on how often the
+    and could be changed in the future. It depends on how often the
     spectrumNumber argument will be added to model calls.
 
     """

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1604,9 +1604,12 @@ def test_xspec_model_kwarg_cached_not_needed():
     At the moment Sherpa does not wrap any of the models (smaug,
     polcost, pollin, polpow, pileup) which have a 1 instead of a 0.
 
-    For this case we test the current behavior (which ignores the
-    spectrumNumber argument), as it is not clear what the best
-    behavior is.
+    Technically we could make the cache ignore the spectrumNumber
+    value, since it does not change the model output, but it is tricky
+    to do, so we do make each call be different. This is a
+    pessimisation (i.e. it potentially slows down model evaluation)
+    and could be changed in the future). It depends on how often the
+    spectrumNumber argument will be added to model calls.
 
     """
 
@@ -1627,13 +1630,13 @@ def test_xspec_model_kwarg_cached_not_needed():
     assert mdl._cache_ctr['misses'] == 1
 
     y2 = mdl(elo, ehi, spectrumNumber=2)
-    assert mdl._cache_ctr['hits'] == 1
-    assert mdl._cache_ctr['misses'] == 1
+    assert mdl._cache_ctr['hits'] == 0
+    assert mdl._cache_ctr['misses'] == 2
 
     assert y2 == pytest.approx(y1)
 
     y3 = mdl(elo, ehi, spectrumNumber=1)
-    assert mdl._cache_ctr['hits'] == 2
-    assert mdl._cache_ctr['misses'] == 1
+    assert mdl._cache_ctr['hits'] == 0
+    assert mdl._cache_ctr['misses'] == 3
 
     assert y3 == pytest.approx(y1)

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1534,7 +1534,6 @@ def test_model_can_send_spectrumnumber_combine():
     assert args[2][1] == "con"
 
 
-@pytest.mark.xfail
 @requires_xspec
 def test_model_can_send_spectrumnumber_combine_non_xspec():
     """Check the spectrumNumber is sent through with non-XSPEC models.
@@ -1585,7 +1584,6 @@ def test_model_can_send_spectrumnumber_combine_non_xspec():
 
     args.clear()
 
-    # This fails
     y21 = comb21(elo, ehi, spectrumNumber=4)
     assert len(args) == 1
     assert args[0][0] == 4

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1380,7 +1380,6 @@ def test_xsparameter_limits(base):
     assert p.hard_max == pytest.approx(8)
 
 
-@pytest.mark.xfail
 @requires_xspec
 @pytest.mark.parametrize("clsname", ["XSpowerlaw", "XSphabs"])
 def test_model_can_send_spectrumnumber_indiv(clsname):

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1378,3 +1378,218 @@ def test_xsparameter_limits(base):
 
     assert p.max == pytest.approx(8)
     assert p.hard_max == pytest.approx(8)
+
+
+@pytest.mark.xfail
+@requires_xspec
+@pytest.mark.parametrize("clsname", ["XSpowerlaw", "XSphabs"])
+def test_model_can_send_spectrumnumber_indiv(clsname):
+    """Check we can send spectrumNumber to individual models.
+
+    All we do is check that the model can be called, and just for
+    additive/multiplicative models that are not expected to use
+    the spectrumNumber argument.
+    """
+
+    from sherpa.astro import xspec
+
+    mdl = getattr(xspec, clsname)("tmp")
+    egrid = np.arange(0.3, 0.4, 0.01)
+    # This fails
+    mdl(egrid[:-1], egrid[1:], spectrumNumber=2)
+
+
+@requires_xspec
+def test_model_can_send_spectrumnumber_indiv_con():
+    """Check we can send spectrumNumber to individual models: convolution
+
+    All we do is check that the model can be called.
+    """
+
+    from sherpa.astro import xspec
+
+    base = xspec.XSpowerlaw("tmp")
+    con = xspec.XScflux("tmp2")
+    mdl = con(base)
+    egrid = np.arange(0.3, 0.4, 0.01)
+
+    # Does this send the argument to the wrapped model? There's no way
+    # to know when calling the actual XSPEC models.
+    #
+    mdl(egrid[:-1], egrid[1:], spectrumNumber=2)
+
+
+@requires_xspec
+def test_model_can_send_spectrumnumber_combine():
+    """Check the spectrumNumber is sent through.
+
+    Mock XSPEC model classes are used to check that we send through
+    the spectrumNumber when combining models. This uses the
+    "old-style" of declaring the model (explicit setting of _calc).
+
+    Due to the way we have to write these tests (with xspec not
+    imported at the top-level) this is not a unit test as we test
+    a number of features.
+    """
+
+    from sherpa.astro import xspec
+    from sherpa.models import Parameter
+
+    # We use the first parameter to identify what model is being
+    # called (relying on the test to change the index value of the
+    # model components).
+    #
+    args = []
+    def test(cls, pars, lo, hi, spectrumNumber=5):
+        args.append((spectrumNumber, pars[0]))
+        return pars[1] * np.ones_like(lo)
+
+    def testcon(cls, pars, fluxes, lo, hi, spectrumNumber=9):
+        args.append((spectrumNumber, "con"))
+        return fluxes + pars[1]
+
+    class TestSpectrumNumber(xspec.XSAdditiveModel):
+        _calc = test
+
+        def __init__(self, name="test"):
+            self.index = Parameter(name, "index", 1, 0, 2)
+            self.norm = Parameter(name, "norm", 1, 0, 1)
+            super().__init__(name, (self.index, self.norm))
+
+    class TestConvSpectrumNumber(xspec.XSConvolutionKernel):
+        _calc = testcon
+
+        def __init__(self, name="test"):
+            self.index = Parameter(name, "index", 1, 0, 2)
+            self.con = Parameter(name, "con", 1, 0, 100)
+            super().__init__(name, (self.index, self.con))
+
+    m1 = TestSpectrumNumber("x1")
+    m1.index = 1
+    m1.norm = 0.2
+    m2 = TestSpectrumNumber("2")
+    m2.index = 2
+    m2.norm = 0.4
+
+    comb = m1 + m2
+
+    # As we evaluate the models multiple times with the same
+    # arguments we need to ensure the models are not cached.
+    #
+    m1._use_caching = False
+    m2._use_caching = False
+    # comb._use_caching = False  no cache for composite models
+
+    egrid = np.arange(1, 4)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    assert len(args) == 0
+    y1 = m1(elo, ehi)
+    assert y1 == pytest.approx([0.2, 0.2])
+    assert len(args) == 1
+    print(args)
+    assert args[0][0] == 5
+    assert args[0][1] == pytest.approx(1)
+
+    args.clear()
+    y2 = m2(elo, ehi, spectrumNumber=1)
+    assert y2 == pytest.approx([0.4, 0.4])
+    assert len(args) == 1
+    assert args[0][0] == 1
+    assert args[0][1] == pytest.approx(2)
+
+    args.clear()
+    y = comb(elo, ehi, spectrumNumber=3)
+    assert y == pytest.approx([0.6, 0.6])
+
+    # The order of evaluation should be guaranteed (i.e we can test
+    # that [0][1] is 1).
+    #
+    assert len(args) == 2
+    assert args[0][0] == 3
+    assert args[0][1] == pytest.approx(1)
+    assert args[1][0] == 3
+    assert args[1][1] == pytest.approx(2)
+
+    # Try with a convolution model.
+    #
+    con = TestConvSpectrumNumber("x")
+    con.con = 10
+    cmdl = con(comb)
+
+    args.clear()
+    ycon = cmdl(elo, ehi, spectrumNumber=6)
+    assert ycon == pytest.approx([10.6, 10.6])
+
+    # NOTE: these are not the answers we want, but test them so we know
+    #       when they change.
+    #
+    assert len(args) == 3
+    assert args[0][0] == 5  # should be 6
+    assert args[0][1] == pytest.approx(1)
+    assert args[1][0] == 5  # should be 6
+    assert args[1][1] == pytest.approx(2)
+    assert args[2][0] == 9  # should be 6
+    assert args[2][1] == "con"
+
+
+@pytest.mark.xfail
+@requires_xspec
+def test_model_can_send_spectrumnumber_combine_non_xspec():
+    """Check the spectrumNumber is sent through with non-XSPEC models.
+
+    An extension of test_model_can_send_spectrumnumber_combine()
+    """
+
+    from sherpa.astro import xspec
+    from sherpa.models import Parameter
+    from sherpa.models.basic import Scale1D
+
+    args = []
+    def test(cls, pars, lo, hi, spectrumNumber=5):
+        args.append((spectrumNumber, pars[0]))
+        return pars[1] * np.ones_like(lo)
+
+    class TestSpectrumNumber2(xspec.XSAdditiveModel):
+        _calc = test
+
+        def __init__(self, name="test"):
+            self.index = Parameter(name, "index", 1, 0, 2)
+            self.norm = Parameter(name, "norm", 1, 0, 1)
+            super().__init__(name, (self.index, self.norm))
+
+    m1 = TestSpectrumNumber2("m1")
+    m1.norm = 0.5
+    m1.index = 2
+
+    m2 = Scale1D("m2")
+    m2.c0 = 1.5
+
+    m1._use_caching = False
+    m2._use_caching = False
+
+    # These should evaluate to the same thing.
+    #
+    comb12 = m1 + m2
+    comb21 = m2 + m1
+
+    elo = np.asarray([0.5, 1, 2])
+    ehi = np.asarray([1, 2, 4])
+
+    assert len(args) == 0
+    y12 = comb12(elo, ehi)
+    assert len(args) == 1
+    assert args[0][0] == 5
+    assert args[0][1] == pytest.approx(2)
+
+    args.clear()
+
+    # This fails
+    y21 = comb21(elo, ehi, spectrumNumber=4)
+    assert len(args) == 1
+    assert args[0][0] == 4
+    assert args[0][1] == pytest.approx(2)
+
+    assert y21 == pytest.approx(y12)
+    assert y12 == pytest.approx([2, 2, 2])

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -46,6 +46,59 @@ __all__ = ('Box1D', 'Const1D', 'Cos', 'Delta1D', 'Erf', 'Erfc', 'Exp', 'Exp10',
            'Integrate1D')
 
 DBL_EPSILON = numpy.finfo(float).eps
+
+# This relies on the PyArg_ParseTypleAndKeywords calls in model_extension.hh
+#
+ALLOWED_KEYWORDS_1D = set(["pars", "xlo", "xhi", "integrate"])
+ALLOWED_KEYWORDS_2D = set(["pars", "x0lo", "x1lo", "x0hi", "x1hi", "integrate"])
+
+
+def clean_kwargs(allowed, model, kwargs):
+    """Remove un-supported keywords for these models.
+
+    Parameters
+    ----------
+    model : Model instance
+        It must have an integrate field.
+    kwargs : dict
+        The input keyword arguments
+    allowed : set of str
+        The allowed keyword names.
+
+    Returns
+    -------
+    allowed : dict
+        The keyword arguments (names and values) that are allowed.
+
+    """
+
+    # TODO: remove the use of bool_cast here.
+    #
+    out = {"integrate": bool_cast(model.integrate)}
+    for key in [k for k in kwargs.keys() if k in allowed]:
+        out[key] = kwargs[key]
+
+    return out
+
+
+def clean_kwargs1d(model, kwargs):
+    """Remove un-supported keywords for these models.
+
+    The supported arguments are ALLOWED_KEYWORDS_1D.
+
+    """
+
+    return clean_kwargs(ALLOWED_KEYWORDS_1D, model, kwargs)
+
+
+def clean_kwargs2d(model, kwargs):
+    """Remove un-supported keywords for these models.
+
+    The supported arguments are ALLOWED_KEYWORDS_2D.
+
+    """
+
+    return clean_kwargs(ALLOWED_KEYWORDS_2D, model, kwargs)
 
 
 class Box1D(RegriddableModel1D):
@@ -101,7 +154,7 @@ class Box1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.box1d(*args, **kwargs)
 
 
@@ -156,7 +209,7 @@ class Const1D(RegriddableModel1D, Const):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.const1d(*args, **kwargs)
 
 
@@ -199,7 +252,7 @@ class Cos(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.cos(*args, **kwargs)
 
 
@@ -255,7 +308,7 @@ class Delta1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.delta1d(*args, **kwargs)
 
 
@@ -308,7 +361,7 @@ class Erf(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.erf(*args, **kwargs)
 
 
@@ -361,7 +414,7 @@ class Erfc(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.erfc(*args, **kwargs)
 
 
@@ -400,7 +453,7 @@ class Exp(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.exp(*args, **kwargs)
 
 
@@ -439,7 +492,7 @@ class Exp10(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.exp10(*args, **kwargs)
 
 
@@ -528,7 +581,7 @@ class Gauss1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.gauss1d(*args, **kwargs)
 
 
@@ -567,7 +620,7 @@ class Log(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.log(*args, **kwargs)
 
 
@@ -606,7 +659,7 @@ class Log10(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.log10(*args, **kwargs)
 
 
@@ -656,7 +709,7 @@ class LogParabola(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.logparabola(*args, **kwargs)
 
 
@@ -722,7 +775,7 @@ class NormGauss1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.ngauss1d(*args, **kwargs)
 
 
@@ -771,7 +824,7 @@ class Poisson(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.poisson(*args, **kwargs)
 
 
@@ -887,7 +940,7 @@ class Polynom1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.poly1d(*args, **kwargs)
 
 
@@ -935,7 +988,7 @@ class PowLaw1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, pars, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         if kwargs['integrate']:
             # avoid numerical issues with C pow() function close to zero,
             # 0.0 +- ~1.e-14.  PowLaw1D integrated has multiple calls to
@@ -1022,7 +1075,7 @@ class Sin(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.sin(*args, **kwargs)
 
 
@@ -1057,7 +1110,7 @@ class Sqrt(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.sqrt(*args, **kwargs)
 
 
@@ -1106,7 +1159,7 @@ class StepHi1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.stephi1d(*args, **kwargs)
 
 
@@ -1155,7 +1208,7 @@ class StepLo1D(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.steplo1d(*args, **kwargs)
 
 
@@ -1198,7 +1251,7 @@ class Tan(RegriddableModel1D):
 
     @modelCacher1d
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.tan(*args, **kwargs)
 
 
@@ -1267,7 +1320,7 @@ class Box2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.box2d(*args, **kwargs)
 
 
@@ -1301,7 +1354,7 @@ class Const2D(RegriddableModel2D, Const):
         self.cache = 0
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.const2d(*args, **kwargs)
 
 
@@ -1399,7 +1452,7 @@ class Delta2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.delta2d(*args, **kwargs)
 
 
@@ -1489,7 +1542,7 @@ class Gauss2D(RegriddableModel2D):
         param_apply_limits(fwhm, self.fwhm, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.gauss2d(*args, **kwargs)
 
 
@@ -1570,7 +1623,7 @@ class SigmaGauss2D(Gauss2D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.sigmagauss2d(*args, **kwargs)
 
 
@@ -1670,7 +1723,7 @@ class NormGauss2D(RegriddableModel2D):
         param_apply_limits(ampl, self.ampl, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.ngauss2d(*args, **kwargs)
 
 
@@ -1780,7 +1833,7 @@ class Polynom2D(RegriddableModel2D):
         param_apply_limits(c22, self.cx2y2, **kwargs)
 
     def calc(self, *args, **kwargs):
-        kwargs['integrate'] = bool_cast(self.integrate)
+        kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.poly2d(*args, **kwargs)
 
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -131,7 +131,7 @@ Linking parameters
 
 One parameter can be made to reference one or more other parameters, a
 process called "linking". The linked parameter is no-longer considered
-a free parameter in a fit since it's value is derived from the other
+a free parameter in a fit since its value is derived from the other
 parameters. This link can be a simple one-to-one case, such as
 ensuring the fwhm parameter of one model is the same as the other:
 
@@ -476,7 +476,7 @@ def modelCacher1d(func):
 # number of invariants the classes rely on. An example is that
 # instances of Unary/BinaryOpModel classes should not cache-related
 # attributes, but they can do if we change to using super. There is
-# mode discussion of this in
+# more discussion of this in
 # https://www.artima.com/weblogs/viewpost.jsp?thread=237121 which
 # points out that you should either always use super or never do (or,
 # that multiple inheritance is tricky in Python).
@@ -913,7 +913,7 @@ class CompositeModel(Model):
                     # parameter, store a hidden, linked proxy
                     # instead. This is presumably to ensure that we
                     # have the correct number of degrees of freedom
-                    # (as pnew is frozen) while stil sending the
+                    # (as pnew is frozen) while still sending the
                     # correct parameters to the different components.
                     #
                     pnew = Parameter(p.modelname, p.name, 0.0, hidden=True)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -20,34 +20,35 @@
 
 """Allow models to be defined and combined.
 
-A single model is defined by the parameters of the model - represented
-as sherpa.models.model.Parameter instances - and the function that
+A single model is defined by the parameters of the model - stored
+as `sherpa.models.model.Parameter` instances - and the function that
 takes the parameter values along with an array of grid values. The
 main classes are:
 
-* Model which is the base class and defines most of the interfaces.
+* `Model` which is the base class and defines most of the interfaces.
 
-* ArithmeticConstantModel and ArithmeticFunctionModel for representing
+* `ArithmeticConstantModel` and `ArithmeticFunctionModel` for representing
   a constant value or a function.
 
-* ArithmeticModel is the main base class for deriving user models since
+* `ArithmeticModel` is the main base class for deriving user models since
   it supports combining models (e.g. by addition or multiplication) and
   a cache to reduce evaluation time at the expense of memory use.
 
-* RegriddableModel builds on ArithmeticModel to allow a model to be
+* `RegriddableModel` builds on ArithmeticModel to allow a model to be
   evaluated on a different grid to that requested: most model classes
-  are derived from the 1D and 2D variants of RegriddableModel.
+  are derived from the 1D (`RegriddableModel1D`) and 2D
+  (`RegriddableModel2D`) variants of RegriddableModel.
 
-* CompositeModel which is used to represent a model expression, that
+* `CompositeModel` which is used to represent a model expression, that
   is combined models, such as `m1 * (m2 + m3)`
 
-  * UnaryOpModel for model expressions such as `- m1`.
+  * `UnaryOpModel` for model expressions such as `-m1`.
 
-  * BinaryOpModel for model expressions such as `m1 + m2`.
+  * `BinaryOpModel` for model expressions such as `m1 + m2`.
 
-  * NestedModel for applying one model to another.
+  * `NestedModel` for applying one model to another.
 
-* SimulFitModel for fitting multiple models and datasets.
+* `SimulFitModel` for fitting multiple models and datasets.
 
 Creating a model
 ================
@@ -92,7 +93,7 @@ be inspected with print or the pars attribute:
     >>> print(m2.pars)
     (<Parameter 'fwhm' of model 'gmdl'>, <Parameter 'pos' of model 'gmdl'>, <Parameter 'ampl' of model 'gmdl'>)
 
-The parameters are instances of the sherpa.models.parameter.Parameter
+The parameters are instances of the `sherpa.models.parameter.Parameter`
 class:
 
     >>> print(m2.fwhm)
@@ -129,8 +130,8 @@ Linking parameters
 ------------------
 
 One parameter can be made to reference one or more other parameters, a
-process called "linking". The lniked is no-longer considered a free
-parameter in a fit since it's value is derived from the other
+process called "linking". The linked parameter is no-longer considered
+a free parameter in a fit since it's value is derived from the other
 parameters. This link can be a simple one-to-one case, such as
 ensuring the fwhm parameter of one model is the same as the other:
 
@@ -169,7 +170,7 @@ to indicate the expression:
 Model evaluation
 ================
 
-With a sherpa.data.Data instance a model can be evaluated with the
+With a `sherpa.data.Data` instance a model can be evaluated with the
 eval_model method of the object. For example:
 
     >>> import numpy as np
@@ -211,9 +212,10 @@ overlap, but they do not need to be consecutive.
 The behavior of a model when given low and high edges depends on
 whether the model is written to support this mode - that is,
 integrating the model across the bin - and the setting of the
-integrate flag of the model. The Gauss1D model does support an
-integrated mode, so switching the integrate flag will change the model
-output:
+integrate flag of the model. For example, the
+`sherpa.models.basic.Gauss1D` model will, by default, integrate the
+model across each bin when given the bin edges, but if the flag is set
+to `False` then just the first array (here ``xlo``) is used:
 
     >>> print(mdl.integrate)
     True
@@ -221,13 +223,9 @@ output:
     >>> y2 = mdl(xlo, xhi)
     >>> print(y2)
     [48.63274737 49.65462477 49.91343163 50.         49.65462477]
-
-The behavior when the integrate flag is False depends on the model but
-it normally just uses the low edge, as shown for the Gauss1D case:
-
     >>> y3 = mdl(xlo)
-    >>> print(y2 == y3)
-    [ True  True  True  True  True]
+    >>> y2 == y3
+    array([ True,  True,  True,  True,  True])
 
 Direct access
 -------------
@@ -247,7 +245,7 @@ The parameter order matches the pars attribute of the model:
 Model expressions
 =================
 
-The CompositeModel class is the base class for creating model
+The `CompositeModel` class is the base class for creating model
 expressions - that is the overall model that is combined of one or
 more model objects along with possible numeric terms, such as a
 model containing two gaussians and a polynomial:
@@ -267,9 +265,9 @@ component:
     >>> x = np.arange(-10, 40, 2)
     >>> y = mdl(x)
 
-This model is written so that the amplitude of the `l2` component is
-half the `l1` component by linking the two `ampl` parameters and then
-including a scaling factor in the model expression for `l2`. An
+This model is written so that the amplitude of the ``l2`` component is
+half the ``l1`` component by linking the two ``ampl`` parameters and then
+including a scaling factor in the model expression for ``l2``. An
 alternative would have been to include this scaling factor in the link
 expression:
 
@@ -278,7 +276,7 @@ expression:
 Model cache
 ===========
 
-The ArithmeticModel class and modelCacher1d decorator provide basic
+The `ArithmeticModel` class and `modelCacher1d` decorator provide basic
 support for caching one-dimensional model evaluations - that is, to
 avoid re-calculating the model. The idea is to save the results of the
 latest calls to a model and return the values from the cache,
@@ -286,22 +284,22 @@ hopefully saving time at the expense of using more memory. This is
 most effective when the same model is used with multiple datasets
 which all have the same grid.
 
-The _use_caching attribute of the model is used to determine whether
+The `_use_caching` attribute of the model is used to determine whether
 the cache is used, but this setting can be over-ridden by the startup
 method, which is automatically called by the fit and est_errors
-methods of a sherpa.fit.Fit object.
+methods of a `sherpa.fit.Fit` object.
 
-The cache_clear and cache_status methods of ArithmeticModel and
-CompositeModel allow you to clear the cache and display to the
-standard output the cache status of each model component.
+The `cache_clear` and `cache_status` methods of the `ArithmeticModel`
+and `CompositeModel` classes allow you to clear the cache and display
+to the standard output the cache status of each model component.
 
 Example
 =======
 
 The following class implements a simple scale model which has a single
-parameter (`scale`) which defaults to 1. It can be used for both
+parameter (``scale``) which defaults to 1. It can be used for both
 non-integrated and integrated datasets of any dimensionality (see
-sherpa.models.basic.Scale1D and sherpa.models.basic.Scale2D)::
+`sherpa.models.basic.Scale1D` and `sherpa.models.basic.Scale2D`)::
 
     class ScaleND(ArithmeticModel):
         '''A constant value per element.'''
@@ -1172,7 +1170,18 @@ class ArithmeticModel(Model):
 
 
 class RegriddableModel(ArithmeticModel):
+    """Support models that can be evaluated on a different grid.
+
+    """
+
     def regrid(self, *args, **kwargs):
+        """Allow a model to be evaluated on a different grid than requested.
+
+        The return value is a new instance of the model, set up to
+        evaluate the model on the supplied axes which will be
+        regridded onto the requested grid.
+
+        """
         raise NotImplementedError
 
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -310,8 +310,8 @@ non-integrated and integrated datasets of any dimensionality (see
             pars = (self.scale, )
             ArithmeticModel.__init__(self, name, pars)
 
-        def calc(self, *args, **kwargs):
-            return self.scale.val * np.ones(len(args[0]))
+        def calc(self, p, *args, **kwargs):
+            return p[0] * np.ones_like(args[0])
 
 """
 
@@ -392,7 +392,7 @@ def modelCacher1d(func):
         def MyModel(ArithmeticModel):
             ...
             @modelCacher1d
-            def calc(self, *args, **kwargs):
+            def calc(self, p, *args, **kwargs):
                 ...
 
     """
@@ -647,6 +647,8 @@ class Model(NoNewAttributesAfterInit):
             and the number depends on the dimensionality of the
             model and whether it is being evaluated over an
             integrated grid or at a point (or points).
+        **kwargs
+            Any model-specific values that are not parameters.
         """
         raise NotImplementedError
 
@@ -1098,6 +1100,7 @@ class ArithmeticConstantModel(Model):
         pass
 
     def calc(self, p, *args, **kwargs):
+        # Shouldn't this return p[0]?
         return self.val
 
     def teardown(self):
@@ -1389,6 +1392,8 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
         CompositeModel.teardown(self)
 
     def calc(self, p, *args, **kwargs):
+        # Note that the kwargs are sent to both model components.
+        #
         nlhs = len(self.lhs.pars)
         lhs = self.lhs.calc(p[:nlhs], *args, **kwargs)
         rhs = self.rhs.calc(p[nlhs:], *args, **kwargs)

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -934,7 +934,7 @@ class ModelDomainRegridder2D():
 
         requested_eval_space = self._make_and_validate_grid(args)
 
-        return self._evaluate(requested_eval_space, pars, modelfunc)
+        return self._evaluate(requested_eval_space, pars, modelfunc, **kwargs)
 
     def _make_and_validate_grid(self, args_array):
         """
@@ -963,7 +963,7 @@ class ModelDomainRegridder2D():
 
         return requested_eval_space
 
-    def _evaluate(self, requested_space, pars, modelfunc):
+    def _evaluate(self, requested_space, pars, modelfunc, **kwargs):
         # Evaluate the model on the user-defined grid and then rebin
         # onto the desired grid.
 
@@ -971,7 +971,7 @@ class ModelDomainRegridder2D():
             warnings.warn("requested space and evaluation space do not overlap, evaluating model to 0")
             return requested_space.zeros_like()
 
-        y = modelfunc(pars, *self.grid)
+        y = modelfunc(pars, *self.grid, **kwargs)
         return rebin_2d(y, self.evaluation_space, requested_space).ravel()
 
 

--- a/sherpa/models/tests/test_basic.py
+++ b/sherpa/models/tests/test_basic.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2020, 2021
-#      Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2020, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,51 +36,52 @@ def userfunc(pars, x, *args, **kwargs):
 EXCLUDED_MODELS = (ArithmeticModel, RegriddableModel1D, RegriddableModel2D,
                    basic.Const)
 
+TESTABLE = []
+for name in dir(basic):
+    cls = getattr(basic, name)
+    if not isinstance(cls, type) or \
+       not issubclass(cls, ArithmeticModel) or \
+       cls in EXCLUDED_MODELS:
+        continue
 
-def test_create_and_evaluate():
+    TESTABLE.append((name, cls))
+
+
+def test_expected_number():
+    assert len(TESTABLE) == 34
+
+
+@pytest.mark.parametrize("name,cls", TESTABLE)
+def test_create_and_evaluate(name, cls):
+
+    # These have very different interfaces than the others
+    if name in ['Integrator1D', 'Integrate1D']:
+        return
 
     x = np.arange(1.0, 5.0)
-    count = 0
 
-    for cls in dir(basic):
-        clsobj = getattr(basic, cls)
+    m = cls()
+    assert type(m).__name__.lower() == m.name
 
-        if not isinstance(clsobj, type) \
-           or not issubclass(clsobj, ArithmeticModel) \
-           or clsobj in EXCLUDED_MODELS:
-            continue
+    if isinstance(m, basic.TableModel):
+        m.load(x, x)
+    if isinstance(m, basic.UserModel):
+        m.calc = userfunc
 
-        # These have very different interfaces than the others
-        if cls == 'Integrator1D' or cls == 'Integrate1D':
-            continue
+    if m.ndim == 2:
+        pt_out = m(x, x)
+        int_out = m(x, x, x, x)
+    else:
+        if m.name in ('log', 'log10'):
+            xx = -x
+        else:
+            xx = x
+        pt_out = m(xx)
+        int_out = m(xx, xx)
 
-        m = clsobj()
-        if isinstance(m, basic.TableModel):
-            m.load(x, x)
-        if isinstance(m, basic.UserModel):
-            m.calc = userfunc
-        assert type(m).__name__.lower() == m.name
-        count += 1
-
-        try:
-            if m.name.count('2d'):
-                pt_out = m(x, x)
-                int_out = m(x, x, x, x)
-            else:
-                if m.name in ('log', 'log10'):
-                    xx = -x
-                else:
-                    xx = x
-                pt_out = m(xx)
-                int_out = m(xx, xx)
-        except ValueError:
-            assert False, "evaluation of model '{}' failed".format(cls)
-
-        for out in (pt_out, int_out):
-            assert out.dtype.type is SherpaFloat
-            assert out.shape == x.shape
-
-    assert count == 32
+    for out in (pt_out, int_out):
+        assert out.dtype.type is SherpaFloat
+        assert out.shape == x.shape
 
 
 def test_polynom2d_guess():

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1124,7 +1124,12 @@ def test_cache_integrate_fall_through_integrate_true():
     pars = []
     data = [numpy.asarray(pars).tobytes(),
             b'1', # integrated
-            x.tobytes()]
+            x.tobytes(),
+            # The integrate setting is included twice because we can
+            # not guarantee it has been sent in with a keyword
+            # argument.
+            b'integrate',
+            numpy.asarray(True).tobytes()]
 
     token = b''.join(data)
     digest = hashfunc(token).digest()
@@ -1151,7 +1156,12 @@ def test_cache_integrate_fall_through_integrate_false():
     pars = []
     data = [numpy.asarray(pars).tobytes(),
             b'0', # not integrated
-            x.tobytes()]
+            x.tobytes(),
+            # The integrate setting is included twice because we can
+            # not guarantee it has been sent in with a keyword
+            # argument.
+            b'integrate',
+            numpy.asarray(False).tobytes()]
 
     token = b''.join(data)
     digest = hashfunc(token).digest()
@@ -1556,13 +1566,13 @@ def test_model_keyword_cache():
     assert len(store) == 1
     assert store[0][1] == {"user_arg": 1}
 
-    # Are the user arguments used as part of the cache index?
-    # At the moment they are not, so the store doesn't get
-    # updated with this call.
-    #
-    mdl(x, user_arg=2)
+    mdl(x, user_arg=1)
     assert len(store) == 1
     assert store[0][1] == {"user_arg": 1}
+
+    mdl(x, user_arg=2)
+    assert len(store) == 2
+    assert store[1][1] == {"user_arg": 2}
 
     # Explicit check what happens when we turn off the cache
     mdl._use_caching = False
@@ -1599,7 +1609,6 @@ def test_model1d_cache_xhi_positional():
     assert y3 == pytest.approx(10, 10, 10)
 
 
-@pytest.mark.xfail
 def test_model1d_cache_xhi_named():
     """Do we cache the model when xhi argument is named?"""
 
@@ -1619,6 +1628,5 @@ def test_model1d_cache_xhi_named():
     # Now change xhi so we can see if it is used in the cache?
     xhi = [x + 1 for x in xlo]
     y3 = mdl(xlo, xhi=xhi)
-    # This fails because it has used the cached values rather than re-evaluate
     assert len(store) == 2
     assert y3 == pytest.approx(10, 10, 10)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1412,7 +1412,6 @@ def test_model_thaw_alwaysfrozen():
     assert mdl.thawedpars == [1.0, 1.0, 1.0]
 
 
-@pytest.mark.xfail
 # just pick some of the models we are already using
 @pytest.mark.parametrize("cls", [Sin, Const1D, Box1D, LogParabola, Polynom1D, Scale1D])
 def test_model1d_existing_keywords(cls):
@@ -1426,12 +1425,10 @@ def test_model1d_existing_keywords(cls):
 
     x = [1.1, 1.6, 3.2]
     y1 = mdl(x)
-    # This fails
     y2 = mdl(x, made_up_argument=False)
     assert y2 == pytest.approx(y1)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("cls", [Const2D, Gauss2D, Scale2D])
 def test_model2d_existing_keywords(cls):
     """Check we can send keyword arguments to existing models"""
@@ -1445,7 +1442,6 @@ def test_model2d_existing_keywords(cls):
     x0 = [1.1, 1.6, 3.2]
     x1 = [-2.1, 0.4, 3.4]
     y1 = mdl(x0, x1)
-    # This fails
     y2 = mdl(x0, x1, made_up_argument=False)
     assert y2 == pytest.approx(y1)
 
@@ -1496,8 +1492,8 @@ def test_model_unop_keywords(kwargs):
 
 
 @pytest.mark.parametrize("kwargs", [None, {},
-                                    pytest.param({"foo": 23}, marks=pytest.mark.xfail),
-                                    pytest.param({"aA": True, "fooFoo": [1, 2]}, marks=pytest.mark.xfail)])
+                                    {"foo": 23},
+                                    {"aA": True, "fooFoo": [1, 2]}])
 def test_model_binop_keywords(kwargs):
     """Check we can send keyword arguments to a BinOp model"""
 
@@ -1530,7 +1526,6 @@ def test_model_binop_keywords(kwargs):
         y = mdl([1, 1.5, 3])
         kwargs = {}
     else:
-        # This fails when kwargs is not empty
         y = mdl([1, 1.5, 3], **kwargs)
 
     assert y == pytest.approx([14, 14, 14])


### PR DESCRIPTION
# Summary

Allow keyword arguments to be passed to models and ensure these arguments are respected by the model cache.

# Details

There is a kind-of follow-up PR: 
- #1671

There is currently no use case that requires passing keyword arguments to models, but

1. it's something that might be useful
2. we partially support it already
3. there is a use for XSPEC models but this requires something like #1615 to have been merged (to allow the `spectrumNumber`/`ifl` keyword to be used to set up data)
4. it turns out we need to deal with kwargs for XSPEC models to handle model regridding (see #830) 

One of the commits actually allows us to pass the `spectrumNumber` value to XSPEC models. It currently does nothing, because

a) we have no models that use this
b) we have no way to pass this information around either at the UI layer or in the object layer (e.g. during a `Fit` evaluation)
c) we have no way to set the data that the models need

An alternative to `spectrumNumber` as the argument name is `ifl`, which is the 'older' term that XSPEC uses, but as this is a low-level feature users are not expected to use directly [although currently how we plan to expose this to users has not been worked through] I decided to go with the more-descriptive term.

As part of this work the documentation has seen some minor updates. 

# Cache

We have a cache system around 1D models so that when sent a set of parameters and a grid we can avoid re-calculating the model, and just return the cache (with a very-small cache size so it's only really helpful when the same model is being evaluated for different datasets that have the same RMF grid, or at least that's the intent; I find it hard to validate the behavior of this code but that's a different concern). The cache is controlled by the `modelCacher1d` decorator and the logic is in the `sherpa.models.model.ArithmeticModel` class. Fortunately we now have some documentation on this I can point to - https://sherpa.readthedocs.io/en/4.15.0/evaluation/cache.html

Keyword arguments to a model need to be added to the cache key (otherwise what is the point of sending them in). This is relatively easy to do but it probably limits the values that can be used for these keywords - the current version assumes we can convert them to a `ndarray`:

```python
# Add any keyword arguments to the list. This will
# include the xhi named argument if given. Can the
# value field fail here?
#
for k, v in kwargs.items():
    data.extend([k.encode(), numpy.asarray(v).tobytes()])
```

You can get away with passing simple tuples and dicts to `asarray`, so it's not as restrictive as it would first seem. An alternative would be to come up with some way to create a `key` from a set of values (I'm sure there are many Python packages to do so but we don't want to be pulling in extra code to do so).

```
>>> import numpy as np
>>> np.asarray(True).tobytes()
b'\x01'
>>> np.asarray("x").tobytes()
b'x\x00\x00\x00'
>>> np.asarray(("x", True)).tobytes()
b'x\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00T\x00\x00\x00r\x00\x00\x00u\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00'
>>> np.asarray({"x": True}).tobytes()
b'\x00\xd8V\n#\x7f\x00\x00'
```

# Notes

This somewhat conflicts with existing XSPEC PRs, some of which have now been merged

- #1396
- #1615
- #830 (maybe)