### PR TITLE
Allow ARF and RMF to be written out

### DIFF
--- a/docs/overview/astro_io.rst
+++ b/docs/overview/astro_io.rst
@@ -21,6 +21,7 @@ The sherpa.astro.io module
       read_pha
       write_image
       write_pha
+      write_arf
       write_table
       pack_table
       pack_image

--- a/docs/overview/astro_io.rst
+++ b/docs/overview/astro_io.rst
@@ -19,9 +19,10 @@ The sherpa.astro.io module
       read_rmf
       read_arrays
       read_pha
+      write_arf
       write_image
       write_pha
-      write_arf
+      write_rmf
       write_table
       pack_table
       pack_image

--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -332,6 +332,7 @@ burden...
       save_pha
       save_quality
       save_resid
+      save_rmf
       save_source
       save_staterror
       save_syserror

--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -320,6 +320,7 @@ burden...
       sample_photon_flux
       save
       save_all
+      save_arf
       save_arrays
       save_data
       save_delchi

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -26,7 +26,7 @@ such as Pulse-Height Amplitudes (PHA) or Pulse-Invariant channels.
 These 'responses' are assumed to follow OGIP standards, such as `OGIP
 Calibration Memo CAL/GEN/92-002, "The Calibration Requirements for
 Spectral Analysis (Definition of RMF and ARF file formats)", Ian
-M. George1, Keith A. Arnaud, Bill Pence, Laddawan Ruamsuwan and
+M. George, Keith A. Arnaud, Bill Pence, Laddawan Ruamsuwan and
 Michael F. Corcoran
 <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
 
@@ -1369,7 +1369,7 @@ def create_non_delta_rmf(rmflo, rmfhi, fname, offset=1,
         The name of the two-dimensional image file which stores the
         response information (the format of this file matches that
         created by the `CIAO tool rmfimg
-        <http://cxc.harvard.edu/ciao/ahelp/rmfimg.html>`_).
+        <https://cxc.harvard.edu/ciao/ahelp/rmfimg.html>`_).
     offset : int, optional
         The starting channel number: expected to be 0 or 1 but this is
         not enforced.

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -18,23 +18,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-"""
-Models of common Astronomical models, particularly in X-rays.
+"""Models of common Astronomical models, particularly in X-rays.
 
 The models in this module include support for instrument models that
 describe how X-ray photons are converted to measurable properties,
 such as Pulse-Height Amplitudes (PHA) or Pulse-Invariant channels.
-These 'responses' are assumed to follow OGIP standards, such as
-[OGIP92-002]_.
-
-References
-----------
-
-.. [OGIP92-002] OGIP Calibration Memo CAL/GEN/92-002, "The Calibration Requirements
-       for Spectral Analysis (Definition of RMF and ARF file formats)",
-       Ian M. George1, Keith A. Arnaud, Bill Pence, Laddawan Ruamsuwan and
-       Michael F. Corcoran,
-       https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html
+These 'responses' are assumed to follow OGIP standards, such as `OGIP
+Calibration Memo CAL/GEN/92-002, "The Calibration Requirements for
+Spectral Analysis (Definition of RMF and ARF file formats)", Ian
+M. George1, Keith A. Arnaud, Bill Pence, Laddawan Ruamsuwan and
+Michael F. Corcoran
+<https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
 
 """
 
@@ -1288,24 +1282,29 @@ def create_delta_rmf(rmflo, rmfhi, offset=1,
     that each channel maps exactly to one energy bin, the
     mapping is monotonic, and there are no gaps.
 
+    .. versionchanged:: 4.16.0
+       The e_min and e_max values will use the rmflo and rmfhi values
+       if not set.
+
     .. versionadded:: 4.10.1
 
     Parameters
     ----------
     rmflo, rmfhi : array
-        The energy bins (low and high, in keV) for the RMF.
-        It is assumed that emfhi_i > rmflo_i, rmflo_j > 0, that the energy
-        bins are either ascending, so rmflo_i+1 > rmflo_i or descending
-        (rmflo_i+1 < rmflo_i), and that there are no overlaps.
-        These correspond to the Elow and Ehigh columns (represented
-        by the ENERG_LO and ENERG_HI columns of the MATRIX block) of
-        the OGIP standard.
+        The energy bins (low and high, in keV) for the RMF.  It is
+        assumed that emfhi_i > rmflo_i, rmflo_j > 0, that the energy
+        bins are either ascending, so rmflo_i+1 > rmflo_i or
+        descending (rmflo_i+1 < rmflo_i), and that there are no
+        overlaps.  These correspond to the Elow and Ehigh columns
+        (represented by the ENERG_LO and ENERG_HI columns of the
+        MATRIX block) of the OGIP standard.
     offset : int, optional
         The starting channel number: expected to be 0 or 1 but this is
         not enforced.
     e_min, e_max : None or array, optional
         The E_MIN and E_MAX columns of the EBOUNDS block of the
-        RMF.
+        RMF. If not set they are taken from rmflo and rmfhi
+        respectively.
     ethresh : number or None, optional
         Passed through to the DataRMF call. It controls whether
         zero-energy bins are replaced.
@@ -1321,6 +1320,7 @@ def create_delta_rmf(rmflo, rmfhi, offset=1,
     See Also
     --------
     create_arf, create_non_delta_rmf
+
     """
 
     # Set up the delta-function response.
@@ -1330,6 +1330,11 @@ def create_delta_rmf(rmflo, rmfhi, offset=1,
     matrix = numpy.ones(nchans, dtype=numpy.float32)
     dummy = numpy.ones(nchans, dtype=numpy.int16)
     f_chan = numpy.arange(1, nchans + 1, dtype=numpy.int16)
+
+    if e_min is None:
+        e_min = rmflo
+    if e_max is None:
+        e_max = rmfhi
 
     return sherpa.astro.data.DataRMF(name, detchans=nchans,
                                      energ_lo=rmflo, energ_hi=rmfhi,
@@ -1343,8 +1348,7 @@ def create_delta_rmf(rmflo, rmfhi, offset=1,
 def create_non_delta_rmf(rmflo, rmfhi, fname, offset=1,
                          e_min=None, e_max=None, ethresh=None,
                          name='delta-rmf', header=None):
-    """
-    Create a RMF using a matrix from a file.
+    """Create a RMF using a matrix from a file.
 
     The RMF matrix (the mapping from channel to energy bin) is
     read in from a file.
@@ -1364,7 +1368,8 @@ def create_non_delta_rmf(rmflo, rmfhi, fname, offset=1,
     fname : str
         The name of the two-dimensional image file which stores the
         response information (the format of this file matches that
-        created by the CIAO tool rmfimg [1]_).
+        created by the `CIAO tool rmfimg
+        <http://cxc.harvard.edu/ciao/ahelp/rmfimg.html>`_).
     offset : int, optional
         The starting channel number: expected to be 0 or 1 but this is
         not enforced.
@@ -1386,11 +1391,6 @@ def create_non_delta_rmf(rmflo, rmfhi, fname, offset=1,
     See Also
     --------
     create_arf, create_delta_rmf
-
-    References
-    ----------
-
-    .. [1] http://cxc.harvard.edu/ciao/ahelp/rmfimg.html
 
     """
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1438,7 +1438,7 @@ def _pack_rmf(dataset):
     # support both types as input.
     #
     if not isinstance(dataset, (DataRMF, RMF1D)):
-        raise IOErr("data set is not an RMF")
+        raise IOErr("data set is not a RMF")
 
     rmfdata = _reconstruct_rmf(dataset)
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -19,10 +19,11 @@
 #
 """Provide Astronomy-specific I/O routines for Sherpa.
 
-This module contains read and write routines for handling FITS [1]_
-and ASCII format data. The actual support is provided by
-the selected I/O backend package (currently Crates, provided
-by CIAO, or the FITS support in the AstroPy package, if installed).
+This module contains read and write routines for handling `FITS
+<https://en.wikipedia.org/wiki/FITS>`_ and ASCII format data. The
+actual support is provided by the selected I/O backend package
+(currently Crates, provided by CIAO, or the FITS support in the
+AstroPy package, if installed).
 
 Which backend is used?
 ----------------------
@@ -45,11 +46,6 @@ interface):
 
   >>> import sherpa.astro.io.pyfits_backend
   >>> io.backend = sherpa.astro.io.pyfits_backend
-
-References
-----------
-
-.. [1] Flexible Image Transport System, https://en.wikipedia.org/wiki/FITS
 
 """
 
@@ -707,8 +703,10 @@ def _pack_pha(dataset):
 
     Notes
     -----
-    The PHA Data Extension header page [1]_ lists the following
-    keywords as either required or we-really-want-them:
+    The `PHA Data Extension header page
+    <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node6.html>`_
+    lists the following keywords as either required or
+    we-really-want-them:
 
         EXTNAME = "SPECTRUM"
         TELESCOP - the "telescope" (i.e. mission/satellite name).
@@ -753,11 +751,6 @@ def _pack_pha(dataset):
     required (here we assume the CHANNEL column is first) and they are
     strongly recommended otherwise.
 
-    References
-    ----------
-
-    .. [1] https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node6.html
-
     """
 
     # The logic here repeats some of the checks that probably should
@@ -777,6 +770,7 @@ def _pack_pha(dataset):
     #
     default_header = {
         "EXTNAME": "SPECTRUM",
+        # "HDUNAME": "SPECTRUM",  - this is a CIAO-specific keyword
         "HDUCLASS": "OGIP",
         "HDUCLAS1": "SPECTRUM",
         "HDUCLAS2": "TOTAL",
@@ -809,8 +803,11 @@ def _pack_pha(dataset):
     #
     header = {**default_header, **header}
 
-    # Over-write the header value (if set)
-    header["EXPOSURE"] = getattr(dataset, "exposure", "none")
+    # Over-write the header value (if set). This value should really
+    # exist (OGIP standards) but may not, particularly for testing.
+    #
+    if dataset.exposure is not None:
+        header["EXPOSURE"] = dataset.exposure
 
     _set_keyword(header, "RESPFILE", rmf)
     _set_keyword(header, "ANCRFILE", arf)
@@ -1045,8 +1042,8 @@ def write_pha(filename, dataset, ascii=True, clobber=False):
     """
     data, hdr = _pack_pha(dataset)
     col_names = list(data.keys())
-    backend.set_pha_data(filename, data, col_names, hdr, ascii=ascii,
-                         clobber=clobber)
+    backend.set_pha_data(filename, data, col_names, header=hdr,
+                         ascii=ascii, clobber=clobber)
 
 
 def pack_table(dataset):
@@ -1129,7 +1126,8 @@ def pack_pha(dataset):
     """
     data, hdr = _pack_pha(dataset)
     col_names = list(data.keys())
-    return backend.set_pha_data('', data, col_names, hdr, packup=True)
+    return backend.set_pha_data('', data, col_names, header=hdr,
+                                packup=True)
 
 
 def read_table_blocks(arg, make_copy=False):

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -68,7 +68,14 @@ def open_crate(filename, crateType=CrateDataset, mode='r'):
     """
     dataset = open_crate_dataset(filename, crateType, mode)
     current = dataset.get_current_crate()
-    return dataset.get_crate(current)
+    try:
+        return dataset.get_crate(current)
+    except Exception as exc:
+        # crates can fail with unsupported data types - e.g.  see
+        # #1898 but also long-long columns for CIAO 4.15.
+        #
+        emsg = f"crates is unable to read '{filename}': {str(exc)}"
+        raise IOErr("openfailed", emsg) from exc
 
 
 def get_filename_from_dmsyntax(filename, blockname=None):
@@ -407,6 +414,13 @@ def _get_crate_by_blockname(dataset, blkname):
         return dataset.get_crate(blkname)
     except IndexError:
         return None
+    except Exception as exc:
+        # crates can fail with unsupported data types - e.g.  see
+        # #1898 but also long-long columns for CIAO 4.15.
+        #
+        filename = dataset.get_filename()
+        emsg = f"crates is unable to read '{filename}': {str(exc)}"
+        raise IOErr("openfailed", emsg) from exc
 
 
 # Read Functions #

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -644,14 +644,9 @@ def get_image_data(arg, make_copy=True, fix_type=True):
                             crota, epoch, equin)
 
     data['header'] = _get_meta_data(img)
-
-    keys = ['MTYPE1', 'MFORM1', 'CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
-            'CDELT2P', 'CRPIX1P', 'CRPIX2P', 'CRVAL1P', 'CRVAL2P',
-            'MTYPE2', 'MFORM2', 'CTYPE1', 'CTYPE2', 'CDELT1', 'CDELT2', 'CRPIX1',
-            'CRPIX2', 'CRVAL1', 'CRVAL2', 'CUNIT1', 'CUNIT2', 'EQUINOX']
-#            'WCSTY1P', 'WCSTY2P']
-
-    for key in keys:
+    for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
+                'CDELT2P', 'CRPIX1P', 'CRPIX2P', 'CRVAL1P', 'CRVAL2P',
+                'EQUINOX']:
         data['header'].pop(key, None)
 
     return data, filename

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -45,7 +45,8 @@ except:
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
-           'set_table_data', 'set_image_data', 'set_pha_data')
+           'set_table_data', 'set_image_data', 'set_pha_data',
+           'set_arf_data')
 
 
 string_types = (str, )
@@ -1202,8 +1203,21 @@ def set_table_data(filename, data, col_names, header=None,
         tbl.write(filename, clobber=True)
 
 
+def set_arf_data(filename, data, col_names, header=None,
+                 ascii=False, clobber=False, packup=False):
+    """Create a PHA dataset/file"""
+
+    if header is None:
+        raise ArgumentTypeErr("badarg", "header", "set")
+
+    # Currently we can use the same logic as set_table_data
+    return set_table_data(filename, data, col_names, header=header,
+                          ascii=ascii, clobber=clobber, packup=packup)
+
+
 def set_pha_data(filename, data, col_names, header=None,
                  ascii=False, clobber=False, packup=False):
+    """Create a PHA dataset/file"""
 
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2022
+#  Copyright (C) 2021, 2022, 2023
 #  MIT
 #
 #
@@ -28,7 +28,8 @@ import logging
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
-           'set_table_data', 'set_image_data', 'set_pha_data')
+           'set_table_data', 'set_image_data', 'set_pha_data',
+           'set_arf_data')
 
 
 lgr = logging.getLogger(__name__)
@@ -54,3 +55,4 @@ get_pha_data = get_table_data
 set_table_data = get_table_data
 set_image_data = get_table_data
 set_pha_data = get_table_data
+set_arf_data = get_table_data

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -29,7 +29,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data')
+           'set_arf_data', 'set_rmf_data')
 
 
 lgr = logging.getLogger(__name__)
@@ -56,3 +56,4 @@ set_table_data = get_table_data
 set_image_data = get_table_data
 set_pha_data = get_table_data
 set_arf_data = get_table_data
+set_rmf_data = get_table_data

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -81,28 +81,27 @@ def _has_hdu(hdulist, name):
 
 def _try_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
 
-    try:
-        key = hdu.header[name]
-    except KeyError:
+    value = hdu.header.get(name, None)
+    if value is None:
         return None
 
     # TODO: As noted with the crates backend, this test is probably
     # overly broad, and we should look at simplifying it.
     #
-    if str(key).find('none') != -1:
+    if str(value).find('none') != -1:
         return None
 
     if not fix_type:
-        return key
+        return value
 
-    return dtype(key)
+    return dtype(value)
 
 
 def _require_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
-    key = _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
-    if key is None:
+    value = _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
+    if value is None:
         raise IOErr('nokeyword', hdu._file.name, name)
-    return key
+    return value
 
 
 def _get_meta_data(hdu):

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -86,8 +86,8 @@ def _try_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
     except KeyError:
         return None
 
-    # TODO: should this comparison be case insensitive, so that
-    # NONE and None are also matched?
+    # TODO: As noted with the crates backend, this test is probably
+    # overly broad, and we should look at simplifying it.
     #
     if str(key).find('none') != -1:
         return None

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -577,15 +577,11 @@ def get_image_data(arg, make_copy=False):
 
         data['sky'] = sky
         data['eqpos'] = eqpos
+
         data['header'] = _get_meta_data(img)
-
-        keys = ['MTYPE1', 'MFORM1', 'CTYPE1P', 'CTYPE2P', 'WCSNAMEP',
-                'CDELT1P', 'CDELT2P', 'CRPIX1P', 'CRPIX2P',
-                'CRVAL1P', 'CRVAL2P', 'MTYPE2', 'MFORM2', 'CTYPE1', 'CTYPE2',
-                'CDELT1', 'CDELT2', 'CRPIX1', 'CRPIX2', 'CRVAL1', 'CRVAL2',
-                'CUNIT1', 'CUNIT2', 'EQUINOX']
-
-        for key in keys:
+        for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
+                    'CDELT2P', 'CRPIX1P', 'CRPIX2P', 'CRVAL1P', 'CRVAL2P',
+                    'EQUINOX']:
             data['header'].pop(key, None)
 
     finally:

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -78,23 +78,27 @@ def _has_hdu(hdulist, name):
     return True
 
 
-def _try_key(hdu, name, fix_type=False, dtype=SherpaFloat):
+def _try_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
 
     try:
         key = hdu.header[name]
     except KeyError:
         return None
 
+    # TODO: should this comparison be case insensitive, so that
+    # NONE and None are also matched?
+    #
     if str(key).find('none') != -1:
         return None
 
-    if fix_type:
-        key = dtype(key)
-    return key
+    if not fix_type:
+        return key
+
+    return dtype(key)
 
 
-def _require_key(hdu, name, fix_type=False, dtype=SherpaFloat):
-    key = _try_key(hdu, name, fix_type, dtype)
+def _require_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
+    key = _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
     if key is None:
         raise IOErr('nokeyword', hdu._file.name, name)
     return key
@@ -121,21 +125,21 @@ def _get_meta_data(hdu):
 
 
 # Note: it is not really WCS specific, but leave the name alone for now.
-def _get_wcs_key(hdu, key0, key1, fix_type=False, dtype=SherpaFloat):
+def _get_wcs_key(hdu, key0, key1):
     """Return the pair of keyword values as an array of values of
     the requested datatype. If either key is missing then return
     ().
     """
 
-    val1 = _try_key(hdu, key0, fix_type, dtype)
+    val1 = _try_key(hdu, key0)
     if val1 is None:
         return ()
 
-    val2 = _try_key(hdu, key1, fix_type, dtype)
+    val2 = _try_key(hdu, key1)
     if val2 is None:
         return ()
 
-    return numpy.array([val1, val2], dtype)
+    return numpy.array([val1, val2], dtype=SherpaFloat)
 
 
 def _add_keyword(hdrlist, name, val):
@@ -150,7 +154,7 @@ def _add_keyword(hdrlist, name, val):
         hdrlist.append(fits.Card(name, val))
 
 
-def _try_col(hdu, name, dtype=SherpaFloat, fix_type=False):
+def _try_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
     try:
         col = hdu.data.field(name)
     except KeyError:
@@ -167,7 +171,7 @@ def _try_col(hdu, name, dtype=SherpaFloat, fix_type=False):
     return col
 
 
-def _try_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
+def _try_tbl_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
     try:
         col = hdu.data.field(name)
     except KeyError:
@@ -184,7 +188,7 @@ def _try_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
     return numpy.column_stack(col)
 
 
-def _try_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
+def _try_vec(hdu, name, *, size=2, dtype=SherpaFloat, fix_type=False):
     try:
         col = hdu.data.field(name)
     except KeyError:
@@ -196,47 +200,46 @@ def _try_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
         col = numpy.asarray(col)
 
     if fix_type:
-        col = col.astype(dtype)
-
-    if col is None:
-        return numpy.array([None] * size)
+        return col.astype(dtype)
 
     return col
 
 
-def _require_col(hdu, name, dtype=SherpaFloat, fix_type=False):
-    col = _try_col(hdu, name, dtype, fix_type)
+def _require_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
+    col = _try_col(hdu, name, dtype=dtype, fix_type=fix_type)
     if col is None:
         raise IOErr('reqcol', name, hdu._file.name)
     return col
 
 
-def _require_tbl_col(hdu, name, dtype=SherpaFloat, fix_type=False):
-    col = _try_tbl_col(hdu, name, dtype, fix_type)
+def _require_tbl_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
+    col = _try_tbl_col(hdu, name, dtype=dtype, fix_type=fix_type)
     if len(col) > 0 and col[0] is None:
         raise IOErr('reqcol', name, hdu._file.name)
     return col
 
 
-def _require_vec(hdu, name, size=2, dtype=SherpaFloat, fix_type=False):
-    col = _try_vec(hdu, name, size, dtype, fix_type)
+def _require_vec(hdu, name, *, size=2, dtype=SherpaFloat, fix_type=False):
+    col = _try_vec(hdu, name, size=size, dtype=dtype, fix_type=fix_type)
     if numpy.equal(col, None).any():
         raise IOErr('reqcol', name, hdu._file.name)
     return col
 
 
-def _try_col_or_key(hdu, name, dtype=SherpaFloat, fix_type=False):
-    col = _try_col(hdu, name, dtype, fix_type)
+def _try_col_or_key(hdu, name, *, dtype=SherpaFloat, fix_type=False):
+    col = _try_col(hdu, name, dtype=dtype, fix_type=fix_type)
     if col is not None:
         return col
-    return _try_key(hdu, name, fix_type, dtype)
+    return _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
 
 
-def _try_vec_or_key(hdu, name, size, dtype=SherpaFloat, fix_type=False):
-    col = _try_col(hdu, name, dtype, fix_type)
+def _try_vec_or_key(hdu, name, size, *, dtype=SherpaFloat, fix_type=False):
+    col = _try_col(hdu, name, dtype=dtype, fix_type=fix_type)
     if col is not None:
         return col
-    return numpy.array([_try_key(hdu, name, fix_type, dtype)] * size)
+
+    got = _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
+    return numpy.array([got] * size)
 
 
 # Read Functions
@@ -422,6 +425,8 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
             hdrkeys = hdu.header.keys()
 
         for key in hdrkeys:
+            # TODO: should this set require_type=true or remove dtype,
+            # as currently it does not change the value to str.
             hdr[key] = _require_key(hdu, key, dtype=str)
 
     finally:
@@ -691,7 +696,8 @@ def _read_rmf_data(arg):
 
         # Beginning of non-Chandra RMF support
         fchan_col = list(hdu.columns.names).index('F_CHAN') + 1
-        tlmin = _try_key(hdu, f"TLMIN{fchan_col}", True, SherpaUInt)
+        tlmin = _try_key(hdu, f"TLMIN{fchan_col}", fix_type=True,
+                         dtype=SherpaUInt)
 
         if tlmin is not None:
             data['offset'] = tlmin
@@ -711,7 +717,8 @@ def _read_rmf_data(arg):
 
             # Beginning of non-Chandra RMF support
             chan_col = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, f"TLMIN{chan_col}", True, SherpaUInt)
+            tlmin = _try_key(hdu, f"TLMIN{chan_col}", fix_type=True,
+                             dtype=SherpaUInt)
             if tlmin is not None:
                 data['offset'] = tlmin
 
@@ -878,44 +885,67 @@ def get_pha_data(arg, make_copy=False, use_background=False):
         if _try_col(hdu, 'SPEC_NUM') is None:
             data = {}
 
+            # Create local versions of the "try" routines.
+            #
+            def try_any_sfloat(key):
+                "Get col/key and return a SherpaFloat"
+                return _try_col_or_key(hdu, key, fix_type=True)
+
+            def try_sfloat(key):
+                "Get col and return a SherpaFloat"
+                return _try_col(hdu, key, fix_type=True)
+
+            def try_sint(key):
+                """Get col and return a SherpaInt
+
+                Or, it looks like it should do this, but at the moment
+                it does not force the data type.
+
+                """
+                # return _try_col(hdu, key, fix_type=True, dtype=SherpaInt)
+                return _try_col(hdu, key, dtype=SherpaInt)
+
+            def req_sfloat(key):
+                "Get col and return a SherpaFloat"
+                return _require_col(hdu, key, fix_type=True)
+
             # Keywords
-            data['exposure'] = _try_key(hdu, 'EXPOSURE', True, SherpaFloat)
+            data['exposure'] = _try_key(hdu, 'EXPOSURE', fix_type=True)
             # data['poisserr'] = _try_key(hdu, 'POISSERR', True, bool)
             data['backfile'] = _try_key(hdu, 'BACKFILE')
             data['arffile'] = _try_key(hdu, 'ANCRFILE')
             data['rmffile'] = _try_key(hdu, 'RESPFILE')
 
             # Keywords or columns
-            data['backscal'] = _try_col_or_key(hdu, 'BACKSCAL', fix_type=True)
-            data['backscup'] = _try_col_or_key(hdu, 'BACKSCUP', fix_type=True)
-            data['backscdn'] = _try_col_or_key(hdu, 'BACKSCDN', fix_type=True)
-            data['areascal'] = _try_col_or_key(hdu, 'AREASCAL', fix_type=True)
+            data['backscal'] = try_any_sfloat('BACKSCAL')
+            data['backscup'] = try_any_sfloat('BACKSCUP')
+            data['backscdn'] = try_any_sfloat('BACKSCDN')
+            data['areascal'] = try_any_sfloat('AREASCAL')
 
             # Columns
-            data['channel'] = _require_col(hdu, 'CHANNEL', fix_type=True)
+            data['channel'] = req_sfloat("CHANNEL")
 
             # Make sure channel numbers not indices
             chan = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, f"TLMIN{chan}", True, SherpaUInt)
+            tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
+                             dtype=SherpaUInt)
             if int(data['channel'][0]) == 0 or tlmin == 0:
                 data['channel'] = data['channel'] + 1
 
-            data['counts'] = _try_col(hdu, 'COUNTS', fix_type=True)
+            data['counts'] = try_sfloat("COUNTS")
             data['staterror'] = _try_col(hdu, 'STAT_ERR')
             if data['counts'] is None:
-                data['counts'] = _require_col(hdu, 'RATE',
-                                              fix_type=True) * data['exposure']
+                data['counts'] = req_sfloat("RATE") * data['exposure']
                 if data['staterror'] is not None:
                     data['staterror'] = data['staterror'] * data['exposure']
+
             data['syserror'] = _try_col(hdu, 'SYS_ERR')
-            data['background_up'] = _try_col(hdu, 'BACKGROUND_UP',
-                                             fix_type=True)
-            data['background_down'] = _try_col(hdu, 'BACKGROUND_DOWN',
-                                               fix_type=True)
-            data['bin_lo'] = _try_col(hdu, 'BIN_LO', fix_type=True)
-            data['bin_hi'] = _try_col(hdu, 'BIN_HI', fix_type=True)
-            data['grouping'] = _try_col(hdu, 'GROUPING', SherpaInt)
-            data['quality'] = _try_col(hdu, 'QUALITY', SherpaInt)
+            data['background_up'] = try_sfloat('BACKGROUND_UP')
+            data['background_down'] = try_sfloat('BACKGROUND_DOWN')
+            data['bin_lo'] = try_sfloat('BIN_LO')
+            data['bin_hi'] = try_sfloat('BIN_HI')
+            data['grouping'] = try_sint('GROUPING')
+            data['quality'] = try_sint('QUALITY')
             data['header'] = _get_meta_data(hdu)
             for key in keys:
                 data['header'].pop(key, None)
@@ -933,25 +963,52 @@ def get_pha_data(arg, make_copy=False, use_background=False):
             specnum = _try_col_or_key(hdu, 'SPEC_NUM')
             num = len(specnum)
 
+            # Create local versions of the "try" routines set for this
+            # size=num value.
+            #
+            def try_any_sfloat(key):
+                "Get col/key and return a SherpaFloat"
+                return _try_vec_or_key(hdu, key, size=num, fix_type=True)
+
+            def try_sfloat(key):
+                "Get col and return a SherpaFloat"
+                return _try_vec(hdu, key, size=num, fix_type=True)
+
+            def try_sint(key):
+                """Get col and return a SherpaInt
+
+                Or, it looks like it should do this, but at the moment
+                it does not force the data type.
+
+                """
+                # return _try_vec(hdu, key, size=num, fix_type=True, dtype=SherpaInt)
+                return _try_vec(hdu, key, size=num, dtype=SherpaInt)
+
+            def req_sfloat(key):
+                "Get col and return a SherpaFloat"
+                return _require_vec(hdu, key, size=num, fix_type=True)
+
             # Keywords
-            exposure = _try_key(hdu, 'EXPOSURE', True, SherpaFloat)
+            exposure = _try_key(hdu, 'EXPOSURE', fix_type=True)
             # poisserr = _try_key(hdu, 'POISSERR', True, bool)
             backfile = _try_key(hdu, 'BACKFILE')
             arffile = _try_key(hdu, 'ANCRFILE')
             rmffile = _try_key(hdu, 'RESPFILE')
 
             # Keywords or columns
-            backscal = _try_vec_or_key(hdu, 'BACKSCAL', num, fix_type=True)
-            backscup = _try_vec_or_key(hdu, 'BACKSCUP', num, fix_type=True)
-            backscdn = _try_vec_or_key(hdu, 'BACKSCDN', num, fix_type=True)
-            areascal = _try_vec_or_key(hdu, 'AREASCAL', num, fix_type=True)
+            backscal = try_any_sfloat('BACKSCAL')
+            backscup = try_any_sfloat('BACKSCUP')
+            backscdn = try_any_sfloat('BACKSCDN')
+            areascal = try_any_sfloat('AREASCAL')
 
             # Columns
-            channel = _require_vec(hdu, 'CHANNEL', num, fix_type=True)
+            # Why does this convert to SherpaFloat?
+            channel = req_sfloat('CHANNEL')
 
             # Make sure channel numbers not indices
             chan = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, f"TLMIN{chan}", True, SherpaUInt)
+            tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
+                             dtype=SherpaUInt)
 
             for ii in range(num):
                 if int(channel[ii][0]) == 0:
@@ -960,27 +1017,26 @@ def get_pha_data(arg, make_copy=False, use_background=False):
             # if ((tlmin is not None) and tlmin == 0) or int(channel[0]) == 0:
             #     channel += 1
 
-            counts = _try_vec(hdu, 'COUNTS', num, fix_type=True)
-            staterror = _try_vec(hdu, 'STAT_ERR', num)
+            # Why does this convert to SherpaFloat?
+            counts = try_sfloat("COUNTS")
+            staterror = _try_vec(hdu, 'STAT_ERR', size=num)
             if numpy.equal(counts, None).any():  # _try_vec can return an array of Nones
-                counts = _require_vec(hdu, 'RATE', num,
-                                      fix_type=True) * exposure
+                counts = req_sfloat("RATE") * exposure
                 if not numpy.equal(staterror, None).any():
                     staterror *= exposure
 
-            syserror = _try_vec(hdu, 'SYS_ERR', num)
-            background_up = _try_vec(hdu, 'BACKGROUND_UP', num, fix_type=True)
-            background_down = _try_vec(hdu, 'BACKGROUND_DOWN', num,
-                                       fix_type=True)
-            bin_lo = _try_vec(hdu, 'BIN_LO', num, fix_type=True)
-            bin_hi = _try_vec(hdu, 'BIN_HI', num, fix_type=True)
-            grouping = _try_vec(hdu, 'GROUPING', num, SherpaInt)
-            quality = _try_vec(hdu, 'QUALITY', num, SherpaInt)
+            syserror = _try_vec(hdu, 'SYS_ERR', size=num)
+            background_up = try_sfloat('BACKGROUND_UP')
+            background_down = try_sfloat('BACKGROUND_DOWN')
+            bin_lo = try_sfloat('BIN_LO')
+            bin_hi = try_sfloat('BIN_HI')
+            grouping = try_sint('GROUPING')
+            quality = try_sint('QUALITY')
 
-            orders = _try_vec(hdu, 'TG_M', num, SherpaInt)
-            parts = _try_vec(hdu, 'TG_PART', num, SherpaInt)
-            specnums = _try_vec(hdu, 'SPEC_NUM', num, SherpaInt)
-            srcids = _try_vec(hdu, 'TG_SRCID', num, SherpaInt)
+            orders = try_sint('TG_M')
+            parts = try_sint('TG_PART')
+            specnums = try_sint('SPEC_NUM')
+            srcids = try_sint('TG_SRCID')
 
             # Iterate over all rows of channels, counts, errors, etc
             # Populate a list of dictionaries containing
@@ -1096,6 +1152,25 @@ def set_table_data(filename, data, col_names, header=None,
     if hdu.name == '':
         tbl.name = 'HISTOGRAM'
 
+    # Add in the header. We should special case the HISTORY/COMMENT
+    # keywords but at the moment we do nothing.
+    #
+    # There is the issue of conflicts between the existing and sent-in
+    # header - fortunately we can just drop those keys from the sent-in
+    # header, and also just whether the sent-in header keys (e.g. if
+    # TUNIT1 and TLMIN1 are set are they valid)? For the latter we rely
+    # on validation done by the code calling set_table_data.
+    #
+    if header is not None:
+        for key, value in header.items():
+            if key in hdu.header:
+                continue
+
+            if value is None:
+                continue
+
+            hdu.header[key] = value
+
     if packup:
         return hdu
 
@@ -1120,22 +1195,9 @@ def _create_header(header):
 def set_pha_data(filename, data, col_names, header=None,
                  ascii=False, clobber=False, packup=False):
 
-    if not packup:
-        check_clobber(filename, clobber)
-
-    tbl = _create_table(col_names, data)
-    if ascii:
-        tbl.write(filename, format='ascii.commented_header',
-                  overwrite=clobber)
-        return
-
-    hdu = fits.table_to_hdu(tbl)
-    hdu.header.extend(_create_header(header))
-
-    if packup:
-        return hdu
-
-    hdu.writeto(filename, overwrite=True)
+    # Currently we can use the same logic as set_table_data
+    return set_table_data(filename, data, col_names, header=header,
+                          ascii=ascii, clobber=clobber, packup=packup)
 
 
 def set_image_data(filename, data, header, ascii=False, clobber=False,

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -43,9 +43,7 @@ def test_image_write_basic(make_data_path, tmp_path):
         # check header for a selected set of keywords
         hdr = obj.header
 
-        # selected OGIP keywords
-        if not backend_is("crates"):
-            assert hdr["HDUNAME"] == "EVENTS_IMAGE"
+        assert "HDUNAME" not in hdr
 
         assert hdr["HDUCLASS"] == "OGIP"
         assert hdr["HDUCLAS1"] == "EVENTS"

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -48,15 +48,6 @@ def backend_is(name):
     return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
 
 
-def check_hduname(hdr, expected):
-    """crates removes the HDUNAME setting but pyfits keeps it"""
-
-    if backend_is("crates"):
-        assert "HDUNAME" not in hdr
-    else:
-        assert hdr["HDUNAME"] == expected
-
-
 @requires_fits
 @requires_data
 def test_pha_write_basic(make_data_path, tmp_path):
@@ -70,9 +61,9 @@ def test_pha_write_basic(make_data_path, tmp_path):
         # check header for a selected set of keywords
         hdr = obj.header
 
-        # selected OGIP keywords
-        check_hduname(hdr, "SPECTRUM")
+        assert "HDUNAME" not in hdr
 
+        # selected OGIP keywords
         assert hdr["HDUCLASS"] == "OGIP"
         assert hdr["HDUCLAS1"] == "SPECTRUM"
         assert hdr["HDUCLAS2"] == "TOTAL"
@@ -201,9 +192,9 @@ def test_pha_write_basic_errors(make_data_path, tmp_path):
         # check header for a selected set of keywords
         hdr = obj.header
 
-        # selected OGIP keywords
-        check_hduname(hdr, "SPECTRUM")
+        assert "HDUNAME" not in hdr
 
+        # selected OGIP keywords
         assert hdr["HDUCLASS"] == "OGIP"
         assert hdr["HDUCLAS1"] == "SPECTRUM"
         assert hdr["HDUCLAS2"] == "TOTAL"
@@ -384,25 +375,14 @@ def test_pha_write_xmm_grating(make_data_path, tmp_path):
         for key in ["RESPFILE", "ANCRFILE", "BACKFILE"]:
             assert key not in hdr
 
-        # WCS attached to the CHANNEL column
-        if backend_is("crates"):
-            assert "TCRYP1" not in hdr
-            assert "TCRVL1" not in hdr
-            assert "TLMIN1" not in hdr
-            assert "TLMAX1" not in hdr
-
-        elif backend_is("pyfits"):
-            assert hdr["TCTYP1"] == ""
-            assert hdr["TCUNI1"] == "Angstrom"
-            assert hdr["TCRPX1"] == 1
-            assert hdr["TCRVL1"] == pytest.approx(4.00500011)
-            assert hdr["TCDLT1"] == pytest.approx(0.01)
-
-            assert hdr["TLMIN1"] == 1
-            assert hdr["TLMAX1"] == 3600
-
-        else:
-            assert False  # programming error
+        # check WCS that was attached to the CHANNEL column
+        assert "TCRYP1" not in hdr
+        assert "TCRVL1" not in hdr
+        assert "TCUNI1" not in hdr
+        assert "TCRPX1" not in hdr
+        assert "TCDLT1" not in hdr
+        assert "TLMIN1" not in hdr
+        assert "TLMAX1" not in hdr
 
     def check_data(obj, roundtrip=False):
         """Basic checks of the data"""
@@ -887,7 +867,7 @@ def test_chandra_phaII_roundtrip(make_data_path, tmp_path):
         assert hdr["TG_M"] == 2
         assert hdr["TG_PART"] == 1
 
-        check_hduname(hdr, "SPECTRUM")
+        assert "HDUNAME" not in hdr
 
         assert hdr["HDUCLASS"] == "OGIP"
         assert hdr["HDUCLAS1"] == "SPECTRUM"
@@ -1097,10 +1077,9 @@ def test_csc_pha_roundtrip(make_data_path, tmp_path):
         # check header for a selected set of keywords
         hdr = obj.header
 
-        # selected OGIP keywords
-        expected = "SPECTRUM" + ("2" if background else "1")
-        check_hduname(hdr, expected)
+        assert "HDUNAME" not in hdr
 
+        # selected OGIP keywords
         assert hdr["HDUCLASS"] == "OGIP"
         assert hdr["HDUCLAS1"] == "SPECTRUM"
         assert hdr["HDUCLAS2"] == "BKG" if background else "TOTAL"

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -476,7 +476,7 @@ def check_write_pha_fits_basic_roundtrip_crates(path):
     assert cr.name == "SPECTRUM"
     assert cr.get_colnames() == ["CHANNEL", "COUNTS"]
 
-    # undortunately crates auto-converts int32 to int64
+    # unfortunately crates auto-converts int32 to int64
     # (this is actually the underlying cxcdm module).
     #
     c0 = cr.get_column(0)
@@ -519,9 +519,11 @@ def check_write_pha_fits_basic_roundtrip_crates(path):
     for key in ["BACKFILE", "CORRFILE", "RESPFILE", "ANCRFILE"]:
         assert cr.get_key_value(key) == "none"
 
-    # keywords we should have but currently don't
-    for key in ["EXPOSURE"]:
-        assert cr.get_key_value(key) is None
+    # The EXPOSURE keyword should be an attribute now, and removed
+    # from the header, but we do not guarantee or require that, so
+    # check whether it exists in the header.
+    #
+    assert cr.get_key_value("EXPOSURE") is None
 
 
 def check_write_pha_fits_basic_roundtrip_pyfits(path):
@@ -574,9 +576,11 @@ def check_write_pha_fits_basic_roundtrip_pyfits(path):
         assert "TLMIN2" not in hdu.header
         assert "TLMAX2" not in hdu.header
 
-        # keywords we should have but currently don't
-        for key in ["EXPOSURE"]:
-            assert key not in hdu.header
+        # The EXPOSURE keyword should be an attribute now, and removed
+        # from the header, but we do not guarantee or require that, so
+        # check whether it exists in the header.
+        #
+        assert "EXPOSURE" not in hdu.header
 
     finally:
         hdus.close()
@@ -586,7 +590,8 @@ def check_write_pha_fits_basic_roundtrip_pyfits(path):
 def test_write_pha_fits_basic_roundtrip(tmp_path):
     """A very-basic PHA output
 
-    No ancillary information and no header.
+    No ancillary information and no extra header information.
+
     """
 
     chans = np.arange(1, 5, dtype=np.int16)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -652,8 +652,9 @@ def test_write_rmf_fits_swift_xrt(make_data_path, tmp_path):
 def test_write_rmf_fits_rosat_pspc(make_data_path, tmp_path):
     """Check we can write out an RMF as a FITS file.
 
-    Use the ROSAT PSPCC as it has it's own DataRosatRMF class.  It's
-    also a RSP rather than a RMF (ie includes the ARF, I believe).
+    Use the ROSAT PSPC-C example dataset as it has it's own
+    DataRosatRMF class.  It's also a RSP rather than a RMF (ie
+    includes the ARF, I believe).
 
     """
 
@@ -757,7 +758,7 @@ def test_write_rmf_fits_rosat_pspc(make_data_path, tmp_path):
 def test_write_rmf_fits_xmm_rgs(make_data_path, tmp_path):
     """Check we can write out an RMF as a FITS file.
 
-    Try out a grating RMF. Use XMM as smaller than Chandra.
+    Try out a grating RMF. Use XMM since it is smaller than Chandra.
 
     """
 

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -37,15 +37,6 @@ def backend_is(name):
     return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
 
 
-def check_hduname(hdr, expected):
-    """crates removes the HDUNAME setting but pyfits keeps it"""
-
-    if backend_is("crates"):
-        assert "HDUNAME" not in hdr
-    else:
-        assert hdr["HDUNAME"] == expected
-
-
 @requires_data
 @requires_fits
 def test_read_arf(make_data_path):
@@ -59,8 +50,7 @@ def test_read_arf(make_data_path):
     assert np.log10(arf.ethresh) == pytest.approx(-10)
 
     hdr = arf.header
-    check_hduname(hdr, "SPECRESP")
-
+    assert "HDUNAME" not in hdr
     assert hdr["CONTENT"] == "SPECRESP"
     assert hdr["HDUCLASS"] == "OGIP"
     assert hdr["HDUCLAS1"] == "RESPONSE"
@@ -120,7 +110,6 @@ def test_read_rmf(make_data_path):
 
     hdr = rmf.header
     assert "HDUNAME" not in hdr
-
     assert hdr["HDUCLASS"] == "OGIP"
     assert hdr["HDUCLAS1"] == "RESPONSE"
     assert hdr["HDUCLAS2"] == "RSP_MATRIX"

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -652,7 +652,7 @@ def test_write_rmf_fits_swift_xrt(make_data_path, tmp_path):
 def test_write_rmf_fits_rosat_pspc(make_data_path, tmp_path):
     """Check we can write out an RMF as a FITS file.
 
-    Use the ROSAT PSPC-C example dataset as it has it's own
+    Use the ROSAT PSPC-C example dataset as it has its own
     DataRosatRMF class.  It's also a RSP rather than a RMF (ie
     includes the ARF, I believe).
 

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2020, 2021, 2022
+#  Copyright (C) 2017, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -685,6 +685,37 @@ def test_arfmodelpha_call(ignore):
 def test_rmfmodelpha_delta_no_ebounds(analysis, caplog):
     """What happens calling an rmf with a pha and no EBOUNDS is set
 
+    create_delta_rmf, prior to 4.16.0, did not set the e_min/max
+    values when called like this, which meant that we couldn't
+    use an energy filter, so a test was created to test the
+    behavior. It now sets the values so we just check it works
+    as expected. See test_rmfmodelpha_delta_no_ebounds_manual.
+
+    """
+
+    egrid = np.arange(0.01, 0.07, 0.01)
+    rdata = create_delta_rmf(egrid[:-1], egrid[1:])
+
+    channels = np.arange(1, 6, dtype=np.int16)
+    counts = np.asarray([10, 5, 12, 7, 3], dtype=np.int16)
+    pha = DataPHA('test-pha', channel=channels, counts=counts)
+    pha.set_rmf(rdata)
+
+    pha.set_analysis(analysis)
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        pha.notice(0.025, 0.045, ignore=False)
+
+    assert len(caplog.records) == 0
+    if analysis == "energy":
+        assert pha.mask == pytest.approx([False, True, True, True, False])
+    else:
+        assert not pha.mask.any()
+
+
+@pytest.mark.parametrize("analysis", ["energy", "wave"])
+def test_rmfmodelpha_delta_no_ebounds_manual(analysis, caplog):
+    """What happens calling an rmf with a pha and no EBOUNDS is set
+
     Ensure we can't filter on energy or wavelength since there's no
     EBOUNDS information. This behavior was seen when writing
     test_rmfmodelpha_call, so a test was written for it.
@@ -693,12 +724,19 @@ def test_rmfmodelpha_delta_no_ebounds(analysis, caplog):
     logged warning.
     """
 
-    estep = 0.01
-    egrid = np.arange(0.01, 0.06, estep)
-    rdata = create_delta_rmf(egrid[:-1], egrid[1:])
+    egrid = np.arange(0.01, 0.07, 0.01)
+    nchans = egrid.size - 1
+    matrix = np.ones(nchans, dtype=np.float32)
+    dummy = np.ones(nchans, dtype=np.int16)
+    f_chan = np.arange(1, nchans + 1, dtype=np.int16)
 
-    channels = np.arange(1, 5, dtype=np.int16)
-    counts = np.asarray([10, 5, 12, 7], dtype=np.int16)
+    rdata = DataRMF(name="f", detchans=nchans, energ_lo=egrid[:-1], energ_hi=egrid[1:],
+                    n_grp=dummy, n_chan=dummy, f_chan=f_chan,
+                    matrix=matrix, offset=1, e_min=None, e_max=None,
+                    ethresh=None, header=None)
+
+    channels = np.arange(1, 6, dtype=np.int16)
+    counts = np.asarray([10, 5, 12, 7, 3], dtype=np.int16)
     pha = DataPHA('test-pha', channel=channels, counts=counts)
     pha.set_rmf(rdata)
 

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -25,7 +25,6 @@
 
 import pytest
 
-from sherpa.utils.testing import requires_data, requires_fits
 from sherpa.astro import ui
 from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import ARF1D, RMF1D

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -29,6 +29,8 @@ from sherpa.utils.testing import requires_data, requires_fits
 from sherpa.astro import ui
 from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import ARF1D, RMF1D
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_xspec
 
 
 FILE_NAME = 'acisf01575_001N001_r0085_pha3.fits'
@@ -131,3 +133,96 @@ def test_hrci_imaging_mode_spectrum(make_data_path, clean_astro_ui):
 
     ui.subtract()
     assert ui.calc_stat() == pytest.approx(39.611346193696164)
+
+
+def check_fit_stats():
+    """Do we get the expected results?"""
+
+    ui.set_method("levmar")
+    ui.set_stat("chi2xspecvar")
+    ui.set_xsabund("angr")
+    ui.set_xsxsect("vern")
+
+    gal = ui.create_model_component("xsphabs", "gal")
+    pl = ui.create_model_component("powlaw1d", "pl")
+    ui.set_source(gal * pl)
+
+    ui.notice(0.5, 6)
+    ui.group_counts(15, tabStops=~ui.get_data().get_mask())
+
+    ui.subtract()
+    ui.fit()
+
+    # This is a regression test, as all we care about is that the
+    # results match for the direct route and after saving the files
+    # and loading them in. Therefore it's okay for these values to
+    # change.
+    #
+    # The test could be changed to just fit a power law, which would
+    # mean no need for the requires_xspec decorator, but given we need
+    # I/O and the data files anyway it doesn't really improve things
+    # if we did that.
+    #
+    # This test produces different results on macOS to Linux, hence
+    # the relaxed tolerances.
+    #
+    assert pl.gamma.val == pytest.approx(1.6870563856336693, rel=1e-5)
+    assert pl.ampl.val == pytest.approx(3.831373278007354e-05, rel=2e-5)
+    assert gal.nH.val == pytest.approx(0.24914805790330877, rel=3e-5)
+    assert ui.calc_stat() == pytest.approx(41.454087606314054, rel=1e-5)
+
+
+@requires_xspec
+@requires_fits
+@requires_data
+def test_pha3_original_check(make_data_path, clean_astro_ui):
+    """Check we get the expected fit statistic with the PHA3 file.
+
+    See also test_pha3_roundtrip_check.
+    """
+
+    fname = make_data_path(FILE_NAME)
+    ui.load_pha(fname)
+
+    check_fit_stats()
+
+
+@requires_xspec
+@requires_fits
+@requires_data
+def test_pha3_roundtrip_check(make_data_path, clean_astro_ui, tmp_path):
+    """Check we get the expected fit statistic with the PHA3 file.
+
+    See also test_pha3_original_check. This version writes out the
+    PHA, background PHA, ARF, and RMF and then reads those back in and
+    fits with those.
+
+    """
+
+    fname = make_data_path(FILE_NAME)
+    ui.load_pha(fname)
+
+    src = str(tmp_path / "src.pi")
+    bkg = str(tmp_path / "bkg.pi")
+    arf = str(tmp_path / "arf")
+    rmf = str(tmp_path / "rmf")
+
+    # This will write out invalid names for the ARF and RMF files (as
+    # it refers to the versions from the original file which do not
+    # exist in the temporary directory) but that's okay and we do not
+    # want to check the screen output to validate this behavior as
+    # this is not the point of this test.
+    #
+    ui.save_pha(1, src)
+    ui.save_pha(1, bkg, bkg_id=1)
+    ui.save_arf(1, arf)
+    ui.save_rmf(1, rmf)
+
+    ui.clean()
+
+    ui.load_pha(src)
+    ui.load_bkg(bkg)
+    ui.load_rmf(rmf)
+    ui.load_arf(arf)
+
+    check_fit_stats()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4776,7 +4776,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        load_pha : Load a PHA data set.
+        load_pha, save_arf
 
         Notes
         -----
@@ -4814,6 +4814,98 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_pha_data(id, bkg_id)
 
         sherpa.astro.io.write_pha(filename, d, ascii=ascii,
+                                  clobber=clobber)
+
+    def save_arf(self, id, filename=None, resp_id=None, bkg_id=None,
+                 ascii=False, clobber=False):
+        """Save an ARF data set to a file.
+
+        .. versionadded:: 4.16.0
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier for the data set to use. If not given then
+           the default identifier is used, as returned by
+           `get_default_id`.
+        filename : str
+           The name of the file to write the array to. The format
+           is determined by the `ascii` argument.
+        resp_id : int or str, optional
+           The identifier for the ARF within this data set, if there
+           are multiple responses.
+        bkg_id : int or str, optional
+           Set if the background ARF should be written out rather
+           than the source ARF.
+        ascii : bool, optional
+           If ``False`` then the data is written as a FITS
+           format binary table. The default is ``True``. The
+           exact format of the output file depends on the
+           I/O library in use (Crates or AstroPy).
+        clobber : bool, optional
+           If `outfile` is not ``None``, then this flag controls
+           whether an existing file can be overwritten (``True``)
+           or if it raises an exception (``False``, the default
+           setting).
+
+        Raises
+        ------
+        sherpa.utils.err.ArgumentErr
+           If the data set does not contain an ARF.
+        sherpa.utils.err.IOErr
+           If `filename` already exists and `clobber` is ``False``.
+
+        See Also
+        --------
+        load_arf, save_pha
+
+        Notes
+        -----
+        The function does not follow the normal Python standards for
+        parameter use, since it is designed for easy interactive use.
+        When called with a single un-named argument, it is taken to be
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
+        respectively. The remaining parameters are expected to be
+        given as named arguments.
+
+        Examples
+        --------
+
+        Write out the ARF data from the default data set to the
+        file 'src.arf':
+
+        >>> save_arf('src.arf')
+
+        Over-write the file it it already exists, and take the data
+        from the data set "jet":
+
+        >>> save_arf('jet', 'out.arf', clobber=True)
+
+        Write the data out as an ASCII file:
+
+        >>> save_arf('pi.arf', ascii=True)
+
+        """
+        clobber = sherpa.utils.bool_cast(clobber)
+        ascii = sherpa.utils.bool_cast(ascii)
+        if filename is None:
+            id, filename = filename, id
+        _check_str_type(filename, 'filename')
+        d = self._get_pha_data(id, bkg_id)
+
+        arf = d.get_arf(id=resp_id)
+        if arf is None:
+            if bkg_id is not None:
+                emsg = f"background '{bkg_id} of "
+            else:
+                emsg = ""
+
+            resp_id = 1 if resp_id is None else resp_id
+            emsg += f"data set '{id}' (response {resp_id}) does not contain an ARF"
+            raise ArgumentErr(emsg)
+
+        sherpa.astro.io.write_arf(filename, arf, ascii=ascii,
                                   clobber=clobber)
 
     def save_grouping(self, id, filename=None, bkg_id=None,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4897,7 +4897,7 @@ class Session(sherpa.ui.utils.Session):
         arf = d.get_arf(id=resp_id)
         if arf is None:
             if bkg_id is not None:
-                emsg = f"background '{bkg_id} of "
+                emsg = f"background '{bkg_id}' of "
             else:
                 emsg = ""
 
@@ -4979,7 +4979,7 @@ class Session(sherpa.ui.utils.Session):
         rmf = d.get_rmf(id=resp_id)
         if rmf is None:
             if bkg_id is not None:
-                emsg = f"background '{bkg_id} of "
+                emsg = f"background '{bkg_id}' of "
             else:
                 emsg = ""
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4857,7 +4857,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        load_arf, save_pha, save_rmf
+        create_arf, load_arf, save_pha, save_rmf
 
         Notes
         -----
@@ -4944,7 +4944,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        load_arf, save_arf, save_pha
+        create_rmf, load_arf, save_arf, save_pha
 
         Notes
         -----
@@ -5497,7 +5497,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        create_rmf, get_arf, set_arf, unpack_arf
+        create_rmf, get_arf, save_arf, set_arf, unpack_arf
 
         Examples
         --------
@@ -5531,6 +5531,10 @@ class Session(sherpa.ui.utils.Session):
         maps to a single energy bin), otherwise the RMF is taken from
         the image data stored in the file pointed to by `fname`.
 
+        .. versionchanged:: 4.16.0
+           The e_min and e_max values will use the rmflo and rmfhi
+           values if not set.
+
         .. versionadded:: 4.10.1
 
         Parameters
@@ -5548,7 +5552,8 @@ class Session(sherpa.ui.utils.Session):
             not enforced.
         e_min, e_max : None or array, optional
             The E_MIN and E_MAX columns of the EBOUNDS block of the
-            RMF.
+            RMF. If not set they are taken from rmflo and rmfhi
+            respectively.
         ethresh : number or None, optional
             Passed through to the DataRMF call. It controls whether
             zero-energy bins are replaced.
@@ -5567,7 +5572,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        create_arf, get_rmf, set_rmf, unpack_rmf
+        create_arf, get_rmf, save_rmf, set_rmf, unpack_rmf
+
         """
 
         if fname is None:
@@ -7728,6 +7734,7 @@ class Session(sherpa.ui.utils.Session):
         ----------
 
         `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+
         Examples
         --------
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4818,8 +4818,8 @@ class Session(sherpa.ui.utils.Session):
 
     # This should be
     #     def save_arf(self, id, filename=None, *, resp_id=None, ...
-    # but the existing logic used to create the ui moduke does not
-    # handle KEYWORD_ONLY so for now do not do this.
+    # but the existing logic used to create the ui module does not
+    # handle KEYWORD_ONLY so for now do not do this. See #1901.
     #
     def save_arf(self, id, filename=None, resp_id=None, bkg_id=None,
                  ascii=False, clobber=False):
@@ -4915,8 +4915,8 @@ class Session(sherpa.ui.utils.Session):
 
     # This should be
     #     def save_rmf(self, id, filename=None, *, resp_id=None, ...
-    # but the existing logic used to create the ui moduke does not
-    # handle KEYWORD_ONLY so for now do not do this.
+    # but the existing logic used to create the ui module does not
+    # handle KEYWORD_ONLY so for now do not do this. See #1901.
     #
     def save_rmf(self, id, filename=None, resp_id=None, bkg_id=None,
                  clobber=False):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4776,7 +4776,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        load_pha, save_arf
+        load_pha, save_arf, save_rmf
 
         Notes
         -----
@@ -4857,7 +4857,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        load_arf, save_pha
+        load_arf, save_pha, save_rmf
 
         Notes
         -----
@@ -4907,6 +4907,87 @@ class Session(sherpa.ui.utils.Session):
 
         sherpa.astro.io.write_arf(filename, arf, ascii=ascii,
                                   clobber=clobber)
+
+    def save_rmf(self, id, filename=None, resp_id=None, bkg_id=None,
+                 clobber=False):
+        """Save an RMF data set to a file.
+
+        .. versionadded:: 4.16.0
+
+        Parameters
+        ----------
+        id : int or str, optional
+           The identifier for the data set to use. If not given then
+           the default identifier is used, as returned by
+           `get_default_id`.
+        filename : str
+           The name of the file to write the array to. The format
+           is always FITS.
+        resp_id : int or str, optional
+           The identifier for the ARF within this data set, if there
+           are multiple responses.
+        bkg_id : int or str, optional
+           Set if the background ARF should be written out rather
+           than the source ARF.
+        clobber : bool, optional
+           If `outfile` is not ``None``, then this flag controls
+           whether an existing file can be overwritten (``True``)
+           or if it raises an exception (``False``, the default
+           setting).
+
+        Raises
+        ------
+        sherpa.utils.err.ArgumentErr
+           If the data set does not contain a RMF.
+        sherpa.utils.err.IOErr
+           If `filename` already exists and `clobber` is ``False``.
+
+        See Also
+        --------
+        load_arf, save_arf, save_pha
+
+        Notes
+        -----
+        The function does not follow the normal Python standards for
+        parameter use, since it is designed for easy interactive use.
+        When called with a single un-named argument, it is taken to be
+        the `filename` parameter. If given two un-named arguments, then
+        they are interpreted as the `id` and `filename` parameters,
+        respectively. The remaining parameters are expected to be
+        given as named arguments.
+
+        Examples
+        --------
+
+        Write out the RMF data from the default data set to the
+        file 'src.rmf':
+
+        >>> save_rmf('src.rmf')
+
+        Over-write the file it it already exists, and take the data
+        from the data set "jet":
+
+        >>> save_rmf('jet', 'out.rmf', clobber=True)
+
+        """
+        clobber = sherpa.utils.bool_cast(clobber)
+        if filename is None:
+            id, filename = filename, id
+        _check_str_type(filename, 'filename')
+        d = self._get_pha_data(id, bkg_id)
+
+        rmf = d.get_rmf(id=resp_id)
+        if rmf is None:
+            if bkg_id is not None:
+                emsg = f"background '{bkg_id} of "
+            else:
+                emsg = ""
+
+            resp_id = 1 if resp_id is None else resp_id
+            emsg += f"data set '{id}' (response {resp_id}) does not contain a RMF"
+            raise ArgumentErr(emsg)
+
+        sherpa.astro.io.write_rmf(filename, rmf, clobber=clobber)
 
     def save_grouping(self, id, filename=None, bkg_id=None,
                       ascii=True, clobber=False):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4816,6 +4816,11 @@ class Session(sherpa.ui.utils.Session):
         sherpa.astro.io.write_pha(filename, d, ascii=ascii,
                                   clobber=clobber)
 
+    # This should be
+    #     def save_arf(self, id, filename=None, *, resp_id=None, ...
+    # but the existing logic used to create the ui moduke does not
+    # handle KEYWORD_ONLY so for now do not do this.
+    #
     def save_arf(self, id, filename=None, resp_id=None, bkg_id=None,
                  ascii=False, clobber=False):
         """Save an ARF data set to a file.
@@ -4824,13 +4829,15 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
-           The identifier for the data set to use. If not given then
-           the default identifier is used, as returned by
-           `get_default_id`.
-        filename : str
-           The name of the file to write the array to. The format
-           is determined by the `ascii` argument.
+        id : int or str
+           The identifier for the data set containing the ARF or the
+           filename (the latter is used when filename is set to None,
+           and in this case the id is set to the default identifier,
+           as returned by `get_default_id`).
+        filename : str or None
+           The name of the file to write the ARF to (when the id value
+           is explicitly given). The format is determined by the
+           `ascii` argument.
         resp_id : int or str, optional
            The identifier for the ARF within this data set, if there
            are multiple responses.
@@ -4838,15 +4845,13 @@ class Session(sherpa.ui.utils.Session):
            Set if the background ARF should be written out rather
            than the source ARF.
         ascii : bool, optional
-           If ``False`` then the data is written as a FITS
-           format binary table. The default is ``True``. The
-           exact format of the output file depends on the
-           I/O library in use (Crates or AstroPy).
+           If ``False`` then the data is written as a FITS format
+           binary table. The exact format of the output file depends
+           on the I/O library in use (Crates or AstroPy).
         clobber : bool, optional
-           If `outfile` is not ``None``, then this flag controls
-           whether an existing file can be overwritten (``True``)
-           or if it raises an exception (``False``, the default
-           setting).
+           This flag controls whether an existing file can be
+           overwritten (``True``) or if it raises an exception
+           (``False``).
 
         Raises
         ------
@@ -4864,9 +4869,9 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the `filename` parameter. If given two un-named arguments, then
-        they are interpreted as the `id` and `filename` parameters,
-        respectively. The remaining parameters are expected to be
+        the `filename` parameter. If given two un-named arguments,
+        then they are interpreted as the `id` and `filename`
+        parameters, respectively. The remaining parameters must be
         given as named arguments.
 
         Examples
@@ -4908,6 +4913,11 @@ class Session(sherpa.ui.utils.Session):
         sherpa.astro.io.write_arf(filename, arf, ascii=ascii,
                                   clobber=clobber)
 
+    # This should be
+    #     def save_rmf(self, id, filename=None, *, resp_id=None, ...
+    # but the existing logic used to create the ui moduke does not
+    # handle KEYWORD_ONLY so for now do not do this.
+    #
     def save_rmf(self, id, filename=None, resp_id=None, bkg_id=None,
                  clobber=False):
         """Save an RMF data set to a file.
@@ -4916,24 +4926,24 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
-           The identifier for the data set to use. If not given then
-           the default identifier is used, as returned by
-           `get_default_id`.
-        filename : str
-           The name of the file to write the array to. The format
-           is always FITS.
+        id : int or str
+           The identifier for the data set containing the RMF or the
+           filename (the latter is used when filename is set to None,
+           and in this case the id is set to the default identifier,
+           as returned by `get_default_id`).
+        filename : str or None
+           The name of the file to write the RMF to (when the id value
+           is explicitly given). Note that the format is always FITS.
         resp_id : int or str, optional
-           The identifier for the ARF within this data set, if there
+           The identifier for the RMF within this data set, if there
            are multiple responses.
         bkg_id : int or str, optional
-           Set if the background ARF should be written out rather
-           than the source ARF.
+           Set if the background RMF should be written out rather
+           than the source RMF.
         clobber : bool, optional
-           If `outfile` is not ``None``, then this flag controls
-           whether an existing file can be overwritten (``True``)
-           or if it raises an exception (``False``, the default
-           setting).
+           This flag controls whether an existing file can be
+           overwritten (``True``) or if it raises an exception
+           (``False``).
 
         Raises
         ------
@@ -4951,9 +4961,9 @@ class Session(sherpa.ui.utils.Session):
         The function does not follow the normal Python standards for
         parameter use, since it is designed for easy interactive use.
         When called with a single un-named argument, it is taken to be
-        the `filename` parameter. If given two un-named arguments, then
-        they are interpreted as the `id` and `filename` parameters,
-        respectively. The remaining parameters are expected to be
+        the `filename` parameter. If given two un-named arguments,
+        then they are interpreted as the `id` and `filename`
+        parameters, respectively. The remaining parameters must be
         given as named arguments.
 
         Examples


### PR DESCRIPTION
# Summary

Support writing out ARF and RMF data to FITS files (and, for ARF, ASCII files). Fix #1699, #1695, and #203.

# Details

[**note** we have just had a helpdesk ticket where this functionality would have been useful, so it's not just me wanting it ;-]

This requires

- an "entry point" in sherpa.astro.io
- support in the backends (mainly to ensure that headers can be written to table files, which should have been present anyway but was not necessarily done), some of this work has now gone into #1841
  - actually, the RMF requires significantly-more work since we need to create two blocks, deal with setting the TLMIN4
    keyword in the MATRIX extension, and working out how to handle Variable-Length Fields for the F_CHAN, N_CHAN,
    and MATRIX columns in the same block 
- plumbing in the sherpa.astro.ui layer

The intent is to create inter-operable files - that is, ones that match the OGIP standards - but as there are many different flavors of RMF in the community there may be some subtle issues the existing tests do not catch (i.e. there may be further tweaks required). This is also partly because we don't currently guarantee full support for PHA files (there are some issues with RATE values and possibly elsewhere), and also because we don't have a good way of defining relevant information - e.g. is the RMF a RSP or "just" a RMF, do we have a source or background response, ... - that would help in setting up some of the metadata that the OGIP standard wants. This is all for future work, as the basic aim is to be able to write out ARF and RMF and then read them back in and get the same data. There are also existing issues over how well we can write out data (with correct data types) which is also "for future consideration".

One complication we have is what we do with FITS header keywords on input: we have previously not had a coherent strategy - we remove WCS keywords for images for both backends but other files and keywords are left alone (somewhat backend dependent,in part because crates removes some "structural" keywords for us anyway). We now are more pro-active, and remove a number of such keywords, such as `TLMIN1`, `PCOUNT`, `BLANK`, `BITPIX`, `NAXIS*`: this was needed because we could end up with invalid files because header values from the input file, which didn't make sense for the output file, were being written out. This is not perfect, and may need more downstream cleanup, but provides a sensible default to begin with. It does mean that the Sherpa "read" routines - such as load_pha, load_image, unpack_rmf, .... - are not guaranteed to provide access to all the data in the input file, but I think I am happy with saying that the user will have to read in any such file with their preferred I/O library if they need this information. The alternative is to only strip out these keywords on output, but that may make it hard to add them if needed [although this would not work for the crates backend].  **There** are some things to think about: I want to support XSPEC models which use XFLT keywords, and Moritz wants to support polarmetric models/other situations where having access to the headers is needed, but I claim that they are not going to be specified via these "structural" keywords but domain-specific keys.

I added in, at the end, a fix for #1695 - which is primarily just to make my life easier when writing tests. It did give me a chance to do a minor spruce up of the related documentation (adding links between methods and reference changes).

Not for this PR, but with this we could allow `save_all` to actually save the data, rather than assuming it has been read in (and do it for all data types, not just PHA). However, this has a lot of "thinking about what's needed" needed first. This is now 
- #1847

# Notes

Writing out ARF data is easy, but for RMF data we have to

- re-construct the original data, as the DataRMF structure has flattened out the on-disk format
- work out what the best format is for the F_CHAN, N_CHAN, and MATRIX columns (scalar, array, or variable-length arrays)
  - I do not guarantee that we match the original on-disk format - for those that have been read in - but it should represent the same actual data

Fix #1699.
Fix #1695.
Fix #203.