### PR TITLE
Fix #1828 - histogram plot issue

### DIFF
--- a/docs/plots/utils.rst
+++ b/docs/plots/utils.rst
@@ -11,5 +11,4 @@ The sherpa.plot.utils module
    .. autosummary::
       :toctree: api
 
-      intersperse
       histogram_line

--- a/sherpa/plot/tests/test_plot_utils.py
+++ b/sherpa/plot/tests/test_plot_utils.py
@@ -130,7 +130,6 @@ def test_histogram_line_integers_single_gap():
     assert yh[good] == pytest.approx([12, 12, 3, 3, 15, 15])
 
 
-@pytest.mark.xfail    
 def test_histogram_line_floats_single_gap():
     """Test based on issue #1838
 

--- a/sherpa/plot/tests/test_plot_utils.py
+++ b/sherpa/plot/tests/test_plot_utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021
+#  Copyright (C) 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -18,6 +18,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import numpy as np
+
+import pytest
 
 from sherpa.plot.utils import histogram_line
 
@@ -53,3 +55,106 @@ def test_histrogram_line():
         assert np.all(np.ma.masked_invalid(y2) ==
                       np.ma.masked_invalid([0.,  0.,  2.5,  2.5, np.nan,  5.,
                                             5., 7.5, 7.5, 10., 10.]))
+
+
+def test_histogram_line_integers_no_gap():
+    """Test based on issue #1838
+
+    This is just a regression test to document the current behavior.
+    """
+
+    x1 = np.asarray([10, 20, 30])
+    x2 = np.asarray([20, 30, 40])
+    y = np.asarray([12, 3, 15])
+
+    # based on https://github.com/numpy/numpy/issues/17325
+    assert np.issubdtype(x1.dtype, np.integer)
+    assert np.issubdtype(x2.dtype, np.integer)
+    assert np.issubdtype(y.dtype, np.integer)
+
+    xh, yh = histogram_line(x1, x2, y)
+    assert np.issubdtype(xh.dtype, np.integer)
+    assert np.issubdtype(yh.dtype, np.integer)
+
+    assert xh == pytest.approx([10, 20, 20, 30, 30, 40])
+    assert yh == pytest.approx([12, 12, 3, 3, 15, 15])
+    
+
+def test_histogram_line_floats_no_gap():
+    """Test based on issue #1838
+
+    This is just a regression test to document the current behavior.
+    """
+
+    x1 = np.asarray([1, 2.5, 3])
+    x2 = np.asarray([2.5, 3, 4])
+    y = np.asarray([12, 3, 15])
+
+    # based on https://github.com/numpy/numpy/issues/17325
+    assert np.issubdtype(x1.dtype, np.floating)
+    assert np.issubdtype(x2.dtype, np.floating)
+    assert np.issubdtype(y.dtype, np.integer)
+
+    xh, yh = histogram_line(x1, x2, y)
+    assert np.issubdtype(xh.dtype, np.floating)
+    assert np.issubdtype(yh.dtype, np.integer)
+
+    assert xh == pytest.approx([1, 2.5, 2.5, 3, 3, 4])
+    assert yh == pytest.approx([12, 12, 3, 3, 15, 15])
+    
+
+def test_histogram_line_integers_single_gap():
+    """Test based on issue #1838
+
+    This is just a regression test to document the current behavior.
+    """
+
+    x1 = np.asarray([10, 20, 30])
+    x2 = np.asarray([20, 25, 40])
+    y = np.asarray([12, 3, 15])
+
+    # based on https://github.com/numpy/numpy/issues/17325
+    assert np.issubdtype(x1.dtype, np.integer)
+    assert np.issubdtype(x2.dtype, np.integer)
+    assert np.issubdtype(y.dtype, np.integer)
+
+    xh, yh = histogram_line(x1, x2, y)
+    assert np.issubdtype(xh.dtype, np.floating)
+    assert np.issubdtype(yh.dtype, np.floating)
+
+    good = np.isfinite(xh)
+    assert good == pytest.approx(np.isfinite(yh))
+    assert good == pytest.approx([1, 1, 1, 1, 0, 1, 1])
+
+    assert xh[good] == pytest.approx([10, 20, 20, 25, 30, 40])
+    assert yh[good] == pytest.approx([12, 12, 3, 3, 15, 15])
+
+
+@pytest.mark.xfail    
+def test_histogram_line_floats_single_gap():
+    """Test based on issue #1838
+
+    This is just a regression test to document the current behavior
+    (apart from the fact this fails because of #1838).
+    """
+
+    x1 = np.asarray([1, 2, 3])
+    x2 = np.asarray([2, 2.5, 4])
+    y = np.asarray([12, 3, 15])
+
+    # based on https://github.com/numpy/numpy/issues/17325
+    assert np.issubdtype(x1.dtype, np.integer)
+    assert np.issubdtype(x2.dtype, np.floating)
+    assert np.issubdtype(y.dtype, np.integer)
+
+    xh, yh = histogram_line(x1, x2, y)
+    assert np.issubdtype(xh.dtype, np.floating)
+    assert np.issubdtype(yh.dtype, np.floating)
+
+    good = np.isfinite(xh)
+    assert good == pytest.approx(np.isfinite(yh))
+    assert good == pytest.approx([1, 1, 1, 1, 0, 1, 1])
+
+    assert xh[good] == pytest.approx([1, 2, 2, 2.5, 3, 4])
+    assert yh[good] == pytest.approx([12, 12, 3, 3, 15, 15])
+    

--- a/sherpa/plot/tests/test_plot_utils.py
+++ b/sherpa/plot/tests/test_plot_utils.py
@@ -133,8 +133,7 @@ def test_histogram_line_integers_single_gap():
 def test_histogram_line_floats_single_gap():
     """Test based on issue #1838
 
-    This is just a regression test to document the current behavior
-    (apart from the fact this fails because of #1838).
+    This is just a regression test to document the current behavior.
     """
 
     x1 = np.asarray([1, 2, 3])

--- a/sherpa/plot/utils.py
+++ b/sherpa/plot/utils.py
@@ -19,51 +19,11 @@
 #
 '''Helper functions for plotting
 
-This module contains a few helper functions for reformatting arrays in ways
-that facilitate easier plotting.
 '''
 
 import numpy as np
 
-__all__ = ('intersperse', 'histogram_line')
-
-
-def intersperse(a, b):
-    '''Interleave two arrays a and b
-
-    Parameters
-    ----------
-    a, b : array
-        Two arrys to interleave. The number of elements in the two arrays cannot
-        differ by more than one.
-
-    Returns
-    -------
-    out : array
-        array that interleaves the input arrays
-
-    Notes
-    -----
-    It is assumed that the two arrays have compatible data types.
-
-    Example
-    -------
-
-    >>> import numpy as np
-    >>> a = np.arange(5)
-    >>> b = np.arange(10, 14)
-    >>> intersperse(a, b)
-    array([ 0, 10,  1, 11,  2, 12,  3, 13,  4])
-
-    Notes
-    -----
-    See https://stackoverflow.com/questions/5347065/interweaving-two-numpy-arrays#5347492
-    for interleaving arrays.
-    '''
-    out = np.empty((a.size + b.size, ), dtype=a.dtype)
-    out[0::2] = a
-    out[1::2] = b
-    return out
+__all__ = ('histogram_line', )
 
 
 def histogram_line(xlo, xhi, y):
@@ -103,11 +63,9 @@ def histogram_line(xlo, xhi, y):
     if (xlo[0] > xhi[0]) ^ (xhi[0] > xhi[-1]):
         xlo, xhi = xhi, xlo
 
-    # Combine the edges and replicate the y array. This used to use
-    # intersperse() but that had an issue when xhi was floating-point
-    # but xlo was an integer (issue #1838) so use this approach
-    # instead, which requires the arrays to match. Using vstack
-    # means we rely on NumPy to do any type coversions.
+    # Combine the edges and replicate the y array. This ensures that x
+    # has the "correct" type (e.g. if xlo is int but xhi is float the
+    # result will be float), which was the cause of issue #1838.
     #
     x = np.vstack((xlo, xhi)).T.flatten()
     y2 = np.vstack((y, y)).T.flatten()


### PR DESCRIPTION
# Summary

Fix up the histogram display for the unlikely case when the bin edges have at least one gap, the low edges are integer values, and the high edges are floating-point values.

# Details

Fix #1838 

We have elected to remove the sherpa.plot.utils.intersperse routine rather than deprecate it as

- this is a relatively-new module so it is unlikely people are using it
- it is a very-low-level module
- it is an easy routine to replace

# Example

Taking the example from #1838 we now get

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available

In [2]: load_arrays(1, [1, 2, 3], [2, 2.5, 4], [12, 5, 11], Data1DInt)

In [3]: set_source(const1d.foo)

In [4]: plot_fit()
```

![lines](https://github.com/sherpa/sherpa/assets/224638/a2f3aa6c-14e9-4f39-88de-938f36275c92)

