### PR TITLE
Allow load_image to change the coordinate system

### DIFF
--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -144,3 +144,32 @@ def test_image_write_basic(make_data_path, tmp_path):
     assert outdata.name.endswith("/test.img")
     check_header(outdata)
     check_data(outdata)
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("incoord,outcoord,x0,x1",
+                         [("logical", None, 1, 1),
+                          ("image", "logical", 1, 1),
+                          ("physical", None, 1, 1),
+                          ("world", None, 1, 1),
+                          ("wcs", "world", 1, 1)])
+def test_1762(incoord, outcoord, x0, x1, make_data_path):
+    """What does setting a non-logical coord system do?
+
+    This is a regression test so depends on whether #1762 is
+    fixed or not.
+    """
+
+    infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")
+    d = io.read_image(infile, coord=incoord)
+
+    if outcoord is None:
+        assert d.coord == incoord
+    else:
+        assert d.coord == outcoord
+
+    # Just check the first element
+    i0, i1 = d.get_indep()
+    assert i0[0] == pytest.approx(x0)
+    assert i1[0] == pytest.approx(x1)

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -151,9 +151,9 @@ def test_image_write_basic(make_data_path, tmp_path):
 @pytest.mark.parametrize("incoord,outcoord,x0,x1",
                          [("logical", None, 1, 1),
                           ("image", "logical", 1, 1),
-                          ("physical", None, 1, 1),
-                          ("world", None, 1, 1),
-                          ("wcs", "world", 1, 1)])
+                          ("physical", None, 2987.3400878906, 4363.16015625),
+                          ("world", None, 150.03707837630427, 2.644383154504334),
+                          ("wcs", "world", 150.03707837630427, 2.644383154504334)])
 def test_1762(incoord, outcoord, x0, x1, make_data_path):
     """What does setting a non-logical coord system do?
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3167,3 +3167,32 @@ def test_set_bkg_not_a_background(clean_astro_ui):
     with pytest.raises(ArgumentTypeErr,
                        match="^'bkg' must be a PHA data set$"):
         ui.set_bkg(ui.Data1D("x", [1, 2], [1, 2]))
+
+
+@requires_fits
+@requires_data
+@pytest.mark.parametrize("incoord,outcoord,x0,x1",
+                         [("logical", None, 1, 1),
+                          ("image", "logical", 1, 1),
+                          ("physical", None, 1, 1),
+                          ("world", None, 1, 1),
+                          ("wcs", "world", 1, 1)])
+def test_1762_ui(incoord, outcoord, x0, x1, clean_astro_ui, make_data_path):
+    """A version of sherpa/astro/ui/tests/test_io_img.py:test_1762"""
+
+    infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")
+    ui.load_image("img", infile, coord=incoord)
+
+    # Not really needed but added in anyway
+    assert ui.list_data_ids() == ["img"]
+
+    got = ui.get_coord("img")
+    if outcoord is None:
+        assert got == incoord
+    else:
+        assert got == outcoord
+
+    # Just check the first element
+    i0, i1 = ui.get_indep("img")
+    assert i0[0] == pytest.approx(x0)
+    assert i1[0] == pytest.approx(x1)

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3174,9 +3174,9 @@ def test_set_bkg_not_a_background(clean_astro_ui):
 @pytest.mark.parametrize("incoord,outcoord,x0,x1",
                          [("logical", None, 1, 1),
                           ("image", "logical", 1, 1),
-                          ("physical", None, 1, 1),
-                          ("world", None, 1, 1),
-                          ("wcs", "world", 1, 1)])
+                          ("physical", None, 2987.3400878906, 4363.16015625),
+                          ("world", None, 150.03707837630427, 2.644383154504334),
+                          ("wcs", "world", 150.03707837630427, 2.644383154504334)])
 def test_1762_ui(incoord, outcoord, x0, x1, clean_astro_ui, make_data_path):
     """A version of sherpa/astro/ui/tests/test_io_img.py:test_1762"""
 


### PR DESCRIPTION
# Summary

Ensure that the coordinate setting used in load_image calls is properly handled (when not set to the default value of "logical"). Fix #1762

# Details

This is likely fall out from addressing #1380 with #1414.

There is a "deep" issue regarding creating a `DataIMG` object with non-logical coordinate values for the independent axes, and how it should respect/nullify changing the coordinate system, but that's not relevant here. In this particular case we read in the logical pixel values from a FITS image with the `sherpa.astro.io.backend.get_image_data` call, which I believe has to return logical units, and then claiming they are whatever the units that the user sends in with the coord parameter. This leads to behavior like  #1762.

The solution is to explicitly set the coordinate - using the `set_coord` method - after creating the dataset (and this does not hold for `Data2D` where we already scrub the `coord` argument from the call). So the fix is pretty clean.

I added a test to show the before and after behavior. I made it a regression test just to make it more obvious what is going on (rather than have the non-logical calls fail, we can see what they return in the initial version).