### PR TITLE
CI do not download miniconda

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash -e
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    miniconda_os=MacOSX
     compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
 
     #Download the macOS 10.9 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
@@ -13,7 +12,6 @@ if [ "`uname -s`" == "Darwin" ] ; then
     tar -C ${GITHUB_WORKSPACE}/10.9SDK -xf MacOSX10.9.sdk.tar.xz
     #End of Conda compilers section
 else
-    miniconda_os=Linux
     compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
 
     if [ -n "${MATPLOTLIBVER}" ]; then
@@ -24,13 +22,9 @@ else
    fi
 fi
 
-# Download and install conda
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-${miniconda_os}-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b -p $miniconda_loc
-
-#Source the Conda profile
-source ${miniconda_loc}/etc/profile.d/conda.sh
+# Ensure we have set up conda
+#
+source ${CONDA}/etc/profile.d/conda.sh
 
 # update and add channels
 conda update --yes conda

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -11,7 +11,6 @@ on:
 env:
   sherpa_channel: sherpa
   xspec_channel: "xspec/label/test"
-  miniconda_loc: ${{ github.workspace }}/miniconda
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.9SDK/MacOSX10.9.sdk
 
 jobs:
@@ -119,7 +118,7 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         source .github/scripts/setup_ds9.sh
         source .github/scripts/setup_xspec.sh
@@ -136,7 +135,7 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         pip install . --verbose
 
@@ -145,14 +144,14 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         pip install -e . --verbose
 
     - name: Install the test data?
       if: matrix.test-data == 'package'
       run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         pip install ./sherpa-test-data
         pip install pytest-xvfb
@@ -172,7 +171,7 @@ jobs:
         if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
         smokevars="${XSPECTEST} ${FITSTEST} -v 3"
         echo "** smoke test: ${smokevars}"
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         cd /home
         sherpa_smoke ${smokevars}
@@ -200,7 +199,7 @@ jobs:
           # make sure pytext-xvfb can find Xvfb
           export PATH="${PATH}:/opt/X11/bin"
         fi
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
         python setup.py -q test -a "--cov sherpa --cov-report xml"
@@ -208,7 +207,7 @@ jobs:
     - name: sherpa_test Tests
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
       run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
         cd $HOME


### PR DESCRIPTION
# Summary

Use the system conda installation on GitHub CI rather than downloading it ourselves each time.

# Details

Test to see if we can use the installed version of conda rather than download it ourselves each time. An alternative to #1663

I want to see if I can have the conda download happen with a subset (maybe one) test so we can ensure we have the "latest version" tested. Hmmm. I've decided I don't have the time/energy to explore this approach.