### PR TITLE
IO: add missing import for pyfits backend

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -47,7 +47,7 @@ from astropy.io import fits
 from astropy.io.fits.column import _VLF
 from astropy.table import Table
 
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils import SherpaInt, SherpaUInt, SherpaFloat
 import sherpa.utils
 from sherpa.io import get_ascii_data, write_arrays


### PR DESCRIPTION
# Summary

Ensure a corner-case error condition when writing out responses fails with the correct error.

# Details

I think I missed this in #1836. It would be triggered in a corner case, which is why the tests did not pick it up (as I didn't add any tests for this particular corner case).

Found working on #1869 but it is completely separate to that.