### PR TITLE
data: group backgrounds before source - fix #1881

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3509,11 +3509,12 @@ It is an integer or string.
         the quality value for these channels will be set to 2.
 
         """
-        self._dynamic_group("grpNumBins", len(self.channel), num,
-                            tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
             bkg.group_bins(num, tabStops=tabStops)
+
+        self._dynamic_group("grpNumBins", len(self.channel), num,
+                            tabStops=tabStops)
 
     def group_width(self, val, tabStops=None):
         """Group into a fixed bin width.
@@ -3551,11 +3552,12 @@ It is an integer or string.
         for these channels will be set to 2.
 
         """
-        self._dynamic_group("grpBinWidth", len(self.channel), val,
-                            tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
             bkg.group_width(val, tabStops=tabStops)
+
+        self._dynamic_group("grpBinWidth", len(self.channel), val,
+                            tabStops=tabStops)
 
     def group_counts(self, num, maxLength=None, tabStops=None):
         """Group into a minimum number of counts per bin.
@@ -3597,11 +3599,12 @@ It is an integer or string.
         quality value for these channels will be set to 2.
 
         """
-        self._dynamic_group("grpNumCounts", self.counts, num,
-                            maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
             bkg.group_counts(num, maxLength=maxLength, tabStops=tabStops)
+
+        self._dynamic_group("grpNumCounts", self.counts, num,
+                            maxLength=maxLength, tabStops=tabStops)
 
     # DOC-TODO: see discussion in astro.ui.utils regarding errorCol
     def group_snr(self, snr, maxLength=None, tabStops=None, errorCol=None):
@@ -3650,13 +3653,14 @@ It is an integer or string.
         quality value for these channels will be set to 2.
 
         """
-        self._dynamic_group("grpSnr", self.counts, snr,
-                            maxLength=maxLength, tabStops=tabStops,
-                            errorCol=errorCol)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
             bkg.group_snr(snr, maxLength=maxLength, tabStops=tabStops,
                           errorCol=errorCol)
+
+        self._dynamic_group("grpSnr", self.counts, snr,
+                            maxLength=maxLength, tabStops=tabStops,
+                            errorCol=errorCol)
 
     def group_adapt(self, minimum, maxLength=None, tabStops=None):
         """Adaptively group to a minimum number of counts.
@@ -3701,12 +3705,13 @@ It is an integer or string.
         quality value for these channels will be set to 2.
 
         """
-        self._dynamic_group("grpAdaptive", self.counts, minimum,
-                            maxLength=maxLength, tabStops=tabStops)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
             bkg.group_adapt(minimum, maxLength=maxLength,
                             tabStops=tabStops)
+
+        self._dynamic_group("grpAdaptive", self.counts, minimum,
+                            maxLength=maxLength, tabStops=tabStops)
 
     # DOC-TODO: see discussion in astro.ui.utils regarding errorCol
     def group_adapt_snr(self, minimum, maxLength=None, tabStops=None,
@@ -3759,13 +3764,14 @@ It is an integer or string.
         quality value for these channels will be set to 2.
 
         """
-        self._dynamic_group("grpAdaptiveSnr", self.counts, minimum,
-                            maxLength=maxLength, tabStops=tabStops,
-                            errorCol=errorCol)
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
             bkg.group_adapt_snr(minimum, maxLength=maxLength,
                                 tabStops=tabStops, errorCol=errorCol)
+
+        self._dynamic_group("grpAdaptiveSnr", self.counts, minimum,
+                            maxLength=maxLength, tabStops=tabStops,
+                            errorCol=errorCol)
 
     def eval_model_to_fit(self, modelfunc):
         model = super().eval_model_to_fit(modelfunc)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3720,7 +3720,6 @@ def test_pha_group_xxx_with_background(caplog):
     # Pick something which creates different grouping for source and
     # background.
     #
-    assert len(caplog.records) == 0
     with caplog.at_level(logging.INFO, logger='sherpa'):
         src.group_counts(4)
 
@@ -3732,8 +3731,4 @@ def test_pha_group_xxx_with_background(caplog):
     assert src.grouped
     assert bkg.grouped
 
-    assert len(caplog.records) == 1
-    rec = caplog.records[0]
-    assert rec.levelname == "INFO"
-    assert rec.module == "data"
-    assert rec.getMessage() == "data set 'bkg' does not specify grouping flags"
+    assert len(caplog.records) == 0

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3694,3 +3694,46 @@ def test_pha_checks_background_size_is_set_bkg():
     with pytest.raises(DataErr,
                        match="^The channel field of the background must be set$"):
         pha.set_background(bkg)
+
+
+def test_pha_group_xxx_with_background(caplog):
+    """Do we get any warning from the background?
+
+    Assume we can test just one of the group_xxx routines.
+
+    This is issue #1881.
+    """
+
+    chans = [1, 2, 3, 4, 5]
+    src = DataPHA("src", chans, [4, 2, 3, 2, 1])
+    bkg = DataPHA("bkg", chans, [1, 2, 0, 2, 2])
+    src.set_background(bkg)
+
+    assert src.grouping is None
+    assert src.quality is None
+    assert bkg.grouping is None
+    assert bkg.quality is None
+
+    assert not src.grouped
+    assert not bkg.grouped
+
+    # Pick something which creates different grouping for source and
+    # background.
+    #
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.INFO, logger='sherpa'):
+        src.group_counts(4)
+
+    assert src.grouping == pytest.approx([1, 1, -1, 1, -1])
+    assert src.quality == pytest.approx([0, 0, 0, 2, 2])
+    assert bkg.grouping == pytest.approx([1, -1, -1, -1, 1])
+    assert bkg.quality == pytest.approx([0, 0, 0, 0, 2])
+
+    assert src.grouped
+    assert bkg.grouped
+
+    assert len(caplog.records) == 1
+    rec = caplog.records[0]
+    assert rec.levelname == "INFO"
+    assert rec.module == "data"
+    assert rec.getMessage() == "data set 'bkg' does not specify grouping flags"


### PR DESCRIPTION
# Summary

Change the ordering of operations when grouping background PHA datasets. Fix #1881 

# Details

With the way the grouping was working, we tried to group the backgrounds before they necessarily had any grouping flags. This would then lead to the background dataset complaining that there was no grouping data, which was confusing for the user. This PR changes the order.

The reason for this is that the DataPHA `group` method now automatically groups any associated background datasets, which was added for 4.15.1 in 

- #1660 

to fix
- #1657

Oh, what a tangled web we weave.

# Example

In CIAO 4.15 we have

```
sherpa In [2]: load_pha("sherpa-test-data/sherpatest/9774.pi")
OSError: File sherpa-test-data/sherpatest/9774.pi does not exist.

sherpa In [3]: load_pha("9774.pi")
read ARF file 9774.arf
read RMF file 9774.rmf
read background file 9774_bg.pi

sherpa In [4]: get_bkg().grouping is None
Out[4]: True

sherpa In [5]: group_counts(20)

sherpa In [6]: get_bkg().grouping is None
Out[6]: False
```

In Sherpa 4.15.1 we have the errant warning line (thanks to #1660)

```
>>> load_pha("sherpa-test-data/sherpatest/9774.pi")
read ARF file sherpa-test-data/sherpatest/9774.arf
read RMF file sherpa-test-data/sherpatest/9774.rmf
read background file sherpa-test-data/sherpatest/9774_bg.pi
>>> get_bkg().grouping is None
True
>>> group_counts(20)
data set 'sherpa-test-data/sherpatest/9774_bg.pi' does not specify grouping flags
dataset 1: 0.00146:14.9504 Energy (keV) (unchanged)
>>> get_bkg().grouping is None
False
```

We now have

```
>>> load_pha("sherpa-test-data/sherpatest/9774.pi")
read ARF file sherpa-test-data/sherpatest/9774.arf
read RMF file sherpa-test-data/sherpatest/9774.rmf
read background file sherpa-test-data/sherpatest/9774_bg.pi
>>> get_bkg().grouping is None
True
>>> group_counts(20)
dataset 1: 0.00146:14.9504 Energy (keV) (unchanged)
>>> get_bkg().grouping is None
False
```