### PR TITLE
Bump GH Action usage to versions that use Node.js 16

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
       with:
         submodules: 'True'
 
@@ -214,7 +214,7 @@ jobs:
         sherpa_test --cov sherpa --cov-report xml
 
     - name: upload coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         # only select the reports that we know are coverage reports, from linux conda, mac conda, and pip
         files: /home/runner/work/sherpa/sherpa/coverage.xml,/Users/runner/work/sherpa/sherpa/coverage.xml,/home/runner/coverage.xml

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
       # As we do not include an I/O backend it is not worth checking out the data submodule.
       #
       # with:

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
       with:
         submodules: 'True'
 
@@ -117,7 +117,7 @@ jobs:
         pytest --cov=sherpa --cov-report=xml
 
     - name: upload coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         # only select the reports that we know are coverage reports, from linux conda, mac conda, and pip
         files: /home/runner/work/sherpa/sherpa/coverage.xml,/Users/runner/work/sherpa/sherpa/coverage.xml,/home/runner/coverage.xml


### PR DESCRIPTION
Deprecation warnings were noted in the GH Actions: 
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, codecov/codecov-action@v2.
```
This should just be a quick bump to the checkout and codecov actions we use. 

Will rebase after #1705 as the fix for the codecov portion is already there. 