### PR TITLE
NumPy 1.25 support

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1284,8 +1284,13 @@ class Fit(NoNewAttributesAfterInit):
         def get_par_name(ii):
             return self.model.pars[self.thaw_indices[ii]].fullname
 
-        # Call from a parameter estimation method, to report
-        # that limits for a given parameter have been found
+        # Call from a parameter estimation method, to report that
+        # limits for a given parameter have been found At present (mid
+        # 2023) it looks like lower/upper are both single-element
+        # ndarrays, hence the need to convert to a scalar by accessing
+        # the first element (otherwise there's a deprecation warning
+        # from NumPy 1.25).
+        #
         def report_progress(i, lower, upper):
             if i < 0:
                 return
@@ -1294,11 +1299,11 @@ class Fit(NoNewAttributesAfterInit):
             if isnan(lower) or isinf(lower):
                 info("%s \tlower bound: -----", name)
             else:
-                info("%s \tlower bound: %g", name, lower)
+                info("%s \tlower bound: %g", name, lower[0])
             if isnan(upper) or isinf(upper):
                 info("%s \tupper bound: -----", name)
             else:
-                info("%s \tupper bound: %g", name, upper)
+                info("%s \tupper bound: %g", name, upper[0])
 
         # If starting fit statistic is chi-squared or C-stat,
         # can calculate reduced fit statistic -- if it is

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -357,9 +357,17 @@ class PSFKernel(Kernel):
             # and Python 3.8 - causes a TypeError with the message
             # "only integer scalar arrays can be converted to a scalar index"
             # to be thrown here if sent directly to set_origin. So
-            # we convert to a Python integer type.
+            # we convert to a Python integer type. In NumPy 1.25 it became
+            # a deprecation error to call int on an array with ndim > 0.
             #
-            origin = set_origin(kshape, int(brightPixel))
+            # assume there is only one element in brightPixel if not
+            # a scalar
+            #
+            if not numpy.isscalar(brightPixel):
+                loc = brightPixel[0]
+            else:
+                loc = brightPixel
+            origin = set_origin(kshape, int(loc))
 
         if self.origin is None:
             self.origin = origin


### PR DESCRIPTION
# Summary

Remove deprecation warnings seen when using NumPy 1.25.0.

# Details

NumPy 1.25 deprecates converting a ndarray that is not a 0d value, so for our cases this is

    int(value)
    info("message %g", value)

where value is a ndarray of length 1. The simple fix is to explictly access the first element - so

    answer = int(value[0])
    info("message %g", value[0])

although for the int case (in the PSF convolution instrument code) I have not looked through to determine if value is always guaranteed to be a ndarray, so it is more like

    if np.isscalar(value):
        newval = value
    else:
        newval = value[0]
    answer = int(newval)