### PR TITLE
Initial support for Python 3.11

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,7 @@ channels:
   - astropy
 
 dependencies:
-  - python=3.8
+  - python=3.10
   - numpy
   - pandoc
   - pip

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.8 to 3.10.
+and is compatible with Python versions 3.8 to 3.11.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.8, 3.9, or 3.10
+* Python 3.8 to 3.11
 * NumPy (the exact lower limit has not been determined,
   1.20.0 or later will work, earlier version may work)
 * Linux or OS-X (patches to add Windows support are welcome)
@@ -140,7 +140,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.8, 3.9, 3.10
+* Python versions: 3.8 to 3.11
 * Python packages: ``setuptools``, ``numpy``
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
   ``bison`` (the aim is to support recent versions of these

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers=
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -909,11 +909,12 @@ def test_img_can_not_set_coord(make_test_image):
     """
     d = make_test_image
 
-    # This dataset does not have a physical system, but we
-    # do not get a DataErr but an AttributeError.
+    # This dataset does not have a physical system, but we do not get
+    # a DataErr but an AttributeError. The text message depends on
+    # Python version (e.g. 3.9, 3.10, and 3.11 all have different
+    # messages) so we do not check the message, just the class.
     #
-    with pytest.raises(AttributeError,
-                       match="can't set attribute"):
+    with pytest.raises(AttributeError):
         d.coord = "physical"
 
 

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022
+#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -94,7 +94,7 @@ def run(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):
                 raise
 
     test_suite = SmokeTestSuite(require_failure=require_failure)
-    test_suite.addTest(unittest.makeSuite(DependencyTest))
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DependencyTest))
     runner = unittest.TextTestRunner(verbosity=int(verbosity))
     result = runner.run(test_suite)
 
@@ -241,7 +241,7 @@ class SmokeTestSuite(unittest.TestSuite):
         unittest.TestSuite.__init__(self, *args, **kwargs)
 
         for test_class in self.test_classes:
-            self.addTest(unittest.makeSuite(test_class))
+            self.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(test_class))
 
         self._set_skips()
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -188,6 +188,19 @@ known_warnings = {
         ],
     VisibleDeprecationWarning:
         [],
+    ImportWarning:
+    [
+        # It is not clear why this happens - seen when testing
+        # https://github.com/sherpa/sherpa/pull/1752 - and the problem appears
+        # to be a setuptools/pip interaction, based on
+        #   https://github.com/pypa/setuptools/issues/2104
+        #   https://github.com/pypa/setuptools/issues/2052
+        #   https://github.com/pypa/setuptools/issues/1383
+        # At present Sherpa forces an old version of setuptoools (<60) so it is
+        # unlikely to be fixed. When the setuptools restriction is removed we can
+        # hopefully remove this.
+        r"VendorImporter.find_spec\(\) not found; falling back to find_module\(\)",
+    ]
 }
 
 if have_astropy:

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2019, 2020, 2021
+#  Copyright (C) 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -324,7 +324,9 @@ class MyDifEvo(Opt):
 
     def all_strategies(self, key):
         rand, index = self.key2.parse(key)
-        random.seed(rand)
+        # convert from numpy int to int otherwise this will
+        # fail in Python 3.11
+        random.seed(int(rand))
         mypop = self.polytope
         best_trial = self.strategies[0](mypop, index)
         for ii in range(1, len(self.strategies)):

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -719,12 +719,10 @@ def test_psf_set_model_to_bool(kernel_func):
     """
 
     m = PSFModel(kernel=kernel_func())
-    with pytest.raises(AttributeError,
-                       # The exact message depends on python version,
-                       # as 3.10 includes the attribute name - here
-                       # 'model' - and 3.9 and earlier does not.
-                       #
-                       match="can't set attribute"):
+    # This used to check the message that was raised, but it changes
+    # with Python versions (3.9, 3.10, 3.11 all had different messages)
+    # and so we now just check the error is raised.
+    with pytest.raises(AttributeError):
         m.model = False
 
 


### PR DESCRIPTION
# Summary

Basic support of Python 3.11.

# Details

Try and fix the problems seen in #1752 - (code in #1735 would be an improvement for the multiprocessing work but this is the minimal change needed, as there is a lot of changes in #1735 which need to be broken into chunks for easier review, which is not going to happen soon).

So the changes made are

- avoid checking the text of an AttributeError call as the text is different for Python 3.9, 3.10, and now different-enough in 3.11 that it's just not worth checking. The important thing is the AttributeError check (and the fact that it isn't being raised by Sherpa code, so it's not really our thing to check)
- the unittest module has replaced a function that affects the smoke tests (both from pytest and the sherpa_smoke command), so use the replacement (which is backwards compatible, at least to python 3.8, as shown by the test passes).
- bump the RTD build from python 3.8 (which now fails unless we were top restrict the packages it uses, because of NEP 29) to python 3.10
- some code used `random.seed(val)` where val was a numpy int rather than an int, and this caused conniptions (the update documentation doesn't make it obvious that this is a problem, at least to my eyes); I note that I plan to rework this bit of code (as part of #1735 which is an attempt to resolve #867) but that is some time off and this is a sensible fix until that point.
-  update documentation to include Python 3.11 as being supported