### PR TITLE
CI: hide NumPy 1.25 array ndim>0 deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,10 @@
 addopts = -rs --ignore=setup.py --ignore=test_requirements.txt
 norecursedirs = .git build dist tmp* .eggs
 text_file_format = rst
+filterwarnings =
+    # Since we can runpytest without loading pytest-doctestplus, hide
+    # the warnings we get when this is done
+    ignore::pytest.PytestConfigWarning
 doctest_plus = enabled
 doctest_plus_atol = 1e-4
 doctest_optionflags =

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -117,6 +117,11 @@ known_warnings = {
             r'np.asscalar\(a\) is deprecated since NumPy v1.16, use a.item\(\) instead',
             r"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working",
 
+            # NumPy 1.25 warnings that are raised by (mid-2023) crates code.
+            # Hopefully this can be removed by December 2023.
+            #
+            r"Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. \(Deprecated NumPy 1.25.\)",
+
         ],
     UserWarning:
         [


### PR DESCRIPTION
# Summary

Allow the tests to run with NumPy 1.25 and with Crates (from CIAO 4.15) as the I/O backend. There are no functional changes.

# Details

NumPy 1.25 now creates deprecation warnings for converting a non-scalar NumPy value (even if only has a size of 1) to a normal Python value. The Sherpa code base was updated in #1807 but when run with crates (as done in CIAO regression tests) we still see the reports. As we can't fix this in crates (and actually finding where it is coming from has proved to be elusive) we can just hide the warnings using our "standard" set of checks in `sherpa/conftest.py`. The hope is we can revert this change by the end of the year (as it should have been addressed in crates by then).

The first commit is unrelated, and odesn't actually change any tests or code. It just hides the warnings you see if you run the tests without `pytest-doctestplus` installed (as this was annoying me when working on this PR).