### PR TITLE
Add security warnings to restore functions

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -445,6 +445,11 @@ class Session(sherpa.ui.utils.Session):
     def restore(self, filename='sherpa.save'):
         """Load in a Sherpa session from a file.
 
+        .. warning::
+             Security risk: The imported functions and objects
+             could contain arbitrary Python code and be malicious.
+             Never use this function on untrusted input.
+
         Parameters
         ----------
         filename : str, optional

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1070,6 +1070,11 @@ class Session(NoNewAttributesAfterInit):
     def restore(self, filename='sherpa.save'):
         """Load in a Sherpa session from a file.
 
+        .. warning::
+             Security risk: The imported functions and objects
+             could contain arbitrary Python code and be malicious.
+             Never use this function on untrusted input.
+
         Parameters
         ----------
         filename : str, optional


### PR DESCRIPTION
Those functions import binary code, and we should be clear about risks involved.