### PR TITLE
DS9 test tweaks

### DIFF
--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -19,7 +19,6 @@
 #
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 import pytest
 
@@ -99,10 +98,6 @@ def get_arr_from_imager(im, yexp):
     return out
 
 
-_atol = 0.0
-_rtol = 1.0e-6
-
-
 @requires_ds9
 def test_ds9():
     ctor = sherpa.image.ds9_backend.DS9.DS9Win
@@ -111,7 +106,7 @@ def test_ds9():
     im.showArray(data.y)
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
-    assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(data.y)
 
 
 @requires_ds9
@@ -120,7 +115,7 @@ def test_image():
     im.image(data.y)
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
-    assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(data.y)
 
 
 @requires_ds9
@@ -130,7 +125,7 @@ def test_data_image():
     im.image()
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
-    assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(data.y)
 
 
 @requires_ds9
@@ -140,7 +135,7 @@ def test_model_image():
     im.image()
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
-    assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(data.y)
 
 
 @requires_ds9
@@ -155,7 +150,7 @@ def test_ratio_image():
     # reassigns the ratio there to be one.
     expval = np.ones(data.y.shape)
     expval[0, 0] = 0
-    assert_allclose(expval, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(expval)
 
 
 @requires_ds9
@@ -166,7 +161,7 @@ def test_resid_image():
     data_out = get_arr_from_imager(im, data.y)
     im.xpaset("quit")
     # Return value is all zeros
-    assert_allclose(data.y * 0, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(np.zeros_like(data.y))
 
 
 @requires_ds9
@@ -196,8 +191,7 @@ def test_connection_with_x_file():
         os.rmdir(dname)
 
     im.xpaset("quit")
-
-    assert_allclose(data.y, data_out, atol=_atol, rtol=_rtol)
+    assert data_out == pytest.approx(data.y)
 
 
 @requires_ds9
@@ -235,5 +229,6 @@ def test_image_getregion(coordsys):
     toks = rval[7:-2].split(',')
     assert len(toks) == 3
 
-    vals = [float(t) for t in toks]
-    assert_allclose(vals, [8.5, 7.0, 0.8])
+    assert float(toks[0]) == pytest.approx(8.5)
+    assert float(toks[1]) == pytest.approx(7.0)
+    assert float(toks[2]) == pytest.approx(0.8)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019
-#     Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -216,8 +216,7 @@ def test_image_getregion(coordsys):
     # This is not ideal.
     from sherpa.image import ds9_backend
 
-    ctor = sherpa.image.ds9_backend.DS9.DS9Win
-    im = ctor(sherpa.image.ds9_backend.DS9._DefTemplate, False)
+    im = ds9_backend.imager
     im.doOpen()
     im.showArray(data.y)
 

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -126,7 +126,6 @@ def test_load_arrays2d(session, shape):
         assert got.shape == pytest.approx(shape)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_data_image(session):
     from sherpa.image import DataImage
@@ -148,7 +147,6 @@ def test_get_data_image(session):
     assert y[2, 5] == pytest.approx(100.0)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_model_image(session):
     from sherpa.image import ModelImage
@@ -172,7 +170,6 @@ def test_get_model_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_model_component_image(session):
     from sherpa.image import ComponentModelImage
@@ -199,7 +196,6 @@ def test_get_model_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_model_component_image_with_convolution(session):
     """What happens if there's a convolution component in play?"""
@@ -235,7 +231,6 @@ def test_get_model_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(42.25302)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_source_image(session):
     """Note that here there's no difference of source and model"""
@@ -260,7 +255,6 @@ def test_get_source_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_source_component_image(session):
     """Note that here there's no difference of source and model"""
@@ -285,7 +279,6 @@ def test_get_source_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_source_component_image_with_convolution(session):
     """There is a difference thanks to the PSF"""
@@ -314,7 +307,6 @@ def test_get_source_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_resid_image(session):
     from sherpa.image import ResidImage
@@ -339,7 +331,6 @@ def test_get_resid_image(session):
     assert y[3, 3] == pytest.approx(-71.0983)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_ratio_image(session):
     from sherpa.image import RatioImage
@@ -364,7 +355,6 @@ def test_get_ratio_image(session):
     assert y[3, 3] == pytest.approx(0.302958)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_psf_image(session):
     from sherpa.image import PSFImage
@@ -389,7 +379,6 @@ def test_get_psf_image(session):
     assert obj.y == pytest.approx(y)
 
 
-@requires_ds9
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_kernel_image(session):
     from sherpa.image import PSFKernelImage


### PR DESCRIPTION
# Summary

Minor cleanup of the DS9 tests (no functional change).

# Details

This started with #1618 but I've pulled out the "just change the tests" part or it (removal of un-needed requires_ds9 decorators) and then added some extra clean up of the code:

- use pytest.approx
- clean up of a test that is a bit odd: it's trying to test a piece of UI behavior but there's no real UI interface to run the test so it uses some low-level parts of the image interface and the change is to basically avoid creating a DS9 instance directly but use the default imager