### PR TITLE
Ensure the background is a DataPHA object

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2794,10 +2794,10 @@ must be an integer.""")
 
         # Check that the background matches the source (i.e. self)
         # dataset.  For this use case we require that the source has
-        # set up it's channel array (ie self.channel can not be None),
+        # set up its channel array (ie self.channel cannot be None),
         # as allowing the background dataset to have channels but not
-        # the source makes tracking the state harder than the ability
-        # is likely worth).
+        # the source makes tracking the state harder and there is no
+        # obvious use case for that.
         #
         if self.channel is None:
             raise DataErr("The channel field must be set before adding a background")

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2792,6 +2792,23 @@ must be an integer.""")
         if not isinstance(bkg, DataPHA):
             raise ArgumentTypeErr("badarg", "bkg", "a PHA data set")
 
+        # Check that the background matches the source (i.e. self)
+        # dataset.  For this use case we require that the source has
+        # set up it's channel array (ie self.channel can not be None),
+        # as allowing the background dataset to have channels but not
+        # the source makes tracking the state harder than the ability
+        # is likely worth).
+        #
+        if self.channel is None:
+            raise DataErr("The channel field must be set before adding a background")
+
+        if bkg.channel is None:
+            raise DataErr("The channel field of the background must be set")
+
+        if len(self.channel) != len(bkg.channel) or \
+           numpy.any(self.channel != bkg.channel):
+            raise DataErr("The source and background channels differ")
+
         id = self._fix_background_id(id)
         self._backgrounds[id] = bkg
         ids = self.background_ids[:]

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2008, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -128,7 +128,7 @@ from sherpa.data import Data1DInt, Data2D, Data, Data1D, \
     IntegratedDataSpace2D, _check
 from sherpa.models.regrid import EvaluationSpace1D
 from sherpa.stats import Chi2XspecVar
-from sherpa.utils.err import DataErr, ImportErr
+from sherpa.utils.err import ArgumentTypeErr, DataErr, ImportErr
 from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
     create_expr, create_expr_integrated, parse_expr, bool_cast, rebin, filter_bins
 from sherpa.utils import formatting
@@ -2788,6 +2788,10 @@ must be an integer.""")
         external programs, such as XSPEC.
 
         """
+
+        if not isinstance(bkg, DataPHA):
+            raise ArgumentTypeErr("badarg", "bkg", "a PHA data set")
+
         id = self._fix_background_id(id)
         self._backgrounds[id] = bkg
         ids = self.background_ids[:]

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021, 2022
+#  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -19,7 +19,6 @@
 #
 
 import logging
-import re
 import warnings
 
 import numpy as np
@@ -27,7 +26,7 @@ import numpy as np
 import pytest
 
 from sherpa.astro.ui.utils import Session
-from sherpa.astro.data import DataARF, DataPHA, DataRMF, DataIMG, DataIMGInt
+from sherpa.astro.data import Data1D, DataARF, DataPHA, DataRMF, DataIMG, DataIMGInt
 from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.models.basic import Gauss2D
 from sherpa.utils import parse_expr, SherpaFloat
@@ -3577,3 +3576,26 @@ def test_len_image_sparse(make_image_sparse):
 
     assert len(data) == len(data.y)
     assert len(data) == 5
+
+
+def test_pha_checks_background_is_pha():
+    """What happens if we send in a non-PHA background?"""
+
+    pha = DataPHA("x", [1, 2], [1, 2])
+    bkg = Data1D("y", [1, 2], [1, 2])
+    with pytest.raises(AttributeError,
+                       match="^'Data1D' object has no attribute 'grouping'$"):
+        pha.set_background(bkg)
+
+
+def test_pha_checks_background_size():
+    """What happens if we send in a background with a different number of channels?
+
+    This is a regression test, as there is an argument that this should error
+    out.
+    """
+
+    pha = DataPHA("x", [1, 2, 3], [1, 2, 3])
+    bkg = DataPHA("y", [1, 2], [1, 2])
+    pha.set_background(bkg)
+    assert pha.background_ids == [1]

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -30,7 +30,7 @@ from sherpa.astro.data import Data1D, DataARF, DataPHA, DataRMF, DataIMG, DataIM
 from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.models.basic import Gauss2D
 from sherpa.utils import parse_expr, SherpaFloat
-from sherpa.utils.err import DataErr
+from sherpa.utils.err import ArgumentTypeErr, DataErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 
 
@@ -3583,8 +3583,8 @@ def test_pha_checks_background_is_pha():
 
     pha = DataPHA("x", [1, 2], [1, 2])
     bkg = Data1D("y", [1, 2], [1, 2])
-    with pytest.raises(AttributeError,
-                       match="^'Data1D' object has no attribute 'grouping'$"):
+    with pytest.raises(ArgumentTypeErr,
+                       match="^'bkg' must be a PHA data set$"):
         pha.set_background(bkg)
 
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -806,9 +806,9 @@ def test_unsubtract():
     This test just subtracts and unsubtracts a few times.
     '''
     session = Session()
-    testdata = DataPHA('testdata', np.arange(50, dtype=float) + 1.,
+    testdata = DataPHA('testdata', np.arange(1, 51, dtype=np.int16),
                        np.zeros(50))
-    testbkg = DataPHA('testbkg', np.arange(50, dtype=float) + .5,
+    testbkg = DataPHA('testbkg', np.arange(1, 51, dtype=np.int16),
                       np.zeros(50))
     session.set_data(1, testdata)
     session.set_bkg(1, testbkg)
@@ -3589,13 +3589,30 @@ def test_pha_checks_background_is_pha():
 
 
 def test_pha_checks_background_size():
-    """What happens if we send in a background with a different number of channels?
-
-    This is a regression test, as there is an argument that this should error
-    out.
-    """
+    """What happens if we send in a background with a different number of channels?"""
 
     pha = DataPHA("x", [1, 2, 3], [1, 2, 3])
     bkg = DataPHA("y", [1, 2], [1, 2])
-    pha.set_background(bkg)
-    assert pha.background_ids == [1]
+    with pytest.raises(DataErr,
+                       match="^The source and background channels differ$"):
+        pha.set_background(bkg)
+
+
+def test_pha_checks_background_size_is_set_source():
+    """Ensure the source PHA has channels when adding a background"""
+
+    pha = DataPHA("x", None, None)
+    bkg = DataPHA("y", [1, 2], [1, 2])
+    with pytest.raises(DataErr,
+                       match="^The channel field must be set before adding a background$"):
+        pha.set_background(bkg)
+
+
+def test_pha_checks_background_size_is_set_bkg():
+    """Ensure the bkg PHA has channels when adding a background"""
+
+    pha = DataPHA("x", [1, 2, 3], [1, 0, 1])
+    bkg = DataPHA("y", None, None)
+    with pytest.raises(DataErr,
+                       match="^The channel field of the background must be set$"):
+        pha.set_background(bkg)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -3182,9 +3182,9 @@ def test_1209_background(make_data_path):
     We use a non-Chandra dataset.
     """
 
-    # We could set up channels and counts, but let's not.
+    # We need to set up the channels array to match the background.
     #
-    d = DataPHA("dummy", None, None)
+    d = DataPHA("dummy", np.arange(1, 801, dtype=np.int16), None)
     assert d.header["TELESCOP"] == "none"
     assert d.header["INSTRUME"] == "none"
     assert d.header["FILTER"] == "none"

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2021
+#  Copyright (C) 2017, 2018, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -531,9 +531,9 @@ def test_1209_background(make_data_path):
     This is related to issue #1209
     """
 
-    # We could set up channels and counts, but let's not.
+    # We need to set up the channels array to match the background.
     #
-    d = DataPHA("dummy", None, None)
+    d = DataPHA("dummy", np.arange(1, 1025, dtype=np.int16), None)
     assert d.header["TELESCOP"] == "none"
     assert d.header["INSTRUME"] == "none"
     assert d.header["FILTER"] == "none"

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3137,3 +3137,33 @@ def test_set_xxxscal_id(label, clean_astro_ui):
 
     assert got2 / got1 == pytest.approx(2)
     assert got2 == pytest.approx(2.4e-2)
+
+
+@pytest.mark.parametrize("idval", [None, 1, "up"])
+@pytest.mark.parametrize("bkg_id", [1, "up"])
+def test_dataspace1d_is_a_background(idval, bkg_id, clean_astro_ui):
+    """What happens if try to make a PHA background?"""
+
+    ui.dataspace1d(1, 10, id=idval, dstype=ui.DataPHA)
+    ui.dataspace1d(1, 10, id=idval, bkg_id=bkg_id, dstype=ui.DataPHA)
+    expected = [1] if idval is None else [idval]
+    assert ui.list_data_ids() == pytest.approx(expected)
+    assert ui.list_bkg_ids(idval) == pytest.approx([bkg_id])
+
+
+def test_dataspace1d_not_a_background(clean_astro_ui):
+    """What happens if try to make a non-PHA background?"""
+
+    ui.dataspace1d(1, 10, dstype=ui.DataPHA)
+    with pytest.raises(AttributeError,
+                       match="^'Data1DInt' object has no attribute 'grouping'$"):
+        ui.dataspace1d(1, 10, bkg_id=1)
+
+
+def test_set_bkg_not_a_background(clean_astro_ui):
+    """What happens if try to make add a non-PHA background?"""
+
+    ui.dataspace1d(1, 10, dstype=ui.DataPHA)
+    with pytest.raises(ArgumentTypeErr,
+                       match="^'bkg' must be a PHA data set$"):
+        ui.set_bkg(ui.Data1D("x", [1, 2], [1, 2]))

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3155,8 +3155,8 @@ def test_dataspace1d_not_a_background(clean_astro_ui):
     """What happens if try to make a non-PHA background?"""
 
     ui.dataspace1d(1, 10, dstype=ui.DataPHA)
-    with pytest.raises(AttributeError,
-                       match="^'Data1DInt' object has no attribute 'grouping'$"):
+    with pytest.raises(ArgumentTypeErr,
+                       match="^'dstype' must be set to DataPHA$"):
         ui.dataspace1d(1, 10, bkg_id=1)
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3142,7 +3142,7 @@ def test_set_xxxscal_id(label, clean_astro_ui):
 @pytest.mark.parametrize("idval", [None, 1, "up"])
 @pytest.mark.parametrize("bkg_id", [1, "up"])
 def test_dataspace1d_is_a_background(idval, bkg_id, clean_astro_ui):
-    """What happens if try to make a PHA background?"""
+    """What happens if we try to make a PHA background?"""
 
     ui.dataspace1d(1, 10, id=idval, dstype=ui.DataPHA)
     ui.dataspace1d(1, 10, id=idval, bkg_id=bkg_id, dstype=ui.DataPHA)
@@ -3152,7 +3152,7 @@ def test_dataspace1d_is_a_background(idval, bkg_id, clean_astro_ui):
 
 
 def test_dataspace1d_not_a_background(clean_astro_ui):
-    """What happens if try to make a non-PHA background?"""
+    """What happens if we try to make a non-PHA background?"""
 
     ui.dataspace1d(1, 10, dstype=ui.DataPHA)
     with pytest.raises(ArgumentTypeErr,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -166,11 +166,7 @@ def _save_errorcol(session, idval, filename, bkg_id,
     idval = session._fix_id(idval)
     _check_str_type(filename, 'filename')
 
-    if bkg_id is None:
-        d = session.get_data(idval)
-    else:
-        d = session.get_bkg(idval, bkg_id)
-
+    d = session._get_data_or_bkg(idval, bkg_id)
     if isinstance(d, DataPHA):
         x = d._get_ebins(group=True)[0]
     else:
@@ -2129,6 +2125,31 @@ class Session(sherpa.ui.utils.Session):
         raise IdentifierErr('getitem', 'background data set', bkg_id,
                             f'in PHA data set {idval} has not been set')
 
+    def _get_data_or_bkg(self, id, bkg_id=None):
+        """Return the given dataset (may be a background).
+
+        Unlike _get_pha_data it does not force the data to
+        be a PHA dataset.
+
+        Parameters
+        ----------
+        id : int or str or None
+            The dataset identifier. A value of None means the
+            default identifier is used.
+        bkg_id : int or None
+            If set then pick the background component instead.
+
+        Returns
+        -------
+        data : sherpa.data.Data instance
+
+        """
+
+        if bkg_id is None:
+            return self.get_data(id)
+
+        return self.get_bkg(id, bkg_id)
+
     def _get_img_data(self, id):
         """Ensure the dataset is an image"""
         idval = self._fix_id(id)
@@ -2455,11 +2476,7 @@ class Session(sherpa.ui.utils.Session):
         if val is None:
             val, id = id, val
 
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         sherpa.ui.utils.set_filter(d, val, ignore=ignore)
 
     # DOC-NOTE: also in sherpa.utils
@@ -2683,11 +2700,7 @@ class Session(sherpa.ui.utils.Session):
         if val is None:
             val, id = id, val
 
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         sherpa.ui.utils.set_dep(d, val)
 
     set_counts = set_dep
@@ -2751,11 +2764,7 @@ class Session(sherpa.ui.utils.Session):
         if val is None:
             val, id = id, val
 
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         sherpa.ui.utils.set_error(d, "staterror", val, fractional=fractional)
 
     # DOC-NOTE: also in sherpa.utils
@@ -2813,13 +2822,8 @@ class Session(sherpa.ui.utils.Session):
         """
         if val is None:
             val, id = id, val
-        err = None
 
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         sherpa.ui.utils.set_error(d, "syserror", val, fractional=fractional)
 
     def set_exposure(self, id, exptime=None, bkg_id=None):
@@ -3065,11 +3069,8 @@ class Session(sherpa.ui.utils.Session):
         array([2, 3, 5])
 
         """
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
 
+        d = self._get_data_or_bkg(id, bkg_id)
         return d.get_staterror(filter, self.get_stat().calc_staterror)
 
     # DOC-NOTE: also in sherpa.utils, where it does not have
@@ -3141,11 +3142,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
         idval = self._fix_id(id)
-        if bkg_id is None:
-            d = self.get_data(idval)
-        else:
-            d = self.get_bkg(idval, bkg_id)
-
+        d = self._get_data_or_bkg(idval, bkg_id)
         err = d.get_syserror(filter)
         if err is None:
             raise DataErr('nosyserr', idval)
@@ -3227,11 +3224,7 @@ class Session(sherpa.ui.utils.Session):
         >>> berr2 = get_error('core', bkg_id=2, filter=True)
 
         """
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         return d.get_error(filter, self.get_stat().calc_staterror)
 
     # DOC-NOTE: also in sherpa.utils
@@ -3343,11 +3336,7 @@ class Session(sherpa.ui.utils.Session):
         array([  16.5,   48.5,   80.5,  112.5,  144.5])
 
         """
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         return d.get_indep(filter=filter)
 
     def get_axes(self, id=None, bkg_id=None):
@@ -3436,11 +3425,8 @@ class Session(sherpa.ui.utils.Session):
         True
 
         """
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
 
+        d = self._get_data_or_bkg(id, bkg_id)
         if isinstance(d, DataPHA):
             return d._get_ebins(group=False)
 
@@ -3533,11 +3519,8 @@ class Session(sherpa.ui.utils.Session):
         (65536,)
 
         """
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
 
+        d = self._get_data_or_bkg(id, bkg_id)
         if isinstance(d, DataPHA):
             old = d._rate
             d._rate = False  # return predicted counts, not rate for PHA
@@ -3953,11 +3936,7 @@ class Session(sherpa.ui.utils.Session):
             id, filename = filename, id
         _check_str_type(filename, 'filename')
 
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_data_or_bkg(id, bkg_id)
         if isinstance(d, (sherpa.astro.data.DataIMG,
                           sherpa.astro.data.DataIMGInt,
                           sherpa.data.Data2D, sherpa.data.Data2DInt)):
@@ -4481,10 +4460,7 @@ class Session(sherpa.ui.utils.Session):
 
         _check_str_type(filename, 'filename')
         idval = self._fix_id(id)
-        if bkg_id is None:
-            d = self.get_data(idval)
-        else:
-            d = self.get_bkg(idval, bkg_id)
+        d = self._get_data_or_bkg(idval, bkg_id)
 
         # Leave this check as d.mask is False since d.mask need not be a boolean
         # and we want different errors if mask is True or False (and leave as
@@ -5196,10 +5172,7 @@ class Session(sherpa.ui.utils.Session):
             id, filename = filename, id
 
         _check_str_type(filename, 'filename')
-        if bkg_id is None:
-            d = self.get_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
+        d = self._get_data_or_bkg(id, bkg_id)
 
         # Wouldn't it be better to key off the data class here, as we
         # know the mapping from class to write routine, rather than
@@ -13343,12 +13316,11 @@ class Session(sherpa.ui.utils.Session):
         """
         _, fit = self._get_fit(id, otherids=otherids)
 
+        data = self._get_data_or_bkg(id, bkg_id)
         if bkg_id is None:
-            data = self.get_data(id)
             if model is None:
                 model = self.get_source(id)
         else:
-            data = self.get_bkg(id, bkg_id)
             if model is None:
                 model = self.get_bkg_source(id, bkg_id)
 
@@ -13575,12 +13547,11 @@ class Session(sherpa.ui.utils.Session):
         """
         _, fit = self._get_fit(id, otherids=otherids)
 
+        data = self._get_data_or_bkg(id, bkg_id)
         if bkg_id is None:
-            data = self.get_data(id)
             if model is None:
                 model = self.get_source(id)
         else:
-            data = self.get_bkg(id, bkg_id)
             if model is None:
                 model = self.get_bkg_source(id, bkg_id)
 
@@ -13756,10 +13727,7 @@ class Session(sherpa.ui.utils.Session):
             raise NotImplementedError("sample_flux(Xrays=False) is currently unsupported")
 
         _, fit = self._get_fit(id)
-        if bkg_id is None:
-            data = self.get_data(id)
-        else:
-            data = self.get_bkg(id, bkg_id)
+        data = self._get_data_or_bkg(id, bkg_id)
 
         if (modelcomponent is not None) and \
            not isinstance(modelcomponent, sherpa.models.model.Model):
@@ -13927,10 +13895,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_cdf(ews)
 
         """
-        if bkg_id is None:
-            data = self.get_data(id)
-        else:
-            data = self.get_bkg(id, bkg_id)
+        data = self._get_data_or_bkg(id, bkg_id)
 
         ####################################################
         if error:
@@ -14110,10 +14075,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is None:
-            data = self.get_data(id)
-        else:
-            data = self.get_bkg(id, bkg_id)
+        data = self._get_data_or_bkg(id, bkg_id)
 
         if model is None:
             if bkg_id is None:
@@ -14230,10 +14192,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is None:
-            data = self.get_data(id)
-        else:
-            data = self.get_bkg(id, bkg_id)
+        data = self._get_data_or_bkg(id, bkg_id)
 
         if model is None:
             if bkg_id is None:
@@ -14334,11 +14293,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is None:
-            data = self.get_data(id)
-        else:
-            data = self.get_bkg(id, bkg_id)
-
+        data = self._get_data_or_bkg(id, bkg_id)
         return sherpa.astro.utils.calc_data_sum(data, lo, hi)
 
     # DOC-TODO: better comparison of calc_source_sum and calc_model_sum
@@ -14446,11 +14401,10 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
+        data = self._get_data_or_bkg(id, bkg_id)
         if bkg_id is None:
-            data = self.get_data(id)
             model = self.get_model(id)
         else:
-            data = self.get_bkg(id, bkg_id)
             model = self.get_bkg_model(id, bkg_id)
 
         return sherpa.astro.utils.calc_model_sum(data, model, lo, hi)
@@ -14791,11 +14745,10 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
+        data = self._get_data_or_bkg(id, bkg_id)
         if bkg_id is None:
-            data = self.get_data(id)
             model = self.get_source(id)
         else:
-            data = self.get_bkg(id, bkg_id)
             model = self.get_bkg_source(id, bkg_id)
 
         return sherpa.astro.utils.calc_source_sum(data, model, lo, hi)
@@ -14919,11 +14872,10 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
+        data = self._get_data_or_bkg(id, bkg_id)
         if bkg_id is None:
-            data = self.get_data(id)
             model = self.get_source(id)
         else:
-            data = self.get_bkg(id, bkg_id)
             model = self.get_bkg_source(id, bkg_id)
 
         return sherpa.astro.utils.calc_kcorr(data, model, z, obslo, obshi,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -112,10 +112,8 @@ def _pha_report_filter_change(session, idval, bkg_id, changefunc):
     idval = session._fix_id(idval)
     idstr = f"dataset {idval}"
 
-    if bkg_id is None:
-        data = session._get_pha_data(idval)
-    else:
-        data = session.get_bkg(idval, bkg_id)
+    data = session._get_pha_data(idval, bkg_id)
+    if bkg_id is not None:
         idstr += f": background {bkg_id}"
 
     # We could not create ofilter, but that depends on what changefunc
@@ -2086,18 +2084,45 @@ class Session(sherpa.ui.utils.Session):
         phasets = self.unpack_pha(arg, use_errors)
         self._load_data(id, phasets)
 
-    def _get_pha_data(self, id):
-        """Ensure the dataset is a PHA"""
-        data = self.get_data(id)
-        if not isinstance(data, sherpa.astro.data.DataPHA):
-            raise ArgumentErr('nopha', self._fix_id(id))
-        return data
+    def _get_pha_data(self, id, bkg_id=None):
+        """Ensure the dataset is a PHA.
+
+        Parameters
+        ----------
+        id : int or str or None
+            The dataset identifier. A value of None means the
+            default identifier is used.
+        bkg_id : int or None
+            If set then pick the background component instead.
+
+        Returns
+        -------
+        data : sherpa.astro.data.DataPHA instance
+
+        """
+
+        idval = self._fix_id(id)
+        data = self.get_data(idval)
+        if not isinstance(data, DataPHA):
+            raise ArgumentErr('nopha', idval)
+
+        if bkg_id is None:
+            return data
+
+        bkg = data.get_background(bkg_id)
+        if bkg is not None:
+            return bkg
+
+        raise IdentifierErr('getitem', 'background data set', bkg_id,
+                            f'in PHA data set {idval} has not been set')
 
     def _get_img_data(self, id):
         """Ensure the dataset is an image"""
-        data = self.get_data(id)
+        idval = self._fix_id(id)
+        data = self.get_data(idval)
         if not isinstance(data, sherpa.astro.data.DataIMG):
-            raise ArgumentErr('noimg', self._fix_id(id))
+            raise ArgumentErr('noimg', idval)
+
         return data
 
     # def _read_error(self, filename, *args, **kwargs):
@@ -2417,8 +2442,9 @@ class Session(sherpa.ui.utils.Session):
         if val is None:
             val, id = id, val
 
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
         sherpa.ui.utils.set_filter(d, val, ignore=ignore)
@@ -2644,8 +2670,9 @@ class Session(sherpa.ui.utils.Session):
         if val is None:
             val, id = id, val
 
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
         sherpa.ui.utils.set_dep(d, val)
@@ -2710,10 +2737,10 @@ class Session(sherpa.ui.utils.Session):
         """
         if val is None:
             val, id = id, val
-        err = None
 
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
         sherpa.ui.utils.set_error(d, "staterror", val, fractional=fractional)
@@ -2775,8 +2802,9 @@ class Session(sherpa.ui.utils.Session):
             val, id = id, val
         err = None
 
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
         sherpa.ui.utils.set_error(d, "syserror", val, fractional=fractional)
@@ -2843,11 +2871,7 @@ class Session(sherpa.ui.utils.Session):
         if exptime is not None:
             exptime = SherpaFloat(exptime)
 
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
-        else:
-            d = self._get_pha_data(id)
-
+        d = self._get_pha_data(id, bkg_id)
         d.exposure = exptime
 
     def set_backscal(self, id, backscale=None, bkg_id=None):
@@ -2895,11 +2919,7 @@ class Session(sherpa.ui.utils.Session):
         elif backscale is not None:
             backscale = SherpaFloat(backscale)
 
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
-        else:
-            d = self._get_pha_data(id)
-
+        d = self._get_pha_data(id, bkg_id)
         d.backscal = backscale
 
     # DOC-TODO: the description needs improving.
@@ -2946,11 +2966,7 @@ class Session(sherpa.ui.utils.Session):
         if area is not None:
             area = SherpaFloat(area)
 
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
-        else:
-            d = self._get_pha_data(id)
-
+        d = self._get_pha_data(id, bkg_id)
         d.areascal = area
 
     # DOC-NOTE: also in sherpa.utils, where it does not have
@@ -3036,9 +3052,11 @@ class Session(sherpa.ui.utils.Session):
         array([2, 3, 5])
 
         """
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
+
         return d.get_staterror(filter, self.get_stat().calc_staterror)
 
     # DOC-NOTE: also in sherpa.utils, where it does not have
@@ -3109,14 +3127,15 @@ class Session(sherpa.ui.utils.Session):
         >>> yerr = get_syserror("core", filter=True)
 
         """
-        id = self._fix_id(id)
-        d = self.get_data(id)
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
+        idval = self._fix_id(id)
+        if bkg_id is None:
+            d = self.get_data(idval)
+        else:
+            d = self.get_bkg(idval, bkg_id)
 
         err = d.get_syserror(filter)
         if err is None:
-            raise DataErr('nosyserr', id)
+            raise DataErr('nosyserr', idval)
 
         return err
 
@@ -3195,9 +3214,11 @@ class Session(sherpa.ui.utils.Session):
         >>> berr2 = get_error('core', bkg_id=2, filter=True)
 
         """
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
+
         return d.get_error(filter, self.get_stat().calc_staterror)
 
     # DOC-NOTE: also in sherpa.utils
@@ -3309,8 +3330,9 @@ class Session(sherpa.ui.utils.Session):
         array([  16.5,   48.5,   80.5,  112.5,  144.5])
 
         """
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
         return d.get_indep(filter=filter)
@@ -3401,11 +3423,12 @@ class Session(sherpa.ui.utils.Session):
         True
 
         """
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(d, DataPHA):
             return d._get_ebins(group=False)
 
         if isinstance(d, (sherpa.data.Data2D,
@@ -3497,11 +3520,12 @@ class Session(sherpa.ui.utils.Session):
         (65536,)
 
         """
-        d = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
-        if isinstance(d, sherpa.astro.data.DataPHA):
+        if isinstance(d, DataPHA):
             old = d._rate
             d._rate = False  # return predicted counts, not rate for PHA
             dep = d.get_y(filter)
@@ -3604,9 +3628,7 @@ class Session(sherpa.ui.utils.Session):
         >>> get_rate(id="grating", bkg_id=2)
 
         """
-        d = self._get_pha_data(id)
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
+        d = self._get_pha_data(id, bkg_id)
 
         old = d._rate
         d._rate = True     # return count rate for PHA
@@ -3651,11 +3673,7 @@ class Session(sherpa.ui.utils.Session):
         >>> barf = get_spectresp("eclipse", bkg_id=2)
 
         """
-        if bkg_id is None:
-            d = self._get_pha_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_pha_data(id, bkg_id)
         return d.get_specresp(filter)
 
     def get_exposure(self, id=None, bkg_id=None):
@@ -3705,11 +3723,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is None:
-            d = self._get_pha_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_pha_data(id, bkg_id)
         return d.exposure
 
     def get_backscal(self, id=None, bkg_id=None):
@@ -3767,11 +3781,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is None:
-            d = self._get_pha_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_pha_data(id, bkg_id)
         return d.backscal
 
     def get_bkg_scale(self, id=None, bkg_id=1, units='counts',
@@ -3860,12 +3870,13 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        dset = self._get_pha_data(id)
+        idval = self._fix_id(id)
+        dset = self._get_pha_data(idval)
         scale = dset.get_background_scale(bkg_id, units=units,
                                           group=group, filter=filter)
         if scale is None:
             # TODO: need to add bkg_id?
-            raise DataErr('nobkg', self._fix_id(id))
+            raise DataErr('nobkg', idval)
 
         return scale
 
@@ -3921,19 +3932,17 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is None:
-            d = self._get_pha_data(id)
-        else:
-            d = self.get_bkg(id, bkg_id)
-
+        d = self._get_pha_data(id, bkg_id)
         return d.areascal
 
     def _save_type(self, objtype, id, filename, bkg_id=None, **kwargs):
         if filename is None:
             id, filename = filename, id
         _check_str_type(filename, 'filename')
-        d = self.get_data(id)
-        if bkg_id is not None:
+
+        if bkg_id is None:
+            d = self.get_data(id)
+        else:
             d = self.get_bkg(id, bkg_id)
 
         if isinstance(d, (sherpa.astro.data.DataIMG,
@@ -4456,13 +4465,13 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        _check_str_type(filename, 'filename')
-        id = self._fix_id(id)
 
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
+        _check_str_type(filename, 'filename')
+        idval = self._fix_id(id)
+        if bkg_id is None:
+            d = self.get_data(idval)
         else:
-            d = self.get_data(id)
+            d = self.get_bkg(idval, bkg_id)
 
         # Leave this check as d.mask is False since d.mask need not be a boolean
         # and we want different errors if mask is True or False (and leave as
@@ -4472,7 +4481,7 @@ class Session(sherpa.ui.utils.Session):
         if d.mask is False:
             raise DataErr('notmask')
         if not numpy.iterable(d.mask):
-            raise DataErr('nomask', id)
+            raise DataErr('nomask', idval)
 
         if isinstance(d, sherpa.astro.data.DataPHA):
             x = d._get_ebins(group=True)[0]
@@ -4560,7 +4569,6 @@ class Session(sherpa.ui.utils.Session):
 
         _save_errorcol(self, id, filename, bkg_id, clobber, ascii,
                        self.get_staterror, 'STAT_ERR')
-
 
     # DOC-NOTE: also in sherpa.utils with a different interface
     def save_syserror(self, id, filename=None, bkg_id=None,
@@ -4790,9 +4798,7 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
         _check_str_type(filename, 'filename')
-        d = self._get_pha_data(id)
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
+        d = self._get_pha_data(id, bkg_id)
 
         sherpa.astro.io.write_pha(filename, d, ascii=ascii,
                                   clobber=clobber)
@@ -4870,14 +4876,11 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
         _check_str_type(filename, 'filename')
-        id = self._fix_id(id)
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
-        else:
-            d = self._get_pha_data(id)
+        idval = self._fix_id(id)
+        d = self._get_pha_data(idval, bkg_id)
 
         if d.grouping is None:
-            raise DataErr('nogrouping', id)
+            raise DataErr('nogrouping', idval)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.grouping],
                                      fields=['CHANNEL', 'GROUPS'], ascii=ascii,
@@ -4955,14 +4958,11 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
         _check_str_type(filename, 'filename')
-        id = self._fix_id(id)
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
-        else:
-            d = self._get_pha_data(id)
+        idval = self._fix_id(id)
+        d = self._get_pha_data(idval, bkg_id)
 
         if d.quality is None:
-            raise DataErr('noquality', id)
+            raise DataErr('noquality', idval)
 
         sherpa.astro.io.write_arrays(filename, [d.channel, d.quality],
                                      fields=['CHANNEL', 'QUALITY'], ascii=ascii,
@@ -5101,7 +5101,6 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
-        id = self._fix_id(id)
         _check_str_type(filename, 'filename')
 
         sherpa.astro.io.write_table(filename, self.get_data(id),
@@ -5182,11 +5181,12 @@ class Session(sherpa.ui.utils.Session):
         ascii = sherpa.utils.bool_cast(ascii)
         if filename is None:
             id, filename = filename, id
+
         _check_str_type(filename, 'filename')
-        if bkg_id is not None:
-            d = self.get_bkg(id, bkg_id)
-        else:
+        if bkg_id is None:
             d = self.get_data(id)
+        else:
+            d = self.get_bkg(id, bkg_id)
 
         # Wouldn't it be better to key off the data class here, as we
         # know the mapping from class to write routine, rather than
@@ -5207,6 +5207,7 @@ class Session(sherpa.ui.utils.Session):
                     # If this errors out then so be it
                     sherpa.io.write_data(filename, d, clobber=clobber)
 
+    # TODO: could add bkg_id parameter
     def pack_pha(self, id=None):
         """Convert a PHA data set into a file structure.
 
@@ -5458,16 +5459,13 @@ class Session(sherpa.ui.utils.Session):
         >>> print(get_model())
 
         """
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-
+        idval = self._fix_id(id)
+        data = self._get_pha_data(idval, bkg_id)
         arf, rmf = data.get_response(resp_id)
         if arf is None:
             raise IdentifierErr('getitem', 'ARF data set',
                                 data._fix_response_id(resp_id),
-                                'in PHA data set %s has not been set' %
-                                str(self._fix_id(id)))
+                                f'in PHA data set {idval} has not been set')
 
         if isinstance(arf, sherpa.astro.data.DataARF):
             arf = sherpa.astro.instrument.ARF1D(arf, data, rmf)
@@ -5547,9 +5545,7 @@ class Session(sherpa.ui.utils.Session):
             arf = arf._arf
         _check_type(arf, sherpa.astro.data.DataARF, 'arf', 'an ARF data set')
 
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
+        data = self._get_pha_data(id, bkg_id)
         data.set_arf(arf, resp_id)
         # Set units of source dataset from channel to energy
         if data.units == 'channel':
@@ -5931,16 +5927,13 @@ class Session(sherpa.ui.utils.Session):
         >>> print(get_model())
 
         """
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-
+        idval = self._fix_id(id)
+        data = self._get_pha_data(idval, bkg_id)
         arf, rmf = data.get_response(resp_id)
         if rmf is None:
             raise IdentifierErr('getitem', 'RMF data set',
                                 data._fix_response_id(resp_id),
-                                'in PHA data set %s has not been set' %
-                                str(self._fix_id(id)))
+                                f'in PHA data set {idval} has not been set')
 
         if isinstance(rmf, sherpa.astro.data.DataRMF):
             rmf = sherpa.astro.instrument.RMF1D(rmf, data, arf)
@@ -6020,9 +6013,7 @@ class Session(sherpa.ui.utils.Session):
             rmf = rmf._rmf
         _check_type(rmf, sherpa.astro.data.DataRMF, 'rmf', 'an RMF data set')
 
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
+        data = self._get_pha_data(id, bkg_id)
         data.set_rmf(rmf, resp_id)
         # Set units of source dataset from channel to energy
         if data.units == 'channel':
@@ -6383,13 +6374,14 @@ class Session(sherpa.ui.utils.Session):
         >>> bg = get_bkg('flare', 2)
 
         """
-        data = self._get_pha_data(id)
+        idval = self._fix_id(id)
+        data = self._get_pha_data(idval)
         bkg = data.get_background(bkg_id)
         if bkg is None:
             raise IdentifierErr('getitem', 'background data set',
                                 data._fix_background_id(bkg_id),
-                                'in PHA data set %s has not been set' %
-                                str(self._fix_id(id)))
+                                f'in PHA data set {idval} has not been set')
+
         return bkg
 
     def set_bkg(self, id, bkg=None, bkg_id=None):
@@ -6512,10 +6504,7 @@ class Session(sherpa.ui.utils.Session):
         load_rmf : Load a RMF from a file and add it to a PHA data set.
 
         """
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-
+        data = self._get_pha_data(id, bkg_id)
         return list(data._responses.keys())
 
     # DOC-TODO: docs need to be added to sherpa.astro.data.set_analysis
@@ -6827,10 +6816,8 @@ class Session(sherpa.ui.utils.Session):
         """
         idval = self._fix_id(id)
         idstr = f"dataset {idval}"
-        if bkg_id is None:
-            data = self._get_pha_data(idval)
-        else:
-            data = self.get_bkg(idval, bkg_id)
+        data = self._get_pha_data(idval, bkg_id)
+        if bkg_id is not None:
             idstr += f": background {bkg_id}"
 
         ofilter = data.get_filter(delim=':', format='%g')
@@ -7760,10 +7747,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-
+        data = self._get_pha_data(id, bkg_id)
         return data.grouping
 
     def set_quality(self, id, val=None, bkg_id=None):
@@ -7841,10 +7825,7 @@ class Session(sherpa.ui.utils.Session):
         if val is None:
             id, val = val, id
 
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-
+        data = self._get_pha_data(id, bkg_id)
         data.quality = val
 
     # DOC TODO: Need to document that routines like get_quality return
@@ -7930,10 +7911,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        data = self._get_pha_data(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-
+        data = self._get_pha_data(id, bkg_id)
         return data.quality
 
     def ungroup(self, id=None, bkg_id=None):
@@ -8012,6 +7990,7 @@ class Session(sherpa.ui.utils.Session):
         False
 
         """
+        data = self._get_pha_data(id, bkg_id)
 
         # This will call the background datasets to be ungrouped
         # as well (when bkg_id is not set).
@@ -9297,13 +9276,9 @@ class Session(sherpa.ui.utils.Session):
         >>> set_full_model(rsp(powlaw1d.pl) + const1d.bgnd)
 
         """
-        id = self._fix_id(id)
-        if bkg_id is not None:
-            pha = self.get_bkg(id, bkg_id)
-        else:
-            pha = self._get_pha_data(id)
-
-        return self._get_response(id, pha)
+        idval = self._fix_id(id)
+        pha = self._get_pha_data(idval, bkg_id)
+        return self._get_response(idval, pha)
 
     def get_pileup_model(self, id=None):
         """Return the pile up model for a data set.
@@ -10903,12 +10878,13 @@ class Session(sherpa.ui.utils.Session):
         if not recalc:
             return plotobj
 
-        id = self._fix_id(id)
-        arf = self._get_pha_data(id).get_arf(resp_id)
+        idval = self._fix_id(id)
+        data = self._get_pha_data(idval)
+        arf = data.get_arf(resp_id)
         if arf is None:
-            raise DataErr('noarf', id)
+            raise DataErr('noarf', idval)
 
-        plotobj.prepare(arf, self._get_pha_data(id))
+        plotobj.prepare(arf, data)
         return plotobj
 
     def get_bkg_fit_plot(self, id=None, bkg_id=None, recalc=True):
@@ -13767,10 +13743,10 @@ class Session(sherpa.ui.utils.Session):
             raise NotImplementedError("sample_flux(Xrays=False) is currently unsupported")
 
         _, fit = self._get_fit(id)
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-        else:
+        if bkg_id is None:
             data = self.get_data(id)
+        else:
+            data = self.get_bkg(id, bkg_id)
 
         if (modelcomponent is not None) and \
            not isinstance(modelcomponent, sherpa.models.model.Model):
@@ -13938,8 +13914,9 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_cdf(ews)
 
         """
-        data = self.get_data(id)
-        if bkg_id is not None:
+        if bkg_id is None:
+            data = self.get_data(id)
+        else:
             data = self.get_bkg(id, bkg_id)
 
         ####################################################
@@ -14343,8 +14320,10 @@ class Session(sherpa.ui.utils.Session):
         >>> calc_data_sum(12, 45, id=3, bkg_id=2)
 
         """
-        data = self.get_data(id)
-        if bkg_id is not None:
+
+        if bkg_id is None:
+            data = self.get_data(id)
+        else:
             data = self.get_bkg(id, bkg_id)
 
         return sherpa.astro.utils.calc_data_sum(data, lo, hi)
@@ -14454,12 +14433,12 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-            model = self.get_bkg_model(id, bkg_id)
-        else:
+        if bkg_id is None:
             data = self.get_data(id)
             model = self.get_model(id)
+        else:
+            data = self.get_bkg(id, bkg_id)
+            model = self.get_bkg_model(id, bkg_id)
 
         return sherpa.astro.utils.calc_model_sum(data, model, lo, hi)
 
@@ -14799,12 +14778,12 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-            model = self.get_bkg_source(id, bkg_id)
-        else:
+        if bkg_id is None:
             data = self.get_data(id)
             model = self.get_source(id)
+        else:
+            data = self.get_bkg(id, bkg_id)
+            model = self.get_bkg_source(id, bkg_id)
 
         return sherpa.astro.utils.calc_source_sum(data, model, lo, hi)
 
@@ -14927,12 +14906,12 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if bkg_id is not None:
-            data = self.get_bkg(id, bkg_id)
-            model = self.get_bkg_source(id, bkg_id)
-        else:
+        if bkg_id is None:
             data = self.get_data(id)
             model = self.get_source(id)
+        else:
+            data = self.get_bkg(id, bkg_id)
+            model = self.get_bkg_source(id, bkg_id)
 
         return sherpa.astro.utils.calc_kcorr(data, model, z, obslo, obshi,
                                              restlo, resthi)

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2021, 2022
+#  Copyright (C) 2016, 2017, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -484,38 +484,6 @@ def test_stats_calc_stat_wstat_pha_nobg():
     data, model = setup_single_pha(False, False, background=False)
     with pytest.raises(StatErr):
         statobj.calc_stat(data, model)
-
-
-def test_stats_calc_stat_wstat_diffbins():
-    """wstat statistic fails when src/bg bin sizes do not match"""
-
-    statobj = WStat()
-
-    data, model = setup_single_pha(True, False, background=True)
-
-    # Tweak data to have one-less bin than the background. This
-    # used to be easy but with data validation we need to
-    # create a new object.
-    #
-    data2 = DataPHA("faked",
-                    channel=data.channel[:-1],
-                    counts=data.counts[:-1],
-                    staterror=data.staterror[:-1],
-                    grouping=data.grouping[:-1],
-                    exposure=data.exposure,
-                    backscal=data.backscal,
-                    areascal=data.areascal)
-
-    # We might expect the ARF/RMF calls to fail if we add validation
-    # (to check the ARF/RMF is valid for the PHA dataset).
-    #
-    data2.set_arf(data.get_arf())
-    data2.set_rmf(data.get_rmf())
-    data2.set_background(data.get_background())
-
-    with pytest.raises(DataErr,
-                       match="size mismatch between data and array: 4 vs 5"):
-        statobj.calc_stat(data2, model)
 
 
 # Numeric answers calculated using CIAO 4.8 (sherpa 4.8.0)


### PR DESCRIPTION
# Summary

Add an explicit check that the background data is a PHA object, to improve error messages. There are internal changes to how the PHA data is accessed in the utils code. Fixes #1718 

# Details

In working on the cleanup for this PR I noted #1718 so added a check that the background is a PHA object, and that it has the same channels as the source dataset (if a user wants to have a different set of channels for the background then they have to treat the datasets as separate - i.e. do  not use the background capability - since the background code implicitly assumes the channels match). Given the recent data validation work added in #1477 I am conscious in not trying to support too many different options, so the rule is that if you add a background then the source dataset must have a channel array set up (we could avoid this, but it would significantly complicate things for little real-world gain).

The main driver was to rework code that looks something like

    d = self._get_pha_data(id)
    if bkg_id is not None:
        d = self.get_bkg(id, bkg_id)

(or the more-recent version where there's a if .. else .. form) by moving the logic for this into _get_pha_data.

There is still repeated code where we don't require a PHA dataset when bkg_id is None and this could do with a similar change. I have tried to move these examples to the same form

    if bkg_id is None:
        d = self.get_data(id)
    else:
        d = self.get_bkg(id, bkg_id)

so it is easier to find if we ever come up with a replacement. Actually, we've now decided to do this (`_get_data_or_bkg`) as part of this PR.

This was taken from https://github.com/sherpa/sherpa/pull/1638 / https://github.com/sherpa/sherpa/pull/1667 as it was meant to be a small, separate, item, but addressing #1718 complicated it a little bit.

# Example

With the main branch - if you set a background that's not DataPHA you get an error about grouping. You can set a background with a different 

```
>>> from sherpa.astro.ui import *
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> dataspace1d(1, 10, dstype=DataPHA)
>>> dataspace1d(1, 10, dstype=Data1D, bkg_id=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in dataspace1d
  File "/lagado.real/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 822, in dataspace1d
    self._get_pha_data(id).set_background(dstype('bkg_dataspace1d',
  File "/lagado.real/sherpa/sherpa-xspec/sherpa/astro/data.py", line 2806, in set_background
    if bkg.grouping is None:
AttributeError: 'Data1D' object has no attribute 'grouping'
>>> dataspace1d(1, 20, dstype=DataPHA, bkg_id=1)
>>>
```

With this branch both the bkg_id lines are errors, but hopefully more descriptive:

```
>>> from sherpa.astro.ui import *
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> dataspace1d(1, 10, dstype=DataPHA)
>>> dataspace1d(1, 10, dstype=Data1D, bkg_id=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in dataspace1d
  File "/lagado.real/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 833, in dataspace1d
    raise ArgumentTypeErr("badarg", "dstype", "set to DataPHA")
sherpa.utils.err.ArgumentTypeErr: 'dstype' must be set to DataPHA
>>> dataspace1d(1, 20, dstype=DataPHA, bkg_id=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in dataspace1d
  File "/lagado.real/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 837, in dataspace1d
    data.set_background(bkg, bkg_id)
  File "/lagado.real/sherpa/sherpa-xspec/sherpa/astro/data.py", line 2810, in set_background
    raise DataErr("The source and background channels differ")
sherpa.utils.err.DataErr: The source and background channels differ
```