### PR TITLE
Limit precision in the comparison of string outputs

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -2527,17 +2527,7 @@ def test_save_delchi_data2d(session, emsg, idval, tmp_path):
             s.save_delchi(idval, str(out))
 
 
-def check_output(expected, got):
-    """Expected is broken down by lines, got is not"""
-
-    toks = got.split("\n")
-    for i, estr in enumerate(expected):
-        assert toks[i] == estr
-
-    assert len(toks) == len(expected)
-
-
-def check_save_ascii2d(session, expected, out, savefunc, idval, kwargs):
+def check_save_ascii2d(session, expected, out, savefunc, idval, kwargs, check_str):
     """Checking the output is tricky.
 
     If crates is in use with the AstroSession backend then the call
@@ -2567,14 +2557,14 @@ def check_save_ascii2d(session, expected, out, savefunc, idval, kwargs):
     else:
         savefunc(idval, str(out), **kwargs)
 
-    check_output(expected, out.read_text())
+    check_str(out.read_text(), expected)
 
 
 @pytest.mark.parametrize("session,kwargs,expected",
                          [(Session, {"comment": "!! "}, ["!! SOURCE", "7 11", ""]),
                           (AstroSession, {"ascii": True}, ["7", "11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
-def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
+def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io, check_str):
     """Basic check it works
 
     The output depends on the backend which is a bit distressing, and
@@ -2594,14 +2584,14 @@ def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, sk
     s.set_source(idval, mdl)
 
     out = tmp_path / "created.dat"
-    check_save_ascii2d(session, expected, out, s.save_source, idval, kwargs)
+    check_save_ascii2d(session, expected, out, s.save_source, idval, kwargs, check_str)
 
 
 @pytest.mark.parametrize("session,kwargs,expected",
                          [(Session, {"comment": ""}, ["MODEL", "7 11", ""]),
                           (AstroSession, {"ascii": True}, ["7", "11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
-def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
+def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io, check_str):
     """Basic check it works
 
     The output depends on the backend which is a bit distressing, and
@@ -2621,14 +2611,14 @@ def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, ski
     s.set_source(idval, mdl)
 
     out = tmp_path / "created.dat"
-    check_save_ascii2d(session, expected, out, s.save_model, idval, kwargs)
+    check_save_ascii2d(session, expected, out, s.save_model, idval, kwargs, check_str)
 
 
 @pytest.mark.parametrize("session,kwargs,expected",
                          [(Session, {}, ["#RESID", "-7 -11", ""]),
                           (AstroSession, {"ascii": True}, ["-7", "-11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
-def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io):
+def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io, check_str):
     """Basic check it works
 
     The output depends on the backend which is a bit distressing.
@@ -2645,7 +2635,7 @@ def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, ski
     s.set_source(idval, mdl)
 
     out = tmp_path / "created.dat"
-    check_save_ascii2d(session, expected, out, s.save_resid, idval, kwargs)
+    check_save_ascii2d(session, expected, out, s.save_resid, idval, kwargs, check_str)
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -696,7 +696,7 @@ eterm = r"(?:e[+-]?\d+)"
 term = "|".join([fr"[+-]?\d+\.\d*{eterm}?",
                  fr"[+-]?\.\d+{eterm}?"
                  fr"[+-]?\d+{eterm}"])
-PATTERN = re.compile(f"(.*)(?<![\d+-])({term})")
+PATTERN = re.compile(fr"(.*)(?<![\d+-])({term})")
 
 
 class NumberChecker:

--- a/sherpa/estmethods/tests/test_estmethods.py
+++ b/sherpa/estmethods/tests/test_estmethods.py
@@ -223,71 +223,52 @@ def test_estmethod_repr(cls, name):
     assert repr(m) == f"<{name} error-estimation method instance '{name.lower()}'>"
 
 
-def check_output(out, expecteds):
-    """Check out (str) matches expecteds after splitting newlines
-
-    There's a special check for the numcores line, as the answer
-    depends on the number of cores present, so we drop that part
-    of the check.
-
-    """
-    toks = out.split("\n")
-    for tok, expected in zip(toks, expecteds):
-
-        if expected is None:
-            assert re.match(r"^numcores     ?= \d+$", tok)
-        else:
-            assert tok == expected
-
-    assert len(toks) == len(expecteds)
-
-
-def test_estmethod_str_covariance():
+def test_estmethod_str_covariance(check_str):
     """Simple check."""
     m = Covariance()
-    check_output(str(m),
-                 ["name        = covariance",
-                  "sigma       = 1",
-                  "eps         = 0.01",
-                  "maxiters    = 200",
-                  "soft_limits = False"])
+    check_str(str(m),
+              ["name        = covariance",
+               "sigma       = 1",
+               "eps         = 0.01",
+               "maxiters    = 200",
+               "soft_limits = False"])
 
 
-def test_estmethod_str_confidence():
+def test_estmethod_str_confidence(check_str):
     """Simple check."""
     m = Confidence()
-    check_output(str(m),
-                 ["name         = confidence",
-                  "sigma        = 1",
-                  "eps          = 0.01",
-                  "maxiters     = 200",
-                  "soft_limits  = False",
-                  "remin        = 0.01",
-                  "fast         = False",
-                  "parallel     = True",
-                  None,  # special-case numcores line
-                  "maxfits      = 5",
-                  "max_rstat    = 3",
-                  "tol          = 0.2",
-                  "verbose      = False",
-                  "openinterval = False"
-                  ])
+    check_str(str(m),
+              ["name         = confidence",
+               "sigma        = 1",
+               "eps          = 0.01",
+               "maxiters     = 200",
+               "soft_limits  = False",
+               "remin        = 0.01",
+               "fast         = False",
+               "parallel     = True",
+               re.compile(r"^numcores     ?= \d+$"),
+               "maxfits      = 5",
+               "max_rstat    = 3",
+               "tol          = 0.2",
+               "verbose      = False",
+               "openinterval = False"
+               ])
 
 
-def test_estmethod_str_projection():
+def test_estmethod_str_projection(check_str):
     """Simple check."""
     m = Projection()
-    check_output(str(m),
-                 ["name        = projection",
-                  "sigma       = 1",
-                  "eps         = 0.01",
-                  "maxiters    = 200",
-                  "soft_limits = False",
-                  "remin       = 0.01",
-                  "fast        = False",
-                  "parallel    = True",
-                  None,  # special-case numcores line
-                  "maxfits     = 5",
-                  "max_rstat   = 3",
-                  "tol         = 0.2"
-                  ])
+    check_str(str(m),
+              ["name        = projection",
+               "sigma       = 1",
+               "eps         = 0.01",
+               "maxiters    = 200",
+               "soft_limits = False",
+               "remin       = 0.01",
+               "fast        = False",
+               "parallel    = True",
+               re.compile(r"^numcores     ?= \d+$"),
+               "maxfits     = 5",
+               "max_rstat   = 3",
+               "tol         = 0.2"
+               ])

--- a/sherpa/sim/tests/test_asymmetric.py
+++ b/sherpa/sim/tests/test_asymmetric.py
@@ -272,7 +272,7 @@ def test_zero_case(reset_seed):
     assert (stats >= bestfit.statval).all()
 
 
-def test_resample_supports_data1d(caplog, reset_seed):
+def test_resample_supports_data1d(caplog, reset_seed, check_str):
 
     orig = Data1D("orig", [1, 2, 3], [4, 2, 5], [0.1, 0.2, 0.5])
     model = Const1D("mdl")
@@ -285,7 +285,8 @@ def test_resample_supports_data1d(caplog, reset_seed):
     lname, lvl, msg = caplog.record_tuples[0]
     assert lname == "sherpa"
     assert lvl == logging.INFO
-    assert msg == "mdl.c0 : avg = 1.0343987745935705 , std = 0.5208696279243179"
+    check_str(msg,
+              ["mdl.c0 : avg = 1.0343987745935705 , std = 0.5208696279243179  # doctest: +FLOAT_CMP"])
 
 
 def test_resample_fails_unsupported_data():

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2828,7 +2828,7 @@ def test_fit_ensures_data_and_model_dimensionality_matches(data_class, ddim, mod
         Fit(data, model)
 
 
-def test_fit_results_str(check_str, check_number):
+def test_fit_results_str(check_str):
     """Just check we can call str() on a fit results instance"""
 
     data = make_data(Data1D)
@@ -2844,10 +2844,10 @@ def test_fit_results_str(check_str, check_number):
                "statname       = cash",
                "succeeded      = True",
                "parnames       = ('const1d.c0',)",
-               check_number("parvals        = (3.33332926058462,)"),
-               check_number("statval        = -4.079456086503793"),
+               "parvals        = (3.33332926058462,)  # doctest: +FLOAT_CMP",
+               "statval        = -4.079456086503793   # doctest: +FLOAT_CMP",
                "istatval       = 6.0",
-               check_number("dstatval       = 10.079456086503793"),
+               "dstatval       = 10.079456086503793   # doctest: +FLOAT_CMP",
                "numpoints      = 3",
                "dof            = 2",
                "qval           = None",
@@ -2882,7 +2882,7 @@ def test_fit_itermethod_requires_known_name():
         Fit(data, model, itermethod_opts={"name": "not-a-name", "grow": 2})
 
 
-def test_fit_results_with_iteration_str(check_str, check_number):
+def test_fit_results_with_iteration_str(check_str):
     """Just check we can call str() on a fit results instance with an iteration method
     """
 
@@ -2901,14 +2901,14 @@ def test_fit_results_with_iteration_str(check_str, check_number):
                "statname       = chi2",
                "succeeded      = True",
                "parnames       = ('const1d.c0',)",
-               check_number("parvals        = (3.250000000000316,)"),
-               check_number("statval        = 4.296875"),
+               "parvals        = (3.250000000000316,)  # doctest: +FLOAT_CMP",
+               "statval        = 4.296875              # doctest: +FLOAT_CMP",
                "istatval       = 225.0",
-               check_number("dstatval       = 220.703125"),
+               "dstatval       = 220.703125            # doctest: +FLOAT_CMP",
                "numpoints      = 4",
                "dof            = 3",
-               check_number("qval           = 0.23114006377865534"),
-               check_number("rstat          = 1.4322916666666667"),
+               "qval           = 0.23114006377865534   # doctest: +FLOAT_CMP",
+               "rstat          = 1.4322916666666667    # doctest: +FLOAT_CMP",
                "message        = successful termination",
                "nfev           = 8"])
 
@@ -3015,7 +3015,7 @@ def test_fit_simulfit_multiple_single_model():
     assert fres.parvals == pytest.approx([3.8333336041446615])
 
 
-def test_esterrorresults_str(check_str, check_number):
+def test_esterrorresults_str(check_str):
     """Basic check of str call."""
 
     data = make_data(Data1D)
@@ -3033,9 +3033,9 @@ def test_esterrorresults_str(check_str, check_number):
                "sigma       = 1",
                "percent     = 68.26894921370858",
                "parnames    = ('mx.c0',)",
-               check_number("parvals     = (3.33332926058462,)"),
-               check_number("parmins     = (-1.0524866849982824,)"),
-               check_number("parmaxes    = (1.0524866849982824,)"),
+               "parvals     = (3.33332926058462,)     # doctest: +FLOAT_CMP",
+               "parmins     = (-1.0524866849982824,)  # doctest: +FLOAT_CMP",
+               "parmaxes    = (1.0524866849982824,)   # doctest: +FLOAT_CMP",
                "nfits       = 0"])
 
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2828,17 +2828,7 @@ def test_fit_ensures_data_and_model_dimensionality_matches(data_class, ddim, mod
         Fit(data, model)
 
 
-def check_str(out, expecteds):
-    """Check that out, when split on a newline, matches expecteds"""
-
-    toks = str(out).split("\n")
-    for tok, expected in zip(toks, expecteds):
-        assert tok[:28] == expected[:28]
-
-    assert len(toks) == len(expecteds)
-
-
-def test_fit_results_str():
+def test_fit_results_str(check_str, check_number):
     """Just check we can call str() on a fit results instance"""
 
     data = make_data(Data1D)
@@ -2854,10 +2844,10 @@ def test_fit_results_str():
                "statname       = cash",
                "succeeded      = True",
                "parnames       = ('const1d.c0',)",
-               "parvals        = (3.33332926058462,)",
-               "statval        = -4.079456086503793",
+               check_number("parvals        = (3.33332926058462,)"),
+               check_number("statval        = -4.079456086503793"),
                "istatval       = 6.0",
-               "dstatval       = 10.079456086503793",
+               check_number("dstatval       = 10.079456086503793"),
                "numpoints      = 3",
                "dof            = 2",
                "qval           = None",
@@ -2892,7 +2882,7 @@ def test_fit_itermethod_requires_known_name():
         Fit(data, model, itermethod_opts={"name": "not-a-name", "grow": 2})
 
 
-def test_fit_results_with_iteration_str():
+def test_fit_results_with_iteration_str(check_str, check_number):
     """Just check we can call str() on a fit results instance with an iteration method
     """
 
@@ -2911,14 +2901,14 @@ def test_fit_results_with_iteration_str():
                "statname       = chi2",
                "succeeded      = True",
                "parnames       = ('const1d.c0',)",
-               "parvals        = (3.250000000000316,)",
-               "statval        = 4.296875",
+               check_number("parvals        = (3.250000000000316,)"),
+               check_number("statval        = 4.296875"),
                "istatval       = 225.0",
-               "dstatval       = 220.703125",
+               check_number("dstatval       = 220.703125"),
                "numpoints      = 4",
                "dof            = 3",
-               "qval           = 0.23114006377865534",
-               "rstat          = 1.4322916666666667",
+               check_number("qval           = 0.23114006377865534"),
+               check_number("rstat          = 1.4322916666666667"),
                "message        = successful termination",
                "nfev           = 8"])
 
@@ -3025,7 +3015,7 @@ def test_fit_simulfit_multiple_single_model():
     assert fres.parvals == pytest.approx([3.8333336041446615])
 
 
-def test_esterrorresults_str():
+def test_esterrorresults_str(check_str, check_number):
     """Basic check of str call."""
 
     data = make_data(Data1D)
@@ -3043,13 +3033,13 @@ def test_esterrorresults_str():
                "sigma       = 1",
                "percent     = 68.26894921370858",
                "parnames    = ('mx.c0',)",
-               "parvals     = (3.33332926058462,)",
-               "parmins     = (-1.0524866849982824,)",
-               "parmaxes    = (1.0524866849982824,)",
+               check_number("parvals     = (3.33332926058462,)"),
+               check_number("parmins     = (-1.0524866849982824,)"),
+               check_number("parmaxes    = (1.0524866849982824,)"),
                "nfits       = 0"])
 
 
-def test_fit_outfile_simple_check(tmp_path):
+def test_fit_outfile_simple_check(tmp_path, check_str):
 
     outfile = tmp_path / "sherpa.save"
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -2833,7 +2833,7 @@ def check_str(out, expecteds):
 
     toks = str(out).split("\n")
     for tok, expected in zip(toks, expecteds):
-        assert tok == expected
+        assert tok[:28] == expected[:28]
 
     assert len(toks) == len(expecteds)
 

--- a/sherpa/tests/test_tests.py
+++ b/sherpa/tests/test_tests.py
@@ -18,15 +18,23 @@
 '''Make sure we tests the test fixtures.'''
 import pytest
 
-def test_check_str(check_str):
+def test_check_str_fails(check_str):
     '''The tests that use check_str make sure that it passes,
-    but what if it were to pass everything? 
+    but what if it were to pass everything?
     So, add a test here to make sure it actually fails when it should.'''
-    with pytest.raises(AssertionError):
-        check_str('foo = 1.23456', 'foo = 1.230000')
+    with pytest.raises(AssertionError, match="^assert 'foo = "):
+        check_str('foo = 1.23456', ['foo = 1.230000'])
 
-    with pytest.raises(AssertionError):
-        check_str('foo = 1.23456', 'foo = 1.230000   # doctest: +FLOAT_CMP')
 
-    with pytest.raises(AssertionError):
-        check_str('1.23456', '1.230000   # doctest: +FLOAT_CMP')
+def test_check_str_fails_with_float_cmp(check_str):
+    # The match value may need updating if pytest.approx changes it's
+    # assertion error.
+    with pytest.raises(AssertionError, match="^assert 1.23456 "):
+        check_str('foo = 1.23456', ['foo = 1.230000   # doctest: +FLOAT_CMP'])
+
+
+def test_check_str_fails_with_float_cmp_number_only(check_str):
+    # The match value may need updating if pytest.approx changes it's
+    # assertion error.
+    with pytest.raises(AssertionError, match="^assert 1.23456 "):
+        check_str('1.23456', ['1.230000   # doctest: +FLOAT_CMP  '])

--- a/sherpa/tests/test_tests.py
+++ b/sherpa/tests/test_tests.py
@@ -1,0 +1,32 @@
+#
+#  Copyright (C) 2023  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''Make sure we tests the test fixtures.'''
+import pytest
+
+def test_check_str(check_str):
+    '''The tests that use check_str make sure that it passes,
+    but what if it were to pass everything? 
+    So, add a test here to make sure it actually fails when it should.'''
+    with pytest.raises(AssertionError):
+        check_str('foo = 1.23456', 'foo = 1.230000')
+
+    with pytest.raises(AssertionError):
+        check_str('foo = 1.23456', 'foo = 1.230000   # doctest: +FLOAT_CMP')
+
+    with pytest.raises(AssertionError):
+        check_str('1.23456', '1.230000   # doctest: +FLOAT_CMP')

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1189,17 +1189,7 @@ def test_set_filter_masked_wrong(clean_ui):
         ui.set_filter(np.asarray([True, False]))
 
 
-def check_str(out, expecteds):
-    """Check that out, when split on a newline, matches expecteds"""
-
-    toks = str(out).split("\n")
-    for tok, expected in zip(toks, expecteds):
-        assert tok == expected
-
-    assert len(toks) == len(expecteds)
-
-
-def test_fit_output_single(clean_ui, caplog):
+def test_fit_output_single(clean_ui, caplog, check_str):
     """This is essentially the test from #1804 but for a single dataset"""
 
     ui.load_arrays(1, [1, 2, 3], [12, 10, 4])
@@ -1225,7 +1215,7 @@ def test_fit_output_single(clean_ui, caplog):
                "   mdl.c0         8.66665      +/- 1.70862     "])
 
 
-def test_calc_stat_info_output_single(clean_ui, caplog):
+def test_calc_stat_info_output_single(clean_ui, caplog, check_str):
     """This is essentially the test from #1804 but for a single dataset
     and converted to check calc_stat
 
@@ -1252,7 +1242,7 @@ def test_calc_stat_info_output_single(clean_ui, caplog):
                "Degrees of freedom    = 2"])
 
 
-def test_fit_output_multi(clean_ui, caplog):
+def test_fit_output_multi(clean_ui, caplog, check_str):
     """This is essentially the test from #1804"""
 
     ui.load_arrays(1, [1, 2, 3], [12, 10, 4])
@@ -1280,7 +1270,7 @@ def test_fit_output_multi(clean_ui, caplog):
                "   mdl.c0         7.83332      +/- 1.14642     "])
 
 
-def test_calc_stat_info_output_multi(clean_ui, caplog):
+def test_calc_stat_info_output_multi(clean_ui, caplog, check_str):
     """This is essentially the test from #1804 but for calc_stat_info"""
 
     ui.load_arrays(1, [1, 2, 3], [12, 10, 4])


### PR DESCRIPTION
# Summary

Update the tests to support running on ARM/AARCH64 platforms where numeric differences can complicate string comparisons. Fix #1815.

# Details

@hamogu introduced a simple fix in #1816 and this is a much-more significant change, but is hopefully more versatile. The idea is that we now have a `check_str` fixture which will compare a string (expected to be `str(some-object)` but doesn't have to be) against a list of values. The input string is broken up on new lines and then each line compared to the corresponding element in the list. There are three possibilities for each check

- give a Pattern, so we can do a regexp check - e.g. `re.compile(r"^numcores ?= \d+$")`
- give a string which ends in `# doctest: +FLOAT_CMP` which acts similarly to [`pytest-doctestplus`](https://pypi.org/project/pytest-doctestplus/) and allows numeric tests to use `pytest.approx` with `rel=1e-4`, `abs=None` [*]
- otherwise it is assumed to be a string and compared for equality

[*] this does not completely match `pytest-doctestplus` because

- the regexp we use to match numbers is a subset of the `doctestplus` one
- we only check for a *single* numeric value in the text

If needed we can update the code to support either, or both of these, but at present they are not needed.

I had hoped to use `pytest-doctestplus` for this (and it would be easy to change the internals to do so), but we currently can not require `pytest-doctestplus` as tests without `sherpa-data` installed would fail - or it's when no I/O is available - or both...  (issue #1818).

I am potentially abusing the `pytest` fixture interface to allow using functionality defined in `sherpa/conftest.py` without having to directly import it. We could move this code to `sherpa.utils.testing` but I do not see the advantage.