### PR TITLE
DS9 use individual names

### DIFF
--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -23,6 +23,10 @@
 At present the only supported application is DS9 [DS9]_, which is
 connected to via XPA [XPA]_.
 
+Communication is with a single DS9 instance. If multiple instances
+are needed then the ``set_template`` routine can be used to select
+a new template name for the next image call.
+
 References
 ----------
 
@@ -32,8 +36,13 @@ References
 
 """
 
+import string
+
 import numpy
+
 from sherpa.utils import NoNewAttributesAfterInit, bool_cast, display_fields
+from sherpa.utils.err import ArgumentTypeErr
+
 
 import logging
 warning = logging.getLogger(__name__).warning
@@ -54,6 +63,53 @@ except Exception as e:
 __all__ = ('Image', 'DataImage', 'ModelImage', 'RatioImage',
            'ResidImage', 'PSFImage', 'PSFKernelImage', 'SourceImage',
            'ComponentModelImage', 'ComponentSourceImage')
+
+
+def get_template() -> str:
+    """Return the template name used to talk to DS9.
+
+    Returns
+    ----------
+    template : str
+        The name used with for the DS9 instance.
+
+    See Also
+    --------
+    set_template
+
+    """
+
+    return backend.get_template()
+
+
+def set_template(template: str) -> None:
+    """Change the template name used by DS9.
+
+    Calling this will cause a new DS9 instance to be created
+    the next time an image is displayed.
+
+    Parameters
+    ----------
+    template : str
+       The name used with the DS9 instance. It must not contain
+       whitespace or be empty.
+
+    See Also
+    --------
+    get_template
+
+    """
+
+    if not isinstance(template, str):
+        raise ArgumentTypeErr("badarg", "template", "a string")
+
+    if template == "":
+        raise ArgumentTypeErr("badarg", "template", "not empty")
+
+    if any(c in template for c in string.whitespace):
+        raise ArgumentTypeErr("badarg", "template", "a string without whitespace")
+
+    backend.set_template(template)
 
 
 class Image(NoNewAttributesAfterInit):

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2017, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2017, 2021, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,7 +19,7 @@
 #
 
 import time
-from os import access, R_OK
+import os
 
 from sherpa.utils.err import DS9Err
 
@@ -163,7 +164,7 @@ def set_region(reg, coord):
         raise DS9Err('open')
     try:
         # Assume a region file defines everything correctly
-        if access(reg, R_OK):
+        if os.access(reg, os.R_OK):
             imager.xpaset("regions load " + "'" + reg + "'")
         else:
             # Assume region string has to be in CIAO format

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2017, 2021, 2023
+#  Copyright (C) 2007, 2016, 2017, 2021, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,7 +25,41 @@ from sherpa.utils.err import DS9Err
 
 from . import DS9
 
-imager = DS9.DS9Win(DS9._DefTemplate, False)
+# If a user wants a unique name they can use set_template - e.g.
+#
+#    set_template(f"sherpa-{os.getpid()}")
+#
+_TemplateName: str = DS9._DefTemplate
+
+
+def get_template() -> str:
+    """The template name used to determine the DS9 instance."""
+    return _TemplateName
+
+
+def set_template(template: str) -> None:
+    """Change the template name for DS9.
+
+    Parameters
+    ----------
+    template : str
+       The name used with the DS9 instance. It must not contain
+       whitespace or be empty.
+
+    """
+
+    # Validation of the template argument is done by the caller.
+    global _TemplateName, imager
+    _TemplateName = template
+
+    imager = DS9.DS9Win(_TemplateName, False)
+
+
+imager = DS9.DS9Win(get_template(), False)
+"""The DS9 instance.
+
+There is only one DS9 instance that can be communicated with.
+"""
 
 
 # TODO: the except blocks would ideally catch explicit errors; the present

--- a/sherpa/image/dummy_backend.py
+++ b/sherpa/image/dummy_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2009,2010,2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009,2010,2016,2026
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,6 +19,25 @@
 #
 
 imager = None
+
+
+def get_template() -> str:
+    """The template name used to determine the DS9 instance."""
+    return "sherpa"  # hard-coded to the default
+
+
+def set_template(template: str) -> None:
+    """Change the template name for DS9.
+
+    Parameters
+    ----------
+    template : str
+       The name used with the DS9 instance. It must not contain
+       whitespace or be empty.
+
+    """
+
+    pass
 
 
 def close(*args, **kwargs):

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -28,7 +28,7 @@ import os
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
-from sherpa.utils.err import DS9Err, RuntimeErr
+from sherpa.utils.err import ArgumentTypeErr, DS9Err, RuntimeErr
 from sherpa.utils.testing import requires_ds9
 
 
@@ -102,8 +102,9 @@ def get_arr_from_imager(im, yexp):
 
 @requires_ds9
 def test_ds9():
-    from sherpa.image import DS9
-    im = DS9.DS9Win(DS9._DefTemplate, False)
+    from sherpa.image import DS9, backend
+    template = backend.get_template()
+    im = DS9.DS9Win(template, False)
     im.doOpen()
     im.showArray(data.y)
     data_out = get_arr_from_imager(im, data.y)
@@ -210,9 +211,9 @@ def test_image_getregion(coordsys):
     """
 
     # This is not ideal.
-    from sherpa.image import ds9_backend
+    from sherpa.image import backend
 
-    im = ds9_backend.imager
+    im = backend.imager
     im.doOpen()
     im.showArray(data.y)
 
@@ -221,7 +222,7 @@ def test_image_getregion(coordsys):
     im.xpaset('regions format ds9')
     im.xpaset('regions', data=imshape)
 
-    rval = ds9_backend.get_region(coordsys)
+    rval = backend.get_region(coordsys)
 
     im.xpaset("quit")
 
@@ -267,3 +268,25 @@ def test_xpaset_error():
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         im.xpaset(command)
+
+
+@pytest.mark.parametrize("arg,emsg",
+                         [(23, "a string"),
+                          (None, "a string"),
+                          ("", "not empty"),
+                          ("  ", "a string without whitespace"),
+                          ("a space", "a string without whitespace"),
+                          (" space", "a string without whitespace"),
+                          ("spacer ", "a string without whitespace")
+                          ])
+def test_set_template_checks_argument(arg, emsg):
+    """Check we error out."""
+
+    from sherpa.image import set_template, get_template
+
+    with pytest.raises(ArgumentTypeErr,
+                       match=f"^'template' must be {emsg}$"):
+        set_template(arg)
+
+    # Check the template hasn't changed.
+    assert get_template() == "sherpa"

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -698,3 +698,55 @@ def test_image_kernel(session):
     # Check the same reagion as test_image_psf
     grid = '0\n0.166667\n0\n0.166667\n0.166667\n0\n0\n0\n0.166667\n0.166667\n0\n0\n0.166667\n0\n0\n0\n'
     check_xpa(backend, 'data image 4 5 4 4 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+def test_change_ds9_template(session):
+    """Can we talk to multiple DS9 instances in the same session?"""
+
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    m = example_model()
+    s.set_data(d)
+    s.set_source(m)
+
+    orig_template = backend.get_template()
+    assert orig_template == "sherpa"  # chcek no other tests have changed it
+
+    new_template = f"{orig_template}-copy"
+
+    try:
+        # Display the image data in the default instance and the model
+        # in the second DS9.
+        #
+        s.image_data()
+        old_cmap = backend.xpaget("cmap")
+
+        # Set notes to be able to distinguish (although the data check
+        # also should verify this).1
+        #
+        backend.xpaset("notes {Hello World}")
+        check_xpa(backend, "notes", "Hello World\n\n")
+
+        backend.set_template(new_template)
+        s.image_model()
+        check_xpa_model(backend)
+        check_xpa(backend, "notes", "\n")
+
+        backend.xpaset("quit")  # clean up the copy
+    finally:
+        backend.set_template(orig_template)
+
+    # Should be back to the original DS9 instance.
+    check_xpa_data(backend)
+    check_xpa(backend, "notes", "Hello World\n\n")
+
+    backend.xpaset("quit")  # clean up the original
+
+    # The finally call should guarantee this.
+    assert backend.get_template() == orig_template


### PR DESCRIPTION
# Summary

Allow the user to change the name used to communicate with DS9 via the sherpa.image.set_template function. This supports multiple DS9 instances within a single session but is primarily meant to support multiple Sherpa sessions, each with a separate DS9 instance.

# Details

The communication with DS9 is based on the template value used to create the `DS9Win` object and once set, the same name is used for all communication. The way that DS9 is initialized is (even after the clean up in #2459 and related) still set at module import time, so there is currently no way for a user to change it (without doing some low-level changes which this PR automates).

So, we introduce the `sherpa.image.set_template` and `sherpa.image.get_template` routines to set or retrieve the current name. The use of "template" here is to match the existing `DS9Win` nomenclature, but this could be changed as `set_template` is not the most-obvious name (but `set_name` is I think too generic and my feeling is that this is not likely to be a common operation). We technically don't need to have the `sherpa.image` variants, as we could just get users to call `sherpa.image.backend.set_template` but this feels a bit too much for the intended use case.

These two routines are then replicated in the backend code since the value is used creating the `sherpa.image.backend.image` instance. One tweak is that the validation in `set_template` is done at the `sherpa.image` layer rather than being in the backend code (with only one viable backend the benefit is not huge). 

Note that `set_template` has to re-generate the `image` value due to the way that the `DS9Win` code works (we could change the `imager.template` field but that then invalidates some of the invariants that `DS9Win` uses so the re-create option seems cleanest.

I had originally hoped to use this to allow parallel runs of the testing code when DS9 is present. However, testing with this approach - e.g. by making a `set_template` call with a unique name for each test - turns out to then cause other issues - e.g. warning messages from Xvfb (via `pytest-xvfb`) about clobbering existing sessions and some pipes not being closed on exit - so I have decided not to introduce that logic here.

Given that I think this is a specialized use case I'm happy with making the user

```
from sherpa.image import set_template
```

rather than having it be part of the `Session` class (i.e. available from the `ui` module).

# Example

```
% XPA_METHOD=local python
Python 3.14.4 | packaged by conda-forge | (main, Apr  8 2026, 02:33:53) [Clang 20.1.8 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from sherpa.astro import ui
>>> from sherpa.image import backend, get_template, set_template
>>> ui.load_image(1, "sherpa-test-data/sherpatest/img.fits")
>>> ui.image_data()
```

Let's check the current "template name"

```
>>> get_template()
'sherpa'
```

We can check that this is being used with the "XPA INFO" command:

```
>>> print(ui.image_xpaget("xpa info"))
XPA_VERSION:	2.1.20
XPA_CLASS:	DS9
XPA_NAME:	sherpa
XPA_METHOD:	/var/folders/kz/nt_fs_wj2yzg99cgs1hfz40m0000gr/T//DS9_sherpa.40079
```

Let's change the colormap of this instance:

```
>>> ui.image_xpaset("cmap heat")
```

Now switch template:

```
>>> set_template("foo")
```

If we try "XPA INFO" it fails

```
>>> print(ui.image_xpaget("xpa info"))
Traceback (most recent call last):
...
  File "/Users/burked/code/sherpa/sherpa-1/sherpa/image/ds9_backend.py", line 221, in xpaget
    raise DS9Err('open')
sherpa.utils.err.DS9Err: Imager not open
```

Let's create an image

```
>>> ui.image_data()
>>> print(backend.xpaget("xpa info"))
XPA_VERSION:	2.1.20
XPA_CLASS:	DS9
XPA_NAME:	foo
XPA_METHOD:	/var/folders/kz/nt_fs_wj2yzg99cgs1hfz40m0000gr/T//DS9_foo.40171
```

So, at this point we have two DS9 windows open.

```
>>> ui.image_xpaget("cmap")
'grey\n'
```

If we switch back we get to talk to the original DS9:

```
>>> set_template("sherpa")
>>> ui.image_xpaget("cmap")
'heat\n'
```
 
So, you can switch between the two (or add more) but it is a bit awkward and you have to remember which one you are talking to. I think this is an okay caveat.

The main interest I think is that I can run multiple sherpa sessions from different terminals and they no-longer try to talk to the same DS9 by choosing a "unique" name - e.g.

```
>>> import os
>>> set_template(f"sherpa-{os.getpid()}")
```
