### PR TITLE
utils: minor code clean up

### DIFF
--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021, 2022
+#  Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -183,8 +183,8 @@ def test_guess_warns_no_guess_names_model(caplog, clean_ui):
     assert len(caplog.records) == 1
     lname, lvl, msg = caplog.record_tuples[0]
     assert lname == "sherpa.ui.utils"
-    assert lvl == logging.INFO
-    assert msg == "WARNING: No guess found for dummy"
+    assert lvl == logging.WARNING
+    assert msg == "No guess found for dummy"
 
 
 def test_guess_warns_no_guess_no_argument(caplog, clean_ui):
@@ -200,8 +200,8 @@ def test_guess_warns_no_guess_no_argument(caplog, clean_ui):
     assert len(caplog.records) == 1
     lname, lvl, msg = caplog.record_tuples[0]
     assert lname == "sherpa.ui.utils"
-    assert lvl == logging.INFO
-    assert msg == "WARNING: No guess found for (dummy + dummy)"
+    assert lvl == logging.WARNING
+    assert msg == "No guess found for (dummy + dummy)"
 
 
 class Parameter2(Parameter):

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8955,16 +8955,14 @@ class Session(NoNewAttributesAfterInit):
             try:
                 model.guess(*self.get_data(idval).to_guess(), **kwargs)
             except NotImplementedError:
-                # TODO: change to warning() from info()
-                info('WARNING: No guess found for %s', model.name)
+                warning('No guess found for %s', model.name)
             return
 
         ids, f = self._get_fit(idval)
         try:
             f.guess(**kwargs)
         except NotImplementedError:
-            # TODO: change to warning() from info()
-            info('WARNING: No guess found for %s', self.get_model(idval).name)
+            warning('No guess found for %s', self.get_model(idval).name)
 
     def calc_stat(self, id=None, *otherids):
         """Calculate the fit statistic for a data set.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -6846,11 +6846,11 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        model : str or a sherpa.models.model.Model object
+        model : `str` or a `sherpa.models.model.Model` object
 
         Returns
         -------
-        model : sherpa.models.model.Model instance
+        model : `sherpa.models.model.Model` instance
 
         Raises
         ------


### PR DESCRIPTION
# Summary

Internal clean up of the sherpa.ui.utils module.

# Details

Created when working on something else.

- Clean up the use of _clean_model (make more use of it) and add a little documentation.
- Avoid using a fully-qualified name when we have the symbol imported anyway.
- use `idval` rather than `id` for an internal variable name (although the API uses `id` so that is left as is)
- clean up of logging to use lazy formatting (%s) rather than f-strings
- change a logging call to use warning(..) rather than info("WARNING: ...")

Technically this last one is a user change - it they had used `SherpaVerbosity("WARNING")` then the message is now seen when it wasn't before, but I don't think we need to explain this. Or we could also just not take the last commit, where this change is made.

# Example

## CIAO 4.15

```
sherpa In [1]: load_arrays(1, [1, 2, 3], [1, 2, 3])

sherpa In [2]: set_source(xsphabs.gal * xsapec.src)

sherpa In [3]: guess(gal)
WARNING: No guess found for xsphabs.gal

sherpa In [4]: guess(src)

sherpa In [5]: guess(gal + src)
WARNING: No guess found for (xsphabs.gal + xsapec.src)

sherpa In [6]: from sherpa.utils.logging import SherpaVerbosity

sherpa In [7]: with SherpaVerbosity("ERROR"):
          ...:     guess(gal)
          ...: 

sherpa In [8]: with SherpaVerbosity("WARNING"):
          ...:     guess(gal)
          ...: 
```

## This PR

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_arrays(1, [1, 2, 3], [1, 2, 3])

In [3]: set_source(xsphabs.gal * xsapec.src)

In [4]: guess(gal)
WARNING: No guess found for xsphabs.gal

In [5]: guess(src)

In [6]: guess(gal + src)
WARNING: No guess found for (xsphabs.gal + xsapec.src)

In [7]: from sherpa.utils.logging import SherpaVerbosity

In [8]: with SherpaVerbosity("ERROR"):
   ...:     guess(gal)
   ...: 

In [9]: with SherpaVerbosity("WARNING"):
   ...:     guess(gal)
   ...: 
WARNING: No guess found for xsphabs.gal
```