### PR TITLE
models: f-string changes

### DIFF
--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -878,8 +878,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.models = models
         self.grid = grid
 
-        expr = ','.join([f'{m.name}({source.name})'
-                         for m in models])
+        expr = ','.join([f'{m.name}({source.name})' for m in models])
         name = f'{type(self).__name__}({expr})'
         CompositeModel.__init__(self, name, (source,))
 

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2010, 2015-2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observator
 #
 #
@@ -106,7 +106,7 @@ def apply_areascal(mdl, pha, instlabel):
 
     if numpy.iterable(ascal) and len(ascal) != len(mdl):
         raise DataErr('mismatch', instlabel,
-                      'AREASCAL: {}'.format(pha.name))
+                      f'AREASCAL: {pha.name}')
 
     return mdl * ascal
 
@@ -345,7 +345,7 @@ class RMFModelPHA(RMFModel):
         out = self.rmf.apply_rmf(src, *self.rmfargs)
 
         return apply_areascal(out, self.pha,
-                              "RMF: {}".format(self.rmf.name))
+                              f"RMF: {self.rmf.name}")
 
 
 class RMFModelNoPHA(RMFModel):
@@ -447,7 +447,7 @@ class ARFModelPHA(ARFModel):
         src = self.arf.apply_arf(src, *self.arfargs)
 
         return apply_areascal(src, self.pha,
-                              "ARF: {}".format(self.arf.name))
+                              f"ARF: {self.arf.name}")
 
 
 class ARFModelNoPHA(ARFModel):
@@ -567,7 +567,7 @@ class RSPModelPHA(RSPModel):
         # Assume any issues with the binning (between AREASCAL
         # and src) is related to the RMF rather than the ARF.
         return apply_areascal(src, self.pha,
-                              "RMF: {}".format(self.rmf.name))
+                              f"RMF: {self.rmf.name}")
 
 
 class RSPModelNoPHA(RSPModel):
@@ -1396,7 +1396,7 @@ def create_non_delta_rmf(rmflo, rmfhi, fname, offset=1,
     """
 
     if fname is not None and not os.path.isfile(fname):
-        raise ValueError("{} is not a file".format(fname))
+        raise ValueError(f"{fname} is not a file")
 
     # Set up the delta-function response.
     # TODO: should f_chan start at startchan?

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -134,7 +134,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.rmfargs = ()
 
-        CompositeModel.__init__(self, 'apply_rmf(%s)' % model.name, (model,))
+        CompositeModel.__init__(self, f'apply_rmf({model.name})', (model,))
         self.filter()
 
     def filter(self):
@@ -183,7 +183,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
         # Logic for ArithmeticModel.__init__
         self.pars = ()
 
-        CompositeModel.__init__(self, 'apply_arf(%s)' % model.name, (model,))
+        CompositeModel.__init__(self, f'apply_arf({model.name})', (model,))
         self.filter()
 
     def filter(self):
@@ -234,7 +234,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
         # Logic for ArithmeticModel.__init__
         self.pars = ()
 
-        CompositeModel.__init__(self, 'apply_rmf(apply_arf(%s))' % model.name,
+        CompositeModel.__init__(self, f'apply_rmf(apply_arf({model.name}))',
                                 (model,))
         self.filter()
 
@@ -878,9 +878,9 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.models = models
         self.grid = grid
 
-        name = '%s(%s)' % (type(self).__name__,
-                           ','.join(['%s(%s)' % (m.name, source.name)
-                                     for m in models]))
+        expr = ','.join([f'{m.name}({source.name})'
+                         for m in models])
+        name = f'{type(self).__name__}({expr})'
         CompositeModel.__init__(self, name, (source,))
 
     def _get_noticed_energy_list(self):
@@ -1048,7 +1048,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         self.otherkwargs = None
         self.pars = ()
         CompositeModel.__init__(self,
-                                ('%s(%s)' % ('apply_rmf', self.model.name)),
+                                f'apply_rmf({self.model.name})',
                                 (self.model,))
 
     def startup(self, cache=False):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1199,7 +1199,7 @@ class RegriddableModel1D(RegriddableModel):
         valid_keys = ('interp',)
         for key in kwargs.keys():
             if key not in valid_keys:
-                raise TypeError("unknown keyword argument: '%s'" % key)
+                raise TypeError(f"unknown keyword argument: '{key}'")
         eval_space = EvaluationSpace1D(*args)
         regridder = ModelDomainRegridder1D(eval_space, **kwargs)
         regridder._make_and_validate_grid(args)
@@ -1366,7 +1366,7 @@ class FilterModel(CompositeModel, ArithmeticModel):
             filter_str = self._make_filter_str(filter)
 
         CompositeModel.__init__(self,
-                                ('(%s)[%s]' % (self.model.name, filter_str)),
+                                f'({self.model.name})[{filter_str}]',
                                 (self.model,))
 
     @staticmethod
@@ -1487,8 +1487,8 @@ class MultigridSumModel(CompositeModel, ArithmeticModel):
 
     def __init__(self, models):
         self.models = tuple(models)
-        name = '%s(%s)' % (type(self).__name__,
-                           ','.join([m.name for m in models]))
+        arg = ','.join([m.name for m in models])
+        name = f'{type(self).__name__}({arg})'
         CompositeModel.__init__(self, name, self.models)
 
     def calc(self, p, arglist):


### PR DESCRIPTION
# Summary

Change the models code to use f-strings where appropriate rather than other methods of string interpolation. There is no change in behavior.

# Details

Convert to f-strings for most cases **in the files I'm looking at**. The warning calls, which use the logging infrastructure, have generally used %s-encoded results but passed as arguments (so `("message %s more message", value)` rather than `("message {value} more message")` or `("message %s more message" % value)`), to please pylint.

I have various versions of these changes in a number of PRs, but they are all subtly different (e.g. change quote style, add or remove a new-line character) which just makes rebasing things harder than the need to be. So I've pulled this out into a simple-to review PR.

Unlike other f-string changes I have coverage for all the lines I'm changing here, so we don't need to worry about issues like #1642 (although, to be honest, having the lines be covered in the tests doesn't catch all problems, but tends to catch the major ones).