### PR TITLE
Allow fake_pha to be called with a list of ARF/RMF names of length 1

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022
+#  Copyright (C) 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -378,7 +378,6 @@ def test_fake_pha_file(make_data_path, clean_astro_ui, reset_seed):
     assert data.counts.sum() < 10000
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_fake_pha_file_as_list(make_data_path, clean_astro_ui, reset_seed):

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -378,6 +378,46 @@ def test_fake_pha_file(make_data_path, clean_astro_ui, reset_seed):
     assert data.counts.sum() < 10000
 
 
+@pytest.mark.xfail
+@requires_fits
+@requires_data
+def test_fake_pha_file_as_list(make_data_path, clean_astro_ui, reset_seed):
+    '''Test fake_pha using real input file. See #1722
+
+    This is test_fake_pha_file with the responses given as a list
+    as that was found to be problematic. The data should match
+    test_fake_pha_file with the same random seed.
+
+    '''
+
+    np.random.seed(22347)
+
+    ui.set_source("gauss1d.g1")
+    g1 = ui.get_source()
+    g1.pos = 3
+    g1.FWHM = .5
+
+    # TODO: this fails with a No instrument response found
+    ui.fake_pha(None,
+                [make_data_path('3c120_heg_-1.arf.gz')],
+                [make_data_path('3c120_heg_-1.rmf.gz')],
+                1000.)
+    data = ui.get_data()
+
+    # Even with noise, maximum should be close to 3 keV. With the
+    # fixed seed this check could be made exact, but leave as is.
+    #
+    assert np.isclose(data.get_x()[np.argmax(data.counts)], 3., atol=.2)
+
+    # The model is localised around 3 keV so we could check that most
+    # of the data is zero, but that seems excessive. Unlike other tests
+    # we can not just check data.counts.sum() equals a certain value
+    # since the value depends on OS: linux gets 6845 but macOS gets 6842.
+    #
+    total = data.counts.sum()
+    assert 6840 <= total <= 6850
+
+
 @requires_fits
 @requires_data
 def test_fake_pha_multi_file(make_data_path, clean_astro_ui, reset_seed):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8985,7 +8985,8 @@ class Session(sherpa.ui.utils.Session):
         # if it was, it would have gone through load_arf already above.
         if not (rmf is None and arf is None):
             if numpy.iterable(arf):
-                self.load_multi_arfs(id, arf, range(len(arf)))
+                resp_ids = range(1, len(arf) + 1)
+                self.load_multi_arfs(id, arf, resp_ids=resp_ids)
             elif arf is None:
                # In some cases, arf is None, but rmf is not.
                # For example, XMM/RGS does uses only a single file (the RMF)
@@ -8995,7 +8996,8 @@ class Session(sherpa.ui.utils.Session):
                self.set_arf(id, arf)
 
             if numpy.iterable(rmf):
-                self.load_multi_rmfs(id, rmf, range(len(rmf)))
+                resp_ids = range(1, len(rmf) + 1)
+                self.load_multi_rmfs(id, rmf, resp_ids=resp_ids)
             else:
                 self.set_rmf(id, rmf)
 


### PR DESCRIPTION
# Summary

Allow fake_pha to be called with a list of ARF and RMF names that only contains one element. Fix #1722

# Details

The problem was that the code used `range(n)` rather than `range(1, n+1)` when loading the ARF/RMF files. This meant that the first response was set with `resp_id=0` rather than `resp_id=1`, and then later on the code called `self.get_response()`, which defaults to looking for `resp_id=1` which is not set. Hence the problem in #1722.

Of course, why is the code calling `get_response()` without an id here, and is that a problem? Well, this happens deep in the code and does actually make sense (it assumes that if there's a single response set up then it has the default id, and it would be up to the caller to change that default id if necessary). Any change to this would require extensive changes that are not warranted at this time.

I originally included this as part of #1684 which started off as being a fix-up of the fake_pha docs,  but has grown somewhat. So I am carving out bits that are easy to review and provide useful user changes.