### PR TITLE
Fix model plot display when factor is set for grouped PHA data (issue #1779)

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4216,7 +4216,7 @@ It is an integer or string.
             xlo, xhi = get_bin_edges()
             if self.units == 'wavelength':
                 dx = hc / xlo - hc / xhi
-            else:
+            else:  # Could be "energy" or "channel"
                 dx = xhi - xlo
 
             val /= numpy.abs(dx)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4225,11 +4225,16 @@ It is an integer or string.
         if self.plot_fac <= 0:
             return val
 
-        scale = self.apply_filter(self.get_x(response_id=response_id),
-                                  self._middle)
-        for ii in range(self.plot_fac):
-            val *= scale
+        # Do we want to use apply_filter or apply_grouping here?
+        # Using just apply_filter leads to #1728.
+        #
+        xvals = self.get_x(response_id=response_id)
+        if filter:
+            xvals = self.apply_filter(xvals, self._middle)
+        elif self.grouped:
+            xvals = self.apply_grouping(xvals, self._middle)
 
+        val *= numpy.power(xvals, self.plot_fac)
         return val
 
     def get_y(self, filter=False, yfunc=None, response_id=None, use_evaluation_space=False):

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -871,37 +871,10 @@ def validate_1779_grouped(pha, mplot, subset, factor):
     ghi = _energies_hi[[0, 2, 3, 5, 7, 8, 9]]
     MODEL_GROUPED = IMODEL_GROUPED / (ghi - glo)
 
-    # Note: the following is issue #1784.
+    # Prior to #1784 being fixed xgrid was different (it averaged the
+    # center of grouped bins).
     #
-    # This is what I expected
-    #    xgrid = (glo + ghi) / 2
-    #
-    # This is what is used: note that xgrid from above evaluates to
-    #
-    #    [0.575, 0.725, 0.85, 1, 1.2, 1.35, 1.45]
-    #
-    # so it's some of the grouped bins that differ. This is
-    # because the code is averaging the mid-points of each
-    # bin, not the low and high edges, so we have a group of
-    # channels 0.65-0.75, 0.75-0.8 keV, which I would
-    # think was (0.65 + 0.8) / 2 = 1.45 / 2 = 0.725 keV,
-    # but we actually combine
-    #     ((0.65 + 0.75) / 2 + (0.75 + 0.8) / 2) / 2
-    #   = (1.4 / 2 + 1.55 / 2) / 2
-    #   = 2.95 / 4
-    #   = 0.7375
-    #
-    # The other bin where we see a difference we have
-    # 1.1-1.12, 1.12-1.3, so we compare
-    #
-    #     (1.1 + 1.3) / 2 = 1.2
-    #
-    # to
-    #
-    #     ((1.1 + 1.12) + (1.12 + 1.3)) / 4
-    #     4.64 / 4 = 1.16
-    #
-    xgrid = np.asarray([0.575, 0.7375, 0.85, 1., 1.16, 1.35, 1.45])
+    xgrid = (glo + ghi) / 2
 
     expected = MODEL_GROUPED * np.power(xgrid, factor)
     if subset:

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -945,7 +945,7 @@ def test_1779_ungrouped_fit(subset, factor):
 @pytest.mark.parametrize("subset", [False, True])
 @pytest.mark.parametrize("factor", [0, 1, 2])
 def test_1779_grouped_model(subset, factor):
-    """This fails for factor > 0 (issue #1779)
+    """This no-longer fails for factor > 0 (issue #1779)
 
     This uses the plot_model() display, which does not group the
     model values.
@@ -959,17 +959,6 @@ def test_1779_grouped_model(subset, factor):
         pha.notice(0.77, 1.125)
 
     mplot = ModelHistogram()
-
-    if subset and factor > 0:
-        # This is #1779. I want the test to pass so we know we have
-        # caught the error we are searching for (as an xfail can just
-        # cover an accidental typo in the test).
-        #
-        with pytest.raises(ValueError,
-                           match=r"operands could not be broadcast together with shapes \(7,\) \(4,\) \(7,\)"):
-            validate_1779(pha, mplot, subset, factor)
-
-        return
 
     validate_1779(pha, mplot, subset, factor)
 


### PR DESCRIPTION
# Summary

Ensure that model plots can be created for PHA data when set_analysis routine is used to set factor  > 0 and the data is grouped. Fixes #1779 and #1784

# Details

The factor setting comes in to the very-end of the internal "fix units" routine for DataPHA objects, and obviously missed-out on the recent work to improve filtering behavior (eg #1477) as we didn't have a test that triggered the problem. So a test has been added to try and cover the problem (at a  lower level than found in #1779, which used the UI layer). Note that we want to check

- grouped and ungrouped data
- filtered and unfiltered data
- plot_model and  plot_fit (the model part) behavior, which is handled by the two `sherpa.astro.plot` model classes

In working on this I came across #1784 so i have addressed this too. As this is all for "approximate" data it may not matter exactly how we calculate the mid-point of each group, but I prefer the newer version.

We should review the DataPHA class for data access to channel/group values (e.g. `get_x` vs `_get_ebins` vs ...) but that is a significant rework but I'm still birnt out by #1477 and related work, so I do not plan on this for quite some time.

I think this should be looked at and then #1828