### PR TITLE
pyfits: be more lenient with FITS files with messed-up headers

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -100,14 +100,22 @@ def _require_key(hdu, name, fix_type=False, dtype=SherpaFloat):
 
 
 def _get_meta_data(hdu):
+    # If the header keywords are not specified correctly then
+    # astropy will error out when we try to access it. Since
+    # this is not an uncommon problem, there is a verify method
+    # that can be used to fix up the data to avoid this: the
+    # "silentfix" option is used so as not to complain too much.
+    #
+    hdu.verify('silentfix')
+
     meta = {}
     for key, val in hdu.header.items():
-
         # empty numpy strings are not recognized by load pickle!
         if isinstance(val, numpy.str_) and val == '':
             val = ''
 
         meta[key] = val
+
     return meta
 
 


### PR DESCRIPTION
# Summary

Allow some FITS files with an invalid header to be used with the AstroPy I/O backend.

# Details

It is easy to end up with a FITS file with an invalid header but valid data. Astropy does allow the header to be "fixed up" when certain problems are found, so do so.

There is a possibility that this verification should be done at a different location, but without attempting to rework the module (e.g. #1091) I elected for the "verify at the point we care about the header" approach.

The other choice is whether any fixes should be silent or let the user know there was something funky: I elected for silentfix as the screen output when there is a problem is rather verbose.

This is not guaranteed to fix all cases, but does help.

# Example

Without this fix I get (for the helpdesk ticket that lead to this PR, and using pyfits as the backend):

```
sherpa-4.15.0> sherpa.astro.io.backend
<module 'sherpa.astro.io.pyfits_backend' from '/lagado2.real/local/anaconda/envs/ciao415-py310/lib/python3.10/site-packages/sherpa/astro/io/pyfits_backend.py'>

sherpa-4.15.0> load_pha("lxp2level2back_shifted.spec")
VerifyError: Unparsable card (OBJECT), fix it first with .verify('fix').
```

If I use crates then the file reads in okay

```
sherpa-4.15.0> sherpa.astro.io.backend
<module 'sherpa.astro.io.crates_backend' from '/lagado2.real/local/anaconda/envs/ciao415-py310/lib/python3.10/site-packages/sherpa/astro/io/crates_backend.py'>

sherpa-4.15.0> load_pha("lxp2level2back_shifted.spec")
WARNING: systematic errors were not found in file 'lxp2level2back_shifted.spec'
statistical errors were found in file 'lxp2level2back_shifted.spec' 
but not used; to use them, re-read with use_errors=True

sherpa-4.15.0> get_data().header["OBJECT"]
'BACKGROUND-may21    / Source information block'
```

With this PR I get

```
>>> from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> sherpa.astro.io.backend
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'sherpa' is not defined
>>> load_pha("lxp2level2back_shifted.spec")
WARNING: systematic errors were not found in file 'lxp2level2back_shifted.spec'
statistical errors were found in file 'lxp2level2back_shifted.spec' 
but not used; to use them, re-read with use_errors=True
>>> get_data().header["OBJECT"]
"'BACKGROUND-may21"
```

We can see that the OBJECT field is different than in the crates case, but this is okay (we don't want to force the same behavior for different backends).