### PR TITLE
Internal clean up of estmethods

### DIFF
--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -741,10 +741,7 @@ class ConfRootBracket(ConfRootNone):
                     warn_user_about_open_interval([xa, xb])
                     return (xa + xb) / 2.0
 
-                if xa < xb:
-                    return (xa, xb)
-
-                return (xb, xa)
+                return min(xa, xb), max(xa, xb)
 
             return None
 

--- a/sherpa/estmethods/tests/test_estmethods.py
+++ b/sherpa/estmethods/tests/test_estmethods.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2018, 2021
+#  Copyright (C) 2007, 2018, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -18,11 +18,13 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import re
+
 import numpy
 
 import pytest
 
-from sherpa.estmethods import Covariance, Projection
+from sherpa.estmethods import Confidence, Covariance, Projection
 
 
 # Test data arrays -- together this makes a line best fit with a
@@ -209,3 +211,84 @@ def test_projection(parallel):
     #
     assert results[0] == pytest.approx(standard_elo)
     assert results[1] == pytest.approx(standard_ehi)
+
+
+@pytest.mark.parametrize("cls,name",
+                         [(Covariance, "Covariance"),
+                          (Confidence, "Confidence"),
+                          (Projection, "Projection")])
+def test_estmethod_repr(cls, name):
+    """Simple check"""
+    m = cls()
+    assert repr(m) == f"<{name} error-estimation method instance '{name.lower()}'>"
+
+
+def check_output(out, expecteds):
+    """Check out (str) matches expecteds after splitting newlines
+
+    There's a special check for the numcores line, as the answer
+    depends on the number of cores present, so we drop that part
+    of the check.
+
+    """
+    toks = out.split("\n")
+    for tok, expected in zip(toks, expecteds):
+
+        if expected is None:
+            assert re.match(r"^numcores     ?= \d+$", tok)
+        else:
+            assert tok == expected
+
+    assert len(toks) == len(expecteds)
+
+
+def test_estmethod_str_covariance():
+    """Simple check."""
+    m = Covariance()
+    check_output(str(m),
+                 ["name        = covariance",
+                  "sigma       = 1",
+                  "eps         = 0.01",
+                  "maxiters    = 200",
+                  "soft_limits = False"])
+
+
+def test_estmethod_str_confidence():
+    """Simple check."""
+    m = Confidence()
+    check_output(str(m),
+                 ["name         = confidence",
+                  "sigma        = 1",
+                  "eps          = 0.01",
+                  "maxiters     = 200",
+                  "soft_limits  = False",
+                  "remin        = 0.01",
+                  "fast         = False",
+                  "parallel     = True",
+                  None,  # special-case numcores line
+                  "maxfits      = 5",
+                  "max_rstat    = 3",
+                  "tol          = 0.2",
+                  "verbose      = False",
+                  "openinterval = False"
+                  ])
+
+
+def test_estmethod_str_projection():
+    """Simple check."""
+    m = Projection()
+    print(str(m))
+    check_output(str(m),
+                 ["name        = projection",
+                  "sigma       = 1",
+                  "eps         = 0.01",
+                  "maxiters    = 200",
+                  "soft_limits = False",
+                  "remin       = 0.01",
+                  "fast        = False",
+                  "parallel    = True",
+                  None,  # special-case numcores line
+                  "maxfits     = 5",
+                  "max_rstat   = 3",
+                  "tol         = 0.2"
+                  ])

--- a/sherpa/estmethods/tests/test_estmethods.py
+++ b/sherpa/estmethods/tests/test_estmethods.py
@@ -277,7 +277,6 @@ def test_estmethod_str_confidence():
 def test_estmethod_str_projection():
     """Simple check."""
     m = Projection()
-    print(str(m))
     check_output(str(m),
                  ["name        = projection",
                   "sigma       = 1",


### PR DESCRIPTION
# Summary

Code clean up of sherpa.estmethods.

# Details

This is clean-up code which I've pulled out of https://github.com/sherpa/sherpa/pull/1735

These changes are driven by pylint, and involve the following, but note [*]

- use of f-strings (although there are plenty of strings that could be converted, the test coverage of these other lines is poor [*] so I don't want to make changes that could break things)
- using modern Python idioms, like
  - do not create a `__init__` call that just calls the superclass
  - do not have `if/elif/.../else` chains when each branch ends in a return or an exception
  - "re-raise" exceptions via "from" to make tracebacks cleaner
  - avoid un-needed brackets
  - use things like "min(xs, val)" and "a < 23" to avoid a "if/then" call
- I have also removed some `__str__` and `__repr__` mehods that were only ever really neded for development/testing (including at least one mis-spelled `__rep__` case)

There's a lot more changes that could be made - this code appears to be written in a Java/C++ style and so uses names like `dir` and `iter` that shadow existing functionality - but I do not want to make the changes too extensive at this time (as I don't plan to be changing this code anytime soon, if ever).

There are some changes that could be made but they will be made either as part of #1735 or some other PR (in particular changes to the parallel code).

[*] coverage is low in part because there's a lot of code written to handle exceptional circumstances (such as finding a better fit during the error analysis, or handling of semi-open intervals, which are hard to find test cases for)