### PR TITLE
Allow arbitrary functions for linking parameters

### DIFF
--- a/docs/model_classes/usermodel.rst
+++ b/docs/model_classes/usermodel.rst
@@ -11,7 +11,7 @@ external code.
 
    There should be some description of what needs to be done, as well
    as examples.
-   Does the 1D example need to be cleaned up to separate out unnescessary code,
+   Does the 1D example need to be cleaned up to separate out unnecessary code,
    perhaps just hiding the setup code (and it would be nice if
    this could be shared with the setup).
    Should the 2D example add commentary to point out the following

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -438,14 +438,14 @@ can be used in the linking expression, for example::
 
 This includes many commonly used mathematical and trigonometric functions
 such as log, exp, sin, cos, which allows building quite complex parameter
-linkage. Only the numpy versions work here, but not the functions from the
+linkage. Only the numpy versions work here, **not** the functions from the
 build-in ``math`` module, so use `numpy.exp` instead of `math.exp`.
 Many more complex functions are available in
 `scipy.special <https://docs.scipy.org/doc/scipy/reference/special.html>`_;
 any arbitrary Python function can be turned into a ufunc with
 `numpy.frompyfunc <https://numpy.org/doc/stable/reference/generated/numpy.frompyfunc.html#numpy.frompyfunc>`_
 and the interface is also available for
-`C extensions <https://numpy.org/doc/stable/user/c-info.ufunc-tutorial.html#creating-a-new-universal-function>`.
+`C extensions <https://numpy.org/doc/stable/user/c-info.ufunc-tutorial.html#creating-a-new-universal-function>`_.
 However, if such complex expressions are required to link model parameters
 together, it might be better to write a
 :ref:`dedicated user model <usermodel>` that describes the data with the
@@ -460,7 +460,7 @@ turning values of parameters into arrays (Sherpa optimisers can only deal
 with scalar parameters.) In practice, such mistakes
 are easy to spot when displaying a model; because Sherpa is meant to be
 a general and flexible modelling application that works with (almost)
-arbitrary user-defined models, the code puts as few a-priory restrictions
+arbitrary user-defined models, the code puts as few restrictions
 as possible on the functions used for linking parameters.
 
 .. _parameter_reset:

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -34,7 +34,7 @@ be set. In this case a one-dimensional gaussian using the
 A description of the model is provided by ``help(g)``.
 
 The parameter values have a current value, a valid range
-(as given by the the minimum and maximum columns in the table above),
+(as given by the minimum and maximum columns in the table above),
 and a units field. The units field is a string, describing the
 expected units for the parameter; there is currently *no support* for
 using `astropy.units
@@ -125,7 +125,7 @@ Changing a parameter
 
 The parameters of a model - those numeric variables that control the
 shape of the model, and that can be varied during a fit -
-can be accesed as attributes, both to read or change
+can be accessed as attributes, both to read or change
 the current settings. The
 :py:attr:`~sherpa.models.parameter.Parameter.val` attribute
 contains the current value::
@@ -220,7 +220,7 @@ values as the hard limits.
 Setting a parameter to a value outside its soft limits will
 raise a :py:exc:`~sherpa.utils.err.ParameterErr` exception.
 
-During a fit the paramater values are bound by the soft limits,
+During a fit the parameter values are bound by the soft limits,
 and a screen message will be displayed if an attempt to move
 outside this range was made. During error analysis the parameter
 values are allowed outside the soft limits, as long as they remain
@@ -233,7 +233,7 @@ Guessing a parameter's value from the data
 
 Sherpa models have a
 :py:meth:`~sherpa.models.model.Model.guess`
-method which is used to seed the paramters (or
+method which is used to seed the parameters (or
 parameter) with values and
 :ref:`soft-limit ranges <params-limits>`
 which match the data.
@@ -334,10 +334,10 @@ related to another: this can be equality, such as saying that
 the width of two model components are the same, or a functional
 form, such as saying that the position of one component is a
 certain distance away from another component. This concept
-is refererred to as linking parameter values. The second case
-incudes the first - where the functional relationship is equality -
+is referred to as linking parameter values. The second case
+includes the first - where the functional relationship is equality -
 but it is treated separately here as it is a common operation.
-Lnking parameters also reduces the number of free parameters in a fit.
+Linking parameters also reduces the number of free parameters in a fit.
 
 The following examples use the same two model components::
 
@@ -426,6 +426,42 @@ directly, it should be multiplied by zero. So, for this example
 the model to be fit would be given by an expression like::
 
    >>> mdl = g1 + g2 + 0 * sep
+
+Complex functional relationships
+--------------------------------
+
+Any `numpy universal function ("ufunc") <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs>`_
+can be used in the linking expression, for example::
+
+    >>> import numpy as np
+    >>> g2.ampl = np.cos(g1.ampl)
+
+This includes many commonly used mathematical and trigonometric functions
+such as log, exp, sin, cos, which allows building quite complex parameter
+linkage. Only the numpy versions work here, but not the functions from the
+build-in ``math`` module, so use `numpy.exp` instead of `math.exp`.
+Many more complex functions are available in
+`scipy.special <https://docs.scipy.org/doc/scipy/reference/special.html>`_;
+any arbitrary Python function can be turned into a ufunc with
+`numpy.frompyfunc <https://numpy.org/doc/stable/reference/generated/numpy.frompyfunc.html#numpy.frompyfunc>`_
+and the interface is also available for
+`C extensions <https://numpy.org/doc/stable/user/c-info.ufunc-tutorial.html#creating-a-new-universal-function>`.
+However, if such complex expressions are required to link model parameters
+together, it might be better to write a
+:ref:`dedicated user model <usermodel>` that describes the data with the
+appropriate parameters in the first place.
+
+Not every possible link function makes sense
+--------------------------------------------
+
+With this flexibility, it is possible to define links that make no sense,
+for example taking the logical not of a parameter that represents a mass or
+turning values of parameters into arrays (Sherpa optimisers can only deal
+with scalar parameters.) In practice, such mistakes
+are easy to spot when displaying a model; because Sherpa is meant to be
+a general and flexible modelling application that works with (almost)
+arbitrary user-defined models, the code puts as few a-priory restrictions
+as possible on the functions used for linking parameters.
 
 .. _parameter_reset:
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1791,3 +1791,33 @@ def test_restore_xspec_hard_limit_max():
     assert not mdl.PhoIndex.frozen
 
     assert mdl.norm.max == pytest.approx(100)
+
+
+def test_restore_linker_parameter_with_function(clean_astro_ui):
+    """Check we can save and restore a numpy ufunc"""
+
+    m1 = ui.create_model_component("gauss1d", "m1")
+    m2 = ui.create_model_component("scale1d", "m2")
+
+    delta = numpy.sqrt((m2.c0 - 23)**2)
+    m1.fwhm = 2 * numpy.exp(delta / 14)
+
+    m2.c0 = 30
+
+    expected = 2 * numpy.exp(0.5)
+
+    # safety check
+    assert m1.fwhm.link is not None
+    assert m1.fwhm.val == pytest.approx(expected)
+
+    restore()
+
+    got = ui.list_model_components()
+    assert len(got) == 2
+    assert "m1" in got
+    assert "m2" in got
+
+    mm1 = ui.get_model_component("m1")
+    assert mm1.name == "gauss1d.m1"
+    assert mm1.fwhm.link is not None
+    assert mm1.fwhm.val == pytest.approx(expected)

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2017, 2020, 2021, 2022
+#  Copyright (C) 2007, 2017, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -647,10 +647,20 @@ class Parameter(NoNewAttributesAfterInit):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if not method == '__call__':
             return NotImplemented
+        if hasattr(numpy, ufunc.__name__):
+            name = f"numpy.{ufunc.__name__}"
+        else:
+            # Unfortunately, there is no ufunc.__module__ we could use
+            # This could be a ufinc from e.g. scipy or generated from an
+            # arbitrary Python function with numpy.frompyfunc.
+            # In the latter case, the name will be something like
+            # "func (vectorized)", which looks confusing in out string
+            # represenantion, so we simplify it.
+            name = ufunc.__name__.replace(' (vectorized)', '')
         if ufunc.nin == 1:
-            return UnaryOpParameter(inputs[0], ufunc, ufunc.__name__)
+            return UnaryOpParameter(inputs[0], ufunc, name)
         if ufunc.nin == 2:
-            return BinaryOpParameter(inputs[0], inputs[1], ufunc, ufunc.__name__,
+            return BinaryOpParameter(inputs[0], inputs[1], ufunc, name,
                                      strformat='{opstr}({lhs}, {rhs})')
         return NotImplemented
 

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2017, 2020, 2021
+#  Copyright (C) 2007, 2017, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -257,18 +257,18 @@ def _make_set_limit(name):
     return _set_limit
 
 
-def _make_unop(op, opstr):
+def _make_unop(op, opstr, **kwargs):
     def func(self):
-        return UnaryOpParameter(self, op, opstr)
+        return UnaryOpParameter(self, op, opstr, **kwargs)
     return func
 
 
-def _make_binop(op, opstr):
+def _make_binop(op, opstr, **kwargs):
     def func(self, rhs):
-        return BinaryOpParameter(self, rhs, op, opstr)
+        return BinaryOpParameter(self, rhs, op, opstr, **kwargs)
 
     def rfunc(self, lhs):
-        return BinaryOpParameter(lhs, self, op, opstr)
+        return BinaryOpParameter(lhs, self, op, opstr, **kwargs)
 
     return (func, rfunc)
 
@@ -367,7 +367,7 @@ class Parameter(NoNewAttributesAfterInit):
     val = property(_get_val, _set_val,
                    doc='The current value of the parameter.\n\n' +
                    'If the parameter is a link then it is possible that accessing\n' +
-                   'the value will raise a ParamaterErr in cases where the link\n' +
+                   'the value will raise a ParameterErr in cases where the link\n' +
                    'expression falls outside the soft limits of the parameter.\n\n' +
                    'See Also\n' +
                    '--------\n' +
@@ -631,7 +631,7 @@ class Parameter(NoNewAttributesAfterInit):
         return html_parameter(self)
 
     # Unary operations
-    __neg__ = _make_unop(numpy.negative, '-')
+    __neg__ = _make_unop(numpy.negative, '-', strformat='-{arg}')
     __abs__ = _make_unop(numpy.absolute, 'abs')
 
     # Binary operations
@@ -643,6 +643,17 @@ class Parameter(NoNewAttributesAfterInit):
     __truediv__, __rtruediv__ = _make_binop(numpy.true_divide, '/')
     __mod__, __rmod__ = _make_binop(numpy.remainder, '%')
     __pow__, __rpow__ = _make_binop(numpy.power, '**')
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if not method == '__call__':
+            return NotImplemented
+        if ufunc.nin == 1:
+            return UnaryOpParameter(inputs[0], ufunc, ufunc.__name__)
+        elif ufunc.nin == 2:
+            return BinaryOpParameter(inputs[0], inputs[1], ufunc, ufunc.__name__,
+                                     strformat='{opstr}({lhs}, {rhs})')
+        else:
+            return NotImplemented
 
     def freeze(self):
         """Set the `frozen` attribute for the parameter.
@@ -815,17 +826,22 @@ class UnaryOpParameter(CompositeParameter):
         The ufunc to apply to the parameter value.
     opstr : str
         The symbol used to represent the operator.
+    strformat : str
+        Format string for printing this operation. Elements
+        than can be used are `arg` and `opstr`, e.g.
+        `strformat='{opstr}({arg})'`.
 
     See Also
     --------
     BinaryOpParameter
     """
 
-    def __init__(self, arg, op, opstr):
+    def __init__(self, arg, op, opstr, strformat='{opstr}({arg})'):
         self.arg = arg
         self.op = op
         CompositeParameter.__init__(self,
-                                    '%s(%s)' % (opstr, self.arg.fullname),
+                                    strformat.format(opstr=opstr,
+                                                     arg=self.arg.fullname),
                                     (self.arg,))
 
     def eval(self):
@@ -845,6 +861,10 @@ class BinaryOpParameter(CompositeParameter):
         The ufunc to apply to the two parameter values.
     opstr : str
         The symbol used to represent the operator.
+    strformat : str
+        Format string for printing this operation. Elements
+        than can be used are `lhs`, `rhs`, and `opstr`, e.g.
+        `strformat='{opstr}({lhs}, {rhs})'`.
 
     See Also
     --------
@@ -857,13 +877,16 @@ class BinaryOpParameter(CompositeParameter):
             return obj
         return ConstantParameter(obj)
 
-    def __init__(self, lhs, rhs, op, opstr):
+    def __init__(self, lhs, rhs, op, opstr,
+                 strformat='({lhs} {opstr} {rhs})'):
         self.lhs = self.wrapobj(lhs)
         self.rhs = self.wrapobj(rhs)
         self.op = op
-        CompositeParameter.__init__(self, '(%s %s %s)' %
-                                    (self.lhs.fullname, opstr,
-                                     self.rhs.fullname), (self.lhs, self.rhs))
+        CompositeParameter.__init__(self,
+                                    strformat.format(lhs=self.lhs.fullname,
+                                                     rhs=self.rhs.fullname,
+                                                     opstr=opstr),
+                                    (self.lhs, self.rhs))
 
     def eval(self):
         return self.op(self.lhs.val, self.rhs.val)

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -649,11 +649,10 @@ class Parameter(NoNewAttributesAfterInit):
             return NotImplemented
         if ufunc.nin == 1:
             return UnaryOpParameter(inputs[0], ufunc, ufunc.__name__)
-        elif ufunc.nin == 2:
+        if ufunc.nin == 2:
             return BinaryOpParameter(inputs[0], inputs[1], ufunc, ufunc.__name__,
                                      strformat='{opstr}({lhs}, {rhs})')
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def freeze(self):
         """Set the `frozen` attribute for the parameter.

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -651,11 +651,11 @@ class Parameter(NoNewAttributesAfterInit):
             name = f"numpy.{ufunc.__name__}"
         else:
             # Unfortunately, there is no ufunc.__module__ we could use
-            # This could be a ufinc from e.g. scipy or generated from an
+            # This could be a ufunc from e.g. scipy or generated from an
             # arbitrary Python function with numpy.frompyfunc.
             # In the latter case, the name will be something like
             # "func (vectorized)", which looks confusing in out string
-            # represenantion, so we simplify it.
+            # representation, so we simplify it.
             name = ufunc.__name__.replace(' (vectorized)', '')
         if ufunc.nin == 1:
             return UnaryOpParameter(inputs[0], ufunc, name)
@@ -837,7 +837,7 @@ class UnaryOpParameter(CompositeParameter):
         The symbol used to represent the operator.
     strformat : str
         Format string for printing this operation. Elements
-        than can be used are `arg` and `opstr`, e.g.
+        that can be used are `arg` and `opstr`, e.g.
         `strformat='{opstr}({arg})'`.
 
     See Also
@@ -872,7 +872,7 @@ class BinaryOpParameter(CompositeParameter):
         The symbol used to represent the operator.
     strformat : str
         Format string for printing this operation. Elements
-        than can be used are `lhs`, `rhs`, and `opstr`, e.g.
+        that can be used are `lhs`, `rhs`, and `opstr`, e.g.
         `strformat='{opstr}({lhs}, {rhs})'`.
 
     See Also

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -172,7 +172,7 @@ def setUp_composite():
 
 @pytest.mark.parametrize("op", [abs, operator.neg,
                                 # Test a selection of numpy ufuncs
-                                #np.abs, np.sin, np.expm1
+                                np.abs, np.sin, np.expm1
                                 ])
 def test_unop(op):
     porig = setUp_p()
@@ -187,16 +187,16 @@ def test_unop_string():
     printing the model representation.
     '''
     porig = setUp_p()
-    assert repr(-porig) == "<UnaryOpParameter '-(model.name)'>"
-    #assert repr(np.cos(porig)) == "<UnaryOpParameter 'cos(model.name)'>"
+    assert repr(-porig) == "<UnaryOpParameter '-model.name'>"
+    assert repr(np.cos(porig)) == "<UnaryOpParameter 'cos(model.name)'>"
 
 
 @pytest.mark.parametrize("op", [operator.add, operator.sub, operator.mul,
                                 operator.floordiv, operator.truediv, operator.mod,
                                 operator.pow,
                                 # Test a random selection of numpy ufuncs
-                                #np.add, np.divide, np.true_divide,
-                                #np.heaviside, np.greater, np.arctan2
+                                np.add, np.divide, np.true_divide,
+                                np.heaviside, np.greater, np.arctan2
                                 ])
 def test_binop(op):
     p, p2 = setUp_composite()
@@ -216,8 +216,8 @@ def test_binop_string():
     assert repr(comp) == "<BinaryOpParameter '(model.p + model.p2)'>"
     comp = 1 + p * 2.7**p2
     assert repr(comp) == "<BinaryOpParameter '(1 + (model.p * (2.7 ** model.p2)))'>"
-    #comp = np.logaddexp2(p, p2)
-    #assert repr(comp) == "<BinaryOpParameter 'logaddexp2(model.p, model.p2)'>"
+    comp = np.logaddexp2(p, p2)
+    assert repr(comp) == "<BinaryOpParameter 'logaddexp2(model.p, model.p2)'>"
 
 
 def test_iter_composite():

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2007, 2016, 2018, 2019, 2020, 2021, 2022
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 import operator
 
-from numpy import arange
+import numpy as np
 
 import pytest
 
@@ -121,7 +121,7 @@ def test_frozen():
     assert p.frozen is False
 
     with pytest.raises(ValueError):
-        p.frozen = arange(10)
+        p.frozen = np.arange(10)
 
     afp = setUp_afp()
     p.link = afp
@@ -170,23 +170,54 @@ def setUp_composite():
     return p, p2
 
 
-@pytest.mark.parametrize("op", (abs, operator.neg))
+@pytest.mark.parametrize("op", [abs, operator.neg,
+                                # Test a selection of numpy ufuncs
+                                #np.abs, np.sin, np.expm1
+                                ])
 def test_unop(op):
     porig = setUp_p()
     p = op(porig)
     assert isinstance(p, UnaryOpParameter)
     assert p.val == op(p.val)
 
+def test_unop_string():
+    '''Check that the string output is sensible.
+
+    This implicitly also checks the logic to define a the format string for
+    printing the model representation.
+    '''
+    porig = setUp_p()
+    assert repr(-porig) == "<UnaryOpParameter '-(model.name)'>"
+    #assert repr(np.cos(porig)) == "<UnaryOpParameter 'cos(model.name)'>"
+
 
 @pytest.mark.parametrize("op", [operator.add, operator.sub, operator.mul,
                                 operator.floordiv, operator.truediv, operator.mod,
-                                operator.pow])
+                                operator.pow,
+                                # Test a random selection of numpy ufuncs
+                                #np.add, np.divide, np.true_divide,
+                                #np.heaviside, np.greater, np.arctan2
+                                ])
 def test_binop(op):
     p, p2 = setUp_composite()
     for comb in (op(p, p2.val), op(p.val, p2),
                  op(p, p2)):
         assert isinstance(comb, BinaryOpParameter)
         assert comb.val == op(p.val, p2.val)
+
+def test_binop_string():
+    '''Check that the string output is sensible.
+
+    This implicitly also checks the logic to define a the format string for
+    printing the model representation.
+    '''
+    p, p2 = setUp_composite()
+    comp = p + p2
+    assert repr(comp) == "<BinaryOpParameter '(model.p + model.p2)'>"
+    comp = 1 + p * 2.7**p2
+    assert repr(comp) == "<BinaryOpParameter '(1 + (model.p * (2.7 ** model.p2)))'>"
+    #comp = np.logaddexp2(p, p2)
+    #assert repr(comp) == "<BinaryOpParameter 'logaddexp2(model.p, model.p2)'>"
 
 
 def test_iter_composite():
@@ -341,7 +372,7 @@ def test_link_parameter_evaluation():
     mdl = PowLaw1D()
     lmdl = Const1D()
 
-    grid = arange(1, 5)
+    grid = np.arange(1, 5)
 
     mdl.gamma = lmdl.c0
     lmdl.c0 = 2

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -183,7 +183,7 @@ def test_unop(op):
 def test_unop_string():
     '''Check that the string output is sensible.
 
-    This implicitly also checks the logic to define a the format string for
+    This implicitly also checks the logic to define a format string for
     printing the model representation.
     '''
     porig = setUp_p()

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -188,15 +188,22 @@ def test_unop_string():
     '''
     porig = setUp_p()
     assert repr(-porig) == "<UnaryOpParameter '-model.name'>"
-    assert repr(np.cos(porig)) == "<UnaryOpParameter 'cos(model.name)'>"
+    assert repr(np.cos(porig)) == "<UnaryOpParameter 'numpy.cos(model.name)'>"
 
+
+def custom_func(a, b):
+   return a + b
+
+custom_ufunc = np.frompyfunc(custom_func, nin=2, nout=1)
 
 @pytest.mark.parametrize("op", [operator.add, operator.sub, operator.mul,
                                 operator.floordiv, operator.truediv, operator.mod,
                                 operator.pow,
                                 # Test a random selection of numpy ufuncs
                                 np.add, np.divide, np.true_divide,
-                                np.heaviside, np.greater, np.arctan2
+                                np.heaviside, np.greater, np.arctan2,
+                                # and out own, custom made ufunc
+                                custom_ufunc,
                                 ])
 def test_binop(op):
     p, p2 = setUp_composite()
@@ -217,7 +224,17 @@ def test_binop_string():
     comp = 1 + p * 2.7**p2
     assert repr(comp) == "<BinaryOpParameter '(1 + (model.p * (2.7 ** model.p2)))'>"
     comp = np.logaddexp2(p, p2)
-    assert repr(comp) == "<BinaryOpParameter 'logaddexp2(model.p, model.p2)'>"
+    assert repr(comp) == "<BinaryOpParameter 'numpy.logaddexp2(model.p, model.p2)'>"
+
+def test_binop_string_with_custom_ufunc():
+    '''Repeat the previous test, but with a custom ufunc.'''
+    def func(a, b):
+        return a + b
+
+    uf = np.frompyfunc(func, nin=2, nout=1)
+    p, p2 = setUp_composite()
+    comp = uf(p, p2)
+    assert repr(comp) == "<BinaryOpParameter 'func(model.p, model.p2)'>"
 
 
 def test_iter_composite():

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -215,7 +215,7 @@ def test_binop(op):
 def test_binop_string():
     '''Check that the string output is sensible.
 
-    This implicitly also checks the logic to define a the format string for
+    This implicitly also checks the logic to define the format string for
     printing the model representation.
     '''
     p, p2 = setUp_composite()


### PR DESCRIPTION
# Summary
Provide a way to use any Python function to be used for linking parameters. Fix #1652
    
# Details
Before this PR, only a few selected mathematical operations where allowed to link parameters, namely those expressed with symbols in Python (+, -, *, **, //, etc.). Internally, those symbols are mapped to numpy ufuncs in `UnaryOpParameter` or `BinaryOpParameter`. Since about numpy 1.13 there is a defined interface to wrap through any ufunc, which gives us access to sin, cos, exp, log etc.

See https://github.com/sherpa/sherpa/issues/1652#issuecomment-1349865957 for an example. There, I want to model how a flare cools down and have many spectra distributed in time. Thus, it makes sense to describe the normalization of the model with an exponential function, essentially `apec_n.norm = apec_0.norm * np.exp(-(t_n-t_0)/decay_time)` where apec_n is the model for the nth spectrum observed at time t_n. `decay_time` is a parameter that I want to fit. Being able to use functions like exp, log, cos, sin can be useful as you can see in that example.
In that particular case, I discovered that `2.71**(-(t_n-t_0) ... ` already works, but we give users much more flexibility if we allow any function to be used.


Code changes are small, because the infrastructure is already there, we just added a bit more flexibility. In fact, we added infinite flexibility, because numpy provides a wrapper to turn any arbitrary Python function into a ufunc - and thus any arbitrary Python function can now be used to link parameters.
    
With such power comes great responsibility. It is easily possible to make links that make no sense or will trip over later.
However, I argue that that's a feature not a bug. Nonsensical links that error out later have always been possible, e.g. with Sherpa 4.14:
```Python
from sherpa.models import Gauss1D
import numpy as np
    
g1 = Gauss1D(name='g1')
g1.fwhm = g1.ampl * np.arange(5)
```
which will fail as soon as the expression is evaluated:
```Python
print(g1.fwhm)
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
    
This has never been reported as a problem, likely because it's unlikely to happen accidentally and can be spotted quite quickly. I chose to not add any additional checking to prevent things like that, in order to leave the maximum flexibility for any user models.