### PR TITLE
update model macro definitions for compiled code

### DIFF
--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,4 +1,4 @@
-//  Copyright (C) 2007, 2015-2018, 2019, 2020, 2021, 2022
+//  Copyright (C) 2007, 2015-2018, 2019, 2020, 2021, 2022, 2023
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -1295,10 +1295,10 @@ static PyMethodDef XSpecMethods[] = {
 
   // XSPEC table models
 #ifdef XSPEC_12_10_1
-  XSPECTABLEMODEL,
+  KWSPEC(tabint, sherpa::astro::xspec::xspectablemodel),
 #else
-  XSPECTABLEMODEL_NORM( xsatbl ),
-  XSPECTABLEMODEL( xsmtbl ),
+  KWSPEC(xsatbl, sherpa::astro::xspec::xspectablemodel<true, xsatbl>),
+  KWSPEC(xsmtbl, sherpa::astro::xspec::xspectablemodel<false, xsmtbl>),
 #endif
 
   // XSPEC convolution models

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2015, 2017, 2020, 2021, 2022
+//  Copyright (C) 2009, 2015, 2017, 2020, 2021, 2022, 2023
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -1209,52 +1209,29 @@ PyObject* xspectablemodel( PyObject* self, PyObject* args, PyObject *kwds ) {
 } } } /* namespace xspec, namespace astro, namespace sherpa */
 
 
-#define _XSPECFCTSPEC(name, npars, has_norm) \
-		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct< npars, has_norm, \
-				name##_ >))
-
-#define XSPECMODELFCT(name, npars)  _XSPECFCTSPEC(name, npars, false)
-#define XSPECMODELFCT_NORM(name, npars)  _XSPECFCTSPEC(name, npars, true)
-
-// double precision
-#define XSPECMODELFCT_DBL(name, npars) \
-		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_dbl< npars, false, \
-				name##_ >))
-
-#define XSPECMODELFCT_C(name, npars) \
-		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_C< npars, false, name >))
-
-#define XSPECMODELFCT_C_NORM(name, npars) \
-		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_C< npars, true, name >))
-
-#define XSPECMODELFCT_CON(name, npars) \
-		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_con< npars, name >))
+// Fortran models
+//
+#define XSPECMODELFCT(name, npars) \
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct< npars, false, name##_ >))
+#define XSPECMODELFCT_NORM(name, npars) \
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct< npars, true, name##_ >))
 
 #define XSPECMODELFCT_CON_F77(name, npars) \
-		FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_con_f77< npars, name##_ >))
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_con_f77< npars, name##_ >))
 
+// C/C++ models
+//
+#define XSPECMODELFCT_DBL(name, npars) \
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_dbl< npars, false, name##_ >))
 
-#ifdef XSPEC_12_10_1
-#define XSPECTABLEMODEL        \
-		{ (char*)"tabint", \
-	(PyCFunction)((PyCFunctionWithKeywords)sherpa::astro::xspec::xspectablemodel), \
-	METH_VARARGS|METH_KEYWORDS, \
-	NULL }
+#define XSPECMODELFCT_C(name, npars) \
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_C< npars, false, name >))
 
-#else
+#define XSPECMODELFCT_C_NORM(name, npars) \
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_C< npars, true, name >))
 
-#define _XSPECTABLEMODELSPEC(name, has_norm) \
-		{ (char*)#name, \
-	(PyCFunction)((PyCFunctionWithKeywords)sherpa::astro::xspec::xspectablemodel< has_norm, name >), \
-	METH_VARARGS|METH_KEYWORDS, \
-	NULL }
+#define XSPECMODELFCT_CON(name, npars) \
+   FCTSPEC(name, (sherpa::astro::xspec::xspecmodelfct_con< npars, name >))
 
-#define XSPECTABLEMODEL(name) \
-		_XSPECTABLEMODELSPEC(name, false)
-
-#define XSPECTABLEMODEL_NORM(name) \
-		_XSPECTABLEMODELSPEC(name, true)
-
-#endif
 
 #endif /* __sherpa_astro_xspec_extension_hh__ */

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2016, 2017, 2020, 2022
+//  Copyright (C) 2007, 2016, 2017, 2020, 2022, 2023
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -73,5 +73,8 @@ PyMODINIT_FUNC PyInit_##name(void) { \
 #define FCTSPECDOC(name, func, doc) \
   { (char*)#name, (PyCFunction)func, METH_VARARGS, PyDoc_STR(doc) }
 
+#define KWSPEC(name, func) \
+  { (char*)#name, (PyCFunction)((PyCFunctionWithKeywords)func), \
+      METH_VARARGS|METH_KEYWORDS, NULL }
 
 #endif /* __sherpa_extension_hh__ */

--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,6 @@
 // 
-//  Copyright (C) 2007, 2016, 2019, 2020 Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2016, 2019, 2020, 2023
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -447,26 +448,22 @@ PyMODINIT_FUNC PyInit_##name(void) { \
 
 // Allow this to be customized on a per-file basis
 
-#define MODSPEC(name, func) \
-  { (char*)#name, (PyCFunction)((PyCFunctionWithKeywords)func), \
-      METH_VARARGS|METH_KEYWORDS, NULL }
-
 #ifndef _MODELFCTPTR
 #define _MODELFCTPTR(name) \
   sherpa::models::name< SherpaFloat, SherpaFloatArray >
 #endif
 
 #define _MODELFCTSPEC(name, ftype, npars) \
-  MODSPEC(name, (sherpa::models::ftype< SherpaFloatArray, SherpaFloat, npars, \
-                                        _MODELFCTPTR(name##_point), \
-                                        _MODELFCTPTR(name##_integrated) >))
+  KWSPEC(name, (sherpa::models::ftype< SherpaFloatArray, SherpaFloat, npars, \
+                                       _MODELFCTPTR(name##_point), \
+                                       _MODELFCTPTR(name##_integrated) >))
 
 #define _MODELFCTSPEC_NOINT(name, ftype, intftype, npars) \
-  MODSPEC(name, \
-          (sherpa::models::ftype< SherpaFloatArray, SherpaFloat, npars, \
-                                  _MODELFCTPTR(name##_point), \
-                                  sherpa::models::intftype \
-                                    < _MODELFCTPTR(name##_point) > >))
+  KWSPEC(name, \
+         (sherpa::models::ftype< SherpaFloatArray, SherpaFloat, npars, \
+                                 _MODELFCTPTR(name##_point), \
+                                 sherpa::models::intftype \
+                                   < _MODELFCTPTR(name##_point) > >))
 
 #define MODELFCT1D(name, npars)		_MODELFCTSPEC(name, modelfct1d, npars)
 #define MODELFCT2D(name, npars)		_MODELFCTSPEC(name, modelfct2d, npars)


### PR DESCRIPTION
# Summary

Re-work the macro definitions used to build the compiled models and use this to clean up the handling of the XSPEC models, in particular table models. There is no functional change.

# Details

Note, I have now made this PR depend on #1681 as there are some urgent test updates needed there. This has now been merged, which simplifies this PR.

PR chains that will depend on this:

 - #1396 
   - #1609 
     - #1615
     - #1630
 - #1617
 - #1179 
   - #830

I have a lot of XSPEC follow-up code and I am trying to break things up so that they are

- easy to review
- reduce the chance for PR collisions, or at least make it a lot easier to deal with when we do so

The change to the include files for the model macros is one of the latter.