### PR TITLE
sherpa_test: tweak how pytest/plugins are installed

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -894,11 +894,11 @@ def _install_test_deps() -> list[str]:
             """)
             raise
 
-    # packages are stored as a dictinary with keys
+    # packages are stored as a dictionary with keys
     #   name:  package name, as used by pip
     #   check: module to check it is installed
     #          (defaults to name if not given)
-    #   constraint: the constaint to use with pip
+    #   constraint: the constraint to use with pip
     #               (defaults to name if not given)
     #
     # So we can have
@@ -909,9 +909,9 @@ def _install_test_deps() -> list[str]:
     #   'check': 'pytest_doctestplus.output_checker'}
     #
     # Note that for pytest plugins, the module name is assumed to be
-    # the name field with hypens replaced by underscores. If necessary
+    # the name field with hyphens replaced by underscores. If necessary
     # this could be updated to be another field in the package
-    # dictonary.
+    # dictionary.
     #
     # The reason for the "check" field is that mid 2023 it was found
     # that


### PR DESCRIPTION
# Summary

Internal changes to how we check for test requirements used by the sherpa_test script.

# Details

We had been doing

    try:
        importlib.import_module("pytest!=1.0,!=5.2.3")
    except ImportError:
        go-and-install-pytest()

which ends up always trying to install pytest (which would be a no-op when already installed). So, this code makes the installation a bit-more verbose, by separating out the package name from the installation-constraint.

It was found when trying to add pytest-doctestplus as a requirement. In doing so I was seeing some bizarre behavior, which made me add the "check" option (another option for specifying a dependency). It isn't actually used here (since this PR does not need any plugin), but I have left the code in.

I added typing rules for the code changed (but did not want to add to more of this module as it turns out it would require some code tweaks).