### PR TITLE
model-wrapped symbols now reference the actual model (fix #215)

### DIFF
--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1114,7 +1114,7 @@ def test_set_default_id_check_invalid(value):
 class ModelWithDoc(Model):
     """This has a doc string
 
-    But we don't grab this.
+    This line is not included in the model-wrapped doc string.
     """
 
     _hidden = False
@@ -1138,7 +1138,7 @@ def test_modelwrapper_checks_session():
     """Check we error out"""
 
     with pytest.raises(ValueError,
-                       match="session is not a Session instance"):
+                       match="session=.* is not a Session instance"):
         ModelWrapper(ModelWithDoc, None)
 
 
@@ -1147,7 +1147,7 @@ def test_modelwrapper_checks_model():
 
     s = Session()
     with pytest.raises(ValueError,
-                       match="modeltype is not a Model instance"):
+                       match="modeltype=Gauss1D is not a Model class"):
         ModelWrapper(s, "Gauss1D")
 
 
@@ -1156,7 +1156,7 @@ def test_modelwrapper_str_with_doc():
 
     s = Session()
     wrap = ModelWrapper(s, ModelWithDoc)
-    assert str(wrap) == "This has a doc string\n\n    But we don't grab this.\n    "
+    assert str(wrap) == "This has a doc string\n\n    This line is not included in the model-wrapped doc string.\n    "
 
 
 def test_modelwrapper_str_no_doc():

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -33,6 +33,7 @@ import numpy
 from sherpa import get_config
 import sherpa.all
 from sherpa.models.basic import TableModel
+from sherpa.models.model import Model
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
@@ -332,19 +333,85 @@ copy_reg.pickle(numpy.ufunc, reduce_ufunc)
 
 
 class ModelWrapper(NoNewAttributesAfterInit):
+    """Wrap up a model class so we can create instances easily.
 
-    def __init__(self, session, modeltype, args=(), kwargs={}):
+    The created instances can be used in a "model language" to create
+    complex expressions. If mdl1 and mdl2 have been created by
+    ModelWrapper then a user can say mdl1.n1 + mdl2.n2 to create model
+    instances named n1 and n2 and then return the expression which
+    represents their sum. Note that the model component is stored in
+    the session object.
+
+    """
+
+    def __init__(self, session, modeltype, args=(), kwargs=None):
+        # This is an internal class so do not bother with
+        # sherpa.utils.err exceptions.
+        #
+        if not isinstance(session, Session):
+            raise ValueError("session is not a Session instance")
+
+        if not _is_subclass(modeltype, Model):
+            raise ValueError("modeltype is not a Model instance")
+
         self._session = session
         self.modeltype = modeltype
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = kwargs if kwargs else {}
+
+        # Edit the docstring of the new object to hide the
+        # ModelWrapper text and replace it with a reference to the
+        # wrapped class.
+        #
+        mname = modeltype.__name__.lower()
+        prefix = "an" if mname[0] in "aeiou" else "a"
+
+        # Grab the first line of the model description. It might be
+        # helpful to also list the parameters but this is not easy to
+        # access without actually creating an instance of the model.
+        #
+        if modeltype.__doc__ is None:
+            mdesc = ""
+        else:
+            # Could try to ensure this is a sentence - e.g. ends in a
+            # "." - but rely on the documentation of the model classes
+            # to enforce that.
+            #
+            mdesc = modeltype.__doc__.split("\n")[0]
+            mdesc += "\n\n    "
+
+        self.__doc__ = f"""Create {prefix} {mname} model instance.
+
+    {mdesc}Instances can be created either as an attribute of {mname},
+    as long as the attribute does not begin with an underscore,
+    or by calling {mname} directly.
+
+    Examples
+    --------
+
+    The model, here called mdl, is returned but it's also stored in
+    the session and can be returned with `get_model_component`:
+
+    >>> m1 = {mname}.mdl
+
+    If the model has already been created with the same name then
+    the old version will be returned, rather than creating a new
+    instance:
+
+    >>> m1 = {mname}.mdl
+    >>> m2 = {mname}("mdl")
+    >>> m1 == m2
+    True
+
+"""
+
         NoNewAttributesAfterInit.__init__(self)
 
     def __call__(self, name):
         _check_str_type(name, "name")
 
         m = self._session._get_model_component(name)
-        if (m is not None) and isinstance(m, self.modeltype):
+        if isinstance(m, self.modeltype):
             return m
 
         m = self.modeltype(name, *self.args, **self.kwargs)
@@ -353,16 +420,20 @@ class ModelWrapper(NoNewAttributesAfterInit):
 
     def __getattr__(self, name):
         if name.startswith('_'):
-            raise AttributeError("'%s\' object has no attribute '%s'" %
-                                 (type(self).__name__, name))
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
         return self(name)
 
     def __repr__(self):
-        return '<%s model type>' % self.modeltype.__name__
+        return f'<{self.modeltype.__name__} model type>'
 
     def __str__(self):
         if self.modeltype.__doc__ is not None:
+            # Use the documentation from wrapped model if available,
+            # rather than a normal "repr" call.
+            #
             return self.modeltype.__doc__
+
         return self.__repr__()
 
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -335,12 +335,13 @@ copy_reg.pickle(numpy.ufunc, reduce_ufunc)
 class ModelWrapper(NoNewAttributesAfterInit):
     """Wrap up a model class so we can create instances easily.
 
-    The created instances can be used in a "model language" to create
-    complex expressions. If mdl1 and mdl2 have been created by
-    ModelWrapper then a user can say mdl1.n1 + mdl2.n2 to create model
-    instances named n1 and n2 and then return the expression which
-    represents their sum. Note that the model component is stored in
-    the session object.
+    Creates a model instance with a given name - you can say mdl.mname
+    or mdl("mname") - and either syntax stores the model instance in
+    the session object with the name "mname", over-writing any
+    previous component with this name.  If mdl1 and mdl2 have been
+    created by ModelWrapper then a user can say mdl1.n1 + mdl2.n2 to
+    create model instances named n1 and n2 and then return the
+    expression which represents their sum.
 
     """
 
@@ -349,10 +350,10 @@ class ModelWrapper(NoNewAttributesAfterInit):
         # sherpa.utils.err exceptions.
         #
         if not isinstance(session, Session):
-            raise ValueError("session is not a Session instance")
+            raise ValueError(f"session={session} is not a Session instance")
 
         if not _is_subclass(modeltype, Model):
-            raise ValueError("modeltype is not a Model instance")
+            raise ValueError(f"modeltype={modeltype} is not a Model class")
 
         self._session = session
         self.modeltype = modeltype


### PR DESCRIPTION
# Summary

Wrapped models, accessible from the UI layer, now reference the wrapped model rather than being devoid of any useful information. Fix #215

# Details

This was pulled out of https://github.com/sherpa/sherpa/pull/1638

This adds documentation to the `ModelWrapper` class (for the implementor) and to model-wrapped classes (for the user). It is unclear what information is best for the user, but this is definitely a significant improvement and we can think about updates in a later PR if necessary. For instance, it might be helpful to include the list of parameters, but unfortunately this is rather hard to grab (you can't grab it from the model being wrapped, you'd need to create an instance of that model, which we could do but is not as safe as you might think), so it isn't done here.

There's some "interesting" over-riding of __repr__ / __str__ going on here (i.e. this is existing code, for which I added some tests in #1662), but I didn't want to delve into it as the code works "as is".

# Examples

We now get

```
>>> from sherpa.astro.ui import *
>>> help(gauss1d)
Help on ModelWrapper in module sherpa.ui.utils:

<Gauss1D model type>
    Create a gauss1d model instance.
    
    One-dimensional gaussian function.

    Instances can be created either as an attribute of gauss1d,
    as long as the attribute does not begin with an underscore,
    or by calling gauss1d directly.
    
    Examples
    --------
    
    The model, here called mdl, is returned but it's also stored in
    the session and can be returned with `get_model_component`:
    
    >>> m1 = gauss1d.mdl
    
    If the model has already been created with the same name then
    the old version will be returned, rather than creating a new
    instance:
    
    >>> m1 = gauss1d.mdl
    >>> m2 = gauss1d("mdl")
    >>> m1 == m2
    True

>>> help(xscflux)
<XScflux model type>
    Create a xscflux model instance.
    
    The XSPEC cflux convolution model: calculate flux
    
    Instances can be created either as an attribute of xscflux,
    as long as the attribute does not begin with an underscore,
    or by calling xscflux directly.
    
    Examples
    --------
    
    The model, here called mdl, is returned but it's also stored in
    the session and can be returned with `get_model_component`:
    
    >>> m1 = xscflux.mdl
    
    If the model has already been created with the same name then
    the old version will be returned, rather than creating a new
    instance:
    
    >>> m1 = xscflux.mdl
    >>> m2 = xscflux("mdl")
    >>> m1 == m2
    True
```

which is not perfect, but a darn site better than the previous, which was

```
Help on ModelWrapper in module sherpa.ui.utils object:

class ModelWrapper(sherpa.utils.NoNewAttributesAfterInit)
 |  ModelWrapper(session, modeltype, args=(), kwargs={})
 |  
 |  Method resolution order:
 |      ModelWrapper
 |      sherpa.utils.NoNewAttributesAfterInit
 |      builtins.object
 |  
 |  Methods defined here:
 |  
 |  __call__(self, name)
 |      Call self as a function.
 |  
 |  __getattr__(self, name)
 |  
 |  __init__(self, session, modeltype, args=(), kwargs={})
 |      Initialize self.  See help(type(self)) for accurate signature.
 |  
 |  __repr__(self)
 |      Return repr(self).
 |  
 |  __str__(self)
 |      Return str(self).
 |  
... continuing like this with no helpful information to the user
```