### PR TITLE
Add grouping tests

### DIFF
--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1692,7 +1692,10 @@ def test_1160(make_data_path):
 
 @pytest.mark.xfail
 def test_pha_remove_grouping(make_test_pha):
-    """Check we can remove the grouping array."""
+    """Check we can remove the grouping array.
+
+    See issue #1659
+    """
 
     pha = make_test_pha
     assert pha.grouping is None
@@ -1710,10 +1713,16 @@ def test_pha_remove_grouping(make_test_pha):
 
     # Can we remove the grouping column?
     pha.grouping = None
-    # This thinks that pha.grouped is still set
-    assert not pha.grouped
+
+    # Check the get_dep ehavior before grouped as this is currently
+    # causes a TypeError rather than not changing a boolean flag
+    # variable.
+    #
     d2 = pha.get_dep(filter=True)
     assert d2 == pytest.approx(no_data)
+
+    # This thinks that pha.grouped is still set
+    assert not pha.grouped
 
 
 @pytest.mark.xfail

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022
+#  Copyright (C) 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1714,7 +1714,7 @@ def test_pha_remove_grouping(make_test_pha):
     # Can we remove the grouping column?
     pha.grouping = None
 
-    # Check the get_dep ehavior before grouped as this is currently
+    # Check the get_dep behavior before grouped as this is currently
     # causes a TypeError rather than not changing a boolean flag
     # variable.
     #

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -34,14 +34,37 @@ import pytest
 from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.astro.ui.utils import Session as AstroSession
-from sherpa.data import Data1D, Data1DInt
+from sherpa.data import Data1D, Data1DInt, Data2D, Data2DInt
+from sherpa.instrument import ConvolutionKernel
 from sherpa.io import get_ascii_data
-from sherpa.models import Const1D
+from sherpa.models import ArithmeticModel, Const1D
 import sherpa.models.basic
 from sherpa.ui.utils import Session
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
-    IdentifierErr, PlotErr
-from sherpa.utils.testing import requires_data, requires_fits, requires_group
+    IdentifierErr, IOErr, ModelErr, PlotErr, SessionErr
+from sherpa.utils.logging import SherpaVerbosity
+from sherpa.utils.testing import requires_data, requires_fits, requires_group, \
+    has_package_from_list
+
+
+@pytest.fixture
+def skip_if_no_io(request):
+    """For tests with a session fixture that need to be skipped if
+    the I/O backend is not present ONLY for AstroSession.
+    """
+
+    if request.getfixturevalue("session") == Session:
+        return
+
+    # This requires knowledge of requires_fits, but we don't make it
+    # possible to access this so we hard code the knowledge here. If
+    # we ever get another I/O backend we need to revisit this.
+    #
+    if has_package_from_list("astropy.io.fits", "pycrates"):
+        return
+
+    pytest.skip(reason="FITS backend required")
+
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
@@ -224,12 +247,20 @@ def test_show_bkg_model_with_bkg(make_data_path):
 
 # Fix 476 - this should be in sherpa/ui/tests/test_session.py
 @requires_group
-def test_zero_division_calc_stat():
+def test_zero_division_calc_stat(caplog):
     ui = AstroSession()
     x = numpy.arange(100)
     y = numpy.zeros(100)
     ui.load_arrays(1, x, y, DataPHA)
-    ui.group_counts(1, 100)
+
+    assert len(caplog.record_tuples) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        ui.group_counts(1, 100)
+
+    assert ui.get_data().grouped
+
+    assert len(caplog.record_tuples) == 0
+
     ui.set_full_model(1, Const1D("const"))
 
     # in principle I wouldn't need to call calc_stat_info(), I could just
@@ -513,11 +544,10 @@ def get_data(path, **kwargs):
     return ans[0], ans[1]
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_model_ascii(session, kwargs, idval, tmp_path):
+def test_save_model_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_model?"""
 
     s = session()
@@ -531,11 +561,10 @@ def test_save_model_ascii(session, kwargs, idval, tmp_path):
     assert data[1] == pytest.approx([4, 4, 8])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_source_ascii(session, kwargs, idval, tmp_path):
+def test_save_source_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_source?"""
 
     s = session()
@@ -549,11 +578,10 @@ def test_save_source_ascii(session, kwargs, idval, tmp_path):
     assert data[1] == pytest.approx([4, 4, 8])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_resid_ascii(session, kwargs, idval, tmp_path):
+def test_save_resid_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_resid?"""
 
     s = session()
@@ -567,11 +595,10 @@ def test_save_resid_ascii(session, kwargs, idval, tmp_path):
     assert data[1] == pytest.approx([-1, 0, -3])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_delchi_ascii(session, kwargs, idval, tmp_path):
+def test_save_delchi_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_delchi?"""
 
     s = session()
@@ -585,11 +612,10 @@ def test_save_delchi_ascii(session, kwargs, idval, tmp_path):
     assert data[1] == pytest.approx([-1, 0, -0.5])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_data_ascii(session, kwargs, idval, tmp_path):
+def test_save_data_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_data?"""
 
     s = session()
@@ -605,11 +631,10 @@ def test_save_data_ascii(session, kwargs, idval, tmp_path):
     assert data[3] == pytest.approx([1, 2, 6])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_staterror_ascii(session, kwargs, idval, tmp_path):
+def test_save_staterror_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_staterror?
 
     The output of this looks wrong (just showing the XLO values not
@@ -628,11 +653,10 @@ def test_save_staterror_ascii(session, kwargs, idval, tmp_path):
     assert data[1] == pytest.approx([1, 2, 6])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_syserror_ascii(session, kwargs, idval, tmp_path):
+def test_save_syserror_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_syserror?
 
     The output of this looks wrong (just showing the XLO values not
@@ -651,11 +675,10 @@ def test_save_syserror_ascii(session, kwargs, idval, tmp_path):
     assert data[1] == pytest.approx([1, 2, 6])
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_syserror_no_data_ascii(session, kwargs, idval, tmp_path):
+def test_save_syserror_no_data_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Check save_syserror needs a systematic-error column."""
 
     s = session()
@@ -667,11 +690,10 @@ def test_save_syserror_no_data_ascii(session, kwargs, idval, tmp_path):
         save_ascii_file(s, kwargs, idval, outfile, s.save_syserror)
 
 
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session,kwargs",
                          [(Session, {}), (AstroSession, {"ascii": True})])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
-def test_save_error_ascii(session, kwargs, idval, tmp_path):
+def test_save_error_ascii(session, kwargs, idval, tmp_path, skip_if_no_io):
     """Can we use save_error?
 
     This does not bother testing the various combinations of
@@ -1159,6 +1181,40 @@ def test_show_bkg_source_output():
 
     assert len(toks) == 10
 
+    out = StringIO()
+    s.show_bkg_model(bkg_id=1, outfile=out)
+
+    toks = out.getvalue().split("\n")
+    assert toks[0] == "Background Model: 1:1"
+    assert toks[1] == "apply_rmf((200.0 * lorentz1d.other))"
+    assert toks[2] == "   Param        Type          Value          Min          Max      Units"
+    assert toks[3] == "   -----        ----          -----          ---          ---      -----"
+    assert toks[4] == "   other.fwhm   thawed           10            0  3.40282e+38           "
+    assert toks[5] == "   other.pos    thawed            1 -3.40282e+38  3.40282e+38           "
+    assert toks[6] == "   other.ampl   thawed            1 -3.40282e+38  3.40282e+38           "
+    assert toks[7] == ""
+    assert toks[8] == ""
+    assert toks[9] == ""
+
+    assert len(toks) == 10
+
+    out = StringIO()
+    s.show_bkg_source(bkg_id=1, outfile=out)
+
+    toks = out.getvalue().split("\n")
+    assert toks[0] == "Background Source: 1:1"
+    assert toks[1] == "lorentz1d.other"
+    assert toks[2] == "   Param        Type          Value          Min          Max      Units"
+    assert toks[3] == "   -----        ----          -----          ---          ---      -----"
+    assert toks[4] == "   other.fwhm   thawed           10            0  3.40282e+38           "
+    assert toks[5] == "   other.pos    thawed            1 -3.40282e+38  3.40282e+38           "
+    assert toks[6] == "   other.ampl   thawed            1 -3.40282e+38  3.40282e+38           "
+    assert toks[7] == ""
+    assert toks[8] == ""
+    assert toks[9] == ""
+
+    assert len(toks) == 10
+
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("idval", [None, "foo"])
@@ -1199,6 +1255,7 @@ def test_show_model(idval, label, session):
     s._add_model_types(sherpa.models.basic)
 
     s.load_arrays(1, [1, 3, 5], [1, 2, 3], Data1D)
+    s.load_arrays("not-interested", [200, 300], [200, 300])
 
     s.create_model_component("gauss1d", "g1")
     s1 = s.create_model_component("scale1d", "s1")
@@ -1419,10 +1476,9 @@ def setup_template_model(session, make_data_path, interp="default"):
 
 
 @requires_data
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
-def test_get_xxx_component_plot_with_templates_recalc_true(session, label, make_data_path):
+def test_get_xxx_component_plot_with_templates_recalc_true(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
 
     This is a regression test as it is not obvious what the intended
@@ -1448,10 +1504,9 @@ def test_get_xxx_component_plot_with_templates_recalc_true(session, label, make_
 
 
 @requires_data
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
-def test_get_xxx_component_plot_with_templates_recalc_true_no_interp(session, label, make_data_path):
+def test_get_xxx_component_plot_with_templates_recalc_true_no_interp(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
 
     Try to catch all code paths.
@@ -1474,10 +1529,9 @@ def test_get_xxx_component_plot_with_templates_recalc_true_no_interp(session, la
 
 
 @requires_data
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
-def test_get_xxx_component_plot_with_templates_recalc_false(session, label, make_data_path):
+def test_get_xxx_component_plot_with_templates_recalc_false(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
 
     This is a regression test as it is not obvious what the intended
@@ -1520,10 +1574,9 @@ def test_get_xxx_component_plot_with_templates_recalc_false(session, label, make
 
 
 @requires_data
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
-def test_get_xxx_component_plot_with_templates_recalc_false_no_interp(session, label, make_data_path):
+def test_get_xxx_component_plot_with_templates_recalc_false_no_interp(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
 
     This is a regresion test.
@@ -1567,10 +1620,9 @@ def test_get_xxx_component_plot_with_templates_recalc_false_no_interp(session, l
 
 
 @requires_data
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
-def test_get_xxx_component_plot_with_templates_data1d(session, label, make_data_path):
+def test_get_xxx_component_plot_with_templates_data1d(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?  Data1D
 
     As this is not a PHA data set the source and model values should
@@ -1612,10 +1664,9 @@ def test_get_xxx_component_plot_with_templates_data1d(session, label, make_data_
 
 
 @requires_data
-@requires_fits  # only for AstroSession, but not worth being clever
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
-def test_get_xxx_component_plot_with_templates_data1d_no_interp(session, label, make_data_path):
+def test_get_xxx_component_plot_with_templates_data1d_no_interp(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?  Data1D, no interpolator
 
     As this is not a PHA data set the source and model values should
@@ -2362,3 +2413,1369 @@ def test_astro_plot_alias_warning(session, success, key, caplog):
         #
         with pytest.raises(PlotErr, match=rf"^Plot type '{alias}' not found in \[.*\]$"):
             s.set_xlog(alias)
+
+
+def test_notice_warning(caplog):
+    """Check we get a warning from notice
+
+    This requires PHA files with different analysis settings
+    """
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
+    s.load_arrays(2, [1, 2, 3], [1, 2, 3], DataPHA)
+
+    egrid = numpy.asarray([0.5, 0.7, 1.0, 2.0])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+    s.set_rmf(2, rmf)
+
+    s.set_analysis(2, "energy")
+
+    assert len(caplog.record_tuples) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        s.notice(lo=2)
+
+    assert len(caplog.record_tuples) == 3
+    loc, lvl, msg = caplog.record_tuples[0]
+    assert loc == "sherpa.astro.ui.utils"
+    assert lvl == logging.WARNING
+    assert msg == "not all PHA datasets have equal analysis quantities"
+
+    loc, lvl, msg = caplog.record_tuples[1]
+    assert loc == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "dataset 1: 1:3 -> 2:3 Channel"
+
+    loc, lvl, msg = caplog.record_tuples[2]
+    assert loc == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "dataset 2: 0.5:2 Energy (keV) -> no data"
+
+
+def test_ignore_warning(caplog):
+    """Check we get a warning from ignore
+
+    The messages are slightly different to notice, hence the
+    separate check
+    """
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
+    s.load_arrays(2, [1, 2, 3], [1, 2, 3], DataPHA)
+
+    egrid = numpy.asarray([0.5, 0.7, 1.0, 2.0])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+    s.set_rmf(2, rmf)
+
+    s.set_analysis(2, "energy")
+
+    assert len(caplog.record_tuples) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        s.ignore(lo=2)
+
+    assert len(caplog.record_tuples) == 4
+    loc, lvl, msg = caplog.record_tuples[0]
+    assert loc == "sherpa.astro.ui.utils"
+    assert lvl == logging.WARNING
+    assert msg == "not all PHA datasets have equal analysis quantities"
+
+    loc, lvl, msg = caplog.record_tuples[1]
+    assert loc == "sherpa.astro.ui.utils"
+    assert lvl == logging.WARNING
+    assert msg == "not all PHA datasets have equal analysis quantities"
+
+    loc, lvl, msg = caplog.record_tuples[2]
+    assert loc == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "dataset 1: 1:3 -> 1 Channel"
+
+    loc, lvl, msg = caplog.record_tuples[3]
+    assert loc == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+    assert msg == "dataset 2: 0.5:2 Energy (keV) (unchanged)"
+
+
+
+@pytest.mark.parametrize("session,emsg",
+                         [(Session, r"save_delchi\(\) can not be used with 2D datasets"),
+                          (AstroSession, r"save_delchi\(\) does not apply for images")])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_save_delchi_data2d(session, emsg, idval, tmp_path):
+    """Check it errors out
+
+    Technically there's no reason why we can't have errors for a 2D
+    dataset but we currently error out.
+
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace2d([4, 3], dstype=Data2D, id=idval)
+
+    mdl = s.create_model_component("const2d", "mdl")
+    s.set_source(idval, mdl)
+
+    out = tmp_path / "not-created.dat"
+    with pytest.raises(AttributeError, match=emsg):
+        if idval is None:
+            s.save_delchi(str(out))
+        else:
+            s.save_delchi(idval, str(out))
+
+
+def check_output(expected, got):
+    """Expected is broken down by lines, got is not"""
+
+    toks = got.split("\n")
+    for i, estr in enumerate(expected):
+        assert toks[i] == estr
+
+    assert len(toks) == len(expected)
+
+
+@pytest.mark.parametrize("session,kwargs,expected",
+                         [pytest.param(Session, {"comment": "!! "}, ["!! SOURCE", "7 11", ""], marks=pytest.mark.xfail),  # bug #1642
+                          (AstroSession, {"ascii": True}, ["7", "11", ""])])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
+    """Basic check it works
+
+    The output depends on the backend which is a bit distressing, and
+    it's just a bit different enough to make it hard to check both
+    source and model with the same test.
+
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace2d([2, 1], dstype=Data2D, id=idval)
+
+    mdl = s.create_model_component("polynom2d", "mdl")
+    mdl.cy1 = 2
+    mdl.cx1 = 4
+    s.set_source(idval, mdl)
+
+    out = tmp_path / "created.dat"
+    if idval is None:
+        s.save_source(str(out), **kwargs)
+    else:
+        s.save_source(idval, str(out), **kwargs)
+
+    check_output(expected, out.read_text())
+
+
+@pytest.mark.parametrize("session,kwargs,expected",
+                         [pytest.param(Session, {"comment": ""}, ["MODEL", "7 11", ""], marks=pytest.mark.xfail),  # bug #1642
+                          (AstroSession, {"ascii": True}, ["7", "11", ""])])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
+    """Basic check it works
+
+    The output depends on the backend which is a bit distressing, and
+    it's just a bit different enough to make it hard to check both
+    source and model with the same test.
+
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace2d([2, 1], dstype=Data2D, id=idval)
+
+    mdl = s.create_model_component("polynom2d", "mdl")
+    mdl.cy1 = 2
+    mdl.cx1 = 4
+    s.set_source(idval, mdl)
+
+    out = tmp_path / "created.dat"
+    if idval is None:
+        s.save_model(str(out), **kwargs)
+    else:
+        s.save_model(idval, str(out), **kwargs)
+
+    check_output(expected, out.read_text())
+
+
+@pytest.mark.parametrize("session,kwargs,expected",
+                         [pytest.param(Session, {}, ["#RESID", "-7 -11", ""], marks=pytest.mark.xfail),  # bug #1642
+                          (AstroSession, {"ascii": True}, ["-7", "-11", ""])])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
+    """Basic check it works
+
+    The output depends on the backend which is a bit distressing.
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace2d([2, 1], dstype=Data2D, id=idval)
+
+    mdl = s.create_model_component("polynom2d", "mdl")
+    mdl.cy1 = 2
+    mdl.cx1 = 4
+    s.set_source(idval, mdl)
+
+    out = tmp_path / "created.dat"
+    if idval is None:
+        s.save_resid(str(out), **kwargs)
+    else:
+        s.save_resid(idval, str(out), **kwargs)
+
+    check_output(expected, out.read_text())
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_template_model_error_mismatched_header(session, tmp_path):
+    """Check error handling: col names and col values differ"""
+
+    mfile = tmp_path / "model.dat"
+    mfile.write_text("# XPAR YPAR MODELFLAG FILENAME\n" +
+                     f"1 2 foo.dat\n")
+
+    s = session()
+    with pytest.raises(IOErr,
+                       match="Expected 3 columns but found 4"):
+        s.load_template_model("tmp", str(mfile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_template_model_error_no_pars(session, tmp_path):
+    """Check error handling: no parameter column"""
+
+    mfile = tmp_path / "model.dat"
+    mfile.write_text("# MODELFLAG FILENAME\n" +
+                     f"1 foo.dat\n")
+
+    s = session()
+    with pytest.raises(IOErr,
+                       match="No parameter columns found in .*/model.dat"):
+        s.load_template_model("tmp", str(mfile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_template_model_error_no_modelfile(session, tmp_path):
+    """Check error handling: no modelfile"""
+
+    mfile = tmp_path / "model.dat"
+    mfile.write_text("# XPAR YPAR\n" +
+                     f"1 2\n1 3\n")
+
+    s = session()
+    with pytest.raises(IOErr,
+                       match="Required column 'filename' not found in .*/model.dat"):
+        s.load_template_model("tmp", str(mfile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_template_model_error_no_modelflag(session, tmp_path):
+    """Check error handling: no modelfile"""
+
+    mfile = tmp_path / "model.dat"
+    mfile.write_text("# XPAR YPAR FILENAME\n" +
+                     f"1 2 a.dat\n1 3 b.dat\n")
+
+    s = session()
+    with pytest.raises(IOErr,
+                       match="Required column 'modelflag' not found in .*/model.dat"):
+        s.load_template_model("tmp", str(mfile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_template_model_error_1_col(session, tmp_path):
+    """Check error handling: template file has < 2 columns"""
+
+    # Note: we need the actual path in the template file
+    foo12 = tmp_path / "foo12.dat"
+    foo12.write_text("1\n2\n")
+
+    mfile = tmp_path / "model.dat"
+    mfile.write_text("# XPAR YPAR MODELFLAG FILENAME\n" +
+                     f"1 2 1 {foo12}\n")
+
+    s = session()
+    with pytest.raises(IOErr,
+                       match="Only found 1 column in .*.dat, need at least 2"):
+        s.load_template_model("tmp", str(mfile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_template_model_error_multi_col(session, tmp_path):
+    """Check error handling: template file has > 2 columns"""
+
+    # Note: we need the actual path in the template file
+    foo12 = tmp_path / "foo12.dat"
+    foo12.write_text("1 2 3\n2 4 5\n")
+
+    mfile = tmp_path / "model.dat"
+    mfile.write_text("# XPAR YPAR MODELFLAG FILENAME\n" +
+                     f"1 2 1 {foo12}\n")
+
+    s = session()
+    with pytest.raises(IOErr,
+                       match="Expected 2 columns but found 3"):
+        s.load_template_model("tmp", str(mfile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_method_unknown(session):
+    """Check we error out"""
+
+    s = session()
+    with pytest.raises(ArgumentErr,
+                       match="'bob' is not a valid method"):
+        s.get_method("bob")
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_method_opt_unknown(session):
+    """Check we error out"""
+
+    s = session()
+    # make sure we use a known method
+    s.set_method("LEVMAR")
+    with pytest.raises(ArgumentErr,
+                       match="'bob' is not a valid option for method levmar"):
+        s.get_method_opt("bob")
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_method_opt_known(session):
+    """Check we get a result.
+
+    This is a regression test so it will need updating if we update
+    the levmar settings.
+
+    """
+
+    s = session()
+    # make sure we use a known method
+    s.set_method("LEVMAR")
+    assert s.get_method_opt("factor") == pytest.approx(100.0)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_set_iter_method_opt_unknown(session):
+    """Check we error out"""
+
+    s = session()
+    with pytest.raises(ArgumentErr,
+                       match="'bob' is not a valid option for method none"):
+        s.set_iter_method_opt("bob", True)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_stat_unknown(session):
+    """Check we error out"""
+
+    s = session()
+    with pytest.raises(ArgumentErr,
+                       match="'bob' is not a valid statistic"):
+        s.get_stat("bob")
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_indep(session):
+    """Somehow we were not calling the Session version"""
+
+    s = session()
+    s.load_arrays(1, [2, 3, 4], [9, 8, 7])
+    got = s.get_indep()
+    assert len(got) == 1
+    assert isinstance(got, tuple)
+    assert got[0] == pytest.approx([2, 3, 4])
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_dims(session):
+    """Somehow we were not calling the Session version"""
+
+    s = session()
+    s.dataspace2d([2, 3], dstype=Data2DInt)
+    got = s.get_dims()
+    assert isinstance(got, tuple)
+    assert got == (2, 3)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("etype", ["stat", "sys"])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_load_xxxerror(session, etype, idval, tmp_path, skip_if_no_io):
+    """Check we are called
+
+    Mainly to ensure we have coverage of the Session class.
+    """
+
+    statfile = tmp_path / "stats.dat"
+    statfile.write_text("1.1\n2.2\n0.0\n")
+
+    s = session()
+    s.load_arrays(idval, [1, 2, 3], [4, 5, 6])
+
+    load = getattr(s, f"load_{etype}error")
+    get = getattr(s, f"get_{etype}error")
+
+    if idval is None:
+        load(str(statfile))
+    else:
+        load(idval, str(statfile))
+
+    assert get(idval) == pytest.approx([1.1, 2.2, 0.0])
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_fake_fixed(session, idval):
+    """Basic check of fake"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(idval, [2, 5, 9], [12, 13, 14])
+    mdl = s.create_model_component("polynom1d", "mdl")
+    s.set_source(idval, mdl)
+    mdl.c0 = 2
+    mdl.c1 = 1
+
+    # We use a custom method which does not add noise
+    #
+    def custom(x):
+        return x
+
+    assert s.get_dep(idval) == pytest.approx([12, 13, 14])
+
+    if idval is None:
+        s.fake(method=custom)
+    else:
+        s.fake(idval, method=custom)
+
+    assert s.get_dep(idval) == pytest.approx([4, 7, 11])
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("idval", [None, "bob"])
+def test_fake_random(session, idval, reset_seed):
+    """Basic check of fake"""
+
+    numpy.random.seed(735)
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(idval, [2, 5, 9], [12, 13, 14])
+    mdl = s.create_model_component("polynom1d", "mdl")
+    s.set_source(idval, mdl)
+    mdl.c0 = 2
+    mdl.c1 = 1
+
+    assert s.get_dep(idval) == pytest.approx([12, 13, 14])
+
+    if idval is None:
+        s.fake()
+    else:
+        s.fake(idval)
+
+    # values will need changing if the random seed <-> generator changes
+    #
+    assert s.get_dep(idval) == pytest.approx([9, 4, 11])
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_save_filter_excluded_everything(session, tmp_path):
+    """Check we error out"""
+
+    s = session()
+    s.load_arrays(1, [10, 15, 20], [1, 2, 3])
+
+    # Hide the messages from ignore
+    with SherpaVerbosity('WARN'):
+        s.ignore()
+
+    ofile = tmp_path / 'not-created.dat'
+    with pytest.raises(DataErr,
+                       match="mask excludes all data"):
+        s.save_filter(str(ofile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_save_filter_noticed_everything(session, tmp_path):
+    """Check we error out"""
+
+    s = session()
+    s.set_default_id("bob")
+    s.load_arrays("bob", [10, 15, 20], [1, 2, 3])
+
+    ofile = tmp_path / 'not-created.dat'
+    with pytest.raises(DataErr,
+                       match="data set 'bob' has no filter"):
+        s.save_filter(str(ofile))
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_add_model_types_simple(session):
+    """coverage check"""
+
+    s = session()
+
+    assert s.list_models() == []
+    s._add_model_types(sherpa.models.basic)
+
+    # This will need updating if models are added to basic
+    assert len(s.list_models()) == 31
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_add_model_types_scalar(session):
+    """coverage check"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic,
+                       baselist=ArithmeticModel)
+
+    # This will need updating if models are added to basic
+    assert len(s.list_models()) == 31
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_model_component_sent_str(session):
+    """Just to match test_get_model_component_sent_model"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+    mdl = s.create_model_component("gauss1d", "g1")
+
+    assert s.get_model_component("g1") == mdl
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_model_component_sent_model(session):
+    """coverage check"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+    mdl = s.create_model_component("gauss1d", "g1")
+
+    assert s.get_model_component(mdl) == mdl
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_create_model_component_sent_model(session):
+    """coverage check"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+    mdl = s.create_model_component("gauss1d", "g1")
+
+    assert s.create_model_component(mdl) == mdl
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_create_model_component_sent_unknown(session):
+    """coverage check"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+    with pytest.raises(ArgumentErr,
+                       match="'notamodel1d' is not a valid model type"):
+        s.create_model_component("notamodel1d", "g1")
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_reset_sent_model(session):
+    """Check model behavior"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl = s.create_model_component("const1d", "foo")
+    mdl.c0 = 2
+
+    # Manually change the model so that reset can change it
+    #
+    mdl.thawedpars = [5]
+
+    assert mdl.c0.val == pytest.approx(5)
+
+    s.reset(mdl)
+
+    assert mdl.c0.val == pytest.approx(2)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_reset_sent_id(session):
+    """Check behavior when sent an id"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl1 = s.create_model_component("const1d", "mdl1")
+    mdl1.c0 = 2
+
+    mdl2 = s.create_model_component("gauss1d", "mdl2")
+    mdl2.pos = 10
+
+    s.set_source(1, mdl1)
+    s.set_source(2, mdl2)
+
+    # Manually change the model so that reset can change it
+    #
+    mdl1.thawedpars = [5]
+    mdl2.thawedpars = [5, 5, 5]
+
+    s.reset(id=2)
+
+    assert mdl1.c0.val == pytest.approx(5)
+    assert mdl2.pos.val == pytest.approx(10)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_reset_sent_nothing(session):
+    """Check behavior when sent nothing"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl1 = s.create_model_component("const1d", "mdl1")
+    mdl1.c0 = 2
+
+    mdl2 = s.create_model_component("gauss1d", "mdl2")
+    mdl2.pos = 10
+
+    s.set_source(1, mdl1)
+    s.set_source(2, mdl2)
+
+    # Manually change the model so that reset can change it
+    #
+    mdl1.thawedpars = [5]
+    mdl2.thawedpars = [5, 5, 5]
+
+    s.reset()
+
+    assert mdl1.c0.val == pytest.approx(2)
+    assert mdl2.pos.val == pytest.approx(10)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_model_type_basic(session):
+    """Check behavior"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl1 = s.create_model_component("const1d", "c1")
+    mdl2 = s.create_model_component("gauss1d", "g1")
+
+    assert s.get_model_type(mdl1) == "const1d"
+    assert s.get_model_type(mdl2) == "gauss1d"
+
+    assert s.get_model_type(-mdl1) == "unaryopmodel"
+    assert s.get_model_type(mdl1 + mdl2) == "binaryopmodel"
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_model_pars_str(session):
+    """Check behavior"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl = s.create_model_component("gauss1d", "g1")
+    assert s.get_model_pars("g1") == ["fwhm", "pos", "ampl"]
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_model_pars_model(session):
+    """Check behavior"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl = s.create_model_component("gauss1d", "g1")
+    assert s.get_model_pars(mdl) == ["fwhm", "pos", "ampl"]
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_num_par(session):
+    """Check behavior"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    mdl1 = s.create_model_component("const1d", "mdl1")
+    mdl2 = s.create_model_component("gauss1d", "mdl2")
+
+    s.set_source(1, mdl1)
+    s.set_source(2, mdl2)
+
+    assert s.get_num_par() == 1
+    assert s.get_num_par(2) == 3
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_model_component_checks_model_name(session):
+    """Check corner case"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    with pytest.raises(IdentifierErr,
+                       match="'gauss1d' is a model type, not allowed as a model name"):
+        s.create_model_component("gauss1d", "gauss1d")
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_model_component_checks_builtin_name(session):
+    """Check corner case"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    with pytest.raises(IdentifierErr,
+                       match="'exit' is reserved for the native Python function"):
+        s.create_model_component("gauss1d", "exit")
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_conf_opt_none(session):
+    """Check corner case
+
+    We could also check get_covar_opt/get_proj_opt but not worth it.
+    """
+
+    s = session()
+    out = s.get_conf_opt()
+    assert isinstance(out, dict)
+    assert len(out) > 0
+
+    # This will need to be updated if the setting changes
+    assert not out["fast"]
+
+
+@requires_fits
+@pytest.mark.parametrize("idval", [None, 1])
+def test_save_filter_astro(idval, tmp_path):
+    """Compare to test_session::test_save_filter_simple"""
+
+    s = AstroSession()
+    s.load_arrays(idval, [1, 2, 3], [12, 15, 2])
+    s.get_data(idval).mask = [True, False, True]
+
+    outfile = tmp_path / "filter.dat"
+    if idval is None:
+        s.save_filter(str(outfile))
+    else:
+        s.save_filter(idval, str(outfile))
+
+    assert outfile.read_text() == "#X FILTER\n1 1\n2 0\n3 1\n"
+
+
+@requires_fits
+@pytest.mark.parametrize("idval", [None, 1])
+def test_save_grouping(idval, tmp_path):
+    """Check corner case"""
+
+    s = AstroSession()
+    s.load_arrays(idval, [1, 2, 3], [12, 15, 2], DataPHA)
+    s.set_grouping(idval, [1, -1, 1])
+
+    outfile = tmp_path / "grp.dat"
+    if idval is None:
+        s.save_grouping(str(outfile))
+    else:
+        s.save_grouping(idval, str(outfile))
+
+    assert outfile.read_text() == "#CHANNEL GROUPS\n1 1\n2 -1\n3 1\n"
+
+
+@requires_fits
+@pytest.mark.parametrize("idval", [None, 1])
+def test_save_quality(idval, tmp_path):
+    """Check corner case"""
+
+    s = AstroSession()
+    s.load_arrays(idval, [1, 2, 3], [12, 15, 2], DataPHA)
+    s.set_quality(idval, [0, 2, 0])
+
+    outfile = tmp_path / "qual.dat"
+    if idval is None:
+        s.save_quality(str(outfile))
+    else:
+        s.save_quality(idval, str(outfile))
+
+    assert outfile.read_text() == "#CHANNEL QUALITY\n1 0\n2 2\n3 0\n"
+
+
+@requires_fits
+@pytest.mark.parametrize("idval", [None, 1])
+def test_save_table(idval, tmp_path):
+    """Check corner case"""
+
+    s = AstroSession()
+    s.load_arrays(idval, [1, 2, 3], [12, 15, 2], DataPHA)
+    s.set_quality(idval, [0, 2, 0])
+
+    outfile = tmp_path / "table.dat"
+    if idval is None:
+        s.save_table(str(outfile), ascii=True)
+    else:
+        s.save_table(idval, str(outfile), ascii=True)
+
+    assert outfile.read_text() == "#CHANNEL COUNTS QUALITY\n1 12 0\n2 15 2\n3 2 0\n"
+
+
+def test_save_all_not_in_session():
+    """This is to note that if we ever change this then test_save_all_empty_stdout can be parametrized"""
+
+    s = Session()
+    assert not hasattr(s, "save_all")
+
+
+def test_save_all_empty_stdout(caplog, capfd):
+    """Check corner case.
+
+    Probably a good idea to check we get screen output.
+
+    For some reason Session does not have save_all.
+
+    """
+
+    s = AstroSession()
+    s.save_all()
+    assert len(caplog.record_tuples) == 0
+
+    out, err = capfd.readouterr()
+    assert err == ""
+
+    # do not check the full output
+    assert out.startswith("import numpy\nfrom sherpa.astro.ui import *\n\n#")
+
+
+def test_calc_data_sum_of_bkg():
+    """Check we recognize the background"""
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [4, 5, 6], DataPHA)
+    s.set_bkg(DataPHA("x", [1, 2, 3], [9, 2, 1]))
+
+    assert s.calc_data_sum(2, 3, bkg_id=1) == 3
+
+
+def test_calc_model_sum_of_bkg():
+    """Check we recognize the background"""
+
+    s = AstroSession()
+    s._add_model_types(sherpa.models.basic)
+    s.load_arrays(1, [1, 2, 3], [4, 5, 6], DataPHA)
+    s.set_bkg(DataPHA("x", [1, 2, 3], [9, 2, 1]))
+
+    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+
+    s.set_rmf(rmf)
+    s.set_rmf(rmf, bkg_id=1)
+
+    s.set_analysis("channel")
+
+    # Pick the source model that is very different to the background
+    # model.
+    #
+    g1 = s.create_model_component("gauss1d", "g1")
+    g1.ampl = 10000
+
+    g2 = s.create_model_component("polynom1d", "g2")
+    g2.c1 = 2
+
+    s.set_source(g1)
+    s.set_bkg_source(g2)
+
+    # The model is y = 1 + 2 * x, so for channels 2:3 it evaluates to
+    # [5, 7]. We then have to filter in the oddness that is PHA files,
+    # which in this case is the fact we have a RMF file applied. So
+    # this is a regression test as I currently can not work out why we
+    # get this value (note that changing egrid changes this result, so
+    # the bin widths are important).
+    #
+    assert s.calc_model_sum(2, 3, bkg_id=1) == pytest.approx(1.2)
+
+    # safety check
+    assert s.calc_model_sum(2, 3) == pytest.approx(5954.871098716832)
+
+
+def test_calc_source_sum_of_bkg():
+    """Check we recognize the background"""
+
+    s = AstroSession()
+    s._add_model_types(sherpa.models.basic)
+    s.load_arrays(1, [1, 2, 3], [4, 5, 6], DataPHA)
+    s.set_bkg(DataPHA("x", [1, 2, 3], [9, 2, 1]))
+
+    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+
+    s.set_rmf(rmf)
+    s.set_rmf(rmf, bkg_id=1)
+
+    s.set_analysis("channel")
+
+    # Pick the source model that is very different to the background
+    # model.
+    #
+    g1 = s.create_model_component("gauss1d", "g1")
+    g1.ampl = 10000
+
+    g2 = s.create_model_component("polynom1d", "g2")
+    g2.c1 = 2
+
+    s.set_source(g1)
+    s.set_bkg_source(g2)
+
+    # This is even more confusing than test_calc_model_sum_of_bkg.
+    # Why is this returning 0?
+    #
+    assert s.calc_source_sum(2, 3, bkg_id=1) == pytest.approx(0)
+
+    # Also what is going on here?
+    assert s.calc_source_sum(2, 3) == pytest.approx(0)
+
+
+def test_fit_bkg_no_models():
+    """Corner case"""
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
+    with pytest.raises(IdentifierErr,
+                       match="model stack is empty"):
+        s.fit_bkg()
+
+
+def test_bkg_fit_data_with_no_model():
+    """Coverage check
+
+    This was aimed at ensuring a particular error condition was checked,
+    but it turns out to be hard to trigger, so we just leave this as is
+    as it is an edge case.
+
+    """
+
+    s = AstroSession()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
+    s.set_bkg(DataPHA("ex", [1, 2, 3], [2, 0, 1]))
+    s.set_bkg(DataPHA("ex", [1, 2, 3], [2, 0, 1]), bkg_id=2)
+
+    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+
+    s.set_rmf(rmf)
+    s.set_rmf(rmf, bkg_id=1)
+
+    g1 = s.create_model_component("gauss1d", "g1")
+    s.set_source(g1)
+
+    g2 = s.create_model_component("gauss1d", "g2")
+    s.set_bkg_source(g2)
+
+    with pytest.raises(ModelErr,
+                       match="background model 2 for data set 1 has not been set"):
+        s.get_stat_info()
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_do_not_fold_all_models(session, tmp_path, skip_if_no_io):
+    """Corner case of _add_convolution_models
+
+    We add a check that the fold model has been called, but it is
+    rather "ugly" as there's no "nice" way to find this out, so we
+    call the model with filtered data and check whether it errors out
+    when it should.
+
+    """
+
+    tblfile = tmp_path / "tbl.dat"
+    tblfile.write_text("!Y\n10\n5\n2\n1\n")
+
+    s = session()
+    s.load_table_model("tbl1", str(tblfile), comment="!", ncols=1)
+    s.load_table_model("tbl2", str(tblfile), comment="!", ncols=1)
+
+    tbl1 = s.get_model_component("tbl1")
+    tbl2 = s.get_model_component("tbl2")
+
+    def does_error(mdl):
+        with pytest.raises(ModelErr, match="Mismatch between table model and data, "):
+            mdl([1, 2, 3])
+
+    does_error(tbl1)
+    does_error(tbl2)
+
+    s.load_arrays(1, [1, 2, 3, 4], [9, 3, 3, 2])
+    s.load_arrays("x", [1, 2, 3, 4], [9, 3, 3, 2])
+    s.set_source("x", "tbl2")
+
+    # Filter the data so we know the data has been folded.
+    # This only works if the table model had no X axis.
+    #
+    s.ignore_id("x", lo=4)
+
+    does_error(tbl1)
+    does_error(tbl2)
+
+    # This call is the main thing being tested; the does_error/tbl2
+    # checks are done as extras.
+    #
+    check = s.get_model("x")
+    assert check == tbl2
+
+    does_error(tbl1)
+    assert tbl2([1, 2, 3]) == pytest.approx([10, 5, 2])
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_delete_psf_not_there(session):
+    """delete_psf does nothing if no PSF exist"""
+
+    s = session()
+    assert s.list_psf_ids() == []
+    s.delete_psf()
+    assert s.list_psf_ids() == []
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_delete_psf_there(session):
+    """delete_psf removes the PSF"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10)
+    s.load_psf("bob", "gauss1d.mdl")
+    s.set_psf("bob")
+
+    s.dataspace1d(1, 10, id=2)
+    s.load_psf("fred", "gauss1d.mdl")
+    s.set_psf(2, "fred")
+
+    assert s.list_psf_ids() == [1, 2]
+    s.delete_psf(2)
+    assert s.list_psf_ids() == [1]
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_fit_ignores_repeated_otherid(session, caplog):
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    # Hmm, using the same id but as a string is a bit dangerous,
+    # so let's see what happens.
+    #
+    s.load_arrays(1, [1, 2], [2, 5])
+    s.load_arrays("1", [10, 20], [7, 8])
+
+    s.set_source(1, "const1d.con")
+    s.set_source("1", "con")
+
+    s.set_stat("leastsq")
+    with SherpaVerbosity("WARN"):
+        s.fit(1, "1", 1, "1")
+
+    res = s.get_fit_results()
+    assert res.datasets == (1, "1")
+    assert res.numpoints == 4
+    assert res.dof == 3
+    assert res.parnames == ("con.c0", )
+    assert len(res.parvals) == 1
+    assert res.parvals[0] == pytest.approx(5.5)
+
+    # We can also check a corner case of calc_stat_info, for
+    # handling multiple datasets.
+    #
+    assert len(caplog.record_tuples) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        s.calc_stat_info()
+
+    assert len(caplog.record_tuples) == 1
+    loc, lvl, msg = caplog.record_tuples[0]
+    assert loc == "sherpa.ui.utils"
+    assert lvl == logging.INFO
+
+    toks = msg.split("\n\n")
+    assert len(toks) == 3
+
+    # This is a case where using the same id as an integer and string
+    # makes it hard to understand the results!
+    #
+    assert toks[0].startswith("Dataset               = 1\n")
+    assert "Fit statistic value   = 12.5\n" in toks[0]
+    assert toks[0].endswith("Degrees of freedom    = 1")
+
+    assert toks[1].startswith("Dataset               = 1\n")
+    assert "Fit statistic value   = 8.5\n" in toks[1]
+    assert toks[1].endswith("Degrees of freedom    = 1")
+
+    assert toks[2].startswith("Datasets              = [1, '1']\n")
+    assert "Fit statistic value   = 21\n" in toks[2]
+    assert toks[2].endswith("Degrees of freedom    = 3")
+
+    # We can also check out calc_chisqr
+    #
+    d1 = [12.25, 0.25]
+    d2 = [2.25, 6.25]
+    assert s.calc_chisqr() == pytest.approx(d1 + d2)  # array concatenation not value addition
+    assert s.calc_chisqr(1) == pytest.approx(d1)
+    assert s.calc_chisqr("1") == pytest.approx(d2)
+    assert s.calc_chisqr(1, "1") == pytest.approx(d1 + d2)
+    assert s.calc_chisqr("1", 1, 1, "1") == pytest.approx(d2 + d1)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_get_draws_wants_errors(session):
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(1, [1, 2], [2, 5])
+    s.set_source(1, "const1d.foo")
+    s.fit()
+
+    with pytest.raises(SessionErr,
+                       match="covariance has not been performed"):
+        s.get_draws(niter=1)
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("method", ["proj", "unc"])
+def test_get_int_xxx_otherids(method, session):
+    """Corner case.
+
+    This does not need a plotting backend.
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(1, [1, 2, 3, 4], [2, 5, 7, 12])
+    s.load_arrays(2, [10, 20, 35, 40], [7, 8, 6, 12])
+
+    s.set_staterror(1, [1, 1, 1, 1])
+    s.set_staterror(2, [1, 1, 1, 1])
+
+    s.set_source(1, "const1d.con")
+    s.set_source(2, "con")
+
+    with SherpaVerbosity("WARN"):
+        s.fit(1, 2)
+
+    # A minimal check of the returned values.
+    #
+    get = getattr(s, f"get_int_{method}")
+    plot = get(id=2, par="con.c0", otherids=[1], recalc=True,
+               min=5, max=8, nloop=5)
+
+    assert plot.min == pytest.approx(5)
+    assert plot.max == pytest.approx(8)
+    assert plot.nloop == 5
+    assert plot.x == pytest.approx([5, 5.75, 6.5, 7.25, 8])
+    assert plot.y == pytest.approx([125, 101, 86, 80, 83])
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("method", ["proj", "unc"])
+def test_get_reg_xxx_otherids(method, session):
+    """Corner case.
+
+    This does not need a plotting backend.
+    """
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.load_arrays(1, [1, 2, 3, 4], [2, 5, 7, 12])
+    s.load_arrays(2, [10, 20, 35, 40], [7, 8, 6, 12])
+
+    s.set_staterror(1, [1, 1, 1, 1])
+    s.set_staterror(2, [1, 1, 1, 1])
+
+    s.set_source(1, "polynom1d.mdl")
+    s.set_source(2, "mdl")
+
+    mdl = s.get_model_component("mdl")
+    mdl.c1.thaw()
+
+    with SherpaVerbosity("WARN"):
+        s.fit(1, 2)
+
+    # A minimal check of the returned values.
+    #
+    get = getattr(s, f"get_reg_{method}")
+    plot = get("mdl.c0", "mdl.c1", id=2, otherids=[1], recalc=True,
+               min=[4, 0], max=[8, 0.2], nloop=[5, 5])
+
+    assert plot.parval0 == pytest.approx(mdl.c0.val)
+    assert plot.parval1 == pytest.approx(mdl.c1.val)
+    assert plot.y.min() == pytest.approx(66.35)
+    assert plot.y.max() == pytest.approx(184.8)
+
+
+@pytest.mark.parametrize("etype", ["stat", "sys"])
+def test_set_xxxerror_bkg(etype):
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [2, 3, 2], DataPHA)
+    s.set_bkg(DataPHA("bkg", [1, 2, 3], [1, 0, 2]))
+
+    setfunc = getattr(s, f"set_{etype}error")
+    setfunc([2, 4, 3], bkg_id=1)
+
+    getfunc = getattr(s, f"get_{etype}error")
+    assert getfunc(bkg_id=1) == pytest.approx([2, 4, 3])
+
+
+@pytest.mark.parametrize("idval", [None,
+                                   pytest.param(1, marks=pytest.mark.xfail),
+                                   pytest.param("bob", marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("field,startval",
+                         [("exposure", 23.0),
+                          ("backscal", 0.23),
+                          ("areascal", 0.23)])
+def test_set_pha_value_none(idval, field, startval):
+    """Corner case.
+
+    Unfortunately, the API makes it hard to set the value to None:
+    it only works for the default id. The errors when the idval is set
+    differ (if an integer then the id gets set as the value, if a
+    string there's a string conversion error).
+
+    """
+
+    s = AstroSession()
+    s.load_arrays(idval, [1, 2, 3], [2, 4, 3], DataPHA)
+
+    setfunc = getattr(s, f"set_{field}")
+    getfunc = getattr(s, f"get_{field}")
+
+    setfunc(idval, startval)
+    assert getfunc(idval) == pytest.approx(startval)
+
+    setfunc(idval, None)
+    assert getfunc(idval) is None
+
+
+@requires_fits
+def test_pack_pha():
+    """Very basic check: does it work?"""
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [4, 5, 2], DataPHA)
+
+    # We do the absolute-minimum as a check
+    assert s.pack_pha() is not None
+
+
+@requires_fits
+def test_pack_table():
+    """Very basic check: does it work?"""
+
+    s = AstroSession()
+    s.load_arrays(1, [1, 2, 3], [4, 5, 2], DataPHA)
+
+    # We do the absolute-minimum as a check
+    assert s.pack_table() is not None
+
+
+@requires_fits
+def test_pack_image():
+    """Very basic check: does it work?"""
+
+    s = AstroSession()
+    s.dataspace2d([2, 3])
+
+    # We do the absolute-minimum as a check
+    assert s.pack_image() is not None
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("idval", [None, 1, "bob"])
+def test_show_kernel(session, idval):
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10, id=idval)
+    s.load_psf("bob", "gauss1d.mdl")
+    if idval is None:
+        s.set_psf("bob")
+    else:
+        s.set_psf(idval, "bob")
+
+    out = StringIO()
+    if idval is None:
+        s.show_kernel(outfile=out)
+    else:
+        s.show_kernel(idval, outfile=out)
+
+    idstr = "1" if idval is None else idval
+
+    toks = out.getvalue().split("\n")
+    assert toks[0] == f"PSF Kernel: {idstr}"
+    assert toks[1] == "psfmodel.bob"
+    assert len(toks) == 12
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_show_kernel_multi(session):
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    s.dataspace1d(1, 10, id=1)
+    s.dataspace1d(1, 10, id="twenty")
+    s.load_psf("bob", "gauss1d.mdl")
+    s.load_psf("fred", "const1d.mdl2")
+
+    bob = s.get_model_component("bob")
+    fred = s.get_model_component("fred")
+    s.set_psf(bob)
+    s.set_psf("twenty", fred)
+
+    out = StringIO()
+    s.show_kernel(outfile=out)
+
+    print(out.getvalue())
+    toks = out.getvalue().split("\n\n")
+    assert toks[0].startswith("PSF Kernel: 1\npsfmodel.bob\n")
+    assert toks[1].startswith("PSF Kernel: twenty\npsfmodel.fred\n")
+    assert toks[2] == "\n"
+    assert len(toks) == 3
+
+
+@pytest.mark.parametrize("session", [Session, AstroSession])
+def test_load_conv_model_instance(session):
+    """Corner case"""
+
+    s = session()
+    s._add_model_types(sherpa.models.basic)
+
+    ngl = s.create_model_component("normgauss1d", "ngl")
+    s.list_model_components() == ["ngl"]
+
+    s.load_conv("bobby", ngl)
+    s.list_model_components() == ["ngl", "bobby"]
+
+    got = s.get_model_component("bobby")
+    assert isinstance(got, ConvolutionKernel)
+    assert got.name == "convolutionkernel.bobby"
+    assert got.kernel == ngl

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -21,7 +21,6 @@
 from collections import namedtuple
 import os
 import re
-import tempfile
 import logging
 
 import numpy
@@ -380,11 +379,17 @@ def test_more_ui_string_model_with_rmf(make_data_path):
 @requires_fits
 @requires_data
 @requires_group
-def test_more_ui_bug38(make_data_path):
+def test_more_ui_bug38(make_data_path, caplog):
     ui.load_pha('3c273', make_data_path('3c273.pi'))
     ui.notice_id('3c273', 0.3, 2)
-    ui.group_counts('3c273', 30)
-    ui.group_counts('3c273', 15)
+
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        ui.group_counts('3c273', 30)
+
+        ui.group_counts('3c273', 15)
+
+    assert len(caplog.records) == 0
 
 
 @requires_fits
@@ -405,7 +410,7 @@ def test_bug38_filtering(make_data_path):
 @requires_fits
 @requires_data
 @requires_group
-def test_bug38_filtering_grouping(make_data_path):
+def test_bug38_filtering_grouping(make_data_path, caplog):
     """Low-level tests related to bugs #38, #917: filter+group"""
 
     from sherpa.astro.io import read_pha
@@ -418,7 +423,14 @@ def test_bug38_filtering_grouping(make_data_path):
     assert pha.get_filter(group=True, format='%.4f') == expected
     assert pha.get_filter(group=False, format='%.4f') == expected
 
-    pha.group_width(40)
+    # Just check that the logging that may happen at the UI level does
+    # not happen here.
+    #
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        pha.group_width(40)
+
+    assert len(caplog.records) == 0
 
     expected = '0.5840:2.9200,3.5040:7.0080'
     assert pha.get_filter(group=True, format='%.4f') == expected
@@ -441,6 +453,153 @@ def test_bug38_filtering_grouping(make_data_path):
 
     assert elo[1] == elo_all[40]
     assert ehi[11] == ehi_all[479]
+
+
+@requires_group
+def test_group_reporting_case(clean_astro_ui, caplog):
+    """logging group output can provide surprising output.
+
+    Filter and grouping can provide surprising results, so check the
+    current behaviour.
+    """
+
+    x = numpy.arange(1, 22)
+    ui.load_arrays(1, x, x, ui.DataPHA)
+    ui.notice(5, 7)
+    ui.notice(9, 11)
+    ui.notice(13, 15)
+
+    assert ui.get_filter() == "5:7,9:11,13:15"
+
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        ui.group_width(3)
+
+    assert len(caplog.records) == 0
+
+    assert ui.get_filter() == "4:15"
+
+
+@requires_group
+@pytest.mark.parametrize("idval", [None, 2])
+def test_group_bins(idval, clean_astro_ui, caplog):
+    """Just check out group_bins"""
+
+    idarg = 1 if idval is None else idval
+
+    x = numpy.arange(1, 22)
+    ui.load_arrays(idarg, x, x, ui.DataPHA)
+    ui.notice(5, 7)
+    ui.notice(9, 11)
+    ui.notice(13, 15)
+
+    assert ui.get_filter(idval) == "5:7,9:11,13:15"
+    assert ui.get_dep(idval) == pytest.approx(x)
+    assert ui.get_dep(idval, filter=True) == pytest.approx([5, 6, 7, 9, 10, 11, 13, 14, 15])
+
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        if idval is None:
+            ui.group_bins(3)
+        else:
+            ui.group_bins(idval, 3)
+
+    assert len(caplog.records) == 0
+
+    assert ui.get_grouping(idval) == pytest.approx([1, -1, -1, -1, -1, -1, -1] * 3)
+    assert ui.get_quality(idval) == pytest.approx([0] * 21)
+
+    # The grouped values are
+    #     1+2+3+4+5+6+7  = 28
+    #     8+..+14        = 77
+    #     15+..+21       = 126
+    # and the widths of each group are 7, hence get_dep returns
+    #     4, 11, 18
+    #
+    assert ui.get_filter(idval) == "1:21"
+    assert ui.get_dep(idval) == pytest.approx([4, 11, 18])
+    assert ui.get_dep(idval, filter=True) == pytest.approx([4, 11, 18])
+
+
+@requires_group
+@pytest.mark.parametrize("idval", [None, 2])
+def test_group_snr(idval, clean_astro_ui, caplog):
+    """Just check out group_snr"""
+
+    idarg = 1 if idval is None else idval
+
+    x = [1, 2, 3, 4, 5, 6]
+    y = [2, 6, 3, 4, 5, 3]
+    ui.load_arrays(idarg, x, y, ui.DataPHA)
+
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        if idval is None:
+            ui.group_snr(3)
+        else:
+            ui.group_snr(idval, 3)
+
+    assert len(caplog.records) == 0
+
+    assert ui.get_grouping(idval) == pytest.approx([1, -1, -1, 1, -1, -1])
+    assert ui.get_quality(idval) == pytest.approx([0] * 6)
+
+    assert ui.get_dep(idval) == pytest.approx([11 / 3, 4])
+    assert ui.get_dep(idval, filter=True) == pytest.approx([11 / 3, 4])
+
+
+@requires_group
+@pytest.mark.parametrize("idval", [None, 2])
+def test_group_adapt(idval, clean_astro_ui, caplog):
+    """Just check out group_adapt"""
+
+    idarg = 1 if idval is None else idval
+
+    x = [1, 2, 3, 4, 5, 6]
+    y = [2, 6, 3, 4, 5, 3]
+    ui.load_arrays(idarg, x, y, ui.DataPHA)
+
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        if idval is None:
+            ui.group_adapt(5)
+        else:
+            ui.group_adapt(idval, 5)
+
+    assert len(caplog.records) == 0
+
+    assert ui.get_grouping(idval) == pytest.approx([1, 1, 1, -1, 1, 1])
+    assert ui.get_quality(idval) == pytest.approx([2] + [0] * 4 + [2])
+
+    assert ui.get_dep(idval) == pytest.approx([2, 6, 3.5, 5, 3])
+    assert ui.get_dep(idval, filter=True) == pytest.approx([2, 6, 3.5, 5, 3])
+
+
+@requires_group
+@pytest.mark.parametrize("idval", [None, 2])
+def test_group_adapt_snr(idval, clean_astro_ui, caplog):
+    """Just check out group_adapt_snr"""
+
+    idarg = 1 if idval is None else idval
+
+    x = [1, 2, 3, 4, 5, 6]
+    y = [2, 6, 3, 4, 5, 3]
+    ui.load_arrays(idarg, x, y, ui.DataPHA)
+
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        if idval is None:
+            ui.group_adapt_snr(3)
+        else:
+            ui.group_adapt_snr(idval, 3)
+
+    assert len(caplog.records) == 0
+
+    assert ui.get_grouping(idval) == pytest.approx([1, 1, -1, 1, -1, -1])
+    assert ui.get_quality(idval) == pytest.approx([2] + [0] * 2 + [2] * 3)
+
+    assert ui.get_dep(idval) == pytest.approx([2, 4.5, 4])
+    assert ui.get_dep(idval, filter=True) == pytest.approx([2, 4.5, 4])
 
 
 # bug #12578
@@ -652,7 +811,7 @@ def test_chi2(make_data_path, clean_astro_ui):
     assert stat12 == 'chi2'
 
 
-def save_arrays(colnames, fits, read_func):
+def save_arrays(tmp_path, colnames, fits, read_func):
     """Write out a small set of data using ui.save_arrays
     and then read it back in, to check it was written out
     correctly (or, at least, in a way that can be read back
@@ -660,6 +819,8 @@ def save_arrays(colnames, fits, read_func):
 
     Parameter
     ---------
+    tmp_path
+        The tmp_path fixture
     colnames, fits : bool
     read_func : function
 
@@ -676,11 +837,11 @@ def save_arrays(colnames, fits, read_func):
     else:
         fields = None
 
-    ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
-    ui.save_arrays(ofh.name, [a, b, c], fields=fields,
+    ofile = str(tmp_path / "out.dat")
+    ui.save_arrays(ofile, [a, b, c], fields=fields,
                    ascii=not fits, clobber=True)
 
-    out = read_func(ofh.name)
+    out = read_func(ofile)
     assert isinstance(out, Data1D)
 
     rtol = 0
@@ -689,7 +850,7 @@ def save_arrays(colnames, fits, read_func):
     # remove potential dm syntax introduced by backend before checking for equality
     out_name = re.sub(r"\[.*\]", "", out.name)
 
-    assert ofh.name == out_name, 'file name'
+    assert ofile == out_name, 'file name'
     assert_allclose(out.x, a, rtol=rtol, atol=atol, err_msg="x column")
     assert_allclose(out.y, b, rtol=rtol, atol=atol, err_msg="y column")
     assert_allclose(out.staterror, c, rtol=rtol, atol=atol,
@@ -699,52 +860,56 @@ def save_arrays(colnames, fits, read_func):
 
 @requires_fits
 @pytest.mark.parametrize("colnames", [False, True])
-def test_save_arrays_FITS(colnames):
+def test_save_arrays_FITS(colnames, tmp_path):
 
     def read_func(filename):
         return ui.unpack_table(filename, ncols=3)
 
-    save_arrays(colnames=colnames, fits=True, read_func=read_func)
+    save_arrays(tmp_path, colnames=colnames, fits=True,
+                read_func=read_func)
 
 
 @requires_fits
 @pytest.mark.parametrize("colnames", [False, True])
-def test_save_arrays_ASCII(colnames):
+def test_save_arrays_ASCII(colnames, tmp_path):
 
     def read_func(filename):
         return ui.unpack_ascii(filename, ncols=3)
 
-    save_arrays(colnames=colnames, fits=False, read_func=read_func)
-
+    save_arrays(tmp_path, colnames=colnames, fits=False,
+                read_func=read_func)
 
 
 @requires_fits
 @pytest.mark.parametrize("ascii_type", [False, True])
-def test_save_arrays_colmismatch_errs(ascii_type):
-    with pytest.raises(IOErr) as exc:
-        a = numpy.asarray([1, 3, 5])
-        b = numpy.asarray([4, 6, 8])
-        c = a*b
-        fields = ["odd", "even"]
-        ui.save_arrays("bogus_tempfile_name", [a, b, c], fields=fields,
-                   ascii=ascii_type, clobber=True)
-    assert 'Expected 3 columns but found 2' in str(exc.value)
+def test_save_arrays_colmismatch_errs(ascii_type, tmp_path):
 
+    ofile = str(tmp_path / "should_not_get_created")
+
+    a = numpy.asarray([1, 3, 5])
+    b = numpy.asarray([4, 6, 8])
+    c = a*b
+    fields = ["odd", "even"]
+
+    with pytest.raises(IOErr,
+                       match="Expected 3 columns but found 2"):
+        ui.save_arrays(ofile, [a, b, c], fields=fields,
+                       ascii=ascii_type, clobber=True)
 
 
 @requires_fits
 @requires_data
-def testWrite(make_data_path):
+def testWrite(make_data_path, tmp_path):
 
     fname = make_data_path('3c273.pi')
     ui.load_pha(1, fname)
     pha_orig = ui.get_data(1)
 
-    ofh = tempfile.NamedTemporaryFile(suffix='sherpa_test')
-    ui.save_pha(1, ofh.name, ascii=False, clobber=True)
+    ofile = str(tmp_path / "saved.pha")
+    ui.save_pha(1, ofile, ascii=False, clobber=True)
 
     # limited checks
-    pha = ui.unpack_pha(ofh.name)
+    pha = ui.unpack_pha(ofile)
     assert isinstance(pha, DataPHA)
 
     for key in ["channel", "counts"]:

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -602,6 +602,37 @@ def test_group_adapt_snr(idval, clean_astro_ui, caplog):
     assert ui.get_dep(idval, filter=True) == pytest.approx([2, 4.5, 4])
 
 
+@requires_group
+@requires_data
+@requires_fits
+def test_group_snr_oddity(make_data_path, clean_astro_ui):
+    """group_snr was changing the filter; why is this?
+
+    Seen originally in PR #1637. See issue #1646 where it turns out to
+    be due to the behavior of the group module.
+
+    This is a regression test (checking the behavior).
+
+    """
+
+    with SherpaVerbosity("ERROR"):
+        ui.load_pha(make_data_path("3c273.pi"))
+
+    ui.ungroup()
+
+    with SherpaVerbosity("WARN"):
+        ui.notice(0.5, 6)
+
+    assert ui.get_data().get_filter(format="%.3f") == "0.496:6.001"
+
+    ui.group_snr(3, tabStops=~ui.get_data().get_mask())
+
+    # Why has the filter changed? One channel mask has been reset
+    # from False to True.
+    #
+    assert ui.get_data().get_filter(format="%.3f") == "0.482:6.001"
+
+
 # bug #12578
 @requires_data
 @requires_fits

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2012, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -704,7 +704,7 @@ def test_psf_model2d(model, clean_astro_ui):
 
 
 def test_dataspace2d_default(clean_astro_ui):
-    """What happens when we calll dataspace2d: default"""
+    """What happens when we call dataspace2d: default"""
 
     ui.dataspace2d([3, 5], 2)
     data = ui.get_data(2)
@@ -717,7 +717,7 @@ def test_dataspace2d_default(clean_astro_ui):
 
 
 def test_dataspace2d_data2d(clean_astro_ui):
-    """What happens when we calll dataspace2d: Data2D"""
+    """What happens when we call dataspace2d: Data2D"""
 
     ui.dataspace2d([3, 5], 2, Data2D)
     data = ui.get_data(2)
@@ -730,7 +730,7 @@ def test_dataspace2d_data2d(clean_astro_ui):
 
 
 def test_dataspace2d_data2dint(clean_astro_ui):
-    """What happens when we calll dataspace2d: Data2DInt"""
+    """What happens when we call dataspace2d: Data2DInt"""
 
     ui.dataspace2d([3, 5], 2, Data2DInt)
     data = ui.get_data(2)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -28,10 +28,10 @@ from numpy.testing import assert_allclose
 
 import pytest
 
-from sherpa.astro.data import DataPHA
+from sherpa.astro.data import DataIMG, DataPHA
 from sherpa.astro.instrument import RMFModelPHA
 from sherpa.astro import ui
-from sherpa.data import Data1D
+from sherpa.data import Data1D, Data2D, Data2DInt
 from sherpa.utils.err import ArgumentErr, DataErr, IdentifierErr, IOErr, StatErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
@@ -701,6 +701,51 @@ def test_psf_model2d(model, clean_astro_ui):
     mdl = ui.get_model_component('mdl')
     assert (numpy.array(mdl.get_center()) ==
             numpy.array([108, 130])).all()
+
+
+def test_dataspace2d_default(clean_astro_ui):
+    """What happens when we calll dataspace2d: default"""
+
+    ui.dataspace2d([3, 5], 2)
+    data = ui.get_data(2)
+    assert isinstance(data, DataIMG)
+    assert data.name == "dataspace2d"
+    assert data.shape == (5, 3)
+    assert data.x0 == pytest.approx([1, 2, 3] * 5)
+    assert data.x1 == pytest.approx([1] * 3 + [2] * 3 + [3] * 3 + [4] * 3 + [5] * 3)
+    assert data.y == pytest.approx(numpy.zeros(15))
+
+
+def test_dataspace2d_data2d(clean_astro_ui):
+    """What happens when we calll dataspace2d: Data2D"""
+
+    ui.dataspace2d([3, 5], 2, Data2D)
+    data = ui.get_data(2)
+    assert isinstance(data, Data2D)
+    assert data.name == "dataspace2d"
+    assert data.shape == (5, 3)
+    assert data.x0 == pytest.approx([1, 2, 3] * 5)
+    assert data.x1 == pytest.approx([1] * 3 + [2] * 3 + [3] * 3 + [4] * 3 + [5] * 3)
+    assert data.y == pytest.approx(numpy.zeros(15))
+
+
+def test_dataspace2d_data2dint(clean_astro_ui):
+    """What happens when we calll dataspace2d: Data2DInt"""
+
+    ui.dataspace2d([3, 5], 2, Data2DInt)
+    data = ui.get_data(2)
+    assert isinstance(data, Data2DInt)
+    assert data.name == "dataspace2d"
+    assert data.shape == (5, 3)
+    assert data.x0lo == pytest.approx([0.5, 1.5, 2.5] * 5)
+    assert data.x0hi == pytest.approx([1.5, 2.5, 3.5] * 5)
+    assert data.x1lo == pytest.approx([0.5] * 3 + [1.5] * 3 + [2.5] * 3 + [3.5] * 3 + [4.5] * 3)
+    assert data.x1hi == pytest.approx([1.5] * 3 + [2.5] * 3 + [3.5] * 3 + [4.5] * 3 + [5.5] * 3)
+    assert data.y == pytest.approx(numpy.zeros(15))
+
+    # These are presumably auto-generated
+    assert data.x0 == pytest.approx([1, 2, 3] * 5)
+    assert data.x1 == pytest.approx([1] * 3 + [2] * 3 + [3] * 3 + [4] * 3 + [5] * 3)
 
 
 def test_psf_pars_are_frozen(clean_astro_ui):
@@ -1508,3 +1553,25 @@ def test_unpack_arrays_dataimg():
     assert ans.shape == pytest.approx(3, 4)
     assert ans.staterror is None
     assert ans.syserror is None
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("idval", [None, 2])
+def test_get_rate_bkg(idval, clean_astro_ui, make_data_path):
+    """Check we can call get_rate with bkg_id"""
+
+    ui.load_pha(idval, make_data_path("3c273.pi"))
+
+    r1 = ui.get_rate(idval)
+    r2 = ui.get_rate(idval, bkg_id=1)
+
+    # All we do is check they are different
+    assert isinstance(r1, numpy.ndarray)
+    assert isinstance(r2, numpy.ndarray)
+
+    # We can not say r1 > r2 as this is not true for all bins.
+    # Technically two bins could be the same, but they are not for
+    # this dataset.
+    #
+    assert numpy.all(r1 != r2)

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021, 2022
+#  Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1925,10 +1925,10 @@ def test_get_axes_datapha_rsp():
 def test_get_axes_datapha_rsp_bkg(clean_astro_ui):
     """Let's have a RMF and ARF for fun (but only for source)
 
-    It is not clear whether we expect the respnose to be automatically
+    It is not clear whether we expect the response to be automatically
     applied to the background here, so treat this as a regression test
     (because, at present, we do not have units=energy for the
-    background(.
+    background).
     """
 
     ui.load_arrays(1, [1, 2, 3], [1, 2, 3], ui.DataPHA)
@@ -2162,7 +2162,7 @@ def test_set_grouping_1636_indirect(clean_astro_ui, caplog):
     """See issue #1636. Also #1635.
 
     I assume this was broken by #1477. Issue #1636 points out this is
-    broken biut #1635 asks what the behavior should be, so this is
+    broken but #1635 asks what the behavior should be, so this is
     a regression test.
 
     See also test_set_grouping_1636_direct.

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2018, 2021 Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016, 2018, 2021, 2022
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -70,12 +71,11 @@ def test_load_template_interpolator(run_thread, clean_ui):
 # not represent (gridsearch with wrong values)
 @requires_data
 def test_load_template_model_without_interpolation_2_31(run_thread, clean_ui):
-    with pytest.raises(ModelErr) as me:
+    emsg = 'Interpolation of template parameters was disabled for this model, but parameter values not in the template library have been requested. Please use gridsearch method and make sure the sequence option is consistent with the template library'
+
+    with pytest.raises(ModelErr, match=emsg):
         run_thread('load_template_without_interpolation',
                    scriptname='test_case_2_and_3.1.py')
-
-    emsg = 'Interpolation of template parameters was disabled for this model, but parameter values not in the template library have been requested. Please use gridsearch method and make sure the sequence option is consistent with the template library'
-    assert str(me.value) == emsg
 
 
 # TestCase 3.2 discrete templates fail when probed for values they do
@@ -83,12 +83,10 @@ def test_load_template_model_without_interpolation_2_31(run_thread, clean_ui):
 #
 @requires_data
 def test_load_template_model_without_interpolation_32(run_thread, clean_ui):
-    with pytest.raises(ModelErr) as me:
+    emsg = r"You are trying to fit a model which has a discrete template model component with a continuous optimization method. Since CIAO4.6 this is not possible anymore. Please use gridsearch as the optimization method and make sure that the 'sequence' option is correctly set, or enable interpolation for the templates you are loading \(which is the default behavior\)."
+    with pytest.raises(ModelErr, match=emsg):
         run_thread('load_template_without_interpolation',
                    scriptname='test_case_3.2.py')
-
-    emsg = "You are trying to fit a model which has a discrete template model component with a continuous optimization method. Since CIAO4.6 this is not possible anymore. Please use gridsearch as the optimization method and make sure that the 'sequence' option is correctly set, or enable interpolation for the templates you are loading (which is the default behavior)."
-    assert str(me.value) == emsg
 
 
 # TestCase 4 gridsearch with right values succeeds
@@ -110,7 +108,6 @@ def setUp():
     x = numpy.linspace(0.1, 5, 50)
 
     num = 4
-    ncoords = 100
     ntemplates = 2**num
     g1 = Gauss1D('g1')
 
@@ -118,7 +115,7 @@ def setUp():
     grid = numpy.mgrid[[slice(0, 2, 1) for ii in range(num)]]
     grid = numpy.asarray(list(map(numpy.ravel, grid))).T
     coords = numpy.linspace(0.01, 6, 100)
-    names = ["p%i" % i for i in range(num)]
+    names = [f"p{i}" for i in range(num)]
     templates = []
     for ii in range(ntemplates):
         t = TableModel()

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -25,20 +25,21 @@ to be kept up to date.
 
 from io import StringIO
 import logging
+import pickle
 from unittest.mock import patch
 
 from numpy.testing import assert_array_equal
 
 import pytest
 
-from sherpa.models import parameter
+from sherpa.models import Model, parameter
 import sherpa.models.basic
 from sherpa import estmethods as est
 from sherpa import optmethods as opt
 from sherpa import stats
-from sherpa.ui.utils import Session
+from sherpa.ui.utils import Session, ModelWrapper
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
-    IdentifierErr, SessionErr
+    IdentifierErr, IOErr, SessionErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_plotting, requires_xspec
 
@@ -111,8 +112,8 @@ def test_list_ids():
 
 
 # bug #297
-def test_save_restore(tmpdir):
-    outfile = tmpdir.join("sherpa.save")
+def test_save_restore(tmp_path):
+    outfile = tmp_path / "sherpa.save"
     session = Session()
     session.load_arrays(1, TEST, TEST2)
     session.save(str(outfile), clobber=True)
@@ -123,6 +124,32 @@ def test_save_restore(tmpdir):
     assert {1, } == set(session.list_data_ids())
     assert_array_equal(TEST, session.get_data(1).get_indep()[0])
     assert_array_equal(TEST2, session.get_data(1).get_dep())
+
+
+def test_save_clobber_check(tmp_path):
+    """Check we handle clobber case"""
+
+    tmp = tmp_path / "x.sherpa"
+    tmp.write_text("not-empty")
+
+    s = Session()
+    with pytest.raises(IOErr,
+                       match="' exists and clobber is not set"):
+        s.save(str(tmp), clobber=False)
+
+
+def test_restore_not_a_session(tmp_path):
+    """Check we error out when it's not a Session object"""
+
+    # Argh tmppath and pickle don't play well together
+    tmp = tmp_path / "not-sherpa.state"
+    with open(tmp, 'wb') as ofh:
+        pickle.dump({"x": 23}, ofh)
+
+    s = Session()
+    with pytest.raises(ArgumentErr,
+                       match="' does not contain a saved Sherpa session"):
+        s.restore(str(tmp))
 
 
 def test_models_models():
@@ -1082,3 +1109,298 @@ def test_set_default_id_check_invalid(value):
         s.set_default_id(value)
 
     assert str(err.value) == f"identifier '{value}' is a reserved word"
+
+
+class ModelWithDoc(Model):
+    """This has a doc string"""
+
+    _hidden = False
+
+
+class ModelWithNoDoc(Model):
+    # This does not have a doc string
+
+    pass
+
+
+def test_modelwrapper_init():
+    """Basic ModelWrapper check"""
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithDoc)
+    assert repr(wrap) == "<ModelWithDoc model type>"
+
+
+def test_modelwrapper_str_with_doc():
+    """Basic ModelWrapper check"""
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithDoc)
+    assert str(wrap) == "This has a doc string"
+
+
+def test_modelwrapper_str_no_doc():
+    """Basic ModelWrapper check"""
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithNoDoc)
+    assert str(wrap) == "<ModelWithNoDoc model type>"
+
+
+def test_modelwrapper_what_is_the_docstring():
+    """What do we want help(wrappedmodel) to return"""
+
+    # Check current behavior
+    assert ModelWrapper.__doc__ is None
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithNoDoc)
+    assert wrap.__doc__ is None
+
+
+@pytest.mark.parametrize("attr", ["_hidden", "_foo_bar"])
+def test_modelwrapper_getattr_no_hidden(attr):
+    """How does attribute access work?
+
+    We can't access attributes of the original model or unknown
+    attribues if they start with _.
+
+    """
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithDoc)
+
+    with pytest.raises(AttributeError,
+                       match=f"^'ModelWrapper' object has no attribute '{attr}'$"):
+        getattr(wrap, attr)
+
+
+def test_modelwrapper_getattr_instance():
+    """The access works for the model instance"""
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithDoc)
+    mdl = wrap("bob")
+    assert not mdl._hidden
+
+
+def test_modelwrapper_getattr_instance_unknown():
+    """The access works for the model instance"""
+
+    s = Session()
+    wrap = ModelWrapper(s, ModelWithNoDoc)
+    mdl = wrap("bob")
+    with pytest.raises(AttributeError,
+                       match="^'ModelWithNoDoc' object has no attribute '_hidden'$"):
+        got = mdl._hidden
+
+
+def test_modelwrapper_direct():
+    """Compare behavior with test_modelwrapper_call"""
+
+    s = Session()
+
+    wrap = ModelWrapper(s, ModelWithNoDoc)
+    assert s.list_model_components() == []
+
+    mdl = wrap("foo")
+    assert isinstance(mdl, ModelWithNoDoc)
+    assert mdl.name == "modelwithnodoc.foo"
+
+    assert s.list_model_components() == ["foo"]
+
+
+def test_modelwrapper_call():
+    """The reason for the class"""
+
+    s = Session()
+
+    wrap = ModelWrapper(s, ModelWithNoDoc)
+    assert s.list_model_components() == []
+
+    mdl = wrap.foo
+    assert isinstance(mdl, ModelWithNoDoc)
+    assert mdl.name == "modelwithnodoc.foo"
+
+    assert s.list_model_components() == ["foo"]
+
+
+def test_show_data_explicit_id():
+    """Check we can call show_data with an id"""
+
+    s = Session()
+    s.load_arrays(1, [1, 2], [10, 20])
+    s.load_arrays("bob", [12, 14, 20], [3, 1, 2])
+
+    out = StringIO()
+    s.show_data("bob", outfile=out)
+
+    # not a full check of the output
+    assert out.getvalue().startswith("Data Set: bob\nname      = \n")
+
+
+def test_show_kernel_explicit_id(tmp_path):
+    """Check we can call show_kernel with an id"""
+
+    s = Session()
+
+    s.load_arrays("bob", [1, 2, 3, 4, 5], [10, 5, 3, 2, 1])
+
+    tmp = tmp_path / "tmp.dat"
+    tmp.write_text("! X Y\n1 10\n2 5\n 3 0\n4 1\n")
+
+    s.load_psf("foo", str(tmp), comment="!")
+    s.set_psf("bob", "foo")
+
+    out = StringIO()
+    s.show_kernel("bob", outfile=out)
+
+    # Since we do not have many other tests of this, do a more-complete
+    # check than some of the other routines here.
+    #
+    toks = out.getvalue().split("\n")
+    assert toks[0] == "PSF Kernel: bob"
+    assert toks[1] == "psfmodel.foo"
+    assert " Param " in toks[2]
+    assert " ----- " in toks[3]
+
+    # Can the file path contain spaces?
+    words = toks[4].split()
+    assert len(words) >= 3
+    assert words[0] == "foo.kernel"
+    assert words[1] == "frozen"
+
+    def check(lstr, name, val, minval, maxval):
+        words = lstr.split()
+        assert len(words) == 5
+        assert words[0] == name
+        assert words[1] == "frozen"
+        assert words[2] == val
+        assert words[3] == minval
+        assert words[4] == maxval
+
+    check(toks[5], "foo.size", "4", "4", "4")
+    check(toks[6], "foo.center", "2", "2", "2")
+    check(toks[7], "foo.radial", "0", "0", "1")
+    check(toks[8], "foo.norm", "1", "0", "1")
+
+    assert toks[9] == ""
+    assert toks[10] == ""
+    assert toks[11] == ""
+    assert len(toks) == 12
+
+
+def test_show_psf_explicit_id(tmp_path):
+    """Check we can call show_psf with an id"""
+
+    s = Session()
+
+    s.load_arrays("bob", [1, 2, 3, 4, 5], [10, 5, 3, 2, 1])
+
+    tmp = tmp_path / "tmp.dat"
+    tmp.write_text("! X Y\n1 10\n2 5\n 3 0\n4 1\n")
+
+    s.load_psf("foo", str(tmp), comment="!")
+    s.set_psf("bob", "foo")
+
+    out = StringIO()
+    s.show_psf("bob", outfile=out)
+
+    print(out.getvalue())
+
+    # Since we do not have many other tests of this, do a more-complete
+    # check than some of the other routines here.
+    #
+    toks = out.getvalue().split("\n")
+    assert toks[0] == "PSF Model: bob"
+    assert toks[1].startswith("name      = ")
+    assert toks[2] == "x         = Float64[4]"
+    assert toks[3] == "y         = Float64[4]"
+    assert toks[4] == "staterror = None"
+    assert toks[5] == "syserror  = None"
+
+    assert toks[6] == ""
+    assert toks[7] == ""
+    assert toks[8] == ""
+    assert len(toks) == 9
+
+
+def test_show_kernel_multiple(tmp_path):
+    """Check we can call show_kernel with multiple datasets, not all with a PSF"""
+
+    s = Session()
+
+    s.load_arrays("bob", [1, 2, 3, 4, 5], [10, 5, 3, 2, 1])
+    s.load_arrays(1, [1, 2, 3], [4, 5, 6])
+
+    tmp = tmp_path / "tmp.dat"
+    tmp.write_text("! X Y\n1 10\n2 5\n 3 0\n4 1\n")
+
+    s.load_psf("foo", str(tmp), comment="!")
+    s.set_psf("bob", "foo")
+
+    out = StringIO()
+    s.show_kernel("bob", outfile=out)
+
+    print(out.getvalue())
+
+    # Since we do not have many other tests of this, do a more-complete
+    # check than some of the other routines here.
+    #
+    toks = out.getvalue().split("\n")
+    assert toks[0] == "PSF Kernel: bob"
+    assert toks[1] == "psfmodel.foo"
+    assert toks[2][2:].startswith(" Param ")
+    assert toks[3][2:].startswith(" ----- ")
+    assert toks[4].startswith("   foo.kernel   frozen ")
+    assert toks[5].startswith("   foo.size     frozen ")
+    assert toks[6].startswith("   foo.center   frozen ")
+    assert toks[7].startswith("   foo.radial   frozen ")
+    assert toks[8].startswith("   foo.norm     frozen ")
+    assert toks[9] == ""
+    assert toks[10] == ""
+    assert toks[11] == ""
+    assert len(toks) == 12
+
+
+@pytest.mark.parametrize("idval", [None, 1])
+def test_load_filter_simple(idval, tmp_path):
+    """Although there is a version in astro we only check the non-astro
+    version as the behavior is different (e.g. the astro version needs
+    I/O suppport.
+
+    """
+
+    s = Session()
+    s.load_arrays(idval, [1, 2, 3], [12, 15, 2])
+
+    infile = tmp_path / "filter.dat"
+    infile.write_text("0\n0\n1\n")
+
+    if idval is None:
+        s.load_filter(str(infile), ncols=1, ignore=True)
+    else:
+        s.load_filter(idval, str(infile), ncols=1, ignore=True)
+
+    assert s.get_data().mask == pytest.approx([True, True, False])
+
+
+@pytest.mark.parametrize("idval", [None, 1])
+def test_save_filter_simple(idval, tmp_path):
+    """Although there is a version in astro we only check the non-astro
+    version as the behavior is different (e.g. the astro version needs
+    I/O suppport.
+
+    """
+
+    s = Session()
+    s.load_arrays(idval, [1, 2, 3], [12, 15, 2])
+    s.get_data(idval).mask = [True, False, True]
+
+    outfile = tmp_path / "filter.dat"
+    if idval is None:
+        s.save_filter(str(outfile), comment="P ", linebreak="+")
+    else:
+        s.save_filter(idval, str(outfile), comment="P ", linebreak="+")
+
+    assert outfile.read_text() == "P X FILTER+1 1+2 0+3 1+"

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2019, 2020, 2021, 2022
+#  Copyright (C) 2016, 2017, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1185,7 +1185,7 @@ def test_modelwrapper_getattr_instance():
 
 
 def test_modelwrapper_getattr_instance_unknown():
-    """The access works for the model instance"""
+    """The access fails for the model instance when field is unknown"""
 
     s = Session()
     wrap = ModelWrapper(s, ModelWithNoDoc)
@@ -1367,7 +1367,7 @@ def test_show_kernel_multiple(tmp_path):
 def test_load_filter_simple(idval, tmp_path):
     """Although there is a version in astro we only check the non-astro
     version as the behavior is different (e.g. the astro version needs
-    I/O suppport.
+    I/O suppport).
 
     """
 
@@ -1389,7 +1389,7 @@ def test_load_filter_simple(idval, tmp_path):
 def test_save_filter_simple(idval, tmp_path):
     """Although there is a version in astro we only check the non-astro
     version as the behavior is different (e.g. the astro version needs
-    I/O suppport.
+    I/O suppport).
 
     """
 


### PR DESCRIPTION
# Summary

Add a number of tests to check out corner case behavior, primarily for grouping PHA data but there's also a number of routines from the UI code that have missed some tests.

# Details

There are a number of PRs that require this PR to be merged:

- #1486 (and a bunch of follow-up PRs)
- #1664 
- #1665 
- #1666

Tests have been found to test current behavior, and to track new bugs found from this work (with the intention being that we fix these in later PRs). Some of these tests have been found during PR development, by seeing what code changes that were made had no existing tests.

Issues with new (i.e. were found doing this work) or extended coverage:

- #1160 
- #1641
- #1642 
- #1646 
- #1659