### PR TITLE
Add support for XSPEC 12.13.0

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -296,7 +296,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.12.1 down to 12.12.0. It may build against
+:term:`XSPEC` versions 12.13.0, 12.12.1, and 12.12.0. It may build against
 newer versions, but if it does it will not provide access to any new
 models in the release. The following sections of the `XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,4 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.12.1 and 12.12.0.
+       Sherpa can be built to use XSPEC versions 12.13.0, 12.12.1, and
+       12.12.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -249,7 +249,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.12.1 system has been built then use::
+1. If the full XSPEC 12.13.0 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.13.0
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.31
+       ccfits_libraries = CCfits_2.6
+       wcslib_libraries = wcs-7.7
+
+   where the version numbers were taken from version 6.31 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.12.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.1
@@ -262,7 +275,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.30.1 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.12.0 system has been built then use::
+3. If the full XSPEC 12.12.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.0
@@ -275,7 +288,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.29 of HEASOFT and
    may need updating with a newer release.
 
-3. If the model-only build of XSPEC - created with the
+4. If the model-only build of XSPEC - created with the
    ``--enable-xs-models-only`` flag when building HEASOFT - has been
    installed, then the configuration is similar, but the library names
    may not need version numbers and locations, depending on how the
@@ -300,7 +313,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.12.0
+    12.13.0
 
 Other options
 ^^^^^^^^^^^^^

--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -52,6 +52,7 @@ The sherpa.astro.xspec module
       XScevmkl
       XScflow
       XScflux
+      XScglumin
       XSclumin
       XScompLS
       XScompPS
@@ -240,5 +241,5 @@ Class Inheritance Diagram
 .. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipcf
    :parts: 1
 
-.. inheritance-diagram:: XScflux XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift
+.. inheritance-diagram:: XScflux XScglumin XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift
    :parts: 1

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2017, 2018, 2020, 2021, 2022
+#  Copyright (C) 2014-2017, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -28,7 +28,8 @@ from .extensions import build_ext
 # major, minor, and micro. We drop the patch level - e.g.
 # "c" in "12.12.0c" as that is not helpful to track here.
 #
-SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1)]
+SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
+                      (12, 13, 0)]
 
 
 # We could use packaging.versions.Version here, but for our needs we

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -961,6 +961,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(C_xscatmodel, 4),
 
   XSPECMODELFCT_CON(C_clumin, 4),
+#ifdef XSPEC_12_13_0
+  XSPECMODELFCT_CON(C_cglumin, 4),
+#endif
   XSPECMODELFCT_CON(C_rfxconv, 5),
   XSPECMODELFCT_CON(C_vashift, 1),
   XSPECMODELFCT_CON(C_vmshift, 1),

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -36,7 +36,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 230
+XSPEC_MODELS_COUNT = 231
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021
+#  Copyright (C) 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -43,6 +43,7 @@ from sherpa.astro import ui
 # as well as the number of thawed and frozen parameters.
 #
 XSPEC_CON_MODELS = [('cflux', 1, 2),
+                    ('cglumin', 1, 3),
                     ('clumin', 1, 3),
                     ('cpflux', 1, 2),
                     ('gsmooth', 1, 1),


### PR DESCRIPTION
# Summary

Add explicit support for XSPEC 12.13.0. Sherpa can be built against XSPEC 12.13.0 without this PR, but this adds in support for the new `cglumin` convolution model added in this release.

# Details

Built on #1609, which means that only the last commit is part of this PR. Recent merges have simplified the history of this PR and there's no-need to work-around some differences with the conda build of XSPEC we use for testing, as well as having recent versions of XSPEC available for testing, including on macOS.

This adds "official" support for building with XSPEC 12.13.0 - that is, the build will not warn you that the version is unknown - and adds support for the cglumin convolution model (as long as you have 12.13.0 or later). Fortunately the changes aren't huge.