### PR TITLE
Ensure string id can be used for the background id in the DataPHA notice/ignore call

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4707,7 +4707,12 @@ will be removed.
         #
         filter_background_only = False
         if bkg_id is not None:
-            if numpy.iterable(bkg_id):
+            # As bkg_id can be
+            #   - int or str
+            #   - iterable of int or str
+            # it's a bit awkward to identify what is meant.
+            #
+            if not isinstance(bkg_id, str) and numpy.iterable(bkg_id):
                 bkg_ids = bkg_id
             else:
                 bkg_ids = [bkg_id]

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1677,8 +1677,8 @@ class DataPHA(Data1D):
         else:
             raise DataErr('bad', 'quantity', val)
 
-        for id in self.background_ids:
-            bkg = self.get_background(id)
+        for bkg_id in self.background_ids:
+            bkg = self.get_background(bkg_id)
             if bkg.get_response() != (None, None) or \
                (bkg.bin_lo is not None and bkg.bin_hi is not None):
                 bkg.units = units
@@ -1693,8 +1693,8 @@ class DataPHA(Data1D):
 
     def _set_rate(self, val):
         self._rate = bool_cast(val)
-        for id in self.background_ids:
-            self.get_background(id).rate = val
+        for bkg_id in self.background_ids:
+            self.get_background(bkg_id).rate = val
 
     rate = property(_get_rate, _set_rate,
                     doc="""Is the Y axis displayed as a rate when plotting data?
@@ -1723,8 +1723,8 @@ a rate.""")
             raise DataErr("bad", "plot_fac setting", val)
 
         self._plot_fac = ival
-        for id in self.background_ids:
-            self.get_background(id).plot_fac = ival
+        for bkg_id in self.background_ids:
+            self.get_background(bkg_id).plot_fac = ival
 
     plot_fac = property(_get_plot_fac, _set_plot_fac,
                         doc="""How the X axis is used to create the Y axis when plotting data.
@@ -1740,16 +1740,19 @@ must be an integer.""")
         if not numpy.iterable(ids):
             raise DataErr('idsnotarray', 'response', str(ids))
 
-        keys = self._responses.keys()
-        for id in ids:
-            if id not in keys:
-                raise DataErr('badids', str(id), 'response', str(keys))
+        keys = list(self._responses.keys())
+        for resp_id in ids:
+            if resp_id not in keys:
+                raise DataErr('badids', str(resp_id), 'response', str(keys))
 
         self._response_ids = list(ids)
 
     response_ids = property(_get_response_ids, _set_response_ids,
-                            doc=('IDs of defined instrument responses ' +
-                                 '(ARF/RMF pairs)'))
+                            doc="""IDs of defined instrument responses (ARF/RMF pairs).
+
+If set, the identifiers must already exist, and any other responses
+will be removed.
+""")
 
     def _get_background_ids(self):
         return self._background_ids
@@ -1758,15 +1761,19 @@ must be an integer.""")
         if not numpy.iterable(ids):
             raise DataErr('idsnotarray', 'background', str(ids))
 
-        keys = self._backgrounds.keys()
-        for id in ids:
-            if id not in keys:
-                raise DataErr('badids', str(id), 'background', str(keys))
+        keys = list(self._backgrounds.keys())
+        for bkg_id in ids:
+            if bkg_id not in keys:
+                raise DataErr('badids', str(bkg_id), 'background', str(keys))
 
         self._background_ids = list(ids)
 
     background_ids = property(_get_background_ids, _set_background_ids,
-                              doc='IDs of defined background data sets')
+                              doc="""IDs of defined background data sets.
+
+If set, the identifiers must already exist, and any other backgrounds
+will be removed.
+""")
 
     def __init__(self, name, channel, counts, staterror=None, syserror=None,
                  bin_lo=None, bin_hi=None, grouping=None, quality=None,
@@ -2222,13 +2229,10 @@ must be an integer.""")
         if (arf is None) and (rmf is None):
             return
 
-        id = self._fix_response_id(id)
-        self._responses[id] = (arf, rmf)
-        ids = self.response_ids[:]
-        if id not in ids:
-            ids.append(id)
-
-        self.response_ids = ids
+        resp_id = self._fix_response_id(id)
+        self._responses[resp_id] = (arf, rmf)
+        if resp_id not in self.response_ids:
+            self.response_ids.append(resp_id)
 
         # To support simulated data (e.g. issue #1209) we over-write
         # the header TELESCOP/INSTRUME/FILTER settings to match the
@@ -2278,11 +2282,9 @@ must be an integer.""")
         set_response
 
         """
-        id = self._fix_response_id(id)
-        self._responses.pop(id, None)
-        ids = self.response_ids[:]
-        ids.remove(id)
-        self.response_ids = ids
+        resp_id = self._fix_response_id(id)
+        self._responses.pop(resp_id, None)
+        self.response_ids.remove(resp_id)
 
     def get_arf(self, id=None):
         """Return the ARF from the response.
@@ -2644,8 +2646,8 @@ must be an integer.""")
 
         else:
             energylist = []
-            for id in self.response_ids:
-                arf, rmf = self.get_response(id)
+            for resp_id in self.response_ids:
+                arf, rmf = self.get_response(resp_id)
                 lo = None
                 hi = None
 
@@ -2730,6 +2732,20 @@ must be an integer.""")
     """The identifier for the background component when not set."""
 
     def _fix_background_id(self, id):
+        """Identify the backround identifier.
+
+        Parameters
+        ----------
+        id : int, str, or None
+            The background identifier, or None. If None then the
+            default_background_id value will be used.
+
+        Returns
+        -------
+        bkg_id : int
+            The background identifier.
+
+        """
         if id is not None:
             return id
 
@@ -2755,8 +2771,8 @@ must be an integer.""")
         delete_background, set_background
 
         """
-        id = self._fix_background_id(id)
-        return self._backgrounds.get(id)
+        bkg_id = self._fix_background_id(id)
+        return self._backgrounds.get(bkg_id)
 
     def set_background(self, bkg, id=None):
         """Add or replace a background component.
@@ -2809,12 +2825,10 @@ must be an integer.""")
            numpy.any(self.channel != bkg.channel):
             raise DataErr("The source and background channels differ")
 
-        id = self._fix_background_id(id)
-        self._backgrounds[id] = bkg
-        ids = self.background_ids[:]
-        if id not in ids:
-            ids.append(id)
-        self.background_ids = ids
+        bkg_id = self._fix_background_id(id)
+        self._backgrounds[bkg_id] = bkg
+        if bkg_id not in self.background_ids:
+            self.background_ids.append(bkg_id)
 
         # Copy over data from the source to the background
         # if its not present in the background:
@@ -2884,14 +2898,15 @@ must be an integer.""")
 
         """
 
-        id = self._fix_background_id(id)
-        self._backgrounds.pop(id, None)
+        bkg_id = self._fix_background_id(id)
+        if bkg_id not in self.background_ids:
+            return
+
+        self._backgrounds.pop(bkg_id, None)
         if len(self._backgrounds) == 0:
             self._subtracted = False
-        ids = self.background_ids[:]
-        if id in ids:
-            ids.remove(id)
-        self.background_ids = ids
+
+        self.background_ids.remove(bkg_id)
 
     def get_background_scale(self, bkg_id=1, units='counts',
                              group=True, filter=False):
@@ -3807,9 +3822,9 @@ must be an integer.""")
 
         bdata_list = []
 
-        for key in self.background_ids:
-            bkg = self.get_background(key)
-            bdata = get_bdata_func(key, bkg)
+        for bkg_id in self.background_ids:
+            bkg = self.get_background(bkg_id)
+            bdata = get_bdata_func(bkg_id, bkg)
 
             backscal = bkg.backscal
             if backscal is not None:
@@ -4034,8 +4049,8 @@ must be an integer.""")
         bkg_counts = []
         bkg_scales = []
 
-        for key in self.background_ids:
-            bkg = self.get_background(key)
+        for bkg_id in self.background_ids:
+            bkg = self.get_background(bkg_id)
             berr, bcounts = get_error(bkg)
             if berr is None:
                 # We do not know how to generate an error, so
@@ -4546,8 +4561,8 @@ must be an integer.""")
         if notice_resp and noticed_chans is None:
             noticed_chans = self.get_noticed_channels()
 
-        for id in self.response_ids:
-            arf, rmf = self.get_response(id)
+        for resp_id in self.response_ids:
+            arf, rmf = self.get_response(resp_id)
             _notice_resp(noticed_chans, arf, rmf)
 
     def notice(self, lo=None, hi=None, ignore=False, bkg_id=None):
@@ -4692,17 +4707,20 @@ must be an integer.""")
         #
         filter_background_only = False
         if bkg_id is not None:
-            if not numpy.iterable(bkg_id):
-                bkg_id = [bkg_id]
+            if numpy.iterable(bkg_id):
+                bkg_ids = bkg_id
+            else:
+                bkg_ids = [bkg_id]
+
             filter_background_only = True
         else:
-            bkg_id = self.background_ids
+            bkg_ids = self.background_ids
 
         # Automatically impose data's filter on background data sets.
         # Units must agree for this to be meaningful, so temporarily
         # make data and background units match.
         #
-        for bid in bkg_id:
+        for bid in bkg_ids:
             bkg = self.get_background(bid)
             old_bkg_units = bkg.units
             try:

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1751,7 +1751,7 @@ must be an integer.""")
                             doc="""IDs of defined instrument responses (ARF/RMF pairs).
 
 If set, the identifiers must already exist, and any other responses
-will be removed. The identiers can be integers or strings.
+will be removed. The identifiers can be integers or strings.
 """)
 
     def _get_background_ids(self):

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1751,7 +1751,7 @@ must be an integer.""")
                             doc="""IDs of defined instrument responses (ARF/RMF pairs).
 
 If set, the identifiers must already exist, and any other responses
-will be removed.
+will be removed. The identiers can be integers or strings.
 """)
 
     def _get_background_ids(self):
@@ -1772,7 +1772,7 @@ will be removed.
                               doc="""IDs of defined background data sets.
 
 If set, the identifiers must already exist, and any other backgrounds
-will be removed.
+will be removed. The identifiers can be integers or strings.
 """)
 
     def __init__(self, name, channel, counts, staterror=None, syserror=None,
@@ -2729,7 +2729,10 @@ will be removed.
         return vals
 
     default_background_id = 1
-    """The identifier for the background component when not set."""
+    """The identifier for the background component when not set.
+
+It is an integer or string.
+"""
 
     def _fix_background_id(self, id):
         """Identify the backround identifier.
@@ -2742,7 +2745,7 @@ will be removed.
 
         Returns
         -------
-        bkg_id : int
+        bkg_id : int or str
             The background identifier.
 
         """
@@ -4584,7 +4587,7 @@ will be removed.
         ignore : bool, optional
             Set to True if the range should be ignored. The default is
             to notice the range.
-        bkg_id : int or sequence of int or None, optional
+        bkg_id : int or str, or sequence of int or str, optional
             If not None then apply the filter to the given background
             dataset or datasets, otherwise change the object and all
             its background datasets.

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3304,7 +3304,7 @@ def test_pha_notice_bkg_id_none():
     assert bup.mask == pytest.approx([False, True])
 
 
-@pytest.mark.parametrize("bkg_id", [1, pytest.param("up", marks=pytest.mark.xfail)])  # bug: #1709
+@pytest.mark.parametrize("bkg_id", [1, "up"])
 def test_pha_notice_bkg_id_scalar(bkg_id):
     """Check bkg_id=scalar."""
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3287,6 +3287,84 @@ def test_pha_compare_mask_and_filter():
     assert data.get_dep(filter=True) == pytest.approx([20, 50, 60, 70])
 
 
+def test_pha_notice_bkg_id_none():
+    """Check bkg_id=None."""
+
+    pha = DataPHA("src", [1, 2], [10, 10])
+    b1 = DataPHA("1", [1, 2], [2, 2])
+    bup = DataPHA("up", [1, 2], [3, 4])
+
+    pha.set_background(b1, id=1)
+    pha.set_background(bup, id="up")
+
+    pha.notice(lo=2, bkg_id=None)  # the default
+
+    assert pha.mask == pytest.approx([False, True])
+    assert b1.mask == pytest.approx([False, True])
+    assert bup.mask == pytest.approx([False, True])
+
+
+@pytest.mark.parametrize("bkg_id", [1, pytest.param("up", marks=pytest.mark.xfail)])  # bug: #1709
+def test_pha_notice_bkg_id_scalar(bkg_id):
+    """Check bkg_id=scalar."""
+
+    pha = DataPHA("src", [1, 2], [10, 10])
+    b1 = DataPHA("1", [1, 2], [2, 2])
+    bup = DataPHA("up", [1, 2], [3, 4])
+
+    pha.set_background(b1, id=1)
+    pha.set_background(bup, id="up")
+
+    pha.notice(lo=2, bkg_id=bkg_id)
+
+    assert pha.mask is True
+    if bkg_id == 1:
+        assert b1.mask == pytest.approx([False, True])
+        assert bup.mask is True
+    else:
+        assert b1.mask is True
+        assert bup.mask == pytest.approx([False, True])
+
+
+def test_pha_notice_bkg_id_array_all():
+    """Check bkg_id=array of all ids."""
+
+    pha = DataPHA("src", [1, 2], [10, 10])
+    b1 = DataPHA("1", [1, 2], [2, 2])
+    bup = DataPHA("up", [1, 2], [3, 4])
+
+    pha.set_background(b1, id=1)
+    pha.set_background(bup, id="up")
+
+    pha.notice(lo=2, bkg_id=["up", 1])
+
+    assert pha.mask is True
+    assert b1.mask == pytest.approx([False, True])
+    assert bup.mask == pytest.approx([False, True])
+
+
+@pytest.mark.parametrize("bkg_id", [1, "up"])
+def test_pha_notice_bkg_id_array_subset(bkg_id):
+    """Check bkg_id=array of one."""
+
+    pha = DataPHA("src", [1, 2], [10, 10])
+    b1 = DataPHA("1", [1, 2], [2, 2])
+    bup = DataPHA("up", [1, 2], [3, 4])
+
+    pha.set_background(b1, id=1)
+    pha.set_background(bup, id="up")
+
+    pha.notice(lo=2, bkg_id=[bkg_id])
+
+    assert pha.mask is True
+    if bkg_id == 1:
+        assert b1.mask == pytest.approx([False, True])
+        assert bup.mask is True
+    else:
+        assert b1.mask is True
+        assert bup.mask == pytest.approx([False, True])
+
+
 def get_img_spatial_mask():
     """This is a regression test, but it does look sensible."""
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -3022,11 +3022,8 @@ def test_pha_xxx_ids_invalid_not_known(attr):
     counts = np.ones_like(chans)
     pha = DataPHA("dummy", chans, counts)
 
-    # The error message could be better (use list to remove the dict_keys)
-    # but it is not a high priority.
-    #
     with pytest.raises(DataErr,
-                       match=re.escape(f"3 is not a valid {attr} id in dict_keys([])")):
+                       match=re.escape(f"3 is not a valid {attr} id in []")):
         setattr(pha, f"{attr}_ids", [3])
 
 
@@ -4263,7 +4260,7 @@ def test_pha_check_background_ids_basic():
     # We can not set an unknown background.
     #
     with pytest.raises(DataErr,
-                       match=r"^foo is not a valid background id in dict_keys\(\['up', 1\]\)$"):
+                       match=r"^foo is not a valid background id in \['up', 1\]$"):
         pha.background_ids = ["foo"]
 
     # And it hasn't changed.
@@ -4328,7 +4325,7 @@ def test_pha_check_response_ids_basic():
     # We can not set an unknown response.
     #
     with pytest.raises(DataErr,
-                       match=r"^foo is not a valid response id in dict_keys\(\['up', 1\]\)$"):
+                       match=r"^foo is not a valid response id in \['up', 1\]$"):
         pha.response_ids = ["foo"]
 
     # And it hasn't changed.

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4205,3 +4205,162 @@ def test_pha_ungroup_background_remove(caplog):
     assert not bkg.grouped
 
     assert len(caplog.record_tuples) == 0
+
+
+def test_pha_check_background_ids_basic():
+    """Check background_ids can be used.
+
+    This is a basic run through to check the behavior.
+    """
+
+    pha = DataPHA("src", [1, 2, 3], [1, 1, 1])
+    b1 = DataPHA("b1", [1, 2, 3], [1, 1, 1])
+    b2 = DataPHA("b2", [1, 2, 3], [1, 1, 1])
+
+    assert len(pha.background_ids) == 0
+
+    pha.set_background(b1)
+    assert pha.background_ids == pytest.approx([1])
+
+    pha.set_background(b2, id="up")
+    assert pha.background_ids == pytest.approx([1, "up"])
+
+    pha.delete_background(1)
+    assert pha.background_ids == pytest.approx(["up"])
+
+    # Check we can delete a background by setting background_ids
+    #
+    pha.background_ids = []
+    assert pha.background_ids == []
+
+    # Does the order matter?
+    #
+    pha.set_background(b2, id="up")
+    pha.set_background(b1)
+    assert pha.background_ids == pytest.approx(["up", 1])
+
+    # Remove one element.
+    #
+    pha.background_ids = [1]
+    assert pha.background_ids == pytest.approx([1])
+
+    # We can do the following, which is technically a no-op but may
+    # change some internal state. This also tests using an
+    # iterable-that-is-not-a-list.
+    #
+    pha.background_ids = {1}
+    assert pha.background_ids == pytest.approx([1])
+
+    # We can change to a currently-unused background as long as we've
+    # used it before.
+    #
+    pha.background_ids = ["up"]
+    assert pha.background_ids == pytest.approx(["up"])
+
+    pha.background_ids = [1, "up"]
+    assert pha.background_ids == pytest.approx([1, "up"])
+
+    # We can not set an unknown background.
+    #
+    with pytest.raises(DataErr,
+                       match=r"^foo is not a valid background id in dict_keys\(\['up', 1\]\)$"):
+        pha.background_ids = ["foo"]
+
+    # And it hasn't changed.
+    #
+    assert pha.background_ids == pytest.approx([1, "up"])
+
+
+def test_pha_check_response_ids_basic():
+    """Check response_ids can be used.
+
+    This is a basic run through to check the behavior.
+    """
+
+    pha = DataPHA("src", [1, 2, 3], [1, 1, 1])
+
+    elo = np.arange(2, 5)
+    ehi = elo + 1
+    rmf1 = create_delta_rmf(elo, ehi, name="rmf1")
+    rmf2 = create_delta_rmf(elo, ehi, name="rmf2")
+
+    pha.set_response(rmf=rmf1)
+    assert pha.response_ids == pytest.approx([1])
+
+    pha.set_response(rmf=rmf2, id="up")
+    assert pha.response_ids == pytest.approx([1, "up"])
+
+    pha.delete_response(1)
+    assert pha.response_ids == pytest.approx(["up"])
+
+    # Check we can delete a response by setting response_ids
+    #
+    pha.response_ids = []
+    assert pha.response_ids == []
+
+    # Does the order matter?
+    #
+    pha.set_response(rmf=rmf2, id="up")
+    pha.set_response(rmf=rmf1)
+    assert pha.response_ids == pytest.approx(["up", 1])
+
+    # Remove one element.
+    #
+    pha.response_ids = [1]
+    assert pha.response_ids == pytest.approx([1])
+
+    # We can do the following, which is technically a no-op but may
+    # change some internal state. This also tests using an
+    # iterable-that-is-not-a-list.
+    #
+    pha.response_ids = {1}
+    assert pha.response_ids == pytest.approx([1])
+
+    # We can change to a currently-unused response as long as we've
+    # used it before.
+    #
+    pha.response_ids = ["up"]
+    assert pha.response_ids == pytest.approx(["up"])
+
+    pha.response_ids = [1, "up"]
+    assert pha.response_ids == pytest.approx([1, "up"])
+
+    # We can not set an unknown response.
+    #
+    with pytest.raises(DataErr,
+                       match=r"^foo is not a valid response id in dict_keys\(\['up', 1\]\)$"):
+        pha.response_ids = ["foo"]
+
+    # And it hasn't changed.
+    #
+    assert pha.response_ids == pytest.approx([1, "up"])
+
+
+def test_pha_delete_missing_background_is_a_noop():
+    """Check this call returns.
+
+    """
+
+    pha = DataPHA("src", [1, 2, 3], [1, 1, 1])
+    bkg = DataPHA("bkg", [1, 2, 3], [1, 1, 1])
+    pha.set_background(bkg)
+    pha.subtract()
+
+    assert pha.subtracted
+    assert pha.background_ids == pytest.approx([1])
+    assert not bkg.subtracted
+    assert bkg.background_ids == []
+
+    # deleting a non-existant background is a no-op:
+    #  - dataset with no backgrounds
+    #  - dataset with a different-background to the requested
+    #
+    bkg.delete_background()
+    pha.delete_background(2)
+
+    # Minimal check that "nothing has happened".
+    #
+    assert pha.subtracted
+    assert pha.background_ids == pytest.approx([1])
+    assert not bkg.subtracted
+    assert bkg.background_ids == []


### PR DESCRIPTION
# Summary

Allow a string identifier to be used for the bkg_id argument to the DataPHA.notice (and ignore) method, fixing #1709 (it does not affect users using the ui layer).

# Details

This was noticed during the grouping/utils handling work. This is primarily a minor clean up but isn't huge. I then noticed #1709 and so added that fix in (and so the summary is all about the bugfix, but most of the code is clean up).

The #1709 fix is easy - we need to decide if bkg_id is sent a single is or a sequence of ids. Unfortunately the code just used numpy.iterable to decide, not recognizing that  a string is a valid scalar argument here (and that iterable returns true for a string). So the easy fix (as used elsewhere in sherpa) is to add in a "not a string instance" check.

There is also a change to an error message, but it's one that is hard to trigger so I've not listed it in the summary. Before this PR we have

```
>>> from sherpa.astro.ui import *
>>> DataPHA("x", None, None).response_ids = [1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/miniconda3/envs/ciao415-py310/lib/python3.10/site-packages/sherpa/utils/__init__.py", line 171, in __setattr__
    object.__setattr__(self, name, val)
  File "/home/dburke/miniconda3/envs/ciao415-py310/lib/python3.10/site-packages/sherpa/astro/data.py", line 1737, in _set_response_ids
    raise DataErr('badids', str(id), 'response', str(keys))
sherpa.utils.err.DataErr: 1 is not a valid response id in dict_keys([])
```

whilst we now get

```
>>> from sherpa.astro.data import DataPHA
>>> DataPHA("x", None, None).response_ids = [1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-master/sherpa/utils/__init__.py", line 171, in __setattr__
    object.__setattr__(self, name, val)
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/data.py", line 1746, in _set_response_ids
    raise DataErr('badids', str(resp_id), 'response', str(keys))
sherpa.utils.err.DataErr: 1 is not a valid response id in []
```

which has just lost the `dict_keys()` wrapper around the list.

# Notes

I was going to rework how the response_ids/background_id setting is done - as we can just take if from the keys of the _response/_backgrounds dictionaries. However, there's one use case (which I added a test for) that my new code would have handled [1], and it wasn't a huge improvement in the code.

[1] the code as is allows us to do the following

   pha.set_background(..., id="up")
   pha.set_background(..., id="down")
   pha.background_ids = ["up"]
   pha.background_ids = ["down"]

I'm no sure how useful it is, but as I mention I don't think that removing this capability actually helps save much code complexity.