### PR TITLE
BUILD: drop the use of oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools >= 51.0.0, < 60",
             "wheel",
-            "oldest-supported-numpy",
+            "numpy",
             ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# Summary

Change the build requirements from `oldest-supported-numpy` to `numpy`.

# Details

According to #1790 we no-longer need the oldest-supported-numpy "helper" so let's see if we can remove it.