### PR TITLE
Bump test workflows to use xspec 12.13.1

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -3,13 +3,13 @@
 if [ "`uname -s`" == "Darwin" ] ; then
     compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
 
-    #Download the macOS 10.9 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
-    mkdir -p ${GITHUB_WORKSPACE}/10.9SDK
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz -O MacOSX10.9.sdk.tar.xz
+    #Download the macOS 10.14 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
+    mkdir -p ${GITHUB_WORKSPACE}/10.14SDK
+    wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz -O MacOSX10.14.sdk.tar.xz
     if [[ $? -ne 0 ]]; then
-      echo "macOS 10.9 SDK download failed"
+      echo "macOS 10.14 SDK download failed"
     fi
-    tar -C ${GITHUB_WORKSPACE}/10.9SDK -xf MacOSX10.9.sdk.tar.xz
+    tar -C ${GITHUB_WORKSPACE}/10.14SDK -xf MacOSX10.14.sdk.tar.xz
     #End of Conda compilers section
 else
     compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"

--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -21,6 +21,9 @@ xspec_include_path=${xspec_root}/include/
 
 case "${XSPECVER}" in
   12.13.0*)
+      xspec_version_string="12.13.1"
+      ;;
+  12.13.0*)
       xspec_version_string="12.13.0"
       ;;
   12.12.1*)

--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -20,7 +20,7 @@ xspec_library_path=${xspec_root}/lib/
 xspec_include_path=${xspec_root}/include/
 
 case "${XSPECVER}" in
-  12.13.0*)
+  12.13.1*)
       xspec_version_string="12.13.1"
       ;;
   12.13.0*)

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -131,7 +131,7 @@ jobs:
         os-dir: ["osx-64"]
         python-version: ["3.9", "3.10", "3.11"]
     env:
-      CONDA_BUILD_SYSROOT: /opt/MacOSX10.9.sdk
+      CONDA_BUILD_SYSROOT: /opt/MacOSX10.14.sdk
 
     steps:
     - name: Conda Setup
@@ -143,16 +143,16 @@ jobs:
         source ${miniconda_loc}/etc/profile.d/conda.sh
         conda create -yq -n builder conda-build conda-verify
 
-    - name: macOS 10.9 SDK
+    - name: macOS 10.14 SDK
       if: ${{ matrix.conda-os == 'MacOSX-x86_64' }}
       run: |
-        #Download the MacOS 10.9 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
+        #Download the MacOS 10.14 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
         mkdir -p /opt
-        curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz -o MacOSX10.9.sdk.tar.xz
+        curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz -o MacOSX10.14.sdk.tar.xz
         if [[ $? -ne 0 ]]; then
-            echo "MacOS 10.9 SDK download failed"
+            echo "MacOS 10.14 SDK download failed"
         fi
-        sudo tar -C /opt -xf MacOSX10.9.sdk.tar.xz
+        sudo tar -C /opt -xf MacOSX10.14.sdk.tar.xz
 
     - name: Checkout Code
       uses: actions/checkout@v3.1.0

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -11,7 +11,7 @@ on:
 env:
   sherpa_channel: sherpa
   xspec_channel: "xspec/label/test"
-  CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.9SDK/MacOSX10.9.sdk
+  CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.14SDK/MacOSX10.14.sdk
 
 jobs:
   tests:

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -31,7 +31,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.13.0c
+            xspec-version: 12.13.1
             # run xvfb with this display
             display: :99
 
@@ -56,7 +56,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.13.0c
+            xspec-version: 12.13.1
 
           - name: Linux Full Build (Python 3.10)
             os: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.12.1c
+            xspec-version: 12.13.0c
 
           - name: Linux Full Build (Python 3.9)
             os: ubuntu-latest

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,2 +1,2 @@
 CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.9.sdk        # [osx]
+  - /opt/MacOSX10.14.sdk        # [osx]


### PR DESCRIPTION
- Bumps the Linux and macOS build tests to use the latest xspec
- Bumps one other Linux job to cover the switched 12.13.0 test
- Switches from the 10.9 SDK to the 10.14 SDK. We built xspec with 10.14 SDK due to the changes to the clock function, so we've updated Sherpa to build against this version as well.