### PR TITLE
Change get_sample to require named arguments

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2019, 2020, 2021
+#  Copyright (C) 2009, 2015, 2016, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -255,10 +255,11 @@ def _sample_flux_get_samples_with_scales(fit, src, correlated, scales,
 
     if correlated:
         sampler = NormalParameterSampleFromScaleMatrix()
+        samples = sampler.get_sample(fit, mycov=scales, num=num)
     else:
         sampler = NormalParameterSampleFromScaleVector()
+        samples = sampler.get_sample(fit, myscales=scales, num=num)
 
-    samples = sampler.get_sample(fit, scales, num=num)
     clipped = sampler.clip(fit, samples, clip=clip)
     return samples, clipped
 

--- a/sherpa/astro/sim/__init__.py
+++ b/sherpa/astro/sim/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2015, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2017, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -53,12 +54,12 @@ from sherpa.astro.sim import fullbayes
 
 
 _samplers = __samplers.copy()
-_samplers.update(dict(pragbayes=pragbayes.PragBayes,
-                      fullbayes=fullbayes.FullBayes))
+_samplers.update({"pragbayes": pragbayes.PragBayes,
+                  "fullbayes": fullbayes.FullBayes})
 
 _walkers = __walkers.copy()
-_walkers.update(dict(pragbayes=pragbayes.WalkWithSubIters,
-                     fullbayes=pragbayes.WalkWithSubIters))
+_walkers.update({"pragbayes": pragbayes.WalkWithSubIters,
+                 "fullbayes": pragbayes.WalkWithSubIters})
 
 
 class MCMC(_MCMC):

--- a/sherpa/astro/sim/fullbayes.py
+++ b/sherpa/astro/sim/fullbayes.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2011, 2016, 2017, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2016, 2017, 2020, 2021, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -47,8 +48,8 @@ class FullBayes(PragBayes):
             self.simarf = ARFSIMFactory()(simarf)
 
         if not isinstance(self.simarf, PCA1DAdd):
-            raise TypeError("Simulation ARF must be PCA for FullBayes" +
-                            " not %s" % type(self.simarf).__name__)
+            raise TypeError("Simulation ARF must be PCA for FullBayes"
+                            f" not {type(self.simarf).__name__}")
 
         self.accept_arfs = [0]
         self.p_M_arf = p_M_arf

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -14032,7 +14032,7 @@ class Session(sherpa.ui.utils.Session):
                                        covar_matrix=covar_matrix)
                 else:
                     sampler = NormalParameterSampleFromScaleMatrix()
-                    tmp = sampler.get_sample(fit, covar_matrix, niter + 1)
+                    tmp = sampler.get_sample(fit, mycov=covar_matrix, num=niter + 1)
                     params = tmp.transpose()
 
             else:

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -166,7 +166,7 @@ here is arbitrarily taken to be 100)::
 
     >>> nburn = 100
     >>> arate = accept[nburn:-1].sum() * 1.0 / (len(accept) - nburn - 1)
-    >>> print("acceptance rate = {}".format(arate))
+    >>> print(f"acceptance rate = {arate}")
 
 The trace of the parameter values can also be displayed; in this
 example a burn-in period has not been removed)::
@@ -240,8 +240,8 @@ def inverse2(x):
     return prior
 
 
-_samplers = dict(metropolismh=MetropolisMH, mh=MH)
-_walkers = dict(metropolismh=Walk, mh=Walk)
+_samplers = {"metropolismh": MetropolisMH, "mh": MH}
+_walkers = {"metropolismh": Walk, "mh": Walk}
 
 
 class MCMC(NoNewAttributesAfterInit):
@@ -349,8 +349,9 @@ class MCMC(NoNewAttributesAfterInit):
         """
         prior = self.priors.get(par.fullname, None)
         if prior is None:
-            raise ValueError("prior function has not been set for '%s'" %
-                             par.fullname)
+            raise ValueError("prior function has not been set for "
+                             f"'{par.fullname}'")
+
         return prior
 
     # ## DOC-TODO: should set_sampler_opt be mentioned here?
@@ -506,7 +507,7 @@ class MCMC(NoNewAttributesAfterInit):
             sampler = str(sampler).lower()
 
             if sampler not in self.__samplers:
-                raise TypeError("Unknown sampler '%s'" % sampler)
+                raise TypeError(f"Unknown sampler '{sampler}'")
 
             self.sampler = self.__samplers.get(sampler)
             self.walker = self.__walkers.get(sampler, Walk)
@@ -516,7 +517,7 @@ class MCMC(NoNewAttributesAfterInit):
             self.walker = self.__walkers.get(sampler, Walk)
 
         else:
-            raise TypeError("Unknown sampler '%s'" % sampler)
+            raise TypeError(f"Unknown sampler '{sampler}'")
 
     def get_sampler(self):
         """Return the current MCMC sampler options.
@@ -680,8 +681,8 @@ class MCMC(NoNewAttributesAfterInit):
 
         """
         if not isinstance(fit.stat, (Cash, CStat, WStat)):
-            raise ValueError("Fit statistic must be cash, cstat or " +
-                             "wstat, not %s" % fit.stat.name)
+            raise ValueError("Fit statistic must be cash, cstat or "
+                             f"wstat, not {fit.stat.name}")
 
         _level = _log.getEffectiveLevel()
         mu = fit.model.thawedpars
@@ -837,7 +838,6 @@ class ReSampleData(NoNewAttributesAfterInit):
         self.data = data
         self.model = model
         NoNewAttributesAfterInit.__init__(self)
-        return
 
     def __call__(self, niter=1000, seed=None):
         return self.call(niter, seed)

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2019, 2020, 2021
+#  Copyright (C) 2011, 2016, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -242,7 +242,7 @@ class Walk():
                 try:
                     proposed_params = self._sampler.draw(current_params)
                 except CovarError:
-                    error("Covariance matrix failed! " + str(proposed_params))
+                    error("Covariance matrix failed! %s", str(proposed_params))
                     # automatically reject if the covar is malformed
                     self._sampler.reject()
                     continue
@@ -543,8 +543,8 @@ class MetropolisMH(MH):
 
         self.p_M = p_M
 
-        debug("X ~ uniform(0,1) <= %.2f --> Metropolis" % float(p_M))
-        debug("X ~ uniform(0,1) >  %.2f --> Metropolis-Hastings" % float(p_M))
+        debug("X ~ uniform(0,1) <= %.2f --> Metropolis", float(p_M))
+        debug("X ~ uniform(0,1) >  %.2f --> Metropolis-Hastings", float(p_M))
 
         return MH.init(self, log, inv, defaultprior, priorshape, priors,
                        originalscale, scale, sigma_m)
@@ -584,5 +584,5 @@ class MetropolisMH(MH):
     def tear_down(self):
         num = float(self.num_metropolis + self.num_mh)
         if num > 0:
-            debug("p_M: %g, Metropolis: %g%%" % (self.p_M, 100 * self.num_metropolis / num))
-            debug("p_M: %g, Metropolis-Hastings: %g%%" % (self.p_M, 100 * self.num_mh / num))
+            debug("p_M: %g, Metropolis: %g%%", self.p_M, 100 * self.num_metropolis / num)
+            debug("p_M: %g, Metropolis-Hastings: %g%%", self.p_M, 100 * self.num_mh / num)

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021
+#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -181,9 +181,8 @@ class ParameterScaleVector(ParameterScale):
                 if lo is not None and hi is not None:
                     scale = numpy.abs(lo)
                 else:
-                    wmsg = "Covariance failed for '{}',".format(par.fullname) + \
-                           " trying Confidence..."
-                    warning(wmsg)
+                    warning("Covariance failed for '%s', trying Confidence...",
+                            par.fullname)
 
                     conf = Confidence()
                     conf.config['sigma'] = self.sigma
@@ -199,10 +198,9 @@ class ParameterScaleVector(ParameterScale):
                                 scale = numpy.abs(t.parmaxes[0])
 
                             else:
-
-                                warning('1 sigma bounds for parameter ' +
-                                        par.fullname +
-                                        ' could not be found, using soft limit minimum')
+                                warning('1 sigma bounds for parameter %s'
+                                        ' could not be found, using soft limit minimum',
+                                        par.fullname)
                                 if 0.0 == numpy.abs(par.min):
                                     scale = 1.0e-16
                                 else:
@@ -215,9 +213,11 @@ class ParameterScaleVector(ParameterScale):
         else:
             if not numpy.iterable(myscales):
                 emsg = "scales option must be iterable of " + \
-                       "length {}".format(len(thawedpars))
+                       f"length {len(thawedpars)}"
                 raise TypeError(emsg)
+
             scales = list(map(abs, myscales))
+
         scales = numpy.asarray(scales).transpose()
         return scales
 
@@ -265,7 +265,7 @@ class ParameterScaleMatrix(ParameterScale):
 
             thawedpars = [par for par in fit.model.pars if not par.frozen]
             npar = len(thawedpars)
-            msg = 'scales must be a numpy array of size ({0},{0})'.format(npar)
+            msg = f'scales must be a numpy array of size ({npar},{npar})'
 
             if not isinstance(myscales, numpy.ndarray):
                 raise EstErr(msg)
@@ -354,7 +354,7 @@ class ParameterSample(NoNewAttributesAfterInit):
             mins = fit.model.thawedparmins
             maxs = fit.model.thawedparmaxes
         else:
-            raise ValueError('invalid clip argument: sent {}'.format(clip))
+            raise ValueError(f'invalid clip argument: sent {clip}')
 
         for pvals, pmin, pmax in zip(samples.T, mins, maxs):
             porig = pvals.copy()

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -296,8 +296,12 @@ class ParameterSample(NoNewAttributesAfterInit):
 
     """
 
-    def get_sample(self, fit, num=1):
+    def get_sample(self, fit, *, num=1):
         """Return the samples.
+
+        .. versionchanged:: 4.16.0
+           All arguments but the first one must be passed as a keyword
+           argument.
 
         Parameters
         ----------
@@ -396,7 +400,7 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
     but the upper bound is not).
     """
 
-    def get_sample(self, fit, factor=4, num=1):
+    def get_sample(self, fit, *, factor=4, num=1):
         """Return the parameter samples.
 
         Parameters
@@ -435,7 +439,7 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
 
     """
 
-    def get_sample(self, fit, myscales=None, num=1):
+    def get_sample(self, fit, *, myscales=None, num=1):
         """Return the parameter samples.
 
         Parameters
@@ -473,7 +477,7 @@ class NormalParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
     """
 
-    def get_sample(self, fit, mycov=None, num=1):
+    def get_sample(self, fit, *, mycov=None, num=1):
         """Return the parameter samples.
 
         Parameters
@@ -509,7 +513,7 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
     """
 
-    def get_sample(self, fit, dof, num=1):
+    def get_sample(self, fit, *, dof, num=1):
         """Return the parameter samples.
 
         Parameters
@@ -598,7 +602,7 @@ class NormalSampleFromScaleMatrix(NormalParameterSampleFromScaleMatrix):
 
     """
 
-    def get_sample(self, fit, num=1, numcores=None):
+    def get_sample(self, fit, *, num=1, numcores=None):
         """Return the statistic and parameter samples.
 
         Parameters
@@ -638,7 +642,7 @@ class NormalSampleFromScaleVector(NormalParameterSampleFromScaleVector):
 
     """
 
-    def get_sample(self, fit, num=1, numcores=None):
+    def get_sample(self, fit, *, num=1, numcores=None):
         """Return the statistic and parameter samples.
 
         Parameters
@@ -675,7 +679,7 @@ class UniformSampleFromScaleVector(UniformParameterSampleFromScaleVector):
     but the upper bound is not).
     """
 
-    def get_sample(self, fit, num=1, factor=4, numcores=None):
+    def get_sample(self, fit, *, num=1, factor=4, numcores=None):
         """Return the statistic and parameter samples.
 
         Parameters
@@ -717,7 +721,7 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
 
     """
 
-    def get_sample(self, fit, num=1, dof=2, numcores=None):
+    def get_sample(self, fit, *, num=1, dof=2, numcores=None):
         """Return the statistic and parameter samples.
 
         Parameters
@@ -744,7 +748,7 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
 
         """
         samples = StudentTParameterSampleFromScaleMatrix.get_sample(
-            self, fit, dof, num)
+            self, fit, dof=dof, num=num)
         return _sample_stat(fit, samples, numcores)
 
 
@@ -798,7 +802,8 @@ def normal_sample(fit, num=1, sigma=1, correlate=True, numcores=None):
     sampler.scale.sigma = sigma
     if correlate:
         sampler = NormalSampleFromScaleMatrix()
-    return sampler.get_sample(fit, num, numcores)
+
+    return sampler.get_sample(fit, num=num, numcores=numcores)
 
 
 def uniform_sample(fit, num=1, factor=4, numcores=None):
@@ -835,7 +840,7 @@ def uniform_sample(fit, num=1, factor=4, numcores=None):
     """
     sampler = UniformSampleFromScaleVector()
     sampler.scale.sigma = 1
-    return sampler.get_sample(fit, num, factor, numcores)
+    return sampler.get_sample(fit, num=num, factor=factor, numcores=numcores)
 
 
 def t_sample(fit, num=1, dof=2, numcores=None):
@@ -872,4 +877,4 @@ def t_sample(fit, num=1, dof=2, numcores=None):
 
     """
     sampler = StudentTSampleFromScaleMatrix()
-    return sampler.get_sample(fit, num, dof, numcores)
+    return sampler.get_sample(fit, num=num, dof=dof, numcores=numcores)

--- a/sherpa/sim/simulate.py
+++ b/sherpa/sim/simulate.py
@@ -127,13 +127,13 @@ class LikelihoodRatioResults(NoNewAttributesAfterInit):
                                         precision=4, suppress_small=False)
 
         output = '\n'.join([
-                'samples = %s' % samples,
-                'stats   = %s' % stats,
-                'ratios  = %s' % ratios,
-                'null    = %s' % repr(self.null),
-                'alt     = %s' % repr(self.alt),
-                'lr      = %s' % repr(self.lr),
-                'ppp     = %s' % repr(self.ppp)
+                f'samples = {samples}',
+                f'stats   = {stats}',
+                f'ratios  = {ratios}',
+                f'null    = {repr(self.null)}',
+                f'alt     = {repr(self.alt)}',
+                f'lr      = {repr(self.lr)}',
+                f'ppp     = {repr(self.ppp)}'
                 ])
 
         return output
@@ -148,13 +148,13 @@ class LikelihoodRatioResults(NoNewAttributesAfterInit):
 
         """
         s = 'Likelihood Ratio Test\n'
-        s += 'null statistic   =  %s\n' % str(self.null)
-        s += 'alt statistic    =  %s\n' % str(self.alt)
-        s += 'likelihood ratio =  %s\n' % str(self.lr)
+        s += f'null statistic   =  {self.null}\n'
+        s += f'alt statistic    =  {self.alt}\n'
+        s += f'likelihood ratio =  {self.lr}\n'
         if self.ppp == 0.0:
-            s += 'p-value          <  %s' % str(1./len(self.samples))
+            s += f'p-value          <  {1./len(self.samples)}'
         else:
-            s += 'p-value          =  %s' % str(self.ppp)
+            s += f'p-value          =  {self.ppp}'
         return s
 
 

--- a/sherpa/sim/simulate.py
+++ b/sherpa/sim/simulate.py
@@ -302,7 +302,7 @@ class LikelihoodRatioTest(NoNewAttributesAfterInit):
 
         # Calculate niter samples using null best-fit and covariance
         sampler = NormalParameterSampleFromScaleMatrix()
-        samples = sampler.get_sample(nullfit, None, niter)
+        samples = sampler.get_sample(nullfit, mycov=None, num=niter)
 
         # Fit with alt model, null component starts at null's best fit params.
         altfit = Fit(data, alt, stat, method, Covariance())

--- a/sherpa/sim/tests/test_asymmetric.py
+++ b/sherpa/sim/tests/test_asymmetric.py
@@ -232,7 +232,7 @@ def test_ui(make_data_path):
         assert sample[p] == pytest.approx(RESAMPLE_BENCH_10[p], rel=1e-4)
 
 
-def test_zero_case():
+def test_zero_case(reset_seed):
     """Check what happens when values can be near -1. See #740"""
 
     xs = np.arange(1, 6)

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -109,14 +109,8 @@ def setup():
         assert float(getattr(results, key)) == pytest.approx(_fit_results_bench[key])
 
     for key in ["parvals"]:
-        try:
-            # used rel and abs tol of 1e-4 with numpy allclose
-            assert getattr(results, key) == pytest.approx(_fit_results_bench[key])
-        except AssertionError:
-            print('parvals bench: ', _fit_results_bench[key])
-            print('parvals fit:   ', getattr(results, key))
-            print('results', results)
-            raise
+        # used rel and abs tol of 1e-4 with numpy allclose
+        assert getattr(results, key) == pytest.approx(_fit_results_bench[key])
 
     fields = ['data', 'model', 'method', 'fit', 'results',
               'covresults', 'dof', 'mu', 'num']
@@ -286,7 +280,7 @@ def test_normal_parameter_sample_matrix(setup, reset_seed):
 
 def test_t_parameter_sample_matrix(setup, reset_seed):
     ps = sim.StudentTParameterSampleFromScaleMatrix()
-    out = ps.get_sample(setup.fit, setup.dof, num=setup.num)
+    out = ps.get_sample(setup.fit, dof=setup.dof, num=setup.num)
 
     assert out == pytest.approx(EXPECTED_T[:, 1:])
 
@@ -323,7 +317,7 @@ def test_normal_sample_matrix(setup, reset_seed):
 
 def test_t_sample_matrix(setup, reset_seed):
     ps = sim.StudentTSampleFromScaleMatrix()
-    out = ps.get_sample(setup.fit, setup.num, setup.dof)
+    out = ps.get_sample(setup.fit, num=setup.num, dof=setup.dof)
 
     assert out == pytest.approx(EXPECTED_T)
 

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -31,6 +31,7 @@ from sherpa.stats import Cash, Chi2DataVar, CStat
 from sherpa.optmethods import NelderMead, LevMar
 from sherpa.estmethods import Covariance
 from sherpa import sim
+from sherpa.utils.err import EstErr
 from sherpa.utils.logging import SherpaVerbosity
 
 
@@ -204,6 +205,32 @@ def test_cauchy(setup, reset_seed):
     assert out == pytest.approx(numpy.asarray(expected))
 
 
+def test_parameter_scale_vector_checks_scale_iterable(setup, reset_seed):
+    """Error check"""
+
+    with pytest.raises(TypeError,
+                       match="^scales option must be iterable of length 5$"):
+        sim.ParameterScaleVector().get_scales(setup.fit, myscales=3)
+
+
+@pytest.mark.parametrize("scales", [3, numpy.asarray([3])])
+def test_parameter_scale_matrix_checks_scale_iterable(scales, setup, reset_seed):
+    """Error check"""
+
+    with pytest.raises(EstErr,
+                       match=r"^scales must be a numpy array of size \(5,5\)$"):
+        sim.ParameterScaleMatrix().get_scales(setup.fit, myscales=scales)
+
+
+def test_parameter_scale_matrix_checks_scale_positive_definite(setup, reset_seed):
+    """Error check"""
+
+    scales = numpy.arange(-10, 15).reshape(5, 5)
+    with pytest.raises(TypeError,
+                       match="^The covariance matrix is not positive definite$"):
+        sim.ParameterScaleMatrix().get_scales(setup.fit, myscales=scales)
+
+
 def test_parameter_scale_vector(setup, reset_seed):
     ps = sim.ParameterScaleVector()
     out = ps.get_scales(setup.fit)
@@ -224,6 +251,17 @@ def test_parameter_scale_matrix(setup, reset_seed):
                 [ 3.89927955e-04, -7.64855819e-03, -8.27934918e-05, -8.41924293e-05,   1.51498514e-02]]
 
     assert out == pytest.approx(numpy.asarray(expected))
+
+
+def test_parameter_sample_checks_clip_argument(setup, reset_seed):
+    """Error check"""
+
+    obj = sim.NormalParameterSampleFromScaleVector()
+    with pytest.raises(ValueError,
+                       match="^invalid clip argument: sent max$"):
+        obj.clip(setup.fit, numpy.arange(20).reshape(4, 5),
+                 clip="max")
+
 
 def test_uniform_parameter_sample(setup, reset_seed):
     ps = sim.UniformParameterSampleFromScaleVector()


### PR DESCRIPTION
# Summary

The `get_sample` method of the `sherpa.sim.sample.ParameterSample` class now requires named arguments for everything but the first argument (the `fit` object). There are also a number of small style changes to the code.

# Details

This is built on #1772, which has now been merged. It is code which I've pulled out of #1735

There are pylint-inspired fix-ups, such as

- f-string changes
- but for logging calls use %-encoded strings
- change if/elif/.../then calls where each branch is a return or raise an error to multiple 'if' calls
- remove un-needed return calls
- use actual dictionaries rather than dict calls

The main change is the last commit. The `ParameterSample` class defines `get_sample` with a signature accepting the parameters `fit, num=1`. This is an abstract class and could be marked as such, but for now it is left as is. Derived classes have a variety of arguments, and unfortunately they do not always extend the `fit, num=1` pattern. For example, `UniformParameterSampleFromScaleVector` uses the arguments `fit, factor=4, num=1`. This means that any call to `get_sample` has to be careful with the arguments it sends (other than the `fit` argument, which we assume is always the first argument). To make the code easier to read, and to avoid worrying about possible issues - such as "is it `dof, num` or `num, dof`" - this commit
    
- explicitly labels all arguments to `get_sample` other than the first argument
    
  This leads to a very-minor code increase as there's at least one place where I have had to replace a generic
    
           samples = sampler.get_sample(fit, arg, num)
    
  since the second argument (i.e. arg) is named `mycov` in one case and `myscales` in the other case.
    
- marked all-but-the first argument as keyword-only - that is, callers must pass in the keyword.

This is a change in API, as old code could start failing because they have not used keyword arguments.

The reason I did this was because i was worried there was strange behavior because arguments were being mis-used, but I believe this was actually more an issue with general functionality - see #1736 - but the approach here should make it easier to follow the code. The question is, **is it worth it**?