### PR TITLE
plot: add sherpa_plot context manager

### DIFF
--- a/docs/plots/plot.rst
+++ b/docs/plots/plot.rst
@@ -57,6 +57,13 @@ The sherpa.plot module
       RegionProjection
       RegionUncertainty
 
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      sherpa_plot
+
 Class Inheritance Diagram
 =========================
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -42,6 +42,7 @@ from sherpa.stats import Cash, CStat, WStat
 from sherpa.models.basic import TableModel
 from sherpa.astro import fake
 from sherpa.astro.data import DataPHA
+from sherpa.plot import sherpa_plot
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info
@@ -12754,8 +12755,7 @@ class Session(sherpa.ui.utils.Session):
 
         self._jointplot.reset()
 
-        try:
-            sherpa.plot.backend.begin()
+        with sherpa_plot():
             self._jointplot.plottop(plot1, overplot=overplot,
                                     clearwindow=clearwindow, **kwargs)
 
@@ -12772,11 +12772,6 @@ class Session(sherpa.ui.utils.Session):
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)
 
             plot2.plot_prefs['xlog'] = oldval
-        except:
-            sherpa.plot.backend.exceptions()
-            raise
-        else:
-            sherpa.plot.backend.end()
 
     def plot_bkg_fit_ratio(self, id=None, bkg_id=None, replot=False,
                            overplot=False, clearwindow=True, **kwargs):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -55,7 +55,7 @@ Creating a plot
 The simplest approach is to use the `sherpa_plot` context manager::
 
     with sherpa_plot():
-        # Now call the plot/overplot or contor/overcontour methods
+        # Now call the plot/overplot or contour/overcontour methods
         obj.plot()
 
 This handles setting up the backend, handles any error handling,
@@ -64,7 +64,7 @@ and then ends the session. It is equivalent to::
     from sherpa import plot
     try:
         plot.backend.begin()
-        # Now call the plot/overplot or contor/overcontour methods
+        # Now call the plot/overplot or contour/overcontour methods
         obj.plot()
     except:
         plot.backend.exceptions()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -34,6 +34,7 @@ from sherpa import get_config
 import sherpa.all
 from sherpa.models.basic import TableModel
 from sherpa.models.model import Model
+from sherpa.plot import sherpa_plot
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
@@ -12725,16 +12726,9 @@ class Session(NoNewAttributesAfterInit):
         sp.reset(nrows, ncols)
         plotmeth = getattr(sp, f"add{plotmeth}")
 
-        try:
-            sherpa.plot.backend.begin()
+        with sherpa_plot():
             while plots:
                 plotmeth(plots.pop(0), **kwargs)
-
-        except:
-            sherpa.plot.backend.exceptions()
-            raise
-        else:
-            sherpa.plot.backend.end()
 
     def _plot(self, plotobj, **kwargs):
         """Display a plot object
@@ -12752,14 +12746,8 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        try:
-            sherpa.plot.backend.begin()
+        with sherpa_plot():
             plotobj.plot(**kwargs)
-        except:
-            sherpa.plot.backend.exceptions()
-            raise
-        else:
-            sherpa.plot.backend.end()
 
     def _set_plot_item(self, plottype, item, value):
         """Change a plot setting.
@@ -14067,9 +14055,7 @@ class Session(NoNewAttributesAfterInit):
 
         self._jointplot.reset()
 
-        try:
-            sherpa.plot.backend.begin()
-
+        with sherpa_plot():
             # Note: the user preferences are set to both plots
             #
             self._jointplot.plottop(plot1, overplot=overplot,
@@ -14095,11 +14081,6 @@ class Session(NoNewAttributesAfterInit):
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)
 
             plot2.plot_prefs['xlog'] = oldval
-        except:
-            sherpa.plot.backend.exceptions()
-            raise
-        else:
-            sherpa.plot.backend.end()
 
     def plot_fit_resid(self, id=None, replot=False, overplot=False,
                        clearwindow=True, **kwargs):
@@ -14681,14 +14662,8 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        try:
-            sherpa.plot.backend.begin()
+        with sherpa_plot():
             plotobj.contour(overcontour=overcontour, **kwargs)
-        except:
-            sherpa.plot.backend.exceptions()
-            raise
-        else:
-            sherpa.plot.backend.end()
 
     # DOC-TODO: how to describe optional plot types
     # DOC-TODO: how to list information/examples about the backends?
@@ -15158,17 +15133,10 @@ class Session(NoNewAttributesAfterInit):
         plot2obj = self.get_resid_contour(id, recalc=not replot)
 
         self._splitplot.reset()
-        try:
-            sherpa.plot.backend.begin()
-
+        with sherpa_plot():
             # Note: the user settings are applied to both contours
             self._splitplot.addcontour(plot1obj, overcontour=overcontour, **kwargs)
             self._splitplot.addcontour(plot2obj, overcontour=overcontour, **kwargs)
-        except:
-            sherpa.plot.backend.exceptions()
-            raise
-        else:
-            sherpa.plot.backend.end()
 
     ###########################################################################
     # Projection and uncertainty plots


### PR DESCRIPTION
# Summary

Add a sherpa_plot context manager to simplify creating a plot with the Sherpa plotting objects (only an issue if calling the plot objects directly, and not with commands like the UI plot_data call).

# Details

Creating a sherpa plot follows the same template, and it fits in well to being a context manager (even though there is no "plot object" we have to attach the open/close logic to, we can use the contextmanager decorator).

This is mainly useful internally, but it may be useful outside of Sherpa.

It should be separate from (but will conflict with) the plot-backend rework in #1382 / #1550. I guess we could add the backend-name as an optional argument to the context manager, to over-ride the backend for just that plot. Not sure how useful that would be, but it sounds cool!

**OOhhhhh** - a thought. We *could* make the backend provide a `sherpa_plot`-like routine, and then this version would just call that. Thoughts

- we could then remove the `setup`/`teardown`/`exceptions` logic as this would now just be handled within the plotend so if you don't need to do anything special with exception-handling you just don't do it
- normally you would add a context manager to a class and have it associated with the lifetime of that object, but that's not true here; is this confusing?