### PR TITLE
Address regression created by #1672

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2014, 2015, 2016, 2019, 2020, 2021, 2022
+#  Copyright (C) 2007, 2014, 2015, 2016, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -51,10 +51,12 @@ __version__ = _version.get_versions()['version']
 
 class Formatter(logging.Formatter):
     def format(self, record):
+        # Get the full message, #1688 shows we can not rely
+        # in record.msg.
+        #
+        msg = record.getMessage()
         if record.levelno > logging.INFO:
-            msg = '%s: %s' % (record.levelname, record.msg)
-        else:
-            msg = record.msg
+            msg = f"{record.levelname}: {msg}"
         return msg
 
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -400,7 +400,7 @@ def test_set_hard_limit_warns(caplog):
     the check using caplog captures the logging output correctly, and
     not as a used would see it (where the %s was not being replaced),
     which means this can not check #1688 is fixed. DJB does not know
-    how to do such a check witout adding extensive testing machinery
+    how to do such a check without adding extensive testing machinery
     which is not warranted in this case.
 
     """


### PR DESCRIPTION
# Summary

Internal change to the Sherpa-specific logging code, to ensure that logged message includes all components. This fixes #1688 which was a regression created when #1672 was recently merged.

# Details

The issue behind #1688 is that the #1672 change had a line like

    warning("foo %s bar", val)

and this is being displayed as "foo %s bar". So, `test_set_hard_limits_warns` was written to test this. However, it turns out that the logging output that is caught by caplog does include the string interpolation, so this check (while useful), is not going to show that #1688 is fixed.

When writing this I initially got confused and ended up adding `test_set_pars_errors__soft_limits` as a check, which is actually urelated to #1688 but I've left it in as it explicitly checks the `ParameterErr` message, to catch this sort of problem. I also updated another test to check the message that the `ModelErr` call was making, for similar reasons (although in that case it was to much to send in the n arguments that are needed for the test, so the tests check against `\d` instead).

However, on a further deep-dive (to understand why the test I added here doesn't catch the problem) I've found out that the problem is actually in our custom logging Formatter, which just grabs the first argument sent to a call like `warning`. I've fixed this to use `getMessage()` instead of `msg` which fixes the problem, and means that I didn't need to update the code I changed in #1672. Note that changing this code would have also "fixed" the problem, but it requires that we only ever send the logging calls a single argument, which we can't easily statically enforce.

I have spent a long time trying to get `pytest` to let me check the `stdout` created by the logger, but it evades both the `capsys` and `capfd` fixtures, which are used to grab `stdout`, and the `caplog` fixture, which captures the logging output. Since we check this output in SDS CIAO regression tests (which is how #1688 was found) I am okay with this, after doing a manual check:

- before this PR

```
>>> from sherpa.models.basic import Box1D
>>> mdl = Box1D('m')
>>> mdl.thawedpars = [-4e40, 4e40, -4e40]
WARNING: value of parameter %s is below minimum; setting to minimum
WARNING: value of parameter %s is above maximum; setting to maximum
WARNING: value of parameter %s is below minimum; setting to minimum
```

- after this PR

```
>>> from sherpa.models.basic import Box1D
>>> mdl = Box1D('m')
>>> mdl.thawedpars = [-4e40, 4e40, -4e40]
WARNING: value of parameter m.xlow is below minimum; setting to minimum
WARNING: value of parameter m.xhi is above maximum; setting to maximum
WARNING: value of parameter m.ampl is below minimum; setting to minimum
```