### PR TITLE
Switch to conda-forge and use new Conda channel

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -28,13 +28,13 @@ source ${CONDA}/etc/profile.d/conda.sh
 
 # update and add channels
 conda update --yes conda
+conda config --add channels conda-forge
 
 # To avoid issues with non-XSPEC builds (e.g.
 # https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )
 # the XSPEC-related channels are only added if needed
 #
 if [ -n "${XSPECVER}" ]; then
- conda config --add channels conda-forge
  conda config --add channels ${xspec_channel}
 fi
 conda config --add channels ${sherpa_channel}

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -37,7 +37,6 @@ conda config --add channels conda-forge
 if [ -n "${XSPECVER}" ]; then
  conda config --add channels ${xspec_channel}
 fi
-conda config --add channels ${sherpa_channel}
 
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -17,9 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  sherpa_channel: sherpa
   sherpa_label: dev
-  miniconda_loc: ${{ github.workspace }}/miniconda
+  conda_loc: ${{ github.workspace }}/conda_loc
 
 defaults:
   run:
@@ -81,9 +80,9 @@ jobs:
       env:
         CONDA_OS: ${{ matrix.conda-os }}
       run: |
-        curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-${CONDA_OS}.sh -o miniconda.sh
-        bash miniconda.sh -b -p ${miniconda_loc}
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${CONDA_OS}.sh -o conda-installer.sh
+        bash conda-installer.sh -b -p ${conda_loc}
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda create -yq -n builder conda-build conda-verify
 
     #Checkout the code with a depth of 0 to grab the tags/branches as well
@@ -107,7 +106,7 @@ jobs:
           echo "Error: SHERPA_VERSION or SHERPA_BUILD_NUMBER not set."
           exit 1
         fi
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate builder
         echo "conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda"
         conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda
@@ -138,9 +137,9 @@ jobs:
       env:
         CONDA_OS: ${{ matrix.conda-os }}
       run: |
-        curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-${CONDA_OS}.sh -o miniconda.sh
-        bash miniconda.sh -b -p ${miniconda_loc}
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${CONDA_OS}.sh -o conda-installer.sh
+        bash conda-installer.sh -b -p ${conda_loc}
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda create -yq -n builder conda-build conda-verify
 
     - name: macOS 10.14 SDK
@@ -174,7 +173,7 @@ jobs:
           echo "Error: SHERPA_VERSION or SHERPA_BUILD_NUMBER not set"
           exit 1
         fi
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate builder
         echo "conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda"
         conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda
@@ -219,9 +218,9 @@ jobs:
         CONDA_OS: ${{ matrix.conda-os }}
       working-directory: ${{ github.workspace }}
       run: |
-        curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-${CONDA_OS}.sh -o miniconda.sh
-        bash miniconda.sh -b -p ${miniconda_loc}
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${CONDA_OS}.sh -o conda-installer.sh
+        bash conda-installer.sh -b -p ${conda_loc}
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda install conda-build
         echo "Packages downloaded here: ${{steps.download.outputs.download-path}}"
         echo "ls packages/*/sherpa*.bz2"
@@ -232,7 +231,7 @@ jobs:
     - name: Run the tests
       working-directory: ${{ github.workspace }}
       run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip 
         echo "conda create -n test39 --yes -q -c file://$(pwd)/packages python=3.9 astropy sherpa matplotlib"
         conda create -n test39 --yes -q -c file://$(pwd)/packages python=3.9 astropy sherpa matplotlib
@@ -252,36 +251,3 @@ jobs:
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test
-
-  deploy:
-    needs: pre-deploy-test
-    name: Deploy to Dev Channel
-    runs-on: ubuntu-latest
-
-    steps:
-    #Download all artifacts
-    - uses: actions/download-artifact@v3
-      with:
-        path: packages
-
-    - name: Anaconda-Client Setup
-      run: |
-        curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
-        bash miniconda.sh -b -p ${miniconda_loc}
-        source ${miniconda_loc}/etc/profile.d/conda.sh
-        conda install -yq anaconda-client
-      
-    - name: Deploy Sherpa
-      working-directory: ${{ github.workspace }}
-      env:
-        CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
-      run: |
-        source ${miniconda_loc}/etc/profile.d/conda.sh
-        conda activate
-        if [ -z ${CONDA_UPLOAD_TOKEN} ] || [ -z ${sherpa_channel} ]; then
-          echo "Error: CONDA_UPLOAD_TOKEN or sherpa_channel is not set."
-          exit 1
-        fi
-        #We can switch this to use "--force" if we run into issues with the upload cutting or needing to re-run
-        anaconda -t ${CONDA_UPLOAD_TOKEN} upload -u ${sherpa_channel} -l ${sherpa_label} --force ${GITHUB_WORKSPACE}/packages/*/linux-64/sherpa*
-        anaconda -t ${CONDA_UPLOAD_TOKEN} upload -u ${sherpa_channel} -l ${sherpa_label} --force ${GITHUB_WORKSPACE}/packages/*/osx-64/sherpa*

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
 
 env:
-  sherpa_channel: sherpa
   xspec_channel: "xspec/label/test"
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.14SDK/MacOSX10.14.sdk
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [Sherpa](#sherpa)
 - [License](#license)
 - [How To Install Sherpa](#how-to-install-sherpa)
-  - [Using Anaconda](#using-anaconda)
+  - [Using Conda](#using-conda)
   - [Using pip](#using-pip)
   - [Building from source](#building-from-source)
 - [History](#history)
@@ -76,14 +76,14 @@ Sherpa is tested against Python versions 3.9, 3.10, and 3.11.
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
 
-Using Anaconda
+Using Conda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
 Python 3.9, 3.10, and 3.11. It can be installed with the `conda`
 package manager by saying
 
-    $ conda install -c sherpa sherpa
+    $ conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa
 
 Using pip
 ---------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -505,8 +505,10 @@ The
 contains the ``sherpatest`` package, which provides a number of
 data files in ASCII and :term:`FITS` formats. This is
 only useful when developing Sherpa, since the package is large.
-Example: Installing the 4.14.1 data via pip::
+A version of the test data is released for each `version of Sherpa <https://doi.org/10.5281/zenodo.593753>`_.
 
-   pip install https://github.com/sherpa/sherpa-test-data/archive/4.14.1.zip
+As an example, the 4.15.1 version of the test data can be installed with pip::
 
-And will then automatically be picked up by the ``sherpa_test`` script.
+   pip install https://github.com/sherpa/sherpa-test-data/archive/4.15.1.zip
+
+The test data will be automatically picked up by the Python tests and the ``sherpa_test`` script.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ your environment and set up.
 
    ::
 
-     conda install -c sherpa sherpa
+     conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa
 
 #. Install Sherpa using pip
 
@@ -98,22 +98,21 @@ Installing a pre-compiled version of Sherpa
 Additional useful Python packages include ``astropy``, ``matplotlib``,
 and ``ipython-notebook``.
 
-Using the Anaconda python distribution
+Using the Conda python distribution
 --------------------------------------
 
 The Chandra X-ray Center provides releases of Sherpa that can be
 installed using
-`Anaconda <https://www.anaconda.com/>`_
-from the ``sherpa`` channel. First check
-to see what the latest available version is by using::
+`Miniforge <https://github.com/conda-forge/miniforge>`_.
+First check to see what the latest available version is by using::
 
-    conda install -c sherpa sherpa --dry-run
+    conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa --dry-run
 
 and then, if there is a version available and there are no
 significant upgrades to the dependencies, Sherpa can be installed
 using::
 
-    conda install -c sherpa sherpa
+    conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa
 
 It is **strongly** suggested that Sherpa is installed into a named
 `conda environment <https://conda.pydata.org/docs/using/envs.html>`_
@@ -501,8 +500,13 @@ Sherpa was configured when built)::
    and ``--runzenodo`` arguments from the
    :ref:`development build <developer-build>` section.
 
-The ``sherpa`` Anaconda channel contains the ``sherpatest`` package, which
-provides a number of data files in ASCII and :term:`FITS` formats. This is
-only useful when developing Sherpa, since the package is large. It
-will automatically be picked up by the ``sherpa_test`` script
-once it is installed.
+The
+`Sherpa test data suite <https://github.com/sherpa/sherpa-test-data>`_
+contains the ``sherpatest`` package, which provides a number of
+data files in ASCII and :term:`FITS` formats. This is
+only useful when developing Sherpa, since the package is large.
+Example: Installing the 4.14.1 data via pip::
+
+   pip install https://github.com/sherpa/sherpa-test-data/archive/4.14.1.zip
+
+And will then automatically be picked up by the ``sherpa_test`` script.


### PR DESCRIPTION
The proposal for this PR  is to:

- Switches Sherpa from "defaults" to "conda-forge"
- Switches Anaconda references to Conda
- Uses a new channel for the official Conda releases
Each run of the deployment pipeline will store the artifacts on github (to expire after 3 days).

New proposed Conda package release process:

- When an official release is being worked, the Sherpa packages will be uploaded to a test channel for checks
- When the release goes out, those packages will be uploaded to an official channel (proposed as: https://cxc.cfa.harvard.edu/conda/sherpa)
