### PR TITLE
Support multi matrix rmf

### DIFF
--- a/docs/overview/astro_io.rst
+++ b/docs/overview/astro_io.rst
@@ -6,8 +6,6 @@ The sherpa.astro.io module
 
 .. automodule:: sherpa.astro.io
 
-   .. rubric:: Attributes
-
    .. rubric:: Functions
 
    .. autosummary::

--- a/docs/overview/astro_io_io_types.rst
+++ b/docs/overview/astro_io_io_types.rst
@@ -14,9 +14,11 @@ The sherpa.astro.io.io_types module
       Column
       HeaderItem
       TableHDU
+      RMFMatrixData
+      RMFEboundsData
 
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: Column HeaderItem TableHDU
+.. inheritance-diagram:: Column HeaderItem TableHDU RMFMatrixData RMFEboundsData
    :parts: 1

--- a/docs/overview/astro_io_io_types.rst
+++ b/docs/overview/astro_io_io_types.rst
@@ -1,0 +1,22 @@
+***********************************
+The sherpa.astro.io.io_types module
+***********************************
+
+.. currentmodule:: sherpa.astro.io.io_types
+
+.. automodule:: sherpa.astro.io.io_types
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      Column
+      HeaderItem
+      TableHDU
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram:: Column HeaderItem TableHDU
+   :parts: 1

--- a/docs/overview/astro_io_xstable.rst
+++ b/docs/overview/astro_io_xstable.rst
@@ -1,0 +1,29 @@
+**********************************
+The sherpa.astro.io.xstable module
+**********************************
+
+.. currentmodule:: sherpa.astro.io.xstable
+
+.. automodule:: sherpa.astro.io.xstable
+
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: api
+
+      IntParam
+      Param
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      make_xstable_model
+      write_xstable_model
+
+Class Inheritance Diagram
+=========================
+
+.. inheritance-diagram:: IntParam Param
+   :parts: 1

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -57,4 +57,5 @@ Reference/API
    astro
    astro_io
    astro_io_wcs
+   astro_io_xstable
    astro_utils_xspec

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -56,6 +56,7 @@ Reference/API
    io
    astro
    astro_io
+   astro_io_io_types
    astro_io_wcs
    astro_io_xstable
    astro_utils_xspec

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -118,8 +118,11 @@ this range to have at least 20 counts per group:
 
 """
 
-import os.path
+from __future__ import annotations
+
 import logging
+import os
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 import warnings
 
 import numpy
@@ -134,6 +137,10 @@ from sherpa.utils import SherpaFloat, pad_bounding_box, interpolate, \
 from sherpa.utils import formatting
 from sherpa.astro import hc
 
+if TYPE_CHECKING:
+    # Avoids an import loop as this symbol is only used for type checking
+    from sherpa.astro.io.io_types import RMFMatrixData
+
 # There are currently (Sep 2015) no tests that exercise the code that
 # uses the compile_energy_grid symbols.
 from sherpa.astro.utils import arf_fold, rmf_fold, filter_resp, \
@@ -144,7 +151,7 @@ warning = logging.getLogger(__name__).warning
 
 regstatus = False
 try:
-    from sherpa.astro.utils._region import Region
+    from sherpa.astro.utils._region import Region  # type: ignore
     regstatus = True
 except ImportError:
     warning('failed to import sherpa.astro.utils._region; Region routines ' +
@@ -152,7 +159,7 @@ except ImportError:
 
 groupstatus = False
 try:
-    import group as pygroup
+    import group as pygroup  # type: ignore
     groupstatus = True
 except ImportError:
     groupstatus = False
@@ -734,7 +741,7 @@ def simulate_rmf_plot(rmf):
     from sherpa import plot
 
     try:
-        from matplotlib import pyplot as plt
+        from matplotlib import pyplot as plt  # type: ignore
     except ImportError:
         return None
 
@@ -802,7 +809,7 @@ def img_plot(img):
     from sherpa import plot
 
     try:
-        from matplotlib import pyplot as plt
+        from matplotlib import pyplot as plt  # type: ignore
     except ImportError:
         return None
 
@@ -1134,10 +1141,10 @@ class DataRMF(DataOgipResponse):
         containing the data.
     detchans : int
     energ_lo, energ_hi : array
-        The values of the ENERG_LO, ENERG_HI, and SPECRESP columns
-        for the ARF. The ENERG_HI values must be greater than the
-        ENERG_LO values for each bin, and the energy arrays must be
-        in increasing or decreasing order.
+        The values of the ENERG_LO and ENERG_HI columns for the RMF
+        (for the MATRIX block). The ENERG_HI values must be greater
+        than the ENERG_LO values for each bin, and the energy arrays
+        must be in increasing or decreasing order.
     n_grp, f_chan, n_chan, matrix : array-like
     offset : int, optional
     e_min, e_max : array-like or None, optional
@@ -1288,6 +1295,116 @@ class DataRosatRMF(DataRMF):
 
     def _validate(self, name, energy_lo, energy_hi, ethresh):
         return energy_lo, energy_hi
+
+
+# Using a single class makes sense given the existing API but there
+# are reasons why we might want the logic in a sherpa.astro.instrument
+# class instead. This is therefore an experiment as we explore
+# supporting this type of data.
+#
+class DataMultiRMF(DataRMF):
+    """Support multi-matrix RMF.
+
+    Allow a multi-block RMF file - where the matrix information is
+    stored at different energy binning - as a `DataRMF` object. This
+    is an *experimental* interface which may change.
+
+    Parameters
+    ----------
+    name : str
+        The name of the data set; often set to the name of the file
+        containing the data.
+    detchans : int
+    matrices : list of RMFMatrixData
+        The matrix information, containing the energ_lo, energ_hi,
+        n_grp, f_chan, n_chan, and matrix arrays. There must be at
+        least two elements.
+    e_min, e_max : array-like
+    offset : int, optional
+    header : dict or None, optional
+    ethresh : number or None, optional
+        If set it must be greater than 0 and is the replacement value
+        to use if the lowest-energy value is 0.0.
+
+    Notes
+    -----
+    The current representations of this RMF (e.g. string
+    representation and the rich visualization in notebooks) use the
+    "highest resolution" matrix only.
+
+    """
+
+    def __init__(self, name: str, detchans: int,
+                 matrices: list[RMFMatrixData],
+                 e_min: numpy.ndarray, e_max: numpy.ndarray,
+                 offset: int = 1,
+                 header: Optional[Mapping[str, Any]] = None,
+                 ethresh: Optional[float] = None) -> None:
+
+        nmat = len(matrices)
+        if nmat < 2:
+            raise ValueError(f"expected at least 2 matrices, sent {nmat}")
+
+        self._matrices: list[RMFMatrixData] = []
+        for mat in matrices:
+            self._matrices.append(mat)
+
+        # Does it really matter what we send to DataRMF here?  For now
+        # pick the matix with the most energy bins, as the assumption
+        # is that this is the "high-res" response, but there's nothing
+        # in the spec to stop "strange" RMFs being created.
+        #
+        # We could instead go and combine the different energ_lo/hi
+        # bins to create an overall grid, and then resample that for
+        # each matrix.
+        #
+        nbins = numpy.asarray([len(mat.energ_lo) for mat in matrices])
+        idx = numpy.argmax(nbins)
+        mat = matrices[idx]
+
+        # Store the identity of the "highest-res" matrix.
+        self._matrix0 = idx
+
+        DataRMF.__init__(self, name, detchans,
+                         mat.energ_lo, mat.energ_hi,
+                         mat.n_grp, mat.f_chan, mat.n_chan, mat.matrix,
+                         offset=offset, e_min=e_min, e_max=e_max,
+                         header=header, ethresh=ethresh)
+
+    # For now we drop all the fancy "restrict to just the range
+    # we care about".
+    #
+    def notice(self, noticed_chans=None):
+        return None
+
+    def apply_rmf(self, src, *args, **kwargs):
+        """Apply the RMF to the source model.
+
+        """
+
+        # We need to fold the model through each RMF and sum the
+        # results. Note that the use of uint64 for detchans can make
+        # the size calculation overflow into a float, hence the int
+        # call.
+        #
+        out = numpy.zeros(int(self.detchans + 1 - self.offset),
+                          dtype=SherpaFloat)
+        for mat in self._matrices:
+            if len(src) == len(mat.energ_lo):
+                tmp_src = src
+            else:
+                # The API should include the evaluation space for the
+                # model, as that would save a lot of issues here. As
+                # mentioned in #1907 this information may be sent
+                # here, bit it's not currently guaranteed.
+                #
+                tmp_src = rebin(src, self._lo, self._hi,
+                                mat.energ_lo, mat.energ_hi)
+
+            out += rmf_fold(tmp_src, mat.n_grp, mat.f_chan, mat.n_chan,
+                            mat.matrix, self.detchans, self.offset)
+
+        return out
 
 
 def validate_wavelength_limits(wlo, whi, emax):

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -26,7 +26,8 @@ import numpy
 from pycrates import CrateDataset, CrateKey, CrateData, TABLECrate, \
     IMAGECrate, WCSTANTransform, RMFCrateDataset, PHACrateDataset
 import pycrates
-import cxcdm  # work around missing TLMIN support in crates CIAO 4.15
+# work around missing TLMIN support in crates CIAO 4.15
+import cxcdm
 
 from sherpa.astro.utils import resp_init
 from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat, is_binary_file
@@ -397,7 +398,7 @@ def _get_crate_by_blockname(dataset, blkname):
 
     Parameters
     ----------
-    dataset : pycrates.CrateDataset
+    dataset : CrateDataset
     blkname : str
 
     Returns
@@ -1421,7 +1422,7 @@ def _add_header(cr, header):
 
     for hdr in header:
         key = (hdr.name, hdr.value, hdr.unit, hdr.desc)
-        cr.add_key(pycrates.CrateKey(key))
+        cr.add_key(CrateKey(key))
 
 
 def _create_primary_crate(hdu):
@@ -1438,13 +1439,13 @@ def _create_primary_crate(hdu):
 
     """
 
-    out = pycrates.IMAGECrate()
+    out = IMAGECrate()
     out.name = "PRIMARY"
 
     # For some reason we need to add an empty image
     # (CIAO 4.15).
     #
-    null = pycrates.CrateData()
+    null = CrateData()
     null.values = numpy.asarray([], dtype=numpy.uint8)
     out.add_image(null)
 
@@ -1461,18 +1462,18 @@ def _create_table_crate(hdu):
 
     Returns
     -------
-    out : pycrates.TABLECrate
+    out : TABLECrate
 
     """
 
     if hdu.data is None:
         raise ValueError("No column data to write out")
 
-    out = pycrates.TABLECrate()
+    out = TABLECrate()
     out.name = hdu.name
 
     for col in hdu.data:
-        cdata = pycrates.CrateData()
+        cdata = CrateData()
         cdata.name = col.name
         cdata.desc = col.desc
         cdata.unit = col.unit
@@ -1491,7 +1492,7 @@ def set_hdus(filename, hdulist, clobber=False):
 
     check_clobber(filename, clobber)
 
-    ds = pycrates.CrateDataset()
+    ds = CrateDataset()
     ds.add_crate(_create_primary_crate(hdulist[0]))
     for hdu in hdulist[1:]:
         ds.add_crate(_create_table_crate(hdu))

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -49,7 +49,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data')
+           'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 string_types = (str, )
@@ -539,21 +539,13 @@ def get_column_data(*args):
 
 
 def get_ascii_data(filename, ncols=2, colkeys=None, **kwargs):
-    """
-    get_table_data( filename [, ncols=2 [, colkeys=None [, **kwargs ]]] )
-    """
+    """Read columns from an ASCII file"""
     return get_table_data(filename, ncols, colkeys)[:3]
 
 
 def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
                    blockname=None, hdrkeys=None):
-    """
-    get_table_data( filename , ncols=1 [, colkeys=None [, make_copy=True [,
-                    fix_type=True [, blockname=None [, hdrkeys=None ]]]]])
-
-    get_table_data( TABLECrate , ncols=1 [, colkeys=None [, make_copy=True [,
-                    fix_type=True [, blockname=None [, hdrkeys=None ] ]]]])
-    """
+    """Read columns from a file or crate."""
     filename = ''
     if type(arg) == str:
 
@@ -615,11 +607,7 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
 
 def get_image_data(arg, make_copy=True, fix_type=True):
-    """
-    get_image_data ( filename [, make_copy=True, fix_type=True ])
-
-    get_image_data ( IMAGECrate [, make_copy=True, fix_type=True ])
-    """
+    """Read image data from a file or crate"""
     filename = ''
     if type(arg) == str:
         img = open_crate(arg)
@@ -683,11 +671,7 @@ def get_image_data(arg, make_copy=True, fix_type=True):
 
 
 def get_arf_data(arg, make_copy=True):
-    """
-    get_arf_data( filename [, make_copy=True ])
-
-    get_arf_data( ARFCrate [, make_copy=True ])
-    """
+    """Read an ARF from a file or crate"""
     filename = ''
     if type(arg) == str:
         arf = open_crate(arg)
@@ -727,11 +711,7 @@ def get_arf_data(arg, make_copy=True):
 
 
 def get_rmf_data(arg, make_copy=True):
-    """
-    get_rmf_data( filename [, make_copy=True ])
-
-    get_rmf_data( RMFCrate [, make_copy=True ])
-    """
+    """Read a RMF from a file or crate"""
     filename = ''
     if type(arg) == str:
         rmfdataset = open_crate_dataset(arg, RMFCrateDataset)
@@ -871,11 +851,7 @@ def get_rmf_data(arg, make_copy=True):
 
 
 def get_pha_data(arg, make_copy=True, use_background=False):
-    """
-    get_pha_data( filename [, make_copy=True [, use_background=False]])
-
-    get_pha_data( PHACrate [, make_copy=True [, use_background=False]])
-    """
+    """Read PHA data from a file or crate"""
     filename = ''
     if type(arg) == str:
         phadataset = open_crate_dataset(arg, PHACrateDataset)
@@ -1431,3 +1407,93 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
         _set_column(tbl, name, val)
 
     tbl.write(filename, clobber=True)
+
+
+def _add_header(cr, header):
+    """Add the header keywords to the crate.
+
+    Parameters
+    ----------
+    cr : TABLECrate or IMAGECrate
+    header : list of sherpa.astro.io.xstable.HeaderItem
+
+    """
+
+    for hdr in header:
+        key = (hdr.name, hdr.value, hdr.unit, hdr.desc)
+        cr.add_key(pycrates.CrateKey(key))
+
+
+def _create_primary_crate(hdu):
+    """Create the primary block
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.xstable.TableHDU
+       Any data is ignored.
+
+    Returns
+    -------
+    out : pycreates.IMAGECrate
+
+    """
+
+    out = pycrates.IMAGECrate()
+    out.name = "PRIMARY"
+
+    # For some reason we need to add an empty image
+    # (CIAO 4.15).
+    #
+    null = pycrates.CrateData()
+    null.values = numpy.asarray([], dtype=numpy.uint8)
+    out.add_image(null)
+
+    _add_header(out, hdu.header)
+    return out
+
+
+def _create_table_crate(hdu):
+    """Create a table block
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.xstable.TableHDU
+
+    Returns
+    -------
+    out : pycrates.TABLECrate
+
+    """
+
+    if hdu.data is None:
+       raise ValueError("No column data to write out")
+
+    out = pycrates.TABLECrate()
+    out.name = hdu.name
+
+    for col in hdu.data:
+        cdata = pycrates.CrateData()
+        cdata.name = col.name
+        cdata.desc = col.desc
+        cdata.unit = col.unit
+        cdata.values = col.values
+        out.add_column(cdata)
+
+    _add_header(out, hdu.header)
+    return out
+
+
+def set_hdus(filename, hdulist, clobber=False):
+    """Write out multiple HDUS to a single file.
+
+    At present we are restricted to tables only.
+    """
+
+    check_clobber(filename, clobber)
+
+    ds = pycrates.CrateDataset()
+    ds.add_crate(_create_primary_crate(hdulist[0]))
+    for hdu in hdulist[1:]:
+        ds.add_crate(_create_table_crate(hdu))
+
+    ds.write(filename, clobber=True)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -936,14 +936,26 @@ def _read_rmf_ebounds(data, filename, ds, make_copy):
 
     # Do we get the offset from the CHANNEL column?
     #
-    if channel is not None:
-        offset = channel.get_tlmin()
-        if offset >= 0:
-            try:
-                if data['offset'] != offset:
-                    raise RuntimeError("ERRRRR")  # TODO: probably an error()
-            except KeyError:
-                data['offset'] = offset
+    if channel is None:
+        return
+
+    # Assume a negative minimum indicates that the file does not set
+    # TLMIN but that it's just using the minimum data value, and so
+    # we can return.
+    #
+    offset = channel.get_tlmin()
+    if offset < 0:
+        return
+
+    try:
+        if data['offset'] == offset:
+            return
+
+        # Drop this value as it is not obvious what to do here
+        warning("TLMIN of CHANNEL column does not match that of F_CHAN")
+    except KeyError:
+        # TLMIN of F_CHAN is not set, so use this TLMIN
+        data['offset'] = offset
 
 
 def get_rmf_data(arg, make_copy=True):

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -29,7 +29,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data')
+           'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 lgr = logging.getLogger(__name__)
@@ -57,3 +57,4 @@ set_image_data = get_table_data
 set_pha_data = get_table_data
 set_arf_data = get_table_data
 set_rmf_data = get_table_data
+set_hdus = get_table_data

--- a/sherpa/astro/io/io_types.py
+++ b/sherpa/astro/io/io_types.py
@@ -23,11 +23,18 @@ This is an experimental module, and is likely to change.
 
 """
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Optional, Union
 
+import numpy as np
 
-__all__ = ("HeaderItem", "Column", "TableHDU")
+
+__all__ = ("HeaderItem", "Column", "TableHDU",
+           "RMFMatrixData", "RMFEboundsData")
+
+
+KeyValue = Union[str, bool, int, float]
 
 
 # Perhaps the HeaderItem and Column types can be used in
@@ -42,7 +49,7 @@ class HeaderItem:
     """
     name: str
     """The keyword name (case insensitive)"""
-    value: Union[str, bool, int, float]  # will we need more?
+    value: KeyValue
     """The keyword value"""
     desc: Optional[str] = None
     """The description for the keyword"""
@@ -96,3 +103,60 @@ class TableHDU:
         self.name = self.name.strip().upper()
         if self.name == "":
             raise ValueError("name can not be empty")
+
+
+@dataclass
+class RMFMatrixData:
+    """The MATRIX block of a RMF as used by DataRMF.
+
+    This is an experimental interface. It does not contain the columns
+    from the MATRIX block as stored in a FITS file, but the
+    "compressed" version used by the I/O layer and the `rmf_fold`
+    routine.
+
+    """
+
+    detchans : int
+    """The number of channels."""
+    energ_lo : np.ndarray
+    """The ENERG_LO column of the MATRIX block."""
+    energ_hi : np.ndarray
+    """The ENERG_HI column of the MATRIX block."""
+    n_grp : np.ndarray
+    """The N_GRP column of the MATRIX block after compression."""
+    f_chan : np.ndarray
+    """The F_CHAN column of the MATRIX block after compression."""
+    n_chan : np.ndarray
+    """The N_CHAN column of the MATRIX block after compression."""
+    matrix : np.ndarray
+    """The MATRIX column of the MATRIX block after compression."""
+    header : Mapping[str, KeyValue]
+    """Metadata associated with the MATRIX block."""
+    offset : Optional[int] = None
+    """The offset for the channel array (also used by f_chan)."""
+
+    def __post_init__(self):
+        # TODO: Need to validate the energy axis and check the lengths
+        pass
+
+
+@dataclass
+class RMFEboundsData:
+    """The EBOUNDS block of a RMF as used by DataRMF.
+
+    This is an experimental interface.
+
+    """
+
+    e_min : np.ndarray
+    """The E_MIN column of the EBOUNDS block."""
+    e_max : np.ndarray
+    """The E_MAX column of the EBOUNDS block."""
+    channel : np.ndarray
+    """The CHANNEL column of the EBOUNDS block."""
+    offset : Optional[int] = None
+    """The offset for the channel array of the EBOUNDS block."""
+
+    def __post_init__(self):
+        # TODO: Need to validate the energy axis and check the lengths
+        pass

--- a/sherpa/astro/io/io_types.py
+++ b/sherpa/astro/io/io_types.py
@@ -1,0 +1,98 @@
+#
+#  Copyright (C) 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Represent FITS-like concepts for the backends.
+
+This is an experimental module, and is likely to change.
+
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+
+__all__ = ("HeaderItem", "Column", "TableHDU")
+
+
+# Perhaps the HeaderItem and Column types can be used in
+# sherpa.astro.io to pass information to and from the backends, rather
+# than the current system. However, that is for later work.
+#
+@dataclass
+class HeaderItem:
+    """Represent a FITS header card.
+
+    This does not support all FITS features.
+    """
+    name: str
+    """The keyword name (case insensitive)"""
+    value: Union[str, bool, int, float]  # will we need more?
+    """The keyword value"""
+    desc: Optional[str] = None
+    """The description for the keyword"""
+    unit: Optional[str] = None
+    """The units of the value"""
+
+
+@dataclass
+class Column:
+    """Represent a FITS column.
+
+    This does not support all FITS features.
+    """
+    name: str
+    """The name of the column (will be converted to upper case and leading/trailing spaces removed)."""
+    values: Any  # should be typed
+    """The values for the column, as a ndarray.
+
+    Variable-field arrays are represented as ndarrays with an object
+    type.
+    """
+    desc: Optional[str] = None
+    """The column description"""
+    unit: Optional[str] = None
+    """The units of the column"""
+
+    def __post_init__(self):
+        self.name = self.name.strip().upper()
+        if self.name == "":
+            raise ValueError("name can not be empty")
+
+
+# To be generic this should probably be split into Primary, Table, and
+# Image HDUs.
+#
+@dataclass
+class TableHDU:
+    """Represent a HDU: header and optional columns"""
+    name: str
+    """The name of the HDU (will be converted to upper case and leading/trailing spaces removed)."""
+    header: list[HeaderItem]
+    """The header values"""
+    data: Optional[list[Column]] = None
+    """The column data.
+
+    This should be empty for a primary header, and have at least one
+    entry for a table HDU.
+    """
+
+    def __post_init__(self):
+        self.name = self.name.strip().upper()
+        if self.name == "":
+            raise ValueError("name can not be empty")

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -68,7 +68,7 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
            'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data')
+           'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 def _has_hdu(hdulist, name):
@@ -1465,3 +1465,100 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     hdu = fits.table_to_hdu(tbl)
     hdu.name = 'TABLE'
     hdu.writeto(filename, overwrite=True)
+
+
+def _add_header(hdu, header):
+    """Add the header items to the HDU.
+
+    Parameters
+    ----------
+    hdu : astropy HDU
+    header : list of sherpa.astro.io.xstable.HeaderItem
+    """
+
+    for hdr in header:
+        card = [hdr.name, hdr.value]
+        if hdr.desc is not None or hdr.unit is not None:
+            comment = "" if hdr.unit is None else f"[{hdr.unit}] "
+            comment += "" if hdr.desc is None else hdr.desc
+            card.append(comment)
+
+        hdu.header.append(tuple(card))
+
+
+def _create_primary_hdu(hdu):
+    """Create a PRIMARY HDU.
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.io.xstable.TableHDU
+       Any data is ignored.
+
+    Returns
+    -------
+    out : astropy.io.fits.PrimaryHDU
+
+    """
+
+    out = fits.PrimaryHDU()
+    _add_header(out, hdu.header)
+    return out
+
+
+def _create_table_hdu(hdu):
+    """Create a Table HDU.
+
+    Parameters
+    ----------
+    hdu : sherpa.astro.io.xstable.TableHDU
+
+    Returns
+    -------
+    out : astropy.io.fits.BinTableHDU
+    """
+
+    if hdu.data is None:
+        raise ValueError("No column data to write out")
+
+    # First create a Table which handles the FITS column settings
+    # correctly.
+    #
+    store = []
+    colnames = []
+    for col in hdu.data:
+        colnames.append(col.name)
+        store.append(col.values)
+
+    out = fits.table_to_hdu(Table(names=colnames, data=store))
+    out.name = hdu.name
+    _add_header(out, hdu.header)
+
+    # Add any column metadata
+    #
+    for idx, col in enumerate(hdu.data, 1):
+        if col.unit is not None:
+            out.header.append((f"TUNIT{idx}", col.unit))
+
+        if col.desc is None:
+            continue
+
+        key = f"TTYPE{idx}"
+        out.header[key] = (col.name, col.desc)
+
+    return out
+
+
+def set_hdus(filename, hdulist, clobber=False):
+    """Write out multiple HDUS to a single file.
+
+    At present we are restricted to tables only.
+    """
+
+    check_clobber(filename, clobber)
+
+    out = fits.HDUList()
+    out.append(_create_primary_hdu(hdulist[0]))
+    for hdu in hdulist[1:]:
+        out.append(_create_table_hdu(hdu))
+
+    out.writeto(filename, overwrite=True)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1480,7 +1480,8 @@ def _add_header(hdu, header):
         card = [hdr.name, hdr.value]
         if hdr.desc is not None or hdr.unit is not None:
             comment = "" if hdr.unit is None else f"[{hdr.unit}] "
-            comment += "" if hdr.desc is None else hdr.desc
+            if hdr.desc is not None:
+                comment += hdr.desc
             card.append(comment)
 
         hdu.header.append(tuple(card))

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -974,7 +974,6 @@ def test_write_fake_perfect_rmf(offset, tmp_path):
     assert np.log10(new.ethresh) == pytest.approx(-10)
 
     hdr = new.header
-    print(hdr)
     assert "HDUNAME" not in hdr
     assert hdr["HDUCLASS"] == "OGIP"
     assert hdr["HDUCLAS1"] == "RESPONSE"
@@ -1102,9 +1101,8 @@ def test_read_multi_matrix_rmf(tmp_path, caplog):
     assert msg.endswith("/multi.rmf contains 2 MATRIX blocks; Sherpa only uses the first block!")
 
     lname, lvl, msg = caplog.record_tuples[1]
-    assert lname == io.backend.__name__
+    assert lname == "sherpa.astro.io"
     assert lvl == logging.ERROR
-    print(msg)
     assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
     assert msg.endswith("/multi.rmf'; Update the offset value in the RMF data set to the appropriate TLMIN value prior to fitting")
 
@@ -1211,17 +1209,10 @@ def test_write_rmf_fits_xmm_epn(make_data_path, tmp_path, caplog):
     rmfname = "epn_ff20_dY9.rmf"
     infile = make_data_path(rmfname)
 
-    # We get a TLMIN warning
+    # We do get a TLMIN warning (prior to 4.16 we did).
     assert len(caplog.record_tuples) == 0
     orig = io.read_rmf(infile)
-    assert len(caplog.record_tuples) == 1
-
-    lname, lvl, msg = caplog.record_tuples[0]
-    assert lname == io.backend.__name__
-    assert lvl == logging.ERROR
-    print(msg)
-    assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
-    assert msg.endswith("'; Update the offset value in the RMF data set to the appropriate TLMIN value prior to fitting")
+    assert len(caplog.record_tuples) == 0
 
     assert isinstance(orig, DataRMF)
     assert orig.name.endswith(f"/{rmfname}")
@@ -1231,7 +1222,7 @@ def test_write_rmf_fits_xmm_epn(make_data_path, tmp_path, caplog):
     outfile = str(outpath)
     io.write_rmf(outfile, orig)
     # Note: no TLMIN warning
-    assert len(caplog.record_tuples) == 1
+    assert len(caplog.record_tuples) == 0
 
     new = io.read_rmf(outfile)
     assert isinstance(new, DataRMF)

--- a/sherpa/astro/io/tests/test_io_xspec_table_model.py
+++ b/sherpa/astro/io/tests/test_io_xspec_table_model.py
@@ -1,0 +1,705 @@
+#
+#  Copyright (C) 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Can we write out XSPEC table models
+
+This can be done without the need for XSPEC. However, in
+order to check the models are sensible we need XSPEC to
+read them in.
+
+This is not a complete test of the functionality of table models, as
+that is assumed to be handled by XSPEC. This is to check we can write
+out the correct data and that it is handled correctly, but, for
+instance, we assume that if something works for additive models then
+it's likely to work for multiplicative models as well (we have other
+table-model tests that provide some of those checks).
+
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.io import xstable
+from sherpa.utils.err import IOErr
+from sherpa.utils.testing import requires_fits, requires_xspec
+
+
+@pytest.mark.parametrize("elo,ehi,msg",
+                         [ ([], [],
+                            "egrid_lo/hi can not be empty"),
+                           ([1, 2], [1, 2, 3],
+                            "egrid_lo/hi do not match: 2 vs 3"),
+                           ([1, 2, 3], [1, 2],
+                            "egrid_lo/hi do not match: 3 vs 2"),
+                           ([1, 2], [],
+                            "egrid_lo/hi do not match: 2 vs 0"),
+                           ([], [1, 2],
+                            "egrid_lo/hi do not match: 0 vs 2"),
+                           ([1, 2, 4], [2, 3, 5],
+                            "egrid_lo/hi are not consecutive"),
+                           ([1, 3, 4], [2, 4, 5],
+                            "egrid_lo/hi are not consecutive"),
+                           ([1, 2, 3, 3], [2, 3, 4, 5],
+                            "egrid_lo is not monotonically increasing"),
+                           ([1, 2, 3, 4], [2, 2, 3, 4],
+                            "egrid_hi is not monotonically increasing"),
+                           ([4, 3, 2, 1], [5, 4, 3, 2],
+                            "egrid_lo is not monotonically increasing")
+                         ])
+def test_check_valid_egrid(elo, ehi, msg):
+    """Check we catch some error-grid errors"""
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    model = [1, 2, 3, 4, 5]
+    with pytest.raises(ValueError, match=f"^{msg}$"):
+        xstable.make_xstable_model("fake", elo, ehi,
+                                   params=[p0], spectra=[model])
+
+
+def test_check_single_spectrum_size():
+    """Check we error out"""
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    model = [1, 2, 3, 4, 5]
+    with pytest.raises(ValueError, match="^Spectrum should have 3 elements but has 5$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model])
+
+
+
+def test_check_intparam_is_not_empty():
+    """I think we have to have at least one integrated parameter"""
+
+    model = [1, 2, 3]
+    with pytest.raises(ValueError, match="^params can not be empty$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[], spectra=[model])
+
+
+@pytest.mark.parametrize("initial,delta,hardmin,softmin,softmax,hardmax,msg",
+                         [(10, -1, 0, 0, 1, 1,
+                           "initial=10 outside softmin=0 to softmax=1"),
+                          (1, -1, 0.5, 0, 1, 1,
+                           "softmin=0 < hardmin=0.5"),
+                          (1, -1, 0, 0, 1, 0.5,
+                           "softmax=1 > hardmax=0.5"),
+                          (1, -1, 1, 1, 0, 0,
+                           "softmin=1 > softmax=0"),
+                         ])
+def test_check_param_valid(initial, delta, hardmin, softmin, softmax, hardmax, msg):
+    """Simple error checks"""
+
+    with pytest.raises(ValueError, match=f"^Parameter nop {msg}$"):
+        xstable.Param("nop", initial, delta,
+                      hardmin, hardmax, softmin=softmin, softmax=softmax)
+
+
+# Note these are subtly different to test_check_param_valid since some
+# of them have softmin/max set to None.
+#
+@pytest.mark.parametrize("initial,delta,hardmin,softmin,softmax,hardmax,values, msg",
+                         [(10, -1, 0, None, None, 1, [0, 1],
+                           "initial=10 outside softmin=0 to softmax=1"),
+                          (1, -1, 0, None, None, 1, [-10, 1],
+                           "hardmin=0 != first value=-10"),
+                          (1, -1, 0, None, None, 1, [0, 10],
+                           "hardmax=1 != last value=10"),
+                          (1, -1, 0.5, 0, 1, 1, [0, 1],
+                           "softmin=0 < hardmin=0.5"),
+                          (1, -1, 0, 0, 1, 0.5, [0, 1],
+                           "softmax=1 > hardmax=0.5"),
+                          (1, -1, 1, 1, 0, 0, [0, 1],
+                           "softmin=1 > softmax=0"),
+                          (1, -1, 0, None, 1, 1, [],
+                           "has no values"),
+                          (1, -1, 0, 0, None, 1, [0, 1, 1],
+                           "values are not monotonically increasing")
+                         ])
+def test_check_intparam_valid(initial, delta, hardmin, softmin, softmax, hardmax, values, msg):
+    """Simple error checks"""
+
+    with pytest.raises(ValueError, match=f"^Parameter nop {msg}$"):
+        xstable.IntParam("nop", initial, delta,
+                         hardmin, hardmax, softmin=softmin, softmax=softmax,
+                         values=values)
+
+
+def mk(n):
+    return xstable.IntParam(n, 0, 0.01, 0, 1, values=[0, 1])
+
+
+def mka(n):
+    return xstable.Param(n, 0, 0.01, 0, 1)
+
+
+@pytest.mark.parametrize("params,addparams",
+                         [([mk("a"), mk("b"), mk("A")], None),
+                          ([mk("a"), mk("b"), mk("x")], [mka("q"), mka("B")])
+                         ])
+def test_check_names_are_unique(params, addparams):
+    """Ensure parameter names are unique"""
+
+    elo = [1, 2, 3]
+    ehi = [2, 3, 4]
+    model = [1, 2, 3]
+    with pytest.raises(ValueError, match="^Parameter names are not unique$"):
+        xstable.make_xstable_model("fake", elo, ehi,
+                                   params=params, addparams=addparams,
+                                   spectra=[model] * 8)
+
+
+def test_check_expected_spectra_size():
+    """Expect 3 spectra but send in 2"""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 0.5, 1])
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Expected 3 spectra, found 2$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2])
+
+
+def test_check_additional_match():
+    """If we send in addparams we need addspectra and vice versa
+
+    This check is written with the knowledge the check is "symmetric",
+    so that if we send in addparams and addspectra is empty there's
+    also a failure.
+
+    """
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="Mismatch between addparams and addspectra sizes: 0 1"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2],
+                                   addspectra=[[model1, model2]])
+
+
+def test_check_additional_match_number_of_spectra():
+    """Check we send in the correct number of additional spectra."""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Expected 2 spectra for additional parameter bob, found 1$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2],
+                                   addparams=[ap0],
+                                   addspectra=[[model1]])
+
+
+def test_check_additional_match_spectra_size():
+    """Check the additional spectra nelem."""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Spectrum for parameter bob should have 3 elements but has 2$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0], spectra=[model1, model2],
+                                   addparams=[ap0],
+                                   addspectra=[[model1, [2, 3]]])
+
+
+def test_check_nxfp_match():
+    """When NXFP is set we need more spectra"""
+
+    p0 = xstable.IntParam("nop", 1, -1, 0, 1, values=[0, 1])
+    ap0 = xstable.Param("bob", 1, -1, 0, 1)
+    model1 = [1, 2, 3]
+    model2 = [2, 5, 6]
+    with pytest.raises(ValueError, match="^Expected 4 spectra, found 2$"):
+        xstable.make_xstable_model("fake", [1, 2, 3], [2, 3, 4],
+                                   params=[p0],
+                                   spectra=[model1, model2],
+                                   xfxp=["foo: 1", "foo: 2"])
+
+
+def make_single_model(elo, ehi, model, addmodel=True,
+                      redshift=False, escale=False,
+                      lolim=0, hilim=0):
+    """Create a single-spectrum model"""
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 12, values=[12])
+    return xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p0], spectra=[model],
+                                      addmodel=addmodel,
+                                      redshift=redshift,
+                                      escale=escale,
+                                      lolim=lolim, hilim=hilim)
+
+
+def load_tmod(lbl, filename):
+    """Read in an XSPEC table model.
+
+    The test must use the requires_xspec fixture.
+    """
+
+    from sherpa.astro.xspec import XSTableModel, read_xstable_model
+
+    mdl = read_xstable_model("foo", filename)
+    assert isinstance(mdl, XSTableModel)
+    return mdl
+
+
+@requires_xspec
+@requires_fits
+def test_atable_single_spectrum(tmp_path):
+    """Write out a model with a single spectrum.
+
+    There is no parameter interpolation here!
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    elo = [0.5, 0.7, 0.9]
+    ehi = [0.7, 0.9, 1.0]
+    model = [2, 4, 5]
+
+    hdus = make_single_model(elo, ehi, model)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 2
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # no apply normalization (the only parameter)
+    #
+    mdl.norm = 10
+    assert mdl(elo, ehi) == pytest.approx([20, 40, 50])
+
+    # Now check regridding and what happens outside the data range.
+    #
+    e2lo = [0.3, 0.4, 0.6, 0.8, 1.1]
+    e2hi = [0.4, 0.6, 0.8, 1.1, 1.2]
+
+    # This is what I expected, but XSPEC 12.13.1a does not return this
+    # (I have asked HEASARC for confirmation but let's just treat this
+    # as a regression test for now).
+    #
+    # expected = [0, 10, 10 + 20, 20 + 50, 0]
+    expected = [0, 0, 10 + 20, 20 + 50, 0]
+    assert mdl(e2lo, e2hi) == pytest.approx(expected)
+
+
+@requires_xspec
+@requires_fits
+def test_mtable_single_spectrum(tmp_path):
+    """Write out a model with a single spectrum.
+
+    There is no parameter interpolation here!
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    elo = [0.5, 0.7, 0.9]
+    ehi = [0.7, 0.9, 1.0]
+    model = [2, 4, 5]
+
+    hdus = make_single_model(elo, ehi, model, addmodel=False)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert not mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert not hasattr(mdl, "norm")
+    assert len(mdl.pars) == 1
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # Now check regridding and what happens outside the data range.
+    #
+    e2lo = [0.3, 0.4, 0.6, 0.8, 1.1]
+    e2hi = [0.4, 0.6, 0.8, 1.1, 1.2]
+
+    # This is a regression test based on the behavior of XSPEC 12.13.1a.
+    #
+    expected = [0, 0, 3, 14 / 3, 0]
+    assert mdl(e2lo, e2hi) == pytest.approx(expected)
+
+
+@requires_xspec
+@requires_fits
+def test_atable_interpolated(tmp_path):
+    """Write out a model with multiple parameters.
+
+    Two parameters:
+         a   0, 5, 10          linear
+         b   0.01, 0.1, 1, 10  logarithmic
+
+    This is more a regression test than a check that the interpolation
+    happens correctly (since we rely on XSPEC to do all of this for us
+    anyway).
+
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.5, 1.6, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    emid = (elo + ehi) / 2
+
+    p1 = xstable.IntParam("a", 1, 0.01, 0, 10, values=[0, 5, 10])
+    p2 = xstable.IntParam("b", 0.2, -0.01, 0.01, 10,
+                          values=[0.01, 0.1, 1, 10], loginterp=True)
+
+    def mkspec(pb, pa):
+        return (20 - pa) + 10**pb * emid
+
+    pvals = [(0.01, 0), (0.1, 0), (1, 0), (10, 0),
+             (0.01, 5), (0.1, 5), (1, 5), (10, 5),
+             (0.01, 10), (0.1, 10), (1, 10), (10, 10)]
+    spectra = [mkspec(*pv) for pv in pvals]
+
+    hdus = xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p1, p2], spectra=spectra)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "a")
+    assert hasattr(mdl, "b")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 3
+
+    assert mdl.a.val == pytest.approx(1)
+    assert mdl.a.min == pytest.approx(0)
+    assert mdl.a.max == pytest.approx(10)
+    assert not mdl.a.frozen
+
+    assert mdl.b.val == pytest.approx(0.2)
+    assert mdl.b.min == pytest.approx(0.01)
+    assert mdl.b.max == pytest.approx(10)
+    assert mdl.b.frozen
+
+    # Evaluate the model with no interpolation (ie 5,0.1 is one of the
+    # cases we sent in).
+    #
+    mdl.a = 5
+    mdl.b = 0.1
+    expected = mkspec(0.1, 5)
+    assert mdl(elo, ehi) == pytest.approx(expected)
+
+    # Evaluate the model with interpolation. We pick a parameter
+    # setting close enough we can use mkspec to generate the expected
+    # result, but the required tolerance in the check is now large (as
+    # the parameter values are not well chosen in this case). The
+    # tolerance may need to be increased for other platforms (this was
+    # generated with XSPEC 12.13.1a and Linux/x86).
+    #
+    mdl.a = 2
+    mdl.b = 0.09
+    expected = mkspec(0.09, 2)
+    assert mdl(elo, ehi) == pytest.approx(expected, rel=2e-3)
+
+
+@requires_xspec
+@requires_fits
+def test_atable_interpolated_with_additional(tmp_path):
+    """Write out a model with multiple parameters and "additional" ones.
+
+    Two parameters:
+         a   0, 5, 10          linear
+         b   0.01, 0.1, 1, 10  logarithmic
+
+    then two additional parameters
+         pa
+         pb
+
+    This is more a regressio test than a check that the interpolation
+    happens correctly (since we rely on XSPEC to do all of this for
+    us anyway).
+
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.5, 1.6, 0.1)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    emid = (elo + ehi) / 2
+
+    p1 = xstable.IntParam("a", 1, 0.01, 0, 10, values=[0, 5, 10])
+    p2 = xstable.IntParam("b", 0.2, -0.01, 0.01, 10,
+                          values=[0.01, 0.1, 1, 10], loginterp=True)
+
+    ap1 = xstable.Param("pa", 1, -0.01, 0, 10)
+    ap2 = xstable.Param("pb", 1, -0.01, 0, 10)
+
+    def mkspec(pb, pa):
+        return (20 - pa) + 10**pb * emid
+
+    # I do not understand how the additional spectra work with the
+    # parameter ranges, so just do something.
+    #
+    def mkaspec1(v):
+        return v * emid
+
+    def mkaspec2(v):
+        return v * np.ones_like(emid)
+
+    pvals = [(0.01, 0), (0.1, 0), (1, 0), (10, 0),
+             (0.01, 5), (0.1, 5), (1, 5), (10, 5),
+             (0.01, 10), (0.1, 10), (1, 10), (10, 10)]
+    spectra = [mkspec(*pv) for pv in pvals]
+    addspectra = [[mkaspec1(pv[0]) for pv in pvals],
+                  [mkaspec2(pv[1]) for pv in pvals]]
+
+    hdus = xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p1, p2], spectra=spectra,
+                                      addparams=[ap1, ap2],
+                                      addspectra=addspectra)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "a")
+    assert hasattr(mdl, "b")
+    assert hasattr(mdl, "pa")
+    assert hasattr(mdl, "pb")
+    assert not hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 5
+
+    assert mdl.a.val == pytest.approx(1)
+    assert mdl.a.min == pytest.approx(0)
+    assert mdl.a.max == pytest.approx(10)
+    assert not mdl.a.frozen
+
+    assert mdl.b.val == pytest.approx(0.2)
+    assert mdl.b.min == pytest.approx(0.01)
+    assert mdl.b.max == pytest.approx(10)
+    assert mdl.b.frozen
+
+    assert mdl.pa.val == pytest.approx(1)
+    assert mdl.pa.min == pytest.approx(0)
+    assert mdl.pa.max == pytest.approx(10)
+    assert mdl.pa.frozen
+
+    assert mdl.pb.val == pytest.approx(1)
+    assert mdl.pb.min == pytest.approx(0)
+    assert mdl.pb.max == pytest.approx(10)
+    assert mdl.pb.frozen
+
+    # A regression test.
+    #
+    mdl.a = 2
+    mdl.b = 0.09
+    mdl.pa = 2
+    mdl.pb = 2
+    expected = [22.791948, 22.93594, 23.079931, 23.223923,
+                23.367912, 23.511902, 23.655893, 23.799883,
+                23.943874, 24.087864]
+    assert mdl(elo, ehi) == pytest.approx(expected)
+
+
+# Used by test_addmodel_redshift/escale.
+#
+Z_POS = 69
+Z_AMPL = 1.9814928
+
+
+@requires_xspec
+@requires_fits
+def test_addmodel_resdhift(tmp_path, xsmodel):
+    """Can we add a redshift parameter to a table model?
+
+    Very-limited testing.
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.1, 2, 0.01)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    fake = xsmodel("gaussian")
+    fake.linee = 1.6
+    fake.norm = 50
+    model = fake(elo, ehi)
+
+    # check peak is where we expect
+    assert np.argmax(model) == 150
+    assert model[150] == pytest.approx(1.991392)
+
+    hdus = make_single_model(elo, ehi, model, redshift=True)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert not hasattr(mdl, "escale")
+    assert hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 3
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # Check the redshift
+    #
+    mdl.redshift = 1
+
+    got = mdl(elo, ehi)
+
+    # The peak should have changed
+    #
+    assert np.argmax(got) == Z_POS
+    assert got[Z_POS] == pytest.approx(Z_AMPL)
+
+
+@requires_xspec
+@requires_fits
+def test_addmodel_escale(tmp_path, xsmodel):
+    """Can we add a escale parameter to a table model?
+
+    Very-limited testing.
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    egrid = np.arange(0.1, 2, 0.01)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    fake = xsmodel("gaussian")
+    fake.linee = 1.6
+    fake.norm = 50
+    model = fake(elo, ehi)
+
+    # check peak is where we expect
+    assert np.argmax(model) == 150
+    assert model[150] == pytest.approx(1.991392)
+
+    hdus = make_single_model(elo, ehi, model, escale=True)
+    xstable.write_xstable_model(outfile, hdus)
+
+    mdl = load_tmod("foo", outfile)
+    assert mdl.addmodel
+
+    assert hasattr(mdl, "nop")
+    assert hasattr(mdl, "escale")
+    assert not hasattr(mdl, "redshift")
+    assert hasattr(mdl, "norm")
+    assert len(mdl.pars) == 3
+
+    assert mdl.nop.val == pytest.approx(12)
+    assert mdl.nop.min == pytest.approx(12)
+    assert mdl.nop.max == pytest.approx(12)
+    assert mdl.nop.frozen
+
+    # Evaluate the model with no interpolation
+    #
+    assert mdl(elo, ehi) == pytest.approx(model)
+
+    # Check the shift (it is not clear to me what escale actually does
+    # so this should be taken to be a regression test).
+    #
+    mdl.escale = 0.5
+
+    got = mdl(elo, ehi)
+
+    # The peak should have changed. We get the same shift as z=1
+    # but the normalization changes (so we tie this test to the
+    # redshift test).
+    #
+    assert np.argmax(got) == Z_POS
+    assert got[Z_POS] == pytest.approx(2 * Z_AMPL)
+
+
+@requires_xspec
+@requires_fits
+def test_atable_with_xfxp(tmp_path):
+    """Write out a model with XFXP keywords.
+
+    Note that Sherpa can not use these models. It is not entirely
+    clear what the keys are meant to be.
+
+    """
+
+    outpath = tmp_path / "xs.mod"
+    outfile = str(outpath)
+
+    elo = [0.5, 0.7, 0.9]
+    ehi = [0.7, 0.9, 1.0]
+    model1 = np.asarray([2, 4, 5])
+    model2 = np.asarray([5, 10, 40])
+
+    p0 = xstable.IntParam("nop", 12, -1, 12, 20, values=[12, 20])
+    hdus = xstable.make_xstable_model("fake", elo, ehi,
+                                      params=[p0],
+                                      spectra=[model1, model1 / 10,
+                                               model2, model2 / 10],
+                                      xfxp=["key: a", "key: b"])
+    xstable.write_xstable_model(outfile, hdus)
+
+    # We need a significant amount of work to support these models, so
+    # we error out for now.
+    #
+    with pytest.raises(IOErr, match="^No support for NXFLTEXP=2 in "):
+        load_tmod("foo", outfile)

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -131,6 +131,7 @@ from typing import Any, Optional, Union
 import numpy as np
 
 import sherpa
+from sherpa.astro.io.io_types import HeaderItem, Column, TableHDU
 
 
 __all__ = ("IntParam", "Param", "make_xstable_model",
@@ -241,64 +242,6 @@ class IntParam(Param):
             raise ValueError(f"Parameter {self.name} values are not monotonically increasing")
 
 
-# Perhaps the HeaderItem and Column types can be used in
-# sherpa.astro.io to pass information to and from the backends, rather
-# than the current system. However, that is for later work.
-#
-@dataclass
-class HeaderItem:
-    """Represent a FITS header card.
-
-    This does not support all FITS features.
-    """
-    name: str
-    """The keyword name (case insensitive)"""
-    value: Union[str, bool, int, float]  # will we need more?
-    """The keyword value"""
-    desc: Optional[str]
-    """The description for the keyword"""
-    unit: Optional[str]
-    """The units of the value"""
-
-
-@dataclass
-class Column:
-    """Represent a FITS column.
-
-    This does not support all FITS features.
-    """
-    name: str
-    """The column name (case insensitive)"""
-    values: Any  # should be typed
-    """The values for the column, as a ndarray.
-
-    Variable-field arrays are represented as ndarrays with an object
-    type.
-    """
-    desc: Optional[str]
-    """The column description"""
-    unit: Optional[str]
-    """The units of the column"""
-
-
-# To be generic this should probably be split into Primary, Table, and
-# Image HDUs.
-#
-@dataclass
-class TableHDU:
-    """Represent a HDU: header and optional columns"""
-    name: str
-    """The name of the HDU"""
-    header: list[HeaderItem]
-    """The header values"""
-    data: Optional[list[Column]] = None
-    """The column data.
-
-    This should be empty for a primary header, and have at least one
-    entry for a table HDU.
-    """
-
-
 def key(name: str,
         value: Union[str, bool, int, float],
         desc: Optional[str] = None,
@@ -388,12 +331,12 @@ def xstable_parameters(params: list[IntParam],
 
     # Provide the parameters and then the additional parameters.
     #
-    def get(field):
-        f1 = [getattr(p, field) for p in params]
+    def get(fld):
+        f1 = [getattr(p, fld) for p in params]
         if addparams is None:
             return f1
 
-        return f1 + [getattr(p, field) for p in addparams]
+        return f1 + [getattr(p, fld) for p in addparams]
 
     methods = [1 if p.loginterp else 0 for p in params] + [0] * nadd
     nvalues = [len(p.values) for p in params] + [0] * nadd

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -34,7 +34,7 @@ Example
 
 The following example creates an additive table model
 that represents a gaussian model where the only parameters are
-the line positon and the normalization.
+the line position and the normalization.
 
 >>> import numpy as np
 >>> from sherpa.astro.io import xstable
@@ -96,7 +96,7 @@ as a FITS file (`write_xstable_model`):
 ...                                   spectra=models)
 >>> xstable.write_xstable_model("example.mod", hdus, clobber=True)
 
-This file can the be used in Sherpa with either
+This file can then be used in Sherpa with either
 `sherpa.astro.ui.load_xstable_model` or
 `sherpa.astro.xspec.read_xstable_model`. For example:
 
@@ -115,11 +115,11 @@ Notes
 XSPEC models can be created without XSPEC support in Sherpa, but it is
 needed to read the files in.
 
-For additive models it is assumed that the model values - each those
-in each bin - have units of photon/cm^2/s. This is easy to
-accidentally change - e.g.  in the example above if mdl.norm were
-changed to a value other than 1 everything would work but Sherpa and
-XSPEC would infer incorrect fluxes or luminosities.
+For additive models it is assumed that the model values - that is,
+each bin - have units of photon/cm^2/s. This is easy to accidentally
+change - e.g.  in the example above if mdl.norm were changed to a
+value other than 1 everything would work but Sherpa and XSPEC would
+infer incorrect fluxes or luminosities.
 
 """
 
@@ -216,9 +216,7 @@ class IntParam(Param):
     """The parameter values used to create the model spectra.
 
     Is is required that they range from hardmin to hardmax and are in
-    monotonically increasing order. That is, it can not remain the
-    empty list.
-
+    monotonically increasing order (so it can not be an empty list).
     """
     loginterp: bool = False
     """Are the values logarithmically interpolated (True) or linearly (False).

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -1,0 +1,754 @@
+#
+#  Copyright (C) 2023
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Create XSPEC table models.
+
+This module supports creating and writing out `XSPEC table models
+<https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html>`_,
+which can then be read in by the
+`sherpa.astro.xspec.read_xstable_model` and
+`sherpa.astro.ui.load_xstable_model` routines.
+
+These routines should be considered experimental, as it is not
+obvious that the interface is as usable as it could be.
+
+Example
+-------
+
+The following example creates an additive table model
+that represents a gaussian model where the only parameters are
+the line positon and the normalization.
+
+>>> import numpy as np
+>>> from sherpa.astro.io import xstable
+>>> from sherpa.astro.xspec import XSgaussian
+
+We shall use the XSPEC gaussian model `sherpa.astro.xspec.XSgaussian`
+to create the template models.
+
+>>> mdl = XSgaussian()
+>>> print(mdl)
+gaussian
+   Param        Type          Value          Min          Max      Units
+   -----        ----          -----          ---          ---      -----
+   gaussian.LineE thawed          6.5            0        1e+06        keV
+   gaussian.Sigma thawed          0.1            0           20        keV
+   gaussian.norm thawed            1            0        1e+24
+
+The models will be evaluated over the 0.1 to 2 keV range, with
+a bin spacing of 0.01 keV (note that the last bin ends at 1.99 and
+not 2.0 keV thanks to the behavior of `numpy.arange`).
+
+>>> egrid = np.arange(0.1, 2, 0.01)
+>>> elo = egrid[:-1]
+>>> ehi = egrid[1:]
+>>> emid = (elo + ehi) / 2
+
+The table model will interpolate over the line position over
+the range of 0 to 2.4 inclusive, with a spacing of 0.1 keV:
+
+>>> linepos = np.arange(0, 2.5, 0.1)
+>>> minval = linepos[0]
+>>> maxval = linepos[-1]
+
+The model is evaluated over the grid defined by ``elo`` and ``ehi``
+for each element of ``linepos``, which is used to set the
+`sherpa.astro.xspec.XSgaussian.LineE` parameter:
+
+>>> models = []
+>>> for lp in linepos:
+...     mdl.linee = lp
+...     ymodel = mdl(elo, ehi)
+...     models.append(ymodel)
+...
+
+This model has a single interpolated parameter which we call
+``"pos"``.  Note that the delta parameter - here set to 0.01 - is only
+used by Sherpa to decide if the parameter is frozen (value is
+negative) or not, but is used by the optimiser in XSPEC. The values
+field is set to those used to generate the spectral models.
+
+>>> param = xstable.IntParam("pos", 1, 0.01, minval, maxval,
+...                          values=linepos)
+
+With this we can create the necessary information to create the
+table model (`make_xstable_model`) and then write it out
+as a FITS file (`write_xstable_model`):
+
+>>> hdus = xstable.make_xstable_model("gaussy", elo, ehi, params=[param],
+...                                   spectra=models)
+>>> xstable.write_xstable_model("example.mod", hdus, clobber=True)
+
+This file can the be used in Sherpa with either
+`sherpa.astro.ui.load_xstable_model` or
+`sherpa.astro.xspec.read_xstable_model`. For example:
+
+>>> from sherpa.astro import ui
+>>> ui.load_xstable_model("mygauss", "example.mod")
+>>> print(mygauss)
+xstablemodel.mygauss
+   Param        Type          Value          Min          Max      Units
+   -----        ----          -----          ---          ---      -----
+   mygauss.pos  thawed            1            0          2.4
+   mygauss.norm thawed            1            0        1e+24
+
+Notes
+-----
+
+XSPEC models can be created without XSPEC support in Sherpa, but it is
+needed to read the files in.
+
+For additive models it is assumed that the model values - each those
+in each bin - have units of photon/cm^2/s. This is easy to
+accidentally change - e.g.  in the example above if mdl.norm were
+changed to a value other than 1 everything would work but Sherpa and
+XSPEC would infer incorrect fluxes or luminosities.
+
+"""
+
+from dataclasses import dataclass, field
+import itertools
+import time
+from typing import Any, Optional, Union
+
+import numpy as np
+
+import sherpa
+
+
+__all__ = ("IntParam", "Param", "make_xstable_model",
+           "write_xstable_model")
+
+
+# In the typing support I have used Any to mean "ndarray".
+#
+
+@dataclass
+class Param:
+    """Represent a parameter.
+
+    The absolute DELTA value is used by XSPEC but ignored by Sherpa.
+    The sign of DELTA is used (by both Sherpa and XSPEC) to decide if
+    the parameter should be frozen (DELTA is negative) or not by
+    default.
+
+    """
+    name: str
+    """The parameter name.
+
+    This must be unique and ideally a valid attribute name in Python,
+    although the latter is not enforced.
+    """
+    initial: float
+    """The default value for the parameter."""
+    delta: float
+    """The delta value for fitting.
+
+    If negative then the parameter defaults to being frozen. Sherpa
+    does not use this value (other than checking the sign) but XSPEC
+    does.
+    """
+    hardmin: float
+    """The minimum value for the parameter."""
+    hardmax: float
+    """The maximum value for the parameter."""
+    softmin: Optional[float] = None
+    """The "soft" minimum. Defaults to hardmin if not given.."""
+    softmax: Optional[float] = None
+    """The "soft" maximum. Defaults to hardmax if not given."""
+
+    def __post_init__(self):
+        """Validate the settings"""
+
+        # Do we need to set up softmin/max?
+        #
+        if self.softmax is None:
+            self.softmax = self.hardmax
+
+        if self.softmin is None:
+            self.softmin = self.hardmin
+
+        # There should probably be a check that the name is not
+        # an invalid Python attribute name.
+        #
+        if self.name.strip() == "":
+            raise ValueError("name can not be empty")
+
+        if self.softmin < self.hardmin:
+            raise ValueError(f"Parameter {self.name} softmin={self.softmin} < hardmin={self.hardmin}")
+
+        if self.softmax > self.hardmax:
+            raise ValueError(f"Parameter {self.name} softmax={self.softmax} > hardmax={self.hardmax}")
+
+        # We allow min == max
+        if self.softmin > self.softmax:
+            raise ValueError(f"Parameter {self.name} softmin={self.softmin} > softmax={self.softmax}")
+
+        if self.initial < self.softmin or self.initial > self.softmax:
+            raise ValueError(f"Parameter {self.name} initial={self.initial} outside softmin={self.softmin} to softmax={self.softmax}")
+
+        if self.delta == 0:
+            raise ValueError("delta can not be 0")
+
+
+@dataclass
+class IntParam(Param):
+    """Represent an interpolated parameter."""
+
+    values: list[float] = field(default_factory=list)
+    """The parameter values used to create the model spectra.
+
+    Is is required that they range from hardmin to hardmax and are in
+    monotonically increasing order. That is, it can not remain the
+    empty list.
+
+    """
+    loginterp: bool = False
+    """Are the values logarithmically interpolated (True) or linearly (False).
+
+    Defaults to linear interpolation.
+    """
+
+    def __post_init__(self):
+        """Validate the settings"""
+        super().__post_init__()
+
+        if len(self.values) == 0:
+            raise ValueError(f"Parameter {self.name} has no values")
+
+        if self.values[0] != self.hardmin:
+            raise ValueError(f"Parameter {self.name} hardmin={self.hardmin} != first value={self.values[0]}")
+
+        if self.values[-1] != self.hardmax:
+            raise ValueError(f"Parameter {self.name} hardmax={self.hardmax} != last value={self.values[-1]}")
+
+        if np.any(np.diff(self.values) <= 0):
+            raise ValueError(f"Parameter {self.name} values are not monotonically increasing")
+
+
+# Perhaps the HeaderItem and Column types can be used in
+# sherpa.astro.io to pass information to and from the backends, rather
+# than the current system. However, that is for later work.
+#
+@dataclass
+class HeaderItem:
+    """Represent a FITS header card.
+
+    This does not support all FITS features.
+    """
+    name: str
+    """The keyword name (case insensitive)"""
+    value: Union[str, bool, int, float]  # will we need more?
+    """The keyword value"""
+    desc: Optional[str]
+    """The description for the keyword"""
+    unit: Optional[str]
+    """The units of the value"""
+
+
+@dataclass
+class Column:
+    """Represent a FITS column.
+
+    This does not support all FITS features.
+    """
+    name: str
+    """The column name (case insensitive)"""
+    values: Any  # should be typed
+    """The values for the column, as a ndarray.
+
+    Variable-field arrays are represented as ndarrays with an object
+    type.
+    """
+    desc: Optional[str]
+    """The column description"""
+    unit: Optional[str]
+    """The units of the column"""
+
+
+# To be generic this should probably be split into Primary, Table, and
+# Image HDUs.
+#
+@dataclass
+class TableHDU:
+    """Represent a HDU: header and optional columns"""
+    name: str
+    """The name of the HDU"""
+    header: list[HeaderItem]
+    """The header values"""
+    data: Optional[list[Column]] = None
+    """The column data.
+
+    This should be empty for a primary header, and have at least one
+    entry for a table HDU.
+    """
+
+
+def key(name: str,
+        value: Union[str, bool, int, float],
+        desc: Optional[str] = None,
+        unit: Optional[str] = None) -> HeaderItem:
+    "Easily make a HeaderItem"
+    return HeaderItem(name=name, value=value, desc=desc, unit=unit)
+
+
+def col(name: str,
+        values: Any,
+        desc: Optional[str] = None,
+        unit: Optional[str] = None) -> Column:
+    "Easily make a column"
+    return Column(name=name, values=values, desc=desc, unit=unit)
+
+
+def xstable_primary(name: str,
+                    unit: str,
+                    addmodel: bool,
+                    redshift: bool,
+                    escale: bool,
+                    lolim: float,
+                    hilim: float,
+                    xfxp: Optional[list[str]] = None) -> TableHDU:
+    """The PRIMARY block for an xspec table model."""
+
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUVERS", "1.2.0",
+            "version of format"),
+        key("MODlNAME", name, "Model name"),
+        key("MODLUNIT", unit, "Model units"),
+        key("ADDMODEL", addmodel,
+            "If T then this is an additive table model"),
+        key("REDSHIFT", redshift,
+            "If T then redshift will be a parameter"),
+        key("ESCALE", escale,
+            "If T then escale will be a parameter"),
+        key("LOELIMIT", lolim,
+            "Model value for energies below ENERGIES block"),
+        key("HIELIMIT", hilim,
+            "Model value for energies above ENERGIES block")
+    ]
+
+    if xfxp:
+        header.append(key("NXFLTEXP", len(xfxp),
+                          "Number of model spectra per grid point"))
+        for idx, val in enumerate(xfxp, 1):
+            header.append(key(f"XFXP{idx:04d}", val,
+                              f"The expression for model {idx}"))
+
+    # Let users know who created the file and when.
+    #
+    header.append(key("CREATOR",
+                      f"sherpa {sherpa.__version__}",
+                      "Code that created the file"))
+    header.append(key("DATE",
+                      time.strftime("%Y-%m-%dT%H:%M:%S"),
+                      "Date file created"))
+
+    return TableHDU(name="PRIMARY", header=header)
+
+
+def xstable_parameters(params: list[IntParam],
+                       addparams: Optional[list[Param]]) -> TableHDU:
+    """The PARAMETERS block for an xspec table model."""
+
+    nint = len(params)
+    nadd = 0 if addparams is None else len(addparams)
+    ntotal = nint + nadd
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUCLAS2", "PARAMETERS",
+            "extension containing parameter info"),
+        key("HDUVERS", "1.0.0", "version of format"),
+        key("NINTPARM", nint,
+            "Number of interpolation parameters"),
+        key("NADDPARM", nadd,
+            "Number of additional parameters")
+    ]
+
+    # Provide the parameters and then the additional parameters.
+    #
+    def get(field):
+        f1 = [getattr(p, field) for p in params]
+        if addparams is None:
+            return f1
+
+        return f1 + [getattr(p, field) for p in addparams]
+
+    methods = [1 if p.loginterp else 0 for p in params] + [0] * nadd
+    nvalues = [len(p.values) for p in params] + [0] * nadd
+
+    # Should the VALUE field use a variable-length field or not?
+    #
+    max_nvalues = max(nvalues)
+    if nint > 1 and max_nvalues > 3:
+        # The main array stores objects as each row can have different
+        # lengths.
+        #
+        # What is the best way to create an "empty" object array?
+        values = np.zeros(ntotal, dtype=object)
+        for idx, p in enumerate(params):
+            values[idx] = np.asarray(p.values, dtype=np.float32)
+
+        # Empty arrays for the additional arrays
+        for idx in range(nint, ntotal):
+            values[idx] = np.asarray([], dtype=np.float32)
+
+    else:
+        values = np.zeros((ntotal, max_nvalues), dtype=np.float32)
+        for idx, p in enumerate(params):
+            values[idx, :len(p.values)] = p.values
+
+    data = [
+        col("NAME", np.asarray(get("name"), dtype="U12"),
+            "name of the parameter"),
+        col("METHOD", np.asarray(methods, dtype=np.int32),
+            "0 if linear, 1 if logarithmic"),
+        col("INITIAL", np.asarray(get("initial"), dtype=np.float32),
+            "Starting point"),
+        col("DELTA", np.asarray(get("delta"), dtype=np.float32),
+            "If negative frozen by default"),
+        col("MINIMUM", np.asarray(get("hardmin"), dtype=np.float32),
+            "hard lower limit"),
+        col("BOTTOM", np.asarray(get("softmin"), dtype=np.float32),
+            "soft lower limit"),
+        col("TOP", np.asarray(get("softmax"), dtype=np.float32),
+            "soft upper limit"),
+        col("MAXIMUM", np.asarray(get("hardmax"), dtype=np.float32),
+            "hard upper limit"),
+        col("NUMBVALS", np.asarray(nvalues, dtype=np.int32),
+            "number of tabulated parameter values"),
+        col("VALUE", values, "tabulated parameter values")
+    ]
+    return TableHDU(name="PARAMETERS", header=header, data=data)
+
+
+def xstable_energies(energ_lo: Any, energ_hi: Any) -> TableHDU:
+    """The ENERGIES block for an xspec table model."""
+
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUCLAS2", "ENERGIES",
+            "extension containing energy bin info"),
+        key("HDUVERS", "1.0.0", "version of format")
+    ]
+    data = [
+        col("ENERG_LO", np.asarray(energ_lo, dtype=np.float32),
+            "Minimum energy of the bin", unit="keV"),
+        col("ENERG_HI", np.asarray(energ_hi, dtype=np.float32),
+            "Maximum energy of the bin", unit="keV"),
+    ]
+    return TableHDU(name="ENERGIES", header=header, data=data)
+
+
+def xstable_spectra(paramvals: list[tuple[float, ...]],
+                    spectra: list[Any],
+                    addparam: Optional[list[Param]],
+                    addspectra: Optional[list[list[Any]]],
+                    units: Optional[str]) -> TableHDU:
+    """The SPECTRA block for an xspec table model."""
+
+    header = [
+        key("HDUCLASS", "OGIP",
+            "format conforms to OGIP standard"),
+        key("HDUCLAS1", "XSPEC TABLE MODEL",
+            "model spectra for XSPEC"),
+        key("HDUCLAS2", "MODEL SPECTRA",
+            "extension containing model spectra"),
+        key("HDUVERS", "1.0.0",
+            "version of format")
+    ]
+
+    # The sizes have already been checked.
+    #
+    unit_opt = None if units == "" else units
+    pvals = np.asarray(paramvals, dtype=np.float32)
+    data = [
+        col("PARAMVAL", np.asarray(paramvals, dtype=np.float32),
+            "Parameter values for spectrum"),
+        col("INTPSPEC", np.asarray(spectra, dtype=np.float32),
+            "Spectrum for interpolated parameters",
+            unit=unit_opt)
+    ]
+
+    # Do we have any additional parameters?
+    #
+    if addparam is not None and addspectra is not None:
+        zipped = zip(addparam, addspectra)
+        for idx, (param, aspec) in enumerate(zipped, 1):
+            data.append(col(f"ADDSP{idx:03d}",
+                            np.asarray(aspec, dtype=np.float32),
+                            desc=f"Additional spectrum {idx:03d}: {param.name}",
+                            unit=unit_opt))
+
+    return TableHDU(name="SPECTRA", header=header, data=data)
+
+
+# We could either send in the parameter values broken up by parameter,
+# or as a list of those used to create spectra (either way, we to
+# deconstruct/reconstruct the other form).  For now we send them in
+# per-parameter, but it could be changed if this approach is found to
+# be more awkward for users.
+#
+def make_xstable_model(name: str,
+                       egrid_lo: Any,
+                       egrid_hi: Any,
+                       params: list[IntParam],
+                       spectra: list[Any],
+                       addparams: Optional[list[Param]] = None,
+                       addspectra: Optional[list[list[Any]]] = None,
+                       addmodel: bool = True,
+                       redshift: bool = False,
+                       escale: bool = False,
+                       lolim: float = 0,
+                       hilim: float = 0,
+                       units: Optional[str] = None,
+                       xfxp: Optional[list[str]] = None
+                       ) -> list[TableHDU]:
+    """Create the blocks for a XSPEC table model.
+
+    An XSPEC table model can be either additive or multiplicative,
+    contain 1 or more interpolated parameters, 0 or more additional
+    parameters, and support additional parameters (redshift and
+    escale), as well as setting the value to use outside the tabulated
+    energy range. The table defines the energy grid the models are
+    defined on, and the models used (one per set of parameters unless
+    the xfxp argument is set).
+
+    Parameters
+    ----------
+    name : str
+       The model name (stored in the table). Any spaces are removed.
+    egrid_lo, egrid_hi : sequence of float
+       The energy grid (in keV) used to define the spectra. It is
+       required that len(egrid_lo) == len(egrid_hi), the arrays are in
+       increasing order, that they are consecutive so that egrid_hi[i]
+       == egrid_lo[i + 1], and that egrid_lo[0] > 0.
+    params : sequence of Param
+       The definitions of the parameters used to interpolate the
+       models. It must have at least one element.
+    spectra : sequence of sequence of float
+       The spectra for each set of parameters in paramvals. It
+       is a 2D array of shape(nrows, len(egrid_lo)), and each row
+       matches the corresponding parameter grouping:
+       paramvals[0].values[i], paramvals[1].values[j], ..
+       where the first parameter loops the slowest. The number of rows
+       is the multiplication of the number of parameter values.
+    addparams : sequence of Param or None, optional
+       The definitions of the additional parametersm that is those
+       that are not interpolated over.
+    addspectra : sequence of sequence of sequence of float or None, optional
+       The spectra for the additonal parameters. It must is a 3D
+       array of shape (nrows, len(addparams), len(egrid_lo)).
+    addmodel : bool, optional
+       Is this an additive model (True) or a multiplicative one (False).
+       The default is True (additive).
+    redshift : bool, optional
+       Should the redshift parameter be added? The default is False.
+    escale : bool, optional
+       Should the escale parameter be added? The default is False.
+    lolim, hilim : bool, optional
+       The value to used when energies are below or above the values
+       in egrid_lo or egrid_hi.
+    units : str or None, optional
+       The model units. For additive models the default is
+       "photons/cm^2/s" and for multiplicative models it is "".
+    xfxp : sequence of str or None
+       If there are multiple spectra per parameter grid point, these
+       values give the expression to use (the number of elements is
+       the number of spectra per grid point). It is expected this is
+       None or has a length more than 1.
+
+    Returns
+    -------
+    hdus : list of TableHDU
+       The header and column data needed to create a FITS file.
+
+    See Also
+    --------
+    write_xstable_model
+
+    Notes
+    -----
+
+    This supports version 1.2.0 of the `XSPEC table model
+    specification
+    <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_92_009/ogip_92_009.html>`_,
+    although this code should be considered experimental.
+
+    It is not designed to be memory efficient, so for models that use
+    a large number of spectra, other tools may make more sense.
+
+    """
+
+    nxfxp = 1 if xfxp is None else len(xfxp)
+
+    # Not sure what the restrictions are, so just remove any spaces.
+    #
+    name_str = name.translate({32: None})
+
+    if units is None:
+        unit_str = "photons/cm^2/s" if addmodel else ""
+    else:
+        unit_str = units
+
+    # Check the parameter ranges make sense.
+    #
+    if len(params) == 0:
+        raise ValueError("params can not be empty")
+
+    # Check the parameter names are unique. We do a case-insensitive
+    # comparison, but we write out the user-specified name.
+    #
+    names = [p.name.lower() for p in params]
+    if addparams is not None:
+        names += [p.name.lower() for p in addparams]
+
+    snames = set(names)
+    if len(names) != len(snames):
+        raise ValueError(f"Parameter names are not unique")
+
+    # Check the additional parameters
+    #
+    nadd = 0 if addparams is None else len(addparams)
+    naddspec = 0 if addspectra is None else len(addspectra)
+    if nadd != naddspec:
+        raise ValueError(f"Mismatch between addparams and addspectra sizes: {nadd} {naddspec}")
+
+    # What are the parameter combinations? The last parameter
+    # loops fastest. If XFXP keyword are given then we have to
+    # replicate each set of parameters nxfxp times.
+    #
+    pvals_indiv = [p.values for p in params]
+    if nxfxp > 1:
+        pvals_indiv.append([0] * nxfxp)
+
+    pvalues = list(itertools.product(*pvals_indiv))
+    if nxfxp > 1:
+        # remove the fake parameter used to duplicate each row
+        pvalues = [pv[:-1] for pv in pvalues]
+
+    # Does pvalues match the expected number of spectra?
+    #
+    npvs = len(pvalues)
+    nspectra = len(spectra)
+    if npvs != nspectra:
+        raise ValueError(f"Expected {npvs} spectra, found {nspectra}")
+
+    if addspectra is not None:
+        for idx, aspec in enumerate(addspectra):
+            naspec = len(aspec)
+            if npvs != naspec:
+                # We should use a type that combines
+                # addparams/spectra but for now make mypy happy.
+                #
+                assert addparams is not None
+                raise ValueError(f"Expected {npvs} spectra for additional parameter {addparams[idx].name}, found {naspec}")
+
+    # Check the energy grid makes sense
+    nlo = len(egrid_lo)
+    nhi = len(egrid_hi)
+    if nlo != nhi:
+        raise ValueError(f"egrid_lo/hi do not match: {nlo} vs {nhi}")
+
+    if nlo == 0:
+        raise ValueError("egrid_lo/hi can not be empty")
+
+    if np.any(np.diff(egrid_lo) <= 0):
+        raise ValueError("egrid_lo is not monotonically increasing")
+
+    if np.any(np.diff(egrid_hi) <= 0):
+        raise ValueError("egrid_hi is not monotonically increasing")
+
+    # Technically we should do a Knuth-like numerical comparison here,
+    # but the assumption is that we created them so that they are
+    # consecutive, so it's okay for this check (and to try and stop
+    # yet-more-Xray-files-from-being-not-quite-valid(TM)).
+    #
+    if np.any(egrid_lo[1:] != egrid_hi[:-1]):
+        raise ValueError("egrid_lo/hi are not consecutive")
+
+    # Check we have the correct number of values in each spectrum.
+    #
+    for sp in spectra:
+        nsp = len(sp)
+        if nsp != nlo:
+            raise ValueError(f"Spectrum should have {nlo} elements "
+                             f"but has {nsp}")
+
+    if addspectra is not None:
+        for idx, aspecs in enumerate(addspectra):
+            for asp in aspecs:
+                nsp = len(asp)
+                if nsp != nlo:
+                    # We should use a type that combines
+                    # addparams/spectra but for now make mypy happy.
+                    #
+                    assert addparams is not None
+                    raise ValueError(f"Spectrum for parameter "
+                                     f"{addparams[idx].name} should "
+                                     f"have {nlo} elements but has {nsp}")
+
+    # Create the separate blocks.
+    #
+    out = []
+    out.append(xstable_primary(name_str, unit_str, bool(addmodel),
+                               bool(redshift), bool(escale),
+                               float(lolim), float(hilim),
+                               xfxp=xfxp))
+    out.append(xstable_parameters(params, addparams))
+    out.append(xstable_energies(egrid_lo, egrid_hi))
+    out.append(xstable_spectra(pvalues, spectra, addparams, addspectra,
+                               units=unit_str))
+    return out
+
+
+def write_xstable_model(filename: str,
+                        hdus: list[TableHDU],
+                        clobber: bool = False) -> None:
+    """Write a XSPEC table model to disk.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to create.
+    hdus : list of TableHDU
+        The output of make_xstable_model.
+    clobber : bool, optional
+       If `True` then the output file will be over-written if it
+       already exists, otherwise an error is raised.
+
+    See Also
+    --------
+    make_xstable_model
+
+    """
+
+    from sherpa.astro import io
+    assert io.backend is not None  # for mypy
+    io.backend.set_hdus(filename, hdus, clobber=clobber)

--- a/sherpa/astro/tests/test_astro_data_rosat_unit.py
+++ b/sherpa/astro/tests/test_astro_data_rosat_unit.py
@@ -379,18 +379,9 @@ def test_read_rmf(make_data_path):
 def test_read_rmf_fails_pha(make_data_path):
     """Just check in we can't read in a PHA file as a RMF."""
 
-    if backend_is("pyfits"):
-        emsg = " does not appear to be an RMF"
-    elif backend_is("crates"):
-        emsg = "Required column 'ENERG_LO' not found in "
-    else:
-        assert False, f"Internal error: unknown backend {io.backend}"
-
     infile = make_data_path(PHAFILE)
-    with pytest.raises(IOErr) as excinfo:
+    with pytest.raises(IOErr, match=" does not appear to be an RMF"):
         io.read_rmf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -132,10 +132,8 @@ def test_read_pha_fails_arf(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(ARFFILE)
-    with pytest.raises(etype) as excinfo:
+    with pytest.raises(etype, match=emsg):
         io.read_pha(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data
@@ -153,10 +151,8 @@ def test_read_pha_fails_rmf(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(RMFFILE)
-    with pytest.raises(etype) as excinfo:
+    with pytest.raises(etype, match=emsg):
         io.read_pha(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 def validate_replacement_warning(ws, rtype, label):
@@ -223,10 +219,8 @@ def test_read_arf_fails_pha(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(PHAFILE)
-    with pytest.raises(IOErr) as excinfo:
+    with pytest.raises(IOErr, match=emsg):
         io.read_arf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data
@@ -242,10 +236,8 @@ def test_read_arf_fails_rmf(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(RMFFILE)
-    with pytest.raises(IOErr) as excinfo:
+    with pytest.raises(IOErr, match=emsg):
         io.read_arf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data
@@ -321,10 +313,8 @@ def test_read_rmf_fails_pha(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(PHAFILE)
-    with pytest.raises(etype) as excinfo:
+    with pytest.raises(etype, match=emsg):
         io.read_rmf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data
@@ -333,7 +323,7 @@ def test_read_rmf_fails_arf(make_data_path):
     """Just check in we can't read in a ARF as a RMF."""
 
     if backend_is("pyfits"):
-        emsg = " does not have a 'DETCHANS' keyword"
+        emsg = " does not appear to be an RMF"
         etype = IOErr
     elif backend_is("crates"):
         emsg = " does not contain a Response Matrix."
@@ -342,10 +332,8 @@ def test_read_rmf_fails_arf(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(ARFFILE)
-    with pytest.raises(etype) as excinfo:
+    with pytest.raises(etype, match=emsg):
         io.read_rmf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data


### PR DESCRIPTION
I've moved some logic into #1912 to warn a user when a multi-matrix RMF is found. Need to think more about the imlpementation (the following is a good start but need to think more about the design).

It now looks like I'll be doing the work in #1921 but I'll leave this open as it'll help me review things.

Actually
- #1944
replaces this PR.

# Summary

Support reading in RMF files with multiple matrix blocks from OGIP Calibration Memo CAL/GEN/92-002  https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html. This support should be considered experimental at this time.

As part of this work the handling of error conditions in both the crates and pyfits backend has changed, so that different errors may be reported compared to earlier versions of Sherpa. 

# Details

This requires

- #1861

as I use some of the new types added in that PR.

Can we handle multi-MATRIX RMF blocks? We have a decision on how to handle this - do we extend `DataRMF` or do we handle this within the multiple-response instrument code? When extending `DataRMF` we have

- [+] it should be seamless to the user (e.g. no difference to using a "normal" RMF)
- [-] this overloads the meaning of the `DataRMF` fields and subverts OO methodology - e.g. https://en.wikipedia.org/wiki/Liskov_substitution_principle
  - I will note we have existing code that does this already, so this is not new 
 
Using the multiple-response code might be nice, but it would require significant work on the part of the user, and it's not clear what should be done.

I have therefore opted to add a `DataMultiRMF` class that extends `DataRMF` since I think the ease-of-use argument is very important. I am slapping on a "this is experimental" notice so we can change it if we find this ends up not working well. I will note that I wrote #1907 in large-part because of this PR, and I think it is something to look at post the 4.16 release (no matter what approach we take for this PR).

There are a surprising number of commits before we get to adding multi-matrix support as

- we had cruft to clean up
- I wanted to add support for multi-matrix RMFs in stages to hopefully make it easier to review and so that we can stop at any point and say "this may not do everything" but does at least move the needle
  - in particular, the existing Sherpa code does not have any idea that multi-matrix files exist (and, in fact, the specification does not make it possible to know we have such a file) and so it is possible to read in one of these RMFs and only get one of the matrices used (and we can't guarantee which one it will be); at least know (with some of the commits,  a user would at least know they've lost data up until the commit where we add support)

As with #1861 - which this PR builds on - I've added dataclasses to describe the data we want to send from the backend to the io layer to describe a RMF. This is instead of just passing around a dictionary with keywords we just have to agree on. These structures have guided the change from supporting a "single matrix" to allowing multiple ones.

For testing, as we don't have a real-world example, I have just created a "fake" response. This response is the combination of a "perfect" grid together with a blurry one, and we can see as the commits progress how much of it we can use.

In doing the clean-up work there has been some changes to both the crates and pyfits handling of error conditions. This has generally removed differences between the two backend, as well as centralizing at least one check (so it's now done in the generic IO code rather than in the backends). The main point is that code will still error out but maybe in a slightly-different manner to before. There are **some** cases which would have worked before but now fail, but these are cases where the RMF does not meet the OGIP standard - e.g. see #1871 - and we do not have tests that fail with the new code, so I claim this is over-engineered code we should clean up. At some point. Which is not now. Other than the clean up I have done.

Since AstroPy just reads in the raw data, the changes needed are not too significant. For the crates backend we were using the RMFCrateDataset to read in data, but this does not support multiple matrices (and will not for the 4.16 release) so we have to augment the existing code. We do so by still using RMFCrateDataset, so we still behave the same with radically-invalid input files (i.e. this is only about error-ing out with invalid data) but then we switch to CrateDataset to read in all the data. The API allows a user to send in a RMFCrateDataset in [just like for AstroPy/pyfints they can send a HDUList in] which we support but users of that will not be able to handle multi-matrix RMF files. I do not believe there are any people who do this because we do not document it (i.e. they would need to be calling routines from `crates_backend` directly), and because there is no way to be sure we have been given a multi-matrix file when looking at a single MATRIX block.

# Issues

One issue is that we only have the spec documentation. There aren't really any files lying around with real data (maybe from XRISM?) which makes testing this out and checking it works properly a bit awkward.

You can not write out a multi-matrix RMF (via `write_rmf`). This should be fixable.

The "representation" of a multi-matrix RMF hides all but the first block - e.g. print(rmf) - which is not ideal. This should be fixable. I think the new `plot_rmf` command should work but I can not be sure.

In part because we have some strange non-OGIP cases (#1871) and in part because of the existing API (#1907) I am not 100% convinced there aren't bugs hiding here.

The new RMF does not do any of the fancy "ignore/notice" handling that `DataRMF` does. I should have this "disabled", but I did mention the issue of hidden bugs, didn't I?

