### PR TITLE
parallel: tweak ordering of checks for parallelization

### DIFF
--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -319,13 +319,12 @@ def parallel_map(function, sequence, numcores=None):
     if not np.iterable(sequence):
         raise TypeError(f"input '{repr(sequence)}' is not iterable")
 
-    size = len(sequence)
-
-    if not _multi or size == 1 or (numcores is not None and numcores < 2):
-        return list(map(function, sequence))
-
     if numcores is None:
         numcores = _ncpus
+
+    size = len(sequence)
+    if not _multi or size == 1 or numcores < 2:
+        return list(map(function, sequence))
 
     # Returns a started SyncManager object which can be used for sharing
     # objects between processes. The returned manager object corresponds


### PR DESCRIPTION
If _ncpus is 1 and _multi is True it was possible to end up using run_tasks with a list of 1, rather than the more obvious list(map(...)) route.

Fix #1820