### PR TITLE
Limit precision in the comparison of string outputs

### DIFF
--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2833,7 +2833,7 @@ def check_str(out, expecteds):
 
     toks = str(out).split("\n")
     for tok, expected in zip(toks, expecteds):
-        assert tok == expected
+        assert tok[:28] == expected[:28]
 
     assert len(toks) == len(expecteds)
 


### PR DESCRIPTION
As described in #1815, running the three tests on a Mac with ARM even with recent numpy versions differs numerically, which makes the string comparison fail.

One way to address that would be split the string and compare the formatting of the output string and the numbers separately, but that's more effort. Just limiting the comparison to the first 6-8 digits is enough to ensure that (a) the test do not fail just due to numerics, but would still detect any meaningful change in the output numbers.

fixes #1815