### PR TITLE
Return more-useful information when an XSPEC model fails

### DIFF
--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -586,7 +586,12 @@ static void create_output(int nbins, T &a, T &b) {
 
         } // eval
 
-        const char* get_err_msg( ) { return "XSPEC model evaluation failed"; }
+	const char* get_err_msg( ) {
+	  if (HasNorm)
+	    return "XSPEC additive model evaluation failed";
+	  else
+	    return "XSPEC multiplicative model evaluation failed";
+	}
 
       protected:
 
@@ -702,7 +707,7 @@ static void create_output(int nbins, T &a, T &b) {
 
         } // eval
 
-        const char* get_err_msg( ) { return "XSPEC convolution model evaluation failed"; }
+	const char* get_err_msg( ) { return "XSPEC convolution model evaluation failed"; }
 
       protected:
 
@@ -801,7 +806,7 @@ static void create_output(int nbins, T &a, T &b) {
 
         } // eval
 
-        const char* get_err_msg( ) { return "XSPEC model evaluation failed"; }
+	const char* get_err_msg( ) { return "XSPEC table model evaluation failed"; }
 
       protected:
         int npts, ifl;


### PR DESCRIPTION
# Summary

Include the model name and parameter values in the error message of a failed XSPEC model (which is a rare occurrence).

# Details

This would have been useful for me in tracking down a recent helpdesk ticket, where the problem was that the XScevmkl class failed/could crash when the Tmax parameter was below ~0.03 (I have an email discussion going on with the XSPEC team about this particular case).In the *vast majority* of cases this error case should not be seen (ideally it would never be seen, but we can not statically guarantee this).

The idea is to change from

    ValueError("XSPEC model evaluation failed")

to something like

    ValueError("XSPEC <type> model evaluation failed <class>.<name> par1=xx ... parN=xx")

where type is one of additive, multiplicative, convolution, or table.

There are several ways this could be done, and I've tried a bunch of them before deciding on this approach, which has the advantage that it is essentially all done in Python scope. It could partially be done in the C++ layer but that's harder to review and doesn't actually address all the changes I wanted (in particular access to the Python class name/model name).

There's also the fact that this is meant to only be needed in extraordinary cases, so let's not spend a lot of engineering time on making it all-singing and dancing.

# Example

This is hard to test, as the point is that the XSPEC models shouldn't be failing in this way... Here's the case I was tracking, with XSPEC 12.13.0 (CIAO 4.15)

Before this PR:

```
>>> from sherpa.astro import xspec
>>> mdl = xspec.XScevmkl()
>>> mdl.tmax = 0.01
>>> mdl([0.1, 0.2, 0.3], [0.3, 0.4, 0.5])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-master/sherpa/models/model.py", line 654, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/models/model.py", line 442, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-master/sherpa/astro/xspec/__init__.py", line 1182, in calc
    out = self._calc(*args, **kwargs)
ValueError: XSPEC model evaluation failed
```

With this PR:

```
>>> mdl([0.1, 0.2, 0.3], [0.3, 0.4, 0.5])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-main/sherpa/models/model.py", line 654, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-main/sherpa/models/model.py", line 442, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-main/sherpa/astro/xspec/__init__.py", line 1199, in calc
    raise ValueError(msg) from None
ValueError: XSPEC additive model evaluation failed: xscevmkl.cevmkl alpha=1.0 Tmax=0.01 nH=1.0 He=1.0 C=1.0 N=1.0 O=1.0 Ne=1.0 Na=1.0 Mg=1.0 Al=1.0 Si=1.0 S=1.0 Ar=1.0 Ca=1.0 Fe=1.0 Ni=1.0 redshift=0.0 switch=1.0 norm=1.0
```
