### PR TITLE
XSPEC test cleanup

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -19,7 +19,6 @@
 #
 
 import numpy
-from numpy.testing import assert_allclose
 
 import pytest
 
@@ -763,7 +762,4 @@ def test_evaluate_xspec_model_noncontiguous2(modelcls):
     assert_is_finite(evals2, modelcls, "energy")
     assert_is_finite(wvals2, modelcls, "wavelength")
 
-    emsg = "{} non-contiguous model evaluation ".format(modelcls) + \
-        "failed: "
-    assert_allclose(evals2, wvals2,
-                    err_msg=emsg + "energy to wavelength")
+    assert wvals2 == pytest.approx(evals2)

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -497,6 +497,21 @@ def test_path_manager_change():
 #
 
 @requires_xspec
+@pytest.mark.parametrize("arg", [{}, True])
+def test_set_xsstate_no_op(arg):
+    """Just check we can sent in a "useless" argument.
+
+    All we do is check the call can be made, we do not check whether
+    anything has changed because of it.
+
+    """
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsstate(arg)
+
+
+@requires_xspec
 def test_get_xsstate_keys():
     """Check get_xsstate returns the expected keys.
 


### PR DESCRIPTION
# Summarize

Minor clean up to some XSPEC tests to make better use of pytest.

# Details

This is pulled out of existing XSPEC PRs but they have been waiting for review for years and I am finding these issues (particularly the first commit) in other unrelated code I am working on. So I have pulled these out of other PRs that I have pulled out of the original PRs in the hope they can get reviewed quickly.

This could just be the first commit, but we may as well take the other test runs which I wrote > 1 year ago as well.