### PR TITLE
ui: add get_plot_prefs/get_contour_prefs calls

### DIFF
--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -89,6 +89,7 @@ burden...
       get_conf_opt
       get_conf_results
       get_confidence_results
+      get_contour_prefs
       get_coord
       get_counts
       get_covar
@@ -146,6 +147,7 @@ burden...
       get_pdf_plot
       get_photon_flux_hist
       get_pileup_model
+      get_plot_prefs
       get_prior
       get_proj
       get_proj_opt

--- a/docs/ui/sherpa_ui.rst
+++ b/docs/ui/sherpa_ui.rst
@@ -53,6 +53,7 @@ hidden away. This needs better explanation...
       get_conf_opt
       get_conf_results
       get_confidence_results
+      get_contour_prefs
       get_covar
       get_covar_opt
       get_covar_results
@@ -102,6 +103,7 @@ hidden away. This needs better explanation...
       get_num_par_thawed
       get_par
       get_pdf_plot
+      get_plot_prefs
       get_prior
       get_proj
       get_proj_opt

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1983,6 +1983,41 @@ def test_plot_defaults(funcname, expected):
     assert prefs == expected
 
 
+@pytest.mark.parametrize("ptype", ["data", "model", "source", "resid"])
+def test_get_plot_prefs_fails_bkg_id_when_not_expected(ptype, clean_astro_ui):
+    """Some calls allow bkg_id to be passed through. These do not."""
+
+    ui.load_arrays("x", [1, 2, 3], [1, 2, 3], DataPHA)
+
+    # Check this works. We do not check on the structure of the dict so we
+    # do not have to have to care about the plot backend.
+    #
+    p = ui.get_plot_prefs(ptype, "x")
+    assert isinstance(p, dict)
+
+    # This fails.
+    #
+    with pytest.raises(TypeError,
+                       match=" got an unexpected keyword argument 'bkg_id'$"):
+        ui.get_plot_prefs(ptype, "x", bkg_id=1)
+
+
+@pytest.mark.parametrize("ptype", ["bkg", "bkg_model", "bkg_source", "bkg_resid"])
+def test_get_plot_prefs_allows_bkg_id(ptype, clean_astro_ui):
+    """Some calls allow bkg_id to be passed through"""
+
+    ui.load_arrays("x", [1, 2, 3], [1, 2, 3], DataPHA)
+
+    # Check this works. We do not check on the structure of the dict so we
+    # do not have to have to care about the plot backend.
+    #
+    p1 = ui.get_plot_prefs(ptype, "x")
+    assert isinstance(p1, dict)
+
+    p2 = ui.get_plot_prefs(ptype, "x", bkg_id=1)
+    assert isinstance(p2, dict)
+
+
 @requires_fits
 @requires_data
 def test_pha1_get_model_plot_filtered(clean_astro_ui, basic_pha1):

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -11507,6 +11507,75 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: discussion of preferences needs better handling
     # of how it interacts with the chosen plot backend.
     #
+    def get_plot_prefs(self, plottype, id=None, **kwargs):
+        """Return the preferences for the given plot type.
+
+        .. versionadded:: 4.16.0
+
+        Parameters
+        ----------
+        plottype : str
+           The type of plt, such as "data", "model", or "resid". The
+           "fit" argument is not supported.
+        id : int or str, optional
+           The data set that provides the data. If not given then the
+           default identifier is used, as returned by `get_default_id`.
+
+        Returns
+        -------
+        prefs : dict
+           Changing the values of this dictionary will change any new
+           data plots. This dictionary will be empty if no plot
+           backend is available.
+
+        See Also
+        --------
+        get_data_plot_prefs, get_model_plot_prefs,
+        set_xlinear, set_xlog, set_ylinear, set_ylog
+
+        Notes
+        -----
+        The meaning of the fields depend on the chosen plot backend.
+        A value of ``None`` means to use the default value for that
+        attribute, or not to use that setting.
+
+        The "fit" argument can not be used, even though there is a
+        get_fit_plot call. Either use the "data" or "model" arguments
+        to access the desired plot type, or use get_fit_plot() and
+        access the dataplot and modelplot attributes directly.
+
+        Examples
+        --------
+
+        After these commands, any data plot will use a green symbol
+        and not display Y error bars.
+
+        >>> prefs = get_plot_prefs("data")
+        >>> prefs['color'] = 'green'
+        >>> prefs['yerrorbars'] = False
+
+        """
+
+        # By accepting kwargs we can send in the bkg_id argument from
+        # the astro version without needing to override this call.
+        #
+        # This relies on each key in _plot_types having a
+        # corresponding get_<key>_plot() call.
+        #
+        ptype = self._get_plottype(plottype)
+
+        # To also catch the astro layer we do not check exactly, just
+        # that fit is an argument. Technically we could adjust the
+        # error message to include 'bkg'/'bkg_model' but this is
+        # excessive.
+        #
+        if ptype.find("fit") > -1:
+            raise ArgumentErr(f"Use 'data' or 'model' instead of '{plottype}'")
+
+        get = getattr(self, f"get_{ptype}_plot")
+        plotobj = get(id, recalc=False, **kwargs)
+        return get_plot_prefs(plotobj)
+
     def get_data_plot_prefs(self, id=None):
         """Return the preferences for plot_data.
 
@@ -11531,11 +11600,8 @@ class Session(NoNewAttributesAfterInit):
 
         See Also
         --------
-        plot_data : Plot the data values.
-        set_xlinear : New plots will display a linear X axis.
-        set_xlog : New plots will display a logarithmically-scaled X axis.
-        set_ylinear : New plots will display a linear Y axis.
-        set_ylog : New plots will display a logarithmically-scaled Y axis.
+        get_plot_prefs, plot_data, set_xlinear, set_xlog, set_ylinear,
+        set_ylog
 
         Notes
         -----
@@ -11913,11 +11979,8 @@ class Session(NoNewAttributesAfterInit):
 
         See Also
         --------
-        plot_model : Plot the model for a data set.
-        set_xlinear : New plots will display a linear X axis.
-        set_xlog : New plots will display a logarithmically-scaled X axis.
-        set_ylinear : New plots will display a linear Y axis.
-        set_ylog : New plots will display a logarithmically-scaled Y axis.
+        get_plot_prefs, plot_model, set_xlinearm set_xlog, set_ylinear,
+        set_ylog
 
         Notes
         -----
@@ -12308,6 +12371,66 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
+    def get_contour_prefs(self, contourtype, id=None):
+        """Return the preferences for the given contour type.
+
+        .. versionadded:: 4.16.0
+
+        Parameters
+        ----------
+        contourtype : str
+           The contour type, such as "data", "model", or "resid". The
+           "fit" argument is not supported.
+        id : int or str, optional
+           The data set that provides the data. If not given then the
+           default identifier is used, as returned by `get_default_id`.
+
+        Returns
+        -------
+        prefs : dict
+           Changing the values of this dictionary will change any new
+           contour plots. This dictionary will be empty if no plot
+           backend is available.
+
+        See Also
+        --------
+        get_data_contour_prefs, get_model_contour_prefs
+
+        Notes
+        -----
+        The meaning of the fields depend on the chosen plot backend.
+        A value of ``None`` means to use the default value for that
+        attribute, or not to use that setting.
+
+        The "fit" argument can not be used, even though there is a
+        get_fit_contour call. Either use the "data" or "model" arguments
+        to access the desired plot type, or use get_fit_contour() and
+        access the datacontour and modelcontour attributes directly.
+
+        Examples
+        --------
+
+        Change the contours of the model to be drawn partly opaque (with
+        the matplotlib backend):
+
+        >>> prefs = get_contour_prefs("data")
+        >>> prefs['alpha'] = 0.7
+        >>> contour_data()
+        >>> contour_model(overcontour=True)
+
+        """
+
+        # This is an identity check but will throw an error if the
+        # argument is invalid. It requires that each contour type has
+        # a get_<contourtype>_contour() call.
+        #
+        ctype = self._get_contourtype(contourtype)
+        if ctype == "fit":
+            raise ArgumentErr("Use 'data' or 'model' instead of 'fit'")
+
+        get = getattr(self, f"get_{ctype}_contour")
+        return get(id, recalc=False).contour_prefs
+
     def get_data_contour_prefs(self):
         """Return the preferences for contour_data.
 
@@ -12319,7 +12442,7 @@ class Session(NoNewAttributesAfterInit):
 
         See Also
         --------
-        contour_data : Contour the values of an image data set.
+        contour_data, get_contour_prefs
 
         Notes
         -----
@@ -12467,7 +12590,7 @@ class Session(NoNewAttributesAfterInit):
 
         See Also
         --------
-        contour_model : Contour the values of the model, including any PSF.
+        contour_model, get_contour_prefs
 
         Notes
         -----


### PR DESCRIPTION
# Summary

Add the get_plot_prefs and get_contour_prefs call to simplify access to the plot and contour preferences.

# Details

This was suggested in https://github.com/sherpa/sherpa/issues/1817#issuecomment-1658504691

For users who want to change the delchi plot preferences this replaces

    prefs = get_resid_plot(...).plot_prefs or .histo_prefs

with

    prefs = get_plot_prefs("resid")

It's a small use-of-life improvement, and we could decide to deprecate the get_data/model_plot/contour_prefs() calls.

There is a subtle issue with the "fit" option, since get_fit_plot() returns

    .dataplot
    .modelplot
    .plot_prefs   which is just {}

and the code would (by defualt) return the plot_prefs setting, which does not do anything. I decided to make "fit" error out rather than have it potentially confuse users. Since the plot option also has to worry about "bkg_fit" from the astro layer we can not just check on "fit".

Another issue with the plot command is we allow **kwargs to be set: this means we can easily support the "bkg_id" argument for the bkg-style plots in the astro layer without having to overload get_plot_prefs. The downside is that the documentation is harder to read, as we do not have a bkg_id keyword.

It's essentially the same thing for the contour plots, but simpler, as:

- do not have to deal with plot_prefs vs histo_prefs
- do not have to worry about extra arguments from "bkg" commands in the astro layer