### PR TITLE
Tweak resample data code

### DIFF
--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -831,7 +831,7 @@ class ReSampleData(NoNewAttributesAfterInit):
 
         # Should this error out if data is an instance of Data1DInt?
         if data.ndim != 1:
-            msg = f"{ReSampleData.__name__} {type(data)}"
+            msg = f"{ReSampleData.__name__} is only implemented for 1D data, got {type(data)} instead."
             raise NotImplementedError(msg)
 
         self.data = data

--- a/sherpa/sim/tests/test_asymmetric.py
+++ b/sherpa/sim/tests/test_asymmetric.py
@@ -35,6 +35,7 @@ from sherpa.sim import ReSampleData
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.astro import ui
 
+
 RESULTS_BENCH_AVG = {
     'rstat': 1.4361549916463103,
     'qval': 0.015715747140941,
@@ -287,13 +288,11 @@ def test_resample_supports_data1d(caplog, reset_seed):
     assert msg == "mdl.c0 : avg = 1.0343987745935705 , std = 0.5208696279243179"
 
 
-def test_resample_fails_unsupported_data(reset_seed):
+def test_resample_fails_unsupported_data():
 
     orig = Data2D("orig", [1, 2, 3], [1, 1, 2], [4, 3, 2])
     model = Const2D("mdl")
 
-    # This does not error out well at the moment.
-    resampler = ReSampleData(orig, model)
-    with pytest.raises(AttributeError,
-                       match="^'Data2D' object has no attribute 'x'$"):
-        resampler(niter=10, seed=123)
+    with pytest.raises(NotImplementedError,
+                       match="^ReSampleData <class 'sherpa.data.Data2D'>$"):
+        ReSampleData(orig, model)

--- a/sherpa/sim/tests/test_asymmetric.py
+++ b/sherpa/sim/tests/test_asymmetric.py
@@ -294,5 +294,5 @@ def test_resample_fails_unsupported_data():
     model = Const2D("mdl")
 
     with pytest.raises(NotImplementedError,
-                       match="^ReSampleData <class 'sherpa.data.Data2D'>$"):
+                       match="^ReSampleData is only implemented for 1D data, got <class 'sherpa.data.Data2D'> instead.$"):
         ReSampleData(orig, model)


### PR DESCRIPTION
# Summary

Internal changes to the ReSampleData class to better handle invalid input.

# Details

This is clean-up code which I've pulled out of https://github.com/sherpa/sherpa/pull/1735. PR #1777 relies on this PR.

In trying to add checks to improve coverage, I realised that the code - which was meant to report an error if ReSampleData was called with an invalid data object - did not actualy work, since it basically required there to be a y attribute, which is not guaranteed for non-1D data types. So, I've moved the check to earlier, taking advantage of the ndim field I recently-ish added (in #1477), rather than check on the data class (I added an earlier commit with a test of this functionality).
    
Should this class warn or error out if given a DataPHA or Data1DInt object? Alternatively, the code could be enhanced to properly handle this (but that is hard for the PHA case as we need to worry about the response).
