### PR TITLE
Let users know they should use load_xstable_model not load_table_model

### DIFF
--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -19,6 +19,7 @@
 #
 
 import struct
+import warnings
 
 import numpy as np
 
@@ -36,11 +37,44 @@ from sherpa.utils.testing import requires_data, requires_fits, requires_group, \
 @requires_data
 @requires_fits
 @requires_xspec
-def test_mod_fits(make_data_path):
+def test_mod_fits(make_data_path, clean_astro_ui, caplog):
+    """Can we read in an XSPEC table model with load_table_model.
+
+    This approach is deprecated. Use load_xstable_model instead.
+    """
+
     tablemodelfile = make_data_path("xspec-tablemodel-RCS.mod")
-    ui.load_table_model("tmod", tablemodelfile)
+    with warnings.catch_warnings(record=True) as warn:
+        ui.load_table_model("tmod", tablemodelfile)
+
+    assert len(warn) == 1
+    assert warn[0].category == DeprecationWarning
+    assert str(warn[0].message) == "Use load_xstable_model to load XSPEC table models"
+
     tmod = ui.get_model_component("tmod")
     assert tmod.name == "xstablemodel.tmod"
+
+    # just check the log output is empty
+    assert len(caplog.records) == 0
+
+
+@requires_data
+@requires_fits
+@requires_xspec
+def test_xsmod_fits(make_data_path, clean_astro_ui, caplog):
+    """Can we read in an XSPEC table model with load_xstable_model."""
+
+    tablemodelfile = make_data_path("xspec-tablemodel-RCS.mod")
+    with warnings.catch_warnings(record=True) as warn:
+        ui.load_xstable_model("tmod", tablemodelfile)
+
+    assert len(warn) == 0
+
+    tmod = ui.get_model_component("tmod")
+    assert tmod.name == "xstablemodel.tmod"
+
+    # just check the log output is empty
+    assert len(caplog.records) == 0
 
 
 @requires_fits

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -47,15 +47,18 @@ def test_mod_fits(make_data_path, clean_astro_ui, caplog):
     with warnings.catch_warnings(record=True) as warn:
         ui.load_table_model("tmod", tablemodelfile)
 
+    msg = "Use load_xstable_model to load XSPEC table models"
     assert len(warn) == 1
     assert warn[0].category == DeprecationWarning
-    assert str(warn[0].message) == "Use load_xstable_model to load XSPEC table models"
+    assert str(warn[0].message) == msg
 
     tmod = ui.get_model_component("tmod")
     assert tmod.name == "xstablemodel.tmod"
 
-    # just check the log output is empty
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 1
+    assert caplog.records[0].name == "sherpa.astro.ui.utils"
+    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].getMessage() == msg
 
 
 @requires_data

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -422,7 +422,7 @@ def test_write_rmf_fits_chandra_acis(make_data_path, tmp_path):
 
 @requires_data
 @requires_fits
-def test_write_rmf_fits_asca_sis(make_data_path, tmp_path):
+def test_write_rmf_fits_asca_sis(make_data_path, tmp_path, caplog):
     """Check we can write out an RMF as a FITS file.
 
     Use the ASCA SIS as it has a different structure to
@@ -437,7 +437,15 @@ def test_write_rmf_fits_asca_sis(make_data_path, tmp_path):
     NUMELT = 505483
 
     infile = make_data_path("sis0.rmf")
+    assert len(caplog.record_tuples) == 0
     orig = io.read_rmf(infile)
+    assert len(caplog.record_tuples) == 1
+
+    lname, lvl, msg = caplog.record_tuples[0]
+    assert lname == io.backend.__name__
+    assert lvl == logging.ERROR
+    assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
+    assert msg.endswith("sis0.rmf'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting")
 
     # Unlike the ACIS case, this does not have NUMELT/GRP and
     # leave in the HDU keys to check they don't get over-written.

--- a/sherpa/astro/ui/tests/test_astro_supports_pha2.py
+++ b/sherpa/astro/ui/tests/test_astro_supports_pha2.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021
+#  Copyright (C) 2017, 2018, 2020, 2021, 2023
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -165,20 +165,16 @@ def test_load_pha2(loader, id0, ids, make_data_path, caplog, clean_astro_ui):
         assert b.name == infile
 
     # Test Log messages
-    msg_one = "systematic errors were not found in file '{}'".format(infile)
+    msg_one = f"systematic errors were not found in file '{infile}'"
 
-    # Editors can remove trailing spaces from lines, so split into
-    # separate lines so the space after the file name is included.
-    # Perhaps this space should be removed from the warning message?
-    #
-    msg_two = "statistical errors were found in file '{}' \n".format(infile) + \
+    msg_two = f"statistical errors were found in file '{infile}'\n" + \
               "but not used; to use them, re-read with use_errors=True"
 
-    msg_three = "read background_up into a dataset from file {}".format(infile)
-    msg_four = "read background_down into a dataset from file {}".format(infile)
+    msg_three = f"read background_up into a dataset from file {infile}"
+    msg_four = f"read background_down into a dataset from file {infile}"
 
     msg_five = "Multiple data sets have been input: " + \
-               "{}-{}".format(ids[0], ids[11])
+               f"{ids[0]}-{ids[11]}"
 
     assert caplog.record_tuples == [
         ('sherpa.astro.io', logging.WARNING, msg_one),
@@ -212,7 +208,7 @@ def test_load_pha2_compare_meg_order1(make_data_path, clean_astro_ui):
     ui.load_pha(pha2file)
 
     for n, lbl in zip([9, 10], ["-1", "1"]):
-        h = '3c120_meg_{}'.format(lbl)
+        h = f'3c120_meg_{lbl}'
         ui.load_arf(n, make_data_path(h + '.arf'))
         ui.load_rmf(n, make_data_path(h + '.rmf'))
 

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -275,13 +275,13 @@ def test_load_data(loader, make_data_path, clean_astro_ui, caplog):
     assert ui.list_data_ids() == ['foo']
 
     msg1 = f"systematic errors were not found in file '{infile}'"
-    msg2 = f"statistical errors were found in file '{infile}' \n" + \
+    msg2 = f"statistical errors were found in file '{infile}'\n" + \
         "but not used; to use them, re-read with use_errors=True"
     msg3 = f"read ARF file {arf}"
     msg4 = f"read RMF file {rmf}"
 
     msg5 = f"systematic errors were not found in file '{bgfile}'"
-    msg6 = f"statistical errors were found in file '{bgfile}' \n" + \
+    msg6 = f"statistical errors were found in file '{bgfile}'\n" + \
         "but not used; to use them, re-read with use_errors=True"
     msg7 = f"read background file {bgfile}"
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -34,7 +34,7 @@ from sherpa.ui.utils import _check_type, _check_str_type, _is_str
 from sherpa.utils import sao_arange, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
-from sherpa.utils.numeric_types import SherpaFloat, SherpaInt
+from sherpa.utils.numeric_types import SherpaFloat
 from sherpa.data import Data1D, Data1DAsymmetricErrs, Data2D, Data2DInt
 import sherpa.astro.all
 import sherpa.astro.plot
@@ -1712,13 +1712,13 @@ class Session(sherpa.ui.utils.Session):
         """
         try:
             return self.unpack_pha(filename, *args, **kwargs)
-        except:
+        except Exception:
             try:
                 return self.unpack_image(filename, *args, **kwargs)
-            except:
+            except Exception:
                 try:
                     return self.unpack_table(filename, *args, **kwargs)
-                except:
+                except Exception:
                     # If this errors out then so be it
                     return self.unpack_ascii(filename, *args, **kwargs)
 
@@ -1874,10 +1874,10 @@ class Session(sherpa.ui.utils.Session):
             ids.append(idval)
 
         if num > 1:
-            info("Multiple data sets have been input: " +
-                 "{}-{}".format(ids[0], ids[-1]))
+            info("Multiple data sets have been input: %s-%s",
+                 ids[0], ids[-1])
         else:
-            info("One data set has been input: {}".format(ids[0]))
+            info("One data set has been input: %s", ids[0])
 
     # DOC-NOTE: also in sherpa.utils without the support for
     #           multiple datasets.
@@ -7041,7 +7041,7 @@ class Session(sherpa.ui.utils.Session):
             else:
                 fstring = f"{nfilter} {data.get_xlabel()}"
 
-            info(f"dataset {idval}: {fstring}")
+            info("dataset %s: %s", idval, fstring)
 
     def get_analysis(self, id=None):
         """Return the units used when fitting spectral data.
@@ -9558,12 +9558,12 @@ class Session(sherpa.ui.utils.Session):
                 resp_ids = range(1, len(arf) + 1)
                 self.load_multi_arfs(id, arf, resp_ids=resp_ids)
             elif arf is None:
-               # In some cases, arf is None, but rmf is not.
-               # For example, XMM/RGS does uses only a single file (the RMF)
-               # to hold all information.
-               pass
+                # In some cases, arf is None, but rmf is not.
+                # For example, XMM/RGS does uses only a single file (the RMF)
+                # to hold all information.
+                pass
             else:
-               self.set_arf(id, arf)
+                self.set_arf(id, arf)
 
             if numpy.iterable(rmf):
                 resp_ids = range(1, len(rmf) + 1)
@@ -9622,7 +9622,7 @@ class Session(sherpa.ui.utils.Session):
         if _is_str(filename_or_model):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
-            except:
+            except Exception:
                 kernel = self.unpack_data(filename_or_model,
                                           *args, **kwargs)
 
@@ -9736,12 +9736,11 @@ class Session(sherpa.ui.utils.Session):
                     if sherpa.ui.utils._is_subclass(type(part), instruments):
                         do_warning = False
                 if do_warning:
-                    warning("PHA source model '%s' \ndoes not" %
-                            model.name +
-                            " have an associated instrument model; " +
-                            "consider using \nset_source() instead of" +
-                            " set_full_model() to include associated " +
-                            "\ninstrument automatically")
+                    warning("PHA source model '%s' \ndoes not"
+                            " have an associated instrument model; "
+                            "consider using \nset_source() instead of"
+                            " set_full_model() to include associated "
+                            "\ninstrument automatically", model.name)
 
     set_full_model.__doc__ = sherpa.ui.utils.Session.set_full_model.__doc__
 
@@ -10237,10 +10236,10 @@ class Session(sherpa.ui.utils.Session):
                     do_warning = False
             if do_warning:
                 self.delete_bkg_model(id, bkg_id)
-                raise TypeError("PHA background source model '%s' \n" % model.name +
-                                " does not have an associated instrument model;" +
-                                " consider using\n set_bkg_source() instead of" +
-                                " set_bkg_model() to include associated\n instrument" +
+                raise TypeError(f"PHA background source model '{model.name}' \n"
+                                " does not have an associated instrument model;"
+                                " consider using\n set_bkg_source() instead of"
+                                " set_bkg_model() to include associated\n instrument"
                                 " automatically")
 
         self._runparamprompt(model.pars)
@@ -10343,9 +10342,9 @@ class Session(sherpa.ui.utils.Session):
         # Delete any previous model set with set_full_bkg_model()
         bkg_mdl = self._background_models.get(id, {}).pop(bkg_id, None)
         if bkg_mdl is not None:
-            warning("Clearing background convolved model\n'%s'\n" %
-                    (bkg_mdl.name) + "for dataset %s background %s" %
-                    (str(id), str(bkg_id)))
+            warning("Clearing background convolved model\n'%s'\n"
+                    "for dataset %s background %s",
+                    bkg_mdl.name, str(id), str(bkg_id))
 
     set_bkg_source = set_bkg_model
 
@@ -10410,7 +10409,7 @@ class Session(sherpa.ui.utils.Session):
         except TypeError:
             y = sherpa.astro.io.backend.get_ascii_data(filename, *args,
                                                        **kwargs)[1].pop()
-        except:
+        except Exception:
             try:
                 data = self.unpack_table(filename, *args, **kwargs)
                 x = data.get_x()
@@ -10422,7 +10421,7 @@ class Session(sherpa.ui.utils.Session):
             except TypeError:
                 y = sherpa.astro.io.backend.get_table_data(filename, *args,
                                                            **kwargs)[1].pop()
-            except:
+            except Exception:
                 # unpack_data doesn't include a call to try
                 # getting data from image, so try that here.
                 data = self.unpack_image(filename, *args, **kwargs)
@@ -10534,14 +10533,13 @@ class Session(sherpa.ui.utils.Session):
         .. note:: Deprecated in Sherpa 4.9
                   The new `load_xstable_model` routine should be used for
                   loading XSPEC table model files. Support for these files
-                  will be removed from `load_table_model` in the next
+                  will be removed from `load_table_model` in the 4.17
                   release.
 
         A table model is defined on a grid of points which is
-        interpolated onto the independent axis of the data set.  The
-        model will have at least one parameter (the amplitude, or
-        scaling factor to multiply the data by), but may have more
-        (if X-Spec table models are used).
+        interpolated onto the independent axis of the data set. The
+        model has a single parameter, ``ampl``, which is used to scale
+        the data, and it can be fixed or allowed to vary during a fit.
 
         Parameters
         ----------
@@ -10595,35 +10593,34 @@ class Session(sherpa.ui.utils.Session):
         >>> set_source('img', emap * gauss2d)
 
         """
-        tablemodel = TableModel(modelname)
-        # interpolation method
-        tablemodel.method = method
-        tablemodel.filename = filename
 
         try:
-            if not sherpa.utils.is_binary_file(filename):
-                # TODO: use a Sherpa exception
-                raise Exception("Not a FITS file")
-
             self.load_xstable_model(modelname, filename)
-            warnings.warn('Use load_xstable_model to load XSPEC table models',
-                          DeprecationWarning)
+
+            # Since users don't see DeprecationWarnings in ipython
+            # let's be explicit now, as most people are not aware of
+            # this change.
+            #
+            msg = 'Use load_xstable_model to load XSPEC table models'
+            warnings.warn(msg, DeprecationWarning)
+            warning(msg)
             return
-
         except Exception:
-            x = None
-            y = None
-            try:
-                x, y = self._read_user_model(filename, *args, **kwargs)
-            except:
-                # Fall back to reading plain ASCII, if no other
-                # more sophisticated I/O backend loaded (such as
-                # pyfits or crates) SMD 05/29/13
-                data = sherpa.io.read_data(filename, ncols=2)
-                x = data.x
-                y = data.y
-            tablemodel.load(x, y)
+            pass
 
+        x = None
+        y = None
+        try:
+            x, y = self._read_user_model(filename, *args, **kwargs)
+        except Exception:
+            data = sherpa.io.read_data(filename, ncols=2)
+            x = data.x
+            y = data.y
+
+        tablemodel = TableModel(modelname)
+        tablemodel.method = method
+        tablemodel.filename = filename
+        tablemodel.load(x, y)
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
 
@@ -10773,16 +10770,18 @@ class Session(sherpa.ui.utils.Session):
             bkg_srcs = self._background_sources.get(s.idval, {})
             if s.data.subtracted:
                 if (bkg_models or bkg_srcs):
-                    warning(f'data set {repr(s.idval)} is background-subtracted; ' +
-                            'background models will be ignored')
+                    warning('data set %s is background-subtracted; '
+                            'background models will be ignored',
+                            repr(s.idval))
 
                 continue
 
             if not (bkg_models or bkg_srcs):
                 if s.data.background_ids and self._current_stat.name != 'wstat':
-                    warning(f'data set {repr(s.idval)} has associated backgrounds, ' +
-                            'but they have not been subtracted, ' +
-                            'nor have background models been set')
+                    warning('data set %s has associated backgrounds, '
+                            'but they have not been subtracted, '
+                            'nor have background models been set',
+                            repr(s.idval))
 
                 continue
 
@@ -14702,12 +14701,11 @@ class Session(sherpa.ui.utils.Session):
                     msg = name + ' must be 2d numpy.ndarray'
                     raise IOErr(msg)
                 if shape[0] != npars:
-                    msg = name + ' must be of dimension (%d, x)' % npars
+                    msg = name + f' must be of dimension ({npars}, x)'
                     raise IOErr(msg)
                 if dim1 is not None:
                     if shape[1] != npars:
-                        msg = name + ' must be of dimension (%d, %d)' % \
-                            (npars, npars)
+                        msg = name + f' must be of dimension ({npars}, {npars})'
                         raise IOErr(msg)
 
             _, fit = self._get_fit(id)
@@ -15768,7 +15766,7 @@ class Session(sherpa.ui.utils.Session):
                 else:
                     raise IOErr('filefound', outfile)
 
-            with open(outfile, 'w') as fh:
+            with open(outfile, 'w', encoding="UTF-8") as fh:
                 serialize.save_all(self, fh)
 
         else:

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9559,7 +9559,7 @@ class Session(sherpa.ui.utils.Session):
                 self.load_multi_arfs(id, arf, resp_ids=resp_ids)
             elif arf is None:
                 # In some cases, arf is None, but rmf is not.
-                # For example, XMM/RGS does uses only a single file (the RMF)
+                # For example, XMM/RGS uses only a single file (the RMF)
                 # to hold all information.
                 pass
             else:

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -437,7 +437,7 @@ def read_template_model(modelname, templatefile,
         tm.ampl.freeze()
         templates.append(tm)
 
-    assert(len(templates) == parvals.shape[0])
+    assert len(templates) == parvals.shape[0]
 
     return create_template_model(modelname, parnames, parvals,
                                  templates,
@@ -1208,7 +1208,7 @@ class Session(NoNewAttributesAfterInit):
             ids = [self._fix_id(id)]
         for id in ids:
             data_str += 'Data Set: %s\n' % id
-            data_str += self.get_data(id).__str__() + '\n\n'
+            data_str += str(self.get_data(id)) + '\n\n'
         return data_str
 
     def _get_show_filter(self, id=None):
@@ -1230,7 +1230,7 @@ class Session(NoNewAttributesAfterInit):
         for id in ids:
             if id in mdl_ids:
                 model_str += 'Model: %s\n' % id
-                model_str += self.get_model(id).__str__() + '\n\n'
+                model_str += str(self.get_model(id)) + '\n\n'
         return model_str
 
     def _get_show_source(self, id=None):
@@ -1242,7 +1242,7 @@ class Session(NoNewAttributesAfterInit):
         for id in ids:
             if id in src_ids:
                 model_str += 'Model: %s\n' % id
-                model_str += self.get_source(id).__str__() + '\n\n'
+                model_str += str(self.get_source(id)) + '\n\n'
         return model_str
 
     def _get_show_kernel(self, id=None):
@@ -1254,7 +1254,7 @@ class Session(NoNewAttributesAfterInit):
             if id in self._psf.keys():
                 kernel_str += 'PSF Kernel: %s\n' % id
                 # Show the PSF parameters
-                kernel_str += self.get_psf(id).__str__() + '\n\n'
+                kernel_str += str(self.get_psf(id)) + '\n\n'
         return kernel_str
 
     def _get_show_psf(self, id=None):
@@ -1266,18 +1266,18 @@ class Session(NoNewAttributesAfterInit):
             if id in self._psf.keys():
                 psf_str += 'PSF Model: %s\n' % id
                 # Show the PSF dataset or PSF model
-                psf_str += self.get_psf(id).kernel.__str__() + '\n\n'
+                psf_str += str(self.get_psf(id).kernel) + '\n\n'
         return psf_str
 
     def _get_show_method(self):
         return ('Optimization Method: %s\n%s\n' %
                 (type(self._current_method).__name__,
-                 self._current_method.__str__()))
+                 str(self._current_method)))
 
     def _get_show_stat(self):
         return ('Statistic: %s\n%s\n' %
                 (type(self._current_stat).__name__,
-                 self._current_stat.__str__()))
+                 str(self._current_stat)))
 
     def _get_show_fit(self):
         if self._fit_results is None:
@@ -2018,7 +2018,8 @@ class Session(NoNewAttributesAfterInit):
         # use the logger interface instead. It does mean that the
         # message will be repeated each time it is used.
         #
-        warning(f"The argument '{plottype}' is deprecated and '{answer}' should be used instead")
+        warning("The argument '%s' is deprecated and "
+                "'%s' should be used instead", plottype, answer)
         return answer
 
     def _check_plottype(self, plottype):
@@ -5968,8 +5969,8 @@ class Session(NoNewAttributesAfterInit):
         name = modelclass.__name__.lower()
 
         if not _is_subclass(modelclass, sherpa.models.ArithmeticModel):
-            raise TypeError("model class '%s' is not a derived class" % name +
-                            " from sherpa.models.ArithmeticModel")
+            raise TypeError(f"model class '{name}' is not a derived class "
+                            "from sherpa.models.ArithmeticModel")
 
         self._model_types[name] = ModelWrapper(self, modelclass, args, kwargs)
         self._model_globals.update(self._model_types)
@@ -6675,7 +6676,7 @@ class Session(NoNewAttributesAfterInit):
                 ntokens = len(tokens)
 
                 if ntokens > 3:
-                    info("Error: Please provide a comma-separated " +
+                    info("Error: Please provide a comma-separated "
                          "list of floats; e.g. val,min,max")
                     continue
 
@@ -6683,21 +6684,21 @@ class Session(NoNewAttributesAfterInit):
                     try:
                         val = float(tokens[0])
                     except Exception as e:
-                        info(f"Please provide a float value; {e}")
+                        info("Please provide a float value; %s", e)
                         continue
 
                 if ntokens > 1 and tokens[1] != '':
                     try:
                         minval = float(tokens[1])
                     except Exception as e:
-                        info(f"Please provide a float value; {e}")
+                        info("Please provide a float value; %s", e)
                         continue
 
                 if ntokens > 2 and tokens[2] != '':
                     try:
                         maxval = float(tokens[2])
                     except Exception as e:
-                        info(f"Please provide a float value; {e}")
+                        info("Please provide a float value; %s", e)
                         continue
 
                 try:
@@ -7367,9 +7368,8 @@ class Session(NoNewAttributesAfterInit):
 
         A table model is defined on a grid of points which is
         interpolated onto the independent axis of the data set. The
-        model has a single parameter, ``ampl``, which is used to
-        scale the data, and it can be fixed or allowed to vary
-        during a fit.
+        model has a single parameter, ``ampl``, which is used to scale
+        the data, and it can be fixed or allowed to vary during a fit.
 
         Parameters
         ----------
@@ -7444,12 +7444,13 @@ class Session(NoNewAttributesAfterInit):
         >>> set_par(filt.ampl, 1e3, min=1, max=1e6)
 
         """
-        tablemodel = TableModel(modelname)
-        # interpolation method
-        tablemodel.method = method
-        tablemodel.filename = filename
+
         x, y = self._read_user_model(filename, ncols, colkeys,
                                      dstype, sep, comment)
+
+        tablemodel = TableModel(modelname)
+        tablemodel.method = method
+        tablemodel.filename = filename
         tablemodel.load(x, y)
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
@@ -7554,8 +7555,8 @@ class Session(NoNewAttributesAfterInit):
         usermodel = sherpa.models.UserModel(modelname)
         usermodel.calc = func
         usermodel._file = filename
-        if (filename is not None):
-            x, usermodel._y = self._read_user_model(filename, ncols, colkeys,
+        if filename is not None:
+            _, usermodel._y = self._read_user_model(filename, ncols, colkeys,
                                                     dstype, sep, comment)
         self._add_model_component(usermodel)
 
@@ -7629,7 +7630,7 @@ class Session(NoNewAttributesAfterInit):
 
         usermodel = self._get_model_component(modelname)
         if (usermodel is None or
-                type(usermodel) is not sherpa.models.UserModel):
+            not isinstance(usermodel, sherpa.models.UserModel)):
             raise ArgumentTypeErr('badarg', modelname, "a user model")
 
         pars = []
@@ -7823,7 +7824,7 @@ class Session(NoNewAttributesAfterInit):
         if _is_str(filename_or_model):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
-            except:
+            except Exception:
                 kernel = self.unpack_data(filename_or_model,
                                           *args, **kwargs)
 
@@ -7887,7 +7888,7 @@ class Session(NoNewAttributesAfterInit):
         if _is_str(filename_or_model):
             try:
                 kernel = self._eval_model_expression(filename_or_model)
-            except:
+            except Exception:
                 kernel = self.unpack_data(filename_or_model,
                                           *args, **kwargs)
 
@@ -8314,9 +8315,9 @@ class Session(NoNewAttributesAfterInit):
 
             try:
                 par.freeze()
-            except AttributeError:
+            except AttributeError as exc:
                 raise ArgumentTypeErr('badarg', 'par',
-                                      'a parameter or model object or expression string')
+                                      'a parameter or model object or expression string') from exc
 
     def thaw(self, *args):
         """Allow model parameters to be varied during a fit.
@@ -8377,9 +8378,9 @@ class Session(NoNewAttributesAfterInit):
 
             try:
                 par.thaw()
-            except AttributeError:
+            except AttributeError as exc:
                 raise ArgumentTypeErr('badarg', 'par',
-                                      'a parameter or model object or expression string')
+                                      'a parameter or model object or expression string') from exc
 
     def link(self, par, val):
         """Link a parameter to a value.
@@ -11895,9 +11896,9 @@ class Session(NoNewAttributesAfterInit):
         id = self._fix_id(id)
         mdl = self._models.get(id, None)
         if mdl is not None:
-            raise IdentifierErr("Convolved model\n'{}'".format(mdl.name) +
-                                "\n is set for dataset {}.".format(id) +
-                                " You should use get_model_plot instead.")
+            raise IdentifierErr(f"Convolved model\n'{mdl.name}'\n"
+                                f" is set for dataset {id}. "
+                                "You should use get_model_plot instead.")
 
         if recalc:
             data = self.get_data(id)
@@ -13968,9 +13969,9 @@ class Session(NoNewAttributesAfterInit):
         id = self._fix_id(id)
         mdl = self._models.get(id, None)
         if mdl is not None:
-            raise IdentifierErr("Convolved model\n'{}'".format(mdl.name) +
-                                "\n is set for dataset {}.".format(id) +
-                                " You should use plot_model instead.")
+            raise IdentifierErr(f"Convolved model\n'{mdl.name}'\n"
+                                f" is set for dataset {id}. "
+                                "You should use plot_model instead.")
 
         plotobj = self.get_source_plot(id, recalc=not replot)
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,


### PR DESCRIPTION
# Summary

Support for XSPEC table models in load_table_model was deprecated in the 4.9 release. Ensure users know that they should be using load_xstable_model instead by adding a warning message whenever it is used.

# Details

This is part of a long sequence of I/O changes I plan to make for 4.16.1. I am trying to make sure PRs are obvious and not-too-large. Next should be #1929 and then #1921.

The warning about the deprecation has been in place since 4.9 but thanks to how Python shows deprecation warnings essentially no-one would see the warning [even with https://peps.python.org/pep-0565/]. So we now have

```
>>> from sherpa.astro import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_table_model("foo", "sherpa-test-data/sherpatest/xspec-tablemodel-RCS.mod")
WARNING: Use load_xstable_model to load XSPEC table models
```

There is the argument as to why we want to deprecate this functionality, to which I say

1. it will make the code slightly-nicer to understand (our code related to I/O is a rats nest so any improvememt is a good improvement)

2. over the years I've seen a lot of confusion about table models as their is a difference between reading in an array which we can then re-normalize for any data set versus the full-blown multi-parameter interpolation supported by XSPEC **for PHA data only**

3. We have documented this deprecation for years

There are also a number of test tweaks (to improve coverage) and minor pylint-inspired changes, which are

- explicitly catch `Exception` rather than no exception

  This technically changes behaviour, as we now no-longer catch `KeyboardInterrupt` (i.e. control-c), but this is actually the
  correct behaviour here

- f-string conversions
- apart for for lazy logging
- remove an unused symbol



