### PR TITLE
CI: temporarily remove ds9 tests on macOS

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -117,7 +117,9 @@ jobs:
       run: |
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
-        source .github/scripts/setup_ds9.sh
+        if [ "$RUNNER_OS" != "macOS" ]; then
+          source .github/scripts/setup_ds9.sh
+        fi
         source .github/scripts/setup_xspec.sh
 
     - name: Build Sherpa (install)
@@ -160,6 +162,14 @@ jobs:
         if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
         if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
         smokevars="${XSPECTEST} ${FITSTEST} -v 3"
+
+        # special case the macOS build as we currently do not
+        # include DS9; as we know the XSPECVER/FITS sittings for
+        # this it is hard-coded
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          smokevars="-x -f ${FITS} -v 3"
+        fi
+
         echo "** smoke test: ${smokevars}"
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -31,8 +31,6 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             xspec-version: 12.13.1
-            # run xvfb with this display
-            display: :99
 
           - name: Linux Minimum Setup (Python 3.9)
             os: ubuntu-latest
@@ -121,13 +119,6 @@ jobs:
         conda activate build
         source .github/scripts/setup_ds9.sh
         source .github/scripts/setup_xspec.sh
-
-    - name: Start Xvfb (macOS)
-      if: runner.os == 'macOS'
-      env:
-        DISPLAY: ${{ matrix.display }}
-      run: |
-        sudo /opt/X11/bin/Xvfb ${DISPLAY} -ac -screen 0 1024x768x8 &
 
     - name: Build Sherpa (install)
       if: matrix.install-type == 'install'


### PR DESCRIPTION
# Summary

Avoid the DS9 tests on the macOS build to avoid the failure case we currently often, but not always, trigger.

# Details

For the last month or so our `macOS` CI run will often, but not-alwas, fail because of connection errors [*] with DS9.  As well as requiring a re-run (often many re-runs) these failures increase the run-time of the CI run (presumably because there's a timeot that happens because of the connection issues). I have tried to identify what is the problem, as has @Marie-Terrell , but it's hard without direct access to a failing machine. One suggestion is that this only happens with an "old" setup, but it doesn't look like we can force a particular setup (or whatever they are called).

As a work-around this PR changes the `macOS` run so that it does not install ds9, and hence doesn't hit this problem. This is not ideal, but we do have ds9 checks on the linux runs, and I would hope we can `git revert` the second commit soon.

The first commit removes the step that started up Xvfb since it is just a waste of time, since the `pytest-xvfb` plugin starts up Xvfb for us anyway. So this commit should stay.

[*] I think. It's hard to track down, but it's definitely some issue with communicating with DS9.
