### PR TITLE
utils: tweak internal _save_type routine

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -3891,9 +3891,10 @@ class Session(sherpa.ui.utils.Session):
             if objtype == 'delchi':
                 raise AttributeError("save_delchi() does not apply for images")
 
-            imgtype = getattr(self, 'get_' + objtype + '_image', None)
+            aname = f'get_{objtype}_image'
+            imgtype = getattr(self, aname, None)
             if imgtype is None:
-                raise AttributeError("'get_%s_image()' not found" % objtype)
+                raise AttributeError(f"'{aname}()' not found")
 
             obj = imgtype(id)
 
@@ -3911,13 +3912,14 @@ class Session(sherpa.ui.utils.Session):
         if bkg_id is not None:
             funcname += 'bkg_'
 
-        plottype = getattr(self, funcname + objtype + '_plot', None)
+        aname = f'{funcname}{objtype}_plot'
+        plottype = getattr(self, aname, None)
         if plottype is None:
-            raise AttributeError("'%s%s_plot()' not found" % (funcname,
-                                                              objtype))
+            raise AttributeError(f"'{aname}()' not found")
 
-        obj = plottype(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            obj = plottype(id)
+        else:
             obj = plottype(id, bkg_id=bkg_id)
 
         args = None


### PR DESCRIPTION
# Summary

Minor internal change to a routine in the utils code. There is no change in behavior.

# Details

Move to using f-strings which then lead to a small run-time improvement (really very minor, is not going to change any performance characteristics) for when bkg_id is set (we don't call the required routine for the source and then call the bkg_id verson, as it is assumed the source version is not worth calling).

The `raise AttributeError` lines turn out to have no tests. I haven't added any because this is a low-level routine which is only meant to be called by other low-level routines, so there should be no code that ever leads to the error condition. We can add a check if it is felt useful.

This was taken from https://github.com/sherpa/sherpa/pull/1638 / https://github.com/sherpa/sherpa/pull/1667 as it is a small, separate, item.