### PR TITLE
XSPEC: table model improvements

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9882,9 +9882,14 @@ class Session(sherpa.ui.utils.Session):
         table model component. These models may have multiple model
         parameters.
 
+        .. versionchanged:: 4.16.0
+           Parameters with negative DELTA values are now made frozen,
+           to match XSPEC. Support for models which use the ESCALE
+           keyword has been added.
+
         .. versionchanged:: 4.14.0
-           The etable argument has been added to allow exponential table
-           models to be used.
+           The etable argument has been added to allow exponential
+           table models to be used.
 
         Parameters
         ----------
@@ -9901,6 +9906,8 @@ class Session(sherpa.ui.utils.Session):
         ------
         sherpa.utils.err.ImportErr
            If XSPEC support is not enabled.
+        sherpa.utils.err.IOErr
+           If the XSPEC table model is not supported by Sherpa.
 
         See Also
         --------
@@ -9913,9 +9920,13 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        NASA's HEASARC site contains a link to community-provided
-        XSPEC table models:
-        https://heasarc.gsfc.nasa.gov/xanadu/xspec/newmodels.html
+        There is no support for table models that provide multiple
+        spectra per parameter: that is, those with the NXFLTEXP keyword
+        set.
+
+        NASA's HEASARC site contains a link to `community-provided
+        XSPEC table models
+        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/newmodels.html>`_.
 
         References
         ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1204,6 +1204,10 @@ class XSTableModel(XSModel):
     way to access this functionality. A simpler interface is provided
     by `read_xstable_model` and `sherpa.astro.ui.load_xstable_model`.
 
+    .. versionchanged:: 4.16.0
+       Parameters with negative DELTA values are now made frozen, to
+       match XSPEC.
+
     .. versionchanged:: 4.14.0
        The etable argument has been added to allow exponential table
        models to be used.
@@ -1225,6 +1229,7 @@ class XSTableModel(XSModel):
     delta : sequence
         The delta value for each parameter. This corresponds to the
         "DELTA" column from the "PARAMETER" block of the input file.
+        A negative value marks a parameter as being frozen.
     mins, maxes, hardmins, hardmaxes : sequence
         The valid range of each parameter. These correspond to the
         "BOTTOM", "TOP", "MINIMUM", and "MAXIMUM" columns from the
@@ -1285,10 +1290,17 @@ class XSTableModel(XSModel):
             parname = parname.strip().lower().translate(tbl)
             par = XSBaseParameter(name, parname, initvals[ii],
                                   mins[ii], maxes[ii],
-                                  hardmins[ii], hardmaxes[ii], frozen=isfrozen)
+                                  hardmins[ii], hardmaxes[ii],
+                                  frozen=isfrozen)
             self.__dict__[parname] = par
             pars.append(par)
             nint -= 1
+
+            # If delta < 0 then the parameter is also frozen. This is
+            # handled separately to the isfrozen check.
+            #
+            if delta[ii] < 0:
+                par.freeze()
 
         self.filename = filename
         self.addmodel = addmodel

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -101,7 +101,7 @@ from sherpa.models import ArithmeticModel, ArithmeticFunctionModel, \
 from sherpa.models.parameter import hugeval
 
 from sherpa.utils import SherpaFloat, guess_amplitude, param_apply_limits, bool_cast
-from sherpa.utils.err import ParameterErr
+from sherpa.utils.err import IOErr, ParameterErr
 from sherpa.astro.utils import get_xspec_position
 
 # Note that utils also imports _xspec so it will error out if it is
@@ -771,6 +771,11 @@ def read_xstable_model(modelname, filename, etable=False):
     XSPEC additive (atable, [1]_), multiplicative (mtable, [2]_), and
     exponential (etable, [3]_) table models are supported.
 
+    .. versionchanged:: 4.16.0
+       Parameters with negative DELTA values are now made frozen, to
+       match XSPEC. Support for models which use the ESCALE keyword
+       has been added.
+
     .. versionchanged:: 4.14.0
        The etable argument has been added to allow exponential table
        models to be used.
@@ -789,6 +794,11 @@ def read_xstable_model(modelname, filename, etable=False):
     Returns
     -------
     tablemodel : XSTableModel instance
+
+    Notes
+    -----
+    There is no support for table models that provide multiple spectra
+    per parameter: that is, those with the NXFLTEXP keyword set.
 
     References
     ----------
@@ -822,16 +832,47 @@ def read_xstable_model(modelname, filename, etable=False):
     read_tbl = sherpa.astro.io.backend.get_table_data
     read_hdr = sherpa.astro.io.backend.get_header_data
 
+    # Not all keywords are going to be present, so check what are.
+    #
     blkname = 'PRIMARY'
-    hdrkeys = ['HDUCLAS1', 'REDSHIFT', 'ADDMODEL']
-    hdr = read_hdr(filename, blockname=blkname, hdrkeys=hdrkeys)
+    hdr = read_hdr(filename, blockname=blkname, hdrkeys=None)
 
-    addmodel = bool_cast(hdr[hdrkeys[2]])
-    addredshift = bool_cast(hdr[hdrkeys[1]])
+    try:
+        hduclas1 = hdr["HDUCLAS1"].upper()
+    except KeyError:
+        raise IOErr("nokeyword", filename, "HDUCLAS1")
 
-    # TODO: change Exception to something more useful
-    if str(hdr[hdrkeys[0]]).upper() != 'XSPEC TABLE MODEL':
+    if hduclas1 != 'XSPEC TABLE MODEL':
+        # TODO: change Exception to something more useful
         raise Exception("Not an XSPEC table model")
+
+    try:
+        addredshift = bool_cast(hdr["REDSHIFT"])
+    except KeyError:
+        raise IOErr("nokeyword", filename, "REDSHIFT")
+
+    try:
+        addmodel = bool_cast(hdr["ADDMODEL"])
+    except KeyError:
+        raise IOErr("nokeyword", filename, "ADDMODEL")
+
+    # ESCALE may not exist in the header, as it is relatively new.
+    #
+    try:
+        addescale = bool_cast(hdr["ESCALE"])
+    except KeyError:
+        addescale = False
+
+    # We want to error out if NXFLTEXP is set (and more than 1). If
+    # set to 1 we ignore it.
+    #
+    try:
+        nxfltexp = int(hdr["NXFLTEXP"])
+    except KeyError:
+        nxfltexp = 1
+
+    if nxfltexp > 1:
+        raise IOErr(f"No support for NXFLTEXP={nxfltexp} in {filename}")
 
     blkname = 'PARAMETERS'
     colkeys = ['NAME', 'INITIAL', 'DELTA', 'BOTTOM', 'TOP',
@@ -841,10 +882,11 @@ def read_xstable_model(modelname, filename, etable=False):
     (colnames, cols,
      name, hdr) = read_tbl(filename, colkeys=colkeys, hdrkeys=hdrkeys,
                            blockname=blkname, fix_type=False)
-    nint = int(hdr[hdrkeys[0]])
+    nint = int(hdr["NINTPARM"])
     return XSTableModel(filename, modelname, *cols,
                         nint=nint, addmodel=addmodel,
-                        addredshift=addredshift, etable=etable)
+                        addredshift=addredshift,
+                        addescale=addescale, etable=etable)
 
 
 # The model classes are added to __all__ at the end of the file
@@ -1206,7 +1248,8 @@ class XSTableModel(XSModel):
 
     .. versionchanged:: 4.16.0
        Parameters with negative DELTA values are now made frozen, to
-       match XSPEC.
+       match XSPEC. Support for models which use the ESCALE keyword
+       has been added.
 
     .. versionchanged:: 4.14.0
        The etable argument has been added to allow exponential table
@@ -1247,9 +1290,18 @@ class XSTableModel(XSModel):
         If `True` then a redshift parameter is added to the parameters.
         It should be set to the value of the "REDSHIFT" keyword of the
         primary header of the input file.
+    addescale : bool
+        If `True` then an Escale parameter is added to the parameters.
+        It should be set to the value of the "ESCALE" keyword of the
+        primary header of the input file.
     etable : bool
         When addmodel is False this defines whether the file is a
         mtable model (`False`, the default) or an etable model (`True`).
+
+    Notes
+    -----
+    There is no support for table models that provide multiple spectra
+    per parameter: that is, those with the NXFLTEXP keyword set.
 
     References
     ----------
@@ -1262,7 +1314,8 @@ class XSTableModel(XSModel):
     def __init__(self, filename, name='xstbl', parnames=(),
                  initvals=(), delta=(), mins=(), maxes=(), hardmins=(),
                  hardmaxes=(), nint=0,
-                 addmodel=False, addredshift=False, etable=False):
+                 addmodel=False, addredshift=False, addescale=False,
+                 etable=False):
 
         # make translation table to turn reserved characters into '_'
         bad = string.punctuation + string.whitespace
@@ -1306,10 +1359,22 @@ class XSTableModel(XSModel):
         self.addmodel = addmodel
         self.etable = etable
 
+        # Order appears to be
+        #   - z
+        #   - Escale
+        #   - norm
+        # (for those models that support the relevant value)
+        #
         if addredshift:
             self.redshift = XSBaseParameter(name, 'redshift', 0., 0., 5.,
                                             0.0, 5, frozen=True)
             pars.append(self.redshift)
+
+        if addescale:
+            # Should this just use Parameter?
+            self.Escale = XSParameter(name, 'Escale', 1, 0, 1e20,
+                                      0, 1e24, frozen=True, units="keV")
+            pars.append(self.Escale)
 
         if addmodel:
             # Normalization parameters are not true XSPEC parameters and

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1686,7 +1686,7 @@ def test_table_mod_negative_delta_1850(addmodel, redshift, escale, make_data_pat
     tbl = xspec.read_xstable_model('tbl', infile)
 
     # issue #1850; is the parameter recognized as frozen
-    assert not tbl.lscale.frozen
+    assert tbl.lscale.frozen
 
     parnames = [p.name for p in tbl.pars]
     assert parnames[0] == "lscale"

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1698,12 +1698,9 @@ def test_table_mod_negative_delta_1850(addmodel, redshift, escale, make_data_pat
         idx += 1
 
     if escale:
-        # At the moment ESCALE is not recognized
-        #
-        # assert parnames[idx] == "Escale"
-        # assert tbl.escale.frozen
-        # idx += 1
-        assert "Escale" not in parnames
+        assert parnames[idx] == "Escale"
+        assert tbl.escale.frozen
+        idx += 1
 
     if addmodel:
         assert parnames[idx] == "norm"
@@ -1778,7 +1775,6 @@ def test_table_mod_add_redshift(make_data_path):
     assert tbl(elo, ehi) / de == pytest.approx(expected, rel=2e-6)
 
 
-@pytest.mark.xfail  # issue #1852
 @requires_xspec
 @requires_data
 @requires_fits
@@ -1882,7 +1878,6 @@ def test_table_mod_mul_redshift(make_data_path):
     assert tbl(elo, ehi) == pytest.approx(expected, rel=2e-6)
 
 
-@pytest.mark.xfail  # issue #1852
 @requires_xspec
 @requires_data
 @requires_fits

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1661,3 +1661,261 @@ def test_xspec_model_kwarg_cached_not_needed():
     assert mdl._cache_ctr['misses'] == 3
 
     assert y3 == pytest.approx(y1)
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("addmodel", [0, 1])
+@pytest.mark.parametrize("redshift", [0, 1])
+@pytest.mark.parametrize("escale", [0, 1])
+def test_table_mod_negative_delta_1850(addmodel, redshift, escale, make_data_path):
+    """Is delta<0 recognized as freezing a parameter?
+
+    The tables in xspec_table_models are numbered in such a way that
+    we can loop through them all, and hence check some other things at
+    the same time (to avoid having to read things in multiple times).
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = f"smod{addmodel}{redshift}{escale}.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    # issue #1850; is the parameter recognized as frozen
+    assert not tbl.lscale.frozen
+
+    parnames = [p.name for p in tbl.pars]
+    assert parnames[0] == "lscale"
+
+    idx = 1
+    if redshift:
+        assert parnames[idx] == "redshift"
+        assert tbl.redshift.frozen
+        idx += 1
+
+    if escale:
+        # At the moment ESCALE is not recognized
+        #
+        # assert parnames[idx] == "Escale"
+        # assert tbl.escale.frozen
+        # idx += 1
+        assert "Escale" not in parnames
+
+    if addmodel:
+        assert parnames[idx] == "norm"
+        assert not tbl.norm.frozen
+        idx += 1
+
+    assert len(parnames) == idx
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_table_mod_add(make_data_path):
+    """Check the additive model is behaving as expected. No z/escale
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = "smod100.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    egrid = np.asarray([0.2, 0.3, 0.5, 0.7, 1.1, 1.6, 2.0, 2.2, 2.5])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    expected = [0, 0, 22.5, 6, 54, 56, 39.5, 0]
+    assert tbl(elo, ehi) == pytest.approx(expected)
+
+    tbl.lscale = 0
+    expected = [0, 0, 15, 12, 52, 48, 15, 0]
+    assert tbl(elo, ehi) == pytest.approx(expected)
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_table_mod_add_redshift(make_data_path):
+    """Check the additive model is behaving as expected with redshift. No escale.
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = "smod110.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    assert tbl.redshift.val == pytest.approx(0)
+
+    egrid = np.linspace(0.2, 2.6, 25)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    de = 0.1
+
+    # Values taken from XSPEC 12.13.1 with
+    #
+    #    dummyrsp 0.2 2.6 24 linear
+    #    mo atable{smod101.tmod}
+    #    iplot model
+    #    wdata
+    #
+    expected = [0, 0, 0, 75, 150] + [15] * 4 + [100] * 4 + [140] * 5 + \
+        [375, 20, 0, 0, 0, 0]
+    assert tbl(elo, ehi) / de == pytest.approx(expected)
+
+    tbl.redshift = 1
+    expected = [0, 82.5, 15, 57.5, 100, 120, 140, 140, 197.5] + [0] * 15
+    assert tbl(elo, ehi) / de == pytest.approx(expected, rel=2e-6)
+
+
+@pytest.mark.xfail  # issue #1852
+@requires_xspec
+@requires_data
+@requires_fits
+def test_table_mod_add_escale(make_data_path):
+    """Check the additive model is behaving as expected with escale. No z.
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = "smod101.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    assert tbl.escale.val == pytest.approx(1.0)
+
+    egrid = np.linspace(0.2, 2.6, 25)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    de = 0.1
+
+    # Values taken from XSPEC 12.13.1 with
+    #
+    #    dummyrsp 0.2 2.6 24 linear
+    #    mo atable{smod101.tmod}
+    #    iplot model
+    #    wdata
+    #
+    expected = [0, 0, 0, 75, 150] + [15] * 4 + [100] * 4 + [140] * 5 + \
+        [375, 20, 0, 0, 0, 0]
+    assert tbl(elo, ehi) / de == pytest.approx(expected)
+
+    tbl.escale = 2
+    expected = [0] * 8 + [37.5] * 2 + [75] * 2 + [7.5] * 8 + [50] * 4
+    assert tbl(elo, ehi) / de == pytest.approx(expected, rel=2e-6)
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_table_mod_mul(make_data_path):
+    """Check the multiplicative model is behaving as expected. No z/escale
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = "smod000.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    egrid = np.asarray([0.2, 0.3, 0.5, 0.7, 1.1, 1.6, 2.0, 2.2, 2.5])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    expected = [0, 0, 11.25, 6, 45, 70, 19.75, 5]
+    assert tbl(elo, ehi) == pytest.approx(expected)
+
+    tbl.lscale = 0
+    expected = [0, 0, 7.5, 12, 40 + 10/3, 60, 7.5, 5]
+    assert tbl(elo, ehi) == pytest.approx(expected)
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_table_mod_mul_redshift(make_data_path):
+    """Check the multiplicative model is behaving as expected with redshift. No escale.
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = "smod010.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    assert tbl.redshift.val == pytest.approx(0)
+
+    egrid = np.linspace(0.2, 2.6, 25)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    # Values taken from XSPEC 12.13.1 with
+    #
+    #    dummyrsp 0.2 2.6 24 linear
+    #    mo mtable{smod001.tmod} * powerlaw
+    #    newpar 3 0
+    #    iplot model
+    #    wdata
+    #
+    expected = [0, 0, 0, 7.5, 15] + [6] * 4 + [40] * 4 + [70] * 5 + \
+        [37.5, 2, 5, 5, 5, 5]
+    assert tbl(elo, ehi) == pytest.approx(expected)
+
+    tbl.redshift = 1
+    expected = [0, 13.2, 6, 23, 40, 50 + 10/3, 70, 70, 19.75] + [5] * 15
+    assert tbl(elo, ehi) == pytest.approx(expected, rel=2e-6)
+
+
+@pytest.mark.xfail  # issue #1852
+@requires_xspec
+@requires_data
+@requires_fits
+def test_table_mod_mul_escale(make_data_path):
+    """Check the multiplicative model is behaving as expected with escale. No z.
+
+    """
+
+    from sherpa.astro import xspec
+
+    name = "smod001.tmod"
+    infile = make_data_path(f"xspec_table_models/{name}")
+
+    tbl = xspec.read_xstable_model('tbl', infile)
+
+    assert tbl.escale.val == pytest.approx(1.0)
+
+    egrid = np.linspace(0.2, 2.6, 25)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    # Values taken from XSPEC 12.13.1 with
+    #
+    #    dummyrsp 0.2 2.6 24 linear
+    #    mo mtable{smod001.tmod} * powerlaw
+    #    newpar 3 0
+    #    iplot model
+    #    wdata
+    #
+    expected = [0, 0, 0, 7.5, 15] + [6] * 4 + [40] * 4 + [70] * 5 + \
+        [37.5, 2, 5, 5, 5, 5]
+    assert tbl(elo, ehi) == pytest.approx(expected)
+
+    tbl.escale = 2
+    expected = [0] * 8 + [7.5] * 2 + [15] * 2 + [6] * 8 + [40] * 4
+    assert tbl(elo, ehi) == pytest.approx(expected, rel=2e-6)


### PR DESCRIPTION
# Summary

Address issues with the XSPEC table model support: models that set an Escale parameter (feature added December 2020) are now supported (previously they could cause a segmentation fault) and ensure that parameters with a negative delta value are marked as frozen. Fix #1850 and #1852.

# Details

With the merging of https://github.com/sherpa/sherpa-test-data/pull/28 I have re-worked this so that we can add tests that show the problem and then fix them.

We had not been marking XSPEC table model parameters as frozen that should be, using the standard "delta < 0" check. It's an easy fix, but we currently don't have any test data (although see https://github.com/sherpa/sherpa-test-data/pull/28). Fix #1850

We had not been looking for models which have the ESCALE keyword (in the PRIMARY block) set. This was added December 2020, and, as noted in #1852 it currently causes Sherpa to go boom. This is a an easy fix (we can follow the handling of the REDSHIFT parameter). I've checked and if noth redshift and escale are set then we have redshift then escale in the parameters. Unfortunately the results appear to be garbage when the model is evaluated, but that's not our issue. I have asked Keith about this combination but don't expect a response soon.

The Dec 2020 change also added support for multiple spectra per grid point. This requires XFLT support (these keywords are used to associate data files to the spectrum to use) and we currently do not support this (we don't have a single issue for this, but 

- #544
- #1225 

are related), so we instead explicitly error out for such a file (identified as having NXFLTEXP > 1 in the PRIMARY header).

As the table model support depends somewhat on the XSPEC version in play (for example, there were changes made in 12.13.1 to address a problem we reported for users of the model library) then there may be some clean up to tweak the tests for different XSPEC versions. 

I actually don't check out all the models added in https://github.com/sherpa/sherpa-test-data/pull/28 because I don't know what we expect when both redshift and escale are set in the header (the tests with XSPEC have been less-than spectacular) so I have held off testing this combination until we find there's a use for it.