### PR TITLE
sherpa_test: ensure pytest-xvfb is installed

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -843,12 +843,17 @@ def _install_test_deps():
             raise
 
     deps = ['pytest>=5.0,!=5.2.3']  # List of packages to be installed
-    pytest_plugins = []  # List of pytest plugins to be installed
+    pytest_plugins = ["pytest-xvfb"]  # List of pytest plugins to be installed
 
     # If the plugins are installed "now", pytest won't load them because they are not registered as python packages
     # by the time this code runs. So we need to keep track of the plugins and explicitly pass them to `pytest.main()`.
     # Note that explicitly passing plugins that were already registered would result in an error, hence this
     # complexity seems to be required.
+    #
+    # Is this still needed? A test with Python 3.10/pip 22.1.2
+    # and "pytest-xvfb" failed when "pytest_xvfb" was added to
+    # installed_plugins.
+    #
     installed_plugins = []
 
     for dep in deps:
@@ -863,7 +868,8 @@ def _install_test_deps():
             importlib.import_module(module)
         except ImportError:
             install(plugin_name)
-            installed_plugins.append(module)
+            # See comment above.
+            # installed_plugins.append(mod)
 
     return installed_plugins
 


### PR DESCRIPTION
# Summary

When sherpa_test is called it will ensure that pytest-xdist is installed so that a DS9 window will not be created during the test. 

# Details

Ensure that the xvfb pytest plugin is installed before running the sherpa_test tests. This means that if a user has DS9 installed they will not see DS9 windows pop up during a test. If the user wishes to see the windows appear then they can add the

  --no-xvfb

argument to the sherpa_test call, or run the tests directly with

  pytest --pyargs sherpa

Note that there is some issue in the code for when we have to install pytest-xvfb as part of the test process: should we pass the new module through to pytest.main? The existing code suggests we should, as the module will not have been registered correctly. However, tests shows that the code fails if done like this, so we do not do this. The import code has not been used for a while so it's not clear if this is one or more of

- python version change
- pip change
- underlying build infrastructure change
- something odd with pytest-catchlog when it was available
- ?