### PR TITLE
Replace pkg_resources as it is deprecated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ python_requires = ~=3.9
 zip_safe = False
 install_requires =
     numpy
-    importlib_resources; python_version < '3.9'
 
 tests_require =
     pytest-xvfb

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ python_requires = ~=3.9
 zip_safe = False
 install_requires =
     numpy
+    importlib_resources; python_version < '3.9'
 
 tests_require =
     pytest-xvfb

--- a/sherpa/utils/formatting.py
+++ b/sherpa/utils/formatting.py
@@ -27,10 +27,7 @@ This is aimed at IPython/Jupiter support but may be useful elsewhere.
 
 import contextlib
 import html
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
+from importlib.resources import files
 
 import numpy as np
 

--- a/sherpa/utils/formatting.py
+++ b/sherpa/utils/formatting.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2020  Smithsonian Astrophysical Observatory
+# Copyright (C) 2020, 2023
+# Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -26,7 +27,10 @@ This is aimed at IPython/Jupiter support but may be useful elsewhere.
 
 import contextlib
 import html
-import pkg_resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 import numpy as np
 
@@ -35,8 +39,9 @@ import numpy as np
 DISPLAY_WIDTH = 80
 
 # The CSS file for the Notebook HTML code
-CSS_FILE_PATH = "/".join(("static", "css", "style.css"))
-CSS_STYLE = pkg_resources.resource_string("sherpa", CSS_FILE_PATH).decode("utf8")
+#
+CSS_FILE_PATH = files("sherpa").joinpath("static", "css", "style.css")
+CSS_STYLE = CSS_FILE_PATH.read_text(encoding="utf-8")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
# Summary

Remove the use of the deprecated pkg_resources module and replace with use of importlib.resources. Fix #1723

# Detalis

The pkg_resources module has long been "somewhat" deprecated but it looks like, with pip 23.1 and Python 3.12  (e.g. see https://discuss.python.org/t/announcement-pip-23-1-release/25844), this is getting more important. Fortunately it is an easy fix - see
    
    https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-string
    
but we don't need to worry about using the importlib-resources
backport as we are now Python > 3.7. **However**, it turns out that
the importlib.resources.files interface was only added in Python
3.9, and we still support Python 3.8. So we use importlib_resources
got pre-3.9 systems (I investigated other approaches, including
using the "deprecated" importlib.resources interface) but none are
particularly useful (which is why this PR has been rebased so-many times).

Although now we have dropped python 3.8 support we can re-simplify™ this.