### PR TITLE
remove non-existent datastack plotting backend initialization attribute

### DIFF
--- a/sherpa/astro/datastack/utils.py
+++ b/sherpa/astro/datastack/utils.py
@@ -235,7 +235,7 @@ def plot_wrapper(func):
         kwargs
            The keyword arguments to the function.
         """
-        shplot.backend.initialize_backend()
+
         for dataset in self.filter_datasets():
             shplot.backend.initialize_plot(dataset, self.ids)
             func(dataset['id'], *args, **kwargs)


### PR DESCRIPTION
Probably left behind by accident, but the `sherpa.plot.backend.initialize_backend` attribute no longer exists for the datastack plotting routines.  Its presence is causing Sherpa to throw an error:

```
sherpa> datastack.plot_data([])
AttributeError: module 'sherpa.plot.pylab_backend' has no attribute 'initialize_backend'
```
but the removal of the line will allow a figure to be plotted for each dataset in the the stack.