### PR TITLE
Allow save_model/source/resid to work with 2D data (fix #1642)

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -2539,7 +2539,7 @@ def check_output(expected, got):
 
 
 @pytest.mark.parametrize("session,kwargs,expected",
-                         [pytest.param(Session, {"comment": "!! "}, ["!! SOURCE", "7 11", ""], marks=pytest.mark.xfail),  # bug #1642
+                         [(Session, {"comment": "!! "}, ["!! SOURCE", "7 11", ""]),
                           (AstroSession, {"ascii": True}, ["7", "11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
@@ -2571,7 +2571,7 @@ def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, sk
 
 
 @pytest.mark.parametrize("session,kwargs,expected",
-                         [pytest.param(Session, {"comment": ""}, ["MODEL", "7 11", ""], marks=pytest.mark.xfail),  # bug #1642
+                         [(Session, {"comment": ""}, ["MODEL", "7 11", ""]),
                           (AstroSession, {"ascii": True}, ["7", "11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
@@ -2603,7 +2603,7 @@ def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, ski
 
 
 @pytest.mark.parametrize("session,kwargs,expected",
-                         [pytest.param(Session, {}, ["#RESID", "-7 -11", ""], marks=pytest.mark.xfail),  # bug #1642
+                         [(Session, {}, ["#RESID", "-7 -11", ""]),
                           (AstroSession, {"ascii": True}, ["-7", "-11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4296,13 +4296,7 @@ class Session(NoNewAttributesAfterInit):
                 raise AttributeError("save_delchi() can not be used " +
                                      "with 2D datasets")
 
-            funcname = "get_{}_image()".format(objtype)
-            """
-            imgtype = getattr(self, funcname, None)
-            if imgtype is None:
-                # raise AttributeErr('attributeerr', 'session', fname)
-                raise AttributeError("Unable to find " + funcname)
-            """
+            funcname = f"get_{objtype}_image"
             imgtype = getattr(self, funcname)
 
             obj = imgtype(id)
@@ -4310,13 +4304,7 @@ class Session(NoNewAttributesAfterInit):
             fields = [str(objtype).upper()]
 
         else:
-            funcname = "get_{}_plot".format(objtype)
-            """
-            plottype = getattr(self, funcname, None)
-            if plottype is None:
-                # raise AttributeErr('attributeerr', 'session', funcname)
-                raise AttributeError("Unable to find " + funcname)
-            """
+            funcname = f"get_{objtype}_plot"
             plottype = getattr(self, funcname)
 
             obj = plottype(id)


### PR DESCRIPTION
# Summary

Fix save_model/source/resid calls when used with 2D data sets. Fix #1642

# Details

This was pulled out of #1638 

This fixes a bug I introduced during pylint fixes in #175 but we didn't have coverage to check it. We now have coverage thanks to #1662.