### PR TITLE
Correct releases to release for deployment branch

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -8,7 +8,7 @@ on:
     branches:
     - main
     - ciaox
-    - 'releases/**'
+    - 'release/**'
 
 #Reduces GH Action duplication:
 # Cancels the previous pipeline for this ref it is still running


### PR DESCRIPTION
The Conda deployment workflow has a minor typo in the branch matching. It looks for branches with "releases" in it instead of "release". This is needed to get official builds for releases. 