### PR TITLE
Minor refresh of AstroPy I/O code for better FITS and ASCII output

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -651,7 +651,8 @@ def _pack_table(dataset):
     Returns
     -------
     data : dict
-        The dictionary containing the columns to write out.
+        The dictionary containing the columns to write out, with
+        the column names being converted to upper case.
 
     """
     data = {}
@@ -663,7 +664,8 @@ def _pack_table(dataset):
         if val is None:
             continue
 
-        data[name] = val
+        # Convert to upper-case names
+        data[name.upper()] = val
 
     return data
 
@@ -708,7 +710,7 @@ def _pack_pha(dataset):
     The PHA Data Extension header page [1]_ lists the following
     keywords as either required or we-really-want-them:
 
-        EXTNAME (= SPECTRUM) - the name (i.e. type) of the extension
+        EXTNAME = "SPECTRUM"
         TELESCOP - the "telescope" (i.e. mission/satellite name).
         INSTRUME - the instrument/detector.
         FILTER - the instrument filter in use (if any)
@@ -718,9 +720,9 @@ def _pack_pha(dataset):
         CORRSCAL - the correction scaling factor.
         RESPFILE - the name of the corresponding (default) redistribution matrix file (RMF; see George et al. 1992a).
         ANCRFILE - the name of the corresponding (default) ancillary response file (ARF; see George et al. 1992a).
-        HDUCLASS - should contain the string "OGIP" to indicate that this is an OGIP style file.
-        HDUCLAS1 - should contain the string "SPECTRUM" to indicate this is a spectrum.
-        HDUVERS - the version number of the format (this document describes version 1.2.1)
+        HDUCLASS = "OGIP"
+        HDUCLAS1 = "SPECTRUM"
+        HDUVERS = "1.2.1"
         POISSERR - whether Poissonian errors are appropriate to the data (see below).
         CHANTYPE - whether the channels used in the file have been corrected in any way (see below).
         DETCHANS - the total number of detector channels available.
@@ -774,6 +776,7 @@ def _pack_pha(dataset):
     # anything set by the input.
     #
     default_header = {
+        "EXTNAME": "SPECTRUM",
         "HDUCLASS": "OGIP",
         "HDUCLAS1": "SPECTRUM",
         "HDUCLAS2": "TOTAL",
@@ -795,7 +798,6 @@ def _pack_pha(dataset):
         "RESPFILE": "none",
         "ANCRFILE": "none",
         "BACKFILE": "none"
-
     }
 
     # Header Keys

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021, 2022
+#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1172,7 +1172,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     img.write(filename, clobber=True)
 
 
-def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
+def set_table_data(filename, data, col_names, header=None,
                    ascii=False, clobber=False, packup=False):
 
     if not packup and not clobber and os.path.isfile(filename):

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -45,6 +45,7 @@ import numpy
 
 from astropy.io import fits
 from astropy.io.fits.column import _VLF
+from astropy.table import Table
 
 from sherpa.utils.err import IOErr
 from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat
@@ -997,23 +998,37 @@ def get_pha_data(arg, make_copy=False, use_background=False):
 
 # Write Functions
 
-def _create_columns(col_names, data):
+def _create_table(names, data):
+    """Create a Table.
 
-    collist = []
-    cols = []
-    coldefs = []
-    for name in col_names:
+    The idea is that by going via a Table we let the AstroPy
+    code deal with all the conversions (e.g. to get the FITS
+    data types on columns correct).
+
+    Parameters
+    ----------
+    names : list of str
+        The order of the column names (must exist in data).
+    data : dict[str, ndarray or None]
+        Any None values are dropped.
+
+    Returns
+    -------
+    tbl : Table
+
+    """
+
+    store = []
+    colnames = []
+    for name in names:
         coldata = data[name]
         if coldata is None:
             continue
 
-        col = fits.Column(name=name.upper(), array=coldata,
-                          format=coldata.dtype.name.upper())
-        cols.append(coldata)
-        coldefs.append(name.upper())
-        collist.append(col)
+        store.append(coldata)
+        colnames.append(name)
 
-    return collist, cols, coldefs
+    return Table(names=colnames, data=store)
 
 
 def check_clobber(filename, clobber):
@@ -1031,25 +1046,20 @@ def set_table_data(filename, data, col_names, header=None,
     if not packup:
         check_clobber(filename, clobber)
 
-    col_names = list(col_names)
-
-    # The code used to create a header containing the
-    # exposure, backscal, and areascal keywords, but this has
-    # since been commented out, and the code has now been
-    # removed.
-
-    collist, cols, coldefs = _create_columns(col_names, data)
-
+    tbl = _create_table(col_names, data)
     if ascii:
-        set_arrays(filename, cols, coldefs, ascii=ascii,
-                   clobber=clobber)
+        tbl.write(filename, format='ascii.commented_header',
+                  overwrite=clobber)
         return
 
-    tbl = fits.BinTableHDU.from_columns(fits.ColDefs(collist))
-    tbl.name = 'HISTOGRAM'
+    hdu = fits.table_to_hdu(tbl)
+    if hdu.name == '':
+        tbl.name = 'HISTOGRAM'
+
     if packup:
-        return tbl
-    tbl.writeto(filename, overwrite=True)
+        return hdu
+
+    hdu.writeto(filename, overwrite=True)
 
 
 def _create_header(header):
@@ -1058,11 +1068,11 @@ def _create_header(header):
     """
 
     hdrlist = fits.Header()
-    for key in header.keys():
-        if header[key] is None:
+    for key, value in header.items():
+        if value is None:
             continue
 
-        _add_keyword(hdrlist, key, header[key])
+        _add_keyword(hdrlist, key, value)
 
     return hdrlist
 
@@ -1073,21 +1083,19 @@ def set_pha_data(filename, data, col_names, header=None,
     if not packup:
         check_clobber(filename, clobber)
 
-    hdrlist = _create_header(header)
-
-    collist, cols, coldefs = _create_columns(col_names, data)
-
+    tbl = _create_table(col_names, data)
     if ascii:
-        set_arrays(filename, cols, coldefs, ascii=ascii,
-                   clobber=clobber)
+        tbl.write(filename, format='ascii.commented_header',
+                  overwrite=clobber)
         return
 
-    pha = fits.BinTableHDU.from_columns(fits.ColDefs(collist),
-                                        header=fits.Header(hdrlist))
-    pha.name = 'SPECTRUM'
+    hdu = fits.table_to_hdu(tbl)
+    hdu.header.extend(_create_header(header))
+
     if packup:
-        return pha
-    pha.writeto(filename, overwrite=True)
+        return hdu
+
+    hdu.writeto(filename, overwrite=True)
 
 
 def set_image_data(filename, data, header, ascii=False, clobber=False,
@@ -1171,23 +1179,29 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         if len(arg) != size:
             raise IOErr('arraysnoteq')
 
-    if not ascii and fields is None:
-        fields = [f'col{ii + 1}' for ii in range(len(args))]
-
     if fields is not None and len(args) != len(fields):
         raise IOErr("wrongnumcols", len(args), len(fields))
 
     if ascii:
-        write_arrays(filename, args, fields, clobber=clobber)
+        # Historically, the serialization doesn't quite match the
+        # AstroPy Table version, so stay with write_arrays. We do
+        # change the form for the comment line (used when fields is
+        # set) to be "# <col1> .." rather than "#<col1> ..." to match
+        # the AstroPy table output used for other "ASCII table" forms
+        # in this module.
+        #
+        # The fields setting can be None here, which means that
+        # write_arrays will not write out a header line.
+        #
+        write_arrays(filename, args, fields,
+                     comment="# ", clobber=clobber)
         return
 
-    cols = []
-    for val, name in zip(args, fields):
-        col = fits.Column(name=name.upper(),
-                          format=val.dtype.name.upper(),
-                          array=val)
-        cols.append(col)
+    if fields is None:
+        fields = [f'COL{ii + 1}' for ii in range(len(args))]
 
-    tbl = fits.BinTableHDU.from_columns(fits.ColDefs(cols))
-    tbl.name = 'TABLE'
-    tbl.writeto(filename, overwrite=True)
+    data = dict(zip(fields, args))
+    tbl = _create_table(fields, data)
+    hdu = fits.table_to_hdu(tbl)
+    hdu.name = 'TABLE'
+    hdu.writeto(filename, overwrite=True)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1016,7 +1016,7 @@ def _create_columns(col_names, data):
     return collist, cols, coldefs
 
 
-def set_table_data(filename, data, col_names, hdr=None, hdrnames=None,
+def set_table_data(filename, data, col_names, header=None,
                    ascii=False, clobber=False, packup=False):
 
     if not packup and not clobber and os.path.isfile(filename):

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1016,11 +1016,20 @@ def _create_columns(col_names, data):
     return collist, cols, coldefs
 
 
+def check_clobber(filename, clobber):
+    """Error out if the file exists and clobber is not set."""
+
+    if clobber or not os.path.isfile(filename):
+        return
+
+    raise IOErr("filefound", filename)
+
+
 def set_table_data(filename, data, col_names, header=None,
                    ascii=False, clobber=False, packup=False):
 
-    if not packup and not clobber and os.path.isfile(filename):
-        raise IOErr("filefound", filename)
+    if not packup:
+        check_clobber(filename, clobber)
 
     col_names = list(col_names)
 
@@ -1061,8 +1070,8 @@ def _create_header(header):
 def set_pha_data(filename, data, col_names, header=None,
                  ascii=False, clobber=False, packup=False):
 
-    if not packup and os.path.isfile(filename) and not clobber:
-        raise IOErr("filefound", filename)
+    if not packup:
+        check_clobber(filename, clobber)
 
     hdrlist = _create_header(header)
 
@@ -1084,8 +1093,8 @@ def set_pha_data(filename, data, col_names, header=None,
 def set_image_data(filename, data, header, ascii=False, clobber=False,
                    packup=False):
 
-    if not packup and not clobber and os.path.isfile(filename):
-        raise IOErr("filefound", filename)
+    if not packup:
+        check_clobber(filename, clobber)
 
     if ascii:
         set_arrays(filename, [data['pixels'].ravel()],
@@ -1147,8 +1156,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
 
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
-    if not clobber and os.path.isfile(filename):
-        raise IOErr("filefound", filename)
+    check_clobber(filename, clobber)
 
     if not numpy.iterable(args) or len(args) == 0:
         raise IOErr('noarrayswrite')

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -466,27 +466,7 @@ def test_pha_write_xmm_grating(make_data_path, tmp_path):
     outfile = tmp_path / "test.pha"
     outfile = str(outfile)  # our IO routines don't recognize paths
 
-    # This is a bit ugly as I want to capture/hide the Astro deprecation
-    # warning, but it's only valid when we are using AstroPy.
-    #
-    if backend_is("pyfits"):
-        from astropy.utils.exceptions import AstropyDeprecationWarning
-        with pytest.warns(AstropyDeprecationWarning) as ws:
-            io.write_pha(outfile, indata, ascii=False, clobber=False)
-
-        # Skip the known "deprecation" error, but flag up any other
-        # errors. This is probably excessive (e.g. the message may change
-        # textually) but for now see how this goes. I did not want to
-        # add this to the generic list of known warnings as I do not like
-        # making these affect all tests.
-        #
-        expected = "The following keywords are now recognized as special column-related attributes and should be set via the Column objects: TCDLTn, TCRPXn, TCRVLn, TCTYPn, TCUNIn. In future, these values will be dropped from manually specified headers automatically and replaced with values generated based on the Column objects."
-        if len(ws) > 0:
-            assert len(ws) == 1, len(ws)
-            assert str(ws[0].message) == expected
-
-    else:
-        io.write_pha(outfile, indata, ascii=False, clobber=False)
+    io.write_pha(outfile, indata, ascii=False, clobber=False)
 
     outdata = io.read_pha(outfile, use_errors=True)
     assert isinstance(outdata, DataPHA)
@@ -576,9 +556,9 @@ def check_write_pha_fits_basic_roundtrip_pyfits(path):
         assert len(hdu.columns) == 2
 
         assert hdu.columns[0].name == "CHANNEL"
-        assert hdu.columns[0].format == "INT32"
+        assert hdu.columns[0].format == "J"
         assert hdu.columns[1].name == "COUNTS"
-        assert hdu.columns[1].format == "INT32"
+        assert hdu.columns[1].format == "J"
 
         assert hdu.header["HDUCLASS"] == "OGIP"
         assert hdu.header["HDUCLAS1"] == "SPECTRUM"
@@ -755,13 +735,13 @@ def check_write_pha_fits_with_extras_roundtrip_pyfits(path, etime, bscal):
         assert len(hdu.columns) == 5
 
         assert hdu.columns[0].name == "CHANNEL"
-        assert hdu.columns[0].format == "INT32"
+        assert hdu.columns[0].format == "J"
         assert hdu.columns[1].name == "COUNTS"
-        assert hdu.columns[1].format == "D"
+        assert hdu.columns[1].format == "E"
         assert hdu.columns[2].name == "GROUPING"
-        assert hdu.columns[2].format == "INT16"
+        assert hdu.columns[2].format == "I"
         assert hdu.columns[3].name == "QUALITY"
-        assert hdu.columns[3].format == "INT16"
+        assert hdu.columns[3].format == "I"
         assert hdu.columns[4].name == "AREASCAL"
         assert hdu.columns[4].format == "D"
 
@@ -1063,9 +1043,9 @@ def check_csc_pha_roundtrip_pyfits(path):
         assert len(hdu.columns) == 2
 
         assert hdu.columns[0].name == "CHANNEL"
-        assert hdu.columns[0].format == "INT32"
+        assert hdu.columns[0].format == "J"
         assert hdu.columns[1].name == "COUNTS"
-        assert hdu.columns[1].format == "D"
+        assert hdu.columns[1].format == "E"
 
         assert hdu.header["HDUCLASS"] == "OGIP"
         assert hdu.header["HDUCLAS1"] == "SPECTRUM"

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022
+#  Copyright (C) 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1293,7 +1293,7 @@ def test_pack_pha_invalid_counts():
                   np.asarray([1, 2], dtype=np.int16),
                   np.asarray([complex(1), complex(2)]))
 
-    with pytest.raises(DataErr) as err:
+    emsg = "The PHA dataset 'dummy' contains an unsupported COUNTS column"
+    with pytest.raises(DataErr,
+                       match=f"^{emsg}$"):
         io.pack_pha(pha)
-
-    assert str(err.value) == "The PHA dataset 'dummy' contains an unsupported COUNTS column"

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -3170,18 +3170,16 @@ def check_text_output(path, header, coldata):
     path is the pathlib object representing the file
     """
 
-    # This requires knowledge of requires_fits, but we don't make it
-    # possible to access this so we hard code the knowledge here. If
-    # we ever get another I/O backend we need to revisit this. It also
-    # assumes that if crates is available then it is in use, which
-    # is technically incorrect but should pass for our tests.
+    # Use the same logic as test_astro_ui_unit.py.
     #
-    if has_package_from_list("pycrates"):
+    from sherpa.astro import io
+    name = io.backend.__name__
+    if name == "sherpa.astro.io.crates_backend":
         expected = f"#TEXT/SIMPLE\n# {header}\n"
-    elif has_package_from_list("astropy.io.fits"):
-        expected = f"#{header}\n"
+    elif name == "sherpa.astro.io.pyfits_backend":
+        expected = f"# {header}\n"
     else:
-        assert False, "Unknown I/O backend"
+        assert False, f"Unknown I/O backend: {name}"
 
     expected += coldata
     assert path.read_text() == expected

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -731,7 +731,7 @@ def check_output(out, colnames, rows):
         assert lines[1] == f"# {cols}"
         lines = lines[2:]
     elif backend_is("pyfits"):
-        assert lines[0] == f"#{cols}"
+        assert lines[0] == f"# {cols}"
         lines = lines[1:]
     else:
         raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")


### PR DESCRIPTION
# Summary

Minor rework of the sherpa.astro.io.pyfits_backend module to improve on the output (both FITS and ASCII), such as a closer mapping of the data type used on disk and written out to file, and some changes to the header lines of ASCII files.

# Details

I started #1836 since I want to be able to write out ARFs and RMFs. However, I realized the FITS files we were creating didn't match what I wanted, which has lead to this change. I assume it overlaps with #1091 but I have not looked at that PR. I am trying to not make large changes here, as I really want to focus on the new functionality that I haven't been able to write yet, so there are other changes that could be made that I have not looked at.

# Example

## CIAO 4.15 behavior with pyfits backend

```
% SHERPARC=sherpa-standalone.rc sherpa
-----------------------------------------------------
Welcome to Sherpa: CXC's Modeling and Fitting Package
-----------------------------------------------------
Sherpa 4.15.0

Python 3.10.12 | packaged by conda-forge | (main, Jun 23 2023, 22:40:32) [GCC 12.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0 -- An enhanced Interactive Python. Type '?' for help.

IPython profile: sherpa
Installed qt5 event loop hook.
Shell is already running a gui event loop for qt5. Call with no arguments to disable the current loop.
Using matplotlib backend: QtAgg
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
sherpa In [1]: from sherpa.astro import io

sherpa In [2]: io.backend
Out[2]: <module 'sherpa.astro.io.pyfits_backend' from '/home/dburke/micromamba/envs/ciao415/lib/python3.10/site-packages/sherpa/astro/io/pyfits_backend.py'>

sherpa In [3]: load_arrays(1, [1,2,3], [12,2,4], DataPHA)

sherpa In [4]: set_exposure(230)

sherpa In [5]: set_backscal(0.125)

sherpa In [6]: pha = get_data()

sherpa In [7]: hdu = io.pack_pha(pha)

sherpa In [8]: print(hdu)
<astropy.io.fits.hdu.table.BinTableHDU object at 0x7f2cdc365c30>

sherpa In [9]: hdu.columns
Out[9]: 
ColDefs(
    name = 'CHANNEL'; format = 'INT32'
    name = 'COUNTS'; format = 'INT32'
)

sherpa In [10]: hdu.header
Out[10]: 
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                    4 / length of dimension 1                          
NAXIS2  =                    3 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    2 / number of table fields                         
HDUCLASS= 'OGIP    '                                                            
HDUCLAS1= 'SPECTRUM'                                                            
HDUCLAS2= 'TOTAL   '                                                            
HDUCLAS3= 'TYPE:I  '                                                            
HDUCLAS4= 'COUNT   '                                                            
HDUVERS = '1.2.1   '                                                            
HDUDOC  = 'Arnaud et al. 1992a Legacy 2  p 65'                                  
TELESCOP= 'none    '                                                            
INSTRUME= 'none    '                                                            
FILTER  = 'none    '                                                            
CORRFILE= 'none    '                                                            
CORRSCAL=                    0                                                  
CHANTYPE= 'PI      '                                                            
RESPFILE= 'none    '                                                            
ANCRFILE= 'none    '                                                            
BACKFILE= 'none    '                                                            
POISSERR=                    T                                                  
EXPOSURE=                230.0                                                  
BACKSCAL=                0.125                                                  
AREASCAL=                  1.0                                                  
SYS_ERR =                  0.0                                                  
QUALITY =                    0                                                  
GROUPING=                    0                                                  
TLMIN1  =                    1                                                  
TLMAX1  =                    3                                                  
DETCHANS=                    3                                                  
TTYPE1  = 'CHANNEL '                                                            
TFORM1  = 'INT32   '                                                            
TTYPE2  = 'COUNTS  '                                                            
TFORM2  = 'INT32   '                                                            
EXTNAME = 'SPECTRUM'           / extension name                                 

sherpa In [11]: hdu.name
Out[11]: 'SPECTRUM'
```

Note the invalid TFORM1/2 keywords.

## This PR

```
In [2]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [3]: load_arrays(1, [1,2,3], [12,2,4], DataPHA)

In [4]: set_exposure(230)

In [5]: set_backscal(0.125)

In [6]: pha = get_data()

In [7]: from sherpa.astro import io

In [8]: hdu = io.pack_pha(pha)

In [9]: print(hdu)
<astropy.io.fits.hdu.table.BinTableHDU object at 0x7f9a45bf6ed0>

In [10]: hdu.columns
Out[10]: 
ColDefs(
    name = 'CHANNEL'; format = 'J'
    name = 'COUNTS'; format = 'J'
)

In [11]: hdu.header
Out[11]: 
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                    8 / length of dimension 1                          
NAXIS2  =                    3 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    2 / number of table fields                         
TTYPE1  = 'CHANNEL '                                                            
TFORM1  = 'J       '                                                            
TTYPE2  = 'COUNTS  '                                                            
TFORM2  = 'J       '                                                            
EXTNAME = 'SPECTRUM'                                                            
HDUCLASS= 'OGIP    '                                                            
HDUCLAS1= 'SPECTRUM'                                                            
HDUCLAS2= 'TOTAL   '                                                            
HDUCLAS3= 'TYPE:I  '                                                            
HDUCLAS4= 'COUNT   '                                                            
HDUVERS = '1.2.1   '                                                            
HDUDOC  = 'Arnaud et al. 1992a Legacy 2  p 65'                                  
TELESCOP= 'none    '                                                            
INSTRUME= 'none    '                                                            
FILTER  = 'none    '                                                            
CORRFILE= 'none    '                                                            
CORRSCAL=                    0                                                  
CHANTYPE= 'PI      '                                                            
RESPFILE= 'none    '                                                            
ANCRFILE= 'none    '                                                            
BACKFILE= 'none    '                                                            
POISSERR=                    T                                                  
EXPOSURE=                230.0                                                  
BACKSCAL=                0.125                                                  
AREASCAL=                  1.0                                                  
SYS_ERR =                  0.0                                                  
QUALITY =                    0                                                  
GROUPING=                    0                                                  
TLMIN1  =                    1                                                  
TLMAX1  =                    3                                                  
DETCHANS=                    3                                                  

In [12]: hdu.name
Out[12]: 'SPECTRUM'
```

We can see the columns now have a TFORM of `J` - which is 32-bit int - e.g. https://docs.astropy.org/en/stable/io/fits/usage/table.html#column-creation - which is closer to the truth (need to check whether J is okay or whether it should be I for 16-bit int, but it's more valid than "INT32".

Note however when the "INT32" columns get written they do get converted to Int2 (not sure the logic of how the replacement is made by AstroPy). The new version is written out as Int4 (because the TFORM is valid).

## ASCII output differences

After

```
>>> load_arrays(1, [1, 2, 3], [5, 2, 3])
>>> load_arrays(2, [1, 2, 3], [2.5, 3, 4], [5, 2, 3], Data1DInt)
>>> save_data(1, "tbl1.dat", ascii=True)
>>> save_data(2, "tbl1.dat", ascii=True)
```

and then if we diff the tbl1,dat file (old vs new)

```
< #X Y
---
> # X Y
```

and for tbl2.dat

```
< #XLO XHI Y
---
> # XLO XHI Y
```

That is, rather than the header line being `#<col1> <col2> ...` we now get `# <col1> <col2> ..` (actually, it's hard to guarantee this for all files as there's a bunch of ways the ASCII gets written out, but I'm pretty sure this holds).
