### PR TITLE
Associated group fixes.

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1929,7 +1929,8 @@ must be an integer.""")
         .. versionchanged:: 4.15.1
            The filter is now re-calculated when the grouping is
            changed. It is suggested that the filter be checked with
-           `get_filter` to check it is still sensible.
+           `get_filter` to check it is still sensible. If set to None
+           then the group flag is cleared.
 
         Returns
         -------
@@ -1965,6 +1966,12 @@ must be an integer.""")
             ofilter = self.get_filter()
 
         self._set_related("grouping", val)
+
+        # If the array has been removed then we need to reset the
+        # group flag.
+        #
+        if val is None and self._NoNewAttributesAfterInit__initialized and self.grouped:
+            self.grouped = False
 
         if ofilter is not None:
             # If the data has been filtered then we want to re-create

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4743,11 +4743,25 @@ must be an integer.""")
         grouping attribute will be used when accessing data values. This
         can be called even if the grouping attribute is empty.
 
+        .. versionchanged:: 4.15.1
+           The grouping status of any background component is now also
+           changed.
+
         See Also
         --------
         ungroup
+
         """
         self.grouped = True
+
+        # Ensure any backgrounds are also grouped.
+        #
+        for bkg_id in self.background_ids:
+            bkg = self.get_background(bkg_id)
+            try:
+                bkg.grouped = True
+            except DataErr as exc:
+                info(str(exc))
 
     def ungroup(self):
         """Remove any data grouping.
@@ -4755,11 +4769,23 @@ must be an integer.""")
         This un-sets the grouping flag which means that the grouping
         attribute will not be used when accessing data values.
 
+        .. versionchanged:: 4.15.1
+           The grouping status of any background component is now also
+           changed.
+
         See Also
         --------
         group
         """
         self.grouped = False
+
+        # Ensure any backgrounds are also grouped.
+        #
+        for bkg_id in self.background_ids:
+            # Unlike the group case we do not need to worry about this
+            # failing.
+            bkg = self.get_background(bkg_id)
+            bkg.grouped = False
 
     def subtract(self):
         """Subtract the background data.

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4037,7 +4037,7 @@ def test_pha_group_background(caplog):
     src.group()
 
     assert src.grouped
-    assert not bkg.grouped
+    assert bkg.grouped
 
     assert len(caplog.record_tuples) == 0
 
@@ -4085,7 +4085,7 @@ def test_pha_ungroup_background(caplog):
     src.ungroup()
 
     assert not src.grouped
-    assert bkg.grouped
+    assert not bkg.grouped
 
     assert len(caplog.record_tuples) == 0
 
@@ -4113,7 +4113,7 @@ def test_pha_ungroup_background_not_set(caplog):
     src.ungroup()
 
     assert not src.grouped
-    assert bkg.grouped
+    assert not bkg.grouped
 
     assert len(caplog.record_tuples) == 0
 
@@ -4142,7 +4142,7 @@ def test_pha_ungroup_background_after(caplog):
     src.ungroup()
 
     assert not src.grouped
-    assert bkg.grouped
+    assert not bkg.grouped
 
     assert len(caplog.record_tuples) == 0
 
@@ -4203,6 +4203,6 @@ def test_pha_ungroup_background_remove(caplog):
     src.ungroup()
 
     assert not src.grouped
-    assert bkg.grouped
+    assert not bkg.grouped
 
     assert len(caplog.record_tuples) == 0

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1685,7 +1685,6 @@ def test_1160(make_data_path):
     assert pha.get_filter(format="%.2f") == fexpr
 
 
-@pytest.mark.xfail
 def test_pha_remove_grouping(make_test_pha):
     """Check we can remove the grouping array.
 

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -2445,7 +2445,7 @@ def test_notice_warning(caplog):
     loc, lvl, msg = caplog.record_tuples[0]
     assert loc == "sherpa.astro.ui.utils"
     assert lvl == logging.WARNING
-    assert msg == "not all PHA datasets have equal analysis quantities"
+    assert msg == "not all PHA datasets have equal analysis quantities: channel, energy"
 
     loc, lvl, msg = caplog.record_tuples[1]
     assert loc == "sherpa.ui.utils"
@@ -2459,10 +2459,10 @@ def test_notice_warning(caplog):
 
 
 def test_ignore_warning(caplog):
-    """Check we get a warning from ignore
+    """Check we get a warning from ignore (was a test of #1641)
 
-    The messages are slightly different to notice, hence the
-    separate check
+    This used to be more-different to test_ignore_warning (before
+    #1641 was fixed), but keep it a separate test.
     """
 
     s = AstroSession()
@@ -2481,23 +2481,18 @@ def test_ignore_warning(caplog):
     with caplog.at_level(logging.INFO, logger='sherpa'):
         s.ignore(lo=2)
 
-    assert len(caplog.record_tuples) == 4
+    assert len(caplog.record_tuples) == 3
     loc, lvl, msg = caplog.record_tuples[0]
     assert loc == "sherpa.astro.ui.utils"
     assert lvl == logging.WARNING
-    assert msg == "not all PHA datasets have equal analysis quantities"
+    assert msg == "not all PHA datasets have equal analysis quantities: channel, energy"
 
     loc, lvl, msg = caplog.record_tuples[1]
-    assert loc == "sherpa.astro.ui.utils"
-    assert lvl == logging.WARNING
-    assert msg == "not all PHA datasets have equal analysis quantities"
-
-    loc, lvl, msg = caplog.record_tuples[2]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
     assert msg == "dataset 1: 1:3 -> 1 Channel"
 
-    loc, lvl, msg = caplog.record_tuples[3]
+    loc, lvl, msg = caplog.record_tuples[2]
     assert loc == "sherpa.ui.utils"
     assert lvl == logging.INFO
     assert msg == "dataset 2: 0.5:2 Energy (keV) (unchanged)"

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -2194,7 +2194,7 @@ def test_group_when_background_has_no_grouping(clean_astro_ui, caplog):
 
     assert len(caplog.records) == 3
     r = caplog.record_tuples[1]
-    assert r[0] == "sherpa.astro.ui.utils"
+    assert r[0] == "sherpa.astro.data"
     assert r[1] == logging.INFO
     assert r[2] == "data set 'bkg' does not specify grouping flags"
 
@@ -2202,6 +2202,7 @@ def test_group_when_background_has_no_grouping(clean_astro_ui, caplog):
     assert r[0] == "sherpa.ui.utils"
     assert r[1] == logging.INFO
     assert r[2] == "dataset 1: 1:3 Channel (unchanged)"
+
 
 
 @pytest.mark.xfail

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -200,14 +200,15 @@ def test_filter_bad_ungrouped(make_data_path, clean_astro_ui, caplog):
 
     assert ui.get_dep().shape == (439, )
     ui.ungroup()
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 1
+    clc_filter(caplog, "dataset 1: 0.0073:14.9504 Energy (keV) (unchanged)")
 
     assert ui.get_dep().shape == (1024, )
     assert pha.quality_filter is None
     assert pha.mask is True
 
     ui.ignore_bad()
-    assert len(caplog.records) == 1
+    assert len(caplog.records) == 2
     clc_filter(caplog, "dataset 1: 0.0073:14.9504 -> 0.0073:14.5416 Energy (keV)")
 
     assert ui.get_dep().shape == (1024, )
@@ -222,7 +223,7 @@ def test_filter_bad_ungrouped(make_data_path, clean_astro_ui, caplog):
     # anything. See issue #1169
     #
     ui.notice(0.5, 7)
-    assert len(caplog.records) == 2
+    assert len(caplog.records) == 3
     clc_filter(caplog, "dataset 1: 0.0073:14.5416 Energy (keV) (unchanged)")
 
     assert pha.mask == pytest.approx(expected)
@@ -230,11 +231,11 @@ def test_filter_bad_ungrouped(make_data_path, clean_astro_ui, caplog):
     # We need to ignore to change the mask.
     #
     ui.ignore(None, 0.5)
-    assert len(caplog.records) == 3
+    assert len(caplog.records) == 4
     clc_filter(caplog, "dataset 1: 0.0073:14.5416 -> 0.511:14.5416 Energy (keV)")
 
     ui.ignore(7, None)
-    assert len(caplog.records) == 4
+    assert len(caplog.records) == 5
     clc_filter(caplog, "dataset 1: 0.511:14.5416 -> 0.511:6.9934 Energy (keV)")
 
     expected[0:35] = False

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -7584,51 +7584,14 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        # We can not use _pha_report_filter_change like we do for
-        # set_grouping / group_counts ... because the logic of what we
-        # do for the background datasets is different. See also issue
-        # #1657 which discusses whether some of this logic should be
-        # in the DataPHA class instead.
+        # This will call the background datasets to be grouped
+        # as well (when bkg_id is not set).
         #
-        idval = self._fix_id(id)
-        idstr = f"dataset {idval}"
+        def change(data):
+            if not data.grouped:
+                data.group()
 
-        if bkg_id is None:
-            data = self._get_pha_data(idval)
-
-            # TODO: Do we care about the lack of grouping if the data
-            # is subtracted? Should we even bother trying to group the
-            # backgrounds?
-            #
-            # We do not just call self.group(idval, bid) here (which
-            # is what we do in ungroup), as we do not want the filter
-            # to be displayed for the backgrounds. This matches
-            # notice/ignore, where we do not dispay the filters for
-            # the background unless the user has explicitly set
-            # bkg_id.
-            #
-            for bid in data.background_ids:
-                bdata = data.get_background(bid)
-                try:
-                    bdata.group()
-
-                except DataErr as e:
-                    info(str(e))
-
-        else:
-            data = self.get_bkg(idval, bkg_id)
-            idstr += f": background {bkg_id}"
-
-        # Note: we always report the change in filter status, even
-        # when already grouped.
-        #
-        ofilter = sherpa.ui.utils._get_filter(data)
-        if not data.grouped:
-            data.group()
-
-        nfilter = sherpa.ui.utils._get_filter(data)
-        sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter,
-                                             data.get_xlabel())
+        _pha_report_filter_change(self, id, bkg_id, change)
 
     def set_grouping(self, id, val=None, bkg_id=None):
         """Apply a set of grouping flags to a PHA data set.
@@ -8039,27 +8002,17 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        # This is different-enough from group that we repeat the code
-        # rather than abstracting away the logic like we do for the
-        # group_xxx calls.
+        # This will call the background datasets to be ungrouped
+        # as well (when bkg_id is not set).
         #
-        idval = self._fix_id(id)
-        if bkg_id is None:
-            data = self._get_pha_data(idval)
+        def change(data):
+            if data.grouped:
+                data.ungroup()
 
-            # First, ungroup backgrounds associated with the
-            # data set ID; report if background(s) already ungrouped.
-            for bid in data.background_ids:
-                try:
-                    self.ungroup(idval, bid)
-                except DataErr as e:
-                    info(str(e))
-
-        else:
-            data = self.get_bkg(idval, bkg_id)
-
-        if data.grouped:
-            data.ungroup()
+        # We can use this as it does not report the filter when the
+        # data is ungrouped, which is true here.
+        #
+        _pha_report_filter_change(self, id, bkg_id, change)
 
     # DOC-TODO: need to document somewhere that this ignores existing
     # quality flags and how to use tabStops to include

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6829,32 +6829,24 @@ class Session(sherpa.ui.utils.Session):
         sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter,
                                              data.get_xlabel())
 
-    def _notice_warning(self):
-        quantities = numpy.asarray([data.get_analysis()
-                                    for data in self._data.values()
-                                    if isinstance(data,
-                                                  sherpa.astro.data.DataPHA)])
-
-        if len(quantities) > 1 and not (quantities == quantities[0]).all():
-            warning("not all PHA datasets have equal analysis quantities")
-
+    # There is no need to overide ignore to add unit checking since
+    # ignore just ends up calling notice anyway.
+    #
     def notice(self, lo=None, hi=None, **kwargs):
 
         if lo is not None or hi is not None:
-            self._notice_warning()
+            units = set(data.get_analysis()
+                        for data in self._data.values()
+                        if isinstance(data, DataPHA))
+            if len(units) > 1:
+                units_str = ", ".join(sorted(units))
+                # This is a logging call so do not use f-strings
+                warning("not all PHA datasets have equal analysis quantities: %s",
+                        units_str)
 
         super().notice(lo, hi, **kwargs)
 
     notice.__doc__ = sherpa.ui.utils.Session.notice.__doc__
-
-    def ignore(self, lo=None, hi=None, **kwargs):
-
-        if lo is not None or hi is not None:
-            self._notice_warning()
-
-        super().ignore(lo, hi, **kwargs)
-
-    ignore.__doc__ = sherpa.ui.utils.Session.ignore.__doc__
 
     # DOC-TODO: how best to document the region support?
     # DOC-TODO: I have not mentioned the support for radii in arcsec/minutes/degrees


### PR DESCRIPTION
# Summary

Clean up of the notice/ignore and group/ungroup code to avoid unnecessary work, move logic from the UI layer into the DataPHA class, and ensure that if the grouping field is set to None that the data is not grouped. Fix #1641, #1657, and #1659

# Details

Noticed when working on recent PRs (in particular #1637). These could be separated into separate PRs but I felt they were small enough, and related, to be worth a single PR. Let me know if they should be broken up. There's some more clean-up code in #1667 which could be included here but I decided to separate it out as these are generally "fix some issue, even if minor" whilst #1667 is more straight-up cleanup.

Each commit fixes a bug and maybe does some code cleanup:

- #1641 
  - `ignore` was set up to do the same check as `notice`, but hadn't noticed that because of how the superclass is set up we always go through `notice` anyway (i.e. `ignore` calls `notice`). So we do not need to override `ignore`
- #1657 
  - move the logic for calling group/ungroup for background PHA files to DataPHA from the UI code
- #1659 
  - if the grouping array is cleared (set to None) then clear the group flag

For #1641 I am breaking backwards compatibility, as I am removing a method from the Session class, but it is an internal method (i.e. the name starts with `_`) and is a very-specialized routine. I do not see the need to note this change.

For #1657, I take heart in the fact that notice/ignore behave somewhat similarly - that is the DataPHA code handles the related background components rather than it being in the UI layer (although there's a distinct possibility that I caused this change in a previous PR). I do think this is one case where it makes sense to push the logic to DataPHA rather than have it in the UI layer, even with the logging that the code does (only for rare cases where the background has no grouping array but the source does have). I thought about changing the code from try/except to "check we can do this" but decided not to make that change as it didn't noticeably improve the code (and is somewhat "anti pythonic" anyway).

For #1659, there is the general question of whether we should be able to clear the array (similar for the quality field), but that's a larger question than we want to deal with here, and this code fixes an existing bug (even if it is a definite corner case).

