### PR TITLE
model: explicity send parameter argument to calc

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -94,11 +94,11 @@ class Atten(RegriddableModel1D):
                                  (self.hcol, self.heiRatio, self.heiiRatio))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         # atten should act like xsphabs, never integrate.
         kwargs['integrate'] = False
-        return _modelfcts.atten(*args, **kwargs)
+        return _modelfcts.atten(p, *args, **kwargs)
 
 
 class BBody(RegriddableModel1D):
@@ -176,9 +176,9 @@ class BBody(RegriddableModel1D):
         param_apply_limits(mod, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.bbody(*args, **kwargs)
+        return _modelfcts.bbody(p, *args, **kwargs)
 
 
 class BBodyFreq(RegriddableModel1D):
@@ -233,9 +233,9 @@ class BBodyFreq(RegriddableModel1D):
         param_apply_limits(t, self.t, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.bbodyfreq(*args, **kwargs)
+        return _modelfcts.bbodyfreq(p, *args, **kwargs)
 
 
 class Beta1D(RegriddableModel1D):
@@ -303,9 +303,9 @@ class Beta1D(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.beta1d(*args, **kwargs)
+        return _modelfcts.beta1d(p, *args, **kwargs)
 
 
 class BPL1D(RegriddableModel1D):
@@ -363,9 +363,9 @@ class BPL1D(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.bpl1d(*args, **kwargs)
+        return _modelfcts.bpl1d(p, *args, **kwargs)
 
 
 # TODO: what are the units of the independent axis: Angstrom?
@@ -428,9 +428,9 @@ class Dered(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.rv, self.nhgal))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.dered(*args, **kwargs)
+        return _modelfcts.dered(p, *args, **kwargs)
 
 
 class Edge(RegriddableModel1D):
@@ -479,9 +479,9 @@ class Edge(RegriddableModel1D):
                                  (self.space, self.thresh, self.abs))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.edge(*args, **kwargs)
+        return _modelfcts.edge(p, *args, **kwargs)
 
 
 # DOC-NOTE:
@@ -544,9 +544,9 @@ class LineBroad(RegriddableModel1D):
         param_apply_limits(mod, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.linebroad(*args, **kwargs)
+        return _modelfcts.linebroad(p, *args, **kwargs)
 
 
 # DOC-NOTE: for some reason the division in the equation in the notes
@@ -612,9 +612,9 @@ class Lorentz1D(RegriddableModel1D):
             param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.lorentz1d(*args, **kwargs)
+        return _modelfcts.lorentz1d(p, *args, **kwargs)
 
 
 class Voigt1D(RegriddableModel1D):
@@ -728,9 +728,9 @@ class Voigt1D(RegriddableModel1D):
         param_apply_limits(ampl, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.wofz(*args, **kwargs)
+        return _modelfcts.wofz(p, *args, **kwargs)
 
 
 class PseudoVoigt1D(RegriddableModel1D):
@@ -815,15 +815,12 @@ class PseudoVoigt1D(RegriddableModel1D):
         param_apply_limits(ampl, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
 
-        pars = args[0]
-        xargs = args[1:]
-
-        frac = pars[0]
-        gmdl = sherpa.models._modelfcts.ngauss1d(pars[1:], *xargs, **kwargs)
-        lmdl = _modelfcts.lorentz1d(pars[1:], *xargs, **kwargs)
+        frac = p[0]
+        gmdl = sherpa.models._modelfcts.ngauss1d(p[1:], *args, **kwargs)
+        lmdl = _modelfcts.lorentz1d(p[1:], *args, **kwargs)
         return frac * gmdl + (1 - frac) * lmdl
 
 
@@ -894,9 +891,9 @@ class NormBeta1D(RegriddableModel1D):
         param_apply_limits(ampl, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.nbeta1d(*args, **kwargs)
+        return _modelfcts.nbeta1d(p, *args, **kwargs)
 
 
 class Schechter(RegriddableModel1D):
@@ -939,11 +936,11 @@ class Schechter(RegriddableModel1D):
         param_apply_limits(norm, self.norm, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         if not self.integrate:
             raise ModelErr('alwaysint', self.name)
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.schechter(*args, **kwargs)
+        return _modelfcts.schechter(p, *args, **kwargs)
 
 
 class Beta2D(RegriddableModel2D):
@@ -1033,9 +1030,9 @@ class Beta2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.beta2d(*args, **kwargs)
+        return _modelfcts.beta2d(p, *args, **kwargs)
 
 
 class DeVaucouleurs2D(RegriddableModel2D):
@@ -1115,9 +1112,9 @@ class DeVaucouleurs2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.devau(*args, **kwargs)
+        return _modelfcts.devau(p, *args, **kwargs)
 
 
 class HubbleReynolds(RegriddableModel2D):
@@ -1201,9 +1198,9 @@ class HubbleReynolds(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.hr(*args, **kwargs)
+        return _modelfcts.hr(p, *args, **kwargs)
 
 
 class Lorentz2D(RegriddableModel2D):
@@ -1275,9 +1272,9 @@ class Lorentz2D(RegriddableModel2D):
         param_apply_limits(ypos, self.ypos, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.lorentz2d(*args, **kwargs)
+        return _modelfcts.lorentz2d(p, *args, **kwargs)
 
 
 class JDPileup(RegriddableModel1D):
@@ -1492,9 +1489,9 @@ class Sersic2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.sersic(*args, **kwargs)
+        return _modelfcts.sersic(p, *args, **kwargs)
 
 
 # ## disk2d and shell2d models

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1153,7 +1153,7 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
 
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         """Calculate the model given the parameters and grid.
 
         Notes
@@ -1167,7 +1167,7 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
         Keyword arguments are ignored.
         """
 
-        nargs = len(args)
+        nargs = 1 + len(args)
         if nargs != 3:
             emsg = f"calc() requires pars,lo,hi arguments, sent {nargs} arguments"
             warnings.warn(emsg, FutureWarning)
@@ -1179,7 +1179,7 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
         #  - it is easier
         #  - it allows for the user to find out what bins are bad,
         #    by directly calling the _calc function of a model
-        out = self._calc(*args, **kwargs)
+        out = self._calc(p, *args, **kwargs)
 
         # This check is being skipped in the 4.8.0 release as it
         # has had un-intended consequences. It should be re-evaluated

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -743,11 +743,11 @@ they do not match.
 
         return ConvolutionModel(kernel, model, self)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         if self.model is None:
             raise PSFErr('nofold')
 
-        psf_space_evaluation = self.model.calc(*args, **kwargs)
+        psf_space_evaluation = self.model.calc(p, *args, **kwargs)
 
         if self._must_rebin:
             return rebin_2d(psf_space_evaluation, self.psf_space, self.data_space).ravel()

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -153,9 +153,9 @@ class Box1D(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.box1d(*args, **kwargs)
+        return _modelfcts.box1d(p, *args, **kwargs)
 
 
 class Const(ArithmeticModel):
@@ -208,9 +208,9 @@ class Const1D(RegriddableModel1D, Const):
         Const.__init__(self, name)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.const1d(*args, **kwargs)
+        return _modelfcts.const1d(p, *args, **kwargs)
 
 
 class Cos(RegriddableModel1D):
@@ -251,9 +251,9 @@ class Cos(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.cos(*args, **kwargs)
+        return _modelfcts.cos(p, *args, **kwargs)
 
 
 class Delta1D(RegriddableModel1D):
@@ -307,9 +307,9 @@ class Delta1D(RegriddableModel1D):
         param_apply_limits(pos, self.pos, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.delta1d(*args, **kwargs)
+        return _modelfcts.delta1d(p, *args, **kwargs)
 
 
 class Erf(RegriddableModel1D):
@@ -360,9 +360,9 @@ class Erf(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.erf(*args, **kwargs)
+        return _modelfcts.erf(p, *args, **kwargs)
 
 
 class Erfc(RegriddableModel1D):
@@ -413,9 +413,9 @@ class Erfc(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.erfc(*args, **kwargs)
+        return _modelfcts.erfc(p, *args, **kwargs)
 
 
 class Exp(RegriddableModel1D):
@@ -452,9 +452,9 @@ class Exp(RegriddableModel1D):
                                  (self.offset, self.coeff, self.ampl))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.exp(*args, **kwargs)
+        return _modelfcts.exp(p, *args, **kwargs)
 
 
 class Exp10(RegriddableModel1D):
@@ -491,9 +491,9 @@ class Exp10(RegriddableModel1D):
                                  (self.offset, self.coeff, self.ampl))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.exp10(*args, **kwargs)
+        return _modelfcts.exp10(p, *args, **kwargs)
 
 
 class Gauss1D(RegriddableModel1D):
@@ -580,9 +580,9 @@ class Gauss1D(RegriddableModel1D):
         param_apply_limits(fwhm, self.fwhm, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.gauss1d(*args, **kwargs)
+        return _modelfcts.gauss1d(p, *args, **kwargs)
 
 
 class Log(RegriddableModel1D):
@@ -619,9 +619,9 @@ class Log(RegriddableModel1D):
                                  (self.offset, self.coeff, self.ampl))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.log(*args, **kwargs)
+        return _modelfcts.log(p, *args, **kwargs)
 
 
 class Log10(RegriddableModel1D):
@@ -658,9 +658,9 @@ class Log10(RegriddableModel1D):
                                  (self.offset, self.coeff, self.ampl))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.log10(*args, **kwargs)
+        return _modelfcts.log10(p, *args, **kwargs)
 
 
 class LogParabola(RegriddableModel1D):
@@ -708,9 +708,9 @@ class LogParabola(RegriddableModel1D):
                                               self.c2, self.ampl))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.logparabola(*args, **kwargs)
+        return _modelfcts.logparabola(p, *args, **kwargs)
 
 
 _gfactor = numpy.sqrt(numpy.pi / (4 * numpy.log(2)))
@@ -774,9 +774,9 @@ class NormGauss1D(RegriddableModel1D):
         param_apply_limits(ampl, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.ngauss1d(*args, **kwargs)
+        return _modelfcts.ngauss1d(p, *args, **kwargs)
 
 
 class Poisson(RegriddableModel1D):
@@ -823,9 +823,9 @@ class Poisson(RegriddableModel1D):
         param_apply_limits(pos, self.mean, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.poisson(*args, **kwargs)
+        return _modelfcts.poisson(p, *args, **kwargs)
 
 
 class Polynom1D(RegriddableModel1D):
@@ -939,9 +939,9 @@ class Polynom1D(RegriddableModel1D):
         param_apply_limits(off, self.offset, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.poly1d(*args, **kwargs)
+        return _modelfcts.poly1d(p, *args, **kwargs)
 
 
 class PowLaw1D(RegriddableModel1D):
@@ -987,7 +987,7 @@ class PowLaw1D(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, pars, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         if kwargs['integrate']:
             # avoid numerical issues with C pow() function close to zero,
@@ -995,11 +995,11 @@ class PowLaw1D(RegriddableModel1D):
             # pow(X, 1.0 - gamma).  So gamma values close to 1.0 +- 1.e-10
             # should be be 1.0 to avoid errors propagating in the calculated
             # model.
-            if sao_fcmp(pars[0], 1.0, 1.e-10) == 0:
+            if sao_fcmp(p[0], 1.0, 1.e-10) == 0:
                 # pars { gamma, ref, ampl }
-                pars[0] = 1.0
+                p[0] = 1.0
 
-        return _modelfcts.powlaw(pars, *args, **kwargs)
+        return _modelfcts.powlaw(p, *args, **kwargs)
 
 
 class Scale1D(Const1D):
@@ -1074,9 +1074,9 @@ class Sin(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.sin(*args, **kwargs)
+        return _modelfcts.sin(p, *args, **kwargs)
 
 
 class Sqrt(RegriddableModel1D):
@@ -1109,9 +1109,9 @@ class Sqrt(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.offset, self.ampl))
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.sqrt(*args, **kwargs)
+        return _modelfcts.sqrt(p, *args, **kwargs)
 
 
 class StepHi1D(RegriddableModel1D):
@@ -1158,9 +1158,9 @@ class StepHi1D(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.stephi1d(*args, **kwargs)
+        return _modelfcts.stephi1d(p, *args, **kwargs)
 
 
 class StepLo1D(RegriddableModel1D):
@@ -1207,9 +1207,9 @@ class StepLo1D(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.steplo1d(*args, **kwargs)
+        return _modelfcts.steplo1d(p, *args, **kwargs)
 
 
 class Tan(RegriddableModel1D):
@@ -1250,9 +1250,9 @@ class Tan(RegriddableModel1D):
         param_apply_limits(norm, self.ampl, **kwargs)
 
     @modelCacher1d
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
-        return _modelfcts.tan(*args, **kwargs)
+        return _modelfcts.tan(p, *args, **kwargs)
 
 
 class Box2D(RegriddableModel2D):
@@ -1319,9 +1319,9 @@ class Box2D(RegriddableModel2D):
         param_apply_limits(yhi, self.yhi, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.box2d(*args, **kwargs)
+        return _modelfcts.box2d(p, *args, **kwargs)
 
 
 class Const2D(RegriddableModel2D, Const):
@@ -1353,9 +1353,9 @@ class Const2D(RegriddableModel2D, Const):
         Const.__init__(self, name)
         self.cache = 0
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.const2d(*args, **kwargs)
+        return _modelfcts.const2d(p, *args, **kwargs)
 
 
 class Scale2D(Const2D):
@@ -1451,9 +1451,9 @@ class Delta2D(RegriddableModel2D):
         param_apply_limits(ypos, self.ypos, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.delta2d(*args, **kwargs)
+        return _modelfcts.delta2d(p, *args, **kwargs)
 
 
 class Gauss2D(RegriddableModel2D):
@@ -1541,9 +1541,9 @@ class Gauss2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(fwhm, self.fwhm, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.gauss2d(*args, **kwargs)
+        return _modelfcts.gauss2d(p, *args, **kwargs)
 
 
 class SigmaGauss2D(Gauss2D):
@@ -1622,9 +1622,9 @@ class SigmaGauss2D(Gauss2D):
         param_apply_limits(fwhm, self.sigma_b, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.sigmagauss2d(*args, **kwargs)
+        return _modelfcts.sigmagauss2d(p, *args, **kwargs)
 
 
 class NormGauss2D(RegriddableModel2D):
@@ -1722,9 +1722,9 @@ class NormGauss2D(RegriddableModel2D):
                 ampl[key] *= norm
         param_apply_limits(ampl, self.ampl, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.ngauss2d(*args, **kwargs)
+        return _modelfcts.ngauss2d(p, *args, **kwargs)
 
 
 class Polynom2D(RegriddableModel2D):
@@ -1832,9 +1832,9 @@ class Polynom2D(RegriddableModel2D):
         param_apply_limits(c22, self.cx2y1, **kwargs)
         param_apply_limits(c22, self.cx2y2, **kwargs)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
-        return _modelfcts.poly2d(*args, **kwargs)
+        return _modelfcts.poly2d(p, *args, **kwargs)
 
 
 class TableModel(ArithmeticModel):
@@ -2230,7 +2230,7 @@ class Integrator1D(CompositeModel, RegriddableModel1D):
         self.otherkwargs = otherkwargs
         self._errflag = 0
         CompositeModel.__init__(self,
-                                ('integrate1d(%s)' % self.model.name),
+                                f'integrate1d({self.model.name})',
                                 (self.model,))
 
     def startup(self, cache=False):

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -97,12 +97,12 @@ class ParameterCase(ArithmeticModel):
         self._basemodel = Sin()
         super().__init__(name, pars)
 
-    def calc(self, *args, **kwargs):
+    def calc(self, p, *args, **kwargs):
         for par in self.pars:
             setattr(self._basemodel, par.name, par.val)
 
         self._basemodel.integrate = self.integrate
-        return self._basemodel.calc(*args, **kwargs)
+        return self._basemodel.calc(p, *args, **kwargs)
 
 
 class ShowableModel(ArithmeticModel):

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -372,9 +372,9 @@ class MyConst1D(Const1D):
         self._calc_store = []
         Const1D.__init__(self, name)
 
-    def calc(self, *args, **kwargs):
-        self._calc_store.append((args, kwargs))
-        return Const1D.calc(self, *args, **kwargs)
+    def calc(self, p, *args, **kwargs):
+        self._calc_store.append((p, args, kwargs))
+        return Const1D.calc(self, p, *args, **kwargs)
 
 
 def test_regrid1d_passes_through_the_grid():
@@ -394,17 +394,16 @@ def test_regrid1d_passes_through_the_grid():
     y = mdl(grid_requested)
     assert len(y) == len(grid_requested)
     assert len(store) == 1
-    store = store[0]
-    assert len(store) == 2
 
-    assert len(store[0]) == 2
-    assert store[1] == {'integrate': True}
+    p, args, kwargs = store[0]
 
-    store = store[0]
-    assert store[0] == [-34.5]
+    assert p == [-34.5]
+
     combine = np.unique(np.append(grid_expected, grid_requested))
-    indices = combine.searchsorted(store[1])
-    assert (store[1] == combine[indices]).all()
+    indices = combine.searchsorted(args)
+    assert (args == combine[indices]).all()
+
+    assert kwargs == {'integrate': True}
 
 
 def test_regrid1d_error_calc_no_args(setup_1d):


### PR DESCRIPTION
# Summary

Ensure that the calc method for models begins with the parameter array (explicitly given) rather than extracting it from the named arguments sent to the routine. This should not change any user code.

# Details

Be expllicit about the required parameter array sent to the calc method of the Model class. This is mainly for documentation, as it shouldn't change the results of any of the existing code, and for future development.