### PR TITLE
models: change defaults for Box1D parameters

### DIFF
--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -108,6 +108,11 @@ class Box1D(RegriddableModel1D):
     inclusive), where it is set to the ``ampl`` parameter. Outside
     this range the model is zero.
 
+    .. versionchanged:: 4.16.0
+       The default value for the xhi parameter has been changed from 0
+       to 1, and the range of ampl now matches xlow and xhi rather
+       than being set to -1 to 1.
+
     Attributes
     ----------
     xlow
@@ -119,7 +124,7 @@ class Box1D(RegriddableModel1D):
 
     See Also
     --------
-    Box2D, Const1D, Delta1D, StepLo1D, StepHi1D
+    Box2D, Const1D, Delta1D, Scale1D, StepLo1D, StepHi1D
 
     Notes
     -----
@@ -137,12 +142,13 @@ class Box1D(RegriddableModel1D):
 
     This behavior is different to how the amplitude is handled in
     other models, such as ``Const1D``.
+
     """
 
     def __init__(self, name='box1d'):
         self.xlow = Parameter(name, 'xlow', 0)
-        self.xhi = Parameter(name, 'xhi', 0)
-        self.ampl = Parameter(name, 'ampl', 1, -1, 1)
+        self.xhi = Parameter(name, 'xhi', 1)
+        self.ampl = Parameter(name, 'ampl', 1)
         ArithmeticModel.__init__(self, name, (self.xlow, self.xhi, self.ampl))
 
     def guess(self, dep, *args, **kwargs):


### PR DESCRIPTION
# Summary

The xlow parameter of Box1D now defaults to 1 and the ampl parameter has a greatly-increased range (from the previous version of -1 to 1).

# Details

This changes the Box1D parameters so that

- xhi now starts at 1 rather than 0
- ampl uses the same range as xlow/xhi rather than -1 to +1

```
>>> print(Box1D())
box1d
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   box1d.xlow   thawed            0 -3.40282e+38  3.40282e+38
   box1d.xhi    thawed            0 -3.40282e+38  3.40282e+38
   box1d.ampl   thawed            1           -1            1
```

to

```
>>> print(Box1D())
box1d
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   box1d.xlow   thawed            0 -3.40282e+38  3.40282e+38
   box1d.xhi    thawed            1 -3.40282e+38  3.40282e+38
   box1d.ampl   thawed            1 -3.40282e+38  3.40282e+38
```

Fix #1265