### PR TITLE
Update sherpa.astro.utils.xspec for recent changes

### DIFF
--- a/docs/overview/astro_utils_xspec.rst
+++ b/docs/overview/astro_utils_xspec.rst
@@ -13,3 +13,21 @@ The sherpa.astro.utils.xspec module
 
       create_xspec_code
       parse_xspec_model_description
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      XSPECcode
+      ModelDefinition
+      AddModelDefinition
+      MulModelDefinition
+      ConModelDefinition
+      MixModelDefinition
+      AcnModelDefinition
+      AmxModelDefinition
+      ParameterDefinition
+      BasicParameterDefinition
+      SwitchParameterDefinition
+      ScaleParameterDefinition

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -356,7 +357,11 @@ kT      keV     1.    0.008   0.008   64.0      64.0      .01
     assert "        self.norm = Parameter(name, 'norm', 1.0, min=0.0, max=1e+24, hard_min=0.0, hard_max=1e+24)" in python
     assert '        XSAdditiveModel.__init__(self, name, (self.kT,self.norm))' in python
 
-    assert converted.compiled.find('\nextern "C" {\n\n}\n') > -1
+    assert 'extern "C" {' in compiled
+    assert "  xsCCall apec;" in compiled
+    assert "  void C_apec(const double* energy, int nFlux, " in converted.compiled
+    assert "{\n    cppModelWrapper(energy, nFlux, " in converted.compiled
+    assert ", initStr, 1, apec);\n" in converted.compiled
     assert '  XSPECMODELFCT_C_NORM(C_apec, 2),' in compiled
 
 
@@ -382,7 +387,7 @@ nH      cm^-3   1.0   1.e-6  1.e-5  1.e19  1.e20   -0.01
     assert "        self.nH = XSParameter(name, 'nH', 1.0, min=1e-05, max=1e+19, hard_min=1e-06, hard_max=1e+20, frozen=True, units='cm^-3')" in python
     assert '        XSMultiplicativeModel.__init__(self, name, (self.nH,))' in python
 
-    assert '  void foos_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);' in compiled
+    assert '  xsf77Call foos_;' in compiled
     assert '  XSPECMODELFCT(foos, 1),' in compiled
 
 
@@ -408,7 +413,7 @@ order    " "  -1.   -3.    -3.      -1.       -1.       -1
     assert "        self.order = XSParameter(name, 'order', -1.0, min=-3.0, max=-1.0, hard_min=-3.0, hard_max=-1.0, frozen=True)" in python
     assert '        XSConvolutionKernel.__init__(self, name, (self.order,))' in python
 
-    assert '  void rgsxsrc_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);' in compiled
+    assert '  xsf77Call rgsxsrc_;' in compiled
     assert '  XSPECMODELFCT_CON_F77(rgsxsrc, 1),' in compiled
 
 

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -1041,6 +1041,7 @@ def create_xspec_code(models):
     #
     mdls = []
     langs = set()
+    requires_warnings = False
     for mdl in models:
         if mdl.modeltype in ['Mix', 'Acn']:
             warning(f"Skipping {mdl.name} as model type = {mdl.modeltype}")
@@ -1057,9 +1058,11 @@ def create_xspec_code(models):
         if nflags > 0:
             if mdl.flags[0] == 1:
                 warning(f"{mdl.name} calculates model variances; this is untested/unsupported in Sherpa")
+                requires_warnings = True
 
             if nflags > 1 and mdl.flags[1] == 1:
                 warning(f"{mdl.name} needs to be re-calculated per spectrum; this is untested.")
+                requires_warnings = True
 
         langs.add(mdl.language)
         mdls.append(mdl)
@@ -1071,5 +1074,12 @@ def create_xspec_code(models):
     out = namedtuple('XSPECcode', ['python', 'compiled'])
 
     out.python = "\n\n".join([model_to_python(mdl) for mdl in mdls])
+
+    # Do we need to import the warnings module? It breaks Python
+    # best-practices to put it here, but it should at least work.
+    #
+    if requires_warnings:
+        out.python = "import warnings\n" + out.python
+
     out.compiled = models_to_compiled(mdls)
     return out

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -58,7 +58,8 @@ class ModelDefinition():
        The class name used to represent this model in Sherpa.
     funcname : str
        The name of the function from the model file (so it should
-       include any prefix like C_).
+       include any prefix like C_, and the case given in the model
+       file, as these will be processed during initialisation).
     flags : sequence of int
        The flags value.
     elo : float
@@ -101,9 +102,12 @@ class ModelDefinition():
         #
         # The use of strings for the language is not ideal; really
         # should use some form of an enumeration.
+        #
+        # Note that we use lower-case for Fortran model names.
+        #
         if self.funcname.startswith('F_'):
             self.language = 'Fortran - double precision'
-            self.funcname = self.funcname[2:]
+            self.funcname = self.funcname[2:].lower()
         elif self.funcname.startswith('c_'):
             self.language = 'C style'
             self.funcname = self.funcname[2:]
@@ -112,6 +116,7 @@ class ModelDefinition():
             self.funcname = self.funcname[2:]
         else:
             self.language = 'Fortran - single precision'
+            self.funcname = self.funcname.lower()
 
         if initString is not None and self.language.startswith('F'):
             initString = None

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -996,7 +996,7 @@ def models_to_compiled(mdls):
     out += f'{defcode}\n}}\n\n// Wrapper\n\n'
     out += 'static PyMethodDef Wrappers[] = {\n'
     out += f'{wrapcode}'
-    out += '\n  { NULL, NULL, 0, NULL }\n}\n'
+    out += '\n  { NULL, NULL, 0, NULL }\n};\n'
     return out
 
 

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2020, 2021
+#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -819,7 +819,7 @@ def simple_wrap(modelname, mdl):
             out += "(variances are calculated by the model) is untested.')\n"
 
         if nflags > 1 and mdl.flags[1] == 1:
-            out += "{t2}warnings.warn('support for models like {mdl.clname.lower()} "
+            out += f"{t2}warnings.warn('support for models like {mdl.clname.lower()} "
             out += "(recalculated per spectrum) is untested.')\n"
 
     out += f"{t2}XS{modelname}.__init__(self, name, {pstr})\n"


### PR DESCRIPTION
Will probably wait until CIAO 4.15 is released before I ask for this to be reviewed (as I need to check it works well with the CIAO 4.15 code, and that'll be a lot easier next year).

# Summary

Update the sherpa.astro.utils.xspec code to better support compiling XSPEC user models for use in Sherpa (fixes several bugs).

# Details

The code generated by the sherpa.astro.utils.xspec module had a few issues

a) outright errors, like a missing ';', a string that should have been interpolated that was not, and importing the warnings module when needed
b) updates needed because of recent changes to the XSPEC interface code
c) FORTRAN is case insensitive, so it looks like the symbols get converted to lowercase in the API which is an issue if a model name is mixed-case, as it is in at least one XSPEC user model; we avoid this now by making the names be lower case
d) ensure that C and C++ models are also declared (and the C++ models use the XSPEC-internal-ish cppModelWrapper routine to handle the conversion between C++ and C interfaces)

These have mostly been found (or taken from) the `convert_xspec_user_model` code (which is where this code came from in the first case).

I have also taken the time to add typing annotations and to move to use a dataclass rather than a namedtuple. As most of this code is internal to the module it should not cause an issue for users.