### PR TITLE
Allow XSPEC table models to be created and written out

### DIFF
--- a/docs/overview/astro_io.rst
+++ b/docs/overview/astro_io.rst
@@ -6,8 +6,6 @@ The sherpa.astro.io module
 
 .. automodule:: sherpa.astro.io
 
-   .. rubric:: Attributes
-
    .. rubric:: Functions
 
    .. autosummary::

--- a/docs/overview/astro_io_xstable.rst
+++ b/docs/overview/astro_io_xstable.rst
@@ -25,5 +25,5 @@ The sherpa.astro.io.xstable module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: IntParam Param
+.. inheritance-diagram:: BaseParam Param
    :parts: 1

--- a/docs/overview/astro_io_xstable.rst
+++ b/docs/overview/astro_io_xstable.rst
@@ -11,7 +11,7 @@ The sherpa.astro.io.xstable module
    .. autosummary::
       :toctree: api
 
-      IntParam
+      BaseParam
       Param
 
    .. rubric:: Functions

--- a/docs/overview/astro_io_xstable.rst
+++ b/docs/overview/astro_io_xstable.rst
@@ -1,0 +1,29 @@
+**********************************
+The sherpa.astro.io.xstable module
+**********************************
+
+.. currentmodule:: sherpa.astro.io.xstable
+
+.. automodule:: sherpa.astro.io.xstable
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      IntParam
+      Param
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      make_xstable_model
+      write_xstable_model
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram:: IntParam Param
+   :parts: 1

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -57,4 +57,5 @@ Reference/API
    astro
    astro_io
    astro_io_wcs
+   astro_io_xstable
    astro_utils_xspec

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -49,7 +49,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data')
+           'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 string_types = (str, )
@@ -539,21 +539,13 @@ def get_column_data(*args):
 
 
 def get_ascii_data(filename, ncols=2, colkeys=None, **kwargs):
-    """
-    get_table_data( filename [, ncols=2 [, colkeys=None [, **kwargs ]]] )
-    """
+    """Read columns from an ASCII file"""
     return get_table_data(filename, ncols, colkeys)[:3]
 
 
 def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
                    blockname=None, hdrkeys=None):
-    """
-    get_table_data( filename , ncols=1 [, colkeys=None [, make_copy=True [,
-                    fix_type=True [, blockname=None [, hdrkeys=None ]]]]])
-
-    get_table_data( TABLECrate , ncols=1 [, colkeys=None [, make_copy=True [,
-                    fix_type=True [, blockname=None [, hdrkeys=None ] ]]]])
-    """
+    """Read columns from a file or crate."""
     filename = ''
     if type(arg) == str:
 
@@ -615,11 +607,7 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
 
 def get_image_data(arg, make_copy=True, fix_type=True):
-    """
-    get_image_data ( filename [, make_copy=True, fix_type=True ])
-
-    get_image_data ( IMAGECrate [, make_copy=True, fix_type=True ])
-    """
+    """Read image data from a file or crate"""
     filename = ''
     if type(arg) == str:
         img = open_crate(arg)
@@ -683,11 +671,7 @@ def get_image_data(arg, make_copy=True, fix_type=True):
 
 
 def get_arf_data(arg, make_copy=True):
-    """
-    get_arf_data( filename [, make_copy=True ])
-
-    get_arf_data( ARFCrate [, make_copy=True ])
-    """
+    """Read an ARF from a file or crate"""
     filename = ''
     if type(arg) == str:
         arf = open_crate(arg)
@@ -727,11 +711,7 @@ def get_arf_data(arg, make_copy=True):
 
 
 def get_rmf_data(arg, make_copy=True):
-    """
-    get_rmf_data( filename [, make_copy=True ])
-
-    get_rmf_data( RMFCrate [, make_copy=True ])
-    """
+    """Read a RMF from a file or crate"""
     filename = ''
     if type(arg) == str:
         rmfdataset = open_crate_dataset(arg, RMFCrateDataset)
@@ -871,11 +851,7 @@ def get_rmf_data(arg, make_copy=True):
 
 
 def get_pha_data(arg, make_copy=True, use_background=False):
-    """
-    get_pha_data( filename [, make_copy=True [, use_background=False]])
-
-    get_pha_data( PHACrate [, make_copy=True [, use_background=False]])
-    """
+    """Read PHA data from a file or crate"""
     filename = ''
     if type(arg) == str:
         phadataset = open_crate_dataset(arg, PHACrateDataset)
@@ -1431,3 +1407,93 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         _set_column(tbl, name, val)
 
     tbl.write(filename, clobber=True)
+
+
+def _add_header(cr, header):
+    """Add the header keywords to the crate.
+
+    Parameters
+    ----------
+    cr : TABLECrate or IMAGECrate
+    header : list of sherpa.astro.io.xstable.HeaderItem
+
+    """
+
+    for hdr in header:
+        key = (hdr.name, hdr.value, hdr.unit, hdr.desc)
+        cr.add_key(pycrates.CrateKey(key))
+
+
+def _create_primary_crate(hdu):
+    """Create the primary block
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.xstable.TableHDU
+       Any data is ignored.
+
+    Returns
+    -------
+    out : pycreates.IMAGECrate
+
+    """
+
+    out = pycrates.IMAGECrate()
+    out.name = "PRIMARY"
+
+    # For some reason we need to add an empty image
+    # (CIAO 4.15).
+    #
+    null = pycrates.CrateData()
+    null.values = numpy.asarray([], dtype=numpy.uint8)
+    out.add_image(null)
+
+    _add_header(out, hdu.header)
+    return out
+
+
+def _create_table_crate(hdu):
+    """Create a table block
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.xstable.TableHDU
+
+    Returns
+    -------
+    out : pycrates.TABLECrate
+
+    """
+
+    if hdu.data is None:
+       raise ValueError("No column data to write out")
+
+    out = pycrates.TABLECrate()
+    out.name = hdu.name
+
+    for col in hdu.data:
+        cdata = pycrates.CrateData()
+        cdata.name = col.name
+        cdata.desc = col.desc
+        cdata.unit = col.unit
+        cdata.values = col.values
+        out.add_column(cdata)
+
+    _add_header(out, hdu.header)
+    return out
+
+
+def set_hdus(filename, hdulist, clobber=False):
+    """Write out multiple HDUS to a single file.
+
+    At present we are restricted to tables only.
+    """
+
+    check_clobber(filename, clobber)
+
+    ds = pycrates.CrateDataset()
+    ds.add_crate(_create_primary_crate(hdulist[0]))
+    for hdu in hdulist[1:]:
+        ds.add_crate(_create_table_crate(hdu))
+
+    ds.write(filename, clobber=True)

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -29,7 +29,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data')
+           'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 lgr = logging.getLogger(__name__)
@@ -57,3 +57,4 @@ set_image_data = get_table_data
 set_pha_data = get_table_data
 set_arf_data = get_table_data
 set_rmf_data = get_table_data
+set_hdus = get_table_data

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -68,7 +68,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data')
+           'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 def _has_hdu(hdulist, name):
@@ -1465,3 +1465,100 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     hdu = fits.table_to_hdu(tbl)
     hdu.name = 'TABLE'
     hdu.writeto(filename, overwrite=True)
+
+
+def _add_header(hdu, header):
+    """Add the header items to the HDU.
+
+    Parameters
+    ----------
+    hdu : astropy HDU
+    header : list of sherpa.astro.io.xstable.HeaderItem
+    """
+
+    for hdr in header:
+        card = [hdr.name, hdr.value]
+        if hdr.desc is not None or hdr.unit is not None:
+            comment = "" if hdr.unit is None else f"[{hdr.unit}] "
+            comment += "" if hdr.desc is None else hdr.desc
+            card.append(comment)
+
+        hdu.header.append(tuple(card))
+
+
+def _create_primary_hdu(hdu):
+    """Create a PRIMARY HDU.
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.io.xstable.TableHDU
+       Any data is ignored.
+
+    Returns
+    -------
+    out : astropy.io.fits.PrimaryHDU
+
+    """
+
+    out = fits.PrimaryHDU()
+    _add_header(out, hdu.header)
+    return out
+
+
+def _create_table_hdu(hdu):
+    """Create a Table HDU.
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.io.xstable.TableHDU
+
+    Returns
+    -------
+    out : astropy.io.fits.BinTableHDU
+    """
+
+    if hdu.data is None:
+        raise ValueError("No column data to write out")
+
+    # First create a Table which handles the FITS column settings
+    # correctly.
+    #
+    store = []
+    colnames = []
+    for col in hdu.data:
+        colnames.append(col.name)
+        store.append(col.values)
+
+    out = fits.table_to_hdu(Table(names=colnames, data=store))
+    out.name = hdu.name
+    _add_header(out, hdu.header)
+
+    # Add any column metadata
+    #
+    for idx, col in enumerate(hdu.data, 1):
+        if col.unit is not None:
+            out.header.append((f"TUNIT{idx}", col.unit))
+
+        if col.desc is None:
+            continue
+
+        key = f"TTYPE{idx}"
+        out.header[key] = (col.name, col.desc)
+
+    return out
+
+
+def set_hdus(filename, hdulist, clobber=False):
+    """Write out multiple HDUS to a single file.
+
+    At present we are restricted to tables only.
+    """
+
+    check_clobber(filename, clobber)
+
+    out = fits.HDUList()
+    out.append(_create_primary_hdu(hdulist[0]))
+    for hdu in hdulist[1:]:
+        out.append(_create_table_hdu(hdu))
+
+    out.writeto(filename, overwrite=True)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1480,7 +1480,8 @@ def _add_header(hdu, header):
         card = [hdr.name, hdr.value]
         if hdr.desc is not None or hdr.unit is not None:
             comment = "" if hdr.unit is None else f"[{hdr.unit}] "
-            comment += "" if hdr.desc is None else hdr.desc
+            if hdr.desc is not None:
+                comment += hdr.desc
             card.append(comment)
 
         hdu.header.append(tuple(card))

--- a/sherpa/astro/io/tests/test_io_xspec_table_model.py
+++ b/sherpa/astro/io/tests/test_io_xspec_table_model.py
@@ -67,7 +67,7 @@ from sherpa.utils.testing import requires_fits, requires_xspec
 def test_check_valid_egrid(elo, ehi, msg):
     """Check we catch some error-grid errors"""
 
-    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    p0 = xstable.Param("nop", 12, -1, 12, 12, values=[12])
     model = [1, 2, 3, 4, 5]
     with pytest.raises(ValueError, match=f"^{msg}$"):
         xstable.make_xstable_model("fake", elo, ehi,
@@ -77,7 +77,7 @@ def test_check_valid_egrid(elo, ehi, msg):
 def test_check_single_spectrum_size():
     """Check we error out"""
 
-    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    p0 = xstable.Param("nop", 12, -1, 12, 12, values=[12])
     model = [1, 2, 3, 4, 5]
     with pytest.raises(ValueError, match="^Spectrum should have 3 elements but has 5$"):
         xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
@@ -108,8 +108,8 @@ def test_check_param_valid(initial, delta, hardmin, softmin, softmax, hardmax, m
     """Simple error checks"""
 
     with pytest.raises(ValueError, match=f"^Parameter nop {msg}$"):
-        xstable.Param("nop", initial, delta,
-                      hardmin, hardmax, softmin=softmin, softmax=softmax)
+        xstable.BaseParam("nop", initial, delta, hardmin, hardmax,
+                          softmin=softmin, softmax=softmax)
 
 
 # Note these are subtly different to test_check_param_valid since some
@@ -137,17 +137,16 @@ def test_check_intparam_valid(initial, delta, hardmin, softmin, softmax, hardmax
     """Simple error checks"""
 
     with pytest.raises(ValueError, match=f"^Parameter nop {msg}$"):
-        xstable.IntParam("nop", initial, delta,
-                         hardmin, hardmax, softmin=softmin, softmax=softmax,
-                         values=values)
+        xstable.Param("nop", initial, delta, hardmin, hardmax,
+                      softmin=softmin, softmax=softmax, values=values)
 
 
 def mk(n):
-    return xstable.IntParam(n, 0, 0.01, 0, 1, values=[0, 1])
+    return xstable.Param(n, 0, 0.01, 0, 1, values=[0, 1])
 
 
 def mka(n):
-    return xstable.Param(n, 0, 0.01, 0, 1)
+    return xstable.BaseParam(n, 0, 0.01, 0, 1)
 
 
 @pytest.mark.parametrize("params,addparams",
@@ -169,7 +168,7 @@ def test_check_names_are_unique(params, addparams):
 def test_check_expected_spectra_size():
     """Expect 3 spectra but send in 2"""
 
-    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 0.5, 1])
+    p0 = xstable.Param("nop", 1, -1, 0, 1, values=[0, 0.5, 1])
     model1 = [1, 2, 3]
     model2 = [2, 5, 6]
     with pytest.raises(ValueError, match="^Expected 3 spectra, found 2$"):
@@ -186,7 +185,7 @@ def test_check_additional_match():
 
     """
 
-    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    p0 = xstable.Param("nop", 1, -1, 0, 1, values=[0, 1])
     model1 = [1, 2, 3]
     model2 = [2, 5, 6]
     with pytest.raises(ValueError, match="Mismatch between addparams and addspectra sizes: 0 1"):
@@ -198,8 +197,8 @@ def test_check_additional_match():
 def test_check_additional_match_number_of_spectra():
     """Check we send in the correct number of additional spectra."""
 
-    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
-    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    p0 = xstable.Param("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.BaseParam("bob", 1, -1, 0, 1)
     model1 = [1, 2, 3]
     model2 = [2, 5, 6]
     with pytest.raises(ValueError, match="^Expected 2 spectra for additional parameter bob, found 1$"):
@@ -212,8 +211,8 @@ def test_check_additional_match_number_of_spectra():
 def test_check_additional_match_spectra_size():
     """Check the additional spectra nelem."""
 
-    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
-    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    p0 = xstable.Param("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.BaseParam("bob", 1, -1, 0, 1)
     model1 = [1, 2, 3]
     model2 = [2, 5, 6]
     with pytest.raises(ValueError, match="^Spectrum for parameter bob should have 3 elements but has 2$"):
@@ -226,8 +225,8 @@ def test_check_additional_match_spectra_size():
 def test_check_nxfp_match():
     """When NXFP is set we need more spectra"""
 
-    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
-    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    p0 = xstable.Param("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.BaseParam("bob", 1, -1, 0, 1)
     model1 = [1, 2, 3]
     model2 = [2, 5, 6]
     with pytest.raises(ValueError, match="^Expected 4 spectra, found 2$"):
@@ -242,7 +241,7 @@ def make_single_model(elo, ehi, model, addmodel=True,
                       lolim=0, hilim=0):
     """Create a single-spectrum model"""
 
-    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    p0 = xstable.Param("nop", 12, -1, 12, 12, values=[12])
     return xstable.make_xstable_model("fake", elo, ehi,
                                       params=[p0], spectra=[model],
                                       addmodel=addmodel,
@@ -389,9 +388,9 @@ def test_atable_interpolated(tmp_path):
     ehi = egrid[1:]
     emid = (elo + ehi) / 2
 
-    p1 = xstable.IntParam("a", 1, 0.01, 0, 10, values=[0, 5, 10])
-    p2 = xstable.IntParam("b", 0.2, -0.01, 0.01, 10,
-                          values=[0.01, 0.1, 1, 10], loginterp=True)
+    p1 = xstable.Param("a", 1, 0.01, 0, 10, values=[0, 5, 10])
+    p2 = xstable.Param("b", 0.2, -0.01, 0.01, 10,
+                       values=[0.01, 0.1, 1, 10], loginterp=True)
 
     def mkspec(pb, pa):
         return (20 - pa) + 10**pb * emid
@@ -473,12 +472,12 @@ def test_atable_interpolated_with_additional(tmp_path):
     ehi = egrid[1:]
     emid = (elo + ehi) / 2
 
-    p1 = xstable.IntParam("a", 1, 0.01, 0, 10, values=[0, 5, 10])
-    p2 = xstable.IntParam("b", 0.2, -0.01, 0.01, 10,
-                          values=[0.01, 0.1, 1, 10], loginterp=True)
+    p1 = xstable.Param("a", 1, 0.01, 0, 10, values=[0, 5, 10])
+    p2 = xstable.Param("b", 0.2, -0.01, 0.01, 10,
+                       values=[0.01, 0.1, 1, 10], loginterp=True)
 
-    ap1 = xstable.Param("pa", 1, -0.01, 0, 10)
-    ap2 = xstable.Param("pb", 1, -0.01, 0, 10)
+    ap1 = xstable.BaseParam("pa", 1, -0.01, 0, 10)
+    ap2 = xstable.BaseParam("pb", 1, -0.01, 0, 10)
 
     def mkspec(pb, pa):
         return (20 - pa) + 10**pb * emid
@@ -690,7 +689,7 @@ def test_atable_with_xfxp(tmp_path):
     model1 = np.asarray([2, 4, 5])
     model2 = np.asarray([5, 10, 40])
 
-    p0 = xstable.IntParam("nop", 12, -1, 12, 20, values=[12, 20])
+    p0 = xstable.Param("nop", 12, -1, 12, 20, values=[12, 20])
     hdus = xstable.make_xstable_model("fake", elo, ehi,
                                       params=[p0],
                                       spectra=[model1, model1 / 10,

--- a/sherpa/astro/io/tests/test_io_xspec_table_model.py
+++ b/sherpa/astro/io/tests/test_io_xspec_table_model.py
@@ -1,0 +1,705 @@
+#
+#  Copyright (C) 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Can we write out XSPEC table models
+
+This can be done without the need for XSPEC. However, in
+order to check the models are sensible we need XSPEC to
+read them in.
+
+This is not a complete test of the functionality of table models, as
+that is assumed to be handled by XSPEC. This is to check we can write
+out the correct data and that it is handled correctly, but, for
+instance, we assume that if something works for additive models then
+it's likely to work for multiplicative models as well (we have other
+table-model tests that provide some of those checks).
+
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.io import xstable
+from sherpa.utils.err import IOErr
+from sherpa.utils.testing import requires_fits, requires_xspec
+
+
+@pytest.mark.parametrize("elo,ehi,msg",
+                         [ ([], [],
+                            "egrid_lo/hi can not be empty"),
+                           ([1, 2], [1, 2, 3],
+                            "egrid_lo/hi do not match: 2 vs 3"),
+                           ([1, 2, 3], [1, 2],
+                            "egrid_lo/hi do not match: 3 vs 2"),
+                           ([1, 2], [],
+                            "egrid_lo/hi do not match: 2 vs 0"),
+                           ([], [1, 2],
+                            "egrid_lo/hi do not match: 0 vs 2"),
+                           ([1, 2, 4], [2, 3, 5],
+                            "egrid_lo/hi are not consecutive"),
+                           ([1, 3, 4], [2, 4, 5],
+                            "egrid_lo/hi are not consecutive"),
+                           ([1, 2, 3, 3], [2, 3, 4, 5],
+                            "egrid_lo is not monotonically increasing"),
+                           ([1, 2, 3, 4], [2, 2, 3, 4],
+                            "egrid_hi is not monotonically increasing"),
+                           ([4, 3, 2, 1], [5, 4, 3, 2],
+                            "egrid_lo is not monotonically increasing")
+                         ])
+def test_check_valid_egrid(elo, ehi, msg):
+    """Check we catch some error-grid errors"""
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    model = [1, 2, 3, 4, 5]
+    with pytest.raises(ValueError, match=f"^{msg}$"):
+        xstable.make_xstable_model("fake", elo, ehi,
+                                   params=[p0], spectra=[model])
+
+
+def test_check_single_spectrum_size():
+    """Check we error out"""
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    model = [1, 2, 3, 4, 5]
+    with pytest.raises(ValueError, match="^Spectrum should have 3 elements but has 5$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model])
+
+
+
+def test_check_intparam_is_not_empty():
+    """I think we have to have at least one integrated parameter"""
+
+    model = [1, 2, 3]
+    with pytest.raises(ValueError, match="^params can not be empty$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[], spectra=[model])
+
+
+@pytest.mark.parametrize("initial,delta,hardmin,softmin,softmax,hardmax,msg",
+                         [(10, -1, 0, 0, 1, 1,
+                           "initial=10 outside softmin=0 to softmax=1"),
+                          (1, -1, 0.5, 0, 1, 1,
+                           "softmin=0 < hardmin=0.5"),
+                          (1, -1, 0, 0, 1, 0.5,
+                           "softmax=1 > hardmax=0.5"),
+                          (1, -1, 1, 1, 0, 0,
+                           "softmin=1 > softmax=0"),
+                         ])
+def test_check_param_valid(initial, delta, hardmin, softmin, softmax, hardmax, msg):
+    """Simple error checks"""
+
+    with pytest.raises(ValueError, match=f"^Parameter nop {msg}$"):
+        xstable.Param("nop", initial, delta,
+                      hardmin, hardmax, softmin=softmin, softmax=softmax)
+
+
+# Note these are subtly different to test_check_param_valid since some
+# of them have softmin/max set to None.
+#
+@pytest.mark.parametrize("initial,delta,hardmin,softmin,softmax,hardmax,values, msg",
+                         [(10, -1, 0, None, None, 1, [0, 1],
+                           "initial=10 outside softmin=0 to softmax=1"),
+                          (1, -1, 0, None, None, 1, [-10, 1],
+                           "hardmin=0 != first value=-10"),
+                          (1, -1, 0, None, None, 1, [0, 10],
+                           "hardmax=1 != last value=10"),
+                          (1, -1, 0.5, 0, 1, 1, [0, 1],
+                           "softmin=0 < hardmin=0.5"),
+                          (1, -1, 0, 0, 1, 0.5, [0, 1],
+                           "softmax=1 > hardmax=0.5"),
+                          (1, -1, 1, 1, 0, 0, [0, 1],
+                           "softmin=1 > softmax=0"),
+                          (1, -1, 0, None, 1, 1, [],
+                           "has no values"),
+                          (1, -1, 0, 0, None, 1, [0, 1, 1],
+                           "values are not monotonically increasing")
+                         ])
+def test_check_intparam_valid(initial, delta, hardmin, softmin, softmax, hardmax, values, msg):
+    """Simple error checks"""
+
+    with pytest.raises(ValueError, match=f"^Parameter nop {msg}$"):
+        xstable.IntParam("nop", initial, delta,
+                         hardmin, hardmax, softmin=softmin, softmax=softmax,
+                         values=values)
+
+
+def mk(n):
+    return xstable.IntParam(n, 0, 0.01, 0, 1, values=[0, 1])
+
+
+def mka(n):
+    return xstable.Param(n, 0, 0.01, 0, 1)
+
+
+@pytest.mark.parametrize("params,addparams",
+                         [([mk("a"), mk("b"), mk("A")], None),
+                          ([mk("a"), mk("b"), mk("x")], [mka("q"), mka("B")])
+                         ])
+def test_check_names_are_unique(params, addparams):
+    """Ensure parameter names are unique"""
+
+    elo = [1, 2, 3]
+    ehi = [2, 3, 4]
+    model = [1, 2, 3]
+    with pytest.raises(ValueError, match="^Parameter names are not unique$"):
+        xstable.make_xstable_model("fake", elo, ehi,
+                                   params=params, addparams=addparams,
+                                   spectra=[model] * 8)
+
+
+def test_check_expected_spectra_size():
+    """Expect 3 spectra but send in 2"""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 0.5, 1])
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Expected 3 spectra, found 2$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2])
+
+
+def test_check_additional_match():
+    """If we send in addparams we need addspectra and vice versa
+
+    This check is written with the knowledge the check is "symmetric",
+    so that if we send in addparams and addspectra is empty there's
+    also a failure.
+
+    """
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="Mismatch between addparams and addspectra sizes: 0 1"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2],
+                                   addspectra=[[model1, model2]])
+
+
+def test_check_additional_match_number_of_spectra():
+    """Check we send in the correct number of additional spectra."""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Expected 2 spectra for additional parameter bob, found 1$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2],
+                                   addparams=[ap0],
+                                   addspectra=[[model1]])
+
+
+def test_check_additional_match_spectra_size():
+    """Check the additional spectra nelem."""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Spectrum for parameter bob should have 3 elements but has 2$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2],
+                                   addparams=[ap0],
+                                   addspectra=[[model1, [2, 3]]])
+
+
+def test_check_nxfp_match():
+    """When NXFP is set we need more spectra"""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Expected 4 spectra, found 2$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0],
+                                   spectra=[model1, model2],
+                                   xfxp=["foo: 1", "foo: 2"])
+
+
+def make_single_model(elo, ehi, model, addmodel=True,
+                      redshift=False, escale=False,
+                      lolim=0, hilim=0):
+    """Create a single-spectrum model"""
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    return xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p0], spectra=[model],
+                                      addmodel=addmodel,
+                                      redshift=redshift,
+                                      escale=escale,
+                                      lolim=lolim, hilim=hilim)
+
+
+def load_tmod(lbl, filename):
+    """Read in an XSPEC table model.
+
+    The test must use the requires_xspec fixture.
+    """
+
+    from sherpa.astro.xspec import XSTableModel, read_xstable_model
+
+    mdl = read_xstable_model("foo", filename)
+    assert isinstance(mdl, XSTableModel)
+    return mdl
+
+
+@requires_xspec
+@requires_fits
+def test_atable_single_spectrum(tmp_path):
+    """Write out a model with a single spectrum.
+
+    There is no parameter interpolation here!
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    elo = [0.5, 0.7, 0.9]
+    ehi = [0.7, 0.9, 1.0]
+    model = [2, 4, 5]
+
+    hdus = make_single_model(elo, ehi, model)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 2
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # no apply normalization (the only parameter)
+    #
+    mdl.norm = 10
+    assert mdl(elo, ehi) == pytest.approx([20, 40, 50])
+
+    # Now check regridding and what happens outside the data range.
+    #
+    e2lo = [0.3, 0.4, 0.6, 0.8, 1.1]
+    e2hi = [0.4, 0.6, 0.8, 1.1, 1.2]
+
+    # This is what I expected, but XSPEC 12.13.1a does not return this
+    # (I have asked HEASARC for confirmation but let's just treat this
+    # as a regression test for now).
+    #
+    # expected = [0, 10, 10 + 20, 20 + 50, 0]
+    expected = [0, 0, 10 + 20, 20 + 50, 0]
+    assert mdl(e2lo, e2hi) == pytest.approx(expected)
+
+
+@requires_xspec
+@requires_fits
+def test_mtable_single_spectrum(tmp_path):
+    """Write out a model with a single spectrum.
+
+    There is no parameter interpolation here!
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    elo = [0.5, 0.7, 0.9]
+    ehi = [0.7, 0.9, 1.0]
+    model = [2, 4, 5]
+
+    hdus = make_single_model(elo, ehi, model, addmodel=False)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert not mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert not hasattr(mdl, "norm")
+    assert len(mdl.pars) == 1
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # Now check regridding and what happens outside the data range.
+    #
+    e2lo = [0.3, 0.4, 0.6, 0.8, 1.1]
+    e2hi = [0.4, 0.6, 0.8, 1.1, 1.2]
+
+    # This is a regression test based on the behavior of XSPEC 12.13.1a.
+    #
+    expected = [0, 0, 3, 14 / 3, 0]
+    assert mdl(e2lo, e2hi) == pytest.approx(expected)
+
+
+@requires_xspec
+@requires_fits
+def test_atable_interpolated(tmp_path):
+    """Write out a model with multiple parameters.
+
+    Two parameters:
+         a   0, 5, 10          linear
+         b   0.01, 0.1, 1, 10  logarithmic
+
+    This is more a regression test than a check that the interpolation
+    happens correctly (since we rely on XSPEC to do all of this for us
+    anyway).
+
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.5, 1.6, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    emid = (elo + ehi) / 2
+
+    p1 = xstable.IntParam("a", 1, 0.01, 0, 10, values=[0, 5, 10])
+    p2 = xstable.IntParam("b", 0.2, -0.01, 0.01, 10,
+                          values=[0.01, 0.1, 1, 10], loginterp=True)
+
+    def mkspec(pb, pa):
+        return (20 - pa) + 10**pb * emid
+
+    pvals = [(0.01, 0), (0.1, 0), (1, 0), (10, 0),
+             (0.01, 5), (0.1, 5), (1, 5), (10, 5),
+             (0.01, 10), (0.1, 10), (1, 10), (10, 10)]
+    spectra = [mkspec(*pv) for pv in pvals]
+
+    hdus = xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p1, p2], spectra=spectra)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "a")
+    assert hasattr(mdl, "b")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 3
+
+    assert mdl.a.val == pytest.approx(1)
+    assert mdl.a.min == pytest.approx(0)
+    assert mdl.a.max == pytest.approx(10)
+    assert not mdl.a.frozen
+
+    assert mdl.b.val == pytest.approx(0.2)
+    assert mdl.b.min == pytest.approx(0.01)
+    assert mdl.b.max == pytest.approx(10)
+    assert mdl.b.frozen
+
+    # Evaluate the model with no interpolation (ie 5,0.1 is one of the
+    # cases we sent in).
+    #
+    mdl.a = 5
+    mdl.b = 0.1
+    expected = mkspec(0.1, 5)
+    assert mdl(elo, ehi) == pytest.approx(expected)
+
+    # Evaluate the model with interpolation. We pick a parameter
+    # setting close enough we can use mkspec to generate the expected
+    # result, but the required tolerance in the check is now large (as
+    # the parameter values are not well chosen in this case). The
+    # tolerance may need to be increased for other platforms (this was
+    # generated with XSPEC 12.13.1a and Linux/x86).
+    #
+    mdl.a = 2
+    mdl.b = 0.09
+    expected = mkspec(0.09, 2)
+    assert mdl(elo, ehi) == pytest.approx(expected, rel=2e-3)
+
+
+@requires_xspec
+@requires_fits
+def test_atable_interpolated_with_additional(tmp_path):
+    """Write out a model with multiple parameters and "additional" ones.
+
+    Two parameters:
+         a   0, 5, 10          linear
+         b   0.01, 0.1, 1, 10  logarithmic
+
+    then two additional parameters
+         pa
+         pb
+
+    This is more a regressio test than a check that the interpolation
+    happens correctly (since we rely on XSPEC to do all of this for
+    us anyway).
+
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.5, 1.6, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    emid = (elo + ehi) / 2
+
+    p1 = xstable.IntParam("a", 1, 0.01, 0, 10, values=[0, 5, 10])
+    p2 = xstable.IntParam("b", 0.2, -0.01, 0.01, 10,
+                          values=[0.01, 0.1, 1, 10], loginterp=True)
+
+    ap1 = xstable.Param("pa", 1, -0.01, 0, 10)
+    ap2 = xstable.Param("pb", 1, -0.01, 0, 10)
+
+    def mkspec(pb, pa):
+        return (20 - pa) + 10**pb * emid
+
+    # I do not understand how the additional spectra work with the
+    # parameter ranges, so just do something.
+    #
+    def mkaspec1(v):
+        return v * emid
+
+    def mkaspec2(v):
+        return v * np.ones_like(emid)
+
+    pvals = [(0.01, 0), (0.1, 0), (1, 0), (10, 0),
+             (0.01, 5), (0.1, 5), (1, 5), (10, 5),
+             (0.01, 10), (0.1, 10), (1, 10), (10, 10)]
+    spectra = [mkspec(*pv) for pv in pvals]
+    addspectra = [[mkaspec1(pv[0]) for pv in pvals],
+                  [mkaspec2(pv[1]) for pv in pvals]]
+
+    hdus = xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p1, p2], spectra=spectra,
+                                      addparams=[ap1, ap2],
+                                      addspectra=addspectra)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "a")
+    assert hasattr(mdl, "b")
+    assert hasattr(mdl, "pa")
+    assert hasattr(mdl, "pb")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 5
+
+    assert mdl.a.val == pytest.approx(1)
+    assert mdl.a.min == pytest.approx(0)
+    assert mdl.a.max == pytest.approx(10)
+    assert not mdl.a.frozen
+
+    assert mdl.b.val == pytest.approx(0.2)
+    assert mdl.b.min == pytest.approx(0.01)
+    assert mdl.b.max == pytest.approx(10)
+    assert mdl.b.frozen
+
+    assert mdl.pa.val == pytest.approx(1)
+    assert mdl.pa.min == pytest.approx(0)
+    assert mdl.pa.max == pytest.approx(10)
+    assert mdl.pa.frozen
+
+    assert mdl.pb.val == pytest.approx(1)
+    assert mdl.pb.min == pytest.approx(0)
+    assert mdl.pb.max == pytest.approx(10)
+    assert mdl.pb.frozen
+
+    # A regression test.
+    #
+    mdl.a = 2
+    mdl.b = 0.09
+    mdl.pa = 2
+    mdl.pb = 2
+    expected = [22.791948, 22.93594, 23.079931, 23.223923,
+                23.367912, 23.511902, 23.655893, 23.799883,
+                23.943874, 24.087864]
+    assert mdl(elo, ehi) == pytest.approx(expected)
+
+
+# Used by test_addmodel_redshift/escale.
+#
+Z_POS = 69
+Z_AMPL = 1.9814928
+
+
+@requires_xspec
+@requires_fits
+def test_addmodel_resdhift(tmp_path, xsmodel):
+    """Can we add a redshift parameter to a table model?
+
+    Very-limited testing.
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.1, 2, 0.01)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    fake = xsmodel("gaussian")
+    fake.linee = 1.6
+    fake.norm = 50
+    model = fake(elo, ehi)
+
+    # check peak is where we expect
+    assert np.argmax(model) == 150
+    assert model[150] == pytest.approx(1.991392)
+
+    hdus = make_single_model(elo, ehi, model, redshift=True)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert not hasattr(mdl, "escale")
+    assert hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 3
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # Check the redshift
+    #
+    mdl.redshift = 1
+
+    got = mdl(elo, ehi)
+
+    # The peak should have changed
+    #
+    assert np.argmax(got) == Z_POS
+    assert got[Z_POS] == pytest.approx(Z_AMPL)
+
+
+@requires_xspec
+@requires_fits
+def test_addmodel_escale(tmp_path, xsmodel):
+    """Can we add a escale parameter to a table model?
+
+    Very-limited testing.
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.1, 2, 0.01)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    fake = xsmodel("gaussian")
+    fake.linee = 1.6
+    fake.norm = 50
+    model = fake(elo, ehi)
+
+    # check peak is where we expect
+    assert np.argmax(model) == 150
+    assert model[150] == pytest.approx(1.991392)
+
+    hdus = make_single_model(elo, ehi, model, escale=True)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 3
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # Check the shift (it is not clear to me what escale actually does
+    # so this should be taken to be a regression test).
+    #
+    mdl.escale = 0.5
+
+    got = mdl(elo, ehi)
+
+    # The peak should have changed. We get the same shift as z=1
+    # but the normalization changes (so we tie this test to the
+    # redshift test).
+    #
+    assert np.argmax(got) == Z_POS
+    assert got[Z_POS] == pytest.approx(2 * Z_AMPL)
+
+
+@requires_xspec
+@requires_fits
+def test_atable_with_xfxp(tmp_path):
+    """Write out a model with XFXP keywords.
+
+    Note that Sherpa can not use these models. It is not entirely
+    clear what the keys are meant to be.
+
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    elo = [0.5, 0.7, 0.9]
+    ehi = [0.7, 0.9, 1.0]
+    model1 = np.asarray([2, 4, 5])
+    model2 = np.asarray([5, 10, 40])
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 20, values=[12, 20])
+    hdus = xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p0],
+                                      spectra=[model1, model1 / 10,
+                                               model2, model2 / 10],
+                                      xfxp=["key: a", "key: b"])
+    xstable.write_xstable_model(outfile, hdus)
+
+    # We need a significant amount of work to support these models, so
+    # we error out for now.
+    #
+    with pytest.raises(IOErr, match="^No support for NXFLTEXP=2 in "):
+        load_tmod("foo", outfile)

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -34,7 +34,7 @@ Example
 
 The following example creates an additive table model
 that represents a gaussian model where the only parameters are
-the line positon and the normalization.
+the line position and the normalization.
 
 >>> import numpy as np
 >>> from sherpa.astro.io import xstable
@@ -96,7 +96,7 @@ as a FITS file (`write_xstable_model`):
 ...                                   spectra=models)
 >>> xstable.write_xstable_model("example.mod", hdus, clobber=True)
 
-This file can the be used in Sherpa with either
+This file can then be used in Sherpa with either
 `sherpa.astro.ui.load_xstable_model` or
 `sherpa.astro.xspec.read_xstable_model`. For example:
 
@@ -115,11 +115,11 @@ Notes
 XSPEC models can be created without XSPEC support in Sherpa, but it is
 needed to read the files in.
 
-For additive models it is assumed that the model values - each those
-in each bin - have units of photon/cm^2/s. This is easy to
-accidentally change - e.g.  in the example above if mdl.norm were
-changed to a value other than 1 everything would work but Sherpa and
-XSPEC would infer incorrect fluxes or luminosities.
+For additive models it is assumed that the model values - that is,
+each bin - have units of photon/cm^2/s. This is easy to accidentally
+change - e.g.  in the example above if mdl.norm were changed to a
+value other than 1 everything would work but Sherpa and XSPEC would
+infer incorrect fluxes or luminosities.
 
 """
 
@@ -216,9 +216,7 @@ class IntParam(Param):
     """The parameter values used to create the model spectra.
 
     Is is required that they range from hardmin to hardmax and are in
-    monotonically increasing order. That is, it can not remain the
-    empty list.
-
+    monotonically increasing order (so it can not be an empty list).
     """
     loginterp: bool = False
     """Are the values logarithmically interpolated (True) or linearly (False).

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -1,0 +1,754 @@
+#
+#  Copyright (C) 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Create XSPEC table models.
+
+This module supports creating and writing out `XSPEC table models
+<https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html>`_,
+which can then be read in by the
+`sherpa.astro.xspec.read_xstable_model` and
+`sherpa.astro.ui.load_xstable_model` routines.
+
+These routines should be considered experimental, as it is not
+obvious that the interface is as usable as it could be.
+
+Example
+-------
+
+The following example creates an additive table model
+that represents a gaussian model where the only parameters are
+the line positon and the normalization.
+
+>>> import numpy as np
+>>> from sherpa.astro.io import xstable
+>>> from sherpa.astro.xspec import XSgaussian
+
+We shall use the XSPEC gaussian model `sherpa.astro.xspec.XSgaussian`
+to create the template models.
+
+>>> mdl = XSgaussian()
+>>> print(mdl)
+gaussian
+   Param        Type          Value          Min          Max      Units
+   -----        ----          -----          ---          ---      -----
+   gaussian.LineE thawed          6.5            0        1e+06        keV
+   gaussian.Sigma thawed          0.1            0           20        keV
+   gaussian.norm thawed            1            0        1e+24
+
+The models will be evaluated over the 0.1 to 2 keV range, with
+a bin spacing of 0.01 keV (note that the last bin ends at 1.99 and
+not 2.0 keV thanks to the behavior of `numpy.arange`).
+
+>>> egrid = np.arange(0.1, 2, 0.01)
+>>> elo = egrid[:-1]
+>>> ehi = egrid[1:]
+>>> emid = (elo + ehi) / 2
+
+The table model will interpolate over the line position over
+the range of 0 to 2.4 inclusive, with a spacing of 0.1 keV:
+
+>>> linepos = np.arange(0, 2.5, 0.1)
+>>> minval = linepos[0]
+>>> maxval = linepos[-1]
+
+The model is evaluated over the grid defined by ``elo`` and ``ehi``
+for each element of ``linepos``, which is used to set the
+`sherpa.astro.xspec.XSgaussian.LineE` parameter:
+
+>>> models = []
+>>> for lp in linepos:
+...     mdl.linee = lp
+...     ymodel = mdl(elo, ehi)
+...     models.append(ymodel)
+...
+
+This model has a single interpolated parameter which we call
+``"pos"``.  Note that the delta parameter - here set to 0.01 - is only
+used by Sherpa to decide if the parameter is frozen (value is
+negative) or not, but is used by the optimiser in XSPEC. The values
+field is set to those used to generate the spectral models.
+
+>>> param = xstable.IntParam("pos", 1, 0.01, minval, maxval,
+...                          values=linepos)
+
+With this we can create the necessary information to create the
+table model (`make_xstable_model`) and then write it out
+as a FITS file (`write_xstable_model`):
+
+>>> hdus = xstable.make_xstable_model("gaussy", elo, ehi, params=[param],
+...                                   spectra=models)
+>>> xstable.write_xstable_model("example.mod", hdus, clobber=True)
+
+This file can the be used in Sherpa with either
+`sherpa.astro.ui.load_xstable_model` or
+`sherpa.astro.xspec.read_xstable_model`. For example:
+
+>>> from sherpa.astro import ui
+>>> ui.load_xstable_model("mygauss", "example.mod")
+>>> print(mygauss)
+xstablemodel.mygauss
+   Param        Type          Value          Min          Max      Units
+   -----        ----          -----          ---          ---      -----
+   mygauss.pos  thawed            1            0          2.4
+   mygauss.norm thawed            1            0        1e+24
+
+Notes
+-----
+
+XSPEC models can be created without XSPEC support in Sherpa, but it is
+needed to read the files in.
+
+For additive models it is assumed that the model values - each those
+in each bin - have units of photon/cm^2/s. This is easy to
+accidentally change - e.g.  in the example above if mdl.norm were
+changed to a value other than 1 everything would work but Sherpa and
+XSPEC would infer incorrect fluxes or luminosities.
+
+"""
+
+from dataclasses import dataclass, field
+import itertools
+import time
+from typing import Any, Optional, Union
+
+import numpy as np
+
+import sherpa
+
+
+__all__ = ("IntParam", "Param", "make_xstable_model",
+           "write_xstable_model")
+
+
+# In the typing support I have used Any to mean "ndarray".
+#
+
+@dataclass
+class Param:
+    """Represent a parameter.
+
+    The absolute DELTA value is used by XSPEC but ignored by Sherpa.
+    The sign of DELTA is used (by both Sherpa and XSPEC) to decide if
+    the parameter should be frozen (DELTA is negative) or not by
+    default.
+
+    """
+    name: str
+    """The parameter name.
+
+    This must be unique and ideally a valid attribute name in Python,
+    although the latter is not enforced.
+    """
+    initial: float
+    """The default value for the parameter."""
+    delta: float
+    """The delta value for fitting.
+
+    If negative then the parameter defaults to being frozen. Sherpa
+    does not use this value (other than checking the sign) but XSPEC
+    does.
+    """
+    hardmin: float
+    """The minimum value for the parameter."""
+    hardmax: float
+    """The maximum value for the parameter."""
+    softmin: Optional[float] = None
+    """The "soft" minimum. Defaults to hardmin if not given.."""
+    softmax: Optional[float] = None
+    """The "soft" maximum. Defaults to hardmax if not given."""
+
+    def __post_init__(self):
+        """Validate the settings"""
+
+        # Do we need to set up softmin/max?
+        #
+        if self.softmax is None:
+            self.softmax = self.hardmax
+
+        if self.softmin is None:
+            self.softmin = self.hardmin
+
+        # There should probably be a check that the name is not
+        # an invalid Python attribute name.
+        #
+        if self.name.strip() == "":
+            raise ValueError("name can not be empty")
+
+        if self.softmin < self.hardmin:
+            raise ValueError(f"Parameter {self.name} softmin={self.softmin} < hardmin={self.hardmin}")
+
+        if self.softmax > self.hardmax:
+            raise ValueError(f"Parameter {self.name} softmax={self.softmax} > hardmax={self.hardmax}")
+
+        # We allow min == max
+        if self.softmin > self.softmax:
+            raise ValueError(f"Parameter {self.name} softmin={self.softmin} > softmax={self.softmax}")
+
+        if self.initial < self.softmin or self.initial > self.softmax:
+            raise ValueError(f"Parameter {self.name} initial={self.initial} outside softmin={self.softmin} to softmax={self.softmax}")
+
+        if self.delta == 0:
+            raise ValueError("delta can not be 0")
+
+
+@dataclass
+class IntParam(Param):
+    """Represent an interpolated parameter."""
+
+    values: list[float] = field(default_factory=list)
+    """The parameter values used to create the model spectra.
+
+    Is is required that they range from hardmin to hardmax and are in
+    monotonically increasing order. That is, it can not remain the
+    empty list.
+
+    """
+    loginterp: bool = False
+    """Are the values logarithmically interpolated (True) or linearly (False).
+
+    Defaults to linear interpolation.
+    """
+
+    def __post_init__(self):
+        """Validate the settings"""
+        super().__post_init__()
+
+        if len(self.values) == 0:
+            raise ValueError(f"Parameter {self.name} has no values")
+
+        if self.values[0] != self.hardmin:
+            raise ValueError(f"Parameter {self.name} hardmin={self.hardmin} != first value={self.values[0]}")
+
+        if self.values[-1] != self.hardmax:
+            raise ValueError(f"Parameter {self.name} hardmax={self.hardmax} != last value={self.values[-1]}")
+
+        if np.any(np.diff(self.values) <= 0):
+            raise ValueError(f"Parameter {self.name} values are not monotonically increasing")
+
+
+# Perhaps the HeaderItem and Column types can be used in
+# sherpa.astro.io to pass information to and from the backends, rather
+# than the current system. However, that is for later work.
+#
+@dataclass
+class HeaderItem:
+    """Represent a FITS header card.
+
+    This does not support all FITS features.
+    """
+    name: str
+    """The keyword name (case insensitive)"""
+    value: Union[str, bool, int, float]  # will we need more?
+    """The keyword value"""
+    desc: Optional[str]
+    """The description for the keyword"""
+    unit: Optional[str]
+    """The units of the value"""
+
+
+@dataclass
+class Column:
+    """Represent a FITS column.
+
+    This does not support all FITS features.
+    """
+    name: str
+    """The column name (case insensitive)"""
+    values: Any  # should be typed
+    """The values for the column, as a ndarray.
+
+    Variable-field arrays are represented as ndarrays with an object
+    type.
+    """
+    desc: Optional[str]
+    """The column description"""
+    unit: Optional[str]
+    """The units of the column"""
+
+
+# To be generic this should probably be split into Primary, Table, and
+# Image HDUs.
+#
+@dataclass
+class TableHDU:
+    """Represent a HDU: header and optional columns"""
+    name: str
+    """The name of the HDU"""
+    header: list[HeaderItem]
+    """The header values"""
+    data: Optional[list[Column]] = None
+    """The column data.
+
+    This should be empty for a primary header, and have at least one
+    entry for a table HDU.
+    """
+
+
+def key(name: str,
+        value: Union[str, bool, int, float],
+        desc: Optional[str] = None,
+        unit: Optional[str] = None) -> HeaderItem:
+    "Easily make a HeaderItem"
+    return HeaderItem(name=name, value=value, desc=desc, unit=unit)
+
+
+def col(name: str,
+        values: Any,
+        desc: Optional[str] = None,
+        unit: Optional[str] = None) -> Column:
+    "Easily make a column"
+    return Column(name=name, values=values, desc=desc, unit=unit)
+
+
+def xstable_primary(name: str,
+                    unit: str,
+                    addmodel: bool,
+                    redshift: bool,
+                    escale: bool,
+                    lolim: float,
+                    hilim: float,
+                    xfxp: Optional[list[str]] = None) -> TableHDU:
+    """The PRIMARY block for an xspec table model."""
+
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUVERS", "1.2.0",
+            "version of format"),
+        key("MODlNAME", name, "Model name"),
+        key("MODLUNIT", unit, "Model units"),
+        key("ADDMODEL", addmodel,
+            "If T then this is an additive table model"),
+        key("REDSHIFT", redshift,
+            "If T then redshift will be a parameter"),
+        key("ESCALE", escale,
+            "If T then escale will be a parameter"),
+        key("LOELIMIT", lolim,
+            "Model value for energies below ENERGIES block"),
+        key("HIELIMIT", hilim,
+            "Model value for energies above ENERGIES block")
+    ]
+
+    if xfxp:
+        header.append(key("NXFLTEXP", len(xfxp),
+                          "Number of model spectra per grid point"))
+        for idx, val in enumerate(xfxp, 1):
+            header.append(key(f"XFXP{idx:04d}", val,
+                              f"The expression for model {idx}"))
+
+    # Let users know who created the file and when.
+    #
+    header.append(key("CREATOR",
+                      f"sherpa {sherpa.__version__}",
+                      "Code that created the file"))
+    header.append(key("DATE",
+                      time.strftime("%Y-%m-%dT%H:%M:%S"),
+                      "Date file created"))
+
+    return TableHDU(name="PRIMARY", header=header)
+
+
+def xstable_parameters(params: list[IntParam],
+                       addparams: Optional[list[Param]]) -> TableHDU:
+    """The PARAMETERS block for an xspec table model."""
+
+    nint = len(params)
+    nadd = 0 if addparams is None else len(addparams)
+    ntotal = nint + nadd
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUCLAS2", "PARAMETERS",
+            "extension containing parameter info"),
+        key("HDUVERS", "1.0.0", "version of format"),
+        key("NINTPARM", nint,
+            "Number of interpolation parameters"),
+        key("NADDPARM", nadd,
+            "Number of additional parameters")
+    ]
+
+    # Provide the parameters and then the additional parameters.
+    #
+    def get(field):
+        f1 = [getattr(p, field) for p in params]
+        if addparams is None:
+            return f1
+
+        return f1 + [getattr(p, field) for p in addparams]
+
+    methods = [1 if p.loginterp else 0 for p in params] + [0] * nadd
+    nvalues = [len(p.values) for p in params] + [0] * nadd
+
+    # Should the VALUE field use a variable-length field or not?
+    #
+    max_nvalues = max(nvalues)
+    if nint > 1 and max_nvalues > 3:
+        # The main array stores objects as each row can have different
+        # lengths.
+        #
+        # What is the best way to create an "empty" object array?
+        values = np.zeros(ntotal, dtype=object)
+        for idx, p in enumerate(params):
+            values[idx] = np.asarray(p.values, dtype=np.float32)
+
+        # Empty arrays for the additional arrays
+        for idx in range(nint, ntotal):
+            values[idx] = np.asarray([], dtype=np.float32)
+
+    else:
+        values = np.zeros((ntotal, max_nvalues), dtype=np.float32)
+        for idx, p in enumerate(params):
+            values[idx, :len(p.values)] = p.values
+
+    data = [
+        col("NAME", np.asarray(get("name"), dtype="U12"),
+            "name of the parameter"),
+        col("METHOD", np.asarray(methods, dtype=np.int32),
+            "0 if linear, 1 if logarithmic"),
+        col("INITIAL", np.asarray(get("initial"), dtype=np.float32),
+            "Starting point"),
+        col("DELTA", np.asarray(get("delta"), dtype=np.float32),
+            "If negative frozen by default"),
+        col("MINIMUM", np.asarray(get("hardmin"), dtype=np.float32),
+            "hard lower limit"),
+        col("BOTTOM", np.asarray(get("softmin"), dtype=np.float32),
+            "soft lower limit"),
+        col("TOP", np.asarray(get("softmax"), dtype=np.float32),
+            "soft upper limit"),
+        col("MAXIMUM", np.asarray(get("hardmax"), dtype=np.float32),
+            "hard upper limit"),
+        col("NUMBVALS", np.asarray(nvalues, dtype=np.int32),
+            "number of tabulated parameter values"),
+        col("VALUE", values, "tabulated parameter values")
+    ]
+    return TableHDU(name="PARAMETERS", header=header, data=data)
+
+
+def xstable_energies(energ_lo: Any, energ_hi: Any) -> TableHDU:
+    """The ENERGIES block for an xspec table model."""
+
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUCLAS2", "ENERGIES",
+            "extension containing energy bin info"),
+        key("HDUVERS", "1.0.0", "version of format")
+    ]
+    data = [
+        col("ENERG_LO", np.asarray(energ_lo, dtype=np.float32),
+            "Minimum energy of the bin", unit="keV"),
+        col("ENERG_HI", np.asarray(energ_hi, dtype=np.float32),
+            "Maximum energy of the bin", unit="keV"),
+    ]
+    return TableHDU(name="ENERGIES", header=header, data=data)
+
+
+def xstable_spectra(paramvals: list[tuple[float, ...]],
+                    spectra: list[Any],
+                    addparam: Optional[list[Param]],
+                    addspectra: Optional[list[list[Any]]],
+                    units: Optional[str]) -> TableHDU:
+    """The SPECTRA block for an xspec table model."""
+
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUCLAS2", "MODEL SPECTRA",
+            "extension containing model spectra"),
+        key("HDUVERS", "1.0.0",
+            "version of format")
+    ]
+
+    # The sizes have already been checked.
+    #
+    unit_opt = None if units == "" else units
+    pvals = np.asarray(paramvals, dtype=np.float32)
+    data = [
+        col("PARAMVAL", np.asarray(paramvals, dtype=np.float32),
+            "Parameter values for spectrum"),
+        col("INTPSPEC", np.asarray(spectra, dtype=np.float32),
+            "Spectrum for interpolated parameters",
+            unit=unit_opt)
+    ]
+
+    # Do we have any additional parameters?
+    #
+    if addparam is not None and addspectra is not None:
+        zipped = zip(addparam, addspectra)
+        for idx, (param, aspec) in enumerate(zipped, 1):
+            data.append(col(f"ADDSP{idx:03d}",
+                            np.asarray(aspec, dtype=np.float32),
+                            desc=f"Additional spectrum {idx:03d}: {param.name}",
+                            unit=unit_opt))
+
+    return TableHDU(name="SPECTRA", header=header, data=data)
+
+
+# We could either send in the parameter values broken up by parameter,
+# or as a list of those used to create spectra (either way, we to
+# deconstruct/reconstruct the other form).  For now we send them in
+# per-parameter, but it could be changed if this approach is found to
+# be more awkward for users.
+#
+def make_xstable_model(name: str,
+                       egrid_lo: Any,
+                       egrid_hi: Any,
+                       params: list[IntParam],
+                       spectra: list[Any],
+                       addparams: Optional[list[Param]] = None,
+                       addspectra: Optional[list[list[Any]]] = None,
+                       addmodel: bool = True,
+                       redshift: bool = False,
+                       escale: bool = False,
+                       lolim: float = 0,
+                       hilim: float = 0,
+                       units: Optional[str] = None,
+                       xfxp: Optional[list[str]] = None
+                       ) -> list[TableHDU]:
+    """Create the blocks for a XSPEC table model.
+
+    An XSPEC table model can be either additive or multiplicative,
+    contain 1 or more interpolated parameters, 0 or more additional
+    parameters, and support additional parameters (redshift and
+    escale), as well as setting the value to use outside the tabulated
+    energy range. The table defines the energy grid the models are
+    defined on, and the models used (one per set of parameters unless
+    the xfxp argument is set).
+
+    Parameters
+    ----------
+    name : str
+       The model name (stored in the table). Any spaces are removed.
+    egrid_lo, egrid_hi : sequence of float
+       The energy grid (in keV) used to define the spectra. It is
+       required that len(egrid_lo) == len(egrid_hi), the arrays are in
+       increasing order, that they are consecutive so that egrid_hi[i]
+       == egrid_lo[i + 1], and that egrid_lo[0] > 0.
+    params : sequence of Param
+       The definitions of the parameters used to interpolate the
+       models. It must have at least one element.
+    spectra : sequence of sequence of float
+       The spectra for each set of parameters in paramvals. It
+       is a 2D array of shape(nrows, len(egrid_lo)), and each row
+       matches the corresponding parameter grouping:
+       paramvals[0].values[i], paramvals[1].values[j], ..
+       where the first parameter loops the slowest. The number of rows
+       is the multiplication of the number of parameter values.
+    addparams : sequence of Param or None, optional
+       The definitions of the additional parametersm that is those
+       that are not interpolated over.
+    addspectra : sequence of sequence of sequence of float or None, optional
+       The spectra for the additonal parameters. It must is a 3D
+       array of shape (nrows, len(addparams), len(egrid_lo)).
+    addmodel : bool, optional
+       Is this an additive model (True) or a multiplicative one (False).
+       The default is True (additive).
+    redshift : bool, optional
+       Should the redshift parameter be added? The default is False.
+    escale : bool, optional
+       Should the escale parameter be added? The default is False.
+    lolim, hilim : bool, optional
+       The value to used when energies are below or above the values
+       in egrid_lo or egrid_hi.
+    units : str or None, optional
+       The model units. For additive models the default is
+       "photons/cm^2/s" and for multiplicative models it is "".
+    xfxp : sequence of str or None
+       If there are multiple spectra per parameter grid point, these
+       values give the expression to use (the number of elements is
+       the number of spectra per grid point). It is expected this is
+       None or has a length more than 1.
+
+    Returns
+    -------
+    hdus : list of TableHDU
+       The header and column data needed to create a FITS file.
+
+    See Also
+    --------
+    write_xstable_model
+
+    Notes
+    -----
+
+    This supports version 1.2.0 of the `XSPEC table model
+    specification
+    <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html>`_,
+    although this code should be considered experimental.
+
+    It is not designed to be memory efficient, so for models that use
+    a large number of spectra, other tools may make more sense.
+
+    """
+
+    nxfxp = 1 if xfxp is None else len(xfxp)
+
+    # Not sure what the restrictions are, so just remove any spaces.
+    #
+    name_str = name.translate({32: None})
+
+    if units is None:
+        unit_str = "photons/cm^2/s" if addmodel else ""
+    else:
+        unit_str = units
+
+    # Check the parameter ranges make sense.
+    #
+    if len(params) == 0:
+        raise ValueError("params can not be empty")
+
+    # Check the parameter names are unique. We do a case-insensitive
+    # comparison, but we write out the user-specified name.
+    #
+    names = [p.name.lower() for p in params]
+    if addparams is not None:
+        names += [p.name.lower() for p in addparams]
+
+    snames = set(names)
+    if len(names) != len(snames):
+        raise ValueError(f"Parameter names are not unique")
+
+    # Check the additional parameters
+    #
+    nadd = 0 if addparams is None else len(addparams)
+    naddspec = 0 if addspectra is None else len(addspectra)
+    if nadd != naddspec:
+        raise ValueError(f"Mismatch between addparams and addspectra sizes: {nadd} {naddspec}")
+
+    # What are the parameter combinations? The last parameter
+    # loops fastest. If XFXP keyword are given then we have to
+    # replicate each set of parameters nxfxp times.
+    #
+    pvals_indiv = [p.values for p in params]
+    if nxfxp > 1:
+        pvals_indiv.append([0] * nxfxp)
+
+    pvalues = list(itertools.product(*pvals_indiv))
+    if nxfxp > 1:
+        # remove the fake parameter used to duplicate each row
+        pvalues = [pv[:-1] for pv in pvalues]
+
+    # Does pvalues match the expected number of spectra?
+    #
+    npvs = len(pvalues)
+    nspectra = len(spectra)
+    if npvs != nspectra:
+        raise ValueError(f"Expected {npvs} spectra, found {nspectra}")
+
+    if addspectra is not None:
+        for idx, aspec in enumerate(addspectra):
+            naspec = len(aspec)
+            if npvs != naspec:
+                # We should use a type that combines
+                # addparams/spectra but for now make mypy happy.
+                #
+                assert addparams is not None
+                raise ValueError(f"Expected {npvs} spectra for additional parameter {addparams[idx].name}, found {naspec}")
+
+    # Check the energy grid makes sense
+    nlo = len(egrid_lo)
+    nhi = len(egrid_hi)
+    if nlo != nhi:
+        raise ValueError(f"egrid_lo/hi do not match: {nlo} vs {nhi}")
+
+    if nlo == 0:
+        raise ValueError("egrid_lo/hi can not be empty")
+
+    if np.any(np.diff(egrid_lo) <= 0):
+        raise ValueError("egrid_lo is not monotonically increasing")
+
+    if np.any(np.diff(egrid_hi) <= 0):
+        raise ValueError("egrid_hi is not monotonically increasing")
+
+    # Technically we should do a Knuth-like numerical comparison here,
+    # but the assumption is that we created them so that they are
+    # consecutive, so it's okay for this check (and to try and stop
+    # yet-more-Xray-files-from-being-not-quite-valid(TM)).
+    #
+    if np.any(egrid_lo[1:] != egrid_hi[:-1]):
+        raise ValueError("egrid_lo/hi are not consecutive")
+
+    # Check we have the correct number of values in each spectrum.
+    #
+    for sp in spectra:
+        nsp = len(sp)
+        if nsp != nlo:
+            raise ValueError(f"Spectrum should have {nlo} elements "
+                             f"but has {nsp}")
+
+    if addspectra is not None:
+        for idx, aspecs in enumerate(addspectra):
+            for asp in aspecs:
+                nsp = len(asp)
+                if nsp != nlo:
+                    # We should use a type that combines
+                    # addparams/spectra but for now make mypy happy.
+                    #
+                    assert addparams is not None
+                    raise ValueError(f"Spectrum for parameter "
+                                     f"{addparams[idx].name} should "
+                                     f"have {nlo} elements but has {nsp}")
+
+    # Create the separate blocks.
+    #
+    out = []
+    out.append(xstable_primary(name_str, unit_str, bool(addmodel),
+                               bool(redshift), bool(escale),
+                               float(lolim), float(hilim),
+                               xfxp=xfxp))
+    out.append(xstable_parameters(params, addparams))
+    out.append(xstable_energies(egrid_lo, egrid_hi))
+    out.append(xstable_spectra(pvalues, spectra, addparams, addspectra,
+                               units=unit_str))
+    return out
+
+
+def write_xstable_model(filename: str,
+                        hdus: list[TableHDU],
+                        clobber: bool = False) -> None:
+    """Write a XSPEC table model to disk.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to create.
+    hdus : list of TableHDU
+        The output of make_xstable_model.
+    clobber : bool, optional
+       If `True` then the output file will be over-written if it
+       already exists, otherwise an error is raised.
+
+    See Also
+    --------
+    make_xstable_model
+
+    """
+
+    from sherpa.astro import io
+    assert io.backend is not None  # for mypy
+    io.backend.set_hdus(filename, hdus, clobber=clobber)


### PR DESCRIPTION
# Summary

Provide experimental support for creating XSPEC table models (additive or multiplicative). The output routines can be found in the sherpa.astro.ui.xstable module. Note that XSPEC support is not required to write out an XSPEC table (but it is to be able to read it back in and use it). Fix #1859

# Details

This is built on #1836. As mentioned below, some of the additions here could be integrated with the changes in #1836 but I think that is too large a project at this time.

This was created because of discussions I had with a local user doing cross-telescope calibration work e.g. see https://github.com/sherpa/sherpa/discussions/1849 

The reason the code is labelled experimental is because I am not 100% convinced that I have come up with a good way of sending in the data: when writing out the data there is some repeated information which we don't need to make the user repeat, and hence ensure that the table is consistent, but there's more than one way to avoid this repetition and so we may decide to tweak the API. There are also other parts of the API that may be a bit lacking in polish. I don't expect the changes to be large, but I want to leave there room for the possibility of changes.

As this is labelled experimental I have not added it as a routine in sherpa.astro.io. Instead users will need to use sherpa.astro.io.xstable to import the routines. This functionality is specialized enough that I think that having it in a separate module is good. Thinking it through, I don't think it makes sense to add to sherpa.astro.io directly, and I really don't want to add it to sherpa.astro.ui since (again) it is very specialized.

Some of the internal abstractions I use could be used with the existing I/O calls (ie used as an interchange between sherpa data objects and the crates/pyfits backends), but I have not tried this here as it is too large a project for me at this time.

I added typing information to sherpa.astro.io.xstsable - and mypy will parse it successfully. It did help me find some logical errors, but I have used Any for handling of ndarray-like data (since the last I looked there was no nice simple way for me to say iterable or 1D ndarray, and also some of the typing assumes lists when really it should be more generic (e.g. sequence). 

# Notes

Writing out the data isn't too hard, it's just a bit clunky as there's four HDUs and some columns are "interesting". Fortunately we can use the XSPEC read_xstable_model to verify that we've written it out correctly (although I will caution you that the error messages XSPEC creates for mal-formed files is not very helpful; the default appears to be to segfault).

# Example

Let's write out an additive table model that just varies the location of a gaussian model (this is not a sensible use but it does show off some features)

```
import numpy as np

from sherpa.astro.io import xstable
from sherpa.astro.xspec impost XSgaussian

egrid = np.arange(0.1, 2, 0.01)
elo = egrid[:-1]
ehi = egrid[1:]

mdl = XSgaussian()

# what is the line postion we can interpolate over
linepos = np.arange(0, 2.5, 0.1)

# evalute the model at these parameter values
models = []
for lp in linepos:
    mdl.linee = lp
    models.append(mdl(elo, ehi))

param = xstable.IntParam("pos", 1, 0.01, 0, linepos[0], linepos[-1], values=linepos)

hdus = xstable.make_xspec_table_model("gaussy", elo, ehi, params=[param], spectra=models)
xstable.write_xpsec_table_model("wat.tmod", hdus, clobber=True)
```

This creates a file called `wat.tmod`:

```
% dmlist wat.tmod blocks
 
--------------------------------------------------------------------------------
Dataset: wat.tmod
--------------------------------------------------------------------------------
 
     Block Name                          Type         Dimensions
--------------------------------------------------------------------------------
Block    1: PRIMARY                        Null        
Block    2: PARAMETERS                     Table        10 cols x 1        rows
Block    3: ENERGIES                       Table         2 cols x 189      rows
Block    4: SPECTRA                        Table         2 cols x 25       rows
% dmlist wat.tmod["primary]" header,clean
 --  COMMENT                FITS (Flexible Image Transport System) format is defined in 'Astronomy
 --  COMMENT                and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H
HDUCLASS             OGIP                           format conforms to OGIP standard
HDUCLAS1             XSPEC TABLE MODEL              model spectra for XSPEC
HDUVERS              1.2.0                          version of format
MODLNAME             gaussy                         Model name
MODLUNIT             photons/cm^2/s                 Model units
ADDMODEL             TRUE                           If T then this is an additive table model
REDSHIFT             FALSE                          If T then redshift will be a parameter
ESCALE               FALSE                          If T then escale will be a parameter
LOELIMIT                                0           Model value for energies below ENERGIES block
HIELIMIT                                0           Model value for energies above ENERGIES block
CREATOR              sherpa 4.15.1+213.ge5b465f0.dirty Code that created the file
DATE                 2023-08-25T17:04:16            Date file created
% dmlist wat.tmod data,clean
#  NAME           METHOD     INITIAL              DELTA                MINIMUM              BOTTOM               TOP                  MAXIMUM              NUMBVALS   VALUE[25]
 pos                     0                  1.0     0.00999999977648                    0                    0         2.4000000954         2.4000000954         25                                  0     0.10000000149012     0.20000000298023     0.30000001192093     0.40000000596046     0.50     0.60000002384186     0.69999998807907     0.80000001192093     0.89999997615814         1.0         1.1000000238         1.2000000477         1.2999999523         1.3999999762         1.50         1.6000000238         1.7000000477         1.7999999523         1.8999999762         2.0         2.0999999046         2.2000000477         2.2999999523         2.4000000954
```

This can then be used in Sherpa

```
sherpa In [1]: load_xstable_model("boom", "wat.tmod")

sherpa In [2]: print(boom)
xstablemodel.boom
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   boom.pos     thawed            1            0          2.4           
   boom.norm    thawed            1            0        1e+24           

sherpa In [3]: egrid = np.arange(0.05, 3, 0.1)

sherpa In [4]: elo = egrid[:-1]

sherpa In [5]: ehi = egrid[1:]

sherpa In [6]: emid = (elo + ehi) / 2

sherpa In [7]: for p in [0.1, 0.5, 0.8, 1.4, 1.8, 2.2]:
          ...:     boom.pos = p
          ...:     plt.plot(emid, boom(elo, ehi), alpha=0.5, label=str(p))
          ...: 

sherpa In [8]: plt.legend()
Out[8]: <matplotlib.legend.Legend at 0x7f80fe9dc430>

sherpa In [9]: for p in [0.1, 0.5, 0.8, 1.4, 1.8, 2.2]:
          ...:     plt.axvline(p, c='k', alpha=0.5)
          ...: 
```

![plot](https://github.com/sherpa/sherpa/assets/224638/7a08d294-29e2-4525-b7ec-bd37e8df38ca)

Now, the line positions look "interesting" but that's for those whose centres lie outside the defined grid (0 to 2), so it's not surprising there's no data there.
