### PR TITLE
First fixes for NumPy 2.0

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -8961,17 +8961,19 @@ class Session(sherpa.ui.utils.Session):
         if rmf is None and len(d.response_ids) == 0:
             raise DataErr('normffake', id)
 
-        if type(rmf) in (str, numpy.string_):
-            if os.path.isfile(rmf):
-                rmf = self.unpack_rmf(rmf)
-            else:
+        # TODO: do we still expect to get bytes here?
+        if isinstance(rmf, (str, numpy.bytes_)):
+            if not os.path.isfile(rmf):
                 raise IOErr("filenotfound", rmf)
 
-        if type(arf) in (str, numpy.string_):
-            if os.path.isfile(arf):
-                arf = self.unpack_arf(arf)
-            else:
+            rmf = self.unpack_rmf(rmf)
+
+        # TODO: do we still expect to get bytes here?
+        if isinstance(arf, (str, numpy.bytes_)):
+            if not os.path.isfile(arf):
                 raise IOErr("filenotfound", arf)
+
+            arf = self.unpack_arf(arf)
 
         if not (rmf is None and arf is None):
             for resp_id in d.response_ids:

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -23,7 +23,11 @@ import re
 import logging
 
 import numpy as np
-from numpy import VisibleDeprecationWarning
+try:
+    from numpy.exceptions import VisibleDeprecationWarning
+except ImportError:
+    # Must be Earlier than NumPy 1.25
+    from numpy import VisibleDeprecationWarning
 
 import pytest
 

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021, 2022, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -619,10 +619,11 @@ they do not match.
             setattr(self, name, None)
             return
 
-        if type(vals) in (str, numpy.string_):
+        # TODO: do we still expect to get bytes here?
+        if isinstance(vals, (str, numpy.bytes_)):
             raise PSFErr('nostr')
 
-        if type(vals) not in (list, tuple, numpy.ndarray):
+        if not isinstance(vals, (list, tuple, numpy.ndarray)):
             vals = [vals]
 
         nvals = len(vals)

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021
+#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -239,7 +239,7 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
 
     for key in colkeys:
         if key not in names:
-            raise IOErr('reqcol', key, numpy.asarray(names, numpy.string_))
+            raise IOErr('reqcol', key, names)
         kwargs.append(args[names.index(key)])
 
     _check_args(len(kwargs), dstype)

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -64,7 +64,7 @@ class Strategy:
         arg[-1] = self.func(arg[:-1])
         tmp = numpy.empty(self.npar + 2)
         tmp[1:] = arg[:]
-        if numpy.finfo(numpy.float_).max == arg[-1]:
+        if numpy.finfo(numpy.float64).max == arg[-1]:
             tmp[0] = 0
         else:
             tmp[0] = 1

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -27,7 +27,7 @@ from sherpa.optmethods.opt import MyNcores, Opt, SimplexNoStep, SimplexStep, \
 
 __all__ = ('ncoresNelderMead', )
 
-EPSILON = np.float_(np.finfo(np.float32).eps)
+EPSILON = np.float64(np.finfo(np.float32).eps)
 
 
 class MyNelderMead(Opt):

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -111,7 +111,7 @@ class Opt:
 
         def func_bounds_wrapper(x, *args):
             if self._outside_limits(x, xmin, xmax):
-                return np.finfo(np.float_).max
+                return np.finfo(np.float64).max
             return func(x, *args)
 
         return func_bounds_wrapper

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -86,20 +86,20 @@ __all__ = ('difevo', 'difevo_lm', 'difevo_nm', 'grid_search', 'lmdif',
 #
 # Use FLT_EPSILON as default tolerance
 #
-EPSILON = numpy.float_(numpy.finfo(numpy.float32).eps)
+EPSILON = numpy.float64(numpy.finfo(numpy.float32).eps)
 
 #
 # Maximum callback function value, used to indicate that the optimizer
 # has exceeded parameter boundaries.  All the optimizers expect double
-# precision arguments, so we use numpy.float_ instead of SherpaFloat.
+# precision arguments, so we use numpy.float64 instead of SherpaFloat.
 #
-FUNC_MAX = numpy.finfo(numpy.float_).max
+FUNC_MAX = numpy.finfo(numpy.float64).max
 
 
 def _check_args(x0, xmin, xmax):
-    x = numpy.array(x0, numpy.float_)  # Make a copy
-    xmin = numpy.asarray(xmin, numpy.float_)
-    xmax = numpy.asarray(xmax, numpy.float_)
+    x = numpy.array(x0, numpy.float64)  # Make a copy
+    xmin = numpy.asarray(xmin, numpy.float64)
+    xmax = numpy.asarray(xmax, numpy.float64)
 
     if (x.shape != xmin.shape) or (x.shape != xmax.shape):
         raise TypeError('input array sizes do not match')
@@ -145,7 +145,7 @@ def _narrow_limits(myrange, xxx, debug):
                 print('x = ', my_x, ' is > upper limit = ', my_h)
 
     def raise_min_limit(xrange, xmin, x, debug=False):
-        myxmin = numpy.asarray(list(map(lambda xx: xx - xrange * numpy.abs(xx), x)), numpy.float_)
+        myxmin = numpy.asarray(list(map(lambda xx: xx - xrange * numpy.abs(xx), x)), numpy.float64)
         if debug:
             print()
             print(f'raise_min_limit: myxmin={myxmin}')
@@ -160,7 +160,7 @@ def _narrow_limits(myrange, xxx, debug):
         return myxmin
 
     def lower_max_limit(xrange, x, xmax, debug=False):
-        myxmax = numpy.asarray(list(map(lambda xx: xx + xrange * numpy.abs(xx), x)), numpy.float_)
+        myxmax = numpy.asarray(list(map(lambda xx: xx + xrange * numpy.abs(xx), x)), numpy.float64)
         if debug:
             print()
             print(f'lower_max_limit: x={x}')
@@ -210,7 +210,7 @@ def _outside_limits(x, xmin, xmax):
 
 
 def _same_par(a, b):
-    b = numpy.array(b, numpy.float_)
+    b = numpy.array(b, numpy.float64)
     same = numpy.flatnonzero(a < b)
     if same.size == 0:
         return 1
@@ -481,7 +481,7 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
 
     if step is None:
         order = 'F' if numpy.isfortran(x) else 'C'
-        step = 0.4*numpy.ones(x.shape, numpy.float_, order)
+        step = 0.4*numpy.ones(x.shape, numpy.float64, order)
     if simp is None:
         simp = 1.0e-2 * ftol
     if maxfev is None:
@@ -631,7 +631,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         if 1 == numcores:
             result = neldermead(myfcn, x, xmin, xmax, maxfev=mymaxfev,
                                 ftol=ftol, finalsimplex=9, step=mystep)
-            x = numpy.asarray(result[1], numpy.float_)
+            x = numpy.asarray(result[1], numpy.float64)
             nfval = result[2]
             nfev = result[4].get('nfev')
         else:
@@ -651,7 +651,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
             result = difevo_nm(myfcn, x, xmin, xmax, ftol, mymaxfev, verbose,
                                seed, pop, xprob, weight)
             nfev += result[4].get('nfev')
-            x = numpy.asarray(result[1], numpy.float_)
+            x = numpy.asarray(result[1], numpy.float64)
             nfval = result[2]
         else:
             ncores_de = ncoresDifEvo()
@@ -683,7 +683,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
                 nfev += result[4].get('nfev')
                 if result[2] < nfval:
                     nfval = result[2]
-                    x = numpy.asarray(result[1], numpy.float_)
+                    x = numpy.asarray(result[1], numpy.float64)
                 if verbose or debug:
                     print(f'f_de_nm{x}={result[2]:.14e} in {result[4].get("nfev")} nfev')
 
@@ -713,7 +713,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
                                 maxfev=min(512*len(x), maxfev - nfev),
                                 ftol=ftol, finalsimplex=9, step=mystep)
 
-            x = numpy.asarray(result[1], numpy.float_)
+            x = numpy.asarray(result[1], numpy.float64)
             fval = result[2]
             nfev += result[4].get('nfev')
         else:
@@ -949,9 +949,9 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
 
     order = 'F' if numpy.isfortran(x) else 'C'
     if step is None or (numpy.iterable(step) and len(step) != len(x)):
-        step = 1.2 * numpy.ones(x.shape, numpy.float_, order)
+        step = 1.2 * numpy.ones(x.shape, numpy.float64, order)
     elif numpy.isscalar(step):
-        step = step * numpy.ones(x.shape, numpy.float_, order)
+        step = step * numpy.ones(x.shape, numpy.float64, order)
 
     def stat_cb0(pars):
         return fcn(pars)[0]
@@ -1051,7 +1051,7 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
     if len(finalsimplex) >= 3 and 0 != iquad:
         nelmea = minim(fcn, x, xmin, xmax, ftol=10.0*ftol,
                        maxfev=maxfev - nfev - 12, iquad=1, reflect=reflect)
-        nelmea_x = numpy.asarray(nelmea[1], numpy.float_)
+        nelmea_x = numpy.asarray(nelmea[1], numpy.float64)
         nelmea_nfev = nelmea[4].get('nfev')
         info = nelmea[4].get('info')
         covarerr = nelmea[4].get('covarerr')

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -5397,7 +5397,8 @@ class Session(NoNewAttributesAfterInit):
         if len(self._data) == 0:
             raise IdentifierErr("nodatasets")
 
-        if lo is not None and type(lo) in (str, numpy.string_):
+        # TODO: do we still expect to get bytes here?
+        if lo is not None and isinstance(lo, (str, numpy.bytes_)):
             return self._notice_expr(lo, **kwargs)
 
         # Jump through the data sets in "order".
@@ -5616,7 +5617,8 @@ class Session(NoNewAttributesAfterInit):
                 raise ArgumentTypeErr('badarg', 'ids',
                                       'an identifier or list of identifiers') from None
 
-        if lo is not None and type(lo) in (str, numpy.string_):
+        # TODO: do we still expect to get bytes here?
+        if lo is not None and isinstance(lo, (str, numpy.bytes_)):
             return self._notice_expr_id(ids, lo, **kwargs)
 
         # Unlike notice() we do not sort the id list as this

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -92,7 +92,7 @@ dividing and multiplying the value by ``_guess_ampl_scale``.
 # Default numeric types (these match the typedefs in extension.hh)
 SherpaInt = numpy.intp
 SherpaUInt = numpy.uintp
-SherpaFloat = numpy.float_
+SherpaFloat = numpy.float64
 
 ###############################################################################
 
@@ -3039,7 +3039,7 @@ class RichardsonExtrapolation(NoRichardsonExtrapolation):
 
     def __call__(self, x, t, tol, maxiter, h, *args):
 
-        richardson = numpy.zeros((maxiter, maxiter), dtype=numpy.float_)
+        richardson = numpy.zeros((maxiter, maxiter), dtype=numpy.float64)
         richardson[0, 0] = self.sequence(x, h, *args)
 
         t_sqr = t * t
@@ -3074,7 +3074,7 @@ def hessian(func, par, extrapolation, algorithm, maxiter, h, tol, t):
     num_dif = algorithm(func, func(par))
     deriv = extrapolation(num_dif)
     npar = len(par)
-    Hessian = numpy.zeros((npar, npar), dtype=numpy.float_)
+    Hessian = numpy.zeros((npar, npar), dtype=numpy.float64)
     for ii in range(npar):
         for jj in range(ii + 1):
             answer = deriv(par, t, tol, maxiter, h, ii, jj)


### PR DESCRIPTION
# Summary

Internal code changes to improve support for NumPy 2.0.

# Details

Spurned on by 

- #1864 

let's see what changes we can make now to future-proof ourselves.

With the dvelopment build of NumPy 2.0 installed

```
% pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
```

and removing `matlpotlib` and `astropy` (as the released versions of these I had, which are admittedly old, also have problems with NumPy 2.0) then most tests pass with this change. We do need to work out what to do with the change in string representation - e.g. https://github.com/sherpa/sherpa/issues/1864#issuecomment-1699713313 - but this forms a nice limited-scope set of changes.

Let's see how it copes with some of the older NumPy versions we have in our CI runs! It's hard to check against numpy 2.0 since we don't have a CI run that provides this.

There will likely be more changes needed for our compiled extensions, but that can come later (and I don't know how to make `pyproject.toml` use a development build of NumPy rather than `oldest-supported-numpy`!).

# Changes

- use `np.exceptions` to import  `VisibleDeprecationWarning`, falling back to the old location if not available
  - this is only needed for the tests
  - `np.exceptions` was added in NumPy 1.25 
- use `np.float64` rather than `np.float_`
  - we could use `np.double` instead, but I think I like the choice of an explicit fixed-size datatype (since we have to deal with compiled code)
  - I didn't find documentation on when `float_` and `float64` become synonyms but I assume it holds for all recent NumPy versions
- use `np.bytes_` rather than `np.string_`
  - I think most uses of this are to handle the old behavior of crates/pyfits which would return byte strings at times, but I can not guarantee this, so I've just left a note for looking this at some future time
  - I didn't find documentation on when `string_` and `bytes_` become synonyms but I assume it holds for all recent NumPy versions
- some minor code cleanups to use `isinstance` rather than an explicit `type` check 