### PR TITLE
Correct the Miniconda Installer for CI

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -26,8 +26,7 @@ fi
 
 # Download and install conda
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-${miniconda_os}-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b -p $miniconda_loc
+bash miniconda.sh -b -p $miniconda_loc
 
 #Source the Conda profile
 source ${miniconda_loc}/etc/profile.d/conda.sh

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -3,7 +3,7 @@ name: Conda CI
 on:
   push:
     branches:
-    - main
+    - '*'
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -3,7 +3,7 @@ name: Conda CI
 on:
   push:
     branches:
-    - '*'
+    - main
     tags:
     - '*'
   pull_request:


### PR DESCRIPTION
Switching to the more official method of installing Miniconda for the Conda CI. The old method of chmod'ing and running the installer seems to have broken and is a bit outdated.