### PR TITLE
Note compatability with XSPEC 12.13.1

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -335,9 +335,10 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.13.0, 12.12.1, and 12.12.0. It may build against
-newer versions, but if it does it will not provide access to any new
-models in the release. The following sections of the `XSPEC manual
+:term:`XSPEC` versions 12.13.1, 12.13.0, 12.12.1, and 12.12.0.  It may
+build against newer versions, but if it does it will not provide
+access to any new models in the release. The following sections of the
+`XSPEC manual
 <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XspecManual.html>`__
 should be reviewed: `Appendix F: Using the XSPEC Models Library in
 Other Programs

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -144,5 +144,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.13.0, 12.12.1, and
-       12.12.0.
+       Sherpa can be built to use XSPEC versions 12.13.1, 12.13.0,
+       12.12.1, and 12.12.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -252,7 +252,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.13.0 system has been built then use::
+1. If the full XSPEC 12.13.1 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.13.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.32
+       ccfits_libraries = CCfits_2.6
+       wcslib_libraries = wcs-7.7
+
+   where the version numbers were taken from version 6.32 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.13.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.13.0
@@ -262,10 +275,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-   where the version numbers were taken from version 6.31 of HEASOFT and
-   may need updating with a newer release.
-
-2. If the full XSPEC 12.12.1 system has been built then use::
+3. If the full XSPEC 12.12.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.1
@@ -275,10 +285,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-   where the version numbers were taken from version 6.30.1 of HEASOFT and
-   may need updating with a newer release.
-
-3. If the full XSPEC 12.12.0 system has been built then use::
+4. If the full XSPEC 12.12.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.0
@@ -287,9 +294,6 @@ match the contents of the XSPEC installation.
        xspec_libraries = XSFunctions XSUtil XS hdsp_6.29
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.3.1
-
-   where the version numbers were taken from version 6.29 of HEASOFT and
-   may need updating with a newer release.
 
 4. If the model-only build of XSPEC - created with the
    ``--enable-xs-models-only`` flag when building HEASOFT - has been

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -29,7 +29,7 @@ from .extensions import build_ext
 # "c" in "12.12.0c" as that is not helpful to track here.
 #
 SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
-                      (12, 13, 0)]
+                      (12, 13, 0), (12, 13, 1)]
 
 
 # We could use packaging.versions.Version here, but for our needs we

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.13.0, 12.12.1, and 12.12.0 of XSPEC [1]_,
+Sherpa supports versions 12.13.1, 12.13.0, 12.12.1, and 12.12.0 of XSPEC [1]_,
 and can be built against the model library or the full application.
 There is no guarantee of support for older or newer versions of XSPEC.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3188,7 +3188,7 @@ class XScemekl(XSAdditiveModel):
 
     def __init__(self, name='cemekl'):
         self.alpha = XSParameter(name, 'alpha', 1.0, 0.01, 10, 0.01, 20, frozen=True)
-        self.Tmax = XSParameter(name, 'Tmax', 1.0, 0.01, 1.e2, 0.01, 1e2, units='keV')
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, 0.02725, 1.e2, 0.02725, 1e2, units='keV')
         self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
         self.abundanc = XSParameter(name, 'abundanc', 1.0, 0., 10., 0.0, 10, frozen=True)
         self.redshift = XSParameter(name, 'redshift', 0., -0.999, 10., -0.999, 10, frozen=True)
@@ -3239,7 +3239,7 @@ class XScevmkl(XSAdditiveModel):
 
     def __init__(self, name='cevmkl'):
         self.alpha = XSParameter(name, 'alpha', 1.0, 0.01, 10, 0.01, 20, frozen=True)
-        self.Tmax = XSParameter(name, 'Tmax', 1.0, 0.01, 1.e2, 0.01, 1e2, units='keV')
+        self.Tmax = XSParameter(name, 'Tmax', 1.0, 0.02725, 1.e2, 0.02725, 1e2, units='keV')
         self.nH = XSParameter(name, 'nH', 1.0, 1.e-5, 1.e19, 1e-6, 1e20, units='cm^-3', frozen=True)
         self.He = XSParameter(name, 'He', 1.0, 0., 10., 0.0, 10, frozen=True)
         self.C = XSParameter(name, 'C', 1.0, 0., 10., 0.0, 10, frozen=True)
@@ -10137,7 +10137,7 @@ class XSgabs(XSMultiplicativeModel):
     Sigma
         The line width (sigma), in keV.
     Strength
-        The line depth. The optical depth at the line center is
+        The line depth, in keV. The optical depth at the line center is
         Strength / (sqrt(2 pi) * Sigma).
 
     References
@@ -10152,7 +10152,7 @@ class XSgabs(XSMultiplicativeModel):
     def __init__(self, name='gabs'):
         self.LineE = XSParameter(name, 'LineE', 1.0, 0., 1.e6, 0.0, 1e6, units='keV')
         self.Sigma = XSParameter(name, 'Sigma', 0.01, 0., 10., 0.0, 20, units='keV')
-        self.Strength = XSParameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, 1e6, aliases=["Tau"])
+        self.Strength = XSParameter(name, 'Strength', 1.0, 0., 1.e6, 0.0, 1e6, units='keV', aliases=["Tau"])
 
         XSMultiplicativeModel.__init__(self, name, (self.LineE, self.Sigma, self.Strength))
 
@@ -13630,11 +13630,11 @@ class XSbwcycl(XSAdditiveModel):
     def __init__(self, name='bwcycl'):
         self.Radius = XSParameter(name, 'Radius', 10, 5, 20, 5, 20, units='km', frozen=True)
         self.Mass = XSParameter(name, 'Mass', 1.4, 1, 3, 1, 3, units='Solar', frozen=True)
-        self.csi = XSParameter(name, 'csi', 1.5, 0.01, 20, 0.01, 20)
-        self.delta = XSParameter(name, 'delta', 1.8, 0.01, 20, 0.01, 20)
+        self.csi = XSParameter(name, 'csi', 3, 0.01, 20, 0.01, 20)
+        self.delta = XSParameter(name, 'delta', 1.0, 0.01, 20, 0.01, 20)
         self.B = XSParameter(name, 'B', 4, 0.01, 100, 0.01, 100, units='1e12G')
         self.Mdot = XSParameter(name, 'Mdot', 1, 1e-6, 1e6, 1e-6, 1e6, units='1e17g/s')
-        self.Te = XSParameter(name, 'Te', 5, 0.1, 100, 0.1, 100, units='keV')
+        self.Te = XSParameter(name, 'Te', 5, 1.3, 100, 1.3, 100, units='keV')
         self.r0 = XSParameter(name, 'r0', 44, 10, 1000, 10, 1000, units='m')
         self.D = XSParameter(name, 'D', 5, 1, 20, 1, 20, units='kpc', frozen=True)
         self.BBnorm = XSParameter(name, 'BBnorm', 0.0, 0, 100, 0, 100, frozen=True)


### PR DESCRIPTION
# Summary

Note that Sherpa can be built against XSPEC 12.13.1 and update some parameter ranges or defaults to match the new values from this release.

# Details

There are no new models in XSPEC 12.13.1 and no obvious changes to the build (at least for non-macOS platforms) so it is as easy as just updating the documentation. However, there are some parameter-range changes (e.g. see #1834) we can update these (including the `cemekl`/`cevmkl` `Tmax` minimum parameter needing to bump up from 0.01 to 

```
>>> 10**5.5 * 8.6171e-8
0.02724966282543694
```

which we reported to HEASARC thanks to a user seeing crashes in Sherpa).