### PR TITLE
Remove defaults channel in CI to avoid conflicts with conda-forge

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -29,6 +29,8 @@ source ${CONDA}/etc/profile.d/conda.sh
 # update and add channels
 conda update --yes conda
 conda config --add channels conda-forge
+#Remove defaults to avoid conflicts with conda-forge
+conda config --remove channels defaults
 
 # To avoid issues with non-XSPEC builds (e.g.
 # https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )


### PR DESCRIPTION
This is an attempt to address #1884. Will check the CI to see if this resolves the issues.

**Background**
Currently, our "deployment" pipeline works because we install Miniforge for Conda (which already has defaults removed). For the development pipeline, the pre-installed miniconda on the GitHub Actions Linux runner does include defaults. We switched to conda-forge for dependencies (adding the channel in the process), but did not remove defaults as an option for the dev workflow. This change does that. 