### PR TITLE
group_counts et al now default to using the existing mask as the tabstops, unless explicitly given

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3520,10 +3520,13 @@ It is an integer or string.
         """Group into a fixed number of bins.
 
         Combine the data so that there `num` equal-width bins (or
-        groups). The binning scheme is applied to all the channels,
-        but any existing filter - created by the `ignore` or `notice`
-        set of functions - is re-applied after the data has been
-        grouped.
+        groups). The binning scheme is, by default, applied to only
+        the noticed data range. It is suggested that filtering is done
+        before calling group_bins.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range.
 
         Parameters
         ----------
@@ -3531,11 +3534,12 @@ It is an integer or string.
            The number of bins in the grouped data set. Each bin
            will contain the same number of channels.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           `True` means that the channel should be ignored from the
-           grouping (use 0 or `False` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set, it should be an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         See Also
         --------
@@ -3564,20 +3568,25 @@ It is an integer or string.
         """Group into a fixed bin width.
 
         Combine the data so that each bin contains `num` channels.
-        The binning scheme is applied to all the channels, but any
-        existing filter - created by the `ignore` or `notice` set of
-        functions - is re-applied after the data has been grouped.
+        The binning scheme is, by default, applied to only the noticed
+        data range. It is suggested that filtering is done before
+        calling group_width.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range.
 
         Parameters
         ----------
         val : int
            The number of channels to combine into a group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           `True` means that the channel should be ignored from the
-           grouping (use 0 or `False` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set, it should be an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         See Also
         --------
@@ -3606,12 +3615,15 @@ It is an integer or string.
         """Group into a minimum number of counts per bin.
 
         Combine the data so that each bin contains `num` or more
-        counts. The binning scheme is applied to all the channels, but
-        any existing filter - created by the `ignore` or `notice` set
-        of functions - is re-applied after the data has been grouped.
-        The background is *not* included in this calculation; the
-        calculation is done on the raw data even if `subtract` has
-        been called on this data set.
+        counts. The background is *not* included in this calculation;
+        the calculation is done on the raw data even if `subtract` has
+        been called on this data set. The binning scheme is, by
+        default, applied to only the noticed data range. It is
+        suggested that filtering is done before calling group_counts.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range.
 
         Parameters
         ----------
@@ -3621,11 +3633,12 @@ It is an integer or string.
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           `True` means that the channel should be ignored from the
-           grouping (use 0 or `False` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set, it should be an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         See Also
         --------
@@ -3641,6 +3654,25 @@ It is an integer or string.
         warning message will be displayed to the screen and the
         quality value for these channels will be set to 2.
 
+        Examples
+        --------
+
+        Group by 20 counts within the range 0.5 to 7 keV (this is
+        the default behavior for 4.16 and later):
+
+        >>> from sherpa.astro.io import read_pha
+        >>> pha = read_pha(data_3c273 + '3c273.pi')
+        >>> pha.set_analysis("energy")
+        >>> pha.notice()
+        >>> pha.notice(0.5, 7)
+        >>> pha.group_counts(20)
+
+        Group by 20 but over the whole channel range, but then
+        filtering to the noticed range of 0.5 to 7 keV (this was the
+        default behaviour before 4.16):
+
+        >>> pha.group_counts(20, tabStops=[0] * pha.size)
+
         """
         self._dynamic_group("grpNumCounts", self.counts, num,
                             maxLength=maxLength, tabStops=tabStops)
@@ -3653,12 +3685,16 @@ It is an integer or string.
         """Group into a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
-        which exceeds `snr`. The binning scheme is applied to all the
-        channels, but any existing filter - created by the `ignore` or
-        `notice` set of functions - is re-applied after the data has
-        been grouped.  The background is *not* included in this
+        which exceeds `snr`. The background is *not* included in this
         calculation; the calculation is done on the raw data even if
-        `subtract` has been called on this data set.
+        `subtract` has been called on this data set. The binning
+        scheme is, by default, applied to only the noticed data
+        range. It is suggested that filtering is done before calling
+        group_snr.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range.
 
         Parameters
         ----------
@@ -3669,11 +3705,12 @@ It is an integer or string.
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           `True` means that the channel should be ignored from the
-           grouping (use 0 or `False` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set, it should be an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
         errorCol : array of num, optional
            If set, the error to use for each channel when calculating
            the signal-to-noise ratio. If not given then Poisson
@@ -3712,10 +3749,13 @@ It is an integer or string.
         order to avoid over-grouping bright features, rather than at
         the first channel of the data. The adaptive nature means that
         low-count regions between bright features may not end up in
-        groups with the minimum number of counts.  The binning scheme
-        is applied to all the channels, but any existing filter -
-        created by the `ignore` or `notice` set of functions - is
-        re-applied after the data has been grouped.
+        groups with the minimum number of counts. The binning scheme
+        is, by default, applied to only the noticed data range. It is
+        suggested that filtering is done before calling group_adapt.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range.
 
         Parameters
         ----------
@@ -3725,11 +3765,12 @@ It is an integer or string.
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           `True` means that the channel should be ignored from the
-           grouping (use 0 or `False` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set, it should be an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         See Also
         --------
@@ -3764,10 +3805,14 @@ It is an integer or string.
         in order to avoid over-grouping bright features, rather than
         at the first channel of the data. The adaptive nature means
         that low-count regions between bright features may not end up
-        in groups with the minimum number of counts.  The binning
-        scheme is applied to all the channels, but any existing filter
-        - created by the `ignore` or `notice` set of functions - is
-        re-applied after the data has been grouped.
+        in groups with the minimum number of counts. The binning
+        scheme is, by default, applied to only the noticed data
+        range. It is suggested that filtering is done before calling
+        group_adapt_snr.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range.
 
         Parameters
         ----------
@@ -3778,11 +3823,12 @@ It is an integer or string.
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           `True` means that the channel should be ignored from the
-           grouping (use 0 or `False` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set, it should be an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
         errorCol : array of num, optional
            If set, the error to use for each channel when calculating
            the signal-to-noise ratio. If not given then Poisson

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3467,6 +3467,19 @@ It is an integer or string.
             if kwargs[key] is None:
                 kwargs.pop(key)
 
+        # If tabstops is given then we want to ensure it is an
+        # ndarray.  Really this should be done on args as well, in
+        # case the array is sent in as a positional argument, but we
+        # always send it in as a keyword argument. An alternative is
+        # to do the conversion in the C++ code, but that is
+        # significantly harder to orchestrate so this approach has
+        # been taken.
+        #
+        try:
+            kwargs["tabStops"] = numpy.asarray(kwargs["tabStops"])
+        except KeyError:
+            pass
+
         self.grouping, self.quality = group_func(*args, **kwargs)
         self.group()
         self._original_groups = False

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3483,12 +3483,15 @@ It is an integer or string.
         # convert the mask into a "per-channel" array (in the same way
         # that get_mask does it).
         #
-        try:
+        if "tabStops" in kwargs:
             ts = numpy.asarray(kwargs["tabStops"])
 
             # We only expand the array if it has the correct size
             # (expand_grouped_mask does not enforce length checks for
             # Sherpa ~ 4.15).
+            #
+            # TODO: this probably doesn't work if we have quality_filter
+            # set.
             #
             nts = len(ts)
             nchan = len(self.channel)
@@ -3497,8 +3500,17 @@ It is an integer or string.
                 ts = expand_grouped_mask(ts, self.grouping)
 
             kwargs["tabStops"] = ts
-        except KeyError:
-            pass
+
+        else:
+            # If there is a mask, and it is an array, invert it for
+            # the tabStops. Note that
+            #
+            # a) use get_mask to ensure we have a value for each channel
+            # b) get_mask can return None or an array.
+            #
+            mask = self.get_mask()
+            if numpy.iterable(mask):
+                kwargs["tabStops"] = ~mask
 
         self.grouping, self.quality = group_func(*args, **kwargs)
         self.group()

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4381,3 +4381,35 @@ def test_img_checks_coord_no_transform(coord):
                        match="^data set 'ex' does not contain a .* coordinate system$"):
         DataIMG("ex", [1, 2, 1, 2], [1, 1, 2, 2], [1, 2, 3, 4],
                 coord=coord)
+
+
+@pytest.mark.parametrize("asarray", [True, pytest.param(False, marks=pytest.mark.xfail)])  # XFAIL: TypeError: grpBinWidth() Could not parse input arguments, ...
+def test_group_xxx_tabtops_not_ndarray(asarray):
+    """What happens if tabStops is not a ndarray?"""
+
+    pha = DataPHA("test", [1, 2, 3, 4, 5], [2, 3, 4, 5, 6])
+    tabstops = [1, 1, 0, 0, 1]
+    if asarray:
+        tabstops = np.asarray(tabstops)
+
+    # This should only group channels 3 and 4.
+    pha.group_width(2, tabStops=tabstops)
+
+    assert pha.get_y() == pytest.approx([2, 3, 4.5, 6])
+    assert pha.mask is True
+    assert pha.get_mask() is None
+
+
+@pytest.mark.parametrize("asarray", [True, pytest.param(False, marks=pytest.mark.xfail)])  # XFAIL: TypeError: grpBinWidth() Could not parse input arguments, ...
+@pytest.mark.parametrize("nelem", [4, 6])
+def test_group_xxx_tabtops_wrong_size(asarray, nelem):
+    """What happens if tabStops is not a ndarray?"""
+
+    pha = DataPHA("test", [1, 2, 3, 4, 5], [2, 3, 4, 5, 6])
+    tabstops = [0] * nelem
+    if asarray:
+        tabstops = np.asarray(tabstops)
+
+    emsg = r"^grpBinWidth\(\) The number of tab stops and number of channels specified in the argument list have different sizes$"
+    with pytest.raises(ValueError, match=emsg):
+        pha.group_width(2, tabStops=tabstops)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4415,7 +4415,6 @@ def test_group_xxx_tabtops_wrong_size(asarray, nelem):
         pha.group_width(2, tabStops=tabstops)
 
 
-@pytest.mark.xfail  # XFAIL: ValueError: grpNumCounts() The tabStops and countsArray have differing length
 def test_group_xxx_tabstops_already_grouped():
     """Check what happens if tabStops is sent ~pha.mask when already grouped."""
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4383,7 +4383,7 @@ def test_img_checks_coord_no_transform(coord):
                 coord=coord)
 
 
-@pytest.mark.parametrize("asarray", [True, pytest.param(False, marks=pytest.mark.xfail)])  # XFAIL: TypeError: grpBinWidth() Could not parse input arguments, ...
+@pytest.mark.parametrize("asarray", [True, False])
 def test_group_xxx_tabtops_not_ndarray(asarray):
     """What happens if tabStops is not a ndarray?"""
 
@@ -4400,7 +4400,7 @@ def test_group_xxx_tabtops_not_ndarray(asarray):
     assert pha.get_mask() is None
 
 
-@pytest.mark.parametrize("asarray", [True, pytest.param(False, marks=pytest.mark.xfail)])  # XFAIL: TypeError: grpBinWidth() Could not parse input arguments, ...
+@pytest.mark.parametrize("asarray", [True, False])
 @pytest.mark.parametrize("nelem", [4, 6])
 def test_group_xxx_tabtops_wrong_size(asarray, nelem):
     """What happens if tabStops is not a ndarray?"""

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8052,10 +8052,14 @@ class Session(sherpa.ui.utils.Session):
         """Group into a fixed number of bins.
 
         Combine the data so that there `num` equal-width bins (or
-        groups). The binning scheme is applied to all the channels,
-        but any existing filter - created by the `ignore` or `notice`
-        set of functions - is re-applied after the data has been
-        grouped.
+        groups). The binning scheme is, by default, applied to only
+        the noticed data range. It is suggested that filtering is done
+        before calling group_bins.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range. The tabStops argument can be set to "nofilter" to
+           use the previous behaviour.
 
         .. versionchanged:: 4.15.1
            The filter is now reported, noting any changes the new
@@ -8075,12 +8079,15 @@ class Session(sherpa.ui.utils.Session):
            When ``bkg_id`` is None (which is the default), the
            grouping is applied to all the associated background
            data sets as well as the source data set.
-        tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           ``True`` means that the channel should be ignored from the
-           grouping (use 0 or ``False`` otherwise).
+        tabStops : str or array of int or bool, optional
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set it can be the string "nofilter", which means
+           that no filter is applied (and matches the behavior prior
+           to the 4.16 release), or an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         Raises
         ------
@@ -8124,29 +8131,33 @@ class Session(sherpa.ui.utils.Session):
 
         >>> group_bins(50)
 
-        Group the 'jet' data set to 50 bins and plot the result,
-        then re-bin to 100 bins and overplot the data:
+        Group the 'jet' data set to 50 bins and plot the result, then
+        re-bin to 100 bins and overplot the data:
 
         >>> group_bins('jet', 50)
         >>> plot_data('jet')
         >>> group_bins('jet', 100)
         >>> plot_data('jet', overplot=True)
 
-        The grouping is applied to the full data set, and then
-        the filter - in this case defined over the range 0.5
-        to 8 keV - will be applied. This means that the
-        noticed data range will likely contain less than
-        50 bins.
+        The grouping is applied to only the data within the 0.5 to 8
+        keV range (this behaviour is new in 4.16):
 
         >>> set_analysis('energy')
+        >>> notice()
         >>> notice(0.5, 8)
         >>> group_bins(50)
         >>> plot_data()
 
-        Do not group any channels numbered less than 20 or
-        800 or more. Since there are 780 channels to be
-        grouped, the width of each bin will be 20 channels
-        and there are no "left over" channels:
+        Group the full channel range and then apply the existing
+        filter (0.5 to 8 keV) so that the noticed range may be larger
+        (this was the default behaviour before 4.16):
+
+        >>> group_bins(50, tabStops="nofilter")
+
+        Do not group any channels numbered less than 20 or 800 or
+        more. Since there are 780 channels to be grouped, the width of
+        each bin will be 20 channels and there are no "left over"
+        channels:
 
         >>> notice()
         >>> channels = get_data().channel
@@ -8170,9 +8181,14 @@ class Session(sherpa.ui.utils.Session):
         """Group into a fixed bin width.
 
         Combine the data so that each bin contains `num` channels.
-        The binning scheme is applied to all the channels, but any
-        existing filter - created by the `ignore` or `notice` set of
-        functions - is re-applied after the data has been grouped.
+        The binning scheme is, by default, applied to only the noticed
+        data range. It is suggested that filtering is done before
+        calling group_width.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range. The tabStops argument can be set to "nofilter" to
+           use the previous behaviour.
 
         .. versionchanged:: 4.15.1
            The filter is now reported, noting any changes the new
@@ -8192,11 +8208,14 @@ class Session(sherpa.ui.utils.Session):
            grouping is applied to all the associated background
            data sets as well as the source data set.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           ``True`` means that the channel should be ignored from the
-           grouping (use 0 or ``False`` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set it can be the string "nofilter", which means
+           that no filter is applied (and matches the behavior prior
+           to the 4.16 release), or an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         Raises
         ------
@@ -8236,28 +8255,34 @@ class Session(sherpa.ui.utils.Session):
         Examples
         --------
 
-        Group the default data set so that each bin contains 20
+        Group the default data set so that each bin contains 5
         channels:
 
-        >>> group_width(20)
+        >>> group_width(5)
 
         Plot two versions of the 'jet' data set: the first uses
-        20 channels per group and the second is 50 channels per
+        2 channels per group and the second is 5 channels per
         group:
 
-        >>> group_width('jet', 20)
+        >>> group_width('jet', 2)
         >>> plot_data('jet')
-        >>> group_width('jet', 50)
+        >>> group_width('jet', 5)
         >>> plot_data('jet', overplot=True)
 
-        The grouping is applied to the full data set, and then
-        the filter - in this case defined over the range 0.5
-        to 8 keV - will be applied.
+        The grouping is applied to only the data within the 0.5 to 8
+        keV range (this behaviour is new in 4.16):
 
         >>> set_analysis('energy')
+        >>> notice()
         >>> notice(0.5, 8)
-        >>> group_width(50)
+        >>> group_width(7)
         >>> plot_data()
+
+        Group the full channel range and then apply the existing
+        filter (0.5 to 8 keV) so that the noticed range may be larger
+        (this was the default behaviour before 4.16):
+
+        >>> group_width(5, tabStops="nofilter")
 
         The grouping is not applied to channels 101 to
         149, inclusive:
@@ -8265,7 +8290,7 @@ class Session(sherpa.ui.utils.Session):
         >>> notice()
         >>> channels = get_data().channel
         >>> ign = (channels > 100) & (channels < 150)
-        >>> group_width(40, tabStops=ign)
+        >>> group_width(4, tabStops=ign)
         >>> plot_data()
 
         """
@@ -8283,12 +8308,16 @@ class Session(sherpa.ui.utils.Session):
         """Group into a minimum number of counts per bin.
 
         Combine the data so that each bin contains `num` or more
-        counts. The binning scheme is applied to all the channels, but
-        any existing filter - created by the `ignore` or `notice` set
-        of functions - is re-applied after the data has been grouped.
-        The background is *not* included in this calculation; the
-        calculation is done on the raw data even if `subtract` has
-        been called on this data set.
+        counts. The background is *not* included in this calculation;
+        the calculation is done on the raw data even if `subtract` has
+        been called on this data set. The binning scheme is, by
+        default, applied to only the noticed data range. It is
+        suggested that filtering is done before calling group_counts.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range. The tabStops argument can be set to "nofilter" to
+           use the previous behaviour.
 
         .. versionchanged:: 4.15.1
            The filter is now reported, noting any changes the new
@@ -8311,11 +8340,14 @@ class Session(sherpa.ui.utils.Session):
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           ``True`` means that the channel should be ignored from the
-           grouping (use 0 or ``False`` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set it can be the string "nofilter", which means
+           that no filter is applied (and matches the behavior prior
+           to the 4.16 release), or an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         Raises
         ------
@@ -8366,14 +8398,20 @@ class Session(sherpa.ui.utils.Session):
         >>> group_counts('jet', 50)
         >>> plot_data('jet', overplot=True)
 
-        The grouping is applied to the full data set, and then
-        the filter - in this case defined over the range 0.5
-        to 8 keV - will be applied.
+        The grouping is applied to only the data within the 0.5 to 8
+        keV range (this behaviour is new in 4.16):
 
         >>> set_analysis('energy')
+        >>> notice()
         >>> notice(0.5, 8)
         >>> group_counts(30)
         >>> plot_data()
+
+        Group the full channel range and then apply the existing
+        filter (0.5 to 8 keV) so that the noticed range may be larger
+        (this was the default behaviour before 4.16):
+
+        >>> group_counts(25, tabStops="nofilter")
 
         If a channel has more than 30 counts then do not group,
         otherwise group channels so that they contain at least 40
@@ -8404,12 +8442,17 @@ class Session(sherpa.ui.utils.Session):
         """Group into a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
-        of at least `snr`. The binning scheme is applied to all the
-        channels, but any existing filter - created by the `ignore` or
-        `notice` set of functions - is re-applied after the data has
-        been grouped.  The background is *not* included in this
+        of at least `snr`. The background is *not* included in this
         calculation; the calculation is done on the raw data even if
-        `subtract` has been called on this data set.
+        `subtract` has been called on this data set. The binning
+        scheme is, by default, applied to only the noticed data
+        range. It is suggested that filtering is done before calling
+        group_snr.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range. The tabStops argument can be set to "nofilter" to
+           use the previous behaviour.
 
         .. versionchanged:: 4.15.1
            The filter is now reported, noting any changes the new
@@ -8433,11 +8476,14 @@ class Session(sherpa.ui.utils.Session):
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           ``True`` means that the channel should be ignored from the
-           grouping (use 0 or ``False`` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set it can be the string "nofilter", which means
+           that no filter is applied (and matches the behavior prior
+           to the 4.16 release), or an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
         errorCol : array of num, optional
            If set, the error to use for each channel when calculating
            the signal-to-noise ratio. If not given then Poisson
@@ -8493,6 +8539,21 @@ class Session(sherpa.ui.utils.Session):
         >>> group_snr('jet', 5)
         >>> plot_data('jet', overplot=True)
 
+        The grouping is applied to only the data within the 0.5 to 8
+        keV range (this behaviour is new in 4.16):
+
+        >>> set_analysis('energy')
+        >>> notice()
+        >>> notice(0.5, 8)
+        >>> group_snr(3)
+        >>> plot_data()
+
+        Group the full channel range and then apply the existing
+        filter (0.5 to 8 keV) so that the noticed range may be larger
+        (this was the default behaviour before 4.16):
+
+        >>> group_snr(3, tabStops="nofilter")
+
         """
         if snr is None:
             id, snr = snr, id
@@ -8513,10 +8574,14 @@ class Session(sherpa.ui.utils.Session):
         order to avoid over-grouping bright features, rather than at
         the first channel of the data. The adaptive nature means that
         low-count regions between bright features may not end up in
-        groups with the minimum number of counts.  The binning scheme
-        is applied to all the channels, but any existing filter -
-        created by the `ignore` or `notice` set of functions - is
-        re-applied after the data has been grouped.
+        groups with the minimum number of counts. The binning scheme
+        is, by default, applied to only the noticed data range. It is
+        suggested that filtering is done before calling group_adapt.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range. The tabStops argument can be set to "nofilter" to
+           use the previous behaviour.
 
         .. versionchanged:: 4.15.1
            The filter is now reported, noting any changes the new
@@ -8539,11 +8604,14 @@ class Session(sherpa.ui.utils.Session):
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           ``True`` means that the channel should be ignored from the
-           grouping (use 0 or ``False`` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set it can be the string "nofilter", which means
+           that no filter is applied (and matches the behavior prior
+           to the 4.16 release), or an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
 
         Raises
         ------
@@ -8595,6 +8663,21 @@ class Session(sherpa.ui.utils.Session):
         >>> group_counts('jet', 20)
         >>> plot_data('jet', overplot=True)
 
+        The grouping is applied to only the data within the 0.5 to 8
+        keV range (this behaviour is new in 4.16):
+
+        >>> set_analysis('energy')
+        >>> notice()
+        >>> notice(0.5, 8)
+        >>> group_adapt(20)
+        >>> plot_data()
+
+        Group the full channel range and then apply the existing
+        filter (0.5 to 8 keV) so that the noticed range may be larger
+        (this was the default behaviour before 4.16):
+
+        >>> group_adapt(20, tabStops="nofilter")
+
         """
         if min is None:
             id, min = min, id
@@ -8616,10 +8699,15 @@ class Session(sherpa.ui.utils.Session):
         order to avoid over-grouping bright features, rather than at
         the first channel of the data. The adaptive nature means that
         low-count regions between bright features may not end up in
-        groups with the minimum number of counts.  The binning scheme
-        is applied to all the channels, but any existing filter -
-        created by the `ignore` or `notice` set of functions - is
-        re-applied after the data has been grouped.
+        groups with the minimum number of counts. The binning scheme
+        is, by default, applied to only the noticed data range. It is
+        suggested that filtering is done before calling
+        group_adapt_snr.
+
+        .. versionchanged:: 4.16.0
+           Grouping now defaults to only using the noticed channel
+           range. The tabStops argument can be set to "nofilter" to
+           use the previous behaviour.
 
         .. versionchanged:: 4.15.1
            The filter is now reported, noting any changes the new
@@ -8643,11 +8731,14 @@ class Session(sherpa.ui.utils.Session):
            The maximum number of channels that can be combined into a
            single group.
         tabStops : array of int or bool, optional
-           If set, indicate one or more ranges of channels that should
-           not be included in the grouped output. The array should
-           match the number of channels in the data set and non-zero or
-           ``True`` means that the channel should be ignored from the
-           grouping (use 0 or ``False`` otherwise).
+           If not set then it will be based on the filtering of the
+           data set, so that the grouping only uses the filtered
+           data. If set it can be the string "nofilter", which means
+           that no filter is applied (and matches the behavior prior
+           to the 4.16 release), or an array of booleans where True
+           indicates that the channel should not be used in the
+           grouping (this array must match the number of channels in
+           the data set).
         errorCol : array of num, optional
            If set, the error to use for each channel when calculating
            the signal-to-noise ratio. If not given then Poisson
@@ -8703,6 +8794,21 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_data('jet')
         >>> group_snr('jet', 4)
         >>> plot_data('jet', overplot=True)
+
+        The grouping is applied to only the data within the 0.5 to 8
+        keV range (this behaviour is new in 4.16):
+
+        >>> set_analysis('energy')
+        >>> notice()
+        >>> notice(0.5, 8)
+        >>> group_adapt_snr(4)
+        >>> plot_data()
+
+        Group the full channel range and then apply the existing
+        filter (0.5 to 8 keV) so that the noticed range may be larger
+        (this was the default behaviour before 4.16):
+
+        >>> group_adapt_snr(3, tabStops="nofilter")
 
         """
         if min is None:


### PR DESCRIPTION
# Summary

When calling group_counts, group_width, ..., use the current mask as the tabStops argument by default (actually, the inverse of the mask), that is, when the tabStops argument is set to None (the default). This means that the grouping is only applied to the selected channels, and means that the filter range is less likely to change when filtered data is grouped.

This is a change in behaviour. To get the previous behaviour users need to set tabStops to an array of zeros (length being the number of channels): e.g. for Chandra ACIS imaging-mode data, group_counts(20, tabStops=[0] * 1024) or group_counts(20, tabStops=np.zeros(1024)).

Fix #417 #956 #1081

# Details

[stupid github interface. Fix #1081 ]

There are some minor clean up changes to allow 

- tabStops to be sent as a list rather than needing to be a ndarray, so that users can say `tabStops=[0] * 1024`
- if tabStops is sent a mask that matches the grouped size we allow this, automatically expanding this to the per-channel array in essentially the same way that the DataPHA get_mask routine does [*]; this is to make things easier for users as it has been an issue in my earlier experiments in getting tabStops to work (it's also the case that with follow-up changes it's unlikely to be useful for most users but it's not a large change)

[*] there are some possible issues with quality filtering here, but there's quality-filtering issues elsewhere too

The main change is so that if tabStops is None (the default) then we pick up the existing mask (inverted) and use that, so whereas before you would have to say

    group_counts(20, tabStops=~get_data().get_mask())

you can now say just

    group_counts(20)

This is a **breaking** change. If you want to get the old behavior you have to say either of

    group_counts(20, tabStops=[0] * 1024)
    group_counts(20, tabStops=np.zeros(1024))

changing 1024 to the number of channels in the dataset.

I spent some time trying to work out how to make this "backwards compatible", but I have come to the conclusion that it's actually better that we make this a breaking change - i.e. default to now only grouping within the noticed data range. However, this is something other people may think differently!

There is an argument to be said that we could have some "symbol" for `tabStops` which means "ignore the filter", so you don't have to say `tabStops=[0] * n` and can just say `tabStops="unfiltered"` (*as an example*).

---

# Example

In CIAO 4.15 we have

```
sherpa-4.15.0> load_pha("3c273.pi")
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi

sherpa-4.15.0> ungroup()

sherpa-4.15.0> ignore(hi=0.5)
dataset 1: 0.00146:14.9504 -> 0.511:14.9504 Energy (keV)

sherpa-4.15.0> ignore(lo=7)
dataset 1: 0.511:14.9504 -> 0.511:6.9934 Energy (keV)

sherpa-4.15.0> get_filter()
'0.510999977589:6.993400096893'

sherpa-4.15.0> group_counts(20)

sherpa-4.15.0> get_filter()
'0.437999993563:13.461199760437'
```

So, after calling `group_counts` the filter has increased from 0.51:6.99 to 0.44:13.46 keV.

We can do the grouping only within the filtered range, but only by manually specifying the `tabStops` argument (in the correct manner):

```
sherpa-4.15.0> ungroup()
          ...: ignore(hi=0.5)
          ...: ignore(lo=7)
dataset 1: 0.438:13.4612 -> 0.511:13.4612 Energy (keV)
dataset 1: 0.511:13.4612 -> 0.511:6.9934 Energy (keV)

sherpa-4.15.0> get_filter()
'0.510999977589:6.993400096893'

sherpa-4.15.0> group_counts(20, tabStops=~get_data().get_mask())

sherpa-4.15.0> get_filter()
'0.510999977589:6.993400096893'
```

Note that the filter has not changed.

With this PR we get (you can see we get more information on the filter changes as we call the various group routines, due to #1637

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: load_pha("3c273.pi")
WARNING: systematic errors were not found in file '3c273.pi'
statistical errors were found in file '3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file 3c273.arf
read RMF file 3c273.rmf
WARNING: systematic errors were not found in file '3c273_bg.pi'
statistical errors were found in file '3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file 3c273_bg.pi

In [3]: ungroup()
dataset 1: 0.00146:14.9504 Energy (keV) (unchanged)

In [4]: ignore(hi=0.5)
dataset 1: 0.00146:14.9504 -> 0.511:14.9504 Energy (keV)

In [5]: ignore(lo=7)
dataset 1: 0.511:14.9504 -> 0.511:6.9934 Energy (keV)

In [6]: group_counts(20)
dataset 1: 0.511:6.9934 Energy (keV) (unchanged)
```

So, the `group_counts` call (and all the other `group_xxx` ones) has automatically set `tabStops` for us.

If we want to behave like the old version we have to manually clear the `tabStops`: we need to know the number of channels - here 1024 - and say

```
In [7]: ungroup()
dataset 1: 0.511:6.9934 Energy (keV) (unchanged)

In [8]: notice()
dataset 1: 0.511:6.9934 -> 0.00146:14.9504 Energy (keV)

In [9]: ignore(lo=7)
dataset 1: 0.00146:14.9504 -> 0.00146:6.9934 Energy (keV)

In [10]: ignore(hi=0.5)
dataset 1: 0.00146:6.9934 -> 0.511:6.9934 Energy (keV)

In [11]: group_counts(20, tabStops=[0] * 1024)
dataset 1: 0.511:6.9934 -> 0.438:13.4612 Energy (keV)
```
 