### PR TITLE
IO: separate pack and set commands

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -51,7 +51,7 @@ fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}"
 
 # Create and activate conda build environment
-conda create --yes -n build python="=${PYTHONVER}=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
 
 conda activate build
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1700,7 +1700,7 @@ def pack_table(dataset):
     """
     data = _pack_table(dataset)
     names = list(data.keys())
-    return backend.set_table_data('', data, names, packup=True)
+    return backend.pack_table_data(data, names)
 
 
 def pack_image(dataset):
@@ -1731,7 +1731,7 @@ def pack_image(dataset):
 
     """
     data, hdr = _pack_image(dataset)
-    return backend.set_image_data('', data, hdr, packup=True)
+    return backend.pack_image_data(data, hdr)
 
 
 def pack_pha(dataset):
@@ -1754,8 +1754,7 @@ def pack_pha(dataset):
     """
     data, hdr = _pack_pha(dataset)
     col_names = list(data.keys())
-    return backend.set_pha_data('', data, col_names, header=hdr,
-                                packup=True)
+    return backend.pack_pha_data(data, col_names, header=hdr)
 
 
 def read_table_blocks(arg, make_copy=False):

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -498,7 +498,7 @@ def _read_ancillary(data, key, label, dname,
 
         out = read_func(data[key])
         if output_once:
-            info(f'read {label} file {data[key]}')
+            info('read %s file %s', label, data[key])
 
     except Exception as exc:
         if output_once:
@@ -580,9 +580,11 @@ def read_pha(arg, use_errors=False, use_background=False):
                 bkg_datasets = []
                 # Do not read backgrounds of backgrounds
                 if not use_background:
-                    bkg_datasets = read_pha(data['backfile'], use_errors, True)
+                    bkg_datasets = read_pha(data['backfile'],
+                                            use_errors=use_errors,
+                                            use_background=True)
                     if output_once:
-                        info(f"read background file {data['backfile']}")
+                        info("read background file %s", data['backfile'])
 
                 if numpy.iterable(bkg_datasets):
                     for bkg_dataset in bkg_datasets:
@@ -615,7 +617,9 @@ def read_pha(arg, use_errors=False, use_background=False):
                               header=data['header'])
                 bkg.set_response(arf, rmf)
                 if output_once:
-                    info(f"read {bkg_type} into a dataset from file {filename}")
+                    info("read %s into a dataset from file %s",
+                         bkg_type, filename)
+
                 backgrounds.append(bkg)
 
         for k in ['backfile', 'arffile', 'rmffile', 'backscup', 'backscdn',
@@ -1230,7 +1234,6 @@ def _make_int_vlf(rows):
 
     """
 
-    nrows = len(rows)
     maxval = 0
     for row in rows:
         if len(row) == 0:

--- a/sherpa/astro/io/backends.py
+++ b/sherpa/astro/io/backends.py
@@ -111,7 +111,7 @@ class BaseBackend(metaclass=ABCMeta):
             otherwise the backend selects. The default is `None`.
             Names are compared using a case insensitive match.
         make_copy: bool, optional
-            If set then the returned NumPy arrays are expictly copied,
+            If set then the returned NumPy arrays are explicitly copied,
             rather than using a reference from the data structure
             created by the backend. Backends are not required to
             honor this setting. The default is `True`.
@@ -195,7 +195,7 @@ class BaseBackend(metaclass=ABCMeta):
             backend but is expected to be a file name or a data structure
             supported by the backend.
         make_copy: bool, optional
-            If set then the returned NumPy arrays are expictly copied,
+            If set then the returned NumPy arrays are explicitly copied,
             rather than using a reference from the data structure
             created by the backend. Backends are not required to
             honor this setting. The default is `True`.
@@ -318,7 +318,7 @@ class BaseBackend(metaclass=ABCMeta):
             is expected to be a file name or a data structure supported by
             the backend.
         make_copy: bool, optional
-            If set then the returned NumPy arrays are expictly copied,
+            If set then the returned NumPy arrays are explicitly copied,
             rather than using a reference from the data structure
             created by the backend. Backends are not required to
             honor this setting. The default is `True`.
@@ -350,7 +350,7 @@ class BaseBackend(metaclass=ABCMeta):
             is expected to be a file name or a data structure supported by
             the backend.
         make_copy: bool, optional
-            If set then the returned NumPy arrays are expictly copied,
+            If set then the returned NumPy arrays are explicitly copied,
             rather than using a reference from the data structure
             created by the backend. Backends are not required to
             honor this setting. The default is `True`.
@@ -383,7 +383,7 @@ class BaseBackend(metaclass=ABCMeta):
             is expected to be a file name or a data structure supported by
             the backend.
         make_copy: bool, optional
-            If set then the returned NumPy arrays are expictly copied,
+            If set then the returned NumPy arrays are explicitly copied,
             rather than using a reference from the data structure
             created by the backend. Backends are not required to
             honor this setting. The default is `True`.
@@ -721,7 +721,7 @@ class BaseBackend(metaclass=ABCMeta):
             backend but is expected to be a file name or a tabular
             data structure supported by the backend.
         make_copy: bool, optional
-            If set then the returned NumPy arrays are expictly copied,
+            If set then the returned NumPy arrays are explicitly copied,
             rather than using a reference from the data structure
             created by the backend. Backends are not required to
             honor this setting. The default is `True`.

--- a/sherpa/astro/io/backends.py
+++ b/sherpa/astro/io/backends.py
@@ -1,0 +1,763 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Defines the routines a backend must provide.
+
+Since this uses the ABCMeta metaclass, it does not provide a usable
+backend. For this, one of the *_backend modules must be used.
+
+The actual backend-specific code should
+
+- be placed in a file called xxx_backend.py (where xxx is the label
+  that is used in the options.io_pkg setting by the user, such as
+  crates),
+
+- and this module should contain a class called Backend, which derives
+  from BaseBackend, over-rides all the abstract methods of the class,
+  and has a name attribute set to the string matching xxx.
+
+This approach is simpler than that used for the plotting backends,
+which uses a registry for the backends, and does not require a fixed
+class name.
+
+"""
+
+from abc import ABCMeta, abstractmethod
+from typing import Any, Mapping, Optional, Sequence, Union
+
+import numpy as np
+
+from ..data import Data1D
+
+from .xstable import TableHDU
+
+
+__all__ = ('BaseBackend', )
+
+
+# Some variants are named xxx and xxxArg, where the former is the
+# return value (an invariant type, like dict) and the latter is
+# covariant (such as Mapping) as it's used as an argument to a
+# function.
+#
+KeyType = Union[str, bool, int, float]
+NamesType = Sequence[str]
+HdrTypeArg = Mapping[str, KeyType]
+HdrType = dict[str, KeyType]
+ColumnsType = Mapping[str, Union[np.ndarray, list, tuple]]
+
+# It's hard to type the arguments to the Data constructors
+DataTypeArg = Mapping[str, Any]
+DataType = dict[str, Any]
+
+
+class BaseBackend(metaclass=ABCMeta):
+    """Define the backend API."""
+
+    name: str = "base"
+    """The name of the backend."""
+
+    @abstractmethod
+    def get_table_data(self, arg,
+                       ncols: int = 1,
+                       colkeys: Optional[NamesType] = None,
+                       make_copy: bool = True,
+                       fix_type: bool = True,
+                       blockname: Optional[str] = None,
+                       hdrkeys: Optional[NamesType] = None
+                       ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
+        """Read columns from a file or object.
+
+        The columns to select depend on the ncols and colkeys arguments,
+        as well as the backend.
+
+        Parameters
+        ----------
+        arg
+            The data to read the columns from. This depends on the
+            backend but is expected to be a file name or a tabular
+            data structure supported by the backend.
+        ncols: int, optional
+            The number of columns to read in when colkeys is not
+            set (the first ncols columns are chosen).
+        colkeys: sequence of str or None, optional
+            If given, what columns from the table should be selected,
+            otherwise the backend selects. The default is `None`.
+            Names are compared using a case insensitive match.
+        make_copy: bool, optional
+            If set then the returned NumPy arrays are expictly copied,
+            rather than using a reference from the data structure
+            created by the backend. Backends are not required to
+            honor this setting. The default is `True`.
+        fix_type: bool, optional
+            Should the returned arrays be converted to the
+            `sherpa.utils.numeric_types.SherpaFloat` type. The default
+            is `True`.
+        blockname: str or None, optional
+            The name of the "block" (HDU) to read the column data (useful
+            for data structures containing multiple blocks/HDUs) or None.
+            Names are compared using a case insensitive match.
+        hdrkeys: sequence of str or None, optional
+            If set, the table structure must contain these keys, and the
+            values are returned.  Names are compared using a case
+            insensitive match.
+
+        Returns
+        -------
+        names, data, filename, hdr
+            The column names, as a list of strings, and the data as
+            a list of NumPy arrays (matching the order and length of
+            the names array). The filename is the name of the file (a
+            string) and hdr is a dictionary with the requested keywords
+            (when hdrkeys is `None` this dictionary will be empty).
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid, or a required column or keyword
+            is missing.
+
+        """
+
+    @abstractmethod
+    def get_header_data(self, arg,
+                        blockname: Optional[str] = None,
+                        hdrkeys: Optional[NamesType] = None
+                        ) -> HdrType:
+        """Read the metadata.
+
+        Parameters
+        ----------
+        arg
+            The data to read the header values from. This depends on the
+            backend but is expected to be a file name or a data structure
+            supported by the backend.
+        blockname: str or None, optional
+            The name of the "block" (HDU) to read the data (useful
+            for data structures containing multiple blocks/HDUs) or None.
+            Names are compared using a case insensitive match.
+        hdrkeys: sequence of str or None, optional
+            If set, the table structure must contain these keys, and the
+            values are returned. Names are compared using a case
+            insensitive match.
+
+        Returns
+        -------
+        hdr: dict
+            A dictionary with the keyword data (only the name and values
+            are returned, any sort of metadata, such as comments or units,
+            are not returned).
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid or a keyword is missing.
+
+        """
+
+    @abstractmethod
+    def get_image_data(self, arg,
+                       make_copy: bool = True,
+                       fix_type: bool = True
+                       ) -> tuple[DataType, str]:
+        """Read image data.
+
+        Parameters
+        ----------
+        arg
+            The data to read the header values from. This depends on the
+            backend but is expected to be a file name or a data structure
+            supported by the backend.
+        make_copy: bool, optional
+            If set then the returned NumPy arrays are expictly copied,
+            rather than using a reference from the data structure
+            created by the backend. Backends are not required to
+            honor this setting. The default is `True`.
+        fix_type: bool, optional
+            Should the returned arrays be converted to the
+            `sherpa.utils.numeric_types.SherpaFloat` type. The default
+            is `True`.
+
+        Returns
+        -------
+        data, filename
+            The data, as a dictionary, and the filename. The keys of the
+            dictionary match the arguments when creating a
+            sherpa.astro.data.DataIMG object.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid or not an image.
+
+        """
+
+    @abstractmethod
+    def get_column_data(self, *args) -> list[np.ndarray]:
+        """Extract the column data.
+
+        Parameters
+        ----------
+        *args
+            Extract column information from each argument. It can be an
+            ndarray, list, or tuple, or a data structure from the backend,
+            with each argument representing a column. 2D arguments are
+            separated by column.
+
+        Returns
+        -------
+        data: list of ndarray
+            The column data.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            There are no arguments or an argument is not supported.
+
+        Notes
+        -----
+
+        An argument can be None, which is just passed back to the caller.
+        This means the typing rules for the function are not quite
+        correct.
+
+        """
+
+    # Follow sherpa.io.get_ascii_data API.
+    #
+    @abstractmethod
+    def get_ascii_data(self,
+                       filename: str,
+                       ncols: int = 1,
+                       colkeys: Optional[NamesType] = None,
+                       sep: str = ' ',
+                       dstype: type = Data1D,
+                       comment: str = '#',
+                       require_floats: bool = True
+                       ) -> tuple[list[str], list[np.ndarray], str]:
+        """Read columns from an ASCII file.
+
+        The `sep`, `dstype`, `comment`, and `require_floats` arguments
+        may be ignored by the backend.q
+
+        Parameters
+        ----------
+        filename : str
+           The name of the ASCII file to read in.
+        ncols : int, optional
+           The number of columns to read in (the first ``ncols`` columns
+           in the file). This is ignored if ``colkeys`` is given.
+        colkeys : array of str, optional
+           An array of the column name to read in. The default is
+           `None`.
+        sep : str, optional
+           The separator character. The default is ``' '``.
+        dstype : data class to use, optional
+           Used to check that the data file contains enough columns.
+        comment : str, optional
+           The comment character. The default is ``'#'``.
+        require_floats : bool, optional
+           If `True` (the default), non-numeric data values will
+           raise a `ValueError`.
+
+        Returns
+        -------
+        colnames, coldata, filename
+           The column names read in, the data for the columns
+           as an array, with each element being the data for the column
+           (the order matches ``colnames``), and the name of the file.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+           Raised if a requested column is missing or the file appears
+           to be a binary file.
+        ValueError
+           If a column value can not be converted into a numeric value
+           and the `require_floats` parameter is `True`.
+
+
+        """
+
+    @abstractmethod
+    def get_arf_data(self, arg,
+                     make_copy: bool = True
+                     ) -> tuple[DataType, str]:
+        """Read in the ARF.
+
+        Parameters
+        ----------
+        arg
+            The data to read the ARF from. This depends on the backend but
+            is expected to be a file name or a data structure supported by
+            the backend.
+        make_copy: bool, optional
+            If set then the returned NumPy arrays are expictly copied,
+            rather than using a reference from the data structure
+            created by the backend. Backends are not required to
+            honor this setting. The default is `True`.
+
+        Returns
+        -------
+        data, filename
+            The data, as a dictionary, and the filename. The keys of the
+            dictionary match the arguments when creating a
+            sherpa.astro.data.DataARF object.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid or not an ARF.
+
+        """
+
+    @abstractmethod
+    def get_rmf_data(self, arg,
+                     make_copy: bool = True
+                     ) -> tuple[DataType, str]:
+        """Read in the RMF.
+
+        Parameters
+        ----------
+        arg
+            The data to read the RMF from. This depends on the backend but
+            is expected to be a file name or a data structure supported by
+            the backend.
+        make_copy: bool, optional
+            If set then the returned NumPy arrays are expictly copied,
+            rather than using a reference from the data structure
+            created by the backend. Backends are not required to
+            honor this setting. The default is `True`.
+
+        Returns
+        -------
+        data, filename
+            The data, as a dictionary, and the filename. The keys of the
+            dictionary match the arguments when creating a
+            sherpa.astro.data.DataRMF object.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid or not a RMF.
+
+        """
+
+    @abstractmethod
+    def get_pha_data(self, arg,
+                     make_copy: bool = True,
+                     use_background: bool = False
+                     ) -> tuple[list[DataType], str]:
+        """Read in the PHA.
+
+        Parameters
+        ----------
+        arg
+            The data to read the PHA from. This depends on the backend but
+            is expected to be a file name or a data structure supported by
+            the backend.
+        make_copy: bool, optional
+            If set then the returned NumPy arrays are expictly copied,
+            rather than using a reference from the data structure
+            created by the backend. Backends are not required to
+            honor this setting. The default is `True`.
+        use_background: bool, optional
+            Should the data be read in as a background file (only relevant
+            for files that contain the background data in a separate block
+            of the same file, such as Chandra Level 3 PHA files, as used
+            by the Chandra Source Catalog). The default is `False`.
+
+        Returns
+        -------
+        datas, filename
+            A list of dictionaries, containing the PHA data (since there
+            can be multiple datasets with a PHA-II file) and the filename.
+            The keys of the dictionary match the arguments when creating
+            a sherpa.astro.data.DataPHA object.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid or not a PHA.
+
+        """
+
+    @abstractmethod
+    def pack_table_data(self,
+                        data: ColumnsType,
+                        col_names: NamesType,
+                        header: Optional[HdrTypeArg] = None) -> Any:
+        """Create the tabular data.
+
+        Parameters
+        ----------
+        data : dict
+            The table data, where the key is the column name and the value
+            the data.
+        col_names : sequence of str
+            The column names from data to use (this also sets the order).
+        header : dict or None, optional
+            Any header information to include.
+
+        Returns
+        -------
+        table
+            A data structure used by the backend to represent tabular data.
+
+        """
+
+    @abstractmethod
+    def pack_image_data(self,
+                        data: DataTypeArg,
+                        header: HdrTypeArg) -> Any:
+        """Create the image data.
+
+        Parameters
+        ----------
+        data : dict
+            The image data, where the keys are arguments used to create a
+            sherpa.astro.data.DataIMG object.
+        header : dict
+            The header information to include.
+
+        Returns
+        -------
+        image
+            A data structure used by the backend to represent image data.
+
+        """
+
+    @abstractmethod
+    def pack_pha_data(self,
+                      data: ColumnsType,
+                      col_names: NamesType,
+                      header: Optional[HdrTypeArg] = None) -> Any:
+        """Create the PHA.
+
+        Parameters
+        ----------
+        data : dict
+            The table data, where the key is the column name and the value
+            the data.
+        col_names : sequence of str
+            The column names from data to use (this also sets the order).
+        header : dict or None, optional
+            Any header information to include.
+
+        Returns
+        -------
+        pha
+            A data structure used by the backend to represent PHA data.
+
+        """
+
+    @abstractmethod
+    def pack_arf_data(self,
+                      data: ColumnsType,
+                      col_names: NamesType,
+                      header: Optional[HdrTypeArg] = None) -> Any:
+        """Create the ARF.
+
+        Parameters
+        ----------
+        data : dict
+            The table data, where the key is the column name and the value
+            the data.
+        col_names : sequence of str
+            The column names from data to use (this also sets the order).
+        header : dict or None, optional
+            Any header information to include.
+
+        Returns
+        -------
+        arf
+            A data structure used by the backend to represent ARF data.
+
+        """
+
+    @abstractmethod
+    def pack_rmf_data(self, blocks) -> Any:
+        """Create the RMF.
+
+        Parameters
+        ----------
+        blocks : sequence of pairs
+            The RMF data, stored as pairs of (data, header), where data is
+            a dictionary of column name (keys) and values, and header is a
+            dictionary of key and values. The first element is the MATRIX
+            block and the second is for the EBOUNDS block.
+
+        Returns
+        -------
+        rmf
+            A data structure used by the backend to represent RMF data.
+
+        """
+
+    @abstractmethod
+    def pack_hdus(self,
+                  blocks: Sequence[TableHDU]) -> Any:
+        """Create a dataset.
+
+        Parameters
+        ----------
+        blocks : sequence of TableHDU
+            The blocks (HDUs) to store.
+
+        Returns
+        -------
+        hdus
+            A data structure used by the backend to represent the data.
+
+        """
+
+    @abstractmethod
+    def set_table_data(self,
+                       filename: str,
+                       data: ColumnsType,
+                       col_names: NamesType,
+                       header: Optional[HdrTypeArg] = None,
+                       ascii: bool = False,
+                       clobber: bool = False) -> None:
+        """Write out the tabular data.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file to create.
+        data : dict
+            The table data, where the key is the column name and the value
+            the data.
+        col_names : sequence of str
+            The column names from data to use (this also sets the order).
+        header : dict or None, optional
+            Any header information to include.
+        ascii : bool, optional
+            Is the file to be written out as a text file (`True`) or a
+            binary file? The default is `False`.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        """
+
+    @abstractmethod
+    def set_image_data(self,
+                       filename: str,
+                       data: DataTypeArg,
+                       header: HdrTypeArg,
+                       ascii: bool = False,
+                       clobber: bool = False) -> None:
+        """Write out the image data.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file to create.
+        data : dict
+            The image data, where the keys are arguments used to create a
+            sherpa.astro.data.DataIMG object.
+        header : dict
+            The header information to include.
+        ascii : bool, optional
+            Is the file to be written out as a text file (`True`) or a
+            binary file? The default is `False`.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        """
+
+    @abstractmethod
+    def set_pha_data(self,
+                     filename: str,
+                     data: ColumnsType,
+                     col_names: NamesType,
+                     header: Optional[HdrTypeArg] = None,
+                     ascii: bool = False,
+                     clobber: bool = False) -> None:
+        """Write out the PHA.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file to create.
+        data : dict
+            The table data, where the key is the column name and the value
+            the data.
+        col_names : sequence of str
+            The column names from data to use (this also sets the order).
+        header : dict or None, optional
+            Any header information to include.
+        ascii : bool, optional
+            Is the file to be written out as a text file (`True`) or a
+            binary file? The default is `False`.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        """
+
+    @abstractmethod
+    def set_arf_data(self,
+                     filename: str,
+                     data: ColumnsType,
+                     col_names: NamesType,
+                     header: Optional[HdrTypeArg] = None,
+                     ascii: bool = False,
+                     clobber: bool = False) -> None:
+        """Write out the ARF.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file to create.
+        data : dict
+            The table data, where the key is the column name and the value
+            the data.
+        col_names : sequence of str
+            The column names from data to use (this also sets the order).
+        header : dict or None, optional
+            Any header information to include.
+        ascii : bool, optional
+            Is the file to be written out as a text file (`True`) or a
+            binary file? The default is `False`.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        """
+
+    @abstractmethod
+    def set_rmf_data(self,
+                     filename: str,
+                     blocks,
+                     clobber: bool = False) -> None:
+        """Write out the RMF.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file to create.
+        blocks : sequence of pairs
+            The RMF data, stored as pairs of (data, header), where data is
+            a dictionary of column name (keys) and values, and header is a
+            dictionary of key and values. The first element is the MATRIX
+            block and the second is for the EBOUNDS block.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        Notes
+        -----
+        There is currently no support for writing out a RMF as an ASCII
+        file.
+
+        """
+
+    @abstractmethod
+    def set_hdus(self,
+                 filename: str,
+                 blocks: Sequence[TableHDU],
+                 clobber: bool = False) -> None:
+        """Write out (possibly multiple) blocks.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file to create.
+        blocks : sequence of TableHDU
+            The blocks (HDUs) to store.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        """
+
+    @abstractmethod
+    def read_table_blocks(self, arg,
+                          make_copy: bool = False
+                          ) -> tuple[str,
+                                     dict[int, dict[str, np.ndarray]],
+                                     dict[int, HdrType]]:
+        """Read in tabular data with no restrictions on the columns.
+
+        Parameters
+        ----------
+        arg
+            The data to read the columns from. This depends on the
+            backend but is expected to be a file name or a tabular
+            data structure supported by the backend.
+        make_copy: bool, optional
+            If set then the returned NumPy arrays are expictly copied,
+            rather than using a reference from the data structure
+            created by the backend. Backends are not required to
+            honor this setting. The default is `True`.
+
+        Returns
+        -------
+        filename, blockdata, hdrdata
+            The filename as a string. The blockdata and hdrdata values are
+            dictionaries where the key is an integer representing the
+            block (or HDU) number (where the first block is numbered 1 and
+            represents the first tabular block, that is it does not
+            include the primary HDU) and the values are dictionaries
+            representing the column data or header data for each block.
+
+        Raises
+        ------
+        sherpa.utils.err.IOErr
+            The arg argument is invalid, or a required column or keyword
+            is missing.
+
+        """
+
+    @abstractmethod
+    def set_arrays(self,
+                   filename: str,
+                   args: Sequence[np.ndarray],
+                   fields: Optional[NamesType] = None,
+                   ascii: bool = True,
+                   clobber: bool = False) -> None:
+        """Write out columns.
+
+        Parameters
+        ----------
+        filename : str
+            The file name.
+        args : sequence of ndarray
+            The column data.
+        fields : sequence of str or None, optional
+            The column names to use. If set to `None` then the columns are
+            named ``col1``, ``col2``, ...
+        ascii : bool, optional
+            Is the file to be written out as a text file (`True`) or a
+            binary file? The default is `True`.
+        clobber : bool, optional
+            If the file already exists can it be over-written (`True`) or
+            will a sherpa.utils.err.IOErr error be raised? The default is
+            `False`.
+
+        """

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -51,13 +51,7 @@ except ImportError:
     warning('failed to import WCS module; WCS routines will not be '
             'available')
 
-__all__ = ('get_table_data', 'get_header_data', 'get_image_data',
-           'get_column_data', 'get_ascii_data',
-           'get_arf_data', 'get_rmf_data', 'get_pha_data',
-           'pack_table_data', 'pack_image_data', 'pack_pha_data',
-           'pack_arf_data', 'pack_rmf_data', 'pack_hdus',
-           'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data', 'set_hdus')
+__all__ = ('Backend', )
 
 
 CrateType = Union[TABLECrate, IMAGECrate]

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -21,7 +21,7 @@
 from collections import defaultdict
 import logging
 import os
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import numpy as np
 
@@ -53,12 +53,16 @@ except ImportError:
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'pack_table_data', 'pack_image_data', 'pack_pha_data',
+           'pack_arf_data', 'pack_rmf_data', 'pack_hdus',
            'set_table_data', 'set_image_data', 'set_pha_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
 CrateType = Union[TABLECrate, IMAGECrate]
-KeyType = Union[bool, int, str, float]
+KeyType = Union[str, bool, int, float]
+NamesType = Sequence[str]
+HdrType = dict[str, KeyType]
 
 
 def open_crate(filename: str,
@@ -182,7 +186,7 @@ def _try_key(crate: CrateType,
     return dtype(value)
 
 
-def _get_meta_data(crate: CrateType) -> dict[str, KeyType]:
+def _get_meta_data(crate: CrateType) -> HdrType:
     """Retrieve the header information from the crate.
 
     This loses the "specialized" keywords like HISTORY and COMMENT.
@@ -464,7 +468,13 @@ def _get_crate_by_blockname(dataset: CrateDataset,
 
 # Read Functions #
 
-def read_table_blocks(arg, make_copy=False):
+def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
+                      make_copy: bool = False
+                      ) -> tuple[str,
+                                 dict[int, dict[str, np.ndarray]],
+                                 dict[int, dict[str, Optional[KeyType]]]
+                                 ]:
+    """Read in tabular data with no restrictions on the columns."""
 
     dataset = None
     if isinstance(arg, TABLECrate):
@@ -479,8 +489,8 @@ def read_table_blocks(arg, make_copy=False):
     else:
         raise IOErr('badfile', arg, "CrateDataset obj")
 
-    cols = {}
-    hdr = {}
+    cols: dict[int, dict[str, np.ndarray]] = {}
+    hdr: dict[int, dict[str, Optional[KeyType]]] = {}
     for idx in range(1, dataset.get_ncrates() + 1):
         crate = dataset.get_crate(idx)
         hdr[idx] = {}
@@ -500,10 +510,11 @@ def read_table_blocks(arg, make_copy=False):
     return filename, cols, hdr
 
 
-def get_header_data(arg, blockname=None, hdrkeys=None):
-    """
-    checked for new crates
-    """
+def get_header_data(arg: Union[str, TABLECrate],
+                    blockname: Optional[str] = None,
+                    hdrkeys: Optional[NamesType] = None
+                    ) -> HdrType:
+    """Read the metadata."""
 
     if isinstance(arg, str):
         arg = get_filename_from_dmsyntax(arg)
@@ -532,16 +543,9 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
     return hdr
 
 
-def get_column_data(*args):
-    """
-    checked for new crates
+def get_column_data(*args) -> list[np.ndarray]:
+    """Extract the column data."""
 
-    get_column_data( *NumPy_args )
-
-    get_column_data( *CrateData_args )
-
-    get_column_data( *NumPy_and_CrateData_args )
-    """
     # args is passed as type list
     if len(args) == 0:
         raise IOErr('noarrays')
@@ -567,13 +571,23 @@ def get_column_data(*args):
     return cols
 
 
-def get_ascii_data(filename, ncols=2, colkeys=None, **kwargs):
+def get_ascii_data(filename: str,
+                   ncols: int = 2,
+                   colkeys: Optional[NamesType] = None,
+                   **kwargs
+                   ) -> tuple[list[str], list[np.ndarray], str]:
     """Read columns from an ASCII file"""
     return get_table_data(filename, ncols, colkeys)[:3]
 
 
-def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
-                   blockname=None, hdrkeys=None):
+def get_table_data(arg: Union[str, TABLECrate],
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   make_copy: bool = True,
+                   fix_type: bool = True,
+                   blockname: Optional[str] = None,
+                   hdrkeys: Optional[NamesType] = None
+                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
     """Read columns from a file or crate."""
 
     if isinstance(arg, str):
@@ -634,7 +648,10 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
     return colkeys, cols, filename, hdr
 
 
-def get_image_data(arg, make_copy=True, fix_type=True):
+def get_image_data(arg: Union[str, IMAGECrate],
+                   make_copy: bool = True,
+                   fix_type: bool = True
+                   ) -> tuple[dict[str, Any], str]:
     """Read image data from a file or crate"""
 
     if isinstance(arg, str):
@@ -652,7 +669,7 @@ def get_image_data(arg, make_copy=True, fix_type=True):
     else:
         raise IOErr('badfile', arg, "IMAGECrate obj")
 
-    data = {}
+    data: dict[str, Any] = {}
 
     data['y'] = _require_image(img, filename, make_copy=make_copy,
                                fix_type=fix_type)
@@ -699,7 +716,9 @@ def get_image_data(arg, make_copy=True, fix_type=True):
     return data, filename
 
 
-def get_arf_data(arg, make_copy=True):
+def get_arf_data(arg: Union[str, TABLECrate],
+                 make_copy: bool = True
+                 ) -> tuple[dict[str, Any], str]:
     """Read an ARF from a file or crate"""
 
     if isinstance(arg, str):
@@ -718,7 +737,7 @@ def get_arf_data(arg, make_copy=True):
     if arf is None or arf.get_colnames() is None:
         raise IOErr('filenotfound', arg)
 
-    data = {}
+    data: dict[str, Any] = {}
 
     data['energ_lo'] = _require_col(arf, 'ENERG_LO',
                                     make_copy=make_copy,
@@ -794,7 +813,9 @@ def _find_matrix_blocks(filename: str,
     return blnames
 
 
-def get_rmf_data(arg, make_copy=True):
+def get_rmf_data(arg: Union[str, RMFCrateDataset],
+                 make_copy: bool = True
+                 ) -> tuple[dict[str, Any], str]:
     """Read a RMF from a file or crate"""
 
     if isinstance(arg, str):
@@ -846,7 +867,7 @@ def get_rmf_data(arg, make_copy=True):
     if not rmf.column_exists('N_CHAN'):
         raise IOErr('reqcol', 'N_CHAN', filename)
 
-    data = {}
+    data: dict[str, Any] = {}
     data['detchans'] = _require_key(rmf, 'DETCHANS', dtype=SherpaInt)
     data['energ_lo'] = _require_col(rmf, 'ENERG_LO',
                                     make_copy=make_copy, fix_type=True)
@@ -921,7 +942,10 @@ def get_rmf_data(arg, make_copy=True):
     return data, filename
 
 
-def get_pha_data(arg, make_copy=True, use_background=False):
+def get_pha_data(arg: Union[str, PHACrateDataset],
+                 make_copy: bool = True,
+                 use_background: bool = False
+                 ) -> tuple[list[dict[str, Any]], str]:
     """Read PHA data from a file or crate"""
 
     if isinstance(arg, str):
@@ -979,7 +1003,7 @@ def get_pha_data(arg, make_copy=True, use_background=False):
     # Here, I instead test for a column, SPEC_NUM, that can
     # *only* be present in Type II. SMD 05/15/13
     if _try_col(pha, 'SPEC_NUM') is None:
-        data = {}
+        data: dict[str, Any] = {}
 
         # Keywords
         data['exposure'] = _try_key(pha, 'EXPOSURE', SherpaFloat)
@@ -1037,7 +1061,6 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
     else:
         # Type 2 PHA file support
-        data = {}
         num = pha.get_nrows()
 
         # Keywords
@@ -1122,39 +1145,39 @@ def get_pha_data(arg, make_copy=True, use_background=False):
                       background_down, bin_lo, bin_hi, grouping, quality,
                       orders, parts, specnums, srcids):
 
-            data = {}
+            idata: dict[str, Any] = {}
 
-            data['exposure'] = exposure
+            idata['exposure'] = exposure
             # data['poisserr'] = poisserr
-            data['backfile'] = backfile
-            data['arffile'] = arffile
-            data['rmffile'] = rmffile
+            idata['backfile'] = backfile
+            idata['arffile'] = arffile
+            idata['rmffile'] = rmffile
 
-            data['backscal'] = bscal
-            data['backscup'] = bscup
-            data['backscdn'] = bscdn
-            data['areascal'] = arsc
+            idata['backscal'] = bscal
+            idata['backscup'] = bscup
+            idata['backscdn'] = bscdn
+            idata['areascal'] = arsc
 
-            data['channel'] = chan
-            data['counts'] = cnt
-            data['staterror'] = staterr
-            data['syserror'] = syserr
-            data['background_up'] = backup
-            data['background_down'] = backdown
-            data['bin_lo'] = binlo
-            data['bin_hi'] = binhi
-            data['grouping'] = grp
-            data['quality'] = qual
-            data['header'] = _get_meta_data(pha)
-            data['header']['TG_M'] = ordr
-            data['header']['TG_PART'] = prt
-            data['header']['SPEC_NUM'] = specnum
-            data['header']['TG_SRCID'] = srcid
+            idata['channel'] = chan
+            idata['counts'] = cnt
+            idata['staterror'] = staterr
+            idata['syserror'] = syserr
+            idata['background_up'] = backup
+            idata['background_down'] = backdown
+            idata['bin_lo'] = binlo
+            idata['bin_hi'] = binhi
+            idata['grouping'] = grp
+            idata['quality'] = qual
+            idata['header'] = _get_meta_data(pha)
+            idata['header']['TG_M'] = ordr
+            idata['header']['TG_PART'] = prt
+            idata['header']['SPEC_NUM'] = specnum
+            idata['header']['TG_SRCID'] = srcid
 
             for key in keys:
-                data['header'].pop(key, None)
+                idata['header'].pop(key, None)
 
-            datasets.append(data)
+            datasets.append(idata)
 
     return datasets, filename
 
@@ -1163,20 +1186,15 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 # Write/Pack Functions #
 #
 
-def check_clobber(filename: str, clobber: bool) -> None:
-    """Error out if the file exists and clobber is not set."""
-
-    if clobber or not os.path.isfile(filename):
-        return
-
-    raise IOErr("filefound", filename)
-
-
 def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
                   filename: str,
                   *,
-                  ascii: bool) -> None:
+                  ascii: bool,
+                  clobber: bool) -> None:
     """Write out the data."""
+
+    if not clobber and os.path.isfile(filename):
+        raise IOErr("filefound", filename)
 
     if ascii and '[' not in filename and ']' not in filename:
         filename += "[opt kernel=text/simple]"
@@ -1197,11 +1215,8 @@ def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
     dataset.write(filename, clobber=True)
 
 
-def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False) -> Optional[IMAGECrate]:
-
-    if not packup:
-        check_clobber(filename, clobber)
+def pack_image_data(data, header) -> IMAGECrate:
+    """Pack up the image data."""
 
     img = IMAGECrate()
 
@@ -1254,23 +1269,21 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     pix_col = CrateData()
     pix_col.values = data['pixels']
     img.add_image(pix_col)
+    return img
 
-    if packup:
-        return img
+
+def set_image_data(filename, data, header, ascii=False, clobber=False) -> None:
+    """Write out the image data."""
 
     if ascii and '[' not in filename and ']' not in filename:
-        # filename += "[opt kernel=text/simple]"
         raise IOErr('writenoimg')
 
-    img.write(filename, clobber=True)
-    return None
+    img = pack_image_data(data, header)
+    write_dataset(img, filename, ascii=ascii, clobber=clobber)
 
 
-def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
-
-    if not packup:
-        check_clobber(filename, clobber)
+def pack_table_data(data, col_names, header=None) -> TABLECrate:
+    """Pack up the table data."""
 
     tbl = TABLECrate()
     hdr = {} if header is None else header
@@ -1278,35 +1291,39 @@ def set_table_data(filename, data, col_names, header=None,
         _set_column(tbl, name, data[name])
 
     _update_header(tbl, hdr, skip_if_known=False)
+    return tbl
 
-    if packup:
-        return tbl
 
-    write_dataset(tbl, filename, ascii=ascii)
-    return None
+def set_table_data(filename, data, col_names, header=None,
+                   ascii=False, clobber=False) -> None:
+    """Write out the table data."""
+
+    tbl = pack_table_data(data, col_names, header=header)
+    write_dataset(tbl, filename, ascii=ascii, clobber=clobber)
+
+
+def pack_arf_data(data, col_names, header=None) -> TABLECrate:
+    """Pack the ARF"""
+
+    if header is None:
+        raise ArgumentTypeErr("badarg", "header", "set")
+
+    return pack_table_data(data, col_names, header)
 
 
 def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
-    """Create an ARF"""
+                 ascii=False, clobber=False) -> None:
+    """Write out the ARF"""
+
+    arf = pack_arf_data(data, col_names, header)
+    write_dataset(arf, filename, ascii=ascii, clobber=clobber)
+
+
+def pack_pha_data(data, col_names, header=None) -> PHACrateDataset:
+    """Pack the PHA data."""
 
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")
-
-    # Currently we can use the same logic as set_table_data
-    return set_table_data(filename, data, col_names, header=header,
-                          ascii=ascii, clobber=clobber, packup=packup)
-
-
-def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False) -> Optional[PHACrateDataset]:
-    """Create a PHA dataset/file"""
-
-    if header is None:
-        raise ArgumentTypeErr("badarg", "header", "set")
-
-    if not packup:
-        check_clobber(filename, clobber)
 
     phadataset = PHACrateDataset()
 
@@ -1325,16 +1342,19 @@ def set_pha_data(filename, data, col_names, header=None,
         _set_column(pha, name, data[name])
 
     phadataset.add_crate(pha)
+    return phadataset
 
-    if packup:
-        return phadataset
 
-    write_dataset(phadataset, filename, ascii=ascii)
-    return None
+def set_pha_data(filename, data, col_names, header=None,
+                 ascii=False, clobber=False) -> None:
+    """Create a PHA dataset/file"""
+
+    pha = pack_pha_data(data, col_names, header)
+    write_dataset(pha, filename, ascii=ascii, clobber=clobber)
 
 
 def _update_header(cr: CrateType,
-                   header: dict[str, Optional[KeyType]],
+                   header: Mapping[str, Optional[KeyType]],
                    skip_if_known: bool = True) -> None:
     """Update the header of the crate."""
 
@@ -1350,17 +1370,8 @@ def _update_header(cr: CrateType,
         _set_key(cr, key, value)
 
 
-def set_rmf_data(filename, blocks, clobber=False):
-    """Save the RMF data to disk.
-
-    Unlike the other save_*_data calls this does not support the ascii
-    or packup arguments. It also relies on the caller to have set up
-    the headers and columns correctly apart for variable-length fields,
-    which are limited to F_CHAN, N_CHAN, and MATRIX.
-
-    """
-
-    check_clobber(filename, clobber)
+def pack_rmf_data(blocks) -> RMFCrateDataset:
+    """Pack up the RMF data."""
 
     # For now assume only two blocks:
     #    MATRIX
@@ -1399,9 +1410,9 @@ def set_rmf_data(filename, blocks, clobber=False):
     # Does RMFCrateDataset offer us anything above creating a
     # CrateDataset manually?
     #
-    ds = RMFCrateDataset()
-    matrix_cr = ds.get_crate("MATRIX")
-    ebounds_cr = ds.get_crate("EBOUNDS")
+    rmf = RMFCrateDataset()
+    matrix_cr = rmf.get_crate("MATRIX")
+    ebounds_cr = rmf.get_crate("EBOUNDS")
 
     matrix_cr.add_column(mkcol("ENERG_LO", matrix_data["ENERG_LO"], units="keV"))
     matrix_cr.add_column(mkcol("ENERG_HI", matrix_data["ENERG_HI"], units="keV"))
@@ -1426,15 +1437,37 @@ def set_rmf_data(filename, blocks, clobber=False):
     _update_header(matrix_cr, matrix_header)
     _update_header(ebounds_cr, ebounds_header)
 
-    ds.write(filename, clobber=True)
+    return rmf
 
 
-def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
+def set_rmf_data(filename: str,
+                 blocks,
+                 clobber: bool = False) -> None:
+    """Save the RMF data to disk.
+
+    Unlike the other save_*_data calls this does not support the ascii
+    argument. It also relies on the caller to have set up the headers
+    and columns correctly apart for variable-length fields, which are
+    limited to F_CHAN, N_CHAN, and MATRIX.
+
+    """
+
+    rmf = pack_rmf_data(blocks)
+    write_dataset(rmf, filename, ascii=False, clobber=clobber)
+
+
+def set_arrays(filename: str,
+               args: Sequence[np.ndarray],
+               fields: Optional[NamesType] = None,
+               ascii: bool = True,
+               clobber: bool = False) -> None:
+    """Write out the columns."""
 
     # Historically the clobber command has been checked before
     # processing the data, so do so here.
     #
-    check_clobber(filename, clobber)
+    if not clobber and os.path.isfile(filename):
+        raise IOErr("filefound", filename)
 
     # Check args is a sequence of sequences (although not a complete
     # check).
@@ -1457,7 +1490,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     if fields is None:
         fieldnames = [f'col{idx + 1}' for idx in range(nargs)]
     elif nargs == len(fields):
-        fieldnames = fields
+        fieldnames = list(fields)
     else:
         raise IOErr('wrongnumcols', nargs, len(fields))
 
@@ -1465,7 +1498,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     for val, name in zip(args, fieldnames):
         _set_column(tbl, name, val)
 
-    write_dataset(tbl, filename, ascii=ascii)
+    write_dataset(tbl, filename, ascii=ascii, clobber=clobber)
 
 
 def _add_header(cr: CrateType,
@@ -1558,20 +1591,29 @@ def _validate_block_names(hdulist: Sequence[TableHDU]) -> list[TableHDU]:
     return out
 
 
-def set_hdus(filename: str,
-             hdulist: Sequence[TableHDU],
-             clobber: bool = False) -> None:
-    """Write out multiple HDUS to a single file.
+def pack_hdus(blocks: Sequence[TableHDU]) -> CrateDataset:
+    """Create a dataset.
 
     At present we are restricted to tables only.
     """
 
-    check_clobber(filename, clobber)
-    nlist = _validate_block_names(hdulist)
+    nblocks = _validate_block_names(blocks)
 
-    ds = CrateDataset()
-    ds.add_crate(_create_primary_crate(nlist[0]))
-    for hdu in nlist[1:]:
-        ds.add_crate(_create_table_crate(hdu))
+    dset = CrateDataset()
+    dset.add_crate(_create_primary_crate(nblocks[0]))
+    for hdu in nblocks[1:]:
+        dset.add_crate(_create_table_crate(hdu))
 
-    ds.write(filename, clobber=True)
+    return dset
+
+
+def set_hdus(filename: str,
+             blocks: Sequence[TableHDU],
+             clobber: bool = False) -> None:
+    """Write out a dataset.
+
+    At present we are restricted to tables only.
+    """
+
+    dset = pack_hdus(blocks)
+    write_dataset(dset, filename, ascii=False, clobber=clobber)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -20,34 +20,33 @@
 
 from collections import defaultdict
 import logging
-import os.path
+import os
+from typing import Any, Optional, Sequence, Union
 
-import numpy
+import numpy as np
 
 from pycrates import CrateDataset, CrateKey, CrateData, TABLECrate, \
     IMAGECrate, WCSTANTransform, RMFCrateDataset, \
     PHACrateDataset  # type: ignore
 import pycrates  # type: ignore
-# work around missing TLMIN support in crates CIAO 4.15
-import cxcdm  # type: ignore
 
-from sherpa.astro.io.xstable import TableHDU
 from sherpa.astro.utils import resp_init
 from sherpa.utils import is_binary_file
 from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 
+from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
 error = logging.getLogger(__name__).error
 info = logging.getLogger(__name__).info
 
-transformstatus = False
 try:
-    from sherpa.astro.io.wcs import WCS
-    transformstatus = True
+    from .wcs import WCS
+    HAS_TRANSFORM = True
 except ImportError:
+    HAS_TRANSFORM = False
     warning('failed to import WCS module; WCS routines will not be '
             'available')
 
@@ -58,21 +57,31 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
-string_types = (str, )
+CrateType = Union[TABLECrate, IMAGECrate]
+KeyType = Union[bool, int, str, float]
 
 
-def open_crate_dataset(filename, crateType=CrateDataset, mode='r'):
-    """
-    checked for new crates
-    """
-    return crateType(filename, mode=mode)
+def open_crate(filename: str,
+               mode: str = "r") -> CrateType:
+    """Get the "most interesting" block of the file.
 
+    Parameters
+    ----------
+    filename : str
+    mode : str
 
-def open_crate(filename, crateType=CrateDataset, mode='r'):
+    Returns
+    -------
+    crate : IMAGECrate or TABLECrate
+
+    Notes
+    -----
+    This routine could just be inlined where necessary, but it is
+    useful because it allows the code to provide unified behaviour
+    when crates can not read a file because of an unknown datatype.
+
     """
-    checked for new crates
-    """
-    dataset = open_crate_dataset(filename, crateType, mode)
+    dataset = CrateDataset(filename, mode=mode)
     current = dataset.get_current_crate()
     try:
         return dataset.get_crate(current)
@@ -84,11 +93,10 @@ def open_crate(filename, crateType=CrateDataset, mode='r'):
         raise IOErr("openfailed", emsg) from exc
 
 
-def get_filename_from_dmsyntax(filename, blockname=None):
+def get_filename_from_dmsyntax(filename: str) -> str:
+    """What is the filename to use?"""
 
-    arg = str(filename)
-    isbinary = True
-    colnames = True
+    out = filename
     dmsyn = ''
 
     if '[' in filename and ']' in filename:
@@ -98,28 +106,36 @@ def get_filename_from_dmsyntax(filename, blockname=None):
             dmsyn = parts.pop(0).lower()
 
     if not is_binary_file(filename):
-        isbinary = False
-        # TODO: set encoding='UTF-8' or maybe 'ascii'
-        with open(filename, mode='r') as fh:
+        colnames = True
+
+        # Crates only guarantees to support ASCII-like variants but it
+        # should be okay to use a less-restrictive encoding here.
+        #
+        with open(filename, mode='r', encoding="UTF8") as fh:
             last = None
             line = fh.readline().strip()
-            while len(line) > 0 and line[0] in '#%':
+            while len(line) > 0 and line.startswith("#"):
                 last = line
                 line = fh.readline().strip()
-            if (last is not None and
-                    (len(last.strip('#').strip().split(' ')) != len(line.strip().split(' ')))):
+
+        # Check whether we have a header line and an actual data line
+        # and, if so, whether they match.
+        #
+        if last is not None:
+            cols_header = last.strip('#').strip().split(' ')
+            cols_data = line.strip().split(' ')
+            if len(cols_header) != len(cols_data):
                 colnames = False
 
-    if blockname is not None:
-        arg += f"[{str(blockname).upper()}]"
+        if not colnames and 'cols' not in dmsyn:
+            out += "[opt colnames=none]"
 
-    if not isbinary and not colnames and 'cols' not in dmsyn:
-        arg += "[opt colnames=none]"
-
-    return arg
+    return out
 
 
-def _try_key(crate, name, dtype=str):
+def _try_key(crate: CrateType,
+             name: str,
+             dtype: type = str) -> Optional[KeyType]:
     """Access the key from the crate returning None if it does not exist.
 
     There's no way to differentiate between a key that does not exist
@@ -166,51 +182,55 @@ def _try_key(crate, name, dtype=str):
     return dtype(value)
 
 
-def _get_meta_data(crate):
+def _get_meta_data(crate: CrateType) -> dict[str, KeyType]:
+    """Retrieve the header information from the crate.
+
+    This loses the "specialized" keywords like HISTORY and COMMENT.
+
     """
-    checked for new crates
-    """
+
     meta = {}
-    names = crate.get_keynames()
-    if names is not None:
-        for name in names:
-            val = crate.get_key(name).value
+    for name in crate.get_keynames():
+        val = crate.get_key(name).value
 
-            # empty numpy strings are not recognized by load pickle!
-            if type(val) is numpy.str_ and val == '':
-                val = ''
+        # empty numpy strings are not recognized by load pickle!
+        if isinstance(val, np.str_) and val == '':
+            val = ''
 
-            meta[name] = val
+        meta[name] = val
 
     return meta
 
 
-def _set_key(crate, name, val, fix_type=False, dtype=str):
-    """
-    checked for new crates
-    """
+def _set_key(crate: CrateType,
+             name: str,
+             val: KeyType,
+             fix_type: bool = False,
+             dtype: type = str) -> None:
+    """Add a key + value to the header."""
+
     key = CrateKey()
-    key.name = str(name).strip().upper()
-
-    if fix_type:
-        key.value = dtype(val)
-    else:
-        key.value = val
-
+    key.name = name.upper()
+    key.value = dtype(val) if fix_type else val
     crate.add_key(key)
 
 
-def _set_column(crate, name, val):
-    """
-    checked for new crates
-    """
+# The typing for this is not ideal.
+#
+def _set_column(crate: TABLECrate,
+                name: str,
+                val: Any) -> None:
+    """Add a column to the table crate."""
+
     col = CrateData()
     col.name = name.upper()
-    col.values = numpy.array(val)
+    col.values = np.array(val)
     crate.add_column(col)
 
 
-def _require_key(crate, name, dtype=str):
+def _require_key(crate: CrateType,
+                 name: str,
+                 dtype: type = str) -> KeyType:
     """Access the key from the crate, erroring out if it does not exist.
 
     There's no way to differentiate between a key that does not exist
@@ -242,38 +262,25 @@ def _require_key(crate, name, dtype=str):
     return key
 
 
-def _try_col(crate, colname, make_copy=False, fix_type=False,
-             dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
+def _try_col(crate: TABLECrate,
+             colname: str,
+             make_copy: bool = False,
+             fix_type: bool = False,
+             dtype: type = SherpaFloat) -> Optional[np.ndarray]:
+    """Return the column data or return None."""
 
     try:
-        col = crate.get_column(colname)
-    except ValueError:
+        return _require_col(crate, colname, make_copy=make_copy,
+                            fix_type=fix_type, dtype=dtype)
+    except IOErr:
         return None
 
-    if col.is_varlen():
-        values = col.get_fixed_length_array()
-    else:
-        values = col.values
 
-    if make_copy:
-        # Make a copy if a filename passed in
-        data = numpy.array(values).ravel()
-
-    else:
-        # Use a reference if a crate passed in
-        data = numpy.asarray(values).ravel()
-
-    if fix_type:
-        data = data.astype(dtype)
-
-    return data
-
-
+# This is surprisingly hard to type (because of column_stack) so skip
+# it.
+#
 def _require_tbl_col(crate, colname, cnames, make_copy=False,
-                     fix_type=False, dtype=SherpaFloat):
+                     fix_type=False):
     """
     checked for new crates
     """
@@ -285,18 +292,22 @@ def _require_tbl_col(crate, colname, cnames, make_copy=False,
 
     if make_copy:
         # Make a copy if a filename passed in
-        data = numpy.array(col.values)
+        data = np.array(col.values)
     else:
         # Use a reference if a crate passed in
-        data = numpy.asarray(col.values)
+        data = np.asarray(col.values)
 
     if fix_type:
-        data = data.astype(dtype)
+        data = data.astype(SherpaFloat)
 
-    return numpy.column_stack(data)
+    return np.column_stack(data)
 
 
-def _try_key_list(crate, keyname, num, dtype=SherpaFloat, fix_type=False):
+def _try_key_list(crate: CrateType,
+                  keyname: str,
+                  num: int,
+                  dtype: type = SherpaFloat,
+                  fix_type: bool = False) -> Optional[np.ndarray]:
     """
     checked for new crates
     """
@@ -307,7 +318,7 @@ def _try_key_list(crate, keyname, num, dtype=SherpaFloat, fix_type=False):
 
     # Make a copy of the data, since we don't know that pycrates will
     # do something sensible wrt reference counting
-    key = numpy.array([key.value] * num)
+    key = np.array([key.value] * num)
 
     if fix_type:
         key = key.astype(dtype)
@@ -315,15 +326,36 @@ def _try_key_list(crate, keyname, num, dtype=SherpaFloat, fix_type=False):
     return key
 
 
-def _try_col_list(crate, colname, num, make_copy=False, fix_type=False,
-                  dtype=SherpaFloat):
+def _try_col_list(crate: TABLECrate,
+                  colname: str,
+                  num: int,
+                  make_copy: bool = False,
+                  fix_type: bool = False) -> np.ndarray:
     """
     checked for the new crates
     """
-    if not crate.column_exists(colname):
-        return numpy.array([None] * num)
 
-    col = crate.get_column(colname)
+    try:
+        return _require_col_list(crate, colname,
+                                 make_copy=make_copy,
+                                 fix_type=fix_type)
+    except IOErr:
+        return np.array([None] * num)
+
+
+def _require_col_list(crate: TABLECrate,
+                      colname: str,
+                      make_copy: bool = False,
+                      fix_type: bool = False) -> np.ndarray:
+    """
+    check for new crates
+    """
+
+    try:
+        col = crate.get_column(colname)
+    except ValueError:
+        raise IOErr("reqcol", colname, crate.get_filename()) from None
+
     if col.is_varlen():
         values = col.get_fixed_length_array()
     else:
@@ -331,75 +363,76 @@ def _try_col_list(crate, colname, num, make_copy=False, fix_type=False,
 
     if make_copy:
         # Make a copy if a filename passed in
-        col = numpy.array(values)
+        col = np.array(values)
     else:
         # Use a reference if a crate passed in
-        col = numpy.asarray(values)
+        col = np.asarray(values)
 
     if fix_type:
-        col = col.astype(dtype)
+        col = col.astype(SherpaFloat)
 
     return col
 
 
-def _require_col_list(crate, colname, num, make_copy=False, fix_type=False,
-                      dtype=SherpaFloat):
-    """
-    check for new crates
-    """
+def _require_col(crate: TABLECrate,
+                 colname: str,
+                 make_copy: bool = False,
+                 fix_type: bool = False,
+                 label: Optional[str] = None,
+                 dtype: type = SherpaFloat) -> np.ndarray:
+    """Return the column data or error out."""
 
-    # _try_col_list returns [None] * num if the column doesn't exist
-    # which is awkward to check for so use an explicit check.
-    #
-    if not crate.column_exists(colname):
-        raise IOErr('badcol', colname)
-    return _try_col_list(crate, colname, num, make_copy, fix_type, dtype)
+    try:
+        col = crate.get_column(colname)
+    except ValueError:
+        msg = colname if label is None else label
+        raise IOErr("reqcol", msg, crate.get_filename()) from None
 
-
-def _require_col(crate, colname, make_copy=False, fix_type=False,
-                 dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
-    data = _try_col(crate, colname, make_copy, fix_type, dtype)
-    if data is None:
-        raise IOErr('badcol', colname)
-    return data
-
-
-def _try_image(crate, make_copy=False, fix_type=False, dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
+    if col.is_varlen():
+        values = col.get_fixed_length_array()
+    else:
+        values = col.values
 
     if make_copy:
         # Make a copy if a filename passed in
-        dat = pycrates.copy_piximgvals(crate).squeeze()
+        data = np.array(values).ravel()
+
     else:
         # Use a reference if a crate passed in
-        dat = pycrates.get_piximgvals(crate).squeeze()
+        data = np.asarray(values).ravel()
 
     if fix_type:
-        dat = dat.astype(dtype)
+        data = data.astype(dtype)
 
-    # FITS standard is FORTRAN filling, Sherpa is c-style
-#    return dat.reshape(dat.shape[::-1])
+    return data
 
-    # Crates now returns image in c-style filling
+
+
+def _require_image(crate: IMAGECrate,
+                   filename: str,
+                   make_copy: bool = False,
+                   fix_type: bool = False) -> np.ndarray:
+    """Return the image pixel data."""
+
+    try:
+        img = crate.get_image()
+    except LookupError:
+        raise IOErr("badimg", filename) from None
+
+    if make_copy:
+        dat = img.values.copy()
+    else:
+        dat = img.values
+
+    dat = dat.squeeze()
+    if fix_type:
+        dat = dat.astype(SherpaFloat)
+
     return dat
 
 
-def _require_image(crate, make_copy=False, fix_type=False, dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
-    dat = _try_image(crate, make_copy, fix_type, dtype)
-    if dat is None:
-        raise IOErr('badimg', crate.get_filename())
-    return dat
-
-
-def _get_crate_by_blockname(dataset, blkname):
+def _get_crate_by_blockname(dataset: CrateDataset,
+                            blkname: str) -> Optional[CrateType]:
     """Select the given block name.
 
     Parameters
@@ -433,7 +466,6 @@ def _get_crate_by_blockname(dataset, blkname):
 
 def read_table_blocks(arg, make_copy=False):
 
-    filename = ''
     dataset = None
     if isinstance(arg, TABLECrate):
         filename = arg.get_filename()
@@ -441,33 +473,29 @@ def read_table_blocks(arg, make_copy=False):
     elif isinstance(arg, CrateDataset):
         filename = arg.get_filename()
         dataset = arg
-    elif isinstance(arg, string_types):
+    elif isinstance(arg, str):
         filename = arg
         dataset = CrateDataset(arg)
     else:
         raise IOErr('badfile', arg, "CrateDataset obj")
 
-    # index of block number starts at 1
-    blockidx = numpy.arange(dataset.get_ncrates()) + 1
-
     cols = {}
     hdr = {}
-
-    for ii in blockidx:
-        crate = dataset.get_crate(ii)
-        hdr[ii] = {}
+    for idx in range(1, dataset.get_ncrates() + 1):
+        crate = dataset.get_crate(idx)
+        hdr[idx] = {}
         names = crate.get_keynames()
         for name in names:
-            hdr[ii][name] = _try_key(crate, name)
+            hdr[idx][name] = _try_key(crate, name)
 
-        cols[ii] = {}
+        cols[idx] = {}
         # skip over primary
         if crate.name == 'PRIMARY':
             continue
 
         names = crate.get_colnames()
         for name in names:
-            cols[ii][name] = crate.get_column(name).values
+            cols[idx][name] = crate.get_column(name).values
 
     return filename, cols, hdr
 
@@ -477,14 +505,9 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
     checked for new crates
     """
 
-    if type(arg) == str:
-
-        # arg = get_filename_from_dmsyntax(arg, blockname)
+    if isinstance(arg, str):
         arg = get_filename_from_dmsyntax(arg)
         tbl = open_crate(arg)
-
-        # Make a copy of the data, since we don't know that pycrates will
-        # do something sensible wrt reference counting
     elif isinstance(arg, TABLECrate):
         tbl = arg
     else:
@@ -529,14 +552,14 @@ def get_column_data(*args):
             # vals = arg.get_values()
             vals = arg.values
 
-        elif arg is None or isinstance(arg, (numpy.ndarray, list, tuple)):
+        elif arg is None or isinstance(arg, (np.ndarray, list, tuple)):
             vals = arg
         else:
             raise IOErr('badarray', arg)
 
         if arg is not None:
-            vals = numpy.asanyarray(vals)
-            for col in numpy.atleast_2d(vals.T):
+            vals = np.asanyarray(vals)
+            for col in np.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(vals)
@@ -552,9 +575,8 @@ def get_ascii_data(filename, ncols=2, colkeys=None, **kwargs):
 def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
                    blockname=None, hdrkeys=None):
     """Read columns from a file or crate."""
-    filename = ''
-    if type(arg) == str:
 
+    if isinstance(arg, str):
         arg = get_filename_from_dmsyntax(arg)
         tbl = open_crate(arg)
         if not isinstance(tbl, TABLECrate):
@@ -562,8 +584,6 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
         filename = tbl.get_filename()
 
-        # Make a copy of the data, since we don't know that pycrates will
-        # do something sensible wrt reference counting
     elif isinstance(arg, TABLECrate):
         tbl = arg
         filename = arg.get_filename()
@@ -585,7 +605,7 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
     if colkeys is not None:
         colkeys = [str(name).strip() for name in list(colkeys)]
 
-    elif (type(arg) == str and (not os.path.isfile(arg))
+    elif (isinstance(arg, str) and (not os.path.isfile(arg))
           and '[' in arg and ']' in arg):
         colkeys = cnames
 
@@ -601,7 +621,9 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
     cols = []
     for name in colkeys:
-        for col in _require_tbl_col(tbl, name, cnames, make_copy, fix_type):
+        for col in _require_tbl_col(tbl, name, cnames,
+                                    make_copy=make_copy,
+                                    fix_type=fix_type):
             cols.append(col)
 
     hdr = {}
@@ -614,10 +636,9 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
 def get_image_data(arg, make_copy=True, fix_type=True):
     """Read image data from a file or crate"""
-    filename = ''
-    if type(arg) == str:
-        img = open_crate(arg)
 
+    if isinstance(arg, str):
+        img = open_crate(arg)
         if not isinstance(img, IMAGECrate):
             raise IOErr('badfile', arg, "IMAGECrate obj")
 
@@ -633,39 +654,41 @@ def get_image_data(arg, make_copy=True, fix_type=True):
 
     data = {}
 
-    data['y'] = _require_image(img, make_copy, fix_type)
+    data['y'] = _require_image(img, filename, make_copy=make_copy,
+                               fix_type=fix_type)
 
-    sky = None
-    skynames = ['SKY', 'sky', 'pos', 'POS']
-    names = img.get_axisnames()
+    if HAS_TRANSFORM:
+        sky = None
+        skynames = ['SKY', 'sky', 'pos', 'POS']
+        names = img.get_axisnames()
 
-    # find the SKY name using the set intersection
-    inter = list(set(names) & set(skynames))
-    if inter:
-        sky = img.get_transform(inter[0])
+        # find the SKY name using the set intersection
+        inter = list(set(names) & set(skynames))
+        if inter:
+            sky = img.get_transform(inter[0])
 
-    wcs = None
-    if 'EQPOS' in names:
-        wcs = img.get_transform('EQPOS')
+        wcs = None
+        if 'EQPOS' in names:
+            wcs = img.get_transform('EQPOS')
 
-    if sky is not None and transformstatus:
-        linear = WCSTANTransform()
-        linear.set_name("LINEAR")
-        linear.set_transform_matrix(sky.get_transform_matrix())
-        cdelt = numpy.array(linear.get_parameter_value('CDELT'))
-        crpix = numpy.array(linear.get_parameter_value('CRPIX'))
-        crval = numpy.array(linear.get_parameter_value('CRVAL'))
-        data['sky'] = WCS('physical', 'LINEAR', crval, crpix, cdelt)
+        if sky is not None:
+            linear = WCSTANTransform()
+            linear.set_name("LINEAR")
+            linear.set_transform_matrix(sky.get_transform_matrix())
+            cdelt = np.array(linear.get_parameter_value('CDELT'))
+            crpix = np.array(linear.get_parameter_value('CRPIX'))
+            crval = np.array(linear.get_parameter_value('CRVAL'))
+            data['sky'] = WCS('physical', 'LINEAR', crval, crpix, cdelt)
 
-    if wcs is not None and transformstatus:
-        cdelt = numpy.array(wcs.get_parameter_value('CDELT'))
-        crpix = numpy.array(wcs.get_parameter_value('CRPIX'))
-        crval = numpy.array(wcs.get_parameter_value('CRVAL'))
-        crota = SherpaFloat(wcs.get_parameter_value('CROTA'))
-        equin = SherpaFloat(wcs.get_parameter_value('EQUINOX'))
-        epoch = SherpaFloat(wcs.get_parameter_value('EPOCH'))
-        data['eqpos'] = WCS('world', 'WCS', crval, crpix, cdelt,
-                            crota, epoch, equin)
+        if wcs is not None:
+            cdelt = np.array(wcs.get_parameter_value('CDELT'))
+            crpix = np.array(wcs.get_parameter_value('CRPIX'))
+            crval = np.array(wcs.get_parameter_value('CRVAL'))
+            crota = SherpaFloat(wcs.get_parameter_value('CROTA'))
+            equin = SherpaFloat(wcs.get_parameter_value('EQUINOX'))
+            epoch = SherpaFloat(wcs.get_parameter_value('EPOCH'))
+            data['eqpos'] = WCS('world', 'WCS', crval, crpix, cdelt,
+                                crota, epoch, equin)
 
     data['header'] = _get_meta_data(img)
     for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
@@ -678,8 +701,8 @@ def get_image_data(arg, make_copy=True, fix_type=True):
 
 def get_arf_data(arg, make_copy=True):
     """Read an ARF from a file or crate"""
-    filename = ''
-    if type(arg) == str:
+
+    if isinstance(arg, str):
         arf = open_crate(arg)
         if not isinstance(arf, TABLECrate):
             raise IOErr('badfile', arg, "ARFCrate obj")
@@ -697,16 +720,15 @@ def get_arf_data(arg, make_copy=True):
 
     data = {}
 
-    if not arf.column_exists('ENERG_LO'):
-        raise IOErr('reqcol', 'ENERG_LO', filename)
-    if not arf.column_exists('ENERG_HI'):
-        raise IOErr('reqcol', 'ENERG_HI', filename)
-    if not arf.column_exists('SPECRESP'):
-        raise IOErr('reqcol', 'SPECRESP', filename)
-
-    data['energ_lo'] = _require_col(arf, 'ENERG_LO', make_copy, fix_type=True)
-    data['energ_hi'] = _require_col(arf, 'ENERG_HI', make_copy, fix_type=True)
-    data['specresp'] = _require_col(arf, 'SPECRESP', make_copy, fix_type=True)
+    data['energ_lo'] = _require_col(arf, 'ENERG_LO',
+                                    make_copy=make_copy,
+                                    fix_type=True)
+    data['energ_hi'] = _require_col(arf, 'ENERG_HI',
+                                    make_copy=make_copy,
+                                    fix_type=True)
+    data['specresp'] = _require_col(arf, 'SPECRESP',
+                                    make_copy=make_copy,
+                                    fix_type=True)
     data['bin_lo'] = _try_col(arf, 'BIN_LO', make_copy, fix_type=True)
     data['bin_hi'] = _try_col(arf, 'BIN_HI', make_copy, fix_type=True)
     data['exposure'] = _try_key(arf, 'EXPOSURE', dtype=SherpaFloat)
@@ -774,9 +796,9 @@ def _find_matrix_blocks(filename: str,
 
 def get_rmf_data(arg, make_copy=True):
     """Read a RMF from a file or crate"""
-    filename = ''
-    if type(arg) == str:
-        rmfdataset = open_crate_dataset(arg, RMFCrateDataset)
+
+    if isinstance(arg, str):
+        rmfdataset = RMFCrateDataset(arg, mode="r")
         if pycrates.is_rmf(rmfdataset) != 1:
             raise IOErr('badfile', arg, "RMFCrateDataset obj")
 
@@ -825,11 +847,13 @@ def get_rmf_data(arg, make_copy=True):
         raise IOErr('reqcol', 'N_CHAN', filename)
 
     data = {}
-    data['detchans'] = _require_key(rmf, 'DETCHANS', SherpaInt)
-    data['energ_lo'] = _require_col(rmf, 'ENERG_LO', make_copy, fix_type=True)
-    data['energ_hi'] = _require_col(rmf, 'ENERG_HI', make_copy, fix_type=True)
-    data['n_grp'] = _require_col(
-        rmf, 'N_GRP', make_copy, dtype=SherpaUInt, fix_type=True)
+    data['detchans'] = _require_key(rmf, 'DETCHANS', dtype=SherpaInt)
+    data['energ_lo'] = _require_col(rmf, 'ENERG_LO',
+                                    make_copy=make_copy, fix_type=True)
+    data['energ_hi'] = _require_col(rmf, 'ENERG_HI',
+                                    make_copy=make_copy, fix_type=True)
+    data['n_grp'] = _require_col(rmf, 'N_GRP', make_copy=make_copy,
+                                 dtype=SherpaUInt, fix_type=True)
 
     f_chan = rmf.get_column('F_CHAN')
     offset = f_chan.get_tlmin()
@@ -837,13 +861,9 @@ def get_rmf_data(arg, make_copy=True):
     fcbuf = _require_col(rmf, 'F_CHAN', make_copy)
     ncbuf = _require_col(rmf, 'N_CHAN', make_copy)
 
-    respbuf = _require_col_list(rmf, 'MATRIX', 1, make_copy)
+    respbuf = _require_col_list(rmf, 'MATRIX', make_copy=make_copy)
 
-    # ebounds = None
-    # if rmfdataset.get_current_crate() < rmfdataset.get_ncrates():
-    #    ebounds = rmfdataset.get_crate(rmfdataset.get_current_crate() + 1)
     ebounds = _get_crate_by_blockname(rmfdataset, 'EBOUNDS')
-
     if ebounds is None:
         ebounds = rmfdataset.get_crate(3)
 
@@ -861,10 +881,10 @@ def get_rmf_data(arg, make_copy=True):
         # data['header'].update(_get_meta_data(ebounds))
 
     if offset < 0:
-        error("Failed to locate TLMIN keyword for F_CHAN" +
-              f" column in RMF file '{filename}'; " +
-              'Update the offset value in the RMF data set to' +
-              ' appropriate TLMIN value prior to fitting')
+        error("Failed to locate TLMIN keyword for F_CHAN "
+              "column in RMF file '%s'; "
+              'Update the offset value in the RMF data set to '
+              'appropriate TLMIN value prior to fitting', filename)
 
     if offset < 0 and channel is not None:
         offset = channel.get_tlmin()
@@ -903,9 +923,9 @@ def get_rmf_data(arg, make_copy=True):
 
 def get_pha_data(arg, make_copy=True, use_background=False):
     """Read PHA data from a file or crate"""
-    filename = ''
-    if type(arg) == str:
-        phadataset = open_crate_dataset(arg, PHACrateDataset)
+
+    if isinstance(arg, str):
+        phadataset = PHACrateDataset(arg, mode="r")
         if pycrates.is_pha(phadataset) != 1:
             raise IOErr('badfile', arg, "PHACrateDataset obj")
 
@@ -939,8 +959,8 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
         # Used to read BKGs found in an additional block of
         # Chandra Level 3 PHA files
-        for ii in range(phadataset.get_ncrates()):
-            block = phadataset.get_crate(ii + 1)
+        for idx in range(phadataset.get_ncrates()):
+            block = phadataset.get_crate(idx + 1)
             if _try_key(block, 'HDUCLAS2') == 'BKG':
                 pha = block
 
@@ -981,11 +1001,9 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
         # Columns
 
-        if not pha.column_exists('CHANNEL'):
-            raise IOErr('reqcol', 'CHANNEL', filename)
-
-        data['channel'] = _require_col(
-            pha, 'CHANNEL', make_copy, fix_type=True)
+        data['channel'] = _require_col(pha, 'CHANNEL',
+                                       make_copy=make_copy,
+                                       fix_type=True)
         # Make sure channel numbers, not indices
         if int(data['channel'][0]) == 0 or pha.get_column('CHANNEL').get_tlmin() == 0:
             data['channel'] = data['channel'] + 1
@@ -993,13 +1011,14 @@ def get_pha_data(arg, make_copy=True, use_background=False):
         data['counts'] = None
         staterror = _try_col(pha, 'STAT_ERR', make_copy)
         if pha.column_exists('COUNTS'):
-            data['counts'] = _require_col(
-                pha, 'COUNTS', make_copy, fix_type=True)
+            data['counts'] = _require_col(pha, 'COUNTS',
+                                          make_copy=make_copy,
+                                          fix_type=True)
         else:
-            if not pha.column_exists('RATE'):
-                raise IOErr('reqcol', 'COUNTS or RATE', filename)
-            data['counts'] = _require_col(
-                pha, 'RATE', make_copy, fix_type=True) * data['exposure']
+            data['counts'] = _require_col(pha, 'RATE', label="COUNTS or RATE",
+                                          make_copy=make_copy,
+                                          fix_type=True)
+            data['counts'] *= data['exposure']
             if staterror is not None:
                 staterror *= data['exposure']
 
@@ -1047,26 +1066,28 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
         # Columns
 
-        if not pha.column_exists('CHANNEL'):
-            raise IOErr('reqcol', 'CHANNEL', filename)
-
-        channel = _require_col_list(
-            pha, 'CHANNEL', num, make_copy, fix_type=True)
+        channel = _require_col_list(pha, 'CHANNEL',
+                                    make_copy=make_copy,
+                                    fix_type=True)
         # Make sure channel numbers, not indices
-        for ii in range(num):
-            if int(channel[ii][0]) == 0:
-                channel[ii] += 1
+        for idx in range(num):
+            if int(channel[idx][0]) == 0:
+                channel[idx] += 1
+
+        staterror = _try_col_list(pha, 'STAT_ERR', num=num,
+                                  make_copy=make_copy)
 
         counts = None
-        staterror = _try_col_list(pha, 'STAT_ERR', num, make_copy)
         if pha.column_exists('COUNTS'):
-            counts = _require_col_list(
-                pha, 'COUNTS', num, make_copy, fix_type=True)
+            counts = _require_col_list(pha, 'COUNTS',
+                                       make_copy=make_copy, fix_type=True)
+
         else:
             if not pha.column_exists('RATE'):
                 raise IOErr('reqcol', 'COUNTS or RATE', filename)
-            counts = _require_col_list(
-                pha, 'RATE', num, make_copy, fix_type=True) * exposure
+            counts = _require_col_list(pha, 'RATE',
+                                       make_copy=make_copy, fix_type=True)
+            counts *= exposure
             if staterror is not None:
                 staterror *= exposure
 
@@ -1142,7 +1163,7 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 # Write/Pack Functions #
 #
 
-def check_clobber(filename, clobber):
+def check_clobber(filename: str, clobber: bool) -> None:
     """Error out if the file exists and clobber is not set."""
 
     if clobber or not os.path.isfile(filename):
@@ -1151,8 +1172,33 @@ def check_clobber(filename, clobber):
     raise IOErr("filefound", filename)
 
 
+def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
+                  filename: str,
+                  *,
+                  ascii: bool) -> None:
+    """Write out the data."""
+
+    if ascii and '[' not in filename and ']' not in filename:
+        filename += "[opt kernel=text/simple]"
+
+        # For CIAO 4.15-era crates, if this is a CrateDataset and the
+        # first block is a "empty" image then the code will fail when
+        # writing out as an ASCII file. So this will remove such a
+        # block.
+        #
+        try:
+            cr = dataset.get_crate(1)
+        except AttributeError:
+            cr = None
+
+        if isinstance(cr, IMAGECrate) and cr.get_image().values.size == 0:
+            dataset.delete_crate(1)
+
+    dataset.write(filename, clobber=True)
+
+
 def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False):
+                   packup=False) -> Optional[IMAGECrate]:
 
     if not packup:
         check_clobber(filename, clobber)
@@ -1160,10 +1206,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     img = IMAGECrate()
 
     # Write Image Header Keys
-    for key, value in header.items():
-        if value is None:
-            continue
-        _set_key(img, key, value)
+    _update_header(img, header, skip_if_known=False)
 
     # Write Image WCS Header Keys
     if data['eqpos'] is not None:
@@ -1192,7 +1235,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         if data['eqpos'] is not None:
             # Simply the inverse of read transformations in get_image_data
             cdeltw = cdeltw * cdeltp
-            crpixw = ((crpixw - crvalp) / cdeltp + crpixp)
+            crpixw = (crpixw - crvalp) / cdeltp + crpixp
 
     if data['eqpos'] is not None:
         _set_key(img, 'MTYPE2', 'EQPOS   ')
@@ -1220,37 +1263,31 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         raise IOErr('writenoimg')
 
     img.write(filename, clobber=True)
+    return None
 
 
 def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False):
+                   ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
 
     if not packup:
         check_clobber(filename, clobber)
 
     tbl = TABLECrate()
     hdr = {} if header is None else header
-    try:
-        for name in col_names:
-            _set_column(tbl, name, data[name])
+    for name in col_names:
+        _set_column(tbl, name, data[name])
 
-        for key, value in hdr.items():
-            if value is None:
-                continue
-            _set_key(tbl, key, value)
+    _update_header(tbl, hdr, skip_if_known=False)
 
-    finally:
-        if packup:
-            return tbl
+    if packup:
+        return tbl
 
-        if ascii and '[' not in filename and ']' not in filename:
-            filename += "[opt kernel=text/simple]"
-
-        tbl.write(filename, clobber=True)
+    write_dataset(tbl, filename, ascii=ascii)
+    return None
 
 
 def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+                 ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
     """Create an ARF"""
 
     if header is None:
@@ -1262,7 +1299,7 @@ def set_arf_data(filename, data, col_names, header=None,
 
 
 def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+                 ascii=False, clobber=False, packup=False) -> Optional[PHACrateDataset]:
     """Create a PHA dataset/file"""
 
     if header is None:
@@ -1278,50 +1315,31 @@ def set_pha_data(filename, data, col_names, header=None,
 
     pha = TABLECrate()
     pha.name = "SPECTRUM"
-    try:
 
-        # Write header values using CrateKey objects
-        for key in header.keys():
-            if header[key] is None:
-                continue
-            _set_key(pha, key, header[key])
+    _update_header(pha, header, skip_if_known=False)
 
-        # Write column values using CrateData objects
-        for name in col_names:
-            if data[name] is None:
-                continue
-            _set_column(pha, name, data[name])
+    # Write column values using CrateData objects
+    for name in col_names:
+        if data[name] is None:
+            continue
+        _set_column(pha, name, data[name])
 
-    finally:
-        phadataset.add_crate(pha)
+    phadataset.add_crate(pha)
 
-        if packup:
-            return phadataset
+    if packup:
+        return phadataset
 
-        if ascii and '[' not in filename and ']' not in filename:
-            filename += "[opt kernel=text/simple]"
-
-        phadataset.write(filename, clobber=True)
+    write_dataset(phadataset, filename, ascii=ascii)
+    return None
 
 
-def _update_header(cr, header):
-    """Update the header of the crate.
-
-    Unlike the dict update method, this is left biased, in that
-    it prefers the keys in the existing header (this is so that
-    structural keywords are not over-written by invalid data from
-    a previous FITS file), and to drop elements which are set
-    to None.
-
-    Parameters
-    ----------
-    cr : Crate
-    header : dict[str, Any]
-
-    """
+def _update_header(cr: CrateType,
+                   header: dict[str, Optional[KeyType]],
+                   skip_if_known: bool = True) -> None:
+    """Update the header of the crate."""
 
     for key, value in header.items():
-        if cr.key_exists(key):
+        if skip_if_known and cr.key_exists(key):
             continue
 
         if value is None:
@@ -1393,10 +1411,11 @@ def set_rmf_data(filename, blocks, clobber=False):
     matrix_cr.add_column(mkcol("MATRIX", matrix_data["MATRIX"]))
 
     # Crates does not have a good API for setting the subspace of an
-    # item. So we manually add the correct TLMIN value after the
-    # file has been written out with the cxcdm module.
+    # item. So we manually add the correct TLMIN value to the header
+    # directly, as this appears to work.
     #
     # matrix_cr.F_CHAN._set_tlmin(matrix_data["OFFSET"])
+    matrix_header["TLMIN4"] = int(matrix_data["OFFSET"])
 
     ebounds_cr.add_column(mkcol("CHANNEL", ebounds_data["CHANNEL"]))
     ebounds_cr.add_column(mkcol("E_MIN", ebounds_data["E_MIN"], units="keV"))
@@ -1409,85 +1428,61 @@ def set_rmf_data(filename, blocks, clobber=False):
 
     ds.write(filename, clobber=True)
 
-    # Add the TLMIN value for the F_CHAN column
-    ds = cxcdm.dmDatasetOpen(filename, update=True)
-    bl = cxcdm.dmBlockOpen("MATRIX", ds, update=True)
-    col = cxcdm.dmTableOpenColumn(bl, "F_CHAN")
-
-    # The lo and hi vals must have the same type, so force them to be
-    # int (so we do not have to worry about whether this should be
-    # Int16 or Int32). The OFFSET value should be an int, but let's
-    # convert it too to make sure.
-    #
-    lval, hval = cxcdm.dmDescriptorGetRange(col)
-    cxcdm.dmDescriptorSetRange(col, int(matrix_data["OFFSET"]), int(hval))
-    cxcdm.dmBlockClose(bl)
-    cxcdm.dmDatasetClose(ds)
-
 
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
+    # Historically the clobber command has been checked before
+    # processing the data, so do so here.
+    #
     check_clobber(filename, clobber)
 
-    if not numpy.iterable(args) or len(args) == 0:
-        raise IOErr('noarrayswrite')
+    # Check args is a sequence of sequences (although not a complete
+    # check).
+    #
+    try:
+        size = len(args[0])
+    except (TypeError, IndexError) as exc:
+        raise IOErr('noarrayswrite') from exc
 
-    if not numpy.iterable(args[0]):
-        raise IOErr('noarrayswrite')
+    for arg in args[1:]:
+        try:
+            argsize = len(arg)
+        except (TypeError, IndexError) as exc:
+            raise IOErr('noarrayswrite') from exc
 
-    size = len(args[0])
-    for arg in args:
-        if not numpy.iterable(arg):
-            raise IOErr('noarrayswrite')
-
-        if len(arg) != size:
+        if argsize != size:
             raise IOErr('arraysnoteq')
 
-    if ascii and '[' not in filename and ']' not in filename:
-        filename += "[opt kernel=text/simple]"
+    nargs = len(args)
+    if fields is None:
+        fieldnames = [f'col{idx + 1}' for idx in range(nargs)]
+    elif nargs == len(fields):
+        fieldnames = fields
+    else:
+        raise IOErr('wrongnumcols', nargs, len(fields))
 
     tbl = TABLECrate()
-
-    if fields is None:
-        fields = [f'col{ii + 1}' for ii in range(len(args))]
-
-    if len(args) != len(fields):
-        raise IOErr('wrongnumcols', len(args), len(fields))
-
-    for val, name in zip(args, fields):
+    for val, name in zip(args, fieldnames):
         _set_column(tbl, name, val)
 
-    tbl.write(filename, clobber=True)
+    write_dataset(tbl, filename, ascii=ascii)
 
 
-def _add_header(cr, header):
-    """Add the header keywords to the crate.
+def _add_header(cr: CrateType,
+                header: Sequence[HeaderItem]) -> None:
+    """Add the header keywords to the crate."""
 
-    Parameters
-    ----------
-    cr : TABLECrate or IMAGECrate
-    header : list of sherpa.astro.io.xstable.HeaderItem
-
-    """
-
-    for hdr in header:
-        key = (hdr.name, hdr.value, hdr.unit, hdr.desc)
-        cr.add_key(CrateKey(key))
+    for item in header:
+        key = CrateKey()
+        key.name = item.name
+        key.value = item.value
+        key.unit = item.unit
+        key.desc = item.desc
+        cr.add_key(key)
 
 
 def _create_primary_crate(hdu: TableHDU) -> IMAGECrate:
-    """Create the primary block
-
-    Parameters
-    ----------
-    hdu : TableHDU
-       Any data is ignored.
-
-    Returns
-    -------
-    out : IMAGECrate
-
-    """
+    """Create the primary block."""
 
     out = IMAGECrate()
     out.name = "PRIMARY"
@@ -1496,7 +1491,7 @@ def _create_primary_crate(hdu: TableHDU) -> IMAGECrate:
     # (CIAO 4.15).
     #
     null = CrateData()
-    null.values = numpy.asarray([], dtype=numpy.uint8)
+    null.values = np.asarray([], dtype=np.uint8)
     out.add_image(null)
 
     _add_header(out, hdu.header)
@@ -1504,17 +1499,7 @@ def _create_primary_crate(hdu: TableHDU) -> IMAGECrate:
 
 
 def _create_table_crate(hdu: TableHDU) -> TABLECrate:
-    """Create a table block
-
-    Parameters
-    ----------
-    hdu : TableHDU
-
-    Returns
-    -------
-    out : TABLECrate
-
-    """
+    """Create a table block."""
 
     if hdu.data is None:
         raise ValueError("No column data to write out")
@@ -1534,7 +1519,7 @@ def _create_table_crate(hdu: TableHDU) -> TABLECrate:
     return out
 
 
-def _validate_block_names(hdulist: list[TableHDU]) -> list[TableHDU]:
+def _validate_block_names(hdulist: Sequence[TableHDU]) -> list[TableHDU]:
     """Ensure the block names are "independent".
 
     Crates will correctly handle the case when blocks are numbered
@@ -1553,7 +1538,7 @@ def _validate_block_names(hdulist: list[TableHDU]) -> list[TableHDU]:
     # If the names are unique do nothing
     #
     if len(multi) == 0:
-        return hdulist
+        return list(hdulist)
 
     out = [hdulist[0]]
     extvers: dict[str, int] = defaultdict(int)
@@ -1574,7 +1559,7 @@ def _validate_block_names(hdulist: list[TableHDU]) -> list[TableHDU]:
 
 
 def set_hdus(filename: str,
-             hdulist: list[TableHDU],
+             hdulist: Sequence[TableHDU],
              clobber: bool = False) -> None:
     """Write out multiple HDUS to a single file.
 

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -27,13 +27,20 @@ imported even if no usable backend is available.
 '''
 
 import logging
+from typing import Any, Optional, Sequence, Union
+
+import numpy as np
 
 from ..data import Data1D
 
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
-           'get_column_data', 'get_ascii_data',
-           'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'get_column_data', 'get_ascii_data', 'get_arf_data',
+           'get_rmf_data', 'get_pha_data',
+           #
+           'pack_table_data', 'pack_image_data', 'pack_pha_data',
+           'pack_arf_data', 'pack_rmf_data', 'pack_hdus',
+           #
            'set_table_data', 'set_image_data', 'set_pha_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
@@ -46,89 +53,169 @@ warning("""Cannot import usable I/O backend.
     If you are using Standalone Sherpa, please install astropy.""")
 
 
-def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
-                   blockname=None, hdrkeys=None):
-    """Read colums."""
+KeyType = Union[str, bool, int, float]
+NamesType = Sequence[str]
+HdrType = dict[str, KeyType]
+
+
+def get_table_data(arg,
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   make_copy: bool = True,
+                   fix_type: bool = True,
+                   blockname: Optional[str] = None,
+                   hdrkeys: Optional[NamesType] = None
+                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
+    """Read columns."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def get_header_data(arg, blockname=None, hdrkeys=None):
+def get_header_data(arg,
+                    blockname: Optional[str] = None,
+                    hdrkeys: Optional[NamesType] = None
+                    ) -> dict[str, KeyType]:
     """Read the metadata."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def get_image_data(arg, make_copy=True, fix_type=True):
+def get_image_data(arg,
+                   make_copy: bool = True,
+                   fix_type: bool = True
+                   ) -> tuple[dict[str, Any], str]:
     """Read image data."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def get_column_data(*args):
+def get_column_data(*args) -> list[np.ndarray]:
     """Extract the column data."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 # Follow sherpa.io.get_ascii_data API.
 #
-def get_ascii_data(filename, ncols=2, colkeys=None, sep=' ',
-                   dstype=Data1D, comment='#', require_floats=True):
+def get_ascii_data(filename: str,
+                   ncols: int = 2,
+                   colkeys: Optional[NamesType] = None,
+                   sep: str = ' ',
+                   dstype: type = Data1D,
+                   comment: str = '#',
+                   require_floats: bool = True
+                   ) -> tuple[list[str], list[np.ndarray], str]:
     """Read columns from an ASCII file"""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def get_arf_data(arg, make_copy=False):
+def get_arf_data(arg,
+                 make_copy: bool = False
+                 ) -> tuple[dict[str, Any], str]:
     """Read in the ARF."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def get_rmf_data(arg, make_copy=False):
+def get_rmf_data(arg,
+                 make_copy: bool = False
+                 ) -> tuple[dict[str, Any], str]:
     """Read in the RMF."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def get_pha_data(arg, make_copy=False, use_background=False):
+def get_pha_data(arg,
+                 make_copy: bool = False,
+                 use_background: bool = False
+                 ) -> tuple[list[dict[str, Any]], str]:
     """Read in the PHA."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False):
+def pack_table_data(data, col_names, header=None) -> Any:
     """Create the tabular data."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False):
+def pack_image_data(data, header, ascii=False) -> Any:
     """Create the image data."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+def pack_pha_data(data, col_names, header=None) -> Any:
     """Create the PHA."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+def pack_arf_data(data, col_names, header=None) -> Any:
     """Create the ARF."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_rmf_data(filename, blocks, clobber=False):
+def pack_rmf_data(blocks) -> Any:
     """Create the ARF."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_hdus(filename, hdulist, clobber=False):
+def pack_hdus(blocks) -> Any:
+    """Create a dataset."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_table_data(filename: str,
+                   data, col_names, header=None,
+                   ascii: bool = False,
+                   clobber: bool = False) -> None:
+    """Write out the tabular data."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_image_data(filename: str,
+                   data, header,
+                   ascii: bool = False,
+                   clobber: bool = False) -> None:
+    """Write out the image data."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_pha_data(filename: str,
+                 data, col_names, header=None,
+                 ascii: bool = False,
+                 clobber: bool = False) -> None:
+    """Write out the PHA."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_arf_data(filename: str,
+                 data, col_names, header=None,
+                 ascii: bool = False,
+                 clobber: bool = False) -> None:
+    """Write out the ARF."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_rmf_data(filename: str,
+                 blocks,
+                 clobber: bool = False) -> None:
+    """Write out the RMF."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_hdus(filename: str,
+             blocks,
+             clobber: bool = False) -> None:
     """Write out (possibly multiple) blocks."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def read_table_blocks(arg, make_copy=False):
+def read_table_blocks(arg,
+                      make_copy: bool = False
+                      ) -> tuple[str,
+                                 dict[int, dict[str, np.ndarray]],
+                                 dict[int, HdrType]]:
     """Read in tabular data with no restrictions on the columns."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
+def set_arrays(filename: str,
+               args: Sequence[np.ndarray],
+               fields: Optional[NamesType] = None,
+               ascii: bool = True,
+               clobber: bool = False) -> None:
     """Write out columns."""
     raise NotImplementedError('No usable I/O backend was imported.')

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -20,10 +20,16 @@
 '''A dummy backend for I/O.
 
 This backend provides no functionality and raises an error if any of its
-functions are used. It is just here to ensure that `sherpa.astro.io` can be
-imported, even if no FITS reader is installed.
+functions are used. It is provided as a model for what is needed in a
+backend, even if it does nothing, and to allow `sherpa.astro.io` to be
+imported even if no usable backend is available.
+
 '''
+
 import logging
+
+from ..data import Data1D
+
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
@@ -40,21 +46,89 @@ warning("""Cannot import usable I/O backend.
     If you are using Standalone Sherpa, please install astropy.""")
 
 
-def get_table_data(*args, **kwargs):
-    """A do-nothing operation"""
+def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
+                   blockname=None, hdrkeys=None):
+    """Read colums."""
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-get_header_data = get_table_data
-get_image_data = get_table_data
-get_column_data = get_table_data
-get_ascii_data = get_table_data
-get_arf_data = get_table_data
-get_rmf_data = get_table_data
-get_pha_data = get_table_data
-set_table_data = get_table_data
-set_image_data = get_table_data
-set_pha_data = get_table_data
-set_arf_data = get_table_data
-set_rmf_data = get_table_data
-set_hdus = get_table_data
+def get_header_data(arg, blockname=None, hdrkeys=None):
+    """Read the metadata."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_image_data(arg, make_copy=True, fix_type=True):
+    """Read image data."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_column_data(*args):
+    """Extract the column data."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+# Follow sherpa.io.get_ascii_data API.
+#
+def get_ascii_data(filename, ncols=2, colkeys=None, sep=' ',
+                   dstype=Data1D, comment='#', require_floats=True):
+    """Read columns from an ASCII file"""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_arf_data(arg, make_copy=False):
+    """Read in the ARF."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_rmf_data(arg, make_copy=False):
+    """Read in the RMF."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_pha_data(arg, make_copy=False, use_background=False):
+    """Read in the PHA."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_table_data(filename, data, col_names, header=None,
+                   ascii=False, clobber=False, packup=False):
+    """Create the tabular data."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_image_data(filename, data, header, ascii=False, clobber=False,
+                   packup=False):
+    """Create the image data."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_pha_data(filename, data, col_names, header=None,
+                 ascii=False, clobber=False, packup=False):
+    """Create the PHA."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_arf_data(filename, data, col_names, header=None,
+                 ascii=False, clobber=False, packup=False):
+    """Create the ARF."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_rmf_data(filename, blocks, clobber=False):
+    """Create the ARF."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_hdus(filename, hdulist, clobber=False):
+    """Write out (possibly multiple) blocks."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def read_table_blocks(arg, make_copy=False):
+    """Read in tabular data with no restrictions on the columns."""
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
+    """Write out columns."""
+    raise NotImplementedError('No usable I/O backend was imported.')

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -250,11 +250,10 @@ class Backend(BaseBackend):
         raise NotImplementedError('No usable I/O backend was imported.')
 
 
-    def set_arrays(self,
-                   filename: str,
-                   args: Sequence[np.ndarray],
-                   fields: Optional[NamesType] = None,
-                   ascii: bool = True,
-                   clobber: bool = False) -> None:
+    def write_arrays(self,
+                     filename: str,
+                     args: Sequence[np.ndarray],
+                     fields: Optional[NamesType] = None,
+                     ascii: bool = True) -> None:
         """Write out columns."""
         raise NotImplementedError('No usable I/O backend was imported.')

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2022, 2023
+#  Copyright (C) 2021 - 2024
 #  MIT
 #
 #
@@ -27,11 +27,13 @@ imported even if no usable backend is available.
 '''
 
 import logging
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import numpy as np
 
 from ..data import Data1D
+
+from .xstable import TableHDU
 
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
@@ -45,17 +47,26 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
-lgr = logging.getLogger(__name__)
-
-warning = lgr.warning
+warning = logging.getLogger(__name__).warning
 warning("""Cannot import usable I/O backend.
     If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
     If you are using Standalone Sherpa, please install astropy.""")
 
 
+# Some variants are named xxx and xxxArg, where the former is the
+# return value (an invariant type, like dict) and the latter is
+# covariant (such as Mapping) as it's used as an argument to a
+# function.
+#
 KeyType = Union[str, bool, int, float]
 NamesType = Sequence[str]
+HdrTypeArg = Mapping[str, KeyType]
 HdrType = dict[str, KeyType]
+ColumnsType = Mapping[str, Union[np.ndarray, list, tuple]]
+
+# It's hard to type the arguments to the Data constructors
+DataTypeArg = Mapping[str, Any]
+DataType = dict[str, Any]
 
 
 def get_table_data(arg,
@@ -66,140 +77,626 @@ def get_table_data(arg,
                    blockname: Optional[str] = None,
                    hdrkeys: Optional[NamesType] = None
                    ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
-    """Read columns."""
+    """Read columns from a file or object.
+
+    The columns to select depend on the ncols and colkeys arguments,
+    as well as the backend.
+
+    Parameters
+    ----------
+    arg
+        The data to read the columns from. This depends on the
+        backend but is expected to be a file name or a tabular
+        data structure supported by the backend.
+    ncols: int, optional
+        The number of columns to read in when colkeys is not
+        set (the first ncols columns are chosen).
+    colkeys: sequence of str or None, optional
+        If given, what columns from the table should be selected,
+        otherwise the backend selects. The default is `None`.
+        Names are compared using a case insensitive match.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are expictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+    fix_type: bool, optional
+        Should the returned arrays be converted to the
+        `sherpa.utils.numeric_types.SherpaFloat` type. The default
+        is `True`.
+    blockname: str or None, optional
+        The name of the "block" (HDU) to read the column data (useful
+        for data structures containing multiple blocks/HDUs) or None.
+        Names are compared using a case insensitive match.
+    hdrkeys: sequence of str or None, optional
+        If set, the table structure must contain these keys, and the
+        values are returned.  Names are compared using a case
+        insensitive match.
+
+    Returns
+    -------
+    names, data, filename, hdr
+        The column names, as a list of strings, and the data as
+        a list of NumPy arrays (matching the order and length of
+        the names array). The filename is the name of the file (a
+        string) and hdr is a dictionary with the requested keywords
+        (when hdrkeys is `None` this dictionary will be empty).
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid, or a required column or keyword
+        is missing.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def get_header_data(arg,
                     blockname: Optional[str] = None,
                     hdrkeys: Optional[NamesType] = None
-                    ) -> dict[str, KeyType]:
-    """Read the metadata."""
+                    ) -> HdrType:
+    """Read the metadata.
+
+    Parameters
+    ----------
+    arg
+        The data to read the header values from. This depends on the
+        backend but is expected to be a file name or a data structure
+        supported by the backend.
+    blockname: str or None, optional
+        The name of the "block" (HDU) to read the data (useful
+        for data structures containing multiple blocks/HDUs) or None.
+        Names are compared using a case insensitive match.
+    hdrkeys: sequence of str or None, optional
+        If set, the table structure must contain these keys, and the
+        values are returned. Names are compared using a case
+        insensitive match.
+
+    Returns
+    -------
+    hdr: dict
+        A dictionary with the keyword data (only the name and values
+        are returned, any sort of metadata, such as comments or units,
+        are not returned).
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or a keyword is missing.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def get_image_data(arg,
                    make_copy: bool = True,
                    fix_type: bool = True
-                   ) -> tuple[dict[str, Any], str]:
-    """Read image data."""
+                   ) -> tuple[DataType, str]:
+    """Read image data.
+
+    Parameters
+    ----------
+    arg
+        The data to read the header values from. This depends on the
+        backend but is expected to be a file name or a data structure
+        supported by the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are expictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+    fix_type: bool, optional
+        Should the returned arrays be converted to the
+        `sherpa.utils.numeric_types.SherpaFloat` type. The default
+        is `True`.
+
+    Returns
+    -------
+    data, filename
+        The data, as a dictionary, and the filename. The keys of the
+        dictionary match the arguments when creating a
+        sherpa.astro.data.DataIMG object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not an image.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def get_column_data(*args) -> list[np.ndarray]:
-    """Extract the column data."""
+    """Extract the column data.
+
+    Parameters
+    ----------
+    *args
+        Extract column information from each argument. It can be an
+        ndarray, list, or tuple, or a data structure from the backend,
+        with each argument representing a column. 2D arguments are
+        separated by column.
+
+    Returns
+    -------
+    data: list of ndarray
+        The column data.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        There are no arguments or an argument is not supported.
+
+    Notes
+    -----
+
+    An argument can be None, which is just passed back to the caller.
+    This means the typing rules for the function are not quite
+    correct.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 # Follow sherpa.io.get_ascii_data API.
 #
 def get_ascii_data(filename: str,
-                   ncols: int = 2,
+                   ncols: int = 1,
                    colkeys: Optional[NamesType] = None,
                    sep: str = ' ',
                    dstype: type = Data1D,
                    comment: str = '#',
                    require_floats: bool = True
                    ) -> tuple[list[str], list[np.ndarray], str]:
-    """Read columns from an ASCII file"""
+    """Read columns from an ASCII file.
+
+    The `sep`, `dstype`, `comment`, and `require_floats` arguments
+    may be ignored by the backend.q
+
+    Parameters
+    ----------
+    filename : str
+       The name of the ASCII file to read in.
+    ncols : int, optional
+       The number of columns to read in (the first ``ncols`` columns
+       in the file). This is ignored if ``colkeys`` is given.
+    colkeys : array of str, optional
+       An array of the column name to read in. The default is
+       `None`.
+    sep : str, optional
+       The separator character. The default is ``' '``.
+    dstype : data class to use, optional
+       Used to check that the data file contains enough columns.
+    comment : str, optional
+       The comment character. The default is ``'#'``.
+    require_floats : bool, optional
+       If `True` (the default), non-numeric data values will
+       raise a `ValueError`.
+
+    Returns
+    -------
+    colnames, coldata, filename
+       The column names read in, the data for the columns
+       as an array, with each element being the data for the column
+       (the order matches ``colnames``), and the name of the file.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+       Raised if a requested column is missing or the file appears
+       to be a binary file.
+    ValueError
+       If a column value can not be converted into a numeric value
+       and the `require_floats` parameter is `True`.
+
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def get_arf_data(arg,
-                 make_copy: bool = False
-                 ) -> tuple[dict[str, Any], str]:
-    """Read in the ARF."""
+                 make_copy: bool = True
+                 ) -> tuple[DataType, str]:
+    """Read in the ARF.
+
+    Parameters
+    ----------
+    arg
+        The data to read the ARF from. This depends on the backend but
+        is expected to be a file name or a data structure supported by
+        the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are expictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+
+    Returns
+    -------
+    data, filename
+        The data, as a dictionary, and the filename. The keys of the
+        dictionary match the arguments when creating a
+        sherpa.astro.data.DataARF object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not an ARF.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def get_rmf_data(arg,
-                 make_copy: bool = False
-                 ) -> tuple[dict[str, Any], str]:
-    """Read in the RMF."""
+                 make_copy: bool = True
+                 ) -> tuple[DataType, str]:
+    """Read in the RMF.
+
+    Parameters
+    ----------
+    arg
+        The data to read the RMF from. This depends on the backend but
+        is expected to be a file name or a data structure supported by
+        the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are expictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+
+    Returns
+    -------
+    data, filename
+        The data, as a dictionary, and the filename. The keys of the
+        dictionary match the arguments when creating a
+        sherpa.astro.data.DataRMF object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not a RMF.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def get_pha_data(arg,
-                 make_copy: bool = False,
+                 make_copy: bool = True,
                  use_background: bool = False
-                 ) -> tuple[list[dict[str, Any]], str]:
-    """Read in the PHA."""
+                 ) -> tuple[list[DataType], str]:
+    """Read in the PHA.
+
+    Parameters
+    ----------
+    arg
+        The data to read the PHA from. This depends on the backend but
+        is expected to be a file name or a data structure supported by
+        the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are expictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+    use_background: bool, optional
+        Should the data be read in as a background file (only relevant
+        for files that contain the background data in a separate block
+        of the same file, such as Chandra Level 3 PHA files, as used
+        by the Chandra Source Catalog). The default is `False`.
+
+    Returns
+    -------
+    datas, filename
+        A list of dictionaries, containing the PHA data (since there
+        can be multiple datasets with a PHA-II file) and the filename.
+        The keys of the dictionary match the arguments when creating
+        a sherpa.astro.data.DataPHA object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not a PHA.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def pack_table_data(data, col_names, header=None) -> Any:
-    """Create the tabular data."""
+def pack_table_data(data: ColumnsType,
+                    col_names: NamesType,
+                    header: Optional[HdrTypeArg] = None) -> Any:
+    """Create the tabular data.
+
+    Parameters
+    ----------
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+
+    Returns
+    -------
+    table
+        A data structure used by the backend to represent tabular data.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def pack_image_data(data, header, ascii=False) -> Any:
-    """Create the image data."""
+def pack_image_data(data: DataTypeArg,
+                    header: HdrTypeArg) -> Any:
+    """Create the image data.
+
+    Parameters
+    ----------
+    data : dict
+        The image data, where the keys are arguments used to create a
+        sherpa.astro.data.DataIMG object.
+    header : dict
+        The header information to include.
+
+    Returns
+    -------
+    image
+        A data structure used by the backend to represent image data.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def pack_pha_data(data, col_names, header=None) -> Any:
-    """Create the PHA."""
+def pack_pha_data(data: ColumnsType,
+                  col_names: NamesType,
+                  header: Optional[HdrTypeArg] = None) -> Any:
+    """Create the PHA.
+
+    Parameters
+    ----------
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+
+    Returns
+    -------
+    pha
+        A data structure used by the backend to represent PHA data.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def pack_arf_data(data, col_names, header=None) -> Any:
-    """Create the ARF."""
+def pack_arf_data(data: ColumnsType,
+                  col_names: NamesType,
+                  header: Optional[HdrTypeArg] = None) -> Any:
+    """Create the ARF.
+
+    Parameters
+    ----------
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+
+    Returns
+    -------
+    arf
+        A data structure used by the backend to represent ARF data.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def pack_rmf_data(blocks) -> Any:
-    """Create the ARF."""
+    """Create the RMF.
+
+    Parameters
+    ----------
+    blocks : sequence of pairs
+        The RMF data, stored as pairs of (data, header), where data is
+        a dictionary of column name (keys) and values, and header is a
+        dictionary of key and values. The first element is the MATRIX
+        block and the second is for the EBOUNDS block.
+
+    Returns
+    -------
+    rmf
+        A data structure used by the backend to represent RMF data.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-def pack_hdus(blocks) -> Any:
-    """Create a dataset."""
+def pack_hdus(blocks: Sequence[TableHDU]) -> Any:
+    """Create a dataset.
+
+    Parameters
+    ----------
+    blocks : sequence of TableHDU
+        The blocks (HDUs) to store.
+
+    Returns
+    -------
+    hdus
+        A data structure used by the backend to represent the data.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def set_table_data(filename: str,
-                   data, col_names, header=None,
+                   data: ColumnsType,
+                   col_names: NamesType,
+                   header: Optional[HdrTypeArg] = None,
                    ascii: bool = False,
                    clobber: bool = False) -> None:
-    """Write out the tabular data."""
+    """Write out the tabular data.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def set_image_data(filename: str,
-                   data, header,
+                   data: DataTypeArg,
+                   header: HdrTypeArg,
                    ascii: bool = False,
                    clobber: bool = False) -> None:
-    """Write out the image data."""
+    """Write out the image data.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The image data, where the keys are arguments used to create a
+        sherpa.astro.data.DataIMG object.
+    header : dict
+        The header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def set_pha_data(filename: str,
-                 data, col_names, header=None,
+                 data: ColumnsType,
+                 col_names: NamesType,
+                 header: Optional[HdrTypeArg] = None,
                  ascii: bool = False,
                  clobber: bool = False) -> None:
-    """Write out the PHA."""
+    """Write out the PHA.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def set_arf_data(filename: str,
-                 data, col_names, header=None,
+                 data: ColumnsType,
+                 col_names: NamesType,
+                 header: Optional[HdrTypeArg] = None,
                  ascii: bool = False,
                  clobber: bool = False) -> None:
-    """Write out the ARF."""
+    """Write out the ARF.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def set_rmf_data(filename: str,
                  blocks,
                  clobber: bool = False) -> None:
-    """Write out the RMF."""
+    """Write out the RMF.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    blocks : sequence of pairs
+        The RMF data, stored as pairs of (data, header), where data is
+        a dictionary of column name (keys) and values, and header is a
+        dictionary of key and values. The first element is the MATRIX
+        block and the second is for the EBOUNDS block.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    Notes
+    -----
+    There is currently no support for writing out a RMF as an ASCII
+    file.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
 def set_hdus(filename: str,
-             blocks,
+             blocks: Sequence[TableHDU],
              clobber: bool = False) -> None:
-    """Write out (possibly multiple) blocks."""
+    """Write out (possibly multiple) blocks.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    blocks : sequence of TableHDU
+        The blocks (HDUs) to store.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
@@ -208,7 +705,37 @@ def read_table_blocks(arg,
                       ) -> tuple[str,
                                  dict[int, dict[str, np.ndarray]],
                                  dict[int, HdrType]]:
-    """Read in tabular data with no restrictions on the columns."""
+    """Read in tabular data with no restrictions on the columns.
+
+    Parameters
+    ----------
+    arg
+        The data to read the columns from. This depends on the
+        backend but is expected to be a file name or a tabular
+        data structure supported by the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are expictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+
+    Returns
+    -------
+    filename, blockdata, hdrdata
+        The filename as a string. The blockdata and hdrdata values are
+        dictionaries where the key is an integer representing the
+        block (or HDU) number (where the first block is numbered 1 and
+        represents the first tabular block, that is it does not
+        include the primary HDU) and the values are dictionaries
+        representing the column data or header data for each block.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid, or a required column or keyword
+        is missing.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
@@ -217,5 +744,24 @@ def set_arrays(filename: str,
                fields: Optional[NamesType] = None,
                ascii: bool = True,
                clobber: bool = False) -> None:
-    """Write out columns."""
+    """Write out columns.
+
+    Parameters
+    ----------
+    filename : str
+        The file name.
+    args : sequence of ndarray
+        The column data.
+    fields : sequence of str or None, optional
+        The column names to use. If set to `None` then the columns are
+        named ``col1``, ``col2``, ...
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `True`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -33,18 +33,11 @@ import numpy as np
 
 from ..data import Data1D
 
+from .backends import BaseBackend
 from .xstable import TableHDU
 
 
-__all__ = ('get_table_data', 'get_header_data', 'get_image_data',
-           'get_column_data', 'get_ascii_data', 'get_arf_data',
-           'get_rmf_data', 'get_pha_data',
-           #
-           'pack_table_data', 'pack_image_data', 'pack_pha_data',
-           'pack_arf_data', 'pack_rmf_data', 'pack_hdus',
-           #
-           'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data', 'set_hdus')
+__all__ = ('Backend', )
 
 
 warning = logging.getLogger(__name__).warning
@@ -69,699 +62,199 @@ DataTypeArg = Mapping[str, Any]
 DataType = dict[str, Any]
 
 
-def get_table_data(arg,
-                   ncols: int = 1,
-                   colkeys: Optional[NamesType] = None,
-                   make_copy: bool = True,
-                   fix_type: bool = True,
-                   blockname: Optional[str] = None,
-                   hdrkeys: Optional[NamesType] = None
-                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
-    """Read columns from a file or object.
+class Backend(BaseBackend):
+    """A dummy backend for I/O.
 
-    The columns to select depend on the ncols and colkeys arguments,
-    as well as the backend.
-
-    Parameters
-    ----------
-    arg
-        The data to read the columns from. This depends on the
-        backend but is expected to be a file name or a tabular
-        data structure supported by the backend.
-    ncols: int, optional
-        The number of columns to read in when colkeys is not
-        set (the first ncols columns are chosen).
-    colkeys: sequence of str or None, optional
-        If given, what columns from the table should be selected,
-        otherwise the backend selects. The default is `None`.
-        Names are compared using a case insensitive match.
-    make_copy: bool, optional
-        If set then the returned NumPy arrays are expictly copied,
-        rather than using a reference from the data structure
-        created by the backend. Backends are not required to
-        honor this setting. The default is `True`.
-    fix_type: bool, optional
-        Should the returned arrays be converted to the
-        `sherpa.utils.numeric_types.SherpaFloat` type. The default
-        is `True`.
-    blockname: str or None, optional
-        The name of the "block" (HDU) to read the column data (useful
-        for data structures containing multiple blocks/HDUs) or None.
-        Names are compared using a case insensitive match.
-    hdrkeys: sequence of str or None, optional
-        If set, the table structure must contain these keys, and the
-        values are returned.  Names are compared using a case
-        insensitive match.
-
-    Returns
-    -------
-    names, data, filename, hdr
-        The column names, as a list of strings, and the data as
-        a list of NumPy arrays (matching the order and length of
-        the names array). The filename is the name of the file (a
-        string) and hdr is a dictionary with the requested keywords
-        (when hdrkeys is `None` this dictionary will be empty).
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid, or a required column or keyword
-        is missing.
+    If used, any attempt to call an I/O routine (read or write) will
+    raise a NotImplementedError exception.
 
     """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def get_header_data(arg,
-                    blockname: Optional[str] = None,
-                    hdrkeys: Optional[NamesType] = None
-                    ) -> HdrType:
-    """Read the metadata.
-
-    Parameters
-    ----------
-    arg
-        The data to read the header values from. This depends on the
-        backend but is expected to be a file name or a data structure
-        supported by the backend.
-    blockname: str or None, optional
-        The name of the "block" (HDU) to read the data (useful
-        for data structures containing multiple blocks/HDUs) or None.
-        Names are compared using a case insensitive match.
-    hdrkeys: sequence of str or None, optional
-        If set, the table structure must contain these keys, and the
-        values are returned. Names are compared using a case
-        insensitive match.
-
-    Returns
-    -------
-    hdr: dict
-        A dictionary with the keyword data (only the name and values
-        are returned, any sort of metadata, such as comments or units,
-        are not returned).
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid or a keyword is missing.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def get_image_data(arg,
-                   make_copy: bool = True,
-                   fix_type: bool = True
-                   ) -> tuple[DataType, str]:
-    """Read image data.
-
-    Parameters
-    ----------
-    arg
-        The data to read the header values from. This depends on the
-        backend but is expected to be a file name or a data structure
-        supported by the backend.
-    make_copy: bool, optional
-        If set then the returned NumPy arrays are expictly copied,
-        rather than using a reference from the data structure
-        created by the backend. Backends are not required to
-        honor this setting. The default is `True`.
-    fix_type: bool, optional
-        Should the returned arrays be converted to the
-        `sherpa.utils.numeric_types.SherpaFloat` type. The default
-        is `True`.
-
-    Returns
-    -------
-    data, filename
-        The data, as a dictionary, and the filename. The keys of the
-        dictionary match the arguments when creating a
-        sherpa.astro.data.DataIMG object.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid or not an image.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def get_column_data(*args) -> list[np.ndarray]:
-    """Extract the column data.
-
-    Parameters
-    ----------
-    *args
-        Extract column information from each argument. It can be an
-        ndarray, list, or tuple, or a data structure from the backend,
-        with each argument representing a column. 2D arguments are
-        separated by column.
-
-    Returns
-    -------
-    data: list of ndarray
-        The column data.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        There are no arguments or an argument is not supported.
-
-    Notes
-    -----
-
-    An argument can be None, which is just passed back to the caller.
-    This means the typing rules for the function are not quite
-    correct.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-# Follow sherpa.io.get_ascii_data API.
-#
-def get_ascii_data(filename: str,
-                   ncols: int = 1,
-                   colkeys: Optional[NamesType] = None,
-                   sep: str = ' ',
-                   dstype: type = Data1D,
-                   comment: str = '#',
-                   require_floats: bool = True
-                   ) -> tuple[list[str], list[np.ndarray], str]:
-    """Read columns from an ASCII file.
-
-    The `sep`, `dstype`, `comment`, and `require_floats` arguments
-    may be ignored by the backend.q
-
-    Parameters
-    ----------
-    filename : str
-       The name of the ASCII file to read in.
-    ncols : int, optional
-       The number of columns to read in (the first ``ncols`` columns
-       in the file). This is ignored if ``colkeys`` is given.
-    colkeys : array of str, optional
-       An array of the column name to read in. The default is
-       `None`.
-    sep : str, optional
-       The separator character. The default is ``' '``.
-    dstype : data class to use, optional
-       Used to check that the data file contains enough columns.
-    comment : str, optional
-       The comment character. The default is ``'#'``.
-    require_floats : bool, optional
-       If `True` (the default), non-numeric data values will
-       raise a `ValueError`.
-
-    Returns
-    -------
-    colnames, coldata, filename
-       The column names read in, the data for the columns
-       as an array, with each element being the data for the column
-       (the order matches ``colnames``), and the name of the file.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-       Raised if a requested column is missing or the file appears
-       to be a binary file.
-    ValueError
-       If a column value can not be converted into a numeric value
-       and the `require_floats` parameter is `True`.
-
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def get_arf_data(arg,
-                 make_copy: bool = True
-                 ) -> tuple[DataType, str]:
-    """Read in the ARF.
-
-    Parameters
-    ----------
-    arg
-        The data to read the ARF from. This depends on the backend but
-        is expected to be a file name or a data structure supported by
-        the backend.
-    make_copy: bool, optional
-        If set then the returned NumPy arrays are expictly copied,
-        rather than using a reference from the data structure
-        created by the backend. Backends are not required to
-        honor this setting. The default is `True`.
-
-    Returns
-    -------
-    data, filename
-        The data, as a dictionary, and the filename. The keys of the
-        dictionary match the arguments when creating a
-        sherpa.astro.data.DataARF object.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid or not an ARF.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def get_rmf_data(arg,
-                 make_copy: bool = True
-                 ) -> tuple[DataType, str]:
-    """Read in the RMF.
-
-    Parameters
-    ----------
-    arg
-        The data to read the RMF from. This depends on the backend but
-        is expected to be a file name or a data structure supported by
-        the backend.
-    make_copy: bool, optional
-        If set then the returned NumPy arrays are expictly copied,
-        rather than using a reference from the data structure
-        created by the backend. Backends are not required to
-        honor this setting. The default is `True`.
-
-    Returns
-    -------
-    data, filename
-        The data, as a dictionary, and the filename. The keys of the
-        dictionary match the arguments when creating a
-        sherpa.astro.data.DataRMF object.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid or not a RMF.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def get_pha_data(arg,
-                 make_copy: bool = True,
-                 use_background: bool = False
-                 ) -> tuple[list[DataType], str]:
-    """Read in the PHA.
-
-    Parameters
-    ----------
-    arg
-        The data to read the PHA from. This depends on the backend but
-        is expected to be a file name or a data structure supported by
-        the backend.
-    make_copy: bool, optional
-        If set then the returned NumPy arrays are expictly copied,
-        rather than using a reference from the data structure
-        created by the backend. Backends are not required to
-        honor this setting. The default is `True`.
-    use_background: bool, optional
-        Should the data be read in as a background file (only relevant
-        for files that contain the background data in a separate block
-        of the same file, such as Chandra Level 3 PHA files, as used
-        by the Chandra Source Catalog). The default is `False`.
-
-    Returns
-    -------
-    datas, filename
-        A list of dictionaries, containing the PHA data (since there
-        can be multiple datasets with a PHA-II file) and the filename.
-        The keys of the dictionary match the arguments when creating
-        a sherpa.astro.data.DataPHA object.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid or not a PHA.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def pack_table_data(data: ColumnsType,
-                    col_names: NamesType,
-                    header: Optional[HdrTypeArg] = None) -> Any:
-    """Create the tabular data.
-
-    Parameters
-    ----------
-    data : dict
-        The table data, where the key is the column name and the value
-        the data.
-    col_names : sequence of str
-        The column names from data to use (this also sets the order).
-    header : dict or None, optional
-        Any header information to include.
-
-    Returns
-    -------
-    table
-        A data structure used by the backend to represent tabular data.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def pack_image_data(data: DataTypeArg,
-                    header: HdrTypeArg) -> Any:
-    """Create the image data.
-
-    Parameters
-    ----------
-    data : dict
-        The image data, where the keys are arguments used to create a
-        sherpa.astro.data.DataIMG object.
-    header : dict
-        The header information to include.
-
-    Returns
-    -------
-    image
-        A data structure used by the backend to represent image data.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def pack_pha_data(data: ColumnsType,
-                  col_names: NamesType,
-                  header: Optional[HdrTypeArg] = None) -> Any:
-    """Create the PHA.
-
-    Parameters
-    ----------
-    data : dict
-        The table data, where the key is the column name and the value
-        the data.
-    col_names : sequence of str
-        The column names from data to use (this also sets the order).
-    header : dict or None, optional
-        Any header information to include.
-
-    Returns
-    -------
-    pha
-        A data structure used by the backend to represent PHA data.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def pack_arf_data(data: ColumnsType,
-                  col_names: NamesType,
-                  header: Optional[HdrTypeArg] = None) -> Any:
-    """Create the ARF.
-
-    Parameters
-    ----------
-    data : dict
-        The table data, where the key is the column name and the value
-        the data.
-    col_names : sequence of str
-        The column names from data to use (this also sets the order).
-    header : dict or None, optional
-        Any header information to include.
-
-    Returns
-    -------
-    arf
-        A data structure used by the backend to represent ARF data.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def pack_rmf_data(blocks) -> Any:
-    """Create the RMF.
-
-    Parameters
-    ----------
-    blocks : sequence of pairs
-        The RMF data, stored as pairs of (data, header), where data is
-        a dictionary of column name (keys) and values, and header is a
-        dictionary of key and values. The first element is the MATRIX
-        block and the second is for the EBOUNDS block.
-
-    Returns
-    -------
-    rmf
-        A data structure used by the backend to represent RMF data.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def pack_hdus(blocks: Sequence[TableHDU]) -> Any:
-    """Create a dataset.
-
-    Parameters
-    ----------
-    blocks : sequence of TableHDU
-        The blocks (HDUs) to store.
-
-    Returns
-    -------
-    hdus
-        A data structure used by the backend to represent the data.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_table_data(filename: str,
-                   data: ColumnsType,
-                   col_names: NamesType,
-                   header: Optional[HdrTypeArg] = None,
-                   ascii: bool = False,
+
+    name  = "dummy"
+
+    def get_table_data(self, arg,
+                       ncols: int = 1,
+                       colkeys: Optional[NamesType] = None,
+                       make_copy: bool = True,
+                       fix_type: bool = True,
+                       blockname: Optional[str] = None,
+                       hdrkeys: Optional[NamesType] = None
+                       ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
+        """Read columns from a file or object."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_header_data(self, arg,
+                        blockname: Optional[str] = None,
+                        hdrkeys: Optional[NamesType] = None
+                        ) -> HdrType:
+        """Read the metadata."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_image_data(self, arg,
+                       make_copy: bool = True,
+                       fix_type: bool = True
+                       ) -> tuple[DataType, str]:
+        """Read image data."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_column_data(self, *args) -> list[np.ndarray]:
+        """Extract the column data."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_ascii_data(self,
+                       filename: str,
+                       ncols: int = 1,
+                       colkeys: Optional[NamesType] = None,
+                       sep: str = ' ',
+                       dstype: type = Data1D,
+                       comment: str = '#',
+                       require_floats: bool = True
+                       ) -> tuple[list[str], list[np.ndarray], str]:
+        """Read columns from an ASCII file."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_arf_data(self, arg,
+                     make_copy: bool = True
+                     ) -> tuple[DataType, str]:
+        """Read in the ARF."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_rmf_data(self, arg,
+                     make_copy: bool = True
+                     ) -> tuple[DataType, str]:
+        """Read in the RMF."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def get_pha_data(self, arg,
+                     make_copy: bool = True,
+                     use_background: bool = False
+                     ) -> tuple[list[DataType], str]:
+        """Read in the PHA."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def pack_table_data(self,
+                        data: ColumnsType,
+                        col_names: NamesType,
+                        header: Optional[HdrTypeArg] = None) -> Any:
+        """Create the tabular data."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def pack_image_data(self,
+                        data: DataTypeArg,
+                        header: HdrTypeArg) -> Any:
+        """Create the image data."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def pack_pha_data(self,
+                      data: ColumnsType,
+                      col_names: NamesType,
+                      header: Optional[HdrTypeArg] = None) -> Any:
+        """Create the PHA."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def pack_arf_data(self,
+                      data: ColumnsType,
+                      col_names: NamesType,
+                      header: Optional[HdrTypeArg] = None) -> Any:
+        """Create the ARF."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def pack_rmf_data(self, blocks) -> Any:
+        """Create the RMF."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def pack_hdus(self,
+                  blocks: Sequence[TableHDU]) -> Any:
+        """Create a dataset."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_table_data(self,
+                       filename: str,
+                       data: ColumnsType,
+                       col_names: NamesType,
+                       header: Optional[HdrTypeArg] = None,
+                       ascii: bool = False,
+                       clobber: bool = False) -> None:
+        """Write out the tabular data."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_image_data(self,
+                       filename: str,
+                       data: DataTypeArg,
+                       header: HdrTypeArg,
+                       ascii: bool = False,
+                       clobber: bool = False) -> None:
+        """Write out the image data."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_pha_data(self,
+                     filename: str,
+                     data: ColumnsType,
+                     col_names: NamesType,
+                     header: Optional[HdrTypeArg] = None,
+                     ascii: bool = False,
+                     clobber: bool = False) -> None:
+        """Write out the PHA."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_arf_data(self,
+                     filename: str,
+                     data: ColumnsType,
+                     col_names: NamesType,
+                     header: Optional[HdrTypeArg] = None,
+                     ascii: bool = False,
+                     clobber: bool = False) -> None:
+        """Write out the ARF."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_rmf_data(self,
+                     filename: str,
+                     blocks,
+                     clobber: bool = False) -> None:
+        """Write out the RMF."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_hdus(self,
+                 filename: str,
+                 blocks: Sequence[TableHDU],
+                 clobber: bool = False) -> None:
+        """Write out (possibly multiple) blocks."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def read_table_blocks(self, arg,
+                          make_copy: bool = False
+                          ) -> tuple[str,
+                                     dict[int, dict[str, np.ndarray]],
+                                     dict[int, HdrType]]:
+        """Read in tabular data with no restrictions on the columns."""
+        raise NotImplementedError('No usable I/O backend was imported.')
+
+
+    def set_arrays(self,
+                   filename: str,
+                   args: Sequence[np.ndarray],
+                   fields: Optional[NamesType] = None,
+                   ascii: bool = True,
                    clobber: bool = False) -> None:
-    """Write out the tabular data.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the file to create.
-    data : dict
-        The table data, where the key is the column name and the value
-        the data.
-    col_names : sequence of str
-        The column names from data to use (this also sets the order).
-    header : dict or None, optional
-        Any header information to include.
-    ascii : bool, optional
-        Is the file to be written out as a text file (`True`) or a
-        binary file? The default is `False`.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_image_data(filename: str,
-                   data: DataTypeArg,
-                   header: HdrTypeArg,
-                   ascii: bool = False,
-                   clobber: bool = False) -> None:
-    """Write out the image data.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the file to create.
-    data : dict
-        The image data, where the keys are arguments used to create a
-        sherpa.astro.data.DataIMG object.
-    header : dict
-        The header information to include.
-    ascii : bool, optional
-        Is the file to be written out as a text file (`True`) or a
-        binary file? The default is `False`.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_pha_data(filename: str,
-                 data: ColumnsType,
-                 col_names: NamesType,
-                 header: Optional[HdrTypeArg] = None,
-                 ascii: bool = False,
-                 clobber: bool = False) -> None:
-    """Write out the PHA.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the file to create.
-    data : dict
-        The table data, where the key is the column name and the value
-        the data.
-    col_names : sequence of str
-        The column names from data to use (this also sets the order).
-    header : dict or None, optional
-        Any header information to include.
-    ascii : bool, optional
-        Is the file to be written out as a text file (`True`) or a
-        binary file? The default is `False`.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_arf_data(filename: str,
-                 data: ColumnsType,
-                 col_names: NamesType,
-                 header: Optional[HdrTypeArg] = None,
-                 ascii: bool = False,
-                 clobber: bool = False) -> None:
-    """Write out the ARF.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the file to create.
-    data : dict
-        The table data, where the key is the column name and the value
-        the data.
-    col_names : sequence of str
-        The column names from data to use (this also sets the order).
-    header : dict or None, optional
-        Any header information to include.
-    ascii : bool, optional
-        Is the file to be written out as a text file (`True`) or a
-        binary file? The default is `False`.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_rmf_data(filename: str,
-                 blocks,
-                 clobber: bool = False) -> None:
-    """Write out the RMF.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the file to create.
-    blocks : sequence of pairs
-        The RMF data, stored as pairs of (data, header), where data is
-        a dictionary of column name (keys) and values, and header is a
-        dictionary of key and values. The first element is the MATRIX
-        block and the second is for the EBOUNDS block.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    Notes
-    -----
-    There is currently no support for writing out a RMF as an ASCII
-    file.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_hdus(filename: str,
-             blocks: Sequence[TableHDU],
-             clobber: bool = False) -> None:
-    """Write out (possibly multiple) blocks.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the file to create.
-    blocks : sequence of TableHDU
-        The blocks (HDUs) to store.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def read_table_blocks(arg,
-                      make_copy: bool = False
-                      ) -> tuple[str,
-                                 dict[int, dict[str, np.ndarray]],
-                                 dict[int, HdrType]]:
-    """Read in tabular data with no restrictions on the columns.
-
-    Parameters
-    ----------
-    arg
-        The data to read the columns from. This depends on the
-        backend but is expected to be a file name or a tabular
-        data structure supported by the backend.
-    make_copy: bool, optional
-        If set then the returned NumPy arrays are expictly copied,
-        rather than using a reference from the data structure
-        created by the backend. Backends are not required to
-        honor this setting. The default is `True`.
-
-    Returns
-    -------
-    filename, blockdata, hdrdata
-        The filename as a string. The blockdata and hdrdata values are
-        dictionaries where the key is an integer representing the
-        block (or HDU) number (where the first block is numbered 1 and
-        represents the first tabular block, that is it does not
-        include the primary HDU) and the values are dictionaries
-        representing the column data or header data for each block.
-
-    Raises
-    ------
-    sherpa.utils.err.IOErr
-        The arg argument is invalid, or a required column or keyword
-        is missing.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
-
-
-def set_arrays(filename: str,
-               args: Sequence[np.ndarray],
-               fields: Optional[NamesType] = None,
-               ascii: bool = True,
-               clobber: bool = False) -> None:
-    """Write out columns.
-
-    Parameters
-    ----------
-    filename : str
-        The file name.
-    args : sequence of ndarray
-        The column data.
-    fields : sequence of str or None, optional
-        The column names to use. If set to `None` then the columns are
-        named ``col1``, ``col2``, ...
-    ascii : bool, optional
-        Is the file to be written out as a text file (`True`) or a
-        binary file? The default is `True`.
-    clobber : bool, optional
-        If the file already exists can it be over-written (`True`) or
-        will a sherpa.utils.err.IOErr error be raised? The default is
-        `False`.
-
-    """
-    raise NotImplementedError('No usable I/O backend was imported.')
+        """Write out columns."""
+        raise NotImplementedError('No usable I/O backend was imported.')

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2011, 2015 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -71,8 +71,8 @@ except ImportError:
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
-           'pack_table_data', 'pack_arf_data', 'pack_arf_data',
-           'pack_rmf_data', 'pack_image_data', 'pack_hdus',
+           'pack_table_data', 'pack_arf_data', 'pack_rmf_data',
+           'pack_image_data', 'pack_hdus',
            'set_table_data', 'set_image_data', 'set_pha_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
@@ -1262,7 +1262,6 @@ def set_table_data(filename: str,
 
     hdu = pack_table_data(data, col_names, header)
     hdu.writeto(filename, overwrite=True)
-    return
 
 
 def _create_header(header: Mapping[str, KeyType]) -> fits.Header:
@@ -1319,8 +1318,11 @@ def set_arf_data(filename: str,
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")
 
-    return set_table_data(filename, data, col_names, header=header,
-                          ascii=ascii, clobber=clobber)
+    # This does not use pack_arf_data as we need to deal with ASCII
+    # support.
+    #
+    set_table_data(filename, data, col_names, header=header,
+                   ascii=ascii, clobber=clobber)
 
 
 def pack_pha_data(data, col_names, header) -> fits.BinTableHDU:
@@ -1338,8 +1340,11 @@ def set_pha_data(filename: str,
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")
 
-    return set_table_data(filename, data, col_names, header=header,
-                          ascii=ascii, clobber=clobber)
+    # This does not use pack_pha_data as we need to deal with ASCII
+    # support.
+    #
+    set_table_data(filename, data, col_names, header=header,
+                   ascii=ascii, clobber=clobber)
 
 
 def pack_rmf_data(blocks) -> fits.HDUList:

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -55,6 +55,7 @@ from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 from sherpa.io import get_ascii_data, write_arrays
 
+from .backends import BaseBackend
 from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
@@ -68,13 +69,7 @@ except ImportError:
     warning('failed to import WCS module; WCS routines will not be '
             'available')
 
-__all__ = ('get_table_data', 'get_header_data', 'get_image_data',
-           'get_column_data', 'get_ascii_data',
-           'get_arf_data', 'get_rmf_data', 'get_pha_data',
-           'pack_table_data', 'pack_arf_data', 'pack_rmf_data',
-           'pack_image_data', 'pack_hdus',
-           'set_table_data', 'set_image_data', 'set_pha_data',
-           'set_arf_data', 'set_rmf_data', 'set_hdus')
+__all__ = ('Backend', )
 
 
 DatasetType = Union[str, fits.HDUList]
@@ -310,45 +305,6 @@ def open_fits(filename: str) -> fits.HDUList:
     return out
 
 
-def read_table_blocks(arg: DatasetType,
-                      make_copy: bool = False
-                      ) -> tuple[str,
-                                 dict[int, dict[str, np.ndarray]],
-                                 dict[int, HdrType]]:
-    """Read in tabular data with no restrictions on the columns."""
-
-    # This sets nobinary=True to match the original version of
-    # the code, which did not use _get_file_contents.
-    #
-    hdus, filename, close = _get_file_contents(arg,
-                                               exptype="BinTableHDU",
-                                               nobinary=True)
-
-    cols: dict[int, dict[str, np.ndarray]] = {}
-    hdr: dict[int, HdrType] = {}
-    try:
-        for blockidx, hdu in enumerate(hdus, 1):
-            hdr[blockidx] = {}
-            header = hdu.header
-            if header is not None:
-                for key in header.keys():
-                    hdr[blockidx][key] = header[key]
-
-            # skip over primary, hdu.data is None
-
-            cols[blockidx] = {}
-            recarray = hdu.data
-            if recarray is not None:
-                for colname in recarray.names:
-                    cols[blockidx][colname] = recarray[colname]
-
-    finally:
-        if close:
-            hdus.close()
-
-    return filename, cols, hdr
-
-
 def _get_file_contents(arg: DatasetType,
                        exptype: str = "PrimaryHDU",
                        nobinary: bool = False
@@ -409,205 +365,6 @@ def _find_binary_table(tbl: fits.HDUList,
     raise IOErr('badext', filename)
 
 
-def get_header_data(arg: DatasetType,
-                    blockname: Optional[str] = None,
-                    hdrkeys: Optional[NamesType] = None
-                    ) -> dict[str, KeyType]:
-    """Read in the header data."""
-
-    tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
-
-    hdr = {}
-    try:
-        hdu = _find_binary_table(tbl, filename, blockname)
-
-        if hdrkeys is None:
-            hdrkeys = hdu.header.keys()
-
-        for key in hdrkeys:
-            # TODO: should this set require_type=true or remove dtype,
-            # as currently it does not change the value to str.
-            hdr[key] = _require_key(hdu, key, dtype=str)
-
-    finally:
-        if close:
-            tbl.close()
-
-    return hdr
-
-
-def get_column_data(*args) -> list[np.ndarray]:
-    """Extract the column data."""
-
-    # args is passed as type list
-    if len(args) == 0:
-        raise IOErr('noarrays')
-
-    cols = []
-    for arg in args:
-        if arg is not None and not isinstance(arg, (np.ndarray, list, tuple)):
-            raise IOErr('badarray', arg)
-        if arg is not None:
-            vals = np.asanyarray(arg)
-            for col in np.atleast_2d(vals.T):
-                cols.append(col)
-        else:
-            cols.append(arg)
-
-    return cols
-
-
-def get_table_data(arg: DatasetType,
-                   ncols: int = 1,
-                   colkeys: Optional[NamesType] = None,
-                   make_copy: bool = False,
-                   fix_type: bool = False,
-                   blockname: Optional[str] = None,
-                   hdrkeys: Optional[NamesType] = None
-                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
-    """Read columns."""
-
-    tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
-
-    try:
-        hdu = _find_binary_table(tbl, filename, blockname)
-        cnames = list(hdu.columns.names)
-
-        # Try Channel, Counts or X,Y before defaulting to the first
-        # ncols columns in cnames (when colkeys is not given).
-        #
-        if colkeys is not None:
-            colkeys = [name.strip().upper() for name in list(colkeys)]
-        elif 'CHANNEL' in cnames and 'COUNTS' in cnames:
-            colkeys = ['CHANNEL', 'COUNTS']
-        elif 'X' in cnames and 'Y' in cnames:
-            colkeys = ['X', 'Y']
-        else:
-            colkeys = cnames[:ncols]
-
-        cols = []
-        for name in colkeys:
-            for col in _require_tbl_col(hdu, name, fix_type=fix_type):
-                cols.append(col)
-
-        hdr = {}
-        if hdrkeys is not None:
-            for key in hdrkeys:
-                hdr[key] = _require_key(hdu, key)
-
-    finally:
-        if close:
-            tbl.close()
-
-    return colkeys, cols, filename, hdr
-
-
-def get_image_data(arg: DatasetType,
-                   make_copy: bool = True,
-                   fix_type: bool = True
-                   ) -> tuple[DataType, str]:
-    """Read image data."""
-
-    hdus, filename, close = _get_file_contents(arg)
-
-    #   FITS uses logical-to-world where we use physical-to-world.
-    #   For all transforms, update their physical-to-world
-    #   values from their logical-to-world values.
-    #   Find the matching physical transform
-    #      (same axis no, but sub = 'P' )
-    #   and use it for the update.
-    #   Physical tfms themselves do not get updated.
-    #
-    #  Fill the physical-to-world transform given the
-    #  logical-to-world and the associated logical-to-physical.
-    #      W = wv + wd * ( P - wp )
-    #      P = pv + pd * ( L - pp )
-    #      W = lv + ld * ( L - lp )
-    # Then
-    #      L = pp + ( P - pv ) / pd
-    # so   W = lv + ld * ( pp + (P-pv)/pd - lp )
-    #        = lv + ( ld / pd ) * ( P - [ pv +  (lp-pp)*pd ] )
-    # Hence
-    #      wv = lv
-    #      wd = ld / pd
-    #      wp = pv + ( lp - pp ) * pd
-
-    #  EG suppose phys-to-world is
-    #         W =  1000 + 2.0 * ( P - 4.0 )
-    #  and we bin and scale to generate a logical-to-phys of
-    #         P =  20 + 4.0 * ( L - 10 )
-    #  Then
-    #         W = 1000 + 2.0 * ( (20-4) - 4 * 10 ) + 2 * 4 $
-    #
-
-    try:
-        data: DataType = {}
-
-        # Look for data in the primary or first block.
-        #
-        img = hdus[0]
-        if img.data is None:
-            img = hdus[1]
-            if img.data is None:
-                raise IOErr('badimg', filename)
-
-        if not isinstance(img, (fits.PrimaryHDU, fits.ImageHDU)):
-            raise IOErr("badimg", filename)
-
-        data['y'] = np.asarray(img.data)
-
-        if HAS_TRANSFORM:
-
-            def _get_wcs_key(key, suffix=""):
-                val1 = _try_key(img, f"{key}1{suffix}")
-                if val1 is None:
-                    return None
-
-                val2 = _try_key(img, f"{key}2{suffix}")
-                if val2 is None:
-                    return None
-
-                return np.array([val1, val2], dtype=SherpaFloat)
-
-            cdeltp = _get_wcs_key('CDELT', 'P')
-            crpixp = _get_wcs_key('CRPIX', 'P')
-            crvalp = _get_wcs_key('CRVAL', 'P')
-            cdeltw = _get_wcs_key('CDELT')
-            crpixw = _get_wcs_key('CRPIX')
-            crvalw = _get_wcs_key('CRVAL')
-
-            # proper calculation of cdelt wrt PHYSICAL coords
-            if cdeltw is not None and cdeltp is not None:
-                cdeltw = cdeltw / cdeltp
-
-            # proper calculation of crpix wrt PHYSICAL coords
-            if (crpixw is not None and crvalp is not None and
-                cdeltp is not None and crpixp is not None):
-                crpixw = crvalp + (crpixw - crpixp) * cdeltp
-
-            if (cdeltp is not None and crpixp is not None and
-                crvalp is not None):
-                data['sky'] = WCS('physical', 'LINEAR', crvalp,
-                                  crpixp, cdeltp)
-
-            if (cdeltw is not None and crpixw is not None and
-                crvalw is not None):
-                data['eqpos'] = WCS('world', 'WCS', crvalw, crpixw,
-                                    cdeltw)
-
-        data['header'] = _get_meta_data(img)
-        for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
-                    'CDELT2P', 'CRPIX1P', 'CRPIX2P', 'CRVAL1P', 'CRVAL2P',
-                    'EQUINOX']:
-            data['header'].pop(key, None)
-
-    finally:
-        if close:
-            hdus.close()
-
-    return data, filename
-
-
 def _is_ogip_block(hdu: HDUType,
                    bltype1: str,
                    bltype2: Optional[str] = None) -> bool:
@@ -644,45 +401,6 @@ def _has_ogip_type(hdus: fits.HDUList,
         return hdu
 
     return None
-
-
-def get_arf_data(arg: DatasetType,
-                 make_copy: bool = False
-                 ) -> tuple[DataType, str]:
-    """Read in the ARF."""
-
-    arf, filename, close = _get_file_contents(arg,
-                                              exptype="BinTableHDU",
-                                              nobinary=True)
-
-    try:
-        try:
-            hdu = arf["SPECREP"]
-        except KeyError:
-            try:
-                hdu = arf["AXAF_ARF"]
-            except KeyError:
-                hdu = _has_ogip_type(arf, 'RESPONSE', 'SPECRESP')
-                if hdu is None:
-                    raise IOErr('notrsp', filename, 'an ARF') from None
-
-        data: DataType = {}
-
-        data['exposure'] = _try_key(hdu, 'EXPOSURE', fix_type=True)
-
-        data['energ_lo'] = _require_col(hdu, 'ENERG_LO', fix_type=True)
-        data['energ_hi'] = _require_col(hdu, 'ENERG_HI', fix_type=True)
-        data['specresp'] = _require_col(hdu, 'SPECRESP', fix_type=True)
-        data['bin_lo'] = _try_col(hdu, 'BIN_LO', fix_type=True)
-        data['bin_hi'] = _try_col(hdu, 'BIN_HI', fix_type=True)
-        data['header'] = _get_meta_data(hdu)
-        data['header'].pop('EXPOSURE', None)
-
-    finally:
-        if close:
-            arf.close()
-
-    return data, filename
 
 
 def _read_col(hdu: fits.BinTableHDU, name: str) -> np.ndarray:
@@ -830,370 +548,6 @@ def _read_rmf_data(arg: DatasetType
     return data, filename
 
 
-def get_rmf_data(arg: DatasetType,
-                 make_copy: bool = False
-                 ) -> tuple[DataType, str]:
-    """Read in the RMF.
-
-    Notes
-    -----
-    For more information on the RMF format see the `OGIP Calibration
-    Memo CAL/GEN/92-002
-    <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
-
-    """
-
-    # Read in the columns from the MATRIX and EBOUNDS extensions.
-    #
-    data, filename = _read_rmf_data(arg)
-
-    # This could be taken from the NUMELT keyword, but this is not
-    # a required value and it is not obvious how trustworthy it is.
-    #
-    # Since N_CHAN can be a VLF we can not just use sum().
-    #
-    numelt = 0
-    for row in data["n_chan"]:
-        try:
-            numelt += sum(row)
-        except TypeError:
-            # assumed to be a scalar
-            numelt += row
-
-    # Remove unwanted data
-    #  - rows where N_GRP=0
-    #  - for each row, any excess data (beyond the sum(N_CHAN) for that row)
-    #
-    # The columns may be 1D or 2D vectors, or variable-field arrays,
-    # where each row is an object containing a number of elements.
-    #
-    # Note that crates uses the sherpa.astro.utils.resp_init routine,
-    # but it's not clear why, so it is not used here for now.
-    #
-    good = data['n_grp'] > 0
-
-    matrix = data['matrix'][good]
-    n_grp = data['n_grp'][good]
-    n_chan = data['n_chan'][good]
-    f_chan = data['f_chan'][good]
-
-    # Flatten the array. There are four cases here:
-    #
-    # a) a variable-length field with no "padding"
-    # b) a variable-length field with padding
-    # c) a rectangular matrix is given, with no "padding"
-    # d) a rectangular matrix is given, but a row can contain
-    #    unused data
-    #
-    if numelt == matrix.size:
-        if isinstance(matrix, _VLF):
-            # case a
-            matrix = np.concatenate([np.asarray(row)
-                                     for row in matrix])
-        else:
-            # case c
-            matrix = matrix.flatten()
-
-    else:
-        # cases b or d; assume we can use the same logic
-        rowdata = []
-        for mrow, ncs in zip(matrix, n_chan):
-            # Need a RMF which ng>1 to test this with.
-            if np.isscalar(ncs):
-                ncs = [ncs]
-
-            start = 0
-            for nc in ncs:
-                # n_chan can be an unsigned integer. Adding a Python
-                # integer to a NumPy unsigned integer appears to return
-                # a float.
-                end = start + int(nc)
-
-                # "perfect" RMFs may have mrow as a scalar
-                try:
-                    rdata = mrow[start:end]
-                except IndexError as ie:
-                    if start != 0 or end != 1:
-                        raise IOErr('bad', 'format', 'MATRIX column formatting') from ie
-
-                    rdata = [mrow]
-
-                rowdata.append(rdata)
-                start = end
-
-        matrix = np.concatenate(rowdata)
-
-    data['matrix'] = matrix.astype(SherpaFloat)
-
-    # Flatten f_chan and n_chan vectors into 1D arrays as crates does
-    # according to group. This is not always needed, but annoying to
-    # check for so we always do it.
-    #
-    xf_chan = []
-    xn_chan = []
-    for grp, fch, nch, in zip(n_grp, f_chan, n_chan):
-        if np.isscalar(fch):
-            # The assumption is that grp==1 here
-            xf_chan.append(fch)
-            xn_chan.append(nch)
-        else:
-            # The arrays may contain extra elements (which
-            # should be 0).
-            #
-            xf_chan.extend(fch[:grp])
-            xn_chan.extend(nch[:grp])
-
-    data['f_chan'] = np.asarray(xf_chan, SherpaUInt)
-    data['n_chan'] = np.asarray(xn_chan, SherpaUInt)
-
-    # Not all fields are "flattened" by this routine. In particular we
-    # need to keep knowledge of these rows with 0 groups. This is why
-    # we set the n_grp entry to data['n_grp'] rather than the n_grp
-    # variable (which has the 0 elements removed).
-    #
-    data['n_grp'] = np.asarray(data['n_grp'], SherpaUInt)
-
-    data['energ_lo'] = np.asarray(data['energ_lo'], SherpaFloat)
-    data['energ_hi'] = np.asarray(data['energ_hi'], SherpaFloat)
-
-    return data, filename
-
-
-def get_pha_data(arg: DatasetType,
-                 make_copy: bool = False,
-                 use_background: bool = False
-                 ) -> tuple[list[DataType], str]:
-    """Read in the PHA."""
-
-    pha, filename, close = _get_file_contents(arg,
-                                              exptype="BinTableHDU")
-
-    try:
-        try:
-            hdu = pha["SPECTRUM"]
-        except KeyError:
-            hdu = _has_ogip_type(pha, 'SPECTRUM')
-            if hdu is None:
-                raise IOErr('notrsp', filename, "a PHA spectrum") from None
-
-        if use_background:
-            for block in pha:
-                if _try_key(block, 'HDUCLAS2') == 'BKG':
-                    hdu = block
-
-        keys = ['BACKFILE', 'ANCRFILE', 'RESPFILE',
-                'BACKSCAL', 'AREASCAL', 'EXPOSURE']
-        datasets = []
-
-        if _try_col(hdu, 'SPEC_NUM') is None:
-            data: DataType = {}
-
-            # Create local versions of the "try" routines.
-            #
-            def try_any_sfloat(key):
-                "Get col/key and return a SherpaFloat"
-                return _try_col_or_key(hdu, key, fix_type=True)
-
-            def try_sfloat(key):
-                "Get col and return a SherpaFloat"
-                return _try_col(hdu, key, fix_type=True)
-
-            def try_sint(key):
-                """Get col and return a SherpaInt
-
-                Or, it looks like it should do this, but at the moment
-                it does not force the data type.
-
-                """
-                # return _try_col(hdu, key, fix_type=True, dtype=SherpaInt)
-                return _try_col(hdu, key, dtype=SherpaInt)
-
-            def req_sfloat(key):
-                "Get col and return a SherpaFloat"
-                return _require_col(hdu, key, fix_type=True)
-
-            # Keywords
-            data['exposure'] = _try_key(hdu, 'EXPOSURE', fix_type=True)
-            # data['poisserr'] = _try_key(hdu, 'POISSERR', True, bool)
-            data['backfile'] = _try_key(hdu, 'BACKFILE')
-            data['arffile'] = _try_key(hdu, 'ANCRFILE')
-            data['rmffile'] = _try_key(hdu, 'RESPFILE')
-
-            # Keywords or columns
-            data['backscal'] = try_any_sfloat('BACKSCAL')
-            data['backscup'] = try_any_sfloat('BACKSCUP')
-            data['backscdn'] = try_any_sfloat('BACKSCDN')
-            data['areascal'] = try_any_sfloat('AREASCAL')
-
-            # Columns
-            data['channel'] = req_sfloat("CHANNEL")
-
-            # Make sure channel numbers not indices
-            chan = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
-                             dtype=SherpaUInt)
-            if int(data['channel'][0]) == 0 or tlmin == 0:
-                data['channel'] = data['channel'] + 1
-
-            data['counts'] = try_sfloat("COUNTS")
-            data['staterror'] = _try_col(hdu, 'STAT_ERR')
-
-            # The following assumes that EXPOSURE is set
-            if data['counts'] is None:
-                data['counts'] = req_sfloat("RATE") * data['exposure']
-                if data['staterror'] is not None:
-                    data['staterror'] = data['staterror'] * data['exposure']
-
-            data['syserror'] = _try_col(hdu, 'SYS_ERR')
-            data['background_up'] = try_sfloat('BACKGROUND_UP')
-            data['background_down'] = try_sfloat('BACKGROUND_DOWN')
-            data['bin_lo'] = try_sfloat('BIN_LO')
-            data['bin_hi'] = try_sfloat('BIN_HI')
-            data['grouping'] = try_sint('GROUPING')
-            data['quality'] = try_sint('QUALITY')
-            data['header'] = _get_meta_data(hdu)
-            for key in keys:
-                data['header'].pop(key, None)
-
-            if data['syserror'] is not None:
-                # SYS_ERR is the fractional systematic error
-                data['syserror'] = data['syserror'] * data['counts']
-
-            datasets.append(data)
-
-        else:
-            # Type 2 PHA file support
-            specnum = _try_col_or_key(hdu, 'SPEC_NUM')
-            num = len(specnum)
-
-            # Create local versions of the "try" routines set for this
-            # size=num value.
-            #
-            def try_any_sfloat(key):
-                "Get col/key and return a SherpaFloat"
-                return _try_vec_or_key(hdu, key, size=num, fix_type=True)
-
-            def try_sfloat(key):
-                "Get col and return a SherpaFloat"
-                return _try_vec(hdu, key, size=num, fix_type=True)
-
-            def try_sint(key):
-                """Get col and return a SherpaInt
-
-                Or, it looks like it should do this, but at the moment
-                it does not force the data type.
-
-                """
-                # return _try_vec(hdu, key, size=num, fix_type=True, dtype=SherpaInt)
-                return _try_vec(hdu, key, size=num, dtype=SherpaInt)
-
-            def req_sfloat(key):
-                "Get col and return a SherpaFloat"
-                return _require_vec(hdu, key, size=num, fix_type=True)
-
-            # Keywords
-            exposure = _try_key(hdu, 'EXPOSURE', fix_type=True)
-            # poisserr = _try_key(hdu, 'POISSERR', True, bool)
-            backfile = _try_key(hdu, 'BACKFILE')
-            arffile = _try_key(hdu, 'ANCRFILE')
-            rmffile = _try_key(hdu, 'RESPFILE')
-
-            # Keywords or columns
-            backscal = try_any_sfloat('BACKSCAL')
-            backscup = try_any_sfloat('BACKSCUP')
-            backscdn = try_any_sfloat('BACKSCDN')
-            areascal = try_any_sfloat('AREASCAL')
-
-            # Columns
-            # Why does this convert to SherpaFloat?
-            channel = req_sfloat('CHANNEL')
-
-            # Make sure channel numbers not indices
-            chan = list(hdu.columns.names).index('CHANNEL') + 1
-            tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
-                             dtype=SherpaUInt)
-
-            for idx in range(num):
-                if int(channel[idx][0]) == 0:
-                    channel[idx] += 1
-
-            # Why does this convert to SherpaFloat?
-            counts = try_sfloat("COUNTS")
-            staterror = _try_vec(hdu, 'STAT_ERR', size=num)
-            if np.equal(staterror, None).any():
-                counts = req_sfloat("RATE") * exposure
-                if not np.equal(staterror, None).any():
-                    staterror *= exposure
-
-            syserror = _try_vec(hdu, 'SYS_ERR', size=num)
-            background_up = try_sfloat('BACKGROUND_UP')
-            background_down = try_sfloat('BACKGROUND_DOWN')
-            bin_lo = try_sfloat('BIN_LO')
-            bin_hi = try_sfloat('BIN_HI')
-            grouping = try_sint('GROUPING')
-            quality = try_sint('QUALITY')
-
-            orders = try_sint('TG_M')
-            parts = try_sint('TG_PART')
-            specnums = try_sint('SPEC_NUM')
-            srcids = try_sint('TG_SRCID')
-
-            # Iterate over all rows of channels, counts, errors, etc
-            # Populate a list of dictionaries containing
-            # individual dataset info
-            for (bscal, bscup, bscdn, arsc, chan, cnt, staterr, syserr,
-                 backup, backdown, binlo, binhi, group, qual, ordr, prt,
-                 specnum, srcid
-                 ) in zip(backscal, backscup, backscdn, areascal, channel,
-                          counts, staterror, syserror, background_up,
-                          background_down, bin_lo, bin_hi, grouping, quality,
-                          orders, parts, specnums, srcids):
-
-                idata: DataType = {}
-
-                idata['exposure'] = exposure
-                # idata['poisserr'] = poisserr
-                idata['backfile'] = backfile
-                idata['arffile'] = arffile
-                idata['rmffile'] = rmffile
-
-                idata['backscal'] = bscal
-                idata['backscup'] = bscup
-                idata['backscdn'] = bscdn
-                idata['areascal'] = arsc
-
-                idata['channel'] = chan
-                idata['counts'] = cnt
-                idata['staterror'] = staterr
-                idata['syserror'] = syserr
-                idata['background_up'] = backup
-                idata['background_down'] = backdown
-                idata['bin_lo'] = binlo
-                idata['bin_hi'] = binhi
-                idata['grouping'] = group
-                idata['quality'] = qual
-                idata['header'] = _get_meta_data(hdu)
-                idata['header']['TG_M'] = ordr
-                idata['header']['TG_PART'] = prt
-                idata['header']['SPEC_NUM'] = specnum
-                idata['header']['TG_SRCID'] = srcid
-
-                for key in keys:
-                    idata['header'].pop(key, None)
-
-                if syserr is not None:
-                    # SYS_ERR is the fractional systematic error
-                    idata['syserror'] = syserr * cnt
-
-                datasets.append(idata)
-
-    finally:
-        if close:
-            pha.close()
-
-    return datasets, filename
-
-
 # Write Functions
 
 def _create_table(names: NamesType,
@@ -1239,49 +593,6 @@ def check_clobber(filename: str, clobber: bool) -> None:
     raise IOErr("filefound", filename)
 
 
-def pack_table_data(data: ColumnsType,
-                    col_names: NamesType,
-                    header: Optional[HdrTypeArg] = None) -> fits.BinTableHDU:
-    """Pack up the table data."""
-
-    tbl = _create_table(col_names, data)
-    hdu = fits.table_to_hdu(tbl)
-
-    # Add in the header. We should special case the HISTORY/COMMENT
-    # keywords but at the moment we do nothing.
-    #
-    # There is the issue of conflicts between the existing and sent-in
-    # header - fortunately we can just drop those keys from the sent-in
-    # header, and also just whether the sent-in header keys (e.g. if
-    # TUNIT1 and TLMIN1 are set are they valid)? For the latter we rely
-    # on validation done by the code calling set_table_data.
-    #
-    if header is not None:
-        _update_header(hdu, header)
-
-    return hdu
-
-
-def set_table_data(filename: str,
-                   data: ColumnsType,
-                   col_names: NamesType,
-                   header: Optional[HdrTypeArg] = None,
-                   ascii: bool = False,
-                   clobber: bool = False) -> None:
-    """Write out the table data."""
-
-    check_clobber(filename, clobber)
-
-    if ascii:
-        tbl = _create_table(col_names, data)
-        tbl.write(filename, format='ascii.commented_header',
-                  overwrite=clobber)
-        return
-
-    hdu = pack_table_data(data, col_names, header)
-    hdu.writeto(filename, overwrite=True)
-
-
 def _create_header(header: Mapping[str, KeyType]) -> fits.Header:
     """Create a FITS header with the contents of header,
     the Sherpa representation of the key,value store.
@@ -1319,323 +630,6 @@ def _update_header(hdu: HDUType,
             continue
 
         hdu.header[key] = value
-
-
-def pack_arf_data(data: ColumnsType,
-                  col_names: NamesType,
-                  header: Optional[HdrTypeArg] = None) -> fits.BinTableHDU:
-    """Pack the ARF"""
-
-    if header is None:
-        raise ArgumentTypeErr("badarg", "header", "set")
-
-    return pack_table_data(data, col_names, header)
-
-
-def set_arf_data(filename: str,
-                 data: ColumnsType,
-                 col_names: NamesType,
-                 header: Optional[HdrTypeArg] = None,
-                 ascii: bool = False,
-                 clobber: bool = False) -> None:
-    """Write out the ARF"""
-
-    if header is None:
-        raise ArgumentTypeErr("badarg", "header", "set")
-
-    # This does not use pack_arf_data as we need to deal with ASCII
-    # support.
-    #
-    set_table_data(filename, data, col_names, header=header,
-                   ascii=ascii, clobber=clobber)
-
-
-def pack_pha_data(data: ColumnsType,
-                  col_names: NamesType,
-                  header: Optional[HdrTypeArg] = None) -> fits.BinTableHDU:
-    """Pack the PHA data."""
-
-    if header is None:
-        raise ArgumentTypeErr("badarg", "header", "set")
-
-    return pack_table_data(data, col_names, header)
-
-
-def set_pha_data(filename: str,
-                 data: ColumnsType,
-                 col_names: NamesType,
-                 header: Optional[HdrTypeArg] = None,
-                 ascii: bool = False,
-                 clobber: bool = False) -> None:
-    """ Write out the PHA."""
-
-    if header is None:
-        raise ArgumentTypeErr("badarg", "header", "set")
-
-    # This does not use pack_pha_data as we need to deal with ASCII
-    # support.
-    #
-    set_table_data(filename, data, col_names, header=header,
-                   ascii=ascii, clobber=clobber)
-
-
-def pack_rmf_data(blocks) -> fits.HDUList:
-    """Pack up the RMF data."""
-
-    # For now assume only two blocks:
-    #    MATRIX
-    #    EBOUNDS
-    #
-    matrix_data, matrix_header = blocks[0]
-    ebounds_data, ebounds_header = blocks[1]
-
-    # Extract the data:
-    #   MATRIX:
-    #     ENERG_LO
-    #     ENERG_HI
-    #     N_GRP
-    #     F_CHAN
-    #     N_CHAN
-    #     MATRIX
-    #
-    #   EBOUNDS:
-    #     CHANNEL
-    #     E_MIN
-    #     E_MAX
-    #
-    # We may need to convert F_CHAN/N_CHAN/MATRIX to Variable-Length
-    # Fields. This is only needed if the ndarray type is object.
-    #
-    # It looks like we can not use the go-via-a-table approach
-    # here, as that does not support Variable Length Fields.
-    #
-    def get_format(val):
-        """We only bother with formats we expect"""
-        if np.issubdtype(val, np.integer):
-            if isinstance(val, np.int16):
-                return "I"
-
-            # default to Int32. AstroPy does support Int64/K but
-            # this should not be needed here.
-            return "J"
-
-        if not np.issubdtype(val, np.floating):
-            raise ValueError(f"Unexpected value '{val}' with type {val.dtype}")
-
-        if isinstance(val,np.float32):
-            return "E"
-
-        # This should not be reached
-        return "D"
-
-    def get_full_format(name, vals):
-        if vals.dtype == object:
-            # We need to get the format from the first non-empty row.
-            bformat = None
-            ny = 0
-            for v in vals:
-                nv = len(v)
-                ny = max(ny, nv)
-                if nv == 0:
-                    continue
-
-                if bformat is not None:
-                    continue
-
-                bformat = get_format(v[0])
-                break
-
-            if bformat is None:
-                # This should not happen
-                raise ValueError(f"Unable to find data for column '{name}'")
-
-            return f"P{bformat}({ny})"
-
-        bformat = get_format(vals[0][0])
-        ny = vals.shape[1]
-        return f"{ny}{bformat}"
-
-    def arraycol(name):
-        vals = matrix_data[name]
-        if name == "MATRIX": print(vals)
-        formatval = get_full_format(name, vals)
-        return fits.Column(name=name, format=formatval, array=vals)
-
-    n_grp = matrix_data["N_GRP"]
-    col1 = fits.Column(name="ENERG_LO", format="E",
-                       array=matrix_data["ENERG_LO"], unit="keV")
-    col2 = fits.Column(name="ENERG_HI", format="E",
-                       array=matrix_data["ENERG_HI"], unit="keV")
-    col3 = fits.Column(name="N_GRP", format=get_format(n_grp[0]),
-                       array=n_grp)
-    col4 = arraycol("F_CHAN")
-    col5 = arraycol("N_CHAN")
-    col6 = arraycol("MATRIX")
-    cols = [col1, col2, col3, col4, col5, col6]
-    matrix_hdu = fits.BinTableHDU.from_columns(cols)
-    _update_header(matrix_hdu, matrix_header)
-
-    # Ensure the TLMIN4 value (for F_CHAN) is set.
-    matrix_hdu.header["TLMIN4"] = matrix_data["OFFSET"]
-
-    channel = ebounds_data["CHANNEL"]
-    col1 = fits.Column(name="CHANNEL", format=get_format(channel[0]),
-                       array=channel)
-    col2 = fits.Column(name="E_MIN", format="E",
-                       array=ebounds_data["E_MIN"], unit="keV")
-    col3 = fits.Column(name="E_MAX", format="E",
-                       array=ebounds_data["E_MAX"], unit="keV")
-    ebounds_hdu = fits.BinTableHDU.from_columns([col1, col2, col3])
-    _update_header(ebounds_hdu, ebounds_header)
-
-    primary_hdu = fits.PrimaryHDU()
-    return fits.HDUList([primary_hdu, matrix_hdu, ebounds_hdu])
-
-
-def set_rmf_data(filename: str,
-                 blocks,
-                 clobber: bool = False) -> None:
-    """Save the RMF data to disk.
-
-    Unlike the other save_*_data calls this does not support the ascii
-    argument. It also relies on the caller to have set up the headers
-    and columns correctly apart for variable-length fields, which are
-    limited to F_CHAN, N_CHAN, and MATRIX.
-
-    """
-
-    check_clobber(filename, clobber)
-    hdus = pack_rmf_data(blocks)
-    hdus.writeto(filename, overwrite=True)
-
-
-def pack_image_data(data: DataTypeArg,
-                    header: HdrTypeArg) -> fits.PrimaryHDU:
-    """Pack up the image data."""
-
-    hdrlist = _create_header(header)
-
-    # Write Image WCS Header Keys
-    if data['eqpos'] is not None:
-        cdeltw = data['eqpos'].cdelt
-        crpixw = data['eqpos'].crpix
-        crvalw = data['eqpos'].crval
-        equin = data['eqpos'].equinox
-
-    if data['sky'] is not None:
-        cdeltp = data['sky'].cdelt
-        crpixp = data['sky'].crpix
-        crvalp = data['sky'].crval
-
-        _add_keyword(hdrlist, 'MTYPE1', 'sky     ')
-        _add_keyword(hdrlist, 'MFORM1', 'x,y     ')
-        _add_keyword(hdrlist, 'CTYPE1P', 'x      ')
-        _add_keyword(hdrlist, 'CTYPE2P', 'y      ')
-        _add_keyword(hdrlist, 'WCSNAMEP', 'PHYSICAL')
-        _add_keyword(hdrlist, 'CDELT1P', cdeltp[0])
-        _add_keyword(hdrlist, 'CDELT2P', cdeltp[1])
-        _add_keyword(hdrlist, 'CRPIX1P', crpixp[0])
-        _add_keyword(hdrlist, 'CRPIX2P', crpixp[1])
-        _add_keyword(hdrlist, 'CRVAL1P', crvalp[0])
-        _add_keyword(hdrlist, 'CRVAL2P', crvalp[1])
-
-    if data['eqpos'] is not None:
-        if data['sky'] is not None:
-            # Simply the inverse of read transformations in get_image_data
-            cdeltw = cdeltw * cdeltp
-            crpixw = (crpixw - crvalp) / cdeltp + crpixp
-
-        _add_keyword(hdrlist, 'MTYPE2', 'EQPOS   ')
-        _add_keyword(hdrlist, 'MFORM2', 'RA,DEC  ')
-        _add_keyword(hdrlist, 'CTYPE1', 'RA---TAN')
-        _add_keyword(hdrlist, 'CTYPE2', 'DEC--TAN')
-        _add_keyword(hdrlist, 'CDELT1', cdeltw[0])
-        _add_keyword(hdrlist, 'CDELT2', cdeltw[1])
-        _add_keyword(hdrlist, 'CRPIX1', crpixw[0])
-        _add_keyword(hdrlist, 'CRPIX2', crpixw[1])
-        _add_keyword(hdrlist, 'CRVAL1', crvalw[0])
-        _add_keyword(hdrlist, 'CRVAL2', crvalw[1])
-        _add_keyword(hdrlist, 'CUNIT1', 'deg     ')
-        _add_keyword(hdrlist, 'CUNIT2', 'deg     ')
-        _add_keyword(hdrlist, 'EQUINOX', equin)
-
-    return fits.PrimaryHDU(data['pixels'], header=fits.Header(hdrlist))
-
-
-def set_image_data(filename: str,
-                   data: DataTypeArg,
-                   header: HdrTypeArg,
-                   ascii: bool = False,
-                   clobber: bool = False) -> None:
-    """Write out the image data."""
-
-    check_clobber(filename, clobber)
-
-    if ascii:
-        set_arrays(filename, [data['pixels'].ravel()],
-                   ascii=True, clobber=clobber)
-        return
-
-    img = pack_image_data(data, header)
-    img.writeto(filename, overwrite=True)
-
-
-def set_arrays(filename: str,
-               args: Sequence[np.ndarray],
-               fields: Optional[NamesType] = None,
-               ascii: bool = True,
-               clobber: bool = False) -> None:
-
-    # Historically the clobber command has been checked before
-    # processing the data, so do so here.
-    #
-    check_clobber(filename, clobber)
-
-    # Check args is a sequence of sequences (although not a complete
-    # check).
-    #
-    try:
-        size = len(args[0])
-    except (TypeError, IndexError) as exc:
-        raise IOErr('noarrayswrite') from exc
-
-    for arg in args[1:]:
-        try:
-            argsize = len(arg)
-        except (TypeError, IndexError) as exc:
-            raise IOErr('noarrayswrite') from exc
-
-        if argsize != size:
-            raise IOErr('arraysnoteq')
-
-    nargs = len(args)
-    if fields is None:
-        fieldnames = [f'COL{idx + 1}' for idx in range(nargs)]
-    elif nargs == len(fields):
-        fieldnames = list(fields)
-    else:
-        raise IOErr("wrongnumcols", nargs, len(fields))
-
-    if ascii:
-        # Historically, the serialization doesn't quite match the
-        # AstroPy Table version, so stay with write_arrays. We do
-        # change the form for the comment line (used when fields is
-        # set) to be "# <col1> .." rather than "#<col1> ..." to match
-        # the AstroPy table output used for other "ASCII table" forms
-        # in this module.
-        #
-        # The fields setting can be None here, which means that
-        # write_arrays will not write out a header line.
-        #
-        write_arrays(filename, args, fields,
-                     comment="# ", clobber=clobber)
-        return
-
-    data = dict(zip(fieldnames, args))
-    tbl = _create_table(fieldnames, data)
-    hdu = fits.table_to_hdu(tbl)
-    hdu.name = 'TABLE'
-    hdu.writeto(filename, overwrite=True)
 
 
 def _add_header(hdu: HDUType,
@@ -1695,28 +689,1037 @@ def _create_table_hdu(hdu: TableHDU) -> fits.BinTableHDU:
     return out
 
 
-def pack_hdus(blocks: Sequence[TableHDU]) -> fits.HDUList:
-    """Create a dataset.
+class Backend(BaseBackend):
+    """Use AstroPy I/O for FITS access."""
 
-    At present we are restricted to tables only.
-    """
+    name = "pyfits"
 
-    out = fits.HDUList()
-    out.append(_create_primary_hdu(blocks[0]))
-    for hdu in blocks[1:]:
-        out.append(_create_table_hdu(hdu))
+    def get_ascii_data(self, *args, **kwargs
+                       ) -> tuple[list[str], list[np.ndarray], str]:
+        return get_ascii_data(*args, **kwargs)
 
-    return out
+    def read_table_blocks(self,
+                          arg: DatasetType,
+                          make_copy: bool = False
+                          ) -> tuple[str,
+                                     dict[int, dict[str, np.ndarray]],
+                                     dict[int, HdrType]]:
+        """Read in tabular data with no restrictions on the columns."""
 
+        # This sets nobinary=True to match the original version of
+        # the code, which did not use _get_file_contents.
+        #
+        hdus, filename, close = _get_file_contents(arg,
+                                                   exptype="BinTableHDU",
+                                                   nobinary=True)
 
-def set_hdus(filename: str,
-             blocks: Sequence[TableHDU],
-             clobber: bool = False) -> None:
-    """Write out multiple HDUS to a single file.
+        cols: dict[int, dict[str, np.ndarray]] = {}
+        hdr: dict[int, HdrType] = {}
+        try:
+            for blockidx, hdu in enumerate(hdus, 1):
+                hdr[blockidx] = {}
+                header = hdu.header
+                if header is not None:
+                    for key in header.keys():
+                        hdr[blockidx][key] = header[key]
 
-    At present we are restricted to tables only.
-    """
+                # skip over primary, hdu.data is None
 
-    check_clobber(filename, clobber)
-    hdus = pack_hdus(blocks)
-    hdus.writeto(filename, overwrite=True)
+                cols[blockidx] = {}
+                recarray = hdu.data
+                if recarray is not None:
+                    for colname in recarray.names:
+                        cols[blockidx][colname] = recarray[colname]
+
+        finally:
+            if close:
+                hdus.close()
+
+        return filename, cols, hdr
+
+    def get_header_data(self,
+                        arg: DatasetType,
+                        blockname: Optional[str] = None,
+                        hdrkeys: Optional[NamesType] = None
+                        ) -> dict[str, KeyType]:
+        """Read in the header data."""
+
+        tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
+
+        hdr = {}
+        try:
+            hdu = _find_binary_table(tbl, filename, blockname)
+
+            if hdrkeys is None:
+                hdrkeys = hdu.header.keys()
+
+            for key in hdrkeys:
+                # TODO: should this set require_type=true or remove dtype,
+                # as currently it does not change the value to str.
+                hdr[key] = _require_key(hdu, key, dtype=str)
+
+        finally:
+            if close:
+                tbl.close()
+
+        return hdr
+
+    def get_column_data(self, *args) -> list[np.ndarray]:
+        """Extract the column data."""
+
+        # args is passed as type list
+        if len(args) == 0:
+            raise IOErr('noarrays')
+
+        cols = []
+        for arg in args:
+            if arg is not None and not isinstance(arg, (np.ndarray, list, tuple)):
+                raise IOErr('badarray', arg)
+            if arg is not None:
+                vals = np.asanyarray(arg)
+                for col in np.atleast_2d(vals.T):
+                    cols.append(col)
+            else:
+                cols.append(arg)
+
+        return cols
+
+    def get_table_data(self,
+                       arg: DatasetType,
+                       ncols: int = 1,
+                       colkeys: Optional[NamesType] = None,
+                       make_copy: bool = False,
+                       fix_type: bool = False,
+                       blockname: Optional[str] = None,
+                       hdrkeys: Optional[NamesType] = None
+                       ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
+        """Read columns."""
+
+        tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
+
+        try:
+            hdu = _find_binary_table(tbl, filename, blockname)
+            cnames = list(hdu.columns.names)
+
+            # Try Channel, Counts or X,Y before defaulting to the first
+            # ncols columns in cnames (when colkeys is not given).
+            #
+            if colkeys is not None:
+                colkeys = [name.strip().upper() for name in list(colkeys)]
+            elif 'CHANNEL' in cnames and 'COUNTS' in cnames:
+                colkeys = ['CHANNEL', 'COUNTS']
+            elif 'X' in cnames and 'Y' in cnames:
+                colkeys = ['X', 'Y']
+            else:
+                colkeys = cnames[:ncols]
+
+            cols = []
+            for name in colkeys:
+                for col in _require_tbl_col(hdu, name, fix_type=fix_type):
+                    cols.append(col)
+
+            hdr = {}
+            if hdrkeys is not None:
+                for key in hdrkeys:
+                    hdr[key] = _require_key(hdu, key)
+
+        finally:
+            if close:
+                tbl.close()
+
+        return colkeys, cols, filename, hdr
+
+    def get_image_data(self,
+                       arg: DatasetType,
+                       make_copy: bool = True,
+                       fix_type: bool = True
+                       ) -> tuple[DataType, str]:
+        """Read image data."""
+
+        hdus, filename, close = _get_file_contents(arg)
+
+        #   FITS uses logical-to-world where we use physical-to-world.
+        #   For all transforms, update their physical-to-world
+        #   values from their logical-to-world values.
+        #   Find the matching physical transform
+        #      (same axis no, but sub = 'P' )
+        #   and use it for the update.
+        #   Physical tfms themselves do not get updated.
+        #
+        #  Fill the physical-to-world transform given the
+        #  logical-to-world and the associated logical-to-physical.
+        #      W = wv + wd * ( P - wp )
+        #      P = pv + pd * ( L - pp )
+        #      W = lv + ld * ( L - lp )
+        # Then
+        #      L = pp + ( P - pv ) / pd
+        # so   W = lv + ld * ( pp + (P-pv)/pd - lp )
+        #        = lv + ( ld / pd ) * ( P - [ pv +  (lp-pp)*pd ] )
+        # Hence
+        #      wv = lv
+        #      wd = ld / pd
+        #      wp = pv + ( lp - pp ) * pd
+
+        #  EG suppose phys-to-world is
+        #         W =  1000 + 2.0 * ( P - 4.0 )
+        #  and we bin and scale to generate a logical-to-phys of
+        #         P =  20 + 4.0 * ( L - 10 )
+        #  Then
+        #         W = 1000 + 2.0 * ( (20-4) - 4 * 10 ) + 2 * 4 $
+        #
+
+        try:
+            data: DataType = {}
+
+            # Look for data in the primary or first block.
+            #
+            img = hdus[0]
+            if img.data is None:
+                img = hdus[1]
+                if img.data is None:
+                    raise IOErr('badimg', filename)
+
+            if not isinstance(img, (fits.PrimaryHDU, fits.ImageHDU)):
+                raise IOErr("badimg", filename)
+
+            data['y'] = np.asarray(img.data)
+
+            if HAS_TRANSFORM:
+
+                def _get_wcs_key(key, suffix=""):
+                    val1 = _try_key(img, f"{key}1{suffix}")
+                    if val1 is None:
+                        return None
+
+                    val2 = _try_key(img, f"{key}2{suffix}")
+                    if val2 is None:
+                        return None
+
+                    return np.array([val1, val2], dtype=SherpaFloat)
+
+                cdeltp = _get_wcs_key('CDELT', 'P')
+                crpixp = _get_wcs_key('CRPIX', 'P')
+                crvalp = _get_wcs_key('CRVAL', 'P')
+                cdeltw = _get_wcs_key('CDELT')
+                crpixw = _get_wcs_key('CRPIX')
+                crvalw = _get_wcs_key('CRVAL')
+
+                # proper calculation of cdelt wrt PHYSICAL coords
+                if cdeltw is not None and cdeltp is not None:
+                    cdeltw = cdeltw / cdeltp
+
+                # proper calculation of crpix wrt PHYSICAL coords
+                if (crpixw is not None and crvalp is not None and
+                    cdeltp is not None and crpixp is not None):
+                    crpixw = crvalp + (crpixw - crpixp) * cdeltp
+
+                if (cdeltp is not None and crpixp is not None and
+                    crvalp is not None):
+                    data['sky'] = WCS('physical', 'LINEAR', crvalp,
+                                      crpixp, cdeltp)
+
+                if (cdeltw is not None and crpixw is not None and
+                    crvalw is not None):
+                    data['eqpos'] = WCS('world', 'WCS', crvalw, crpixw,
+                                        cdeltw)
+
+            data['header'] = _get_meta_data(img)
+            for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
+                        'CDELT2P', 'CRPIX1P', 'CRPIX2P', 'CRVAL1P', 'CRVAL2P',
+                        'EQUINOX']:
+                data['header'].pop(key, None)
+
+        finally:
+            if close:
+                hdus.close()
+
+        return data, filename
+
+    def get_arf_data(self,
+                     arg: DatasetType,
+                     make_copy: bool = False
+                     ) -> tuple[DataType, str]:
+        """Read in the ARF."""
+
+        arf, filename, close = _get_file_contents(arg,
+                                                  exptype="BinTableHDU",
+                                                  nobinary=True)
+
+        try:
+            try:
+                hdu = arf["SPECREP"]
+            except KeyError:
+                try:
+                    hdu = arf["AXAF_ARF"]
+                except KeyError:
+                    hdu = _has_ogip_type(arf, 'RESPONSE', 'SPECRESP')
+                    if hdu is None:
+                        raise IOErr('notrsp', filename, 'an ARF') from None
+
+            data: DataType = {}
+
+            data['exposure'] = _try_key(hdu, 'EXPOSURE', fix_type=True)
+
+            data['energ_lo'] = _require_col(hdu, 'ENERG_LO', fix_type=True)
+            data['energ_hi'] = _require_col(hdu, 'ENERG_HI', fix_type=True)
+            data['specresp'] = _require_col(hdu, 'SPECRESP', fix_type=True)
+            data['bin_lo'] = _try_col(hdu, 'BIN_LO', fix_type=True)
+            data['bin_hi'] = _try_col(hdu, 'BIN_HI', fix_type=True)
+            data['header'] = _get_meta_data(hdu)
+            data['header'].pop('EXPOSURE', None)
+
+        finally:
+            if close:
+                arf.close()
+
+        return data, filename
+
+    def get_rmf_data(self,
+                     arg: DatasetType,
+                     make_copy: bool = False
+                     ) -> tuple[DataType, str]:
+        """Read in the RMF.
+
+        Notes
+        -----
+        For more information on the RMF format see the `OGIP Calibration
+        Memo CAL/GEN/92-002
+        <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
+
+        """
+
+        # Read in the columns from the MATRIX and EBOUNDS extensions.
+        #
+        data, filename = _read_rmf_data(arg)
+
+        # This could be taken from the NUMELT keyword, but this is not
+        # a required value and it is not obvious how trustworthy it is.
+        #
+        # Since N_CHAN can be a VLF we can not just use sum().
+        #
+        numelt = 0
+        for row in data["n_chan"]:
+            try:
+                numelt += sum(row)
+            except TypeError:
+                # assumed to be a scalar
+                numelt += row
+
+        # Remove unwanted data
+        #  - rows where N_GRP=0
+        #  - for each row, any excess data (beyond the sum(N_CHAN) for that row)
+        #
+        # The columns may be 1D or 2D vectors, or variable-field arrays,
+        # where each row is an object containing a number of elements.
+        #
+        # Note that crates uses the sherpa.astro.utils.resp_init routine,
+        # but it's not clear why, so it is not used here for now.
+        #
+        good = data['n_grp'] > 0
+
+        matrix = data['matrix'][good]
+        n_grp = data['n_grp'][good]
+        n_chan = data['n_chan'][good]
+        f_chan = data['f_chan'][good]
+
+        # Flatten the array. There are four cases here:
+        #
+        # a) a variable-length field with no "padding"
+        # b) a variable-length field with padding
+        # c) a rectangular matrix is given, with no "padding"
+        # d) a rectangular matrix is given, but a row can contain
+        #    unused data
+        #
+        if numelt == matrix.size:
+            if isinstance(matrix, _VLF):
+                # case a
+                matrix = np.concatenate([np.asarray(row)
+                                         for row in matrix])
+            else:
+                # case c
+                matrix = matrix.flatten()
+
+        else:
+            # cases b or d; assume we can use the same logic
+            rowdata = []
+            for mrow, ncs in zip(matrix, n_chan):
+                # Need a RMF which ng>1 to test this with.
+                if np.isscalar(ncs):
+                    ncs = [ncs]
+
+                start = 0
+                for nc in ncs:
+                    # n_chan can be an unsigned integer. Adding a Python
+                    # integer to a NumPy unsigned integer appears to return
+                    # a float.
+                    end = start + int(nc)
+
+                    # "perfect" RMFs may have mrow as a scalar
+                    try:
+                        rdata = mrow[start:end]
+                    except IndexError as ie:
+                        if start != 0 or end != 1:
+                            raise IOErr('bad', 'format', 'MATRIX column formatting') from ie
+
+                        rdata = [mrow]
+
+                    rowdata.append(rdata)
+                    start = end
+
+            matrix = np.concatenate(rowdata)
+
+        data['matrix'] = matrix.astype(SherpaFloat)
+
+        # Flatten f_chan and n_chan vectors into 1D arrays as crates does
+        # according to group. This is not always needed, but annoying to
+        # check for so we always do it.
+        #
+        xf_chan = []
+        xn_chan = []
+        for grp, fch, nch, in zip(n_grp, f_chan, n_chan):
+            if np.isscalar(fch):
+                # The assumption is that grp==1 here
+                xf_chan.append(fch)
+                xn_chan.append(nch)
+            else:
+                # The arrays may contain extra elements (which
+                # should be 0).
+                #
+                xf_chan.extend(fch[:grp])
+                xn_chan.extend(nch[:grp])
+
+        data['f_chan'] = np.asarray(xf_chan, SherpaUInt)
+        data['n_chan'] = np.asarray(xn_chan, SherpaUInt)
+
+        # Not all fields are "flattened" by this routine. In particular we
+        # need to keep knowledge of these rows with 0 groups. This is why
+        # we set the n_grp entry to data['n_grp'] rather than the n_grp
+        # variable (which has the 0 elements removed).
+        #
+        data['n_grp'] = np.asarray(data['n_grp'], SherpaUInt)
+
+        data['energ_lo'] = np.asarray(data['energ_lo'], SherpaFloat)
+        data['energ_hi'] = np.asarray(data['energ_hi'], SherpaFloat)
+
+        return data, filename
+
+    def get_pha_data(self,
+                     arg: DatasetType,
+                     make_copy: bool = False,
+                     use_background: bool = False
+                     ) -> tuple[list[DataType], str]:
+        """Read in the PHA."""
+
+        pha, filename, close = _get_file_contents(arg,
+                                                  exptype="BinTableHDU")
+
+        try:
+            try:
+                hdu = pha["SPECTRUM"]
+            except KeyError:
+                hdu = _has_ogip_type(pha, 'SPECTRUM')
+                if hdu is None:
+                    raise IOErr('notrsp', filename, "a PHA spectrum") from None
+
+            if use_background:
+                for block in pha:
+                    if _try_key(block, 'HDUCLAS2') == 'BKG':
+                        hdu = block
+
+            keys = ['BACKFILE', 'ANCRFILE', 'RESPFILE',
+                    'BACKSCAL', 'AREASCAL', 'EXPOSURE']
+            datasets = []
+
+            if _try_col(hdu, 'SPEC_NUM') is None:
+                data: DataType = {}
+
+                # Create local versions of the "try" routines.
+                #
+                def try_any_sfloat(key):
+                    "Get col/key and return a SherpaFloat"
+                    return _try_col_or_key(hdu, key, fix_type=True)
+
+                def try_sfloat(key):
+                    "Get col and return a SherpaFloat"
+                    return _try_col(hdu, key, fix_type=True)
+
+                def try_sint(key):
+                    """Get col and return a SherpaInt
+
+                    Or, it looks like it should do this, but at the moment
+                    it does not force the data type.
+
+                    """
+                    # return _try_col(hdu, key, fix_type=True, dtype=SherpaInt)
+                    return _try_col(hdu, key, dtype=SherpaInt)
+
+                def req_sfloat(key):
+                    "Get col and return a SherpaFloat"
+                    return _require_col(hdu, key, fix_type=True)
+
+                # Keywords
+                data['exposure'] = _try_key(hdu, 'EXPOSURE', fix_type=True)
+                # data['poisserr'] = _try_key(hdu, 'POISSERR', True, bool)
+                data['backfile'] = _try_key(hdu, 'BACKFILE')
+                data['arffile'] = _try_key(hdu, 'ANCRFILE')
+                data['rmffile'] = _try_key(hdu, 'RESPFILE')
+
+                # Keywords or columns
+                data['backscal'] = try_any_sfloat('BACKSCAL')
+                data['backscup'] = try_any_sfloat('BACKSCUP')
+                data['backscdn'] = try_any_sfloat('BACKSCDN')
+                data['areascal'] = try_any_sfloat('AREASCAL')
+
+                # Columns
+                data['channel'] = req_sfloat("CHANNEL")
+
+                # Make sure channel numbers not indices
+                chan = list(hdu.columns.names).index('CHANNEL') + 1
+                tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
+                                 dtype=SherpaUInt)
+                if int(data['channel'][0]) == 0 or tlmin == 0:
+                    data['channel'] = data['channel'] + 1
+
+                data['counts'] = try_sfloat("COUNTS")
+                data['staterror'] = _try_col(hdu, 'STAT_ERR')
+
+                # The following assumes that EXPOSURE is set
+                if data['counts'] is None:
+                    data['counts'] = req_sfloat("RATE") * data['exposure']
+                    if data['staterror'] is not None:
+                        data['staterror'] = data['staterror'] * data['exposure']
+
+                data['syserror'] = _try_col(hdu, 'SYS_ERR')
+                data['background_up'] = try_sfloat('BACKGROUND_UP')
+                data['background_down'] = try_sfloat('BACKGROUND_DOWN')
+                data['bin_lo'] = try_sfloat('BIN_LO')
+                data['bin_hi'] = try_sfloat('BIN_HI')
+                data['grouping'] = try_sint('GROUPING')
+                data['quality'] = try_sint('QUALITY')
+                data['header'] = _get_meta_data(hdu)
+                for key in keys:
+                    data['header'].pop(key, None)
+
+                if data['syserror'] is not None:
+                    # SYS_ERR is the fractional systematic error
+                    data['syserror'] = data['syserror'] * data['counts']
+
+                datasets.append(data)
+
+            else:
+                # Type 2 PHA file support
+                specnum = _try_col_or_key(hdu, 'SPEC_NUM')
+                num = len(specnum)
+
+                # Create local versions of the "try" routines set for this
+                # size=num value.
+                #
+                def try_any_sfloat(key):
+                    "Get col/key and return a SherpaFloat"
+                    return _try_vec_or_key(hdu, key, size=num, fix_type=True)
+
+                def try_sfloat(key):
+                    "Get col and return a SherpaFloat"
+                    return _try_vec(hdu, key, size=num, fix_type=True)
+
+                def try_sint(key):
+                    """Get col and return a SherpaInt
+
+                    Or, it looks like it should do this, but at the moment
+                    it does not force the data type.
+
+                    """
+                    # return _try_vec(hdu, key, size=num, fix_type=True, dtype=SherpaInt)
+                    return _try_vec(hdu, key, size=num, dtype=SherpaInt)
+
+                def req_sfloat(key):
+                    "Get col and return a SherpaFloat"
+                    return _require_vec(hdu, key, size=num, fix_type=True)
+
+                # Keywords
+                exposure = _try_key(hdu, 'EXPOSURE', fix_type=True)
+                # poisserr = _try_key(hdu, 'POISSERR', True, bool)
+                backfile = _try_key(hdu, 'BACKFILE')
+                arffile = _try_key(hdu, 'ANCRFILE')
+                rmffile = _try_key(hdu, 'RESPFILE')
+
+                # Keywords or columns
+                backscal = try_any_sfloat('BACKSCAL')
+                backscup = try_any_sfloat('BACKSCUP')
+                backscdn = try_any_sfloat('BACKSCDN')
+                areascal = try_any_sfloat('AREASCAL')
+
+                # Columns
+                # Why does this convert to SherpaFloat?
+                channel = req_sfloat('CHANNEL')
+
+                # Make sure channel numbers not indices
+                chan = list(hdu.columns.names).index('CHANNEL') + 1
+                tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
+                                 dtype=SherpaUInt)
+
+                for idx in range(num):
+                    if int(channel[idx][0]) == 0:
+                        channel[idx] += 1
+
+                # Why does this convert to SherpaFloat?
+                counts = try_sfloat("COUNTS")
+                staterror = _try_vec(hdu, 'STAT_ERR', size=num)
+                if np.equal(staterror, None).any():
+                    counts = req_sfloat("RATE") * exposure
+                    if not np.equal(staterror, None).any():
+                        staterror *= exposure
+
+                syserror = _try_vec(hdu, 'SYS_ERR', size=num)
+                background_up = try_sfloat('BACKGROUND_UP')
+                background_down = try_sfloat('BACKGROUND_DOWN')
+                bin_lo = try_sfloat('BIN_LO')
+                bin_hi = try_sfloat('BIN_HI')
+                grouping = try_sint('GROUPING')
+                quality = try_sint('QUALITY')
+
+                orders = try_sint('TG_M')
+                parts = try_sint('TG_PART')
+                specnums = try_sint('SPEC_NUM')
+                srcids = try_sint('TG_SRCID')
+
+                # Iterate over all rows of channels, counts, errors, etc
+                # Populate a list of dictionaries containing
+                # individual dataset info
+                for (bscal, bscup, bscdn, arsc, chan, cnt, staterr, syserr,
+                     backup, backdown, binlo, binhi, group, qual, ordr, prt,
+                     specnum, srcid
+                     ) in zip(backscal, backscup, backscdn, areascal, channel,
+                              counts, staterror, syserror, background_up,
+                              background_down, bin_lo, bin_hi, grouping, quality,
+                              orders, parts, specnums, srcids):
+
+                    idata: DataType = {}
+
+                    idata['exposure'] = exposure
+                    # idata['poisserr'] = poisserr
+                    idata['backfile'] = backfile
+                    idata['arffile'] = arffile
+                    idata['rmffile'] = rmffile
+
+                    idata['backscal'] = bscal
+                    idata['backscup'] = bscup
+                    idata['backscdn'] = bscdn
+                    idata['areascal'] = arsc
+
+                    idata['channel'] = chan
+                    idata['counts'] = cnt
+                    idata['staterror'] = staterr
+                    idata['syserror'] = syserr
+                    idata['background_up'] = backup
+                    idata['background_down'] = backdown
+                    idata['bin_lo'] = binlo
+                    idata['bin_hi'] = binhi
+                    idata['grouping'] = group
+                    idata['quality'] = qual
+                    idata['header'] = _get_meta_data(hdu)
+                    idata['header']['TG_M'] = ordr
+                    idata['header']['TG_PART'] = prt
+                    idata['header']['SPEC_NUM'] = specnum
+                    idata['header']['TG_SRCID'] = srcid
+
+                    for key in keys:
+                        idata['header'].pop(key, None)
+
+                    if syserr is not None:
+                        # SYS_ERR is the fractional systematic error
+                        idata['syserror'] = syserr * cnt
+
+                    datasets.append(idata)
+
+        finally:
+            if close:
+                pha.close()
+
+        return datasets, filename
+
+    def pack_table_data(self,
+                        data: ColumnsType,
+                        col_names: NamesType,
+                        header: Optional[HdrTypeArg] = None) -> fits.BinTableHDU:
+        """Pack up the table data."""
+
+        tbl = _create_table(col_names, data)
+        hdu = fits.table_to_hdu(tbl)
+
+        # Add in the header. We should special case the HISTORY/COMMENT
+        # keywords but at the moment we do nothing.
+        #
+        # There is the issue of conflicts between the existing and sent-in
+        # header - fortunately we can just drop those keys from the sent-in
+        # header, and also just whether the sent-in header keys (e.g. if
+        # TUNIT1 and TLMIN1 are set are they valid)? For the latter we rely
+        # on validation done by the code calling set_table_data.
+        #
+        if header is not None:
+            _update_header(hdu, header)
+
+        return hdu
+
+    def set_table_data(self,
+                       filename: str,
+                       data: ColumnsType,
+                       col_names: NamesType,
+                       header: Optional[HdrTypeArg] = None,
+                       ascii: bool = False,
+                       clobber: bool = False) -> None:
+        """Write out the table data."""
+
+        check_clobber(filename, clobber)
+
+        if ascii:
+            tbl = _create_table(col_names, data)
+            tbl.write(filename, format='ascii.commented_header',
+                      overwrite=clobber)
+            return
+
+        hdu = self.pack_table_data(data, col_names, header)
+        hdu.writeto(filename, overwrite=True)
+
+    def pack_arf_data(self,
+                      data: ColumnsType,
+                      col_names: NamesType,
+                      header: Optional[HdrTypeArg] = None) -> fits.BinTableHDU:
+        """Pack the ARF"""
+
+        if header is None:
+            raise ArgumentTypeErr("badarg", "header", "set")
+
+        return seld.pack_table_data(data, col_names, header)
+
+    def set_arf_data(self,
+                     filename: str,
+                     data: ColumnsType,
+                     col_names: NamesType,
+                     header: Optional[HdrTypeArg] = None,
+                     ascii: bool = False,
+                     clobber: bool = False) -> None:
+        """Write out the ARF"""
+
+        if header is None:
+            raise ArgumentTypeErr("badarg", "header", "set")
+
+        # This does not use pack_arf_data as we need to deal with ASCII
+        # support.
+        #
+        self.set_table_data(filename, data, col_names, header=header,
+                            ascii=ascii, clobber=clobber)
+
+    def pack_pha_data(self,
+                      data: ColumnsType,
+                      col_names: NamesType,
+                      header: Optional[HdrTypeArg] = None) -> fits.BinTableHDU:
+        """Pack the PHA data."""
+
+        if header is None:
+            raise ArgumentTypeErr("badarg", "header", "set")
+
+        return self.pack_table_data(data, col_names, header)
+
+    def set_pha_data(self,
+                     filename: str,
+                     data: ColumnsType,
+                     col_names: NamesType,
+                     header: Optional[HdrTypeArg] = None,
+                     ascii: bool = False,
+                     clobber: bool = False) -> None:
+        """ Write out the PHA."""
+
+        if header is None:
+            raise ArgumentTypeErr("badarg", "header", "set")
+
+        # This does not use pack_pha_data as we need to deal with ASCII
+        # support.
+        #
+        self.set_table_data(filename, data, col_names, header=header,
+                            ascii=ascii, clobber=clobber)
+
+    def pack_rmf_data(self, blocks) -> fits.HDUList:
+        """Pack up the RMF data."""
+
+        # For now assume only two blocks:
+        #    MATRIX
+        #    EBOUNDS
+        #
+        matrix_data, matrix_header = blocks[0]
+        ebounds_data, ebounds_header = blocks[1]
+
+        # Extract the data:
+        #   MATRIX:
+        #     ENERG_LO
+        #     ENERG_HI
+        #     N_GRP
+        #     F_CHAN
+        #     N_CHAN
+        #     MATRIX
+        #
+        #   EBOUNDS:
+        #     CHANNEL
+        #     E_MIN
+        #     E_MAX
+        #
+        # We may need to convert F_CHAN/N_CHAN/MATRIX to Variable-Length
+        # Fields. This is only needed if the ndarray type is object.
+        #
+        # It looks like we can not use the go-via-a-table approach
+        # here, as that does not support Variable Length Fields.
+        #
+        def get_format(val):
+            """We only bother with formats we expect"""
+            if np.issubdtype(val, np.integer):
+                if isinstance(val, np.int16):
+                    return "I"
+
+                # default to Int32. AstroPy does support Int64/K but
+                # this should not be needed here.
+                return "J"
+
+            if not np.issubdtype(val, np.floating):
+                raise ValueError(f"Unexpected value '{val}' with type {val.dtype}")
+
+            if isinstance(val,np.float32):
+                return "E"
+
+            # This should not be reached
+            return "D"
+
+        def get_full_format(name, vals):
+            if vals.dtype == object:
+                # We need to get the format from the first non-empty row.
+                bformat = None
+                ny = 0
+                for v in vals:
+                    nv = len(v)
+                    ny = max(ny, nv)
+                    if nv == 0:
+                        continue
+
+                    if bformat is not None:
+                        continue
+
+                    bformat = get_format(v[0])
+                    break
+
+                if bformat is None:
+                    # This should not happen
+                    raise ValueError(f"Unable to find data for column '{name}'")
+
+                return f"P{bformat}({ny})"
+
+            bformat = get_format(vals[0][0])
+            ny = vals.shape[1]
+            return f"{ny}{bformat}"
+
+        def arraycol(name):
+            vals = matrix_data[name]
+            if name == "MATRIX": print(vals)
+            formatval = get_full_format(name, vals)
+            return fits.Column(name=name, format=formatval, array=vals)
+
+        n_grp = matrix_data["N_GRP"]
+        col1 = fits.Column(name="ENERG_LO", format="E",
+                           array=matrix_data["ENERG_LO"], unit="keV")
+        col2 = fits.Column(name="ENERG_HI", format="E",
+                           array=matrix_data["ENERG_HI"], unit="keV")
+        col3 = fits.Column(name="N_GRP", format=get_format(n_grp[0]),
+                           array=n_grp)
+        col4 = arraycol("F_CHAN")
+        col5 = arraycol("N_CHAN")
+        col6 = arraycol("MATRIX")
+        cols = [col1, col2, col3, col4, col5, col6]
+        matrix_hdu = fits.BinTableHDU.from_columns(cols)
+        _update_header(matrix_hdu, matrix_header)
+
+        # Ensure the TLMIN4 value (for F_CHAN) is set.
+        matrix_hdu.header["TLMIN4"] = matrix_data["OFFSET"]
+
+        channel = ebounds_data["CHANNEL"]
+        col1 = fits.Column(name="CHANNEL", format=get_format(channel[0]),
+                           array=channel)
+        col2 = fits.Column(name="E_MIN", format="E",
+                           array=ebounds_data["E_MIN"], unit="keV")
+        col3 = fits.Column(name="E_MAX", format="E",
+                           array=ebounds_data["E_MAX"], unit="keV")
+        ebounds_hdu = fits.BinTableHDU.from_columns([col1, col2, col3])
+        _update_header(ebounds_hdu, ebounds_header)
+
+        primary_hdu = fits.PrimaryHDU()
+        return fits.HDUList([primary_hdu, matrix_hdu, ebounds_hdu])
+
+    def set_rmf_data(self,
+                     filename: str,
+                     blocks,
+                     clobber: bool = False) -> None:
+        """Save the RMF data to disk.
+
+        Unlike the other save_*_data calls this does not support the ascii
+        argument. It also relies on the caller to have set up the headers
+        and columns correctly apart for variable-length fields, which are
+        limited to F_CHAN, N_CHAN, and MATRIX.
+
+        """
+
+        check_clobber(filename, clobber)
+        hdus = self.pack_rmf_data(blocks)
+        hdus.writeto(filename, overwrite=True)
+
+    def pack_image_data(self,
+                        data: DataTypeArg,
+                        header: HdrTypeArg) -> fits.PrimaryHDU:
+        """Pack up the image data."""
+
+        hdrlist = _create_header(header)
+
+        # Write Image WCS Header Keys
+        if data['eqpos'] is not None:
+            cdeltw = data['eqpos'].cdelt
+            crpixw = data['eqpos'].crpix
+            crvalw = data['eqpos'].crval
+            equin = data['eqpos'].equinox
+
+        if data['sky'] is not None:
+            cdeltp = data['sky'].cdelt
+            crpixp = data['sky'].crpix
+            crvalp = data['sky'].crval
+
+            _add_keyword(hdrlist, 'MTYPE1', 'sky     ')
+            _add_keyword(hdrlist, 'MFORM1', 'x,y     ')
+            _add_keyword(hdrlist, 'CTYPE1P', 'x      ')
+            _add_keyword(hdrlist, 'CTYPE2P', 'y      ')
+            _add_keyword(hdrlist, 'WCSNAMEP', 'PHYSICAL')
+            _add_keyword(hdrlist, 'CDELT1P', cdeltp[0])
+            _add_keyword(hdrlist, 'CDELT2P', cdeltp[1])
+            _add_keyword(hdrlist, 'CRPIX1P', crpixp[0])
+            _add_keyword(hdrlist, 'CRPIX2P', crpixp[1])
+            _add_keyword(hdrlist, 'CRVAL1P', crvalp[0])
+            _add_keyword(hdrlist, 'CRVAL2P', crvalp[1])
+
+        if data['eqpos'] is not None:
+            if data['sky'] is not None:
+                # Simply the inverse of read transformations in get_image_data
+                cdeltw = cdeltw * cdeltp
+                crpixw = (crpixw - crvalp) / cdeltp + crpixp
+
+            _add_keyword(hdrlist, 'MTYPE2', 'EQPOS   ')
+            _add_keyword(hdrlist, 'MFORM2', 'RA,DEC  ')
+            _add_keyword(hdrlist, 'CTYPE1', 'RA---TAN')
+            _add_keyword(hdrlist, 'CTYPE2', 'DEC--TAN')
+            _add_keyword(hdrlist, 'CDELT1', cdeltw[0])
+            _add_keyword(hdrlist, 'CDELT2', cdeltw[1])
+            _add_keyword(hdrlist, 'CRPIX1', crpixw[0])
+            _add_keyword(hdrlist, 'CRPIX2', crpixw[1])
+            _add_keyword(hdrlist, 'CRVAL1', crvalw[0])
+            _add_keyword(hdrlist, 'CRVAL2', crvalw[1])
+            _add_keyword(hdrlist, 'CUNIT1', 'deg     ')
+            _add_keyword(hdrlist, 'CUNIT2', 'deg     ')
+            _add_keyword(hdrlist, 'EQUINOX', equin)
+
+        return fits.PrimaryHDU(data['pixels'], header=fits.Header(hdrlist))
+
+    def set_image_data(self,
+                       filename: str,
+                       data: DataTypeArg,
+                       header: HdrTypeArg,
+                       ascii: bool = False,
+                       clobber: bool = False) -> None:
+        """Write out the image data."""
+
+        check_clobber(filename, clobber)
+
+        if ascii:
+            self.set_arrays(filename, [data['pixels'].ravel()],
+                            ascii=True, clobber=clobber)
+            return
+
+        img = self.pack_image_data(data, header)
+        img.writeto(filename, overwrite=True)
+
+    def set_arrays(self,
+                   filename: str,
+                   args: Sequence[np.ndarray],
+                   fields: Optional[NamesType] = None,
+                   ascii: bool = True,
+                   clobber: bool = False) -> None:
+
+        # Historically the clobber command has been checked before
+        # processing the data, so do so here.
+        #
+        check_clobber(filename, clobber)
+
+        # Check args is a sequence of sequences (although not a complete
+        # check).
+        #
+        try:
+            size = len(args[0])
+        except (TypeError, IndexError) as exc:
+            raise IOErr('noarrayswrite') from exc
+
+        for arg in args[1:]:
+            try:
+                argsize = len(arg)
+            except (TypeError, IndexError) as exc:
+                raise IOErr('noarrayswrite') from exc
+
+            if argsize != size:
+                raise IOErr('arraysnoteq')
+
+        nargs = len(args)
+        if fields is None:
+            fieldnames = [f'COL{idx + 1}' for idx in range(nargs)]
+        elif nargs == len(fields):
+            fieldnames = list(fields)
+        else:
+            raise IOErr("wrongnumcols", nargs, len(fields))
+
+        if ascii:
+            # Historically, the serialization doesn't quite match the
+            # AstroPy Table version, so stay with write_arrays. We do
+            # change the form for the comment line (used when fields is
+            # set) to be "# <col1> .." rather than "#<col1> ..." to match
+            # the AstroPy table output used for other "ASCII table" forms
+            # in this module.
+            #
+            # The fields setting can be None here, which means that
+            # write_arrays will not write out a header line.
+            #
+            write_arrays(filename, args, fields,
+                         comment="# ", clobber=clobber)
+            return
+
+        data = dict(zip(fieldnames, args))
+        tbl = _create_table(fieldnames, data)
+        hdu = fits.table_to_hdu(tbl)
+        hdu.name = 'TABLE'
+        hdu.writeto(filename, overwrite=True)
+
+    def pack_hdus(self,
+                  blocks: Sequence[TableHDU]) -> fits.HDUList:
+        """Create a dataset.
+
+        At present we are restricted to tables only.
+        """
+
+        out = fits.HDUList()
+        out.append(_create_primary_hdu(blocks[0]))
+        for hdu in blocks[1:]:
+            out.append(_create_table_hdu(hdu))
+
+        return out
+
+    def set_hdus(self,
+                 filename: str,
+                 blocks: Sequence[TableHDU],
+                 clobber: bool = False) -> None:
+        """Write out multiple HDUS to a single file.
+
+        At present we are restricted to tables only.
+        """
+
+        check_clobber(filename, clobber)
+        hdus = self.pack_hdus(blocks)
+        hdus.writeto(filename, overwrite=True)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1508,7 +1508,6 @@ class Backend(BaseBackend):
 
         def arraycol(name):
             vals = matrix_data[name]
-            if name == "MATRIX": print(vals)
             formatval = get_full_format(name, vals)
             return fits.Column(name=name, format=formatval, array=vals)
 

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -559,3 +559,21 @@ def test_read_table_pha(make_data_path):
     assert tbl.y[-1] == pytest.approx(128)
     assert tbl.y[:-1].max() == pytest.approx(78)
     assert np.argmax(tbl.y[:-1]) == 74
+
+
+@requires_data
+@requires_fits
+def test_read_ascii_3_col(make_data_path):
+    """Found when working on #1921 so explicitly test this case."""
+
+    infile = make_data_path("data1.dat")
+    tbl = io.read_ascii(infile, 3)
+    assert isinstance(tbl, Data1D)
+    assert tbl.name.find("/data1.dat")
+    assert tbl.x == pytest.approx(np.arange(0.5, 11.5))
+    assert tbl.y == pytest.approx([1.6454, 1.7236, 1.9472,
+                                   2.2348, 2.6187, 2.8642,
+                                   3.1263, 3.2073, 3.2852,
+                                   3.3092, 3.4496])
+    assert tbl.staterror == pytest.approx(0.04114 * np.ones(11))
+    assert tbl.syserror is None

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -594,17 +594,17 @@ def test_read_table_object(make_data_path):
     infile = make_data_path("1838_rprofile_rmid.fits")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if io.backend.name == "crates":
         import pycrates
         arg = pycrates.read_file(infile)
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif io.backend.name == "pyfits":
         from astropy.io import fits
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend.name}"
 
     try:
         # this implicitly checks case insensitivity on column names

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -32,7 +32,7 @@ from sherpa.utils.testing import requires_data, requires_fits, \
 
 def backend_is(name):
     """Are we using the given backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 @requires_fits
@@ -293,17 +293,17 @@ def test_read_image_object(make_data_path):
     infile = make_data_path("psf_0.0_00_bin1.img")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         import pycrates
         arg = pycrates.read_file(infile)
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif backend_is("pyfits"):
         from astropy.io import fits
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend.name}"
 
     try:
         img = io.read_image(arg)

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -45,7 +45,7 @@ from sherpa.utils.testing import requires_data, requires_fits
 
 def backend_is(name):
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 @requires_fits
@@ -1392,17 +1392,17 @@ def test_read_pha_object(make_data_path):
     infile = make_data_path("acisf01575_001N001_r0085_pha3.fits.gz")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         import pycrates
         arg = pycrates.PHACrateDataset(infile, mode="r")
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif backend_is("pyfits"):
         from astropy.io import fits
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend.name}"
 
     try:
         pha = io.read_pha(arg)
@@ -1437,7 +1437,7 @@ def test_read_pha_object(make_data_path):
     # For now treat this as a regression test so we can find out
     # when it's fixed.
     #
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         assert pha.response_ids == []
         assert pha.background_ids == []
         return

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020, 2021, 2022, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1375,3 +1375,77 @@ def test_read_hrci_rmf(make_data_path):
 
     assert rmf.e_min[0] == pytest.approx(0.06)
     assert rmf.e_max[-1] == pytest.approx(10)
+
+
+@requires_fits
+@requires_data
+def test_read_pha_object(make_data_path):
+    """Check we can send in a 'object'.
+
+    This support is not well advertised so it could perhaps be
+    removed, but let's add a basic test at least.
+
+    """
+
+    # Could create the "object" manually, but let's just read one in
+    #
+    infile = make_data_path("acisf01575_001N001_r0085_pha3.fits.gz")
+    close = False
+
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        import pycrates
+        arg = pycrates.PHACrateDataset(infile, mode="r")
+
+    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        from astropy.io import fits
+        arg = fits.open(infile)
+        close = True
+
+    else:
+        assert False, f"unknown backend: {io.backend.__name__}"
+
+    try:
+        pha = io.read_pha(arg)
+
+    finally:
+        if close:
+            arg.close()
+
+    assert isinstance(pha, DataPHA)
+
+    # basic test that the data is read in (do not do a complete
+    # test)
+    assert pha.counts.max() == pytest.approx(15.0)
+    assert pha.exposure == pytest.approx(37664.157219191)
+
+    # Check we've loaded in the response and background
+    #
+    # For 4.16.0 and earlier, the crates backend "fails" because it
+    # does not load in the response or background datasets, instead
+    # saying:
+    #
+    # WARNING: File acisf01575_001N001_r0085_arf3.fits does not exist.
+    # WARNING: File acisf01575_001N001_r0085_rmf3.fits does not exist.
+    # WARNING: File acisf01575_001N001_r0085_pha3.fits does not exist.
+    #
+    # So there is an issue in handling compressed files, since the
+    # responses are saved as .gz files, although perhaps its more
+    # that the paths aren't being set up correctly. The background
+    # should be taken from the object itself, but perhaps it's
+    # easiest just to re-read it, and then we hit the same issue.
+    #
+    # For now treat this as a regression test so we can find out
+    # when it's fixed.
+    #
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        assert pha.response_ids == []
+        assert pha.background_ids == []
+        return
+
+    assert len(pha.response_ids) == 1
+    assert len(pha.background_ids) == 1
+
+    assert pha.get_arf().specresp.max() == pytest.approx(711.6605834960938)
+    assert pha.get_rmf().matrix.max() == pytest.approx(0.1611403226852417)
+
+    assert pha.get_background().counts[-1] == pytest.approx(59)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -41,7 +41,7 @@ from sherpa.utils.testing import requires_data, requires_fits
 
 def backend_is(name):
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 @requires_data
@@ -442,7 +442,7 @@ def test_write_rmf_fits_asca_sis(make_data_path, tmp_path, caplog):
     assert len(caplog.record_tuples) == 1
 
     lname, lvl, msg = caplog.record_tuples[0]
-    assert lname == io.backend.__name__
+    assert lname == f"sherpa.astro.io.{io.backend.name}_backend"
     assert lvl == logging.ERROR
     assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
     assert msg.endswith("sis0.rmf'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting")
@@ -982,7 +982,6 @@ def test_write_fake_perfect_rmf(offset, tmp_path):
     assert np.log10(new.ethresh) == pytest.approx(-10)
 
     hdr = new.header
-    print(hdr)
     assert "HDUNAME" not in hdr
     assert hdr["HDUCLASS"] == "OGIP"
     assert hdr["HDUCLAS1"] == "RESPONSE"
@@ -1105,9 +1104,8 @@ def test_write_rmf_fits_xmm_epn(make_data_path, tmp_path, caplog):
     assert len(caplog.record_tuples) == 1
 
     lname, lvl, msg = caplog.record_tuples[0]
-    assert lname == io.backend.__name__
+    assert lname == f"sherpa.astro.io.{io.backend.name}_backend"
     assert lvl == logging.ERROR
-    print(msg)
     assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
     assert msg.endswith("'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting")
 
@@ -1217,13 +1215,13 @@ def test_read_multi_matrix_rmf(tmp_path, caplog):
     assert len(caplog.record_tuples) == 2
 
     lname, lvl, msg = caplog.record_tuples[0]
-    assert lname == io.backend.__name__
+    assert lname == f"sherpa.astro.io.{io.backend.name}_backend"
     assert lvl == logging.ERROR
     assert msg.startswith("RMF in ")
     assert msg.endswith("/multi.rmf contains 2 MATRIX blocks; Sherpa only uses the first block!")
 
     lname, lvl, msg = caplog.record_tuples[1]
-    assert lname == io.backend.__name__
+    assert lname == f"sherpa.astro.io.{io.backend.name}_backend"
     assert lvl == logging.ERROR
     assert msg.startswith("Failed to locate TLMIN keyword for F_CHAN column in RMF file '")
     assert msg.endswith("/multi.rmf'; Update the offset value in the RMF data set to appropriate TLMIN value prior to fitting")
@@ -1271,17 +1269,17 @@ def test_read_arf_object(make_data_path):
     infile = make_data_path("MNLup_2138_0670580101_EMOS1_S001_spec.arf")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         import pycrates
         arg = pycrates.read_file(infile)
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif backend_is("pyfits"):
         from astropy.io import fits
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend.name}"
 
     try:
         with warnings.catch_warnings(record=True) as ws:
@@ -1320,17 +1318,17 @@ def test_read_rmf_object(make_data_path):
     infile = make_data_path("source.rmf")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         import pycrates
         arg = pycrates.RMFCrateDataset(infile, mode='r')
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif backend_is("pyfits"):
         from astropy.io import fits
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend.name}"
 
     try:
         rmf = io.read_rmf(arg)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1254,3 +1254,92 @@ def test_read_multi_matrix_rmf(tmp_path, caplog):
     expected_blurry = mdl(e4lo, e4hi) @ blurry_matrix
 
     assert y == pytest.approx(expected_perfect)
+
+
+@requires_fits
+@requires_data
+def test_read_arf_object(make_data_path):
+    """Check we can send in a 'object'.
+
+    This support is not well advertised so it could perhaps be
+    removed, but let's add a basic test at least.
+
+    """
+
+    # Could create the "object" manually, but let's just read one in
+    #
+    infile = make_data_path("MNLup_2138_0670580101_EMOS1_S001_spec.arf")
+    close = False
+
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        import pycrates
+        arg = pycrates.read_file(infile)
+
+    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        from astropy.io import fits
+        arg = fits.open(infile)
+        close = True
+
+    else:
+        assert False, f"unknown backend: {io.backend.__name__}"
+
+    try:
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+            arf = io.read_arf(arg)
+
+    finally:
+        if close:
+            arg.close()
+
+    assert isinstance(arf, DataARF)
+    assert arf.energ_lo[0:4] == pytest.approx([1e-10, 0.005, 0.01, 0.015])
+    assert arf.energ_hi[0:4] == pytest.approx([0.005, 0.01, 0.015, 0.02])
+    assert arf.specresp.max() == pytest.approx(449.2618408203125)
+
+    assert len(ws) == 1
+    msg = ws[0].message
+    assert isinstance(msg, UserWarning)
+    msg = str(msg)
+    assert msg.startswith("The minimum ENERG_LO in the ARF '")
+    assert msg.endswith("_spec.arf' was 0 and has been replaced by 1e-10")
+
+
+@requires_fits
+@requires_data
+def test_read_rmf_object(make_data_path):
+    """Check we can send in a 'object'.
+
+    This support is not well advertised so it could perhaps be
+    removed, but let's add a basic test at least.
+
+    """
+
+    # Could create the "object" manually, but let's just read one in
+    #
+    infile = make_data_path("source.rmf")
+    close = False
+
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        import pycrates
+        arg = pycrates.RMFCrateDataset(infile, mode='r')
+
+    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        from astropy.io import fits
+        arg = fits.open(infile)
+        close = True
+
+    else:
+        assert False, f"unknown backend: {io.backend.__name__}"
+
+    try:
+        rmf = io.read_rmf(arg)
+
+    finally:
+        if close:
+            arg.close()
+
+    assert isinstance(rmf, DataRMF)
+    assert rmf.energ_lo[0:4] == pytest.approx([0.1, 0.11, 0.12, 0.13])
+    assert rmf.energ_hi[0:4] == pytest.approx([0.11, 0.12, 0.13, 0.14])
+    assert rmf.matrix.max() == pytest.approx(0.12998242676258087)

--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -20,14 +20,14 @@
 
 import logging
 
-import numpy
+import numpy as np
 
 from sherpa.utils import NoNewAttributesAfterInit
 
 warning = logging.getLogger(__name__).warning
 
 try:
-    from sherpa.astro.utils._wcs import pix2world, world2pix
+    from sherpa.astro.utils._wcs import pix2world, world2pix  # type: ignore
 except ImportError:
     warning('WCS support is not available')
 
@@ -44,9 +44,9 @@ class WCS(NoNewAttributesAfterInit):
                  crota=0.0, epoch=2000.0, equinox=2000.0):
         self.name = name
         self.type = type
-        self.crval = numpy.asarray(crval, dtype=float)
-        self.crpix = numpy.asarray(crpix, dtype=float)
-        self.cdelt = numpy.asarray(cdelt, dtype=float)
+        self.crval = np.asarray(crval, dtype=float)
+        self.crpix = np.asarray(crpix, dtype=float)
+        self.cdelt = np.asarray(cdelt, dtype=float)
         self.crota = crota
         self.epoch = epoch
         self.equinox = equinox
@@ -58,9 +58,9 @@ class WCS(NoNewAttributesAfterInit):
 
     def __str__(self):
         val = [self.name,
-               ' crval    = %s' % numpy.array2string(self.crval, separator=',', precision=4, suppress_small=False),
-               ' crpix    = %s' % numpy.array2string(self.crpix, separator=',', precision=4, suppress_small=False),
-               ' cdelt    = %s' % numpy.array2string(self.cdelt, separator=',', precision=4, suppress_small=False)]
+               ' crval    = %s' % np.array2string(self.crval, separator=',', precision=4, suppress_small=False),
+               ' crpix    = %s' % np.array2string(self.crpix, separator=',', precision=4, suppress_small=False),
+               ' cdelt    = %s' % np.array2string(self.cdelt, separator=',', precision=4, suppress_small=False)]
 
         if self.type == 'WCS':
             val.append(' crota    = %g' % self.crota)

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -41,7 +41,7 @@ except ImportError:
 
 try:
     from sherpa.astro.io import backend
-    is_crates_io = "sherpa.astro.io.crates_backend" == backend.__name__
+    is_crates_io = backend.name == "crates"
 except ImportError:
     is_crates_io = False
 

--- a/sherpa/astro/tests/test_astro_data_rosat_unit.py
+++ b/sherpa/astro/tests/test_astro_data_rosat_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2019, 2021
+#  Copyright (C) 2017, 2019, 2021, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -44,7 +44,7 @@ from sherpa.astro import ui
 
 def backend_is(name):
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 # The RMF includes the ARF (so is a "RSP" file).

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2021, 2023
+#  Copyright (C) 2017, 2018, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -47,7 +47,7 @@ from sherpa.astro import ui
 
 def backend_is(name):
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 # PHA and ARF are stored uncompressed while RMF is gzip-compressed.

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2019, 2021, 2023
+#  Copyright (C) 2015, 2016, 2019, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1330,7 +1330,7 @@ def _save_dataset(out: OutType,
     infile = data.name
     if TYPE_CHECKING:
         assert io.backend is not None
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if io.backend.name == "crates":
         import pycrates  # type: ignore
         try:
             pycrates.read_file(infile)

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2016, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -59,7 +59,7 @@ def skip_if_no_io(request):
     # If the I/O backend is not the dummy backend then we assume that
     # we can return.
     #
-    if io.backend.__name__ != "sherpa.astro.io.dummy_backend":
+    if io.backend.name != "dummy":
         return
 
     pytest.skip(reason="FITS backend required")
@@ -2602,7 +2602,7 @@ def check_save_ascii2d(session, expected, out, savefunc, idval, kwargs, check_st
 
     """
 
-    if session == AstroSession and io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if session == AstroSession and io.backend.name == "crates":
         if idval is None:
             with pytest.raises(IOErr,
                                match="writing images in ASCII is not supported"):
@@ -3234,10 +3234,10 @@ def check_text_output(path, header, coldata):
     # Use the same logic as test_astro_ui_unit.py.
     #
     from sherpa.astro import io
-    name = io.backend.__name__
-    if name == "sherpa.astro.io.crates_backend":
+    name = io.backend.name
+    if name == "crates":
         expected = f"#TEXT/SIMPLE\n# {header}\n"
-    elif name == "sherpa.astro.io.pyfits_backend":
+    elif name == "pyfits":
         expected = f"# {header}\n"
     else:
         assert False, f"Unknown I/O backend: {name}"

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -2624,7 +2624,7 @@ def check_save_ascii2d(session, expected, out, savefunc, idval, kwargs, check_st
 
 @pytest.mark.parametrize("session,kwargs,expected",
                          [(Session, {"comment": "!! "}, ["!! SOURCE", "7 11", ""]),
-                          (AstroSession, {"ascii": True}, ["7", "11", ""])])
+                          (AstroSession, {"ascii": True}, ["# col1", "7", "11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io, check_str):
     """Basic check it works
@@ -2651,7 +2651,7 @@ def test_save_source_ascii_data2d(session, kwargs, expected, idval, tmp_path, sk
 
 @pytest.mark.parametrize("session,kwargs,expected",
                          [(Session, {"comment": ""}, ["MODEL", "7 11", ""]),
-                          (AstroSession, {"ascii": True}, ["7", "11", ""])])
+                          (AstroSession, {"ascii": True}, ["# col1", "7", "11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io, check_str):
     """Basic check it works
@@ -2678,7 +2678,7 @@ def test_save_model_ascii_data2d(session, kwargs, expected, idval, tmp_path, ski
 
 @pytest.mark.parametrize("session,kwargs,expected",
                          [(Session, {}, ["#RESID", "-7 -11", ""]),
-                          (AstroSession, {"ascii": True}, ["-7", "-11", ""])])
+                          (AstroSession, {"ascii": True}, ["# col1", "-7", "-11", ""])])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, skip_if_no_io, check_str):
     """Basic check it works

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -47,7 +47,7 @@ from sherpa.utils.testing import requires_data, requires_fits, \
 
 
 def backend_is(name):
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 def check_table(hdu, colinfo):
@@ -730,7 +730,7 @@ def check_output(out, colnames, rows):
         assert lines[0] == f"# {cols}"
         lines = lines[1:]
     else:
-        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")
+        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.name}")
 
     assert lines[-1] == ""
     lines = lines[:-1]
@@ -856,7 +856,7 @@ def test_save_data_data2d(tmp_path):
     elif backend_is("pyfits"):
         expected = "\n".join([str(zz) for zz in z]) + "\n"
     else:
-        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")
+        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.name}")
 
     assert cts == expected
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -854,7 +854,7 @@ def test_save_data_data2d(tmp_path):
         expected = "\n".join(expected) + "\n"
 
     elif backend_is("pyfits"):
-        expected = "\n".join([str(zz) for zz in z]) + "\n"
+        expected = "\n".join(["# col1"] + [str(zz) for zz in z]) + "\n"
     else:
         raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.name}")
 
@@ -907,7 +907,7 @@ def test_save_data_dataimg(tmp_path):
     ui.save_data(outfile)
 
     cts = out.read_text()
-    expected = "\n".join([str(zz) for zz in z]) + "\n"
+    expected = "\n".join(["# col1"] + [str(zz) for zz in z]) + "\n"
     assert cts == expected
 
 
@@ -1443,7 +1443,7 @@ def test_save_resid_dataimg(tmp_path):
     ui.save_resid(outfile, ascii=True)
 
     cts = out.read_text()
-    expected = "\n".join([str(zz - 10) for zz in z]) + "\n"
+    expected = "\n".join(["# col1"] + [str(zz - 10) for zz in z]) + "\n"
     assert cts == expected
 
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3400,7 +3400,7 @@ def test_load_data(make_data_path):
                        match="data set '1' does not specify systematic errors"):
         ui.get_syserror()
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if io.backend.name == "crates":
         term = "@@/data1.dat"
         idx = _canonical_load_data.find(term)
         expected_output = _canonical_load_data[:idx] + term + \

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -185,33 +185,6 @@ known_warnings = {
          ],
     ResourceWarning:
         [
-            r"unclosed file .*king_kernel.txt.* closefd=True>",
-            r"unclosed file .*phas.dat.* closefd=True>",
-            r"unclosed file .*data.txt.* closefd=True>",
-            r"unclosed file .*cstat.dat.* closefd=True>",
-            r"unclosed file .*data1.dat.* closefd=True>",
-            r"unclosed file .*aref_Cedge.fits.* closefd=True>",
-            r"unclosed file .*aref_sample.fits.* closefd=True>",
-            r"unclosed file .*/tmp.* closefd=True>",
-            # added for sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
-            r"unclosed file .*/dev/null.* closefd=True>",
-            r"unclosed file .*table.txt.* closefd=True>",
-            # tests in sherpa/astro/ui/tests/test_astro_ui_unit.py
-            # seen in some macOS test runs (e.g. pip, not conda) and python 3.8
-            r"unclosed file .*/data.dat'.* closefd=True>",
-            r"unclosed file .*/model.dat'.* closefd=True>",
-            r"unclosed file .*/resid.out'.* closefd=True>",
-
-            # It would be nice if we could find this out from first principles,
-            # rather than only finding them from random CI runs
-            r"unclosed file <_io.BufferedReader name='.*/data.dat'>",
-            r"unclosed file <_io.BufferedReader name='.*/model.dat'>",
-            r"unclosed file <_io.BufferedReader name='.*/resid.out'>",
-
-            # Does this replace the versions above?
-            r"unclosed file <_io.BufferedReader name='.*/aref_Cedge.fits'>",
-            r"unclosed file <_io.BufferedReader name='.*/aref_sample.fits'>",
-
         ],
     VisibleDeprecationWarning:
         [],

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021, 2023
+#  Copyright (C) 2007, 2015, 2016, 2019 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -19,6 +19,7 @@
 #
 
 import os
+from typing import Optional, Sequence
 
 import numpy
 
@@ -30,6 +31,9 @@ from sherpa.utils.numeric_types import SherpaFloat
 
 __all__ = ('read_data', 'write_data', 'get_ascii_data', 'read_arrays',
            'write_arrays')
+
+
+NamesType = Sequence[str]
 
 
 def _is_subclass(t1, t2):
@@ -123,8 +127,14 @@ def get_column_data(*args):
     return cols
 
 
-def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
-                   comment='#', require_floats=True):
+def get_ascii_data(filename: str,
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   sep: str = ' ',
+                   dstype: type = Data1D,
+                   comment: str = '#',
+                   require_floats: bool = True
+                   ) -> tuple[list[str], list[numpy.ndarray], str]:
     r"""Read in columns from an ASCII file.
 
     Parameters

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2009, 2015, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -174,16 +174,21 @@ def set_backend(new_backend):
     if isinstance(new_backend, str):
         if new_backend in PLOT_BACKENDS:
             backend = PLOT_BACKENDS[new_backend]()
-        else:
-            raise IdentifierErr('noplotbackend', new_backend,
-                                list(PLOT_BACKENDS.keys()))
+            return
+
+        raise IdentifierErr('noplotbackend', new_backend,
+                            list(PLOT_BACKENDS.keys()))
+
     # It's a class and that class is a subclass of BaseBackend
-    elif isinstance(new_backend, type) and issubclass(new_backend, BaseBackend):
+    if isinstance(new_backend, type) and issubclass(new_backend, BaseBackend):
         backend = new_backend()
-    elif isinstance(new_backend, BaseBackend):
+        return
+
+    if isinstance(new_backend, BaseBackend):
         backend = new_backend
-    else:
-        raise ArgumentTypeErr('tempplotbackend', new_backend)
+        return
+
+    raise ArgumentTypeErr('tempbackend', new_backend)
 
 
 class TemporaryPlottingBackend(contextlib.AbstractContextManager):

--- a/sherpa/utils/err.py
+++ b/sherpa/utils/err.py
@@ -93,7 +93,7 @@ class ArgumentTypeErr(TypeError, SherpaErr):
     dict = {'badarg': "'%s' must be %s",
             'intstr': 'identifiers must be integers or strings',
             'plotargs': 'not enough arguments to plot()',
-            'tempplotbackend': "'%s' is not a backend class, instance, or string name",
+            'tempbackend': "'%s' is not a backend class, instance, or string name",
             }
 
     def __init__(self, key, *args):


### PR DESCRIPTION
# Summary

Replace the logic of the packup argument to the set I/O commands by adding new pack_xxx_data commands (which return an object, and so correspond to the old packup=True case) and make the existing set_xxx_data calls never return anything (the old packup=False behaviour). As part of this, ensure that the dummy backend provides arguments and - for most arguments - types, which means the dummy backend can be thought of as defining the backend interface. There should be little change to users who use the sherpa.astro.io module routines.


# Details

Required
- #1926 

Followed by
- #1921 

A clean up of the crates and pyfits backend modules, as well as the general backend. These changes generally should not change behaviour, but there may be some corner cases where it may make a difference (e.g. what is the name of a FITS HDU for a "generic" table). Although there are a number of additional changes that can be made to the backend code, this is planned for a later PR (#1921), with the changes here being enough to make it clearer (to me) what the code is doing and what changes we can make in the future (the idea being that we can move much of the logic into the generic layer, and remove the special-case behavior, particularly for the OGIP file types, from the backend code). The changes here include

- pylint suggestions
- add typing for some of the routines to make it clearer what is going on
- move to f-strings except for logging statements, where we want to use "lazy formatting"
- remove some code that appears to have been either "wishful thinking" or is no-longer relevant (normally this is about removing some special-case behaviour we can't trigger in our tests)
- crates:
  - simplify the recent code added in 4.16.0 to create the TLMIN value fo the F_CHAN column of RMF files with the crates backend (there is a simpler way to do it than the low-level use of cxcdm added in PR #1836)
  - simplify or remove some of the wrapper code as we can just create the dataset objects directly rather than going through a wrapper
  - generally try to have the "get a column/key" routine logic be in the "require" version and then the "try" version catches the error and returns a None (rather than have the "require" version call the "try" version and then error out if None is returned)
- pyfits:
  - the internal open routine, which takes a string of a fits.HDUList, did not record whether the file was opened, and hence should be closed, which has now been fixed (to better avoid getting "buffer still open" errors on exit of the interpreter)
  - simplify the wrapper code as a number of cases appear to no-longer be relevant or could never happen

The dummy backend can now be thought of as defining the API for a general backend (e.g. there is now an indication of both the input and output from all the routines). We could make this into a class, which could help, but to be honest is it worth it? We aren't likely to add a new backend any time soon, or want to sub-class either of the existing backends, so I am not convinced moving to a class will improve the code in any way.

The final commit changes the backend code to add pack_xxx_data routines and to drop the packup argument from the set_xxx_data calls. The idea is that the set_xxx_data call can just call pack_xxx_data and then write out the response but it's not always done like this (since we can go via the set_table_data call, for example). However, the individual pack routines are more used in the follow-up PR #1921.