### PR TITLE
Tests: add regrid corner case tests

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -1,0 +1,639 @@
+#
+#  Copyright (C) 2020, 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Check we can regrid XSPEC models.
+
+Basic testing is based on the XSPEC wabs and powerlaw models, since
+they are "simple" and unlikely to change significantly. They are
+mutiplicative and additive models respectively.
+
+These tests do not exercise the whole set of regrid options, since
+it is expected that these should just work (from other tests). This
+is to check sepcialized behavior with the XSPEC models.
+
+"""
+
+import numpy as np
+import pytest
+
+from sherpa.models.basic import Const1D, Gauss1D
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_xspec
+
+
+# To make sure we track current behavior, we check that routines fail
+# in the expected way rather than just marking them as xfail.  This
+# way, when support is finally unlocked, we should find out from the
+# tests (rather that just going from xfail to xpass which is easy to
+# miss). It also lets us check why a test fails (in case the failure
+# mode changes due to other parts of Sherpa).
+#
+IntegrateError = "'integrate' is an invalid keyword argument for this function"
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_name(mname, xsmodel):
+    """What is the name of the regrid component"""
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    mdl = xsmodel(mname, "base")
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    assert mdl.name == 'base'
+    assert regrid.name == 'regrid1d(base)'
+
+
+@requires_xspec
+def test_regrid_name_combined():
+    """What is the name of the regrid component"""
+
+    from sherpa.astro import xspec
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    c1 = xspec.XSwabs()
+    c2 = xspec.XSpowerlaw()
+    mdl = c1 * c2
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    assert mdl.name == '(wabs * powerlaw)'
+    assert regrid.name == 'regrid1d((wabs * powerlaw))'
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_does_not_require_bins(mname, xsmodel):
+    """The regrid method does not require lo,hi bins but running it does"""
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    mdl = xsmodel(mname, "base")
+    regrid = mdl.regrid(ebase)
+
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
+        with pytest.raises(TypeError) as exc:
+            regrid([0.4, 0.5, 0.6])
+
+    # assert str(exc.value) == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+    # assert str(exc.value).endswith('() takes no keyword arguments')
+    assert str(exc.value) == IntegrateError
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+def test_regrid_table_requires_bins(make_data_path):
+    """Does the regrid method require lo,hi bins for XSPEC tables?"""
+
+    from sherpa.astro import xspec
+
+    path = make_data_path('testpcfabs.mod')
+    tbl = xspec.read_xstable_model('bar', path)
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    regrid = tbl.regrid(ebase)
+
+    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg):
+        y = regrid([0.52, 0.57, 0.62])
+
+    # Answer calculated with XSPEC 12.12.1
+    assert y == pytest.approx([0.50037217, 0.50017911, 0.50086778])
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_identity(mname, xsmodel):
+    """Check regrid returns the same data when grids are equal"""
+
+    elo = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85]
+    ehi = [0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    mdl = xsmodel(mname, "base")
+    regrid = mdl.regrid(elo, ehi)
+
+    # scale y values to make them closer to unity
+    y1 = 100 * mdl(elo, ehi)
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = 100 * regrid(elo, ehi)
+
+    # assert y2 == pytest.approx(y1)
+
+
+@requires_xspec
+def test_regrid_identity_combined():
+    """Check regrid returns the same data when grids are equal"""
+
+    from sherpa.astro import xspec
+
+    elo = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85]
+    ehi = [0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    c1 = xspec.XSwabs()
+    c2 = xspec.XSpowerlaw()
+    c1.nh = 0.05
+    c2.norm = 100
+
+    # The mdl.regrid call fails with a TypeError:
+    # 'integrate' is an invalid keyword argument for this function
+    #
+    mdl = c1 * c2
+    regrid = mdl.regrid(elo, ehi)
+
+    # scale y values to make them closer to unity
+    y1 = mdl(elo, ehi)
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(elo, ehi)
+
+    # assert y2 == pytest.approx(y1)
+
+
+@requires_xspec
+def test_additive():
+    """Simple test of an additive model"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(1.1, 1.5, 0.01)
+    egrid = np.arange(1.1, 1.5, 0.05)
+
+    mdl = xspec.XSpowerlaw('add')
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # will change regrid too
+    mdl.norm = 100
+
+    y1 = mdl(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(y1)
+
+
+# ideally we would test all three cases
+#   no overlap
+#   overlaps low
+#   overlaps high
+#
+overlap_none = np.arange(10, 15, 0.1)
+overlap_low = np.arange(0.8, 1.3, 0.05)
+overlap_high = np.arange(1.2, 1.8, 0.05)
+
+ans_none = np.zeros(overlap_none.size - 1)
+ans_low = np.asarray([0, 0, 0, 0, 0, 0,
+                      4.44517626, 4.25596144, 4.08219945])
+ans_high = np.asarray([4.08219945, 3.92207132, 3.7740328, 3.63676442,
+                       3.50913198, 2.72125635,  # this is a partial bin
+                       0, 0, 0, 0, 0, 0])
+
+
+@requires_xspec
+@pytest.mark.parametrize("egrid,yexp",
+                         [(overlap_none, ans_none),
+                          (overlap_low, ans_low),
+                          (overlap_high, ans_high)
+                         ])
+def test_additive_overlap(egrid, yexp):
+    """Simple test of an additive model.
+
+    There is only partial overlap of the two grids.
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(1.1, 1.5, 0.01)
+
+    mdl = xspec.XSpowerlaw()
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # will change regrid too
+    mdl.norm = 100
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(yexp)
+
+
+# To make it easy to compare the multiplicative tests we want
+# the center of the bins to match. To do this I am just shifting
+# the bins, so for an output of
+#
+#   0.1-0.2   entered at 0.15
+#   0.2-0.3              0.25
+#   0.3-0.4              0.35 ...
+#
+# we use a "regrid" that looks like
+#   0.125-0.175  this is centered at 0.15
+#   0.175-0.225
+#   0.225-0.275  this is centered at 0.25
+#   0.275-0.325
+#
+
+@requires_xspec
+def test_multiplicative():
+    """Simple test of a multiplicative model"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    mdl = xspec.XSwabs('mul')
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    mdl.nh = 0.05
+
+    y1 = mdl(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(y1, rel=0.04)
+
+
+# The expected values have been calculated based on akima interpolation
+# of the grided values, and differ from evaluating mdl on egrid (for
+# those bins which overlap the ebase range).
+#
+overlap2_low = np.arange(0.4, 0.9, 0.1)
+overlap2_high = np.arange(0.7, 1.3, 0.1)
+
+ans2_low = np.asarray([0, 0.641675, 0.7399567, 0.7984249])
+ans2_high = np.asarray([0.7984249, 0.84757835, 0.8698429, 0, 0, 0])
+
+
+@requires_xspec
+@pytest.mark.parametrize("egrid,yexp",
+                         [(overlap_none, ans_none),
+                          (overlap2_low, ans2_low),
+                          (overlap2_high, ans2_high)
+                         ])
+def test_multiplicative_overlap(egrid, yexp):
+    """Simple test of a multiplicative model
+
+    There is only partial overlap of the two grids.
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+
+    mdl = xspec.XSwabs()
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # will change regrid too
+    mdl.nh = 0.05
+
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(yexp)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name1,par1,val1,name2,par2,val2",
+                         [('wabs', 'nh', 0.05,
+                           'powerlaw', 'norm', 100),
+                          ('powerlaw', 'norm', 100,
+                           'wabs', 'nh', 0.05)])
+def test_combined(name1, par1, val1, name2, par2, val2, xsmodel):
+    """Simple test of an additive model * multiplicative model
+
+    We want to check it works for both a * b and
+    b * a (there is logic in the BinaryOp model
+    that favors the left-hand model, so we want to check
+    it is handled correctly here).
+    """
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    com1 = xsmodel(name1, "com1")
+    com2 = xsmodel(name2, "com2")
+    setattr(com1, par1, val1)
+    setattr(com2, par2, val2)
+
+    mdl = com1 * com2
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    y1 = mdl(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y2 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y2 == pytest.approx(y1, rel=0.04)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name,par,val",
+                         [('wabs', 'nh', 0.05),
+                          ('powerlaw', 'norm', 100)])
+def test_combined_arithmetic_left(name, par, val, xsmodel):
+    """Simple test of an additive model * multiplicative model"""
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    com = xsmodel(name, "com")
+    setattr(com, par, val)
+
+    mdl = 4 * com
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    yexp = 4 * com(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y1 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y1 == pytest.approx(yexp, rel=0.04)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name,par,val",
+                         [('wabs', 'nh', 0.05),
+                          ('powerlaw', 'norm', 100)])
+def test_combined_arithmetic_right(name, par, val, xsmodel):
+    """Simple test of an additive model * multiplicative model"""
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+
+    com = xsmodel(name, "com")
+    setattr(com, par, val)
+
+    mdl = com * 4
+    regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    yexp = 4 * com(egrid[:-1], egrid[1:])
+    with pytest.raises(TypeError, match=IntegrateError):
+        y1 = regrid(egrid[:-1], egrid[1:])
+
+    # assert y1 == pytest.approx(yexp, rel=0.04)
+
+
+@requires_xspec
+def test_multi_combined_additive():
+    """Can we handle a "deep" binop tree?
+
+    What happens with (2 * mul) / (3 + mul)? Does it get
+    treated as additive?
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    m1 = xspec.XSgaussian('m1')
+    m2 = xspec.XSgaussian('m2')
+
+    mdl = (2 * m1) / (3 + m2)
+    with pytest.raises(RecursionError):
+        regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # expected = mdl(elo, ehi)
+    # with pytest.raises(TypeError, match=IntegrateError):
+    #     got = regrid(elo, ehi)
+
+    ## assert got == pytest.approx(expected)
+
+
+@requires_xspec
+def test_multi_combined_multiplicative():
+    """Can we handle a "deep" binop tree?
+
+    What happens with (2 * mul) / (3 + mul)? Does it get
+    treated as multiplicative?
+    """
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    m1 = xspec.XSconstant('m1')
+    m2 = xspec.XSconstant('m2')
+
+    mdl = (2 * m1) / (3 + m2)
+    with pytest.raises(RecursionError):
+        regrid = mdl.regrid(ebase[:-1], ebase[1:])
+
+    # expected = mdl(elo, ehi)
+    # with pytest.raises(TypeError, match=IntegrateError):
+    #     got = regrid(elo, ehi)
+
+    # # assert got == pytest.approx(expected)
+
+
+@requires_xspec
+@pytest.mark.parametrize('sherpa_first', [True, False])
+def test_sherpa_mul_xspec_add(sherpa_first):
+    """Check sherpa (multiplicative) * xspec (additive)"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    msherpa = Const1D('m1')
+    msherpa.c0 = 2
+    msherpa.integrate = False
+
+    mxspec = xspec.XSpowerlaw('m2')
+    mxspec.phoindex = 1.8
+
+    if sherpa_first:
+        comb = msherpa * mxspec
+    else:
+        comb = mxspec * msherpa
+
+    rcomb = comb.regrid(ebase[:-1], ebase[1:])
+
+    # Check the results make sense, but do not check the absolute values
+    yexp = 2 * mxspec(eg1, eg2)
+
+    # Note the tolerance is different to test_sherpa_add_xspec_mul
+    assert comb(eg1, eg2) == pytest.approx(yexp)
+    with pytest.raises(TypeError, match=IntegrateError):
+        assert rcomb(eg1, eg2) == pytest.approx(yexp, rel=0.006)
+
+
+@requires_xspec
+@pytest.mark.parametrize('sherpa_first', [True, False])
+def test_sherpa_add_xspec_mul(sherpa_first):
+    """Check sherpa (additive) * xspec (multiplicative)"""
+
+    from sherpa.astro import xspec
+
+    ebase = np.arange(0.475, 1.025, 0.05)
+    egrid = np.arange(0.5, 1.0, 0.1)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    msherpa = Gauss1D('m1')
+    msherpa.pos = 1.02
+    msherpa.fwhm = 0.4
+    msherpa.integrate = True
+
+    mxspec = xspec.XSconstant('m2')
+    mxspec.factor = 2
+
+    if sherpa_first:
+        comb = msherpa * mxspec
+    else:
+        comb = mxspec * msherpa
+
+    rcomb = comb.regrid(ebase[:-1], ebase[1:])
+
+    # Check the results make sense, but do not check the absolute values
+    yexp = 2 * msherpa(eg1, eg2)
+
+    # Note the tolerance is different to test_sherpa_mul_xspec_add
+    assert comb(eg1, eg2) == pytest.approx(yexp)
+    with pytest.raises(TypeError, match=IntegrateError):
+        assert rcomb(eg1, eg2) == pytest.approx(yexp, rel=0.07)
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+@pytest.mark.parametrize('name,iflag,tol',
+                         [('xspec-tablemodel-RCS.mod', True, 1e-6),
+                          pytest.param('testpcfabs.mod', False, 1e-3, marks=pytest.mark.xfail)])  # XFAIL: iflag is wrong and values do not match
+def test_regrid_table(name, iflag, tol, make_data_path):
+    """Can we regrid a table model?
+
+    We test out both additive and multiplicative models.
+    """
+
+    from sherpa.astro import xspec as xs
+
+    infile = make_data_path(name)
+    tbl = xs.read_xstable_model('mod', infile)
+
+    assert tbl.ndim == 1
+    assert tbl.integrate == iflag
+
+    egrid = np.arange(0.5, 1.5, 0.1)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    exp = tbl(eg1, eg2)
+    assert (exp > 0).all()
+
+    ebase = np.arange(0.45, 1.55, 0.05)
+    rtbl = tbl.regrid(ebase[:-1], ebase[1:])
+    y = rtbl(eg1, eg2)
+
+    assert y == pytest.approx(exp, rel=tol)
+
+
+@requires_xspec
+@pytest.mark.parametrize("mname", ["wabs", "powerlaw"])
+def test_regrid_convolution_requires_bins(mname, xsmodel):
+    """Does the regrid method require lo,hi bins?
+
+    This just checks the current behavior, which is about what is
+    allowed and what warnings are created, not the returned values.
+
+    """
+
+    ebase = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9]
+
+    conv = xsmodel("cflux")
+    mdl = xsmodel(mname, "base")
+    cmdl = conv(mdl)
+
+    rmdl = cmdl.regrid(ebase)
+    with pytest.warns(FutureWarning) as record:
+        rmdl([0.57, 0.62, 0.66, 0.72])
+
+    assert len(record) == 3
+    assert record[0].message.args[0] == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+    assert record[1].message.args[0] == 'calc() requires pars,rhs,lo,hi arguments, sent 3 arguments'
+    assert record[2].message.args[0] == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
+
+
+@requires_xspec
+@pytest.mark.parametrize('model,tol',
+                         [('powerlaw', 1e-3),
+                          ('wabs', 0.72)])  # was tol=0.31 at one point
+def test_regrid_convolution_single(model, tol, xsmodel):
+    """regriding an additive model or multiplicative.
+    """
+
+    ebase = np.arange(0.4, 10, 0.1)
+    egrid = np.arange(0.5, 10, 0.2)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    conv = xsmodel("cflux")
+    conv.emin = 1
+    conv.emax = 9
+
+    mdl = xsmodel(model)
+    cmdl = conv(mdl)
+
+    rmdl = cmdl.regrid(ebase[:-1], ebase[1:])
+
+    exp = cmdl(eg1, eg2)
+    assert (exp > 0).all()
+
+    y = rmdl(eg1, eg2)
+    assert y == pytest.approx(exp, rel=tol)
+
+
+@requires_xspec
+@pytest.mark.parametrize('name1,name2',
+                         [('wabs', 'powerlaw'),
+                          ('powerlaw', 'wabs')])
+def test_regrid_convolution_combined(name1, name2, xsmodel):
+    """regriding convolved(mdl1 * mdl2)
+
+    The tolerance is very large
+    """
+
+    ebase = np.arange(0.4, 10, 0.1)
+    egrid = np.arange(0.5, 10, 0.2)
+    eg1 = egrid[:-1]
+    eg2 = egrid[1:]
+
+    conv = xsmodel("cflux")
+    conv.emin = 1
+    conv.emax = 9
+
+    mdl1 = xsmodel(name1)
+    mdl2 = xsmodel(name2)
+    cmdl = conv(mdl1 * mdl2)
+
+    rmdl = cmdl.regrid(ebase[:-1], ebase[1:])
+
+    exp = cmdl(eg1, eg2)
+    assert (exp > 0).all()
+
+    y = rmdl(eg1, eg2)
+    assert y == pytest.approx(exp, rel=0.35)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -812,3 +812,27 @@ def check_str():
     """
 
     return check_str_fixture
+
+
+@pytest.fixture
+def xsmodel():
+    """fixture that returns an XS<name> model instance.
+
+    The test needs to be marked @requires_xspec when using this
+    fixture.
+
+    """
+
+    try:
+        from sherpa.astro import xspec
+    except ImportError:
+        raise RuntimeError("Test needs the requires_xspec decorator")
+
+    def func(name, mname=None):
+        cls = getattr(xspec, f"XS{name}")
+        if mname is None:
+            return cls()
+
+        return cls(mname)
+
+    return func

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021, 2023
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -21,6 +22,7 @@
 
 from functools import reduce
 import operator
+import re
 
 import numpy as np
 
@@ -28,7 +30,8 @@ import pytest
 
 from sherpa.astro.ui.utils import Session
 from sherpa.models import basic
-from sherpa.models.model import ArithmeticConstantModel, BinaryOpModel, UnaryOpModel
+from sherpa.models.model import ArithmeticConstantModel, \
+    ArithmeticFunctionModel, BinaryOpModel, UnaryOpModel
 from sherpa.utils.err import ModelErr
 from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
 
@@ -201,10 +204,9 @@ def test_combine_models_1d_2d():
     m1 = basic.Box1D()
     m2 = basic.Box2D()
 
-    with pytest.raises(ModelErr) as exc:
+    with pytest.raises(ModelErr,
+                       match=re.escape("Models do not match: 1D (box1d) and 2D (box2d)")):
         m1 + m2
-
-    assert str(exc.value) == 'Models do not match: 1D (box1d) and 2D (box2d)'
 
 
 @pytest.mark.parametrize("val", [2, [1, 3, 4]])
@@ -223,10 +225,9 @@ def test_arithmeticconstantmodel(val):
 def test_arithmeticconstantmodel_dimerr():
 
     x = np.ones(6).reshape(2, 3)
-    with pytest.raises(ModelErr) as exc:
+    with pytest.raises(ModelErr,
+                       match="The constant must be a scalar or 1D, not 2D"):
         ArithmeticConstantModel(x)
-
-    assert str(exc.value) == 'The constant must be a scalar or 1D, not 2D'
 
 
 @requires_xspec
@@ -281,3 +282,131 @@ def test_load_table_model(make_data_path):
     s.load_table_model('tbl', make_data_path('double.dat'))
     tbl = s.get_model_component('tbl')
     assert tbl.ndim is None
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_unop_integrate(flag):
+    """Is the integrate flag carried over"""
+
+    mdl = basic.Const1D()
+    mdl.integrate = flag
+
+    umdl = -mdl
+    with pytest.raises(AttributeError):
+        assert umdl.integrate == flag
+
+
+def test_aconstant_integrate():
+    """Do we have an integrate setting?
+
+    test_unop_integrate_unset and others use an
+    ArithmeticConstantModel (implicitly) because at the time of
+    writing it doesn't have an integrate setting. Make this a
+    regression test (it is not a priori a problem if it does change
+    behavior, we just want to know we have a test).
+
+    """
+
+    mdl = ArithmeticConstantModel(3.2)
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+def test_unop_integrate_unset():
+    """Is the integrate flag not set for an unary op model"""
+
+    # UnaryOpModel converts the constant to an
+    # ArithmeticConstantModel.
+    #
+    mdl = UnaryOpModel(4, np.negative, "-")
+
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_binop_integrate_same(flag):
+    """Is the integrate flag carried over when the same"""
+
+    mdl1 = basic.Const1D()
+    mdl1.integrate = flag
+
+    mdl2 = basic.Const1D()
+    mdl2.integrate = flag
+
+    mdl = mdl1 + mdl2
+    with pytest.raises(AttributeError):
+        assert mdl.integrate == flag
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_binop_integrate_different(flag):
+    """Is the integrate flag not carried over when different"""
+
+    mdl1 = basic.Const1D()
+    mdl1.integrate = flag
+
+    mdl2 = basic.Const1D()
+    mdl2.integrate = not flag
+
+    mdl = mdl1 + mdl2
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+def test_binop_integrate_unset():
+    """Is the integrate flag not set for a binary op model"""
+
+    # The ArithmeticConstantModel, which the binary-op model casts
+    # the constant terms, has no integrate setting.
+    #
+    mdl = BinaryOpModel(4, 4, np.add, '+')
+    with pytest.raises(AttributeError):
+        mdl.integrate
+
+
+@pytest.mark.parametrize("m1,m2", [(1, basic.Const1D()),
+                                   (basic.Const1D(), 1),
+                                   (1, basic.Scale1D()),
+                                   (basic.Scale1D(), 1)])
+def test_binop_arithmeticmodel_integrate(m1, m2):
+    """Do we have an integrate setting?
+
+    This is a regression test.
+    """
+
+    mdl = m1 + m2
+    assert not hasattr(mdl, "integrate")
+
+
+AMODEL = ArithmeticFunctionModel(np.sin)
+
+
+@pytest.mark.parametrize("m1,m2", [(AMODEL, basic.Const1D()),
+                                   (basic.Const1D(), AMODEL),
+                                   (AMODEL, basic.Scale1D()),
+                                   (basic.Scale1D(), AMODEL)])
+def test_binop_arithmeticfunction_integrate(m1, m2):
+    """What's the integrate setting when ArithmeticFunctionModel is present?
+
+    This is a regression test.
+    """
+
+    mdl = m1 + m2
+    assert not hasattr(mdl, "integrate")
+
+
+@pytest.mark.parametrize("m1,m2", [(AMODEL, 2),
+                                   (2, AMODEL)])
+def test_binop_arithmeticfunction_works(m1, m2):
+    """Check we can evaluate a function model in a binop"""
+
+    grid = np.asarray([-0.2, -0.1, 0.1, 0.3])
+
+    # There's no support for creating these models easily.
+    #
+    mdl = BinaryOpModel(m1, m2, np.multiply, '*')
+    y = mdl(grid)
+
+    expected = 2 * np.sin(grid)
+    assert y == pytest.approx(expected)

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -25,8 +25,9 @@ from numpy.testing import assert_allclose
 
 import pytest
 
-from sherpa.models.model import Model, ArithmeticModel, CompositeModel, \
-    ArithmeticFunctionModel, RegridWrappedModel
+from sherpa.models.model import Model, ArithmeticModel, BinaryOpModel, \
+    CompositeModel, ArithmeticConstantModel, ArithmeticFunctionModel, \
+    RegridWrappedModel, UnaryOpModel
 from sherpa.models.basic import Box1D, Const1D, Gauss1D, \
     PowLaw1D, StepLo1D
 from sherpa.models.parameter import Parameter
@@ -147,7 +148,7 @@ def test_regrid1d_wrapping_name():
     #       incorrect. There is "prior art" here with PSF, ARF,
     #       and RMF models to look at.
     #
-    expected_name = 'regrid1d({})'.format(imodel_name)
+    expected_name = f'regrid1d({imodel_name})'
     assert mdl.name == expected_name
 
 
@@ -172,7 +173,7 @@ def test_regrid1d_wrapping_str():
     rmdl = ModelDomainRegridder1D(name='test')
     mdl = rmdl.apply_to(internal_model)
 
-    expected_name = 'test({})'.format(imodel_name)
+    expected_name = f'test({imodel_name})'
 
     # need to strip off the first line and replace it with
     # the new model name
@@ -389,7 +390,7 @@ def test_regrid1d_passes_through_the_grid():
 
     rmdl.grid = grid_expected
     store = imdl._calc_store
-    len(store) == 0
+    assert len(store) == 0
 
     y = mdl(grid_requested)
     assert len(y) == len(grid_requested)
@@ -827,15 +828,13 @@ class ReNormalizerModel1DInt(CompositeModel, ArithmeticModel):
     def wrapobj(obj):
         if isinstance(obj, ArithmeticModel):
             return obj
-        else:
-            return ArithmeticFunctionModel(obj)
+
+        return ArithmeticFunctionModel(obj)
 
     def __init__(self, model, wrapper):
         self.model = self.wrapobj(model)
         self.wrapper = wrapper
-        CompositeModel.__init__(self,
-                                "{}({})".format(self.wrapper.name,
-                                                self.model.name),
+        CompositeModel.__init__(self, f"{self.wrapper.name}({self.model.name})",
                                 (self.wrapper, self.model))
 
     def calc(self, p, *args, **kwargs):
@@ -1260,3 +1259,190 @@ def test_unop_binop_combo():
     with pytest.raises(ModelErr,
                        match="Neither component supports regrid method"):
         mdl.regrid([1, 2, 3])
+
+
+def test_regrid_binop_arithmeticconstantmodel():
+    """If you have managed to create binop(constants) then regridded, does it work"""
+
+    grid = np.linspace(20, 30, 21)
+    orig = BinaryOpModel(4, 6, np.add, '+')
+
+    with pytest.raises(ModelErr,
+                       match="Neither component supports regrid method"):
+        orig.regrid(grid)
+
+
+def test_box1d_point():
+    """This model is used in several tests so check it out"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = cpt
+    exp = np.asarray([0, 0, 1, 1, 1, 1, 1])
+
+    xgrid = np.arange(105, 195, 13)
+    assert mdl(xgrid) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase)
+    assert rmdl(xgrid) == pytest.approx(exp)
+
+
+def test_constant_box1d_point():
+    """Check 3 + mdl"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = 3 + cpt
+
+    exp = 3 + np.asarray([0, 0, 1, 1, 1, 1, 1])
+
+    xgrid = np.arange(105, 195, 13)
+    assert mdl(xgrid) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase)
+    assert rmdl(xgrid) == pytest.approx(exp)
+
+
+def test_box1d_bin():
+    """This model is used in several tests so check it out"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = cpt
+    exp = np.asarray([0, 1, 13, 13, 13, 13])
+
+    # Ideally this would be exp, but it's not quite
+    exp2 = np.asarray([0, 1, 13, 13, 13, 12.7])
+
+    xgrid = np.arange(105, 195, 13)
+    xg1 = xgrid[:-1]
+    xg2 = xgrid[1:]
+    assert mdl(xg1, xg2) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase[:-1], xbase[1:])
+    assert rmdl(xg1, xg2) == pytest.approx(exp2)
+
+
+def test_constant_box1d_bin():
+    """Check 3 + mdl"""
+
+    cpt = Box1D()
+    cpt.xlow = 130
+    cpt.xhi = 189
+
+    mdl = 3 + cpt
+
+    # What is the correct value here? That is, what do
+    # we expect the "integrated" version of the constant
+    # to be? It should just be 3 (i.e. it doesn't care about
+    # the bin width), but once we start rebinning things it
+    # gets complicated.
+    #
+    exp = 3 + np.asarray([0, 1, 13, 13, 13, 13])
+
+    # Just report the current value
+    exp2 = 3.9 + np.asarray([0, 1, 13, 13, 13, 12.7])
+
+    xgrid = np.arange(105, 195, 13)
+    xg1 = xgrid[:-1]
+    xg2 = xgrid[1:]
+    assert mdl(xg1, xg2) == pytest.approx(exp)
+
+    xbase = np.arange(100, 200, 10)
+    rmdl = mdl.regrid(xbase[:-1], xbase[1:])
+    assert rmdl(xg1, xg2) == pytest.approx(exp2)
+
+
+@pytest.mark.parametrize("integrate", [True, False])
+def test_deep_binop_points(integrate):
+    """Can we handle a "deep" binop tree?
+
+    (2 * model) / (3 + model)
+
+    We evaluate it on a set of points, not a grid,
+    so the integration setting doesn't matter.
+    """
+
+    yexp = np.asarray([0, 2/3, 0.5, 0.5, 0.5, 0, 0])
+
+    xbase = np.arange(100, 200, 10)
+    xgrid = np.arange(105, 195, 13)
+
+    m1 = Box1D('m1')
+    m2 = Box1D('m2')
+    m1.xlow = 110
+    m1.xhi = 160
+    m2.xlow = 130
+    m2.xhi = 189
+
+    m1.integrate = integrate
+    m2.integrate = integrate
+
+    mdl = (2 * m1) / (3 + m2)
+    with pytest.raises(RecursionError):
+        regrid = mdl.regrid(xbase)
+
+    # ym = mdl(xgrid)
+    # assert ym == pytest.approx(yexp)
+
+    # yr = regrid(xgrid)
+    # assert yr == pytest.approx(ym)
+
+
+@pytest.mark.parametrize("integrate,yexp,yexp2",
+                         [(True,
+                           [16/3, 26/4, 26/16, 26/16, 6/16, 0, 0],
+                           [40/7.5, 8.15384615, 2, 2, 0.46153846, 0, 0]),
+                          (False,
+                           [0, 2/3, 0.5, 0.5, 0.5, 0, 0],
+                           [4/7.5, 0.85, 0.65, 0.65, 0.65, 0, 0])
+                          ])
+def test_deep_binop_bins(integrate, yexp, yexp2):
+    """Can we handle a "deep" binop tree?
+
+    (2 * model) / (3 + model)
+
+    We evaluate it on bins (lo,hi) so the integration
+    setting does matter here.
+
+    We have to give separate "expected" results for the un-regridded
+    and regridded models as they are not close enough to use the same
+    values. The values for integrate=False (yexp, yexp2) may be wrong,
+    but hard to diagnose when issue #1802 is not fixed.
+
+    """
+
+    yexp = np.asarray(yexp)
+    yexp2 = np.asarray(yexp2)
+
+    xbase = np.arange(100, 200 + 10, 10)
+    xgrid = np.arange(105, 195 + 13, 13)
+
+    m1 = Box1D('m1')
+    m2 = Box1D('m2')
+    m1.xlow = 110
+    m1.xhi = 160
+    m2.xlow = 130
+    m2.xhi = 189
+
+    m1.integrate = integrate
+    m2.integrate = integrate
+
+    mdl = (2 * m1) / (3 + m2)
+    with pytest.raises(RecursionError):
+        regrid = mdl.regrid(xbase[:-1], xbase[1:])
+
+    # ym = mdl(xgrid[:-1], xgrid[1:])
+    # assert ym == pytest.approx(yexp)
+
+    # yr = regrid(xgrid[:-1], xgrid[1:])
+    # assert yr == pytest.approx(yexp2)

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1194,3 +1194,69 @@ def test_evaluationspace1d_zeros_like_point():
 def test_evaluationspace1d_zeros_like_integrated():
 
     assert EvaluationSpace1D([3, 2, -1], [2, 1, -3]).zeros_like() == pytest.approx([0, 0, 0])
+
+
+@pytest.mark.parametrize("flag,mdl",
+                         [(False, Box1D() * Const1D() * Gauss1D()),
+                          (False, Box1D() * Const1D() * (1 + Gauss1D())),
+                          (False, 1 / (1 + Const1D())),
+                          (False, 1 / (Box1D() * Gauss1D())),
+                          (False, 1 / (1 + Box1D() * Gauss1D())),
+                          (False, ((Box1D() + Const1D()) / (Box1D() + Gauss1D()))),
+                          (False, (Const1D() / (Box1D() + Gauss1D()) + Box1D())),
+                          (False, (1 / (1 - (-Const1D())))),
+                          (False, ((-Box1D()) / ((-Const1D()) - (-Gauss1D())))),
+                          (True, Box1D() * Gauss1D()),
+                          (True, Box1D() / (Const1D() + Gauss1D())),
+                          (True, Const1D() / (1 + Box1D() * Gauss1D())),
+                          (True, (Box1D() + Const1D() / (Box1D() + Gauss1D())))
+                          ])
+@pytest.mark.parametrize("args", [([1, 2, 3], ), ([1, 2, 4], [2, 3, 5])])
+def test_recursion_1802(flag, mdl, args):
+    """Can we create moderately-complex models to regrid?
+
+    Test cases from #1802. It is unlikely that the axis choice (point
+    or integrated) makes a difference, but add a test just in case.
+
+    """
+
+    # This test could be marked XFAIL but I want to make it obvious
+    # once it gets fixed.
+    #
+    if flag:
+        rmdl = mdl.regrid(*args)
+        # basic check to see if we have got a regrid model
+        assert isinstance(rmdl, RegridWrappedModel)
+        assert rmdl.name == f"regrid1d({mdl.name})"
+        return
+
+    with pytest.raises(RecursionError):
+        mdl.regrid(*args)
+
+
+def test_unop_regrid():
+    """Can we regrid a unary op model?"""
+
+    mdl = Gauss1D()
+    mdl.pos = 100
+    mdl.ampl = 10
+
+    egrid = [80, 90, 95, 107, 115]
+    expected = -mdl(egrid)
+
+    nmdl = -mdl
+    with pytest.raises(AttributeError):
+        rgrid = nmdl.regrid(np.arange(70, 120, 2))
+
+    # assert rgrid(egrid) == pytest.approx(expected)
+
+
+def test_unop_binop_combo():
+    """What happens if a binop is given two unops: can we regrid?"""
+
+    mdl1 = Box1D()
+    mdl2 = Gauss1D()
+    mdl = (-mdl1 - (-mdl2))
+    with pytest.raises(ModelErr,
+                       match="Neither component supports regrid method"):
+        mdl.regrid([1, 2, 3])

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -27,7 +27,7 @@ import pytest
 
 from sherpa.models.model import Model, ArithmeticModel, BinaryOpModel, \
     CompositeModel, ArithmeticConstantModel, ArithmeticFunctionModel, \
-    RegridWrappedModel, UnaryOpModel
+    RegriddableModel1D, RegridWrappedModel, UnaryOpModel
 from sherpa.models.basic import Box1D, Const1D, Gauss1D, \
     PowLaw1D, StepLo1D
 from sherpa.models.parameter import Parameter
@@ -1446,3 +1446,82 @@ def test_deep_binop_bins(integrate, yexp, yexp2):
 
     # yr = regrid(xgrid[:-1], xgrid[1:])
     # assert yr == pytest.approx(yexp2)
+
+
+class SimpleModel(RegriddableModel1D):
+    """A model which uses the middle of integrated bins"""
+
+    def __init__(self, name='simplemodel'):
+        self.scale = Parameter(name, "scale", 0, min=-5, max=5)
+        RegriddableModel1D.__init__(self, name, (self.scale, ))
+
+    def calc(self, p, xlo, xhi=None, **kwargs):
+        "This ignores the integrate setting"
+        x = np.asarray(xlo)
+        if xhi is not None:
+            x = x + np.asarray(xhi)
+            x /= 2
+
+        return p[0] * x
+
+
+def get_non_integrated_model_on_integrated_axis_1d(integrated):
+
+    mdl = SimpleModel()
+    mdl.scale = 2
+    assert mdl.integrate is True  # regression test
+
+    mdl.integrate = integrated
+
+    eval_grid = [0.5, 1, 1.5, 2, 2.5, 3]
+    rmdl = mdl.regrid(eval_grid[:-1], eval_grid[1:])
+
+    # These bins do not fill the space (ie there are gaps between
+    # bins).
+    #
+    req_lo = [0.6, 0.8, 1.0, 1.4, 2.0, 2.6]
+    req_hi = [0.8, 1.0, 1.2, 2.0, 2.4, 2.8]
+
+    # We expect 2 * (xlo + xhi) / 2, = xlo + xh, so
+    #
+    #   [ 1.4, 1.8, 2.2, 3.4, 4.4, 5.4]
+    #
+    # at least when "non integrated".
+    #
+    return rmdl(req_lo, req_hi)
+
+
+def test_non_integrated_model_on_integrated_axis_1d_false():
+    """Check what happens with a 'multiplicative' model given an integrated axis."""
+
+    got = get_non_integrated_model_on_integrated_axis_1d(False)
+
+    # The relative tolerance is guessed here as the test currently
+    # fails quite badly for the first bin.
+    #
+    # expected = [1.4, 1.8, 2.2, 3.4, 4.4, 5.4]
+    # assert got == pytest.approx(expected, rel=0.1)
+
+    # For the moment this is a regression test, so we just check
+    # the values we get from running the code on 4.15.1 era code.
+    #
+    expected = [0, 1.8, 2.2, 3.4, 4.4, 5.4]
+    assert got == pytest.approx(expected)
+
+
+def test_non_integrated_model_on_integrated_axis_1d_true():
+    """Check what happens with a 'multiplicative' model given an integrated axis."""
+
+    got = get_non_integrated_model_on_integrated_axis_1d(True)
+
+    # The relative tolerance is guessed here as the test currently
+    # fails quite badly (as there's uncertainty over the behavior).
+    #
+    # expected = [1.4, 1.8, 2.2, 3.4, 4.4, 5.4]
+    # assert got == pytest.approx(expected, rel=0.1)
+
+    # For the moment this is a regression test, so we just check
+    # the values we get from running the code on 4.15.1 era code.
+    #
+    expected = [0.6, 0.6, 1, 4, 3.6, 2.2]
+    assert got == pytest.approx(expected)


### PR DESCRIPTION
# Summary

Add tests for corner-cases for the regrid method. Many of these tests are currently regression tests, and check that the code behaviour has not changed, rather than that it works correctly. There is no functional change to the code.

# Details

These tests have been lying around for a while but I am not convinced the PRs they come from are going to make it into 4.16, so I want the actual tests in so I don't keep on re-inventing them, and also so we can easily see when the behaviour changes (hopefully fixed).

- adds explicit tests of #1802 
- taken from 
  - #1179 
  - #1803 
 although much of this code has been re-worked from previous un-merged PRs
