### PR TITLE
Test cleanup related to #1334

### DIFF
--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -36,6 +36,24 @@ from sherpa.models.basic import Box1D, Box2D, Const1D, Const2D, Gauss1D, \
 from sherpa.utils.err import PSFErr
 
 
+def check_lines(out, lines):
+    """Check out, when split on new line, matches lines.
+
+    Parameters
+    ----------
+    out : str
+        Text to check
+    lines : list of str
+        The expected output of out.split("\n")
+    """
+
+    olines = out.split("\n")
+    for oline, expected in zip(olines, lines):
+        assert oline == expected
+
+    assert len(olines) == len(lines)
+
+
 def make_none():
     """We can use this to create no kernel"""
 
@@ -152,16 +170,16 @@ def test_psf1d_model_show():
     dfold = Data1D('fold', np.arange(10), np.zeros(10))
     m.fold(dfold)
 
-    out = str(m).split("\n")
-    assert len(out) == 8
-    assert out[0] == "pmodel1"
-    assert out[1] == "   Param        Type          Value          Min          Max      Units"
-    assert out[2] == "   -----        ----          -----          ---          ---      -----"
-    assert out[3] == "   pmodel1.kernel frozen         box1"
-    assert out[4] == "   pmodel1.size frozen           10           10           10"
-    assert out[5] == "   pmodel1.center frozen            5            5            5"
-    assert out[6] == "   pmodel1.radial frozen            0            0            1           "
-    assert out[7] == "   pmodel1.norm frozen            1            0            1           "
+    check_lines(str(m),
+                [ "pmodel1"
+                , "   Param        Type          Value          Min          Max      Units"
+                , "   -----        ----          -----          ---          ---      -----"
+                , "   pmodel1.kernel frozen         box1"
+                , "   pmodel1.size frozen           10           10           10"
+                , "   pmodel1.center frozen            5            5            5"
+                , "   pmodel1.radial frozen            0            0            1           "
+                , "   pmodel1.norm frozen            1            0            1           "
+                ])
 
 
 def test_psf2d_data_show():
@@ -182,16 +200,16 @@ def test_psf2d_data_show():
     dfold = Data2D('fold', xx, yy, zz)
     m.fold(dfold)
 
-    out = str(m).split("\n")
-    assert len(out) == 8
-    assert out[0] == "pdata2"
-    assert out[1] == "   Param        Type          Value          Min          Max      Units"
-    assert out[2] == "   -----        ----          -----          ---          ---      -----"
-    assert out[3] == "   pdata2.kernel frozen        data2"
-    assert out[4] == "   pdata2.size  frozen       (6, 6)       (6, 6)       (6, 6)"
-    assert out[5] == "   pdata2.center frozen       (3, 3)       (3, 3)       (3, 3)"
-    assert out[6] == "   pdata2.radial frozen            0            0            1           "
-    assert out[7] == "   pdata2.norm  frozen            1            0            1           "
+    check_lines(str(m),
+                [ "pdata2"
+                , "   Param        Type          Value          Min          Max      Units"
+                , "   -----        ----          -----          ---          ---      -----"
+                , "   pdata2.kernel frozen        data2"
+                , "   pdata2.size  frozen       (6, 6)       (6, 6)       (6, 6)"
+                , "   pdata2.center frozen       (3, 3)       (3, 3)       (3, 3)"
+                , "   pdata2.radial frozen            0            0            1           "
+                , "   pdata2.norm  frozen            1            0            1           "
+                ])
 
 
 def test_psf2d_model_show():
@@ -206,17 +224,16 @@ def test_psf2d_model_show():
     dfold = Data2D('fold', xx, yy, zz)
     m.fold(dfold)
 
-    print(m)
-    out = str(m).split("\n")
-    assert len(out) == 8
-    assert out[0] == "pmodel2"
-    assert out[1] == "   Param        Type          Value          Min          Max      Units"
-    assert out[2] == "   -----        ----          -----          ---          ---      -----"
-    assert out[3] == "   pmodel2.kernel frozen         box2"
-    assert out[4] == "   pmodel2.size frozen     (72, 72)     (72, 72)     (72, 72)"
-    assert out[5] == "   pmodel2.center frozen     (36, 36)     (36, 36)     (36, 36)"
-    assert out[6] == "   pmodel2.radial frozen            0            0            1           "
-    assert out[7] == "   pmodel2.norm frozen            1            0            1           "
+    check_lines(str(m),
+                [ "pmodel2"
+                , "   Param        Type          Value          Min          Max      Units"
+                , "   -----        ----          -----          ---          ---      -----"
+                , "   pmodel2.kernel frozen         box2"
+                , "   pmodel2.size frozen     (72, 72)     (72, 72)     (72, 72)"
+                , "   pmodel2.center frozen     (36, 36)     (36, 36)     (36, 36)"
+                , "   pmodel2.radial frozen            0            0            1           "
+                , "   pmodel2.norm frozen            1            0            1           "
+                ])
 
 
 def test_psf1d_empty_pars():
@@ -758,24 +775,22 @@ def test_convolutionkernel_repr():
 def test_kernel_show_1d():
 
     kern = Kernel([5], [3])
-    out = str(kern).split("\n")
-
-    assert out[0] == "dshape   = [5]"
-    assert out[1] == "kshape   = [3]"
-    assert out[2] == "skshape  = None"
-    assert out[3] == "norm     = False"
-    assert out[4] == "origin   = [0.]"
-    assert out[5] == "frozen   = True"
-    assert out[6] == "center   = None"
-    assert out[7] == "args     = []"
-    assert out[8] == "kwargs   = {}"
-    assert out[9] == "renorm_shape  = None"
-    assert out[10] == "renorm   = None"
-    assert out[11] == "do_pad   = False"
-    assert out[12] == "pad_mask = None"
-    assert out[13] == "frac     = None"
-
-    assert len(out) == 14
+    check_lines(str(kern),
+                [ "dshape   = [5]"
+                , "kshape   = [3]"
+                , "skshape  = None"
+                , "norm     = False"
+                , "origin   = [0.]"
+                , "frozen   = True"
+                , "center   = None"
+                , "args     = []"
+                , "kwargs   = {}"
+                , "renorm_shape  = None"
+                , "renorm   = None"
+                , "do_pad   = False"
+                , "pad_mask = None"
+                , "frac     = None"
+                ])
 
 
 def test_convolutionkernel_show_2d():
@@ -783,75 +798,68 @@ def test_convolutionkernel_show_2d():
     mdl = Const2D()
     mdl.c0.set(2, min=2, max=2)
     kern = ConvolutionKernel(mdl)
-    out = str(kern).split("\n")
-    print(kern)
-
-    assert out[0] == "Convolution Kernel:"
-    assert out[1] == "const2d"
-    assert out[2] == "   Param        Type          Value          Min          Max      Units"
-    assert out[3] == "   -----        ----          -----          ---          ---      -----"
-    assert out[4] == "   const2d.c0   thawed            2            2            2           "
-
-    assert len(out) == 5
+    check_lines(str(kern),
+                [ "Convolution Kernel:"
+                , "const2d"
+                , "   Param        Type          Value          Min          Max      Units"
+                , "   -----        ----          -----          ---          ---      -----"
+                , "   const2d.c0   thawed            2            2            2           "
+                ])
 
 
 def test_psfkernel_show_1d():
 
     kern = PSFKernel([5], [3])
-    out = str(kern).split("\n")
-
-    assert out[0] == "dshape   = [5]"
-    assert out[1] == "kshape   = [3]"
-    assert out[2] == "skshape  = None"
-    assert out[3] == "norm     = True"
-    assert out[4] == "origin   = None"
-    assert out[5] == "frozen   = True"
-    assert out[6] == "center   = None"
-    assert out[7] == "args     = []"
-    assert out[8] == "kwargs   = {}"
-    assert out[9] == "renorm_shape  = None"
-    assert out[10] == "renorm   = None"
-    assert out[11] == "do_pad   = False"
-    assert out[12] == "pad_mask = None"
-    assert out[13] == "frac     = None"
-    assert out[14] == "is_model = False"
-    assert out[15] == "size     = None"
-    assert out[16] == "lo       = None"
-    assert out[17] == "hi       = None"
-    assert out[18] == "width    = None"
-    assert out[19] == "radial   = 0"
-
-    assert len(out) == 20
+    check_lines(str(kern),
+                [ "dshape   = [5]"
+                , "kshape   = [3]"
+                , "skshape  = None"
+                , "norm     = True"
+                , "origin   = None"
+                , "frozen   = True"
+                , "center   = None"
+                , "args     = []"
+                , "kwargs   = {}"
+                , "renorm_shape  = None"
+                , "renorm   = None"
+                , "do_pad   = False"
+                , "pad_mask = None"
+                , "frac     = None"
+                , "is_model = False"
+                , "size     = None"
+                , "lo       = None"
+                , "hi       = None"
+                , "width    = None"
+                , "radial   = 0"
+                ])
 
 
 def test_radialprofilekernel_show_1d():
 
     kern = RadialProfileKernel([5], [3])
-    out = str(kern).split("\n")
-
-    assert out[0] == "dshape   = [5]"
-    assert out[1] == "kshape   = [3]"
-    assert out[2] == "skshape  = None"
-    assert out[3] == "norm     = True"
-    assert out[4] == "origin   = None"
-    assert out[5] == "frozen   = True"
-    assert out[6] == "center   = None"
-    assert out[7] == "args     = []"
-    assert out[8] == "kwargs   = {}"
-    assert out[9] == "renorm_shape  = None"
-    assert out[10] == "renorm   = None"
-    assert out[11] == "do_pad   = False"
-    assert out[12] == "pad_mask = None"
-    assert out[13] == "frac     = None"
-    assert out[14] == "is_model = False"
-    assert out[15] == "size     = None"
-    assert out[16] == "lo       = None"
-    assert out[17] == "hi       = None"
-    assert out[18] == "width    = None"
-    assert out[19] == "radial   = 1"
-    assert out[20] == "radialsize = None"
-
-    assert len(out) == 21
+    check_lines(str(kern),
+                [ "dshape   = [5]"
+                , "kshape   = [3]"
+                , "skshape  = None"
+                , "norm     = True"
+                , "origin   = None"
+                , "frozen   = True"
+                , "center   = None"
+                , "args     = []"
+                , "kwargs   = {}"
+                , "renorm_shape  = None"
+                , "renorm   = None"
+                , "do_pad   = False"
+                , "pad_mask = None"
+                , "frac     = None"
+                , "is_model = False"
+                , "size     = None"
+                , "lo       = None"
+                , "hi       = None"
+                , "width    = None"
+                , "radial   = 1"
+                , "radialsize = None"
+                ])
 
 
 def test_empty_psfmodel_has_no_kernel():
@@ -862,8 +870,6 @@ def test_empty_psfmodel_has_no_kernel():
 def test_psfmodel_set_kernel():
 
     mdl = PSFModel(kernel=Box1D())
-    print(mdl.kernel)
-    print(type(mdl.kernel))
     assert isinstance(mdl.kernel, Box1D)
 
 

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022
+#  Copyright (C) 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -515,7 +515,6 @@ def test_psf1d_step():
     assert y == pytest.approx([10.0, 10.0, 10.0, 0, 0, 0], abs=1e-4)
 
 
-@pytest.mark.xfail  # see #1334
 def test_psf1d_step_v2():
     """Trying to track down why we have seen different behavior in
     test_regrid_unit.py.

--- a/sherpa/utils/tests/test_psf_lowlevel.py
+++ b/sherpa/utils/tests/test_psf_lowlevel.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -251,7 +251,6 @@ def test_convolve_simple_1d():
     assert out2 == pytest.approx(out)
 
 
-@pytest.mark.xfail  # see #1334
 def test_convolve_combined_1d():
     """Try to replicate the logic of test_psf1d_step_v2
     from sherpa/tests/test_instrument.py

--- a/sherpa/utils/tests/test_psf_lowlevel.py
+++ b/sherpa/utils/tests/test_psf_lowlevel.py
@@ -53,10 +53,9 @@ def test_tcdData_convolve_error1():
     out = _psf.tcdData()
     data = [1, 2, 3]
     kernel = [1, 2, 2, 1]
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match, dims_src: 1 vs dims_kern: 2$"):
         out.convolve(data, kernel, [3], [2, 2], [0])
-
-    assert str(te.value) == 'input array sizes do not match, dims_src: 1 vs dims_kern: 2'
 
 
 @pytest.mark.parametrize('center', [[0], 0])
@@ -65,10 +64,9 @@ def test_tcdData_convolve_error2(center):
     out = _psf.tcdData()
     data = [1, 2, 3, 4]
     kernel = [1, 2, 2, 1]
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match, dims_kern: 2 vs center: 1$"):
         out.convolve(data, kernel, [2, 2], [2, 2], center)
-
-    assert str(te.value) == 'input array sizes do not match, dims_kern: 2 vs center: 1'
 
 
 def test_tcdData_convolve_error3():
@@ -76,10 +74,9 @@ def test_tcdData_convolve_error3():
     out = _psf.tcdData()
     data = [1, 2, 3]
     kernel = [1, 2, 2, 1]
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match dimensions, source size: 3 vs source dim: 4$"):
         out.convolve(data, kernel, [2, 2], [2, 2], [0, 0])
-
-    assert str(te.value) == 'input array sizes do not match dimensions, source size: 3 vs source dim: 4'
 
 
 def test_tcdData_convolve_error4():
@@ -87,10 +84,9 @@ def test_tcdData_convolve_error4():
     out = _psf.tcdData()
     data = [1, 2, 3, 2]
     kernel = [1, 2, 2]
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match dimensions, kernel size: 3 vs kernel dim: 4$"):
         out.convolve(data, kernel, [2, 2], [2, 2], [0, 0])
-
-    assert str(te.value) == 'input array sizes do not match dimensions, kernel size: 3 vs kernel dim: 4'
 
 
 def test_tcdData_convolve_error_3d():
@@ -98,10 +94,9 @@ def test_tcdData_convolve_error_3d():
     out = _psf.tcdData()
     data = [1, 2, 3, 4, 5, 6, 7, 8]
     kernel = [1, 2, 2, 1]
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^Padding dimension not supported$"):
         out.convolve(data, kernel, [2, 2, 2], [2, 2, 1], [0, 0, 0])
-
-    assert str(te.value) == 'Padding dimension not supported'
 
 
 @pytest.mark.parametrize('actual,expected',
@@ -120,10 +115,9 @@ def test_get_padsize(actual, expected):
 def test_get_padsize_too_large():
     """Pick one larger than the current maximum"""
 
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^Padding dimension length 32401 not supported$"):
         _psf.get_padsize(32401)
-
-    assert str(te.value) == 'Padding dimension length 32401 not supported'
 
 
 def test_pad_data_basic():
@@ -152,10 +146,9 @@ def test_unpad_data_basic():
                           (_psf.unpad_data, 2, 1)])
 def test_xpad_data_error1(func, i, j):
 
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match=f"^input array sizes do not match, shape: {i} vs padshape: {j}$"):
         func([1, 2, 3], [3], [1, 3])
-
-    assert str(te.value) == f'input array sizes do not match, shape: {i} vs padshape: {j}'
 
 
 @pytest.mark.parametrize('func,i',
@@ -163,40 +156,36 @@ def test_xpad_data_error1(func, i, j):
                           (_psf.unpad_data, 1)])
 def test_xpad_data_error2(func, i):
 
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match=fr"^pad size is smaller than data shape, padshape\[{i}\]: 1 < shape\[{i}\]: 3$"):
         func([1, 2, 3], [3, 1], [1, 3])
-
-    assert str(te.value) == f'pad size is smaller than data shape, padshape[{i}]: 1 < shape[{i}]: 3'
 
 
 def test_pad_data_error3():
 
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match dimensions, kernel size: 3 vs kernel dim: 2$"):
         _psf.pad_data([1, 2, 3], [2], [3])
-
-    assert str(te.value) == 'input array sizes do not match dimensions, kernel size: 3 vs kernel dim: 2'
 
 
 def test_unpad_data_error3():
 
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match dimensions, kernel size: 3 vs kernel dim: 4$"):
         _psf.unpad_data([1, 2, 3], [4], [3])
-
-    assert str(te.value) == 'input array sizes do not match dimensions, kernel size: 3 vs kernel dim: 4'
 
 
 @pytest.mark.parametrize('func', [_psf.pad_data, _psf.unpad_data])
 def test_xpad_data_error4(func):
-
-    with pytest.raises(TypeError) as te:
-        func([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2], [2, 2, 2])
 
     if func.__name__ == 'pad_data':
         emsg = 'Padding dimension not supported'
     else:
         emsg = 'unpadding kernel failed-dimension unsupported'
 
-    assert str(te.value) == emsg
+    with pytest.raises(TypeError,
+                       match=f"^{emsg}$"):
+        func([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2], [2, 2, 2])
 
 
 @pytest.mark.parametrize('flags,expected',
@@ -218,11 +207,10 @@ def test_pad_bounding_box_basic(flags, expected):
 
 def test_pad_bounding_box_error():
 
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(TypeError,
+                       match="^kernel size: 5 is > than mask size: 4$"):
         _psf.pad_bounding_box([1, 2, 3, 4, 5],
                               [4, 3, 0, 1])
-
-    assert str(te.value) == 'kernel size: 5 is > than mask size: 4'
 
 
 def test_convolve_simple_1d():


### PR DESCRIPTION
# Summary

Complete the cleanup related to removing the #1334 workaround which was added in #1336. These two tests were missed from #1472 (which was meant to remove these changes). The two test files have also seen some minor style changes (no change in behavior).

# Details

I'm not sure how I missed the two #1334 changes in #1472 but I apparently did. When looking at the test files I noticed some style changes to apply

- use `match` argument of pytest.raises
- use a routine to check the str output of classes (makes the tests easier to update if the model representation ever changes)

I still have no idea what caused #1334 but I couldn't get a system to show the problem then, and definitely not now.