### PR TITLE
Automatically split a model expression into additive components and plot the results

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -2002,7 +2002,7 @@ def model_deconstruct(model: Model) -> list[Model]:
     # lhs for this case.
     #
     if model.op == np.divide:
-        return [BinaryOpModel(lterm, model.rhs, model.op, model.opstr)
+        return [BinaryOpModel(lterm, model.rhs, np.divide, '/')
                 for lterm in lhs]
 
     try:
@@ -2023,7 +2023,7 @@ def model_deconstruct(model: Model) -> list[Model]:
         #     (*, b, c)
         #     (*, a, -d)
         #
-        return [BinaryOpModel(lterm, rterm, model.op, model.opstr)
+        return [BinaryOpModel(lterm, rterm, np.multiply, '*')
                 for lterm, rterm in itertools.product(lhs, rhs)]
 
     # The terms are intended to be summed together, so for subtraction

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -2021,7 +2021,7 @@ def model_deconstruct(model: Model) -> list[Model]:
         #     (*, a, c)
         #     (*, a, -d)
         #     (*, b, c)
-        #     (*, a, -d)
+        #     (*, b, -d)
         #
         return [BinaryOpModel(lterm, rterm, np.multiply, '*')
                 for lterm, rterm in itertools.product(lhs, rhs)]

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -319,6 +319,7 @@ non-integrated and integrated datasets of any dimensionality (see
 from __future__ import annotations
 
 import functools
+import itertools
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, \
     Sequence, SupportsFloat, SupportsIndex, Type, TypeVar, Union
@@ -1869,6 +1870,178 @@ def _wrapobj(obj, wrapper: Callable[..., Model]) -> Model:
         return obj
 
     return wrapper(obj)
+
+
+# Simple model "deconstruction" - that is, turn a model expression
+# like "mdl1 * (mdl2 + mdl3)" into "mdl1 * mdl2" and "mdl1 * mdl3".
+#
+# The code could be re-worked to use continuation-passing style to
+# avoid the recursion error, but that would significantly complicate
+# the code. For example
+# https://www.tweag.io/blog/2023-01-19-fp2-dial-m-for-monoid/#what-the-thunk
+# For now we try to catch any recursion errors and treat the model
+# as a "singleton" for that component.
+#
+def model_deconstruct(model: Model) -> list[Model]:
+    """Separate models into additive components.
+
+    Identify the separate "additive" components in the model
+    expression, that is the terms separated by addition or
+    subtraction. The resulting list can be summed together to recreate
+    the original model expression. This is not guaranteed to create
+    the expand the expression completely, and the resulting terms are
+    not guaranteed to be "simplified".
+
+    .. versionadded:: 4.16.1
+
+    Parameters
+    ----------
+    model : Model instance
+       The model expression to separate.
+
+    Returns
+    -------
+    terms : list of Model instances
+       The separated terms (this list may contain a single
+       element).
+
+    Notes
+    -----
+
+    If the model includes a subtracted component, such as:
+
+        a - b
+
+    then the b component will be negated in the output. This negation
+    is applied directly rather than applied to any term combined with
+    it (such as "a * (b - c)", which will create terms
+
+        a * b
+        a * -(c)
+
+    While an expression like
+
+        -(a + b * c + d)
+
+    could be split up, at present it is not. However, when written as
+    part of a binary expression it is split up, so
+
+        x - (a + b * c + d)
+
+    is split into
+
+        x, -(a), -(b * x), -(d)
+
+    Examples
+    --------
+
+    >>> from sherpa.models.basic import Box1D, Gauss1D
+    >>> b1 = Box1D("b1")
+    >>> g1 = Gauss1D("g1")
+    >>> g2 = Gauss1D("g2")
+    >>> model_deconstruct(b1)
+    [<Box1D model instance 'b1'>]
+    >>> model_deconstruct(b1 * (g1 + g2))
+    [<BinaryOpModel model instance 'b1 * g1'>, <BinaryOpModel model instance 'b1 * g2'>]
+    >>> model_deconstruct(b1 * (g1 - g2))
+    [<BinaryOpModel model instance 'b1 * g1'>, <BinaryOpModel model instance 'b1 * -(g2)'>]
+
+    Unary operators are not expanded by this routine, which makes the
+    behaviour a bit different than the binary-operator case, as shown
+    below:
+
+    >>> model_deconstruct(-(g1 + b1 * g2))
+    [<UnaryOpModel model instance '-(g1 + b1 * g2)'>]
+
+    >>> model_deconstruct(b1 - (g1 + b1 * g2))
+    [<Box1D model instance 'b1'>, <UnaryOpModel model instance '-(g1)'>, <UnaryOpModel model instance '-(b1 * g2)'>]
+
+    >>> model_deconstruct(-g1 - g2)
+    [<UnaryOpModel model instance '-(g1)'>, <UnaryOpModel model instance '-(g2)'>]
+
+    """
+
+    # The return is a list of components that add together to match
+    # the input model. So, if we are not a binary operation the result
+    # is simple.
+    #
+    # Note that there is no attempt to simplify an expression, that is,
+    #
+    #     -a * -b
+    #
+    # is not changed to
+    #
+    #     a * b
+    #
+    if not isinstance(model, BinaryOpModel):
+        return [model]
+
+    # The idea is to separate terms for model expressions that users
+    # are expected to write, not to separate all possible
+    # expressions. This means that the code forgoes the possibility of
+    # certain cases to simplify things. Also, the binary operator
+    # could technically be anything, and all that is checked here are
+    # the NumPy versions.
+    #
+    # Note that
+    #     (a + b) / c -> a / b, a / c
+    # but
+    #     (a + b) // c -> unchanged
+    #
+    if model.op not in [np.add, np.multiply,
+                        np.subtract, np.divide]:
+        return [model]
+
+    try:
+        lhs = model_deconstruct(model.lhs)
+    except RecursionError:
+        # If we can not recurse treat this as a single term.
+        lhs = [model.lhs]
+
+    # Special case division, since we do only want to deconstruct the
+    # lhs for this case.
+    #
+    if model.op == np.divide:
+        return [BinaryOpModel(lterm, model.rhs, model.op, model.opstr)
+                for lterm in lhs]
+
+    try:
+        rhs = model_deconstruct(model.rhs)
+    except RecursionError:
+        # If we can not recurse treat this as a single term.
+        rhs = [model.rhs]
+
+    if model.op == np.multiply:
+        # Expand the term, so
+        #
+        #     (a + b) * (c - d)
+        #
+        # will go to
+        #
+        #     (*, a, c)
+        #     (*, a, -d)
+        #     (*, b, c)
+        #     (*, a, -d)
+        #
+        return [BinaryOpModel(lterm, rterm, model.op, model.opstr)
+                for lterm, rterm in itertools.product(lhs, rhs)]
+
+    # The terms are intended to be summed together, so for subtraction
+    # the RHS terms must be negated.
+    #
+    if model.op == np.subtract:
+        # Since we claim that model is a Model and not ArithmeticModel
+        # we explicitly create the UnaryOpModel term (rather than just
+        # say "-term").
+        #
+        rhs = [UnaryOpModel(term, np.negative, '-')
+               for term in rhs]
+
+    # This is either addition or subtraction, so we return the
+    # combined list.
+    #
+    lhs.extend(rhs)
+    return lhs
 
 
 # Notebook representation

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -852,7 +852,7 @@ def test_model_deconstruct(model, expecteds):
     all the relevant code paths. Particular care is needed to ensure
     conditions like m1 / (m2 + m3) are included. At some point this
     becomes a regression test, as it's not neessarily important that
-    the best possible" deconstruction is created, just that we get
+    the best possible deconstruction is created, just that we get
     consistent results (e.g. given that the code does not simplify
     expressions, in particular the handling of negation).
 
@@ -861,7 +861,7 @@ def test_model_deconstruct(model, expecteds):
         model(x) = sum_i term_i(x)
 
     for all the terms that model_deconstruct creates. The idea is that
-    the models are set to non-zero values over the range use (ie
+    the models are set to non-zero values over the range they use (ie
     within -10 to 10 for the box components), and that there are some
     components which vary with x just to check everything passes
     through correctly.

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -589,6 +589,17 @@ class BaseBackend(metaclass=MetaBaseBackend):
         """
         pass
 
+    def set_title(self, title: str) -> None:
+        """Change the display title.
+
+        Parameters
+        ----------
+        title : str
+           The title text to use.
+
+        """
+        pass
+
     def get_latex_for_string(self, txt):
         """Convert LaTeX formula
 

--- a/sherpa/plot/bokeh_backend.py
+++ b/sherpa/plot/bokeh_backend.py
@@ -18,8 +18,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 '''
-
-
+Plotting using bokeh.
 '''
 
 import logging
@@ -786,6 +785,26 @@ class BokehBackend(BasicBackend):
                               "Use create=True to create an entirely new, " +
                               "complete grid of plots.") from None
         self.current_axis = self.current_fig.children[plotnum][0]
+
+    def set_title(self, title: str) -> None:
+        """Change the display title.
+
+        Parameters
+        ----------
+        title : str
+           The title text to use.
+
+        """
+
+        # It is not at all obvious how to do this since is it the
+        # first component or all components or ?
+        #
+        plotnum = self._index_axis(0, 0)
+        if plotnum is None:
+            # Should this error out?
+            return
+
+        self.current_fig.children[plotnum][0].title.text = title
 
     # HTML representation
 

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -716,6 +716,18 @@ class PylabBackend(BasicBackend):
 
         plt.sca(ax)
 
+    def set_title(self, title: str) -> None:
+        """Change the display title.
+
+        Parameters
+        ----------
+        title : str
+           The title text to use.
+
+        """
+
+        plt.title(title)
+
     # HTML representation as SVG plots
 
     def as_svg(self, func):

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -3089,13 +3089,4 @@ def test_plot_xxx_components_simple_bokeh(session, ptype):
     assert fig0.yaxis.axis_label == "y"
     assert fig0.title.text == "Component plot"
 
-    """
-    # How would we check the plotted data?
-
-    assert axes.lines[0].get_xdata() == pytest.approx([1, 10, 50])
-    assert axes.lines[1].get_xdata() == pytest.approx([1, 10, 50])
-
-    # This should be c1 * c2 and c1 * c3
-    assert axes.lines[0].get_ydata() == pytest.approx([1, 1, 1])
-    assert axes.lines[1].get_ydata() == pytest.approx([0, 2, 2])
-    """
+    # Unlike the matplotlib case we do not check the plotted data.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12076,12 +12076,6 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The function does not follow the normal Python standards for
-        parameter use, since it is designed for easy interactive use.
-        When called with a single un-named argument, it is taken to be
-        the `model` parameter. If given two un-named arguments, then
-        they are interpreted as the `id` and `model` parameters,
-        respectively.
 
         Unlike get_model_component this routine does not accept
         either model or recalc arguments.
@@ -12206,12 +12200,6 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The function does not follow the normal Python standards for
-        parameter use, since it is designed for easy interactive use.
-        When called with a single un-named argument, it is taken to be
-        the `model` parameter. If given two un-named arguments, then
-        they are interpreted as the `id` and `model` parameters,
-        respectively.
 
         Unlike get_source_component this routine does not accept
         either model or recalc arguments.


### PR DESCRIPTION
# Summary

Add plot_source_components and plot_model_components calls that will split up a model like `gal * (pl + line)` into two lines: one for `gal * pl` and one for `gal * line`. There are also corresponding `get_source_components_plot` and `get_model_components_plot` calls, and the "source_components" and "model_components" arguments can be used with the plot call.

# Details

This is a simplified #1022 (which used to be larger but had been split up). It is based on #1972 - not because it needs to but because it touches very-similar parts of code so it's just easier to do them one after the other.

The aim is to let users write models like `gal * (pl + line)` but to be able to recognize this as two terms, `gal * pl` and `gal * line`. We can then plot these component terms separately.  

After adding some tests and minor code-level tweaks, there's two basic parts

1. the `sherpa.models.model.model_deconstruct` routine which does the model split
2. the plot code

Whilst `model_deconstruct` should just be simple grade school PEMDAS/BODMAS/... work, it's a little tricky to do effectively. I have chosen to implement this relatively simply, at the expense of not catching all possible situations. For example

- this explicitly only looks for numpy operations (add, multiply, divide, subtract) and does not worry about things like exponentiation, reminder, or "integer divide"
- we are not trying to simplify "a / a - b" to "1 - b", but to two terms "a / a" and "- b" (this follows the general approach of #1972 that we want to try and replicate the original expression as much as possible, but in this case it's obviously not as clear cut).
- there are some oddities, since "-(a + b * c + d)" will not get changed but "x - (a + b * c + d)" will get expanded to "x", "-(a)", "-(b * c)", and "-(d)", but I do not expect users to be writing such models (e.g. use a unary operator on a model expression) so I would rather not try to address this issue (it is documented and tested).

In fact, we don't actually want to simplify the terms, since we still want to reflect the actual computation (so if a user says "a - a" then we don't want to just say "0" because the code will compute the model `a` and we don't want to hide this.

Since this is a recursive algorithm I add explicit checks for a recursion error - if found we just stop simplifying - even though it is hard to imagine most users of this functionality are likely to care. I do have tests for this (but since this depends on Python then we can never guarantee the recursion limit is not going to change, so at some point we might want to tweak this, but at present it seems like 1000 iterations is going to trigger the recursion error).

I have simplified the plot changes here - instead those changes have become 

- #1973
- #1977
- #1984 
- #1988

Here we now start of with returning a list of plots and then adding a "MultiPlot" class which handles this case, since the list-of-plot case doesn't handle the plot title well. Of course, this means that I've added a new method to the plot backend: `set_title`. I needed this to be able to over-ride the titles from the individual plot objects, and there didn't' seem to be a way to do this with the existing code. I think it makes sense, but comments are welcome. I also haven't tried the bokeh backend to see if my implementation actually works there.

I thought about how we could use the MultiPlot code in the existing code base. The two obvious choices are

- for fit plots (i.e. rather than have explicit dataplot and modelplot components we could just send in the plots)
  - unfortunately the user experience would be significantly different (although I guess we could add a subclass to
    try and paper over the differences; I just don't see it as worth it)
- the `OrderPlot` class
  - there's enough I don't understand about this class that I would only want to work on this in a later PR

However, nothing that I feel can or should be done in this PR.

# Notes

The `plot_model_components` call (and the source one) is a great example where the `label` concept would be useful - e.g.
- #938 

It's not obvious to me if there's other places than `plot_xxx_components` where it would be useful to be able to separate models. Flux calculations comes to mind. Anything? How do we add this capability to such a piece of the API?

I have tried several different ways of doing this over the years, and this is by-far the most successful, as well as being surprisingly self-contained. For fun I just tried an approach where we track the additive components as the model expression is built up (i.e. within `BinaryOpModel.__init__` we can replicate much of the logic of `model_deconstruct`) but

- as suggested, it doesn't really make the code simpler than the logic being in `model_deconstruct`
- why should every user pay for this feature compared to the current approach of only those wanting it have to spend that extra time
- perhaps most importantly, doing it during model creation leads to recursion errors and it just doesn't seem to be worth the effort to avoid this (and the issue of recursion errors is where I've come stuck in previous attempts).
 
# Examples

These are from an older version of the code, but they should still behave the same, except that as this is now based on #1972 the model expressions will have a lot-less unnecessary brackets.

## xsphabs * (powlaw1d + gauss1d)

Here the parameter values are chosen to not be crazy, given the data, but it's not a good fit to the data so they are just for show

```
>>> load_pha("3c273.pi")
>>> notice(0.5, 6)
>>> set_source(xsphabs.gal * (powlaw1d.pl + gauss1d.g1)
>>> gal.nh = 0.1
>>> pl.gamma = 1.7
>>> pl.ampl = 2e-4
>>> g1.pos = 4
>>> g1.fwhm = 0.5
>>> g1.ampl = 5e-5
```

With this we have

```
>>> plot_data(ylog=True)
>>> plot_model_components(overplot=True, alpha=0.7)
>>> plt.ylim(1e-5, 4e-2)
```

![sherpa1](https://user-images.githubusercontent.com/224638/214111802-07db7db4-b8ce-4702-b49b-4522932e231d.png)

and

```
>>> plot_model()
>>> plot_model_components(overplot=True, alpha=0.7)
```

![sherpa2](https://user-images.githubusercontent.com/224638/214111844-1d17aace-0fdd-4800-a6d6-df5b781aaf02.png)

If we do `plot_model_components` first we can see that the title isn't great (it is for the first component, and is something to be fixed). We can see how the components compare to the unabsorbed powerlaw with:

```
>>> plot_model_components(color='black', alpha=0.5)
>>> plot_model_component(pl, alpha=0.5, overplot=True)
```

![sherpa3](https://user-images.githubusercontent.com/224638/214113796-15a4db60-be86-4bd4-8f9b-d3ac90eb943a.png)

## IACHEC style model

```
In [27]: get_source()
Out[27]: <BinaryOpModel model instance '((xsconstant.m1 * xstbabs.m2) * ((((((((((((((((((((xsbremss.m3 + xsbremss.m4) + xsbremss.m5) + xsbremss.m6) + xsgaussian.m7) + xsgaussian.m8) + xsgaussian.m9) + xsgaussian.m10) + xsgaussian.m11) + xsgaussian.m12) + xsgaussian.m13) + xsgaussian.m14) + xsgaussian.m15) + xsgaussian.m16) + xsgaussian.m17) + xsgaussian.m18) + xsgaussian.m19) + xsgaussian.m20) + xsgaussian.m21) + xsgaussian.m22) + xsgaussian.m23))'>
```

Here we get

```
plot_model(ylog=True)
plot_model_components(alpha=0.2, overplot=True)
plt.xlim(0, 12)
plt.ylim(1e-4, 1e-2)
```

which produces

![sherpa4](https://user-images.githubusercontent.com/224638/214117452-5fdad006-1924-4aba-b597-bf6ff6668465.png)

and we can check the terms with

```
In [28]: from sherpa.models.model import model_deconstruct

In [29]: src = get_source()

In [30]: for i, term in enumerate(model_deconstruct(src), 1):
    ...:     print(f"{i:02d} - {term.name}")
    ...: 
01 - ((xsconstant.m1 * xstbabs.m2) * xsbremss.m3)
02 - ((xsconstant.m1 * xstbabs.m2) * xsbremss.m4)
03 - ((xsconstant.m1 * xstbabs.m2) * xsbremss.m5)
04 - ((xsconstant.m1 * xstbabs.m2) * xsbremss.m6)
05 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m7)
06 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m8)
07 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m9)
08 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m10)
09 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m11)
10 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m12)
11 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m13)
12 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m14)
13 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m15)
14 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m16)
15 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m17)
16 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m18)
17 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m19)
18 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m20)
19 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m21)
20 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m22)
21 - ((xsconstant.m1 * xstbabs.m2) * xsgaussian.m23)
```