### PR TITLE
Correctly handle XSPEC table models with both ESCALE and Z parameters

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1359,22 +1359,25 @@ class XSTableModel(XSModel):
         self.addmodel = addmodel
         self.etable = etable
 
-        # Order appears to be
-        #   - z
+        # Order should be (z and escale were incorrectly mixed up
+        # in XSPEC 12.13.1 and earlier):
+        #
         #   - Escale
+        #   - z
         #   - norm
+        #
         # (for those models that support the relevant value)
         #
-        if addredshift:
-            self.redshift = XSBaseParameter(name, 'redshift', 0., 0., 5.,
-                                            0.0, 5, frozen=True)
-            pars.append(self.redshift)
-
         if addescale:
             # Should this just use Parameter?
             self.Escale = XSParameter(name, 'Escale', 1, 0, 1e20,
                                       0, 1e24, frozen=True, units="keV")
             pars.append(self.Escale)
+
+        if addredshift:
+            self.redshift = XSBaseParameter(name, 'redshift', 0., 0., 5.,
+                                            0.0, 5, frozen=True)
+            pars.append(self.redshift)
 
         if addmodel:
             # Normalization parameters are not true XSPEC parameters and

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1681,15 +1681,18 @@ def test_table_mod_negative_delta_1850(addmodel, redshift, escale, make_data_pat
     parnames = [p.name for p in tbl.pars]
     assert parnames[0] == "lscale"
 
+    # Ordering taken from XSPEC 12.13.1a (unreleased at the time of
+    # writing of the test).
+    #
     idx = 1
-    if redshift:
-        assert parnames[idx] == "redshift"
-        assert tbl.redshift.frozen
-        idx += 1
-
     if escale:
         assert parnames[idx] == "Escale"
         assert tbl.escale.frozen
+        idx += 1
+
+    if redshift:
+        assert parnames[idx] == "redshift"
+        assert tbl.redshift.frozen
         idx += 1
 
     if addmodel:
@@ -1800,7 +1803,6 @@ def test_table_mod_add_escale(make_data_path):
     assert tbl(elo, ehi) / de == pytest.approx(ADD_TABLE_E2, rel=2e-6)
 
 
-@pytest.mark.xfail
 @requires_xspec
 @requires_data
 @requires_fits
@@ -1935,7 +1937,6 @@ def test_table_mod_mul_escale(make_data_path):
     assert tbl(elo, ehi) == pytest.approx(MUL_TABLE_E2, rel=2e-6)
 
 
-@pytest.mark.xfail
 @requires_xspec
 @requires_data
 @requires_fits


### PR DESCRIPTION
# Summary

Update XSPEC table model support for models with both ESCALE and REDSHIFT keywords set to work correctly. Fix #1857 

# Details

I reported to HEASARC that models with both ESCALE and REDHISFT keywords set were producing garbage and they confirmed the bug. They are fixing this in XSPEC 12.13.1a (but it hasn't been released at the time of writing of this PR).

The fix is easy - just switch the ordering of the escale and redshift parameters. I have added tests to show this works (and the results of evaluating the model are as expected).

Note that we have only just added support for the ESCALE keyword setting in XSPEC table models, so we don't need to add documentation about this fix.