### PR TITLE
Warn when reading in a multi-matrix rmf

### DIFF
--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -22,16 +22,19 @@
 
 """
 
+import logging
 import warnings
 
 import numpy as np
 
 import pytest
 
-from sherpa.astro import io
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
-from sherpa.astro.instrument import create_arf, create_delta_rmf
+from sherpa.astro.instrument import RMF1D, create_arf, create_delta_rmf
+from sherpa.astro import io
+from sherpa.astro.io.xstable import HeaderItem, Column, TableHDU
 from sherpa.data import Data1DInt
+from sherpa.models.basic import Gauss1D
 from sherpa.utils.err import ArgumentErr, IOErr
 from sherpa.utils.testing import requires_data, requires_fits
 
@@ -1000,3 +1003,246 @@ def test_write_fake_perfect_rmf(offset, tmp_path):
 
     assert new.e_min == pytest.approx(elo)
     assert new.e_max == pytest.approx(ehi)
+
+
+@requires_data
+@requires_fits
+def test_write_rmf_fits_xmm_epn(make_data_path, tmp_path, caplog):
+    """This XMM dataset has been useful for edge cases. So re-use it.
+
+    See sherpa-test-data/sherpatest/xmm-fit.py
+    """
+
+    NCHAN = 4096
+    NENERGY = 1319
+    NUMELT = 487198
+
+    def check(rmf):
+        assert rmf.detchans == NCHAN
+        assert rmf.offset == 0
+        assert np.log10(rmf.ethresh) == pytest.approx(-10)
+
+        hdr = rmf.header
+        assert "HDUNAME" not in hdr
+        assert hdr["HDUCLASS"] == "OGIP"
+        assert hdr["HDUCLAS1"] == "RESPONSE"
+        assert hdr["HDUCLAS2"] == "RSP_MATRIX"
+        assert hdr["HDUCLAS3"] == "DETECTOR"
+        assert hdr["HDUVERS1"] == "1.0.0"
+        assert hdr["HDUVERS2"] == "1.1.0"
+        assert "RMFVERSN" not in hdr
+
+        assert hdr["TELESCOP"] == "XMM"
+        assert hdr["INSTRUME"] == "EPN"
+        assert hdr["FILTER"] == "NONE"
+
+        assert hdr["CHANTYPE"] == "PI"
+        assert hdr["LO_THRES"] == pytest.approx(2e-6)
+
+        assert len(rmf.energ_lo) == NENERGY
+        assert len(rmf.energ_hi) == NENERGY
+        assert len(rmf.n_grp) == NENERGY
+
+        assert len(rmf.f_chan) == NENERGY
+        assert len(rmf.n_chan) == NENERGY
+
+        assert len(rmf.matrix) == NUMELT
+
+        assert len(rmf.e_min) == NCHAN
+        assert len(rmf.e_max) == NCHAN
+
+        assert rmf.n_grp.dtype == np.uint64
+
+        for field in ["f_chan", "n_chan"]:
+            attr = getattr(rmf, field)
+            if backend_is("crates"):
+                assert attr.dtype == np.uint32
+            elif backend_is("pyfits"):
+                assert attr.dtype == np.uint64
+            else:
+                raise RuntimeError(f"unsupported I/O backend: {io.backend}")
+
+        for field in ["energ_lo", "energ_hi", "matrix", "e_min", "e_max"]:
+            attr = getattr(rmf, field)
+            assert attr.dtype == np.float64
+
+        assert (rmf.energ_lo[1:] == rmf.energ_hi[:-1]).all()
+        assert rmf.energ_lo[0] == pytest.approx(0.05000000074505806)
+        assert rmf.energ_hi[-1] == pytest.approx(18.049999237060547)
+
+        assert rmf.n_grp.sum() == NENERGY
+        assert np.argmax(rmf.n_grp) == 0
+
+        # It is not obvious how the RMF is flattened here, so treat this
+        # as a regression test rather than "from first principles"
+        #
+        assert rmf.f_chan.sum() == 544580
+        assert rmf.n_chan.sum() == NUMELT
+
+        assert rmf.matrix.sum() == pytest.approx(1200.610821738967)
+
+        # e_min/max come from the EBOUNDS block
+        #
+        assert (rmf.e_min[1:] == rmf.e_max[:-1]).all()
+        assert rmf.e_min[0] == pytest.approx(0)
+        assert rmf.e_max[-1] == pytest.approx(20.48000144958496)
+
+
+    rmfname = "epn_ff20_dY9.rmf"
+    infile = make_data_path(rmfname)
+
+    # We get a TLMIN warning
+    assert len(caplog.record_tuples) == 0
+    orig = io.read_rmf(infile)
+    assert len(caplog.record_tuples) == 1
+
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == io.backend.__name__
+    assert lvl == logging.ERROR
+    print(msg)
+    assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
+    assert msg.endswith("'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting")
+
+    assert isinstance(orig, DataRMF)
+    assert orig.name.endswith(f"/{rmfname}")
+    check(orig)
+
+    outpath = tmp_path / "out.rmf"
+    outfile = str(outpath)
+    io.write_rmf(outfile, orig)
+    # Note: no TLMIN warning
+    assert len(caplog.record_tuples) == 1
+
+    new = io.read_rmf(outfile)
+    assert isinstance(new, DataRMF)
+    check(new)
+
+
+@requires_fits
+def test_read_multi_matrix_rmf(tmp_path, caplog):
+    """Check reading in a multi-MATRIX RMF block.
+
+    As we don't currently have one "in the wild" we manually create
+    one.
+
+    This is a regression test since we currently only read in one of
+    the matrices. It also turns out to depend on which backend is in
+    use (AstroPy picks the first and Crates the second, at least in
+    the file used here).
+
+    """
+
+    # First block is "perfect" and the second adds a "blob"
+    # component.
+    #
+    egrid = np.linspace(0.1, 2.1, 21)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf1 = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi,
+                            name="perfect")
+    rmf1.header["TESTBLCK"] = 1
+
+    # reduce the "energy" resolution of the second block.
+    #
+    e4grid = np.linspace(0.1, 2.1, 6)
+    e4lo = e4grid[:-1]
+    e4hi = e4grid[1:]
+    matrix = np.zeros((5, 4), dtype=np.float32)
+    blur = [0.1, 0.3, 0.4, 0.2]
+    for i in range(5):
+        matrix[i] = blur
+
+    rmf2 = DataRMF("blob", detchans=rmf1.detchans,
+                   energ_lo=e4lo, energ_hi=e4hi,
+                   n_grp=np.ones(5, dtype=np.int32),
+                   f_chan=np.asarray([2, 4, 6, 8, 10], dtype=np.int32),
+                   n_chan=4 * np.ones(5, dtype=np.int32),
+                   matrix=matrix.flatten(),
+                   e_min=elo, e_max=ehi,
+                   header={"TESTBLCK": 2})
+
+    # Extract the data and then reconstruct a "multi" RMF.
+    #
+    matrix1, bounds1 = io._pack_rmf(rmf1)
+    matrix2, bounds2 = io._pack_rmf(rmf2)
+
+    # Convert to a form that set_hdus can use. It also doesn't create
+    # a "proper" RMF since it does not set the TLMIN value for the
+    # F_CHAN column (an infelicity in the Column type).
+    #
+    def mkhdr(old):
+        return [HeaderItem(name=n, value=v, desc=None, unit=None)
+                for n,v in old.items()]
+
+    def mkdata(old):
+        # We drop the OFFSET value (only from the matrix1/2 versions
+        # but doesn't harm to include in the bounds1 call).
+        #
+        return [Column(name=n, values=v, desc=None, unit=None)
+                for n,v in old.items()
+                if n != "OFFSET"]
+
+    m1_header = mkhdr(matrix1[1])
+    m1_data = mkdata(matrix1[0])
+
+    m2_header = mkhdr(matrix2[1])
+    m2_data = mkdata(matrix2[0])
+
+    eb_header = mkhdr(bounds1[1])
+    eb_data = mkdata(bounds1[0])
+
+    hdus = [TableHDU("PRIMARY", header=mkhdr({"TESTKEY": 12})),
+            TableHDU("MATRIX", header=m1_header, data=m1_data),
+            TableHDU("MATRIX", header=m2_header, data=m2_data),
+            TableHDU("EBOUNDS", header=eb_header, data=eb_data)]
+
+    outpath = tmp_path / "multi.rmf"
+    outfile = str(outpath)
+    io.backend.set_hdus(outfile, hdus)
+
+    # What happens if we try to read this in? As we haven't written
+    # out the correct TLMIN value we will get a warning about
+    # that. There is no warning about this being a multi-matrix RMF.
+    #
+    assert len(caplog.record_tuples) == 0
+    rmf = io.read_rmf(outfile)
+    assert len(caplog.record_tuples) == 1
+
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == io.backend.__name__
+    assert lvl == logging.ERROR
+    assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
+    assert msg.endswith("/multi.rmf'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting")
+
+    # What happens if we apply the RMF to a model? At the moment it
+    # depends on the backend because pyfits picks the first block, so
+    # the "perfect" RMF, whereas crates picks the second one (which
+    # blurs out the data, and we check using values calculated by Sherpa
+    # rather than created from the existing matrix).
+    #
+    mdl = Gauss1D()
+    mdl.pos = 1.1
+    mdl.fwhm = 0.8
+    mdl.ampl = 1e4
+
+    resp = RMF1D(rmf)
+    conv = resp(mdl)
+    chans = np.arange(1, 21, dtype=np.int16)
+    y = conv(chans)
+
+    # The check is a bit annoying.
+    #
+    if backend_is("pyfits"):
+        expected_perfect = mdl(elo, ehi)
+        assert y == pytest.approx(expected_perfect)
+    elif backend_is("crates"):
+        # Create a 2D array to represent the blurry matrix
+        #
+        blurry_matrix = np.zeros((5, 20))
+        for idx, fchan in enumerate([2, 4, 6, 8, 10]):
+            blurry_matrix[idx, fchan - 1:fchan + 3] = blur
+
+        expected_blurry = mdl(e4lo, e4hi) @ blurry_matrix
+        assert y == pytest.approx(expected_blurry)
+    else:
+        raise RuntimeError(f"unsupported I/O backend: {io.backend}")

--- a/sherpa/astro/tests/test_astro_data_rosat_unit.py
+++ b/sherpa/astro/tests/test_astro_data_rosat_unit.py
@@ -379,18 +379,11 @@ def test_read_rmf(make_data_path):
 def test_read_rmf_fails_pha(make_data_path):
     """Just check in we can't read in a PHA file as a RMF."""
 
-    if backend_is("pyfits"):
-        emsg = " does not appear to be an RMF"
-    elif backend_is("crates"):
-        emsg = "Required column 'ENERG_LO' not found in "
-    else:
-        assert False, f"Internal error: unknown backend {io.backend}"
+    emsg = " does not appear to be an RMF"
 
     infile = make_data_path(PHAFILE)
-    with pytest.raises(IOErr) as excinfo:
+    with pytest.raises(IOErr, match=emsg):
         io.read_rmf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -333,7 +333,7 @@ def test_read_rmf_fails_arf(make_data_path):
     """Just check in we can't read in a ARF as a RMF."""
 
     if backend_is("pyfits"):
-        emsg = " does not have a 'DETCHANS' keyword"
+        emsg = " does not appear to be an RMF"
         etype = IOErr
     elif backend_is("crates"):
         emsg = " does not contain a Response Matrix."
@@ -342,10 +342,8 @@ def test_read_rmf_fails_arf(make_data_path):
         assert False, f"Internal error: unknown backend {io.backend}"
 
     infile = make_data_path(ARFFILE)
-    with pytest.raises(etype) as excinfo:
+    with pytest.raises(etype, match=emsg):
         io.read_rmf(infile)
-
-    assert emsg in str(excinfo.value)
 
 
 @requires_data

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6434,6 +6434,11 @@ class Session(sherpa.ui.utils.Session):
     def unpack_rmf(self, arg):
         """Create a RMF data structure.
 
+        .. versionchanged:: 4.16.0
+           This command does not support multi-matrix RMF files and
+           will warn the user when given such a file (as only the
+           first matrix is read in, the results will not be correct).
+
         Parameters
         ----------
         arg
@@ -6491,6 +6496,11 @@ class Session(sherpa.ui.utils.Session):
         Load in the redistribution matrix function for a PHA data set,
         or its background. The `load_bkg_rmf` function can be used for
         setting most background RMFs.
+
+        .. versionchanged:: 4.16.0
+           This command does not support multi-matrix RMF files and
+           will warn the user when given such a file (as only the
+           first matrix is read in, the results will not be correct).
 
         Parameters
         ----------


### PR DESCRIPTION
# Summary

Ensure that attempts to read in a multi-matrix RMF will warn the user that they are not yet supported.

# Details

This is a very-slimmed down #1869, concentrating on

- adding a test case
- raising a warning (technically an error log message) when the RMF contains multiple MATRIX blocks

so that user's aren't going to accidentally get the wrong result. It is tempered slightly by the fact we don't have any real-world test data to use as a test!

The idea would be we can supply "contrib" code for the 4.16 release which will let users use these files, but without the concerns I have over the code in #1869 (too many changes).

As part of this several error messages have changed - that is, when trying to read in an invalid OGIP response file the error you now get may be slightly different (and the difference depends on the backend). We can improve this somewhat, but

a) that's for later
b) there's always going to be some case you get backend-specific behaviour

This PR starts to use the "generic FITS handling" code added with the XSPEC table PR #1861 but I am attempting to minimize this PR so it doesn't do much (e.g. we want to move the code into a separate module, add better optional behaviour, ... whic we can do later). 

I have run the tests with both the pyfits and crates backends (only the former gets exercised by the CI runs).

# Example

This is from a RMF I have hacked together - I have checked that I get the "expected" output when I pass it to XSPEC (i.e. that it is really a multi-matrix RMF andI understand how it's behaving):

```
>>> rmf = ui.unpack_rmf("multi.rmf")
ERROR: RMF in multi.rmf contains 2 MATRIX blocks; Sherpa only uses the first block!
```