### PR TITLE
Zenodo broke the API we were using to request citation details.

### DIFF
--- a/scripts/make_zenodo_release.py
+++ b/scripts/make_zenodo_release.py
@@ -19,6 +19,7 @@ is expected.
 import datetime
 import json
 import ssl
+from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 
@@ -87,7 +88,11 @@ def dump_zenodo(version):
         are reported.
     """
 
-    url = 'https://zenodo.org/api/records/?q=conceptrecid:"593753"&all_versions=True&sort=mostrecent'
+    params = {"q": "parent.id:593753",
+              "all_versions": 1,
+              "sort": "mostrecent"}
+    paramstr = urlencode(params)
+    url = f'https://zenodo.org/api/records?{paramstr}'
     while True:
         jsdata = download_json(url)
         for hit in jsdata['hits']['hits']:

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -182,6 +182,11 @@ def _get_citation_hardcoded(version):
         cite[version] = dict(**kwargs)
         cite[version]['version'] = version
 
+    add(version='4.16.0', title='sherpa/sherpa: Sherpa 4.16.0',
+        date=todate(2023, 10, 26),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'Hans Moritz Günther', 'Marie-Terrell', 'dtnguyen2', 'Aneta Siemiginowska', 'Harlan Cheer', 'Jamie Budynkiewicz', 'Tom Aldcroft', 'Christoph Deil', 'Brigitta Sipőcz', 'Johannes Buchner', 'nplee', 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber', 'Todd'],
+        idval='825839')
+
     add(version='4.15.1', title='sherpa/sherpa: Sherpa 4.15.1',
         date=todate(2023, 5, 18),
         authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'Marie-Terrell',


### PR DESCRIPTION
# Summary

Ensure that the sherpa.citation() command can query Zenodo for the release information. Fix #1933.

# Details

Argh. The "important" change is how we query the Zenodo API to get the data we need. I find the Zenodo documentatin to be really hard to understand beyond "these are the parameters we accept" as there's essentially no context or help provided.

The change looks larger than it needs to be as there's a little bit of code clean up (use of f strings).