### PR TITLE
XSPEC: fix link for XSPEC gauss/zgauss models

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -4717,7 +4717,7 @@ class XSgaussian(XSAdditiveModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGaussian.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGauss.html
 
     """
 
@@ -9735,7 +9735,7 @@ class XSzgauss(XSAdditiveModel):
     References
     ----------
 
-    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGaussian.html
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGauss.html
 
     """
 


### PR DESCRIPTION
# Summary

Fix the link to the XSPEC documentation for the gauss and zgauss models.

# Details

Found during SDS review.