### PR TITLE
GH Actions: Update xspec to min 12.12.0g with conda-forge

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -33,8 +33,11 @@ conda update --yes conda
 # https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )
 # the XSPEC-related channels are only added if needed
 #
+if [ -n "${XSPECVER}" ]; then
+ conda config --add channels conda-forge
+ conda config --add channels ${xspec_channel}
+fi
 conda config --add channels ${sherpa_channel}
-if [ -n "${XSPECVER}" ]; then conda config --add channels ${xspec_channel}; fi
 
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi

--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -20,14 +20,14 @@ xspec_library_path=${xspec_root}/lib/
 xspec_include_path=${xspec_root}/include/
 
 case "${XSPECVER}" in
+  12.13.0*)
+      xspec_version_string="12.13.0"
+      ;;
   12.12.1*)
       xspec_version_string="12.12.1"
       ;;
-  12.11.1*)
-      xspec_version_string="12.11.1"
-      ;;
-  12.10.1*)
-      xspec_version_string="12.10.1"
+  12.12.0*)
+      xspec_version_string="12.12.0"
       ;;
   *)
       echo "Xspec version listed currently unsupported in GitHub Actions jobs."

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -31,7 +31,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.10.1s
+            xspec-version: 12.13.0c
             # run xvfb with this display
             display: :99
 
@@ -56,7 +56,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.12.1
+            xspec-version: 12.13.0c
 
           - name: Linux Full Build (Python 3.9)
             os: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.11.1
+            xspec-version: 12.12.1c
 
           - name: Linux Full Build (Python 3.8)
             os: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.10.1s
+            xspec-version: 12.12.0g
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest


### PR DESCRIPTION
I've added new packages to the xspec channel at label "test". These use "conda-forge" and are ONLY there for testing purposes (not for deployment):

- cfitsio: 4.0.0, 4.1.0 (macOS ONLY since we already have one for Linux), 4.2.0 
- xspec-modelsonly: 12.12.0g (macOS not uploaded due to space), 12.12.1c (macOS not uploaded due to space), and 12.13.0c

These packages include the movement of the CCfits header files into the CCfits directory in the include area. Only the 12.13.0c packages have been tested to the side thus far (and not exhaustively). So, I have this as a draft at the moment.

I can upload the additional macOS packages noted above, but I would need to make a bit more space on that channel.

With this PR, I'm bumping all of the xspec tests to use these new version (12.13.0c for macOS and various versions for Linux) with the minimum of 12.12.0g. This is mean to coincide with #1609.