### PR TITLE
Drop python2 ism in the fit code

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -18,16 +18,15 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from functools import wraps
 import logging
 import os
 import signal
 
-from functools import wraps
-
 import numpy as np
+from numpy import arange, array, iterable, sqrt, where, \
+    ones_like, isnan, isinf
 
-from numpy import arange, array, abs, iterable, sqrt, where, \
-    ones_like, isnan, isinf, any
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, \
     bool_cast, is_in, is_iterable, list_to_open_interval, sao_fcmp
 from sherpa.utils.err import DataErr, EstErr, FitErr, SherpaErr
@@ -111,6 +110,9 @@ class StatInfoResults(NoNewAttributesAfterInit):
         self.qval = qval
         self.rstat = rstat
 
+        # TODO: should this call
+        # NoNewAttributesAfterInit.__init__(self)
+
     def __repr__(self):
         return '<Statistic information results instance>'
 
@@ -129,24 +131,28 @@ class StatInfoResults(NoNewAttributesAfterInit):
         txt : str
             A multi-line representation of the statistic value or values.
         """
-        s = ''
+        out = []
         if self.ids is not None and self.bkg_ids is None:
             if len(self.ids) == 1:
-                s = 'Dataset               = %s\n' % str(self.ids[0])
+                out.append(f'Dataset               = {self.ids[0]}')
             else:
-                s = 'Datasets              = %s\n' % str(self.ids).strip("()")
+                out.append(f'Datasets              = {self.ids}')
+
         elif self.ids is not None and self.bkg_ids is not None:
-            s = 'Background %s in Dataset = %s\n' % (str(self.bkg_ids[0]),
-                                                     str(self.ids[0]))
-        s += 'Statistic             = %s\n' % self.statname
-        s += 'Fit statistic value   = %g\n' % self.statval
-        s += 'Data points           = %g\n' % self.numpoints
-        s += 'Degrees of freedom    = %g' % self.dof
+            out.append(f'Background {self.bkg_ids[0]} in Dataset = {self.ids[0]}')
+
+        out.extend([f'Statistic             = {self.statname}',
+                    f'Fit statistic value   = {self.statval:g}',
+                    f'Data points           = {self.numpoints:g}',
+                    f'Degrees of freedom    = {self.dof:g}'])
+
         if self.qval is not None:
-            s += '\nProbability [Q-value] = %g' % self.qval
+            out.append(f'Probability [Q-value] = {self.qval:g}')
+
         if self.rstat is not None:
-            s += '\nReduced statistic     = %g' % self.rstat
-        return s
+            out.append(f'Reduced statistic     = {self.rstat:g}')
+
+        return "\n".join(out)
 
 
 def _cleanup_chi2_name(stat, data):
@@ -265,7 +271,7 @@ class FitResults(NoNewAttributesAfterInit):
         self.parvals = tuple(results[1])
         self.istatval = init_stat
         self.statval = results[2]
-        self.dstatval = abs(results[2] - init_stat)
+        self.dstatval = np.abs(results[2] - init_stat)
         self.numpoints = len(_vals)
         self.dof = _dof
         self.qval = _qval
@@ -312,44 +318,50 @@ class FitResults(NoNewAttributesAfterInit):
         txt : str
             A multi-line representation of the fit results.
         """
-        s = ''
+        out = []
         if self.datasets is not None:
             if len(self.datasets) == 1:
-                s = 'Dataset               = %s\n' % str(self.datasets[0])
+                out.append(f'Dataset               = {self.datasets[0]}')
             else:
-                s = 'Datasets              = %s\n' % str(
-                    self.datasets).strip("()")
-        if self.itermethodname is not None and self.itermethodname != 'none':
-            s += 'Iterative Fit Method  = %s\n' % self.itermethodname.capitalize()
-        s += 'Method                = %s\n' % self.methodname
-        s += 'Statistic             = %s\n' % self.statname
-        s += 'Initial fit statistic = %g\n' % self.istatval
-        s += 'Final fit statistic   = %g' % self.statval
-        if self.nfev is not None:
-            s += ' at function evaluation %d' % self.nfev
+                out.append(f'Datasets              = {self.datasets}')
 
-        s += '\nData points           = %g' % self.numpoints
-        s += '\nDegrees of freedom    = %g' % self.dof
+        if self.itermethodname is not None and self.itermethodname != 'none':
+            out.append(f'Iterative Fit Method  = {self.itermethodname.capitalize()}')
+
+        out.extend([f'Method                = {self.methodname}',
+                    f'Statistic             = {self.statname}',
+                    f'Initial fit statistic = {self.istatval:g}'])
+
+        outstr = f'Final fit statistic   = {self.statval:g}'
+        if self.nfev is not None:
+            outstr += f' at function evaluation {self.nfev}'
+
+        out.extend([outstr,
+                    f'Data points           = {self.numpoints:g}',
+                    f'Degrees of freedom    = {self.dof:g}'])
 
         if self.qval is not None:
-            s += '\nProbability [Q-value] = %g' % self.qval
+            out.append(f'Probability [Q-value] = {self.qval:g}')
+
         if self.rstat is not None:
-            s += '\nReduced statistic     = %g' % self.rstat
-        s += '\nChange in statistic   = %g' % self.dstatval
+            out.append(f'Reduced statistic     = {self.rstat:g}')
+
+        out.append(f'Change in statistic   = {self.dstatval:g}')
 
         if self.covar is None:
-            for name, val in zip(self.parnames, self.parvals):
-                s += '\n   %-12s   %-12g' % (name, val)
+            out.extend(f'   {name:<12s}   {val:<12g}'
+                       for name, val in zip(self.parnames, self.parvals))
         else:
             covar_err = sqrt(self.covar.diagonal())
-            for name, val, covarerr in zip(self.parnames, self.parvals,
-                                           covar_err):
-                s += '\n   %-12s   %-12g +/- %-12g' % (name, val, covarerr)
+            out.extend(f'   {name:<12s}   {val:<12g} +/- {covarerr:<12g}'
+                       for name, val, covarerr in zip(self.parnames,
+                                                      self.parvals,
+                                                      covar_err))
 
         if self.param_warnings != "":
-            s += "\n" + self.param_warnings
+            out.append(self.param_warnings)
 
-        return s
+        return "\n".join(out)
 
 
 class ErrorEstResults(NoNewAttributesAfterInit):
@@ -401,11 +413,10 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         if parlist is None:
             parlist = [p for p in fit.model.pars if not p.frozen]
 
+        # TODO: Can we not just import them at the top level?
         from sherpa.estmethods import est_hardmin, est_hardmax, \
             est_hardminmax
 
-        warning_hmin = "hard minimum hit for parameter "
-        warning_hmax = "hard maximum hit for parameter "
         self.datasets = None  # To be set by calling function
         self.methodname = type(fit.estmethod).__name__.lower()
         self.iterfitname = fit._iterfit.itermethod_opts['name']
@@ -423,14 +434,14 @@ class ErrorEstResults(NoNewAttributesAfterInit):
             if (results[2][i] == est_hardmin or
                     results[2][i] == est_hardminmax):
                 self.parmins = self.parmins + (None,)
-                warning(warning_hmin + self.parnames[i])
+                warning("hard minimum hit for parameter %s", self.parnames[i])
             else:
                 self.parmins = self.parmins + (results[0][i],)
 
             if (results[2][i] == est_hardmax or
                     results[2][i] == est_hardminmax):
                 self.parmaxes = self.parmaxes + (None,)
-                warning(warning_hmax + self.parnames[i])
+                warning("hard maximum hit for parameter %s", self.parnames[i])
             else:
                 self.parmaxes = self.parmaxes + (results[1][i],)
 
@@ -446,7 +457,7 @@ class ErrorEstResults(NoNewAttributesAfterInit):
             self.__dict__['iterfitname'] = 'none'
 
     def __repr__(self):
-        return '<%s results instance>' % self.methodname
+        return f'<{self.methodname} results instance>'
 
     def __str__(self):
         return print_fields(self._fields, vars(self))
@@ -463,46 +474,47 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         txt : str
             A multi-line representation of the error estimates.
         """
-        s = ""
+
+        out = []
         if self.datasets is not None:
             if len(self.datasets) == 1:
-                s = 'Dataset               = %s\n' % str(self.datasets[0])
+                out.append(f'Dataset               = {self.datasets[0]}')
             else:
-                s = 'Datasets              = %s\n' % str(
-                    self.datasets).strip("()")
-        s += 'Confidence Method     = %s\n' % self.methodname
+                out.append(f'Datasets              = {self.datasets}')
+
+        out.append(f'Confidence Method     = {self.methodname}')
+
         if self.iterfitname is not None or self.iterfitname != 'none':
-            s += 'Iterative Fit Method  = %s\n' % self.iterfitname.capitalize()
-        s += 'Fitting Method        = %s\n' % self.fitname
-        s += 'Statistic             = %s\n' % self.statname
+            out.append(f'Iterative Fit Method  = {self.iterfitname.capitalize()}')
 
-        s += "%s %g-sigma (%2g%%) bounds:" % (self.methodname, self.sigma,
-                                              self.percent)
+        out.extend([f'Fitting Method        = {self.fitname}',
+                    f'Statistic             = {self.statname}',
+                    f"{self.methodname} {self.sigma:g}-sigma ({self.percent:2g}%) bounds:"])
 
-        def myformat(hfmt, str, lowstr, lownum, highstr, highnum):
-            str += hfmt % ('Param', 'Best-Fit', 'Lower Bound', 'Upper Bound')
-            str += hfmt % ('-' * 5, '-' * 8, '-' * 11, '-' * 11)
+        def myformat(hfmt, lowstr, lownum, highstr, highnum):
+            out = hfmt % ('Param', 'Best-Fit', 'Lower Bound', 'Upper Bound')
+            out += hfmt % ('-' * 5, '-' * 8, '-' * 11, '-' * 11)
 
             for name, val, lower, upper in zip(self.parnames, self.parvals,
                                                self.parmins, self.parmaxes):
 
-                str += '\n   %-12s %12g ' % (name, val)
+                out += f'\n   {name:<12s} {val:12g} '
                 if is_iterable(lower):
-                    str += ' '
-                    str += list_to_open_interval(lower)
+                    out += ' '
+                    out += list_to_open_interval(lower)
                 elif lower is None:
-                    str += lowstr % '-----'
+                    out += lowstr % '-----'
                 else:
-                    str += lownum % lower
+                    out += lownum % lower
                 if is_iterable(upper):
-                    str += '  '
-                    str += list_to_open_interval(upper)
+                    out += '  '
+                    out += list_to_open_interval(upper)
                 elif upper is None:
-                    str += highstr % '-----'
+                    out += highstr % '-----'
                 else:
-                    str += highnum % upper
+                    out += highnum % upper
 
-            return str
+            return out
 
         low = map(is_iterable, self.parmins)
         high = map(is_iterable, self.parmaxes)
@@ -534,7 +546,7 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         else:
             hfmt = '\n   %-12s %12s %12s %12s'
 
-        return myformat(hfmt, s, lowstr, lownum, highstr, highnum)
+        return "\n".join(out) + myformat(hfmt, lowstr, lownum, highstr, highnum)
 
 
 class IterFit(NoNewAttributesAfterInit):
@@ -542,6 +554,7 @@ class IterFit(NoNewAttributesAfterInit):
     def __init__(self, data, model, stat, method, itermethod_opts=None):
         if itermethod_opts is None:
             itermethod_opts = {'name': 'none'}
+
         # Even if there is only a single data set, I will
         # want to treat the data and models I am given as
         # collections of data and models -- so, put data and
@@ -550,9 +563,11 @@ class IterFit(NoNewAttributesAfterInit):
         self.data = data
         if type(data) is not DataSimulFit:
             self.data = DataSimulFit('simulfit data', (data,))
+
         self.model = model
         if type(model) is not SimulFitModel:
             self.model = SimulFitModel('simulfit model', (model,))
+
         self.stat = stat
         self.method = method
         # Data set attributes needed to store fitting values between
@@ -571,6 +586,9 @@ class IterFit(NoNewAttributesAfterInit):
         if itermethod_opts['name'] != 'none':
             self.current_func = self.funcs[itermethod_opts['name']]
             self.iterate = True
+
+        # TODO: should this call
+        # NoNewAttributesAfterInit.__init__(self)
 
     # SIGINT (i.e., typing ctrl-C) can dump the user to the Unix prompt,
     # when signal is sent from G95 compiled code.  What we want is to
@@ -599,10 +617,11 @@ class IterFit(NoNewAttributesAfterInit):
         if outfile is not None:
             if not clobber and os.path.isfile(outfile):
                 raise FitErr('noclobererr', outfile)
-            self._file = open(outfile, 'w')
+
             names = ['# nfev statistic']
-            names.extend(['%s' % par.fullname for par in self.model.pars
-                          if not par.frozen])
+            names.extend(f'{par.fullname}' for par in self.model.pars
+                         if not par.frozen)
+            self._file = open(outfile, 'w', encoding="ascii")
             print(' '.join(names), file=self._file)
 
         def cb(pars):
@@ -613,15 +632,14 @@ class IterFit(NoNewAttributesAfterInit):
             stat = self.stat.calc_stat(self.data, self.model)
 
             if self._file is not None:
-                vals = ['%5e %5e' % (self._nfev, stat[0])]
-                vals.extend(['%5e' % val for val in self.model.thawedpars])
+                vals = [f'{self._nfev:5e} {stat[0]:5e}']
+                vals.extend([f'{val:5e}' for val in self.model.thawedpars])
                 print(' '.join(vals), file=self._file)
 
             self._nfev += 1
             return stat
 
         return cb
-
 
     def sigmarej(self, statfunc, pars, parmins, parmaxes, statargs=(),
                  statkwargs=None, cache=True):
@@ -665,13 +683,13 @@ class IterFit(NoNewAttributesAfterInit):
         """
         if statkwargs is None:
             statkwargs = {}
+
         # Sigma-rejection can only be used with chi-squared;
         # raise exception if it is attempted with least-squares,
-        # or maximum likelihood
-        if (isinstance(self.stat, Chi2) and
+        # or maximum likelihood.
+        #
+        if not (isinstance(self.stat, Chi2) and
                 type(self.stat) is not LeastSq):
-            pass
-        else:
             raise FitErr('needchi2', 'Sigma-rejection')
 
         # Get maximum number of allowed iterations, high and low
@@ -770,9 +788,7 @@ class IterFit(NoNewAttributesAfterInit):
                             break
                         if residuals[i] <= -lrej or residuals[i] >= hrej:
                             rejected = True
-                            kmin = j - grow
-                            if kmin < 0:
-                                kmin = 0
+                            kmin = max(j - grow, 0)
                             kmax = j + grow
                             if kmax >= filsize:
                                 kmax = filsize - 1
@@ -783,7 +799,7 @@ class IterFit(NoNewAttributesAfterInit):
                         # If we've masked out *all* data,
                         # immediately raise fit error, clean up
                         # on way out.
-                        if not(any(newmask)):
+                        if not np.any(newmask):
                             raise FitErr('nobins')
                         d.mask = newmask
 
@@ -837,14 +853,16 @@ class IterFit(NoNewAttributesAfterInit):
 
     def fit(self, statfunc, pars, parmins, parmaxes,
             statargs=(), statkwargs=None):
+
         if statkwargs is None:
             statkwargs = {}
+
         if not self.iterate:
             return self.method.fit(statfunc, pars, parmins, parmaxes,
                                    statargs, statkwargs)
-        else:
-            return self.current_func(statfunc, pars, parmins, parmaxes,
-                                     statargs, statkwargs)
+
+        return self.current_func(statfunc, pars, parmins, parmaxes,
+                                 statargs, statkwargs)
 
 
 class Fit(NoNewAttributesAfterInit):
@@ -922,8 +940,8 @@ class Fit(NoNewAttributesAfterInit):
 
     def calc_thaw_indices(self):
         self.thaw_indices = \
-            tuple([i for i, par in enumerate(self.model.pars)
-                   if not par.frozen])
+            tuple(i for i, par in enumerate(self.model.pars)
+                  if not par.frozen)
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -934,16 +952,12 @@ class Fit(NoNewAttributesAfterInit):
                                                 {'name': 'none'})
 
     def __str__(self):
-        return (('data      = %s\n' +
-                 'model     = %s\n' +
-                 'stat      = %s\n' +
-                 'method    = %s\n' +
-                 'estmethod = %s') %
-                (self.data.name,
-                 self.model.name,
-                 type(self.stat).__name__,
-                 type(self.method).__name__,
-                 type(self.estmethod).__name__))
+        out = [f'data      = {self.data.name}',
+               f'model     = {self.model.name}',
+               f'stat      = {type(self.stat).__name__}',
+               f'method    = {type(self.method).__name__}',
+               f'estmethod = {type(self.estmethod).__name__}']
+        return "\n".join(out)
 
     def guess(self, **kwargs):
         """Guess parameter values and limits.
@@ -1047,6 +1061,8 @@ class Fit(NoNewAttributesAfterInit):
         return StatInfoResults(name, statval, numpoints, model,
                                dof, qval, rstat)
 
+    # TODO: the numcores argument is currently unused.
+    #
     @evaluates_model
     def fit(self, outfile=None, clobber=False, numcores=1):
         """Fit the model to the data.
@@ -1123,15 +1139,13 @@ class Fit(NoNewAttributesAfterInit):
         for par in self.model.pars:
             if not par.frozen:
                 if sao_fcmp(par.val, par.min, tol) == 0:
-                    param_warnings += ("WARNING: parameter value %s is at its minimum boundary %s\n" %
-                                       (par.fullname, str(par.min)))
+                    param_warnings += f"WARNING: parameter value {par.fullname} is at its minimum boundary {par.min}\n"
                 if sao_fcmp(par.val, par.max, tol) == 0:
-                    param_warnings += ("WARNING: parameter value %s is at its maximum boundary %s\n" %
-                                       (par.fullname, str(par.max)))
+                    param_warnings += f"WARNING: parameter value {par.fullname} is at its maximum boundary {par.max}\n"
 
         if self._iterfit._file is not None:
-            vals = ['%5e %5e' % (self._iterfit._nfev, tmp[2])]
-            vals.extend(['%5e' % val for val in self.model.thawedpars])
+            vals = [f'{self._iterfit._nfev:5e}', f'{tmp[2]:5e}']
+            vals.extend([f'{val:5e}' for val in self.model.thawedpars])
             print(' '.join(vals), file=self._iterfit._file)
             self._iterfit._file.close()
             self._iterfit._file = None
@@ -1249,10 +1263,10 @@ class Fit(NoNewAttributesAfterInit):
 
         def thaw_par(i):
             if i < 0:
-                pass
-            else:
-                self.model.pars[self.thaw_indices[i]].frozen = False
-                self.current_frozen = -1
+                return
+
+            self.model.pars[self.thaw_indices[i]].frozen = False
+            self.current_frozen = -1
 
         # confidence needs to know which parameter it is working on.
         def get_par_name(ii):
@@ -1262,17 +1276,17 @@ class Fit(NoNewAttributesAfterInit):
         # that limits for a given parameter have been found
         def report_progress(i, lower, upper):
             if i < 0:
-                pass
+                return
+
+            name = self.model.pars[self.thaw_indices[i]].fullname
+            if isnan(lower) or isinf(lower):
+                info("%s \tlower bound: -----", name)
             else:
-                name = self.model.pars[self.thaw_indices[i]].fullname
-                if isnan(lower) or isinf(lower):
-                    info("%s \tlower bound: -----" % name)
-                else:
-                    info("%s \tlower bound: %g" % (name, lower))
-                if isnan(upper) or isinf(upper):
-                    info("%s \tupper bound: -----" % name)
-                else:
-                    info("%s \tupper bound: %g" % (name, upper))
+                info("%s \tlower bound: %g", name, lower)
+            if isnan(upper) or isinf(upper):
+                info("%s \tupper bound: -----", name)
+            else:
+                info("%s \tupper bound: %g", name, upper)
 
         # If starting fit statistic is chi-squared or C-stat,
         # can calculate reduced fit statistic -- if it is
@@ -1313,8 +1327,8 @@ class Fit(NoNewAttributesAfterInit):
         if (type(self.estmethod) is not Covariance and
                 type(self.method) is not NelderMead and
                 type(self.method) is not LevMar):
-            warning(self.method.name + " is inappropriate for confidence " +
-                    "limit estimation")
+            warning("%s is inappropriate for confidence limit estimation",
+                    self.method.name)
 
         oldmethod = self.method
         if (hasattr(self.estmethod, "fast") and
@@ -1323,13 +1337,13 @@ class Fit(NoNewAttributesAfterInit):
             if isinstance(self.stat, Likelihood):
                 if type(self.method) is not NelderMead:
                     self.method = methoddict['neldermead']
-                    warning("Setting optimization to " + self.method.name
-                            + " for confidence limit search")
+                    warning("Setting optimization to %s "
+                            "for confidence limit search", self.method.name)
             else:
                 if type(self.method) is not LevMar:
                     self.method = methoddict['levmar']
-                    warning("Setting optimization to " + self.method.name
-                            + " for confidence limit search")
+                    warning("Setting optimization to %s "
+                            "for confidence limit search", self.method.name)
 
         # Now, set up before we call the confidence limit function
         # Keep track of starting values, will need to set parameters
@@ -1403,7 +1417,7 @@ class Fit(NoNewAttributesAfterInit):
             # If maximum number of refits has occurred, don't
             # try to reminimize again.
             if (hasattr(self.estmethod, "maxfits") and
-                    not(self.refits < self.estmethod.maxfits - 1)):
+                    not self.refits < (self.estmethod.maxfits - 1)):
                 self.refits = 0
                 thaw_par(self.current_frozen)
                 self.model.thawedpars = startpars
@@ -1420,16 +1434,16 @@ class Fit(NoNewAttributesAfterInit):
                 p.frozen = False
             self.current_frozen = -1
 
-            if e.args != ():
+            if e.args:
                 self.model.thawedpars = e.args[0]
 
             self.model.thawedparmins = startsoftmins
             self.model.thawedparmaxes = startsoftmaxs
             results = self.fit()
             self.refits = self.refits + 1
-            warning("New minimum statistic found while computing " +
+            warning("New minimum statistic found while computing "
                     "confidence limits")
-            warning("New best-fit parameters:\n" + results.format())
+            warning("New best-fit parameters:\n%s", results.format())
 
             # Now, recompute errors for new best-fit parameters
             results = self.est_errors(methoddict, parlist)
@@ -1491,11 +1505,11 @@ def html_fitresults(fit):
     if has_covar:
         for pname, pval, perr in zip(fit.parnames, fit.parvals,
                                      sqrt(fit.covar.diagonal())):
-            rows.append((pname, '{:12g}'.format(pval),
-                         '&#177; {:12g}'.format(perr)))
+            rows.append((pname, f'{pval:12g}',
+                         f'&#177; {perr:12g}'))
     else:
         for pname, pval in zip(fit.parnames, fit.parvals):
-            rows.append((pname, '{:12g}'.format(pval)))
+            rows.append((pname, f'{pval:12g}'))
 
     out = formatting.html_table(header, rows, classname='fit',
                                 rowcount=False,
@@ -1538,7 +1552,7 @@ def html_fitresults(fit):
     for lbl, field, is_float in rows:
         val = getattr(fit, field)
         if is_float:
-            val = '{:g}'.format(val)
+            val = f'{val:g}'
 
         meta.append((lbl, val))
 
@@ -1567,18 +1581,17 @@ def html_errresults(errs):
 
         if limit is None:
             return '-----'
-        elif is_iterable(limit):
+
+        if is_iterable(limit):
             return list_to_open_interval(limit)
-        else:
-            return '{:12g}'.format(limit)
+
+        return f'{limit:12g}'
 
     for pname, pval, pmin, pmax in zip(errs.parnames, errs.parvals, errs.parmins, errs.parmaxes):
-        rows.append((pname, '{:12g}'.format(pval),
+        rows.append((pname, f'{pval:12g}',
                      display(pmin), display(pmax)))
 
-    summary = '{} {:g}&#963; ({:2g}%)'.format(errs.methodname,
-                                              errs.sigma,
-                                              errs.percent)
+    summary = f'{errs.methodname} {errs.sigma:g}&#963; ({errs.percent:2g}%)'
     summary += ' bounds'
 
     out = formatting.html_table(header, rows,
@@ -1661,7 +1674,7 @@ def html_statinfo(stats):
     for lbl, field, is_float in rows:
         val = getattr(stats, field)
         if is_float:
-            val = '{:g}'.format(val)
+            val = f'{val:g}'
 
         meta.append((lbl, val))
 

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1429,7 +1429,7 @@ class Fit(NoNewAttributesAfterInit):
             # If maximum number of refits has occurred, don't
             # try to reminimize again.
             if (hasattr(self.estmethod, "maxfits") and
-                    not self.refits < (self.estmethod.maxfits - 1)):
+                    not (self.refits < (self.estmethod.maxfits - 1))):
                 self.refits = 0
                 thaw_par(self.current_frozen)
                 self.model.thawedpars = startpars

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -291,7 +291,7 @@ class FitResults(NoNewAttributesAfterInit):
         if 'itermethodname' not in state:
             self.__dict__['itermethodname'] = 'none'
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.succeeded
 
     def __repr__(self):

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2879,7 +2879,6 @@ def test_fit_results_bool_true():
     assert fres
 
 
-@pytest.mark.xfail
 def test_fit_results_bool_false():
     """Just check we so call bool() on a fit results instance
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2866,6 +2866,65 @@ def test_fit_results_str():
                "nfev           = 9"])
 
 
+def test_fit_itermethod_requires_name():
+    """Just check we error out gracefully.
+
+    This is a corner case.
+    """
+
+    data = make_data(Data1D)
+    model = Const1D()
+    with pytest.raises(ValueError,
+                       match="^Missing name field in itermethod_opts argument$"):
+        Fit(data, model, itermethod_opts={"grow": 2})
+
+
+def test_fit_itermethod_requires_known_name():
+    """Just check we error out gracefully.
+
+    This is a corner case.
+    """
+
+    data = make_data(Data1D)
+    model = Const1D()
+    with pytest.raises(ValueError,
+                       match="^not-a-name is not an iterative fitting method$"):
+        Fit(data, model, itermethod_opts={"name": "not-a-name", "grow": 2})
+
+
+def test_fit_results_with_iteration_str():
+    """Just check we so call str() on a fit results instance with an iteration method
+
+    We have not picked a dataset where the
+    """
+
+    data = Data1D("x", [1, 2, 3, 4, 5], [2, 4, 12, 3, 4])
+    data.staterror = [0.8] * 5
+    model = Const1D()
+    iter_opts = {'name': 'sigmarej', 'maxiters': 5, 'hrej': 5, 'lrej': 5, 'grow': 0}
+    fit = Fit(data, model, stat=Chi2(), itermethod_opts=iter_opts)
+    fres = fit.fit()
+    assert fres.succeeded
+
+    check_str(fres,
+              ["datasets       = None",
+               "itermethodname = sigmarej",
+               "methodname     = levmar",
+               "statname       = chi2",
+               "succeeded      = True",
+               "parnames       = ('const1d.c0',)",
+               "parvals        = (3.250000000000316,)",
+               "statval        = 4.296875",
+               "istatval       = 225.0",
+               "dstatval       = 220.703125",
+               "numpoints      = 4",
+               "dof            = 3",
+               "qval           = 0.23114006377865534",
+               "rstat          = 1.4322916666666667",
+               "message        = successful termination",
+               "nfev           = 8"])
+
+
 def test_fit_results_bool_true():
     """Just check we so call bool() on a fit results instance"""
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2839,7 +2839,7 @@ def check_str(out, expecteds):
 
 
 def test_fit_results_str():
-    """Just check we so call str() on a fit results instance"""
+    """Just check we can call str() on a fit results instance"""
 
     data = make_data(Data1D)
     model = Const1D()
@@ -2893,9 +2893,7 @@ def test_fit_itermethod_requires_known_name():
 
 
 def test_fit_results_with_iteration_str():
-    """Just check we so call str() on a fit results instance with an iteration method
-
-    We have not picked a dataset where the
+    """Just check we can call str() on a fit results instance with an iteration method
     """
 
     data = Data1D("x", [1, 2, 3, 4, 5], [2, 4, 12, 3, 4])
@@ -2926,7 +2924,7 @@ def test_fit_results_with_iteration_str():
 
 
 def test_fit_results_bool_true():
-    """Just check we so call bool() on a fit results instance"""
+    """Just check we can call bool() on a fit results instance"""
 
     # This is the same test as test_fit_results_str which explicitly
     # checks whether .succeeded passes or not.

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022
+#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -2826,3 +2826,194 @@ def test_fit_ensures_data_and_model_dimensionality_matches(data_class, ddim, mod
     with pytest.raises(DataErr,
                        match=f"Data and model dimensionality do not match: {ddim}D and {mdim}D"):
         Fit(data, model)
+
+
+def check_str(out, expecteds):
+    """Check that out, when split on a newline, matches expecteds"""
+
+    toks = str(out).split("\n")
+    for tok, expected in zip(toks, expecteds):
+        assert tok == expected
+
+    assert len(toks) == len(expecteds)
+
+
+def test_fit_results_str():
+    """Just check we so call str() on a fit results instance"""
+
+    data = make_data(Data1D)
+    model = Const1D()
+    fit = Fit(data, model, stat=Cash())
+    fres = fit.fit()
+    assert fres.succeeded
+
+    check_str(fres,
+              ["datasets       = None",
+               "itermethodname = none",
+               "methodname     = levmar",
+               "statname       = cash",
+               "succeeded      = True",
+               "parnames       = ('const1d.c0',)",
+               "parvals        = (3.33332926058462,)",
+               "statval        = -4.079456086503793",
+               "istatval       = 6.0",
+               "dstatval       = 10.079456086503793",
+               "numpoints      = 3",
+               "dof            = 2",
+               "qval           = None",
+               "rstat          = None",
+               "message        = successful termination",
+               "nfev           = 9"])
+
+
+def test_fit_results_bool_true():
+    """Just check we so call bool() on a fit results instance"""
+
+    # This is the same test as test_fit_results_str which explicitly
+    # checks whether .succeeded passes or not.
+    #
+    data = make_data(Data1D)
+    model = Const1D()
+    fit = Fit(data, model, stat=Cash())
+    fres = fit.fit()
+    assert fres
+
+
+@pytest.mark.xfail
+def test_fit_results_bool_false():
+    """Just check we so call bool() on a fit results instance
+
+    The "negation" of test_fit_results_bool_true()
+    """
+
+    data = make_data(Data1D)
+    model = Const1D()
+    fit = Fit(data, model, stat=Cash())
+    fres = fit.fit()
+
+    # Hacky way to test falsiness
+    fres.succeeded = False
+    assert not fres
+
+
+def test_fit_simulfit_single():
+    """Basic test of simulfit.
+
+    It's not obvious this functionality is used.
+    """
+
+    data = make_data(Data1D)
+    model = Const1D()
+    fit = Fit(data, model, stat=Cash())
+
+    # This just calls fit.fit() which is what test_fit_results_str
+    # does/checks.
+    #
+    fres = fit.simulfit()
+    assert fres
+    assert fres.parvals == pytest.approx([3.3333292605846])
+
+
+def test_fit_simulfit_multiple_models():
+    """Basic test of simulfit.
+
+    It's not obvious this functionality is used.
+    """
+
+    data1 = make_data(Data1D)
+    model1 = Const1D("m1")
+    fit1 = Fit(data1, model1, stat=Cash())
+
+    # Duplicate the data but shifted by one, so fitting the same
+    # model type (but a separate model) will get two parameter
+    # values returned.
+    #
+    data2 = make_data(Data1D)
+    data2.set_dep(data2.get_dep() + 1)
+    model2 = Const1D("m2")
+    fit2 = Fit(data2, model2, stat=Cash())
+
+    # This just calls fit.fit() which is what test_fit_results_str
+    # does/checks.
+    #
+    fres = fit1.simulfit(fit2)
+    assert fres
+    v0 = 3.3333292605846
+    assert fres.parnames == ("m1.c0", "m2.c0")
+    assert fres.parvals == pytest.approx([v0, v0 + 1])
+
+
+def test_fit_simulfit_multiple_single_model():
+    """Basic test of simulfit.
+
+    Like test_fit_simulfit_multiple_models but fit the same
+    model to the two "shifted" datasets.
+
+    """
+
+    data1 = make_data(Data1D)
+    model1 = Const1D("mx")
+    fit1 = Fit(data1, model1, stat=Cash())
+
+    # Duplicate the data but shifted by one.
+    #
+    data2 = make_data(Data1D)
+    data2.set_dep(data2.get_dep() + 1)
+    fit2 = Fit(data2, model1, stat=Cash())
+
+    # This just calls fit.fit() which is what test_fit_results_str
+    # does/checks.
+    #
+    fres = fit1.simulfit(fit2)
+    assert fres.parnames == ("mx.c0", )
+    assert fres.parvals == pytest.approx([3.8333336041446615])
+
+
+def test_esterrorresults_str():
+    """Basic check of str call."""
+
+    data = make_data(Data1D)
+    mdl = Const1D("mx")
+    fit = Fit(data, mdl, stat=Cash())
+    fit.fit()
+
+    errs = fit.est_errors()
+    check_str(errs,
+              ["datasets    = None",
+               "methodname  = covariance",
+               "iterfitname = none",
+               "fitname     = levmar",
+               "statname    = cash",
+               "sigma       = 1",
+               "percent     = 68.26894921370858",
+               "parnames    = ('mx.c0',)",
+               "parvals     = (3.33332926058462,)",
+               "parmins     = (-1.0524866849982824,)",
+               "parmaxes    = (1.0524866849982824,)",
+               "nfits       = 0"])
+
+
+def test_fit_outfile_simple_check(tmp_path):
+
+    outfile = tmp_path / "sherpa.save"
+
+    data = make_data(Data1D)
+    mdl = Const1D("mx")
+    fit = Fit(data, mdl, stat=Cash())
+    fit.fit(outfile=outfile)
+
+    out = outfile.read_text()
+    check_str(out,
+              ["# nfev statistic mx.c0",
+               "0.000000e+00 6.000000e+00 1.000000e+00",
+               "1.000000e+00 6.000000e+00 1.000000e+00",
+               "2.000000e+00 5.995167e+00 1.000345e+00",
+               "3.000000e+00 -3.230695e+00 2.454143e+00",
+               "4.000000e+00 -3.232515e+00 2.454991e+00",
+               "5.000000e+00 -4.073187e+00 3.250567e+00",
+               "6.000000e+00 -4.073357e+00 3.251690e+00",
+               "7.000000e+00 -4.079456e+00 3.333285e+00",
+               "8.000000e+00 -4.079455e+00 3.334435e+00",
+               "9.000000e+00 -4.079456e+00 3.333329e+00",
+               "1.000000e+01 -4.079456e+00 3.333329e+00",
+               ""])


### PR DESCRIPTION
# Summary

Internal clean up of the fit code to replace a Python 2 method with a Python 3 version and to use f-strings.

# Details

This is clean-up code which I've pulled out of #1735

- added some corner cases for the fit module (based on reviewing the un-tested code reported in #1735); basically whether the string output of various classes is explicitly checked, but also the "save-each-iteration" part of the fit call
  - it's a bit worrying here as the numbers we test against could depend on platform (e.g Intel vs ARM vs ...) but let's just see how they work with the current CI tests
- one test is whether the `Fit` object can be used in a boolean context
- the reason why we care about the boolean-ness of `Fit` is because we had been using the `__nonzero__` dunder method, but this appears to have been a Python-2 ism, so let's use the modern dunder method `__bool__`. Alternatively, we could just remove it as I'm not convinced people are using it, but as it is not a lot of code, I think we should keep it to avoid the possibility of breaking code (I couldn't actually find much,if anything, on the nonzero dunder method, so there is an argument to just remove it, and you do note that the boolean-ness of Fit is changed by this work)
- I've changed a number of routines to use f strings (there's still some use of the old style "format % vals" approach, but that's because it's building strings to then build later strings, and so it's just not worth touching this at the moment), and to build up a list of strings which we can then concatenate rather than lot's of `str += ...` lines, where it's easy to miss lines (and technically faster but I know Python has spent a lot of effort on making a + b + .. + z to be fast, so I don't expect any actual difference, and this is not performance-sensitive code anyway)
  - there's a few other code-style changes here
- I then add a case to check the fit results when called with an itermethod (as code coverage showed it wasn't covered) and this lead to a few small code improvements to catch error cases

Here's a note on the `__nonzero__` to `__bool__` change: https://portingguide.readthedocs.io/en/latest/core-obj-misc.html#customizing-truthiness-bool