### PR TITLE
Autoupdate copyright year in sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,8 +289,8 @@ main_doc = 'index'
 
 # General information about the project.
 project = 'Sherpa'
-copyright = '2019-2022, Chandra X-ray Center, Smithsonian Astrophysical Observatory.'
 author = 'Chandra X-ray Center, Smithsonian Astrophysical Observatory'
+copyright = f"2019–{datetime.datetime.utcnow().year}, " + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
# Summary
Autoupdate copyright year in sphinx docs

## details
The docs are only build if something has been updated in the repro and that means the copyright year should be updated to the current year.
Using `datetime` we can never again forget to update that.

This trick is taken from astropy.