### PR TITLE
Note when a XSPEC model is changed to F77 form (double precision)

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -346,7 +346,11 @@ XSPEC 12.12.0 (released in HEASOFT 6.29) support was added::
    There can be other output due to parameter-value changes
    which are also important to review but this is just focussing
    on the list of models that could be added to
-   :py:mod:`sherpa.astro.xspec`
+   :py:mod:`sherpa.astro.xspec`.
+
+   The screen output may differ slightly from that shown above, such
+   as including the interface used by the model (e.g. C, C++,
+   FORTRAN).
 
 The code needed to add support for the wdem module can be found with::
 

--- a/scripts/check_xspec_update.py
+++ b/scripts/check_xspec_update.py
@@ -68,7 +68,7 @@ def compare_xspec_models(models, hard=True):
         try:
             xscls = getattr(xspec, mdl.clname)
         except AttributeError:
-            print(f"We do not support {mdl.name} ({mdl.modeltype}; {mdl.funcname})\n")
+            print(f"We do not support {mdl.name} ({mdl.modeltype}; {mdl.language}; {mdl.funcname})\n")
             continue
 
         seen.add(mdl.clname)
@@ -96,9 +96,14 @@ def compare_xspec_models(models, hard=True):
         #
         reports = []
 
+        # parse_xspec_user_model has removed the "language-type" flags
+        # on the function name, so we need to restore them.
+        #
         funcname = mdl.funcname
         if mdl.language == 'C++ style':
             funcname = f'C_{funcname}'
+        elif mdl.language == "Fortran - double precision":
+            funcname = f"F_{funcname}"
 
         if xs._calc.__name__ != funcname:
             reports.append(f"function name change: {xs._calc.__name__} to {funcname}")


### PR DESCRIPTION
# Summary

Update a script used when updating the XSPEC support to point out models that use the double-precision FORTRAN support. There is no functional change to the code.

# Details

The model "name" stored in the model.dat file includes information on the interface type of the model, in a form of Hungarian notation [1], but the parse_xspec_model_description routine strips this out, storing the information as a free-form string in the language field of the model (I should really have used an ENUM but decided to use a string). We already recognized this when checking C++ models, but did not for the F77 models (FORTRAN double precision). We now do, and points out that, as of XSPEC 12.12.0, we now have models that progice a double-precision FORTRAN model. At the moment we do not support these models (and are unlikely to do so for the 4.16.0 release), but it would be nice to reminded we need to look at adding support.

Note that the three "double precision FORTRAN" models currently use the single precision version of the model that the XSPEC library provides.

[1] https://en.wikipedia.org/wiki/Hungarian_notation

# Example

Before this change, the XSPEC 12.13.1 file reports

```
% ./scripts/check_xspec_update.py /lagado.real/local/heasoft-6.32/spectral/manager/model.dat | grep "change" 
```

It now reports

```
% ./scripts/check_xspec_update.py /lagado.real/local/heasoft-6.31/spectral/manager/model.dat | grep "change" 
  [ 1] function name change: ismabs to F_ismabs
  [ 1] function name change: ismdust to F_ismdust
  [ 1] function name change: olivineabs to F_olivineabs
```

Thanks to how XSPEC is set up - it creates wrappers to handle calling a model as if it were a different type of model [at least for some cases] - we can still use the models even with these apparent differences. We just may be losing precision or doing more work than we need to.