### PR TITLE
Unify the fake and fake_pha calls

### DIFF
--- a/docs/evaluation/simulate.rst
+++ b/docs/evaluation/simulate.rst
@@ -133,7 +133,7 @@ can be set to indicate to sherpa that the model is not a naked source
 model, but includes all required instrumental effects. In this
 way, :py:func:`~sherpa.astro.fake.fake_pha` can be used with arbitrarily
 complex models which may include such components as the instrumental
-backgound (which should not be folded through the ARF) or arbitary
+background (which should not be folded through the ARF) or arbitrary
 other components::
 
   >>> fake_pha(data, model=inst_bkg + my_arf(my_rmf(srcmodel)), is_source=False)  # doctest: +SKIP
@@ -153,7 +153,7 @@ Sample background from a PHA file
 
 One way to include background is to sample it from a
 :py:class:`~sherpa.astro.data.DataPHA` object. To do so, a background need to be
-loaded into the dataset before running the simluation and, if not done
+loaded into the dataset before running the simulation and, if not done
 before, the scale of the background scaling has to be set::
 
   >>> data.set_background(read_pha('sherpa-test-data/sherpatest/9774_bg.pi'))
@@ -169,7 +169,7 @@ is a Poisson distribution again). This works best if the background is
 well exposed and has a large number or counts.
 
 Why do we need to set the ``add_bkgs=True`` argument and do not simply
-use all available backgrounds? The reason for that is it is often
+use all available backgrounds? Often is is
 useful to read in a file with ``data = read_pha('9774.pi')``, which
 might automatically read in the background as well. Using the
 `add_bkgs` to switch the background on or off in the simulation
@@ -192,7 +192,7 @@ have. To avoid this problem, a background model may be used instead::
   >>> fake_pha(data, mdl, add_bkgs=True, bkg_models={'1': bkgmdl})
 
 The keys in the `bkg_models` dictionary are the identifiers of the
-backgrounds. Above, we loaded a background with the default identifyer
+backgrounds. Above, we loaded a background with the default identifier
 (which is ``1``).
 
 

--- a/sherpa/astro/fake.py
+++ b/sherpa/astro/fake.py
@@ -54,7 +54,7 @@ def fake_pha(data, model,
     backgrounds as well as the source spectrum, call this function on the
     source PHA dataset and the background PHA dataset(s) independently.
 
-    .. versionchanged:: 4.15.1
+    .. versionchanged:: 4.16.0
        The method parameter was added.
 
     Parameters

--- a/sherpa/astro/tests/test_fake_pha.py
+++ b/sherpa/astro/tests/test_fake_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021
+#  Copyright (C) 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -31,7 +31,8 @@ from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.astro.data import DataPHA
 from sherpa.astro.fake import fake_pha
 from sherpa.astro import io
-from sherpa.models import Const1D
+from sherpa.models import Box1D, Const1D
+from sherpa.utils.err import DataErr
 from sherpa.utils.testing import requires_data, requires_fits
 
 
@@ -46,12 +47,52 @@ arf = create_arf(elo, ehi)
 rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
 
 
+def test_fake_pha_requires_pha():
+    """Check what happens when the first argument is not a PHA.
+
+    This is a regression test, in that the error may not be
+    directly caught (i.e. from an explicit error check) but
+    from using an object incorrectly.
+    """
+
+    pha = DataPHA("x", [1, 2, 3], [0, 0, 0])
+    mdl = Const1D()
+    with pytest.raises(AttributeError,
+                       match="^'Const1D' object has no attribute 'response_ids'$"):
+        fake_pha(mdl, pha)
+
+
+def test_fake_pha_requires_model():
+    """Check what happens when the second argument is not a model.
+
+    This is a regression test, in that the error may not be
+    directly caught (i.e. from an explicit error check) but
+    from using an object incorrectly.
+    """
+
+    # We require that the PHA has a response
+    pha = DataPHA("x", channels, channels * 0)
+    pha.set_rmf(rmf)
+    pha.set_arf(arf)
+    with pytest.raises(AttributeError,
+                       match="^'list' object has no attribute 'name'$"):
+        fake_pha(pha, [1, 2, 3])
+
+
+def test_fake_pha_requires_response():
+    """Check we error out when there's no response"""
+
+    pha = DataPHA("x", [1, 2, 3], [0, 0, 0])
+    mdl = Const1D()
+    with pytest.raises(DataErr,
+                       match="^An RMF has not been found or supplied for data set x$"):
+        fake_pha(pha, mdl)
+
+
 @pytest.mark.parametrize("has_bkg", [True, False])
 @pytest.mark.parametrize("is_source", [True, False])
 def test_fake_pha_basic(has_bkg, is_source, reset_seed):
     """No background.
-
-    See also test_fake_pha_add_background
 
     For simplicity we use perfect responses.
 
@@ -92,43 +133,28 @@ def test_fake_pha_basic(has_bkg, is_source, reset_seed):
         assert data.background_ids == []
 
     if is_source:
-        # check we've faked counts (the scaling is such that it is
-        # very improbable that this condition will fail)
-        assert (data.counts > counts).all()
-
         # For reference the predicted source signal is
         #    [200, 400, 400]
         #
-        # What we'd like to say is that the predicted counts are
-        # similar, but this is not easy to do. What we can try
-        # is summing the counts (to average over the randomness)
-        # and then a simple check
-        #
-        assert data.counts.sum() > 500
-        assert data.counts.sum() < 1500
-        # This is more likely to fail by chance, but still very unlikely
-        assert data.counts[1] > data.counts[0]
+        assert data.counts == pytest.approx([184, 423, 427])
     else:
-        # No multiplication with exposure time, arf binning, etc.
-        # so we just expect very few counts
-        assert data.counts.sum() < 10
-        assert data.counts.sum() >= 2
+        # Very few counts.
+        #
+        assert data.counts == pytest.approx([1, 1, 0])
 
     # Essentially double the exposure by having two identical arfs
+    #
     data.set_arf(arf, 2)
     data.set_rmf(rmf, 2)
     fake_pha(data, mdl, is_source=is_source, add_bkgs=False)
     if is_source:
-        assert data.counts.sum() > 1200
-        assert data.counts.sum() < 3000
-        assert data.counts[1] > data.counts[0]
+        assert data.counts == pytest.approx([428, 773, 800])
     else:
-        assert data.counts.sum() < 20
-        assert data.counts.sum() >=4
+        assert data.counts == pytest.approx([2, 2, 0])
 
 
 def test_fake_pha_background_pha(reset_seed):
-    """Sample from background pha"""
+    """Sample from background pha (no background model)"""
     np.random.seed(1234)
 
     data = DataPHA("any", channels, counts, exposure=1000.)
@@ -140,28 +166,55 @@ def test_fake_pha_background_pha(reset_seed):
 
     mdl = Const1D("mdl")
     mdl.c0 = 0
+
     # Just make sure that the model does not contribute
     fake_pha(data, mdl, is_source=True, add_bkgs=False)
-    assert data.counts.sum() == 0
+    assert data.counts == pytest.approx([0, 0, 0])
 
+    # The background signal (as each bin is the same) is
+    #
+    #   background = 1000 counts
+    #   exposure_background / exposure_source = 2
+    #   backscal_background / backscal_source = 2.5
+    #
+    # and there's no other scaling (no areascal), so the
+    # predicted background count in the source is
+    #
+    #   1000 / 2 / 2.5 = 1000 / 5 = 200
+    #
     fake_pha(data, mdl, is_source=True, add_bkgs=True)
-    # expected is [200, 200, 200]
-    assert data.counts.sum() > 400
-    assert data.counts.sum() < 1000
+    assert data.counts == pytest.approx([186, 197, 212])
 
-    # Add several more backgrounds. Actual background should be average.
-    # We add 5 background with half the exposure time as this first oned
-    # and essentially 0 counts. So, we should find 1/11 of the counts
-    # we found in the last run.
+    # Add several more backgrounds with, compared to the first
+    # background,
+    #
+    #   - same backscal
+    #   - half the exposure time (so same as the source)
+    #   - much smaller counts (1 rather than 1000)
+    #
+    # For each of the new background components the background
+    # contribution to the source is
+    #
+    #    1 / 1 / 2.5 = 1 / 2.5 = 0.4
+    #
+    # So the full contribution is
+    #
+    #    200 + 0.4 * 5 = 202
+    #
+    # and the average of this is 202 / 6 = 33 2/3.
+    #
     for i in range(5):
-        bkg = DataPHA("bkg", channels, np.ones(3, dtype=np.int16),
+        bkg = DataPHA("bkg", channels, counts,
                       exposure=1000, backscal=2.5)
         data.set_background(bkg, id=i)
 
+    # Note: the expected value is ~ 33 but we are getting more like 6,
+    # which happens to be 202 / 6 / 6 = 5.6 because the code is
+    # dividing by the number of backgrounds twice. So these values
+    # are wrong.
+    #
     fake_pha(data, mdl, is_source=True, add_bkgs=True)
-    # expected is about [18, 18, 18]
-    assert data.counts.sum() > 10
-    assert data.counts.sum() < 200
+    assert data.counts == pytest.approx([9, 4, 6])
 
 
 def test_fake_pha_bkg_model(reset_seed):
@@ -208,36 +261,185 @@ def test_fake_pha_bkg_model(reset_seed):
     assert data.get_arf().name == "user-arf"
     assert data.get_rmf().name == "delta-rmf"
 
-    # The background itself is unchanged
+    # The background itself is unchanged by the simulation.
     assert data.background_ids == ["used-bkg"]
     bkg = data.get_background("used-bkg")
     assert bkg.name == "bkg"
     assert bkg.counts == pytest.approx(bcounts)
     assert bkg.exposure == pytest.approx(2000)
 
-    # Apply a number of regression checks to test the output. These
-    # can expect to change if the randomization changes (either
-    # explicitly or implicity). There used to be a number of checks
-    # that compares the simulated data to the input values, but these
-    # could occasionally fail, and so the seed was fixed for these
-    # tests.
+    # The expected number of counts here comes from the background
+    # model, and not the background dataset. This means that, unlike
+    # test_fake_pha_background_pha where the background is flat, we
+    # have the potential for a different expected count per bin. The
+    # ARF and RMF are "flat", as is the model (when plotted per keV),
+    # *but* the bin widths are not constant in energy, so when the
+    # model is integrated across each bin you get
     #
-    # For reference the predicted signal is
-    #    [200, 400, 400]
-    # but, unlike in the test above, this time it's all coming
-    # from the background.
+    #    bin 0: 1.1 - 1.2 keV, width = 0.1 keV
+    #        1  1.2 - 1.4              0.2
+    #        2  1.4 - 1.6              0.2
+    #
+    # So the signal in the first bin will be half the other two.
+    #
+    # With a model of 2 photon/cm^2/s/keV and a perfect ARF/RMF
+    # the predicted signal is, for a source exposure time of 1000s,
+    #
+    #    2 * 1000 * [0.1, 0.2, 0.2] = [200, 400, 400]
     #
     assert data.counts == pytest.approx([186, 411, 405])
 
-    # Now add a second set of arf/rmf for the data.
-    # However, all the signal is background, so this does not change
-    # any of the results.
+    # Now add a second set of arf/rmf for the data. However, all the
+    # signal is background, so this does not change any of the
+    # results.
+    #
     data.set_arf(arf, 2)
     data.set_rmf(rmf, 2)
     fake_pha(data, mdl, is_source=True, add_bkgs=True,
              bkg_models={"used-bkg": bmdl})
 
     assert data.counts == pytest.approx([197, 396, 389])
+
+
+def test_fake_pha_bkg_model_multiple(reset_seed):
+    """Test background model with multiple backgounds
+
+    This is to check the different scaling factors, in particular
+    the exposure to background exposure differences.
+    """
+
+    np.random.seed(873)
+
+    data = DataPHA("any", channels, counts, exposure=1000.)
+
+    bkg1 = DataPHA("bkg1", channels, bcounts,
+                   exposure=2000, backscal=1.)
+    bkg2 = DataPHA("bkg2", channels, bcounts,
+                   exposure=6000, backscal=2.)
+    bkg3 = DataPHA("bkg3", channels, bcounts,
+                   exposure=500, backscal=4.)
+
+    data.set_arf(arf)
+    data.set_rmf(rmf)
+
+    for i, bkg in enumerate([bkg1, bkg2, bkg3], 1):
+        data.set_background(bkg, id=i)
+        bkg.set_arf(arf)
+        bkg.set_rmf(rmf)
+
+    # Add a flat source component that is not 0 unlike the
+    # other background checks.
+    #
+    mdl = Const1D("mdl")
+    mdl.c0 = 4
+
+    # Have the background models depend on energy to make it
+    # obvious how the scaling works.
+    #
+    # The energy bins are 1.1-1.2, 1.2-1.4, and 1.4-1.6 keV.
+    #
+    bmdl1 = Box1D("bmdl1")
+    bmdl1.xlow = 1.1
+    bmdl1.xhi = 1.2
+    bmdl1.ampl.set(10, max=10)
+
+    bmdl2 = Box1D("bmdl2")
+    bmdl2.xlow = 1.2
+    bmdl2.xhi = 1.4
+    bmdl2.ampl.set(10, max=10)
+
+    bmdl3 = Box1D("bmdl3")
+    bmdl3.xlow = 1.4
+    bmdl3.xhi = 1.6
+    bmdl3.ampl.set(-8, min=-8)
+
+    bmodels = {1: bmdl1, 2: bmdl2, 3: bmdl3}
+
+    # Source-model only.
+    #
+    # The predicted counts are
+    #
+    #   1000 * 4 * [0.1, 0.2, 0.2] = [400, 800, 800]
+    #
+    fake_pha(data, mdl, is_source=True, add_bkgs=False,
+             bkg_models=bmodels)
+
+    assert data.exposure == pytest.approx(1000.0)
+    assert data.counts == pytest.approx([388, 777, 755])
+
+    # Check we create the expected signal, which is all from the
+    # backgrounds and the source.
+    #
+    fake_pha(data, mdl, is_source=True, add_bkgs=True,
+             bkg_models=bmodels)
+
+    # The background identifiers haven't changed.
+    #
+    assert data.background_ids == [1, 2, 3]
+
+    # Check the exposure times have not changed.
+    #
+    assert data.exposure == pytest.approx(1000.0)
+    assert data.get_background(1).exposure == pytest.approx(2000)
+    assert data.get_background(2).exposure == pytest.approx(6000)
+    assert data.get_background(3).exposure == pytest.approx(500)
+
+    # The signal is a sum of the source and weighted background
+    # components. The source exposure time should be used, not the
+    # background, so all we care about is the ratio of the backscal
+    # values (as the areascal is None in all cases here).
+    #
+    # In the following we show
+    #
+    #     exposure * model * bin-width / (backscal relative to source)
+    #
+    #   Source:
+    #     1000 * 4 * [0.1, 0.2, 0.2] / 1           = [400, 800, 800]
+    #
+    #   Bkg 1:
+    #     1000 * [10, 0, 0] * [0.1, 0.2, 0.2] / 1  = [1000, 0, 0]
+    #
+    #   Bkg 2:
+    #     1000 * [0, 10, 0] * [0.1, 0.2, 0.2] / 2   = [0, 1000, 0]
+    #
+    #   Bkg 1:
+    #     1000 * [0, 0, -8] * [0.1, 0.2, 0.2] / 4  = [0, 0, -400]
+    #
+    # So the expected total is, because we average the background
+    # contributions:
+    #
+    #     [400, 800, 800] + [1000, 1000, -400] / 3
+    #   = [733.333, 1133.333, 666.66]
+    #
+    # These values are wrong (they could be drawn from the above, but
+    # it would be very unlikely).
+    #
+    assert data.counts == pytest.approx([479, 957, 785])
+
+
+@pytest.mark.parametrize("add_bkgs", [False, True])
+def test_fake_pha_with_no_background(add_bkgs, reset_seed):
+    """Check add_bkgs keyword does nothing if no background."""
+
+    np.random.seed(3567)
+
+    # For fun we only set a RMF, not a ARF.
+    data = DataPHA("x", channels, counts, exposure=1000)
+    data.set_rmf(rmf)
+    data.set_analysis("energy")
+
+    mdl = Const1D()
+    mdl.c0 = 4
+
+    assert data.exposure == pytest.approx(1000.0)
+    assert data.channel == pytest.approx(channels)
+    assert data.counts == pytest.approx(counts)
+
+    fake_pha(data, mdl, add_bkgs=add_bkgs)
+
+    assert data.exposure == pytest.approx(1000.0)
+    assert data.channel == pytest.approx(channels)
+    assert data.counts == pytest.approx([433, 793, 806])
 
 
 @requires_fits
@@ -342,7 +544,13 @@ def test_fake_pha_has_valid_ogip_keywords_from_real(make_data_path, tmp_path, re
     # if it turns out not to be repeatable across platforms), but for
     # now keep the check.
     #
-    assert inpha.counts.sum() == 19
+    expected = np.zeros(1024)
+    for idx in [70, 92, 104, 138, 171, 457, 623, 670, 685, 706, 776,
+                792, 860, 894, 950, 1019]:
+        expected[idx] = 1
+
+    expected[1023] = 3
+    assert inpha.counts == pytest.approx(expected)
 
     for field in ["staterror", "syserror", "bin_lo", "bin_hi",
                   "grouping", "quality"]:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8859,14 +8859,15 @@ class Session(sherpa.ui.utils.Session):
            If left empty, then only the source emission is simulated.
            If set to a PHA data object, then the counts from this data
            set are scaled appropriately and added to the simulated
-           source signal. To use background model, set ``bkg="model"`. In that
-           case a background dataset with ``bkg_id=1`` has to be set before
-           calling ``fake_pha``. That background dataset needs to include
-           the data itself (not used in this function), the background model,
-           and the response.
+           source signal. To use background model, set
+           ``bkg="model"``. In that case a background dataset with
+           ``bkg_id=1`` has to be set before calling
+           ``fake_pha``. That background dataset needs to include the
+           data itself (not used in this function), the background
+           model, and the response.
         method : callable or None, optional
            If None, the default, then the data is simulated using the
-           sherpa.utils.poisson_noise routine. If set, it must be a
+           `sherpa.utils.poisson_noise` routine. If set, it must be a
            callable that takes a ndarray of the predicted values and
            returns a ndarray of the same size with the simulated data.
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8806,13 +8806,17 @@ class Session(sherpa.ui.utils.Session):
             d.unsubtract()
 
     def fake_pha(self, id, arf, rmf, exposure, backscal=None, areascal=None,
-                 grouping=None, grouped=False, quality=None, bkg=None):
+                 grouping=None, grouped=False, quality=None, bkg=None,
+                 method=None):
         """Simulate a PHA data set from a model.
 
         The function creates a simulated PHA data set based on a source
         model, instrument response (given as an ARF and RMF), and exposure
         time, along with a Poisson noise term. A background component can
         be included.
+
+        .. versionchanged:: 4.15.1
+           The method parameter was added.
 
         .. versionchanged:: 4.15.0
            The arf argument can now be set to `None` when the data
@@ -8860,6 +8864,11 @@ class Session(sherpa.ui.utils.Session):
            calling ``fake_pha``. That background dataset needs to include
            the data itself (not used in this function), the background model,
            and the response.
+        method : callable or None, optional
+           If None, the default, then the data is simulated using the
+           sherpa.utils.poisson_noise routine. If set, it must be a
+           callable that takes a ndarray of the predicted values and
+           returns a ndarray of the same size with the simulated data.
 
         Raises
         ------
@@ -9039,7 +9048,7 @@ class Session(sherpa.ui.utils.Session):
         m = self.get_model(id)
 
         fake.fake_pha(d, m, is_source=False, add_bkgs=bkg is not None,
-                      id=str(id), bkg_models=bkg_models)
+                      id=str(id), bkg_models=bkg_models, method=method)
         d.name = 'faked'
 
     ###########################################################################

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8843,12 +8843,17 @@ class Session(sherpa.ui.utils.Session):
            the data set given by id.
         exposure : number
            The exposure time, in seconds.
+           Set this to `None` to use any exposure that is already set for
+           the data set given by id.
         backscal : number, optional
            The 'BACKSCAL' value for the data set.
         areascal : number, optional
            The 'AREASCAL' value for the data set.
         grouping : array, optional
            The grouping array for the data (see `set_grouping`).
+           Set this to `None` to use any grouping that is already set for
+           the data set given by id; the grouping is only applied if
+           `grouped` is ``True``.
         grouped : bool, optional
            Should the simulated data be grouped (see `group`)?  The
            default is ``False``. This value is only used if the

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8815,7 +8815,7 @@ class Session(sherpa.ui.utils.Session):
         time, along with a Poisson noise term. A background component can
         be included.
 
-        .. versionchanged:: 4.15.1
+        .. versionchanged:: 4.16.0
            The method parameter was added.
 
         .. versionchanged:: 4.15.0


### PR DESCRIPTION
# Summary

The fake_pha call now accepts a method argument to match the fake call.

# Details

Requires
- #1733 

Next in series
- #1684

The fake_pha call now accepts a method argument, to match the fake call.  This is likely not that useful for users, as we really only expect a poisson distribution. There are those users who have RATE PHAs, where we can not assume Poisson stats, but I'm not sure we handle this case particularly well throughout Sherpa anyway (but we can now handle it better in fake_pha with this change). It is, however, very useful for testing the fake_pha call since you can send method the identity function (e.g. `lambda x: x`) and test the actual calculated numbers, rather than have to worry about RNG variations (which make subtle errors impossible to distinguish, as I mention below). 

A number of tests are updated to make use of this (by sending in an identity function) showing some of these problem cases. For example, in sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py there is now

```python
def identity(x):
    return x

@pytest.mark.parametrize("method,expected",
                         [(None, [42, 137, 53]),
                          (identity, [50, 151.25, 50])  # TODO: should be [50, 150, 50]
                          ])
def test_fake_pha_background_model(method, expected, clean_astro_ui, reset_seed):
    ...
```

I have not marked this as `xfail` because

- for the `None` case, it is very hard to know that 137 is coming from the "wrong" distribution (expected value of 151.15 rather than 150)
- when it gets fixed it is easier to see in the difference (in the `git diff` output)
- maybe I'm wrong and it really should be 151.25, but I have tried to add a lot of text to explain what the predicted values are, so we can fix them (e.g. in #1684) 

There are also a large number of corner-cases for the fake-pha code path added. These could be removed (and moved into #1684) if it would make this easier to review. 