### PR TITLE
Add versionadded note to set_plot_backend

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -993,6 +993,8 @@ class Session(NoNewAttributesAfterInit):
         This will reset any plot structures, such as that returned by
         get_data_plot.
 
+        .. versionadded:: 4.16.0
+
         Parameters
         ----------
         backend : str


### PR DESCRIPTION
# Summary

Note that the set_plot_backend command is new in 4,16,

# Detiails

I use these to trigger some behaviour in the ahelp files to make it easier to highlight changes and additions.