### PR TITLE
Tests: replace use of attrs package by dataclass

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -201,7 +201,7 @@ jobs:
         fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
-        conda install -yq pytest-cov attrs
+        conda install -yq pytest-cov
         python setup.py -q test -a "--cov sherpa --cov-report xml"
 
     - name: sherpa_test Tests
@@ -209,7 +209,7 @@ jobs:
       run: |
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
-        conda install -yq pytest-cov attrs
+        conda install -yq pytest-cov
         cd $HOME
         sherpa_test --cov sherpa --cov-report xml
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -105,7 +105,6 @@ jobs:
         TEST: ${{ matrix.test-data }}
       run: |
         git submodule deinit -f .
-        pip install -r test_requirements.txt
         pip install pytest-cov
         sherpa_test --cov=sherpa --cov-report=xml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
 tests_require =
     pytest-xvfb
     pytest>=5.0,!=5.23
-    attrs
 
 # Be explicit as something doesn't seem quite right when using find.
 #

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
 pytest>=5.0,!=5.2.3
 pytest-xvfb
 pytest-doctestplus
-attrs


### PR DESCRIPTION
# Summary

Change a test file to use dataclasses rather than use the attrs module, which means that attrs is no-longer needed to test Sherpa. There is no functional change in this PR.

# Details

The test_psf_rebinning_unit.py test was written before dataclasses were available for all supported Python packages (Python >= 3.7). So the test used attrs, and fortunately did not use any functionality that can not be handled by a dataclass (there is one small technical change, in that we now have to give types for the fields, which has lead to a small change to the `WcsSubs` class to make it easier to type, but conceptually `WcsSubs` is more honest know as we only test data with square pixels).

This PR reverts #1751 as it is no longer needed.