### PR TITLE
un-whitelist deprecation warnings

### DIFF
--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -110,16 +110,7 @@ known_warnings = {
         [
             r"unorderable dtypes.*",
             r"Non-string object detected for the array ordering.*",
-            r"using a non-integer number instead of an integer will result in an error in the future",
             r"Use load_xstable_model to load XSPEC table models",
-            #  This does not have to do with Sherpa and is coming from some versions of
-            #  jupyter_client
-            r"metadata .* was set from the constructor.*",
-
-            # Matplotlib version 2 warnings (from HTML notebook represention)
-            #
-            r'np.asscalar\(a\) is deprecated since NumPy v1.16, use a.item\(\) instead',
-            r"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working",
 
             # NumPy 1.25 warnings that are raised by (mid-2023) crates code.
             # Hopefully this can be removed by December 2023.
@@ -157,13 +148,6 @@ known_warnings = {
         ],
     RuntimeWarning:
         [r"invalid value encountered in sqrt",
-         # See https://github.com/ContinuumIO/anaconda-issues/issues/6678
-         r"numpy.dtype size changed, may indicate binary " +
-         r"incompatibility. Expected 96, got 88",
-         # See https://github.com/numpy/numpy/pull/432
-         r"numpy.ufunc size changed",
-         # numpy 1.20 shows this in some tests
-         r"numpy.ndarray size changed, may indicate binary "
          ],
     ResourceWarning:
         [


### PR DESCRIPTION
We have whitelisted a number of deprecation warnings and others in our testing. I believe that some of them are not longer relevant and thus should be removed. I'm pushing this as a PR so we get CI to run and see if any of our current tests fail with this.

Some of them date back to the Python 2.7 era according to a git blame.

Why do I care? I just had tests fail locally with an "np.asscalar\(a\) is deprecated" and I wondered why. I looked into Sherpa and did not find the string "asscalar" anywhere (because @DougBurke probably fixed that years ago). So, why did my test fail locally? Well, I had a recent version of numpy where assaclar has actually been removed and an older version of one of our other dependencies (astropy), which still used it. Since we whitelist this warning (even after Sherpa itself has been fixed) I;d never noticed that that particular environment still had such an old version of astropy. 

So, I might as well try and see how many of those warning we can remove from our whitelist and still pass our current matrix of tests.