### PR TITLE
Drop Python 3.8 and Pick up Python 3.11 as a beta

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -71,7 +71,7 @@ jobs:
         image: ["redhat/ubi8"]
         conda-os: ["Linux-x86_64"]
         os-dir: ["linux-64"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - name: Install git and diff
@@ -129,7 +129,7 @@ jobs:
         os-type: ["macos-11"]
         conda-os: ["MacOSX-x86_64"]
         os-dir: ["osx-64"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     env:
       CONDA_BUILD_SYSROOT: /opt/MacOSX10.9.sdk
 
@@ -243,6 +243,12 @@ jobs:
         echo "conda create -n test310 --yes -q -c file://$(pwd)/packages python=3.10 astropy sherpa matplotlib"
         conda create -n test310 --yes -q -c file://$(pwd)/packages python=3.10 astropy sherpa matplotlib
         conda activate test310
+        pip install main.zip
+        sherpa_smoke -f astropy
+        sherpa_test
+        echo "conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib"
+        conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib
+        conda activate test311
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -71,7 +71,7 @@ jobs:
         image: ["redhat/ubi8"]
         conda-os: ["Linux-x86_64"]
         os-dir: ["linux-64"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - name: Install git and diff
@@ -129,7 +129,7 @@ jobs:
         os-type: ["macos-11"]
         conda-os: ["MacOSX-x86_64"]
         os-dir: ["osx-64"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     env:
       CONDA_BUILD_SYSROOT: /opt/MacOSX10.9.sdk
 
@@ -234,12 +234,6 @@ jobs:
       run: |
         source ${miniconda_loc}/etc/profile.d/conda.sh
         curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip 
-        echo "conda create -n test38 --yes -q -c file://$(pwd)/packages python=3.8 astropy sherpa matplotlib"
-        conda create -n test38 --yes -q -c file://$(pwd)/packages python=3.8 astropy sherpa matplotlib
-        conda activate test38
-        pip install main.zip
-        sherpa_smoke -f astropy
-        sherpa_test
         echo "conda create -n test39 --yes -q -c file://$(pwd)/packages python=3.9 astropy sherpa matplotlib"
         conda create -n test39 --yes -q -c file://$(pwd)/packages python=3.9 astropy sherpa matplotlib
         conda activate test39

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -35,10 +35,10 @@ jobs:
             # run xvfb with this display
             display: :99
 
-          - name: Linux Minimum Setup (Python 3.8)
+          - name: Linux Minimum Setup (Python 3.9)
             os: ubuntu-latest
-            python-version: "3.8"
-            numpy-version: "1.18"
+            python-version: "3.9"
+            numpy-version: "1.21"
             install-type: develop
             test-data: none
 
@@ -67,9 +67,9 @@ jobs:
             matplotlib-version: 3
             xspec-version: 12.12.1c
 
-          - name: Linux Full Build (Python 3.8)
+          - name: Linux Full Build (Python 3.9)
             os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -85,8 +85,8 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.8"
-            numpy-version: "1.20"
+            python-version: "3.9"
+            numpy-version: "1.21"
             install-type: develop
             fits: astropy
             test-data: none

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -42,25 +42,25 @@ jobs:
             install-type: develop
             test-data: none
 
-          - name: Linux Minimum Setup (Python 3.10)
+          - name: Linux Minimum Setup (Python 3.11)
             os: ubuntu-latest
-            python-version: "3.10"
-            numpy-version: "1.21"
+            python-version: "3.11"
+            numpy-version: "1.23"
             install-type: develop
             test-data: none
 
-          - name: Linux Full Build (Python 3.10)
+          - name: Linux Full Build (Python 3.11)
             os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             install-type: develop
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
             xspec-version: 12.13.0c
 
-          - name: Linux Full Build (Python 3.9)
+          - name: Linux Full Build (Python 3.10)
             os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -78,7 +78,7 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.11"
             install-type: install
             test-data: package
             matplotlib-version: 3

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -26,9 +26,9 @@ jobs:
             install-type: develop
             test-data: none
 
-          - name: Linux Build (w/o Xspec; Python 3.10)
+          - name: Linux Build (w/o Xspec; Python 3.11)
             os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package
@@ -45,7 +45,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -21,8 +21,8 @@ jobs:
         include:
           - name: Linux Minimum Setup
             os: ubuntu-latest
-            python-version: "3.8"
-            numpy-pkg: 'numpy>=1.20,<1.21'
+            python-version: "3.9"
+            numpy-pkg: 'numpy>=1.21,<1.22'
             install-type: develop
             test-data: none
 
@@ -45,7 +45,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,9 @@ Example: new functionality, such as
 
 **Software versions**
 
-Development should use Python 3.8 or later.
+Development should use Python 3.9 or later.
 
-Ideally, NumPy support should be 1.20 or greater, but please include a comment
+Ideally, NumPy support should be 1.21 or greater, but please include a comment
 if you need to restrict (or relax) this further.
 
 Sherpa requires a C compiler, along with related tools, to build. Additional

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.8,3.9,3.10-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.9,3.10-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -71,7 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.8, 3.9, and 3.10.
+Sherpa is tested against Python versions 3.9 and 3.10.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -80,7 +80,7 @@ Using Anaconda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.8 to 3.10. It can be installed with the `conda`
+Python 3.9 and 3.10. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c sherpa sherpa

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.9,3.10-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.9,3.10,3.11-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -71,7 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.9 and 3.10.
+Sherpa is tested against Python versions 3.9, 3.10, and 3.11.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -80,7 +80,7 @@ Using Anaconda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.9 and 3.10. It can be installed with the `conda`
+Python 3.9, 3.10, and 3.11. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c sherpa sherpa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.8 to 3.11.
+and is compatible with Python versions 3.9 to 3.11.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,9 +33,9 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.8 to 3.11
+* Python 3.9 to 3.11
 * NumPy (the exact lower limit has not been determined,
-  1.20.0 or later will work, earlier version may work)
+  1.21.0 or later will work, earlier version may work)
 * Linux or OS-X (patches to add Windows support are welcome)
 
 Sherpa can take advantage of the following Python packages
@@ -140,7 +140,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.8 to 3.11
+* Python versions: 3.9 to 3.11
 * Python packages: ``setuptools``, ``numpy``
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -18,8 +18,7 @@ requirements:
 
  host:
   - python
-  - numpy 1.20.* # [py<=39]
-  - numpy 1.21.* # [py>39]
+  - numpy 1.21.*
   - setuptools <60.0.0
   - six
 

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -18,7 +18,8 @@ requirements:
 
  host:
   - python
-  - numpy 1.21.*
+  - numpy 1.21.* # [py<=310]
+  - numpy 1.23.* # [py>310]
   - setuptools <60.0.0
   - six
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers=
     Intended Audience :: Science/Research
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Programming Language :: C
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -25,7 +24,7 @@ classifiers=
     Topic :: Scientific/Engineering :: Physics
 
 [options]
-python_requires = ~=3.8
+python_requires = ~=3.9
 zip_safe = False
 install_requires =
     numpy

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ import sys
 # This is done before we load in any non-core modules to avoid people
 # installing software that they can not use.
 #
-if sys.version_info < (3, 8):
-    sys.stderr.write("Sherpa 4.15 (and later) requires Python 3.8 or later.\n\n")
-    sys.stderr.write("Please use Sherpa 4.14.1 if you need to use Python 3.7\n")
+if sys.version_info < (3, 9):
+    sys.stderr.write("Sherpa 4.15.1 (and later) requires Python 3.9 or later.\n\n")
+    sys.stderr.write("Please use Sherpa 4.15.0 if you need to use Python 3.8\n")
     sys.exit(1)
 
 # We need to import setuptools so that 'python setup.py develop'


### PR DESCRIPTION
Still have to let the tests run to see (and merge the attrs change). 
However, this is to put us in line with [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) with Python 3.9+ (as of April 14th) and Numpy 1.21+ (as of January 31st).