### PR TITLE
Ignore bad clarification

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1623,6 +1623,8 @@ class DataPHA(Data1D):
 
         self.bin_lo = None
         self.bin_hi = None
+
+        self.quality_filter = None
         self.quality = _check(quality)
         self.grouping = _check(grouping)
         self.exposure = exposure
@@ -1661,7 +1663,6 @@ class DataPHA(Data1D):
         self._rate = True
         self._plot_fac = 0
         self.units = "channel"
-        self.quality_filter = None
         super().__init__(name, channel, counts, staterror, syserror)
 
         # special-case the labels
@@ -1856,8 +1857,13 @@ will be removed. The identifiers can be integers or strings.
                      ) -> None:
         ...
 
-    def _set_related(self, attr, val, check_mask=True,
-                     allow_scalar=False, **kwargs):
+    def _set_related(self,
+                     attr: str,
+                     val: float | ArrayType | None,
+                     check_mask: bool = True,
+                     allow_scalar: bool = False,
+                     **kwargs
+                     ) -> None:
         """Set a field that must match the independent axes size.
 
         The value can be None, a scalar (if allow_scalar is set), or
@@ -2090,6 +2096,11 @@ will be removed. The identifiers can be integers or strings.
         # quality_filter?
         #
         self._set_related("quality", val)
+        if self.quality_filter is not None:
+            # This needs re-wording
+            warning("The ignore_bad() call has been removed as quality has changed")
+
+        self.quality_filter = None
 
     # It is unclear exactly what the quality_filter is meant to
     # represent, so as part of improving support for ignore_bad, add
@@ -6409,4 +6420,3 @@ class DataIMGInt(DataIMG):
         x0hi, x1hi = convert(x0hi, x1hi)
 
         return (x0lo, x1lo, x0hi, x1hi)
-

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2391,32 +2391,6 @@ def test_pha_quality_bad_filter_remove(make_test_pha):
     assert pha.get_filter() == "2:4"
 
 
-@pytest.mark.parametrize("field,expected",
-                         [("channel", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
-                          ("counts", [1, 2, 0, 3, 12, 2, 9, 8, 7]),
-                          ("grouping", [1, -1, -1, -1, 1, 1, 1, -1, -1]),
-                          ("quality", [0, 5, 5, 0, 0, 0, 2, 2, 5])
-                          ])
-def test_pha_quality_bad_field(field, expected, make_quality_pha):
-    """After ignore_bad what does the field return?"""
-
-    pha = make_quality_pha
-    assert getattr(pha, field) == pytest.approx(expected)
-
-    pha.ignore_bad()
-    assert getattr(pha, field) == pytest.approx(expected)
-
-
-def test_pha_quality_bad_mask(make_quality_pha):
-    """What does the mask look like?"""
-
-    pha = make_quality_pha
-    assert pha.mask is True
-
-    pha.ignore_bad()
-    assert pha.mask is True
-
-
 def test_pha_quality_bad_mask_grouped(make_quality_pha):
     """What does the mask look like?"""
 
@@ -2426,26 +2400,7 @@ def test_pha_quality_bad_mask_grouped(make_quality_pha):
     assert pha.mask is True
 
 
-def test_pha_quality_bad_get_mask(make_quality_pha):
-    """What does the get_mask() look like?"""
 
-    pha = make_quality_pha
-    assert pha.get_mask() == pytest.approx([1] * 9)
-
-    pha.ignore_bad()
-    assert pha.get_mask() == pytest.approx([1, 0, 0, 1, 1, 1, 0, 0, 0])
-
-
-def test_pha_no_quality_ignore_bad(make_test_pha):
-    """What happens if call ignore_bad and no quality data"""
-
-    pha = make_test_pha
-    with pytest.raises(DataErr,
-                       match="^data set 'p' does not specify quality flags$"):
-        pha.ignore_bad()
-
-
-@requires_group
 def test_pha_change_quality_values(caplog):
     """What happens if we change the quality column?
 
@@ -2482,6 +2437,138 @@ def test_pha_change_quality_values(caplog):
     assert pha.quality_filter == pytest.approx(qfilt)
     assert pha.get_dep(filter=True) == pytest.approx([4, 2])
     assert pha.get_filter() == '1:7'
+
+    # Do we provide any logging information?
+    #
+    assert len(caplog.record_tuples) == 0
+
+
+def test_pha_group_adapt_check(caplog):
+    """Found when testing ignore_bad so added as a test case.
+
+    This is a regression test since the existing behaviour is not
+    obvious.
+    """
+
+    pha = DataPHA('ex', [1, 2, 3, 4, 5, 6, 7], [4, 2, 3, 1, 5, 6, 7])
+    pha.group_adapt(6)
+
+    assert pha.quality_filter is None
+    assert pha.get_dep(filter=True) == pytest.approx([6, 3, 6, 6, 7])
+    # TODO: why is the last element 2 not 0 here?
+    assert pha.quality == pytest.approx([0, 0, 2, 0, 0, 0, 2])
+    assert pha.get_filter() == '1:7'
+
+    assert len(caplog.record_tuples) == 0
+
+
+def test_pha_ignore_bad_then_filter(caplog):
+    """Check what happens with ignore_bad then filters"""
+
+    pha = DataPHA('ex', [1, 2, 3, 4, 5, 6, 7], [4, 2, 3, 1, 5, 6, 4])
+    assert pha.mask is True
+    assert pha.quality_filter is None
+    assert pha.get_filter() == '1:7'
+
+    pha.group_adapt(6)
+    assert pha.mask is True
+    assert pha.quality_filter is None
+
+    pha.ignore_bad()
+
+    assert pha.mask is True
+    assert pha.get_mask() == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.quality_filter == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.get_dep(filter=True) == pytest.approx([6, 6, 6])
+    assert pha.quality == pytest.approx([0, 0, 2, 0, 0, 0, 2])
+    assert pha.get_filter() == '1:7'  # TODO: should this have changed?
+
+    pha.ignore(4, 5)
+
+    print(pha.get_mask())
+    assert pha.mask == pytest.approx([1, 0, 1])
+    assert pha.get_mask() == pytest.approx([1, 1, 0, 0, 1])
+    assert pha.quality_filter == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.get_dep(filter=True) == pytest.approx([6, 6])
+    assert pha.quality == pytest.approx([0, 0, 2, 0, 0, 0, 2])
+    assert pha.get_filter() == '1:2,6'
+
+    assert len(caplog.record_tuples) == 0
+
+
+def test_pha_ignore_bad_then_group(caplog):
+    """Check what happens with ignore_bad then a second group call"""
+
+    pha = DataPHA('ex', [1, 2, 3, 4, 5, 6, 7], [4, 2, 3, 1, 5, 6, 4])
+    pha.group_adapt(6)
+    pha.ignore_bad()
+
+    # Since there's bad channels this grouping should behave
+    # differently to when there's been no such ignore_bad call.
+    #
+    pha.group_counts(4)
+
+    assert pha.mask is True
+    assert pha.get_mask() == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.quality_filter == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 6, 6])
+    assert pha.quality == pytest.approx([0, 2, 0, 0, 0, 0, 0])
+    assert pha.get_filter() == '1:7'  # TODO: should this have changed?
+
+    # Will this apply the new quality values?
+    pha.ignore_bad()
+
+    assert pha.mask is True
+    assert pha.get_mask() == pytest.approx([1, 0, 1, 1, 1, 1, 1])
+    assert pha.quality_filter == pytest.approx([1, 0, 1, 1, 1, 1, 1])
+    assert pha.get_dep(filter=True) == pytest.approx([4, 3, 6, 6, 4])
+    assert pha.quality == pytest.approx([0, 2, 0, 0, 0, 0, 0])
+    assert pha.get_filter() == '1:7'  # TODO: should this have changed?
+
+    assert len(caplog.record_tuples) == 0
+
+
+def test_pha_filter_ignore_bad_filter(caplog):
+    """Check what happens with ignore_bad within filter calls"""
+
+    pha = DataPHA('ex', [1, 2, 3, 4, 5, 6, 7], [4, 2, 3, 1, 5, 6, 4])
+
+    pha.ignore(lo=4, hi=4)
+    assert len(caplog.record_tuples) == 0
+
+    assert pha.mask == pytest.approx([1, 1, 1, 0, 1, 1, 1])
+    assert pha.get_mask() == pytest.approx([1, 1, 1, 0, 1, 1, 1])
+    assert pha.quality_filter is None
+    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 3, 5, 6, 4])
+    assert pha.quality is None
+    assert pha.get_filter() == '1:3,5:7'
+
+    pha.group_counts(5)
+    assert len(caplog.record_tuples) == 0
+    pha.ignore_bad()
+    assert len(caplog.record_tuples) == 1
+    assert caplog.record_tuples[0][0] == "sherpa.astro.data"
+    assert caplog.record_tuples[0][1] == logging.WARNING
+    assert caplog.record_tuples[0][2] == "filtering grouped data with quality flags, previous filters deleted"
+
+    assert pha.mask is True  # TODO: is this expected?
+    assert pha.get_mask() == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.quality_filter == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.get_dep(filter=True) == pytest.approx([6, 1, 5, 6])
+    assert pha.quality == pytest.approx([0, 0, 2, 0, 0, 0, 2])
+    assert pha.get_filter() == '1:7'  # TODO: is this expected?
+
+    pha.ignore(lo=2, hi=2)
+    assert len(caplog.record_tuples) == 1
+
+    assert pha.mask == pytest.approx([0, 1, 1, 1])
+    assert pha.get_mask() == pytest.approx([0, 0, 1, 1, 1])
+    assert pha.quality_filter == pytest.approx([1, 1, 0, 1, 1, 1, 0])
+    assert pha.get_dep(filter=True) == pytest.approx([1, 5, 6])
+    assert pha.quality == pytest.approx([0, 0, 2, 0, 0, 0, 2])
+    assert pha.get_filter() == '4:6'  # TODO: is this expected?
+
+    assert len(caplog.record_tuples) == 1
 
 
 @requires_group
@@ -3154,6 +3241,8 @@ def test_quality_pha_fields(field, expected, make_quality_pha):
     # fake in a backscal array but scalar areascal
     pha.areascal = 0.9
     pha.backscal = [0.2, 99, 98, 0.4, 0.5, 0.6, 2, 3, 4]
+
+    assert getattr(pha, field) == pytest.approx(expected)
 
     pha.ignore_bad()
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2428,19 +2428,23 @@ def test_pha_change_quality_values(caplog):
     # With no tabStops set it uses ~pha.get_mask() which in this case
     # is [False] * 5 + [True] * 2,
     #
-    pha.group_counts(4)
-    assert len(caplog.records) == 0
+    assert len(caplog.record_tuples) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        pha.group_counts(4)
 
     assert pha.quality == pytest.approx([0, 0, 0, 2, 2, 0, 0])
 
     # Should quality filter be reset?
-    assert pha.quality_filter == pytest.approx(qfilt)
-    assert pha.get_dep(filter=True) == pytest.approx([4, 2])
+    assert pha.quality_filter is None
+    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 2, 1])
     assert pha.get_filter() == '1:7'
 
-    # Do we provide any logging information?
+    # check captured log
     #
-    assert len(caplog.record_tuples) == 0
+    emsg = "The ignore_bad() call has been removed as quality has changed"
+    assert caplog.record_tuples == [
+        ("sherpa.astro.data", logging.WARNING, emsg)
+        ]
 
 
 def test_pha_group_adapt_check(caplog):
@@ -2509,9 +2513,9 @@ def test_pha_ignore_bad_then_group(caplog):
     pha.group_counts(4)
 
     assert pha.mask is True
-    assert pha.get_mask() == pytest.approx([1, 1, 0, 1, 1, 1, 0])
-    assert pha.quality_filter == pytest.approx([1, 1, 0, 1, 1, 1, 0])
-    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 6, 6])
+    assert pha.get_mask() == pytest.approx([True] * 7)
+    assert pha.quality_filter is None
+    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 3, 6, 6, 4])
     assert pha.quality == pytest.approx([0, 2, 0, 0, 0, 0, 0])
     assert pha.get_filter() == '1:7'  # TODO: should this have changed?
 
@@ -2525,7 +2529,12 @@ def test_pha_ignore_bad_then_group(caplog):
     assert pha.quality == pytest.approx([0, 2, 0, 0, 0, 0, 0])
     assert pha.get_filter() == '1:7'  # TODO: should this have changed?
 
-    assert len(caplog.record_tuples) == 0
+    # check captured log
+    #
+    emsg = "The ignore_bad() call has been removed as quality has changed"
+    assert caplog.record_tuples == [
+        ("sherpa.astro.data", logging.WARNING, emsg)
+        ]
 
 
 def test_pha_filter_ignore_bad_filter(caplog):
@@ -2659,22 +2668,28 @@ def test_pha_group_ignore_bad_then_group(caplog):
     # quality" data?
     #
     pha.group_counts(4)
-    assert len(caplog.records) == 0
+
+    # check captured log
+    #
+    emsg = "The ignore_bad() call has been removed as quality has changed"
+    assert caplog.record_tuples == [
+        ("sherpa.astro.data", logging.WARNING, emsg)
+        ]
 
     assert pha.mask is True
-    assert pha.get_mask() == pytest.approx(qual_mask)
+    assert pha.get_mask() == pytest.approx([True] * 7)
     assert pha.get_filter() == '1:7'
-    assert pha.quality_filter == pytest.approx(qual_mask)
+    assert pha.quality_filter is None
     assert pha.quality == pytest.approx([0, 2, 0, 0, 0, 0, 0])
     assert pha.get_dep(filter=False) == pytest.approx(counts)
-    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 6, 6])
+    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 3, 6, 6, 7])
 
     # Shouldn't this be a no-op. It isn't because the group call
     # didn't change the quality_filter array, so it now changes what
     # are the good/bad channels.
     #
     pha.ignore_bad()
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 1  # should not have changed
 
     qual_mask = np.asarray([True] + [False] + [True] * 5)
     assert pha.mask is True

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3264,15 +3264,21 @@ def test_pha_group_ignore_bad_group(caplog, clean_astro_ui):
     assert ui.get_dep(filter=True) == pytest.approx([3.5, 4])
 
     ui.group_counts(3)
-    assert len(caplog.records) == 4
+    assert len(caplog.records) == 5
 
-    assert ui.get_dep(filter=False) == pytest.approx([5, 2, 4])
-    assert ui.get_dep(filter=True) == pytest.approx([5, 2, 4])
+    assert ui.get_dep(filter=False) == pytest.approx([5, 2, 3, 4, 55])
+    assert ui.get_dep(filter=True) == pytest.approx([5, 2, 3, 4, 55])
 
     r = caplog.records[3]
+    assert r.name == "sherpa.astro.data"
+    assert r.levelname == "WARNING"
+    assert r.getMessage() == "The ignore_bad() call has been removed as quality has changed"
+
+    r = caplog.records[4]
     assert r.name == "sherpa.ui.utils"
     assert r.levelname == "INFO"
     assert r.getMessage() == "dataset 1: 1:5 Channel (unchanged)"
+
 
 
 def test_pha_group_filter_ignore_bad_group(caplog, clean_astro_ui):


### PR DESCRIPTION
It only really helps for grouped data; if the data is not grouped then resetting the quality array does not reset things **because** in this case we just piggy-back onto the mask system so you can't "remove" the bad-quality filter.

I also want to add in checks for the quality_filter array and think about what it means to ignore channels within a group.

**note to self** should we always apply the `quality_filter` setting (when set) to the `mask` field (technically get_mask) ? I was thinking we could xor it out when removing/changing it, but that doesn't work (as it's always removed). Perhaps we need an explicit mask field separate from the one changed by notice/ignore? However, still need to think about what happens when grouping - e.g. are the bad-quality channels just ignored [then make the widths harder to track] or do they always cause a group to start/end?