### PR TITLE
Fix a cache error with TableModel

### DIFF
--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1902,13 +1902,6 @@ class TableModel(ArithmeticModel):
         self.ampl = Parameter(name, 'ampl', 1)
         ArithmeticModel.__init__(self, name, (self.ampl,))
 
-    def __setstate__(self, state):
-        self.__x = None
-        self.__y = state.pop('_y', None)
-        self.__filtered_y = state.pop('_filtered_y', None)
-        self.filename = state.pop('_file', None)
-        ArithmeticModel.__setstate__(self, state)
-
     def load(self, x, y):
         """Set the model values.
 

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1783,22 +1783,25 @@ class Polynom2D(RegriddableModel2D):
 
 
 class TableModel(ArithmeticModel):
-    """Tabulated values in this model are simply linearly scaled.
+    """Tabulated values are linearly scaled and may be interpolated.
 
     After initializing this model, the independent and dependent
     arrays need to be loaded using the ``load`` method before the
     model can be used (see examples below); interpolation is used if
-    the grids of the data and the table do not match.
+    the grids of the data and the table do not match (this requires
+    that the independent axis is set rather than being left as
+    `None`). The interpolation scheme can be changed by setting the
+    `method` attribute.
 
-    When used with an integrated data set (for example,
-    `Data1DInt`) the independent axis loaded should be the left-edge
-    of the bin, and the dependent axis is the integrated value for that bin.
+    When used with an integrated data set (for example, `Data1DInt`)
+    the independent axis loaded should be the left-edge of the bin,
+    and the dependent axis is the integrated value for that bin.
 
     This model can also be used as to fit indexed data where the
     independent axis is not a continuous variable, e.g. the
     independent variable may hold the index for a number of stars and
     the dependent variable some measured property for each star. In
-    this case, the independent variable needs to be loaded as ``None``
+    this case, the independent variable needs to be loaded as `None`
     and the length of the dependent array needs to match the length of
     the data array exactly.
 
@@ -1806,42 +1809,87 @@ class TableModel(ArithmeticModel):
     Attributes
     ----------
     ampl
-        The linear scaling factor for table values
+        The linear scaling factor for the table values
 
     See Also
     --------
-    Const1D
+    Const1D, Scale1D
 
     Examples
     --------
     Below is an example for the "indexed" use:
 
-      >>> import numpy as np
-      >>> from sherpa.models.basic import TableModel
-      >>> from sherpa.data import Data1D
-      >>> from sherpa.stats import Chi2
-      >>> from sherpa.optmethods import NelderMead
-      >>> from sherpa.fit import Fit
-      >>> d = Data1D('data', [1,2,3,4,5], [1.2, .4, 2.2, .3, 1.],
-      ...             staterror=[.2, .2, .2, .2, .2])
-      >>> tm = TableModel('tabmodel')
-      >>> tm.load(None, np.array([.6, .2, 1.1, .2, .5]))
-      >>> fit = Fit(d, tm)
-      >>> res = fit.fit()
+    >>> import numpy as np
+    >>> from sherpa.models.basic import TableModel
+    >>> from sherpa.data import Data1D
+    >>> from sherpa.fit import Fit
+    >>> d = Data1D('data', [1,2,3,4,5], [1.2, .4, 2.2, .3, 1.],
+    ...             staterror=[.2, .2, .2, .2, .2])
+    >>> tm = TableModel('tabmodel')
+    >>> tm.load(None, np.array([.6, .2, 1.1, .2, .5]))
+    >>> fit = Fit(d, tm)
+    >>> res = fit.fit()
 
     This even works for masked data, if the model's ``fold`` method is
     called first, which informs the model which values are masked.
 
-      >>> d = Data1D('data', [1,2,3,4,5],
-      ...            np.ma.masked_invalid([np.nan, np.nan, 2.2, .3, 1.]),
-      ...            staterror=[.2, .2, .2, .2, .2])
-      >>> tm = TableModel('tabmodel')
-      >>> tm.load(None, np.array([.6, .2, 1.1, .2, .5]))
-      >>> tm.fold(d)
-      >>> fit = Fit(d, tm)
-      >>> res = fit.fit()
+    >>> d = Data1D('data', [1,2,3,4,5],
+    ...            np.ma.masked_invalid([np.nan, np.nan, 2.2, .3, 1.]),
+    ...            staterror=[.2, .2, .2, .2, .2])
+    >>> tm = TableModel('tabmodel')
+    >>> tm.load(None, np.array([.6, .2, 1.1, .2, .5]))
+    >>> tm.fold(d)
+    >>> fit = Fit(d, tm)
+    >>> res = fit.fit()
+
+    The masking also holds if the notice or ignore method has been
+    used on the dataset:
+
+    >>> d = Data1D('data', [1, 2, 3, 4, 5], [1.2, .4, 2.2, .3, 1],
+    ...            staterror=[.2, .2, .2, .2, .2])
+    >>> d.ignore(hi=2)
+    >>> tm = TableModel('tabmodel')
+    >>> tm.load(None, np.array([.6, .2, 1.1, .2, .5]))
+    >>> tm.fold(d)
+    >>> fit = Fit(d, tm)
+    >>> res = fit.fit()
+
+    If the x array is given to the `load` call then the model can
+    interpolate from the requested grid onto the load data (the
+    default is linear interpolation):
+
+    >>> tm = TableModel()
+    >>> tm.load([10, 20, 25, 30], [14, 12, 17, 18])
+    >>> tm.ampl = 10
+    >>> tm([15, 20, 27])
+    array([130. , 120. , 174.])
+    >>> from sherpa.utils import neville
+    >>> tm.method = neville
+    >>> tm([15, 20, 27])
+    array([ 90.   , 120.   , 182.16])
 
     """
+
+    @property
+    def method(self):
+        """The interpolation method, used when x is not None in the load call.
+
+        The method argument is a function that accepts arguments (xout,
+        xin, yin) and returns the yout values from interpolating xout onto
+        (xin, yin). The default is linear interpolation
+        (sherpa.utils.linear_interp).
+        """
+        return self._method
+
+    @method.setter
+    def method(self, val):
+        # we should check it's callable
+        self._method = val
+
+        # as the method affects the cache, clear it (we could skip
+        # this if the method has not changed but is it worth it?)
+        #
+        self.cache_clear()
 
     def __init__(self, name='tablemodel'):
         # these attributes should remain somewhat private
@@ -1850,7 +1898,7 @@ class TableModel(ArithmeticModel):
         self.__y = None
         self.__filtered_y = None
         self.filename = None
-        self.method = linear_interp  # interpolation method
+        self._method = linear_interp
         self.ampl = Parameter(name, 'ampl', 1)
         ArithmeticModel.__init__(self, name, (self.ampl,))
 
@@ -1862,46 +1910,133 @@ class TableModel(ArithmeticModel):
         ArithmeticModel.__setstate__(self, state)
 
     def load(self, x, y):
-        self.__y = y
-        self.__x = x
+        """Set the model values.
 
-        # Input grid is sorted!
-        if x is not None:
-            idx = numpy.asarray(x).argsort()
-            self.__y = numpy.asarray(y)[idx]
-            self.__x = numpy.asarray(x)[idx]
+        Parameters
+        ----------
+        x, y : None or sequence
+           The model values. It is expected that either both are
+           given, and have the same number of elements, or that only y
+           is set, although the model can be cleared by setting both
+           to None.
+
+        """
+
+        if x is not None and y is None:
+            raise ModelErr("y must be set if x is set")
+
+        # Clear the cache. We could avoid doing this if the
+        # data has not changed but this is not worth the
+        # complexity.
+        #
+        self.cache_clear()
+
+        # A simplified version of sherpa.data._check, which is not
+        # used here to avoid circular dependencies. Rather than raise
+        # DataErr, we raise ModelErr with a similar message.
+        #
+        def _check(val):
+            if val is None:
+                return None
+
+            val = numpy.asarray(val)
+            if val.ndim != 1:
+                raise ModelErr("Array must be 1D or None")
+
+            return val
+
+        self.__y = _check(y)
+        self.__x = _check(x)
+
+        # clear the filtered array
+        self.__filtered_y = None
+
+        if x is None:
+            return
+
+        nx = len(self.__x)
+        ny = len(self.__y)
+        if nx != ny:
+            raise ModelErr(f"size mismatch between x and y: {nx} vs {ny}")
+
+        # Ensure the data is sorted. Is this useful?
+        #
+        idx = self.__x.argsort()
+        self.__y = self.__y[idx]
+        self.__x = self.__x[idx]
 
     def get_x(self):
+        """Return the independent axis, if set"""
         return self.__x
 
     def get_y(self):
+        """Return the dependent axis, if set"""
         return self.__y
 
     def fold(self, data):
+        """Ensure the model matches the data filter.
+
+        This should be called after load, to ensure that any existing
+        filter is applied correctly during a fit. It is only necessary
+        for models where x is None in the load call.
+
+        Parameters
+        ----------
+        data : sherpa.data.Data instance
+           An object with a mask attribute.
+
+        """
+
+        if self.__y is None:
+            raise ModelErr("The tablemodel's load method must be called first")
+
+        # Clear out the setting. If needed it will get reset.
+        #
+        self.__filtered_y = None
+
+        # If we are interpolating the data we do not care about the
+        # data mask.
+        #
+        if self.__x is not None:
+            return
+
+        # What should we do with data.mask = {True, False}?
+        #
         mask = data.mask
-        if self.__x is None and numpy.iterable(mask):
-            if len(mask) != len(self.__y):
-                raise ModelErr("filtermismatch", 'table model',
-                               'data, (%s vs %s)' %
-                               (len(self.__y), len(mask)))
-            self.__filtered_y = self.__y[mask]
+        if not numpy.iterable(mask):
+            return
+
+        if len(mask) != len(self.__y):
+            raise ModelErr("filtermismatch", 'table model',
+                           f"data, ({len(self.__y)} vs {len(mask)})")
+
+        self.__filtered_y = self.__y[mask]
 
     @modelCacher1d
     def calc(self, p, x0, x1=None, *args, **kwargs):
+        """Evaluate the model.
 
-        if self.__x is not None and self.__y is not None:
+        The load method must have been called first. If both x and y
+        were given then the model is interpoalted onto the x0 grid,
+        otherwise x0 is only checked to see if it has the right size
+        (fold should have been called if the data has been filtered).
+
+        """
+        if self.__y is None:
+            raise ModelErr("The tablemodel's load method must be called first")
+
+        if self.__x is not None:
             return p[0] * interpolate(x0, self.__x, self.__y, function=self.method)
 
-        elif (self.__filtered_y is not None and
+        if (self.__filtered_y is not None and
               len(x0) == len(self.__filtered_y)):
             return p[0] * self.__filtered_y
 
-        elif (self.__y is not None and
-              len(x0) == len(self.__y)):
+        if len(x0) == len(self.__y):
             return p[0] * self.__y
 
-        raise ModelErr("filtermismatch", 'table model', 'data, (%s vs %s)' %
-                       (len(self.__y), len(x0)))
+        raise ModelErr("filtermismatch", 'table model',
+                       f"data, ({len(self.__y)} vs {len(x0)})")
 
 
 class UserModel(ArithmeticModel):

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -2039,6 +2039,9 @@ class TableModel(ArithmeticModel):
         if not numpy.iterable(mask):
             return
 
+        # At this point we know mask is an iterable, so it should
+        # match the y data of the model.
+        #
         if len(mask) != len(self.__y):
             raise ModelErr("filtermismatch", 'table model',
                            f"data, ({len(self.__y)} vs {len(mask)})")
@@ -2050,7 +2053,7 @@ class TableModel(ArithmeticModel):
         """Evaluate the model.
 
         The load method must have been called first. If both x and y
-        were given then the model is interpoalted onto the x0 grid,
+        were given then the model is interpolated onto the x0 grid,
         otherwise x0 is only checked to see if it has the right size
         (fold should have been called if the data has been filtered).
 

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1951,7 +1951,7 @@ class TableModel(ArithmeticModel):
            The model values. It is expected that either both are
            given, and have the same number of elements, or that only y
            is set, although the model can be cleared by setting both
-           to None. If x is given then the data is saved after bing
+           to None. If x is given then the data is saved after being
            sorted into increasing order of x.
 
         See Also

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1951,7 +1951,12 @@ class TableModel(ArithmeticModel):
            The model values. It is expected that either both are
            given, and have the same number of elements, or that only y
            is set, although the model can be cleared by setting both
-           to None.
+           to None. If x is given then the data is saved after bing
+           sorted into increasing order of x.
+
+        See Also
+        --------
+        get_x, get_y
 
         """
 
@@ -1992,18 +1997,30 @@ class TableModel(ArithmeticModel):
         if nx != ny:
             raise ModelErr(f"size mismatch between x and y: {nx} vs {ny}")
 
-        # Ensure the data is sorted. Is this useful?
+        # Ensure the data is sorted.
         #
         idx = self.__x.argsort()
         self.__y = self.__y[idx]
         self.__x = self.__x[idx]
 
     def get_x(self):
-        """Return the independent axis, if set"""
+        """Return the independent axis or None.
+
+        See Also
+        --------
+        get_y, load
+
+        """
         return self.__x
 
     def get_y(self):
-        """Return the dependent axis, if set"""
+        """Return the dependent axis or None.
+
+        See Also
+        --------
+        get_x, load
+
+        """
         return self.__y
 
     def fold(self, data):

--- a/sherpa/models/tests/test_tablemodel.py
+++ b/sherpa/models/tests/test_tablemodel.py
@@ -71,7 +71,7 @@ def test_filename():
 def test_ndim():
     """What is the ndim?
 
-    At the moment we can use this with nD data but ony really if we do
+    At the moment we can use this with nD data but only really if we do
     not set the "x" argument.
     """
 

--- a/sherpa/models/tests/test_tablemodel.py
+++ b/sherpa/models/tests/test_tablemodel.py
@@ -150,7 +150,7 @@ def test_load_x_y_sorted():
 
 
 def test_load_x_y_unsorted():
-    """load: x and y (sorted)"""
+    """load: x and y (unsorted)"""
 
     mdl = TableModel()
     mdl.load([17, 12, 14], [7, 3, 2])

--- a/sherpa/models/tests/test_tablemodel.py
+++ b/sherpa/models/tests/test_tablemodel.py
@@ -1,0 +1,706 @@
+#
+#  Copyright (C) 2022
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test the tablemodel class.
+
+The behavior of the tablemodel is rather specialized, which means that
+some contorted tests need to be written.
+"""
+
+import pickle
+
+import numpy as np
+
+import pytest
+
+from sherpa.data import Data1D
+from sherpa.models.basic import TableModel
+from sherpa.models.model import ArithmeticModel
+from sherpa.utils import linear_interp, nearest_interp
+from sherpa.utils.err import ModelErr
+
+
+def test_create():
+    """Basic creation test"""
+
+    mdl = TableModel()
+    assert isinstance(mdl, ArithmeticModel)
+
+
+def test_name():
+    """Basic creation test: name"""
+
+    mdl = TableModel()
+    assert mdl.name == "tablemodel"
+
+
+def test_named():
+    """Basic creation test: name"""
+
+    mdl = TableModel("bobby")
+    assert mdl.name == "bobby"
+
+
+def test_filename():
+    """Basic creation test: filename
+
+    How is the filename attribute meant to be used?
+    """
+
+    mdl = TableModel()
+    assert mdl.filename is None
+
+
+def test_ndim():
+    """What is the ndim?
+
+    At the moment we can use this with nD data but ony really if we do
+    not set the "x" argument.
+    """
+
+    mdl = TableModel()
+    assert mdl.ndim is None
+
+
+def test_pars():
+    """We have a single parameter."""
+
+    mdl = TableModel()
+    assert len(mdl.pars) == 1
+    assert mdl.pars[0].name == "ampl"
+    assert mdl.pars[0].val == pytest.approx(1)
+    assert not mdl.pars[0].frozen
+
+
+def test_show():
+    """Basic show test"""
+
+    mdl = TableModel("test")
+    out = str(mdl).split("\n")
+    assert out[0] == "test"
+    assert out[1].startswith("   Param        Type ")
+    assert out[2].startswith("   -----        ---- ")
+    assert out[3].startswith("   test.ampl    thawed ")
+    assert len(out) == 4
+
+
+def test_empty():
+    """Basic creation test: no data"""
+
+    mdl = TableModel()
+    assert mdl.get_x() is None
+    assert mdl.get_y() is None
+
+
+def test_method_change():
+    """We can change the method"""
+
+    mdl = TableModel()
+    assert mdl.method == linear_interp
+
+    mdl.method = nearest_interp
+    assert mdl.method == nearest_interp
+
+
+def test_method_must_be_callable():
+    """method must be callable"""
+
+    mdl = TableModel()
+
+    # This comes from NoNewAttributesAfterInit via AttrithmeticModel
+    #
+    with pytest.raises(AttributeError,
+                       match="^'TableModel' object attribute 'method' cannot be replaced with a non-callable attribute$"):
+        mdl.method = 23
+
+
+def test_load_no_x():
+    """load: y only"""
+
+    mdl = TableModel()
+    mdl.load(None, [3, 2, 7])
+    assert mdl.get_x() is None
+    assert mdl.get_y() == pytest.approx([3, 2, 7])
+
+
+def test_load_x_y_sorted():
+    """load: x and y (sorted)"""
+
+    mdl = TableModel()
+    mdl.load([12, 14, 17], [3, 2, 7])
+    assert mdl.get_x() == pytest.approx([12, 14, 17])
+    assert mdl.get_y() == pytest.approx([3, 2, 7])
+
+
+def test_load_x_y_unsorted():
+    """load: x and y (sorted)"""
+
+    mdl = TableModel()
+    mdl.load([17, 12, 14], [7, 3, 2])
+    assert mdl.get_x() == pytest.approx([12, 14, 17])
+    assert mdl.get_y() == pytest.approx([3, 2, 7])
+
+
+def test_load_no_x_check_storage():
+    """How are the x/y values stored?
+
+    This is a regression test (that is, the behavior could be
+    changed).
+
+    """
+
+    mdl = TableModel()
+    mdl.load(None, [1, 3, 7])
+    y = mdl.get_y()
+    assert isinstance(y, list)  # Note: not ndarray
+
+
+def test_load_x_y_sorted_check_storage():
+    """How are the x/y values stored?
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    mdl.load([1, 2, 3], [1, 3, 7])
+    x = mdl.get_x()
+    y = mdl.get_y()
+    assert isinstance(x, np.ndarray)
+    assert isinstance(y, np.ndarray)
+
+
+def test_load_x_y_unsorted_check_storage():
+    """How are the x/y values stored?
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    mdl.load([3, 2, 1], [1, 3, 7])
+    x = mdl.get_x()
+    y = mdl.get_y()
+    assert isinstance(x, np.ndarray)
+    assert isinstance(y, np.ndarray)
+
+
+def test_load_no_y():
+    """do we error out or not?
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    with pytest.raises(IndexError,
+                       match="too many indices for array"):
+        mdl.load([12, 14, 17], None)
+
+
+def test_load_x_longer_than_y():
+    """do we error out or not?
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    with pytest.raises(IndexError,
+                       match="index 2 is out of bounds"):
+        mdl.load([12, 14, 17], [3, 2])
+
+
+def test_load_x_shorter_than_y():
+    """do we error out or not?
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    mdl.load([12, 17, 14], [3, 2, 4, 5])
+    assert mdl.get_x() == pytest.approx([12, 14, 17])
+    assert mdl.get_y() == pytest.approx([3, 4, 2])
+
+
+def test_load_y_not_1d():
+    """do we error out or not?
+
+    This is a regression test.
+    """
+
+    x = np.arange(6) + 1
+    y = np.arange(6).reshape(2, 3)
+    mdl = TableModel()
+    with pytest.raises(IndexError,
+                       match="index 2 is out of bounds"):
+        mdl.load(x, y)
+
+
+# sherpa.utils.interpolate assumes inputs are ndarray, so work around
+# this by forcing the input to be one.
+#
+@pytest.mark.parametrize("x2,iflag",
+                         [(None, False),
+                          ([14, 16, 20, 25], False),
+                          ([14, 16, 20, 25], True)])
+def test_eval_x_y(x2, iflag):
+    """Check we can interpolate onto a grid after load(x,y)
+
+    The application ignores the integrate setting/upper-edge of the bin.
+    """
+
+    tm = TableModel()
+    tm.load([10, 15, 20], [4, 6, 2])
+    tm.ampl = 10
+    tm.integrate = iflag
+
+    yout = tm(np.asarray([12, 14, 16, 20]), x2)
+    exp = 10 * np.asarray([4.8, 5.6, 5.2, 2])
+    assert yout == pytest.approx(exp)
+
+
+@pytest.mark.parametrize("y", [pytest.param([4, 6, 2], marks=pytest.mark.xfail), np.asarray([4, 6, 2])])
+@pytest.mark.parametrize("x2,iflag",
+                         [(None, False),
+                          ([14, 16, 20], False),
+                          ([14, 16, 20], True)])
+def test_eval_no_x(y, x2, iflag):
+    """Check we can return something after load(None,y)
+
+    The application ignores the integrate setting/upper-edge of the
+    bin.  We also ignore the x array values, presumably to allow users
+    to load data with no dependent axis (or that we know we don't care
+    about the x axis).
+
+    """
+
+    tm = TableModel()
+    tm.load(None, y)
+    tm.ampl = 10
+    tm.integrate = iflag
+
+    # fails when y is not a ndarray
+    yout = tm([12, 14, 16], x2)
+    assert yout == pytest.approx([40, 60, 20])
+
+
+@pytest.mark.parametrize("y", [pytest.param([4, 6, 2, 8, 7], marks=pytest.mark.xfail), np.asarray([4, 6, 2, 8, 7])])
+@pytest.mark.parametrize("iflag", [False, True])
+def test_eval_filtered(y, iflag):
+    """Check we can return something after load(None, y) and filtering the dataset.
+    """
+
+    tm = TableModel()
+    tm.load(None, y)
+    tm.ampl = 10
+    tm.integrate = iflag
+
+    d = Data1D("ex", [100, 200, 300, 400, 500], [4, 5, 6, 7, 8])
+    d.ignore(xhi=100)
+    d.ignore(xlo=350, xhi=450)
+
+    tm.fold(d)
+
+    yout = d.eval_model_to_fit(tm)
+    assert yout == pytest.approx([60, 20, 70])
+
+
+@pytest.mark.xfail
+def test_eval_pick_up_changed_load():
+    """Corner case: does __filtered_y get cleaned up?
+
+    There's no "nice" way to check if __filtered_y gets cleared after
+    a second load call, so we test it by evaluating the model.
+
+    """
+
+    tm = TableModel()
+    tm.load(None, np.asarray([5, 7, 2, 8, 4]))
+    tm.ampl = 10
+
+    d = Data1D('simple', [20, 30, 40, 50, 70], [1, 2, 3, 4, 5])
+    d.notice(25)
+
+    # Sets up tm.__filtered_y to be [7, 2, 8, 4]
+    tm.fold(d)
+
+    # check
+    assert tm([1, 2, 3, 4]) == pytest.approx([70, 20, 80, 40])
+
+    # Call load with a different y array
+    #
+    tm.load(None, np.asarray([2, 3, 1, 4, 2]))
+
+    # The way the code is written, if we send it a 5-element array we
+    # will get back the new data.
+    #
+    assert tm([1, 2, 3, 4, 5]) == pytest.approx([20, 30, 10, 40, 20])
+
+    # In reality we'd expect the user to call fold again, which would
+    # pick up the change, but if you do not do so then we should check
+    # what the answer is.
+    #
+    # What is the correct answer here? Shouldn't we error out here
+    # because the model hasn't been updated with fold, so it shouldn't
+    # know about the filter - that is, shouldn't this fall over
+    # because the model should be evaluated on a 5-element array?
+    #
+    # This fails as it returns [70, 20, 80, 40], which is frmo the
+    # old data.
+    #
+    assert tm([1, 2, 3, 4]) == pytest.approx([30, 10, 40, 20])
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_eval_filter_all_or_none(flag):
+    """Check that .fold does nothing when the mask is True or False
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    mdl.load(None, np.asarray([5, 3, 4]))
+
+    d = Data1D("ex", [1, 2, 3], [1, 1, 2])
+
+    # Either ensure all the data is noticed or ignored.
+    #
+    d.mask = flag
+
+    # If all the data is ignored, should we error out?
+    #
+    mdl.fold(d)
+
+    y = mdl([1, 2, 3])
+    assert y == pytest.approx([5, 3, 4])
+
+
+def test_eval_pass_kwargs():
+    """Check we can pass kwargs, even though we ignore them.
+
+    This is a regression test.
+    """
+
+    mdl = TableModel()
+    mdl.load(None, np.asarray([10, 12 , 2]))
+    mdl.ampl = 5
+
+    y = mdl([1, 2, 3], arg1=True, not_a_kwarg={"answer": 23})
+    assert y == pytest.approx([50, 60, 10])
+
+
+@pytest.mark.xfail
+def test_eval_checks_length():
+    """Check we error out when the lengths are wrong: calc via model evaluation
+
+    This requires
+      - the table data not being loaded
+
+    """
+
+    tm = TableModel('tbl')
+
+    # It is not clear what we want the error message to be
+    with pytest.raises(ModelErr,
+                       match="Mismatch between table model and data"):
+        # This fails with an internal error
+        tm([1, 2, 3])
+
+
+@pytest.mark.xfail
+def test_fold_no_load_checks_length():
+    """Check we error out when the lengths are wrong: fold.
+
+    This requires
+      - the table data having no X array
+      - the data being partially filtered
+
+    """
+
+    ytbl = np.asarray([5, 7, 3, 2])
+    tm = TableModel('tbl')
+
+    xdata = np.asarray([0, 10, 20, 25, 30, 40])
+    ydata = np.ones_like(xdata)
+    d = Data1D('ex', xdata, ydata)
+    d.ignore(xhi=7)
+
+    # It is not clear what we want the error message to be
+    with pytest.raises(ModelErr,
+                       match="Mismatch between table model and data"):
+        # This fails with an internal error
+        tm.fold(d)
+
+
+def test_fold_load_checks_length():
+    """Check we error out when the lengths are wrong: fold.
+
+    This requires
+      - the table data having no X array
+      - the data being partially filtered
+
+    """
+
+    ytbl = np.asarray([5, 7, 3, 2])
+    tm = TableModel('tbl')
+    tm.load(None, ytbl)
+
+    xdata = np.asarray([0, 10, 20, 25, 30, 40])
+    ydata = np.ones_like(xdata)
+    d = Data1D('ex', xdata, ydata)
+    d.ignore(xhi=7)
+
+    with pytest.raises(ModelErr,
+                       match=r"^Mismatch between table model and data, \(4 vs 6\)$"):
+        tm.fold(d)
+
+
+def test_cached_basic():
+    """Basic check the cache works.
+
+    This is mainly here so we can have confidence in
+    test_cache_is_revoked.
+    """
+
+    mdl = TableModel()
+    mdl.load([1, 2, 3], [5, 2, 12])
+
+    # We could check the _cache_ctr all in one go but we do want false
+    # positives if we ever decide to change how the cache works, so
+    # test individual fields.
+    #
+    assert mdl._cache_ctr["check"] == 0
+
+    y = mdl([1, 2, 3])
+    assert y == pytest.approx([5, 2, 12])
+    assert mdl._cache_ctr["check"] == 1
+    assert mdl._cache_ctr["hits"] == 0
+    assert mdl._cache_ctr["misses"] == 1
+
+    # Is cached
+    y = mdl([1, 2, 3])
+    assert y == pytest.approx([5, 2, 12])
+    assert mdl._cache_ctr["check"] == 2
+    assert mdl._cache_ctr["hits"] == 1
+    assert mdl._cache_ctr["misses"] == 1
+
+    # Not cached
+    y = mdl([1, 3])
+    assert y == pytest.approx([5, 12])
+    assert mdl._cache_ctr["check"] == 3
+    assert mdl._cache_ctr["hits"] == 1
+    assert mdl._cache_ctr["misses"] == 2
+
+
+@pytest.mark.xfail
+def test_cache_is_revoked():
+    """Loading new data should clear the cache. Does it?
+    """
+
+    mdl = TableModel()
+    mdl.load([1, 2, 3], [5, 2, 12])
+
+    y = mdl([1, 2, 3])
+    assert y == pytest.approx([5, 2, 12])
+
+    mdl.load([1, 2, 3], [4, 9, -3])
+
+    # We could check the "check" field here but I want an explicit
+    # check that the model cache works (that is, the model evaluation
+    # works), rather than an implicit check which can come later.
+    #
+    cache = mdl._cache_ctr.copy()
+
+    y = mdl([1, 2, 3])
+    assert y == pytest.approx([4, 9, -3])
+
+    assert cache["check"] == 0
+
+    assert mdl._cache_ctr["check"] == 1
+    assert mdl._cache_ctr["hits"] == 0
+    assert mdl._cache_ctr["misses"] == 1
+
+
+@pytest.mark.xfail
+def test_cache_method():
+    """Does changing the method cause the cache to change?
+
+    In this case we just test the model evaluation,
+    and not the actual cache values.
+    """
+
+    mdl = TableModel()
+    mdl.load([1, 2, 3], [5, 2, 12])
+    assert mdl.method == linear_interp
+
+    y = mdl([1.4, 2.6])
+    assert y == pytest.approx([3.8, 8])
+
+    mdl.method = nearest_interp
+    y = mdl([1.4, 2.6])
+    assert y == pytest.approx([5, 12])
+
+
+def test_pickle_none(tmp_path):
+    """Can we save/restore a TableModel with no data?"""
+
+    x = [1, 2, 3]
+    y = [4, -2, 13]
+    xtest = [1.5, 2, 2.5, 3]
+    ytest = [1, -2, 5.5, 13]
+
+    mdl = TableModel("fred")
+
+    out = tmp_path / "model.state"
+    out = str(out)
+    with open(out, "wb") as ofh:
+        pickle.dump(mdl, ofh)
+
+    with open(out, "rb") as ifh:
+        nmdl = pickle.load(ifh)
+
+    assert isinstance(nmdl, TableModel)
+    assert nmdl.name == "fred"
+    assert nmdl.filename is None
+    assert nmdl.get_x() is None
+    assert nmdl.get_y() is None
+    assert nmdl.ampl.val == pytest.approx(1)
+    assert not nmdl.ampl.frozen
+
+    assert nmdl.method is linear_interp
+
+    # Check we can use the restored object
+    #
+    nmdl.load(x, y)
+    assert nmdl(xtest) == pytest.approx(ytest)
+
+
+def test_pickle_x_y(tmp_path):
+    """Can we save/restore a TableModel with x/y?"""
+
+    x = [1, 2, 3]
+    y = [4, -2, 13]
+    xtest = [1.5, 2, 2.5, 3]
+    ytest = [-5 * 1, -5 * -2, -5 * 5.5, -5 * 13]
+
+    mdl = TableModel()
+    mdl.load(x, y)
+    mdl.ampl = -5
+    mdl.ampl.freeze()
+    assert mdl(xtest) == pytest.approx(ytest)
+
+    out = tmp_path / "model.state"
+    out = str(out)
+    with open(out, "wb") as ofh:
+        pickle.dump(mdl, ofh)
+
+    with open(out, "rb") as ifh:
+        nmdl = pickle.load(ifh)
+
+    assert isinstance(nmdl, TableModel)
+    assert nmdl.name == "tablemodel"
+    assert nmdl.filename is None
+    assert nmdl.get_x() == pytest.approx(x)
+    assert nmdl.get_y() == pytest.approx(y)
+    assert nmdl.ampl.val == pytest.approx(-5)
+    assert nmdl.ampl.frozen
+
+    assert nmdl(xtest) == pytest.approx(ytest)
+
+
+def test_pickle_y(tmp_path):
+    """Can we save/restore a TableModel with just y and filtered?"""
+
+    x = [0, 1, 2, 3, 5]
+    y = np.asarray([0, 4, -2, 13, 2])
+    xtest = [1, 2, 3]
+    ytest = [-5 * 4, -5 * -2, -5 * 13]
+
+    mdl = TableModel("test")
+    mdl.load(None, y)
+    mdl.ampl = -5
+    mdl.ampl.freeze()
+
+    # let's change the filename to test
+    filename = "dummy.dat"
+    mdl.filename = filename
+
+    data = Data1D("dummy", x, [1] * 5)
+    data.notice(1, 3)
+
+    mdl.fold(data)
+
+    assert mdl(xtest) == pytest.approx(ytest)
+
+    out = tmp_path / "model.state"
+    out = str(out)
+    with open(out, "wb") as ofh:
+        pickle.dump(mdl, ofh)
+
+    with open(out, "rb") as ifh:
+        nmdl = pickle.load(ifh)
+
+    assert isinstance(nmdl, TableModel)
+    assert nmdl.name == "test"
+    assert nmdl.filename == filename
+    assert nmdl.get_x() is None
+    assert nmdl.get_y() == pytest.approx(y)
+    assert nmdl.ampl.val == pytest.approx(-5)
+    assert nmdl.ampl.frozen
+
+    assert nmdl(xtest) == pytest.approx(ytest)
+
+
+def test_pickle_interpolation(tmp_path):
+    """Can we save/restore a TableModel with different interpolation
+
+    This is only relevant for load(x, y) cases.
+    """
+
+    x = [0, 1, 2, 3, 5]
+    y = [0, 4, -2, 13, 2]
+    xtest = [0.6, 3.9]
+    ytest = [-5 * 4, -5 * 13]
+
+    mdl = TableModel("test")
+    mdl.load(x, y)
+    mdl.ampl = -5
+    mdl.ampl.freeze()
+
+    mdl.method = nearest_interp
+
+    assert mdl(xtest) == pytest.approx(ytest)
+
+    out = tmp_path / "model.state"
+    out = str(out)
+    with open(out, "wb") as ofh:
+        pickle.dump(mdl, ofh)
+
+    with open(out, "rb") as ifh:
+        nmdl = pickle.load(ifh)
+
+    assert isinstance(nmdl, TableModel)
+    assert nmdl.name == "test"
+    assert nmdl.filename is None
+    assert nmdl.get_x() == pytest.approx(x)
+    assert nmdl.get_y() == pytest.approx(y)
+    assert nmdl.ampl.val == pytest.approx(-5)
+    assert nmdl.ampl.frozen
+
+    assert nmdl.method is nearest_interp
+
+    assert nmdl(xtest) == pytest.approx(ytest)


### PR DESCRIPTION
# Summary

Fix cache errors with the TableModel class (#1622), add validation of input values, and minor additions to the documentation.

# Details

See #1620 for background, but that includes some possible longer-term changes (eg splitting out the "interpolation" from "non interpolation" models) that need more discussion/thinking about.

The model cache is now cleared whenever `load` is called or the `method` attribute is changed. This fixes #1622. There is a small "optimisation" that could be made (only clearing the cache if the data has changed) but I do not believe it is worth it. There's some discussion to be had over whether caching is useful in this model, at least when interpolation is not in use, but that really needs resolving some of the deeper issues discussed in 1620 and we should take these fixes now.

Following #1477 - which adds validation for the data classes - this PR includes checks for the arguments sent to the `load` method, including: convert to ndarray (which fixes some downstream bugs), ensure 1D, check the lengths match (if both set), and error out if only `x` is set. There are also related checks in `fold` and `calc` to ensure that data has been loaded. In #1477 the errors that were used were essentially already-existing cases (although I forget if I added any), and were `DataErr` exceptions. In this case I elected to raise `ModelErr` exceptions, with similar names to the `DataErr` case. There is an argument to be had that we should rethink the error classes (e.g. go back to things like `ValueError` where appropriate), but that is a completely separate issue and not one that would be easy to resolve.

The `__setstate__` method has been removed as it didn't seem to add anything. It looks like it was intended to support restoring "old" objects written with different attribute names, but the code was present when the git conversion happened, so the changes must have been very old. We have had a number of changes since then (in the Sherpa system) that have likely broken support, so there's no benefit in keeping this particular piece. It's also hard to understand how to map the restored values to the new scheme (e.g. ensuring data is in a ndarray).

The `method` attribute is now defined as such - as a class member - which we then change during `__init__`. This was done for documentation - so that RTD now mentions this attribute - and is a little tricky as if we'd just done `method = linear_interp` then the doctring we wrote would have been clobbered by that from `linear_interp`, which is why the need to set it in `__init__`.

## Examples

Here are some examples of the code behavior before and after this PR.

### Not a ndarray

```
>>> from sherpa.models.basic import TableModel  # main
>>> mdl = TableModel()
>>> mdl.load(None, [1, 2, 3])
>>> mdl([2, 3, 4])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/miniconda3/envs/ciao415-b2-py310/lib/python3.10/site-packages/sherpa/models/model.py", line 652, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
  File "/home/dburke/miniconda3/envs/ciao415-b2-py310/lib/python3.10/site-packages/sherpa/models/model.py", line 442, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
  File "/home/dburke/miniconda3/envs/ciao415-b2-py310/lib/python3.10/site-packages/sherpa/models/basic.py", line 1901, in calc
    return p[0] * self.__y
TypeError: can't multiply sequence by non-int of type 'numpy.float64'
```

This now works:

```
>>> from sherpa.models.basic import TableModel  # this PR
>>> mdl = TableModel()
>>> mdl.load(None, [1, 2, 3])
>>> mdl([2, 3, 4])
array([1., 2., 3.])
```

### Sanity check

```
>>> from sherpa.models.basic import TableModel  # main
>>> mdl = TableModel()
>>> mdl([1, 2, 3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/miniconda3/envs/ciao415-b2-py310/lib/python3.10/site-packages/sherpa/models/model.py", line 652, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
  File "/home/dburke/miniconda3/envs/ciao415-b2-py310/lib/python3.10/site-packages/sherpa/models/model.py", line 442, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
  File "/home/dburke/miniconda3/envs/ciao415-b2-py310/lib/python3.10/site-packages/sherpa/models/basic.py", line 1904, in calc
    (len(self.__y), len(x0)))
TypeError: object of type 'NoneType' has no len()
```

vs

```
>>> from sherpa.models.basic import TableModel  # this PR
>>> mdl = TableModel()
>>> mdl([1, 2, 3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/model.py", line 652, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/model.py", line 442, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/basic.py", line 2059, in calc
    raise ModelErr("The tablemodel's load method must be called first")
sherpa.utils.err.ModelErr: The tablemodel's load method must be called first
```

### cache

This is the original problem. The second `load` should invalidate the cache but it does not. Fortunately we can use non-ndarray values with the main branch

```
>>> from sherpa.models.basic import TableModel  # main
>>> mdl = TableModel()
>>> mdl.load([1, 2, 3], [10, 20, 30])
>>> mdl.ampl = 0.1
>>> mdl([1.5, 2.5])
array([1.5, 2.5])
>>> mdl.load([1, 2, 3], [4, 5, 6])
>>> mdl([1.5, 2.5])
array([1.5, 2.5])
```

vs

```
>>> from sherpa.models.basic import TableModel  # this PR
>>> mdl = TableModel()
>>> mdl.load([1, 2, 3], [10, 20, 30])
>>> mdl.ampl = 0.1
>>> mdl([1.5, 2.5])
array([1.5, 2.5])
>>> mdl.load([1, 2, 3], [4, 5, 6])
>>> mdl([1.5, 2.5])
array([0.45, 0.55])
```

There are other variants of this issue - e.g. when x is `None` and what happens if you change the interpolation method - which have also been fixed and tested.