### PR TITLE
plot: add linewidth option

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2022
+#  Copyright (C) 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1931,6 +1931,7 @@ DATA_PREFS = {'alpha': None,
               'ecolor': None,
               'linecolor': None,
               'linestyle': 'None',
+              'linewidth': None,
               'marker': '.',
               'markerfacecolor': None,
               'markersize': None,
@@ -1949,6 +1950,7 @@ MODEL_PREFS = {'alpha': None,
                'ecolor': None,
                'linecolor': None,
                'linestyle': '-',
+               'linewidth': None,
                'marker': 'None',
                'markerfacecolor': None,
                'markersize': None,

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2017, 2019, 2020, 2021
+#  Copyright (C) 2010, 2015, 2017, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -211,6 +211,7 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
           xlog=False,
           ylog=False,
           linestyle='solid',
+          linewidth=None,
           drawstyle='default',
           color=None,
           alpha=None,
@@ -250,7 +251,7 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
                 xerrorbars=False, yerrorbars=False,
                 ecolor=ecolor, capsize=capsize, barsabove=barsabove,
                 xlog=xlog, ylog=ylog,
-                linestyle=linestyle,
+                linestyle=linestyle, linewidth=linewidth,
                 drawstyle=drawstyle,
                 color=color, marker=None, alpha=alpha,
                 xaxis=False, ratioline=False)
@@ -275,11 +276,11 @@ def histo(xlo, xhi, y, yerr=None, title=None, xlabel=None, ylabel=None,
     #
     # Unlike plot, using errorbar for both cases.
     #
-
     axes.errorbar(xmid, y, yerr, xerr,
                   color=color,
                   alpha=alpha,
                   linestyle='',
+                  linewidth=linewidth,
                   marker=marker,
                   markersize=markersize,
                   markerfacecolor=markerfacecolor,
@@ -364,6 +365,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
          xlog=False,
          ylog=False,
          linestyle='solid',
+         linewidth=None,
          drawstyle='default',
          color=None,
          marker='None',
@@ -409,6 +411,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
         objs = axes.errorbar(x, y, yerr, xerr,
                              color=color,
                              linestyle=linestyle,
+                             linewidth=linewidth,
                              marker=marker,
                              markersize=markersize,
                              markerfacecolor=markerfacecolor,
@@ -423,6 +426,7 @@ def plot(x, y, yerr=None, xerr=None, title=None, xlabel=None, ylabel=None,
                          color=color,
                          alpha=alpha,
                          linestyle=linestyle,
+                         linewidth=linewidth,
                          drawstyle=drawstyle,
                          marker=marker,
                          markersize=markersize,


### PR DESCRIPTION
# Summary

Add the linewidth option for data and model plots.

# Details

This is easy to add, although it is "matplotlib" specific (but I'd imagine any plotting backend would let you set this).

This was a request from a recent helpdesk user, and it has been sitting around for ages (this has been taken from #938). It will conflict with the backend rework but I don't want to hold back useful changes for ever.