### PR TITLE
Update the hardcoded Zenodo releases to include the 4.14/4.15 releases

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -183,6 +183,42 @@ def _get_citation_hardcoded(version):
         cite[version] = dict(**kwargs)
         cite[version]['version'] = version
 
+    add(version='4.15.1', title='sherpa/sherpa: Sherpa 4.15.1',
+        date=todate(2023, 5, 18),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'Marie-Terrell',
+                 'dtnguyen2', 'Hans Moritz Günther', 'Aneta Siemiginowska',
+                 'Jamie Budynkiewicz', 'Harlan Cheer', 'Tom Aldcroft',
+                 'Christoph Deil', 'Brigitta Sipőcz', 'Johannes Buchner',
+                 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber',
+                 'nplee', 'Todd'],
+        idval='7948720')
+    add(version='4.15.0', title='sherpa/sherpa: Sherpa 4.15.0',
+        date=todate(2022, 10, 11),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',
+                 'Hans Moritz Günther', 'Marie-Terrell', 'Aneta Siemiginowska',
+                 'Jamie Budynkiewicz', 'Harlan Cheer', 'Tom Aldcroft',
+                 'Christoph Deil', 'Brigitta Sipőcz', 'Johannes Buchner',
+                 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber',
+                 'nplee', 'Todd'],
+        idval='7186379')
+    add(version='4.14.1', title='sherpa/sherpa: Sherpa 4.14.1',
+        date=todate(2022, 5, 20),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',
+                 'Hans Moritz Günther', 'Marie-Terrell', 'Aneta Siemiginowska',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Christoph Deil',
+                 'Harlan Cheer', 'Brigitta Sipőcz', 'Johannes Buchner',
+                 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber',
+                 'nplee', 'Todd'],
+        idval='6567264')
+    add(version='4.14.0', title='sherpa/sherpa: Sherpa 4.14.0',
+        date=todate(2021, 10, 7),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',
+                 'Hans Moritz Günther', 'Marie-Terrell', 'Aneta Siemiginowska',
+                 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Christoph Deil',
+                 'Brigitta Sipőcz', 'Johannes Buchner', 'Iva Laginja',
+                 'Katrin Leinweber', 'nplee', 'Todd'],
+        idval='5554957')
+
     add(version='4.13.1', title='sherpa/sherpa: Sherpa 4.13.1',
         date=todate(2021, 5, 18),
         authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'dtnguyen2',


### PR DESCRIPTION
# Summary

Update the stored Zenodo releases to include the 4.14.* and 4.15.* Sherpa releases. Users should see no difference (other than avoiding the need for an http call to retrieve this information) when calling sherpa.citation().

# Details

The text was created by running

```
% ./scripts/make_zenodo_release.py 
```

and then copying over the relevant text to `sherpa/__init__.py`