### PR TITLE
UI: set_analysis reports the filter change - fix #1590

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -2552,6 +2552,15 @@ def test_set_analysis_messages(caplog):
     clc_filter(caplog, "dataset foo: no data", astro=True, pos=5)
 
 
+def test_set_analysis_no_data():
+    """What happens with no data"""
+
+    s = AstroSession()
+    with pytest.raises(IdentifierErr,
+                       match="^No data sets found$"):
+        s.set_analysis("energy")
+
+
 @pytest.mark.parametrize("session,emsg",
                          [(Session, r"save_delchi\(\) can not be used with 2D datasets"),
                           (AstroSession, r"save_delchi\(\) does not apply for images")])

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -74,10 +74,11 @@ def check_last_caplog(caplog, lname, lvl, msg):
     assert msg_got == msg
 
 
-def clc_filter(caplog, msg):
+def clc_filter(caplog, msg, astro=False):
     """Special case for the ignore/notice filter check"""
 
-    check_last_caplog(caplog, "sherpa.ui.utils", logging.INFO, msg)
+    reporter = "sherpa.astro.ui.utils" if astro else "sherpa.ui.utils"
+    check_last_caplog(caplog, reporter, logging.INFO, msg)
 
 
 @requires_fits
@@ -553,23 +554,28 @@ def test_notice_reporting_datapha_with_response(caplog):
 
     # switch analysis units so the ignore call returns different values
     s.set_analysis("wave")
+    assert len(caplog.record_tuples) == 3
+    clc_filter(caplog, "dataset 1: 6.19921:6.88801,7.29319:9.53725 Wavelength (Angstrom)",
+               astro=True)
 
     s.ignore_id(1)
-    assert len(caplog.record_tuples) == 3
+    assert len(caplog.record_tuples) == 4
     clc_filter(caplog, "dataset 1: 6.19921:6.88801,7.29319:9.53725 Wavelength (Angstrom) -> no data")
 
     s.ignore()
-    assert len(caplog.record_tuples) == 4
+    assert len(caplog.record_tuples) == 5
     clc_filter(caplog, "dataset 1: no data (unchanged)")
 
     s.notice(8, 12)
-    assert len(caplog.record_tuples) == 5
+    assert len(caplog.record_tuples) == 6
     clc_filter(caplog, "dataset 1: no data -> 7.74901:12.3984 Wavelength (Angstrom)")
 
     s.set_analysis("chan")
+    assert len(caplog.record_tuples) == 7
+    clc_filter(caplog, "dataset 1: 10:15 Channel", astro=True)
 
     s.notice_id(1)
-    assert len(caplog.record_tuples) == 6
+    assert len(caplog.record_tuples) == 8
     clc_filter(caplog, "dataset 1: 10:15 -> 1:19 Channel")
 
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6559,7 +6559,8 @@ class Session(sherpa.ui.utils.Session):
            If the given dataset does not contain a response.
 
         sherpa.utils.err.IdentifierErr
-           If the `id` argument is not recognized.
+           If the `id` argument is not recognized or no data has been
+           loaded.
 
         See Also
         --------
@@ -6605,15 +6606,18 @@ class Session(sherpa.ui.utils.Session):
         _check_str_type(quantity, "quantity")
         _check_str_type(type, "type")
 
-        ids = self.list_data_ids()
         if id is not None:
             ids = [id]
+        else:
+            ids = self.list_data_ids()
+            if len(ids) == 0:
+                raise IdentifierErr("nodatasets")
 
-        for id in ids:
+        for idval in ids:
             # We do not use _pha_report_filter_change as that assumes
             # the quantity hasn't changed.
             #
-            data = self._get_pha_data(id, bkg_id=None)
+            data = self._get_pha_data(idval, bkg_id=None)
             data.set_analysis(quantity=quantity, type=type, factor=factor)
 
             nfilter = sherpa.ui.utils._get_filter(data)
@@ -6625,7 +6629,7 @@ class Session(sherpa.ui.utils.Session):
             else:
                 fstring = f"{nfilter} {data.get_xlabel()}"
 
-            info(f"dataset {id}: {fstring}")
+            info(f"dataset {idval}: {fstring}")
 
     def get_analysis(self, id=None):
         """Return the units used when fitting spectral data.
@@ -6746,12 +6750,12 @@ class Session(sherpa.ui.utils.Session):
 
         _check_str_type(coord, "coord")
 
-        ids = self.list_data_ids()
         if id is not None:
             ids = [id]
-
-        if len(ids) == 0:
-            raise IdentifierErr('nodatasets')
+        else:
+            ids = self.list_data_ids()
+            if len(ids) == 0:
+                raise IdentifierErr("nodatasets")
 
         for id in ids:
             self._get_img_data(id).set_coord(coord)


### PR DESCRIPTION
# Summary

The sherpa.astro.ui.set_analysis call now reports the new filter. It will also now error out if no data has been loaded. Fix #1590 and #1368.

# Details

This follows notice/ignore (#1562) and group_xxx (#1637) changes to report the filter for any dataset that set_analysis operates on. Unfortunately it can't easily use the code used in the previous PRs since that doesn't support the "analysis units" changing, which is the main reason for set_analysis! So the code does it manually, but it's not a lot of code.

The fix for #1368 is also done here because it's in the same bit of code and is an easy fix.
Fix #1368

# Example

Let's load up two ACIS files (one grouped, one not, and an XMM file)

```
>>> from sherpa.astro.ui import *
>>> load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi' 
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi' 
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi
>>> load_pha("foo", "sherpa-test-data/sherpatest/9774.pi")
read ARF file sherpa-test-data/sherpatest/9774.arf
read RMF file sherpa-test-data/sherpatest/9774.rmf
read background file sherpa-test-data/sherpatest/9774_bg.pi
>>> load_pha(44, "sherpa-test-data/sherpatest/pn_pi_src_bin10.ds")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/pn_pi_src_bin10.ds'
statistical errors were found in file 'sherpa-test-data/sherpatest/pn_pi_src_bin10.ds' 
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/pn_pi_src.arf
WARNING: file '/data/anto/xmm/rmf/epn_ff20_sdY9.rmf' not found
WARNING: file 'sherpa-test-data/sherpatest/pn_pi_bgd.ds' not found
>>> load_rmf(44, "sherpa-test-data/sherpatest/epn_ff20_dY9.rmf")
ERROR: Failed to locate TLMIN keyword for F_CHAN column in RMF file 'sherpa-test-data/sherpatest/epn_ff20_dY9.rmf'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting
```

We can now set the noticed range for 0.5 to 6 keV:

```
>>> notice(0.5, 6)
dataset 1: 0.00146:14.9504 -> 0.4672:6.57 Energy (keV)
dataset 44: 0:20.48 -> 0.483874:6 Energy (keV)
dataset foo: 0.00146:14.9504 -> 0.4964:6.0006 Energy (keV)
```

If we call `set_analysis` we now get info on the new settings:

```
>>> set_analysis("channel")
dataset 1: 33:450 Channel
dataset 44: 91:1200 Channel
dataset foo: 35:411 Channel
```

You can change an individual dataset:

```
>>> set_analysis(44, "wave")
dataset 44: 2.0664:25.6233 Wavelength (Angstrom)
```

We can change all datasets at once:

```
>>> set_analysis("wave")
dataset 1: 1.88713:26.5377 Wavelength (Angstrom)
dataset 44: 2.0664:25.6233 Wavelength (Angstrom)
dataset foo: 2.0662:24.9767 Wavelength (Angstrom)
```

We could mirror `notice`/`ignore` and not the change in the filter (e.g. going from "33:45 Channel" to "1.887:23.43 Wavelength (Angstrom)" say), but I really think that just adds more complication than is needed here, and is likely to lead to more user confusion. We could identify those datasets where the analysis setting hasn't changed and add a " (unchanged)" label, like we do for `notice`/`group_xxx`, but again I don't thin it's worth it (dataset 44 is an example for this in the call above).



