### PR TITLE
Explicitly require attrs module when testing Sherpa

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -201,7 +201,7 @@ jobs:
         fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
-        conda install -yq pytest-cov
+        conda install -yq pytest-cov attrs
         python setup.py -q test -a "--cov sherpa --cov-report xml"
 
     - name: sherpa_test Tests
@@ -209,7 +209,7 @@ jobs:
       run: |
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
-        conda install -yq pytest-cov
+        conda install -yq pytest-cov attrs
         cd $HOME
         sherpa_test --cov sherpa --cov-report xml
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -105,6 +105,7 @@ jobs:
         TEST: ${{ matrix.test-data }}
       run: |
         git submodule deinit -f .
+        pip install -r test_requirements.txt
         pip install pytest-cov
         sherpa_test --cov=sherpa --cov-report=xml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
 tests_require =
     pytest-xvfb
     pytest>=5.0,!=5.23
+    attrs
 
 # Be explicit as something doesn't seem quite right when using find.
 #

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest>=5.0,!=5.2.3
 pytest-xvfb
 pytest-doctestplus
+attrs


### PR DESCRIPTION
# Summary

Ensure that the attrs module is available for testing Sherpa.

# Details

The attrs moodule is required for one test so make sure it is installed. It is not clear why this is needed now, as it always should have been needed: what changed to make it a requirement? 

I am not sure all the changes are needed as I forget now exactly what we use (does the `tests_require` stansa in `setup.cfg` actually get used) but it's best to be safe rather than sorry, particularly as there's larger changes I've been waiting to get landed (e.g. #1608).

Without this I find my CI runs fail.