### PR TITLE
Allow all matrices in a RMF to be used

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015-2025
+#  Copyright (C) 2008, 2015-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -132,13 +132,12 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 import logging
 import os
-from typing import Any, Literal, cast, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 import warnings
 
 import numpy as np
 import numpy.typing as npt
 
-from sherpa.astro import hc
 from sherpa.data import Data1DInt, Data2D, Data, Data1D, \
     IntegratedDataSpace2D, _check
 from sherpa.models.regrid import EvaluationSpace1D
@@ -152,9 +151,11 @@ from sherpa.utils.numeric_types import SherpaFloat
 from sherpa.utils.types import ArrayType, IdType, IdTypes, \
     ModelFunc, StatErrFunc
 
+from . import hc
+
 # There are currently (Sep 2015) no tests that exercise the code that
 # uses the compile_energy_grid symbols.
-from sherpa.astro.utils import arf_fold, rmf_fold, filter_resp, \
+from .utils import arf_fold, rmf_fold, filter_resp, \
     compile_energy_grid, do_group, expand_grouped_mask
 
 __doctest_requires__ = {
@@ -163,14 +164,14 @@ __doctest_requires__ = {
     }
 
 if TYPE_CHECKING:
-    from sherpa.astro.io.wcs import WCS
+    from .io.wcs import WCS
 
 info = logging.getLogger(__name__).info
 warning = logging.getLogger(__name__).warning
 
 regstatus = False
 try:
-    from sherpa.astro.utils._region import Region  # type: ignore
+    from .utils._region import Region  # type: ignore
     regstatus = True
 except ImportError:
     warning('failed to import sherpa.astro.utils._region; Region routines ' +

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1068,7 +1068,8 @@ class DataRMF(DataOgipResponse):
     """RMF data set.
 
     The RMF format is described in OGIP documents [CAL_92_002]_ and
-    [CAL_92_002a]_.
+    [CAL_92_002a]_. However, the data use to create a DataRMF
+    instance has been modified from the on-disk format.
 
     Parameters
     ----------
@@ -1082,6 +1083,9 @@ class DataRMF(DataOgipResponse):
         than the ENERG_LO values for each bin, and the energy arrays
         must be in increasing or decreasing order.
     n_grp, f_chan, n_chan, matrix : array-like
+        These map to the N_GRP, F_CHAN, N_CHAN, and MATRIX columns of
+        the RMF FITS format, but with changes described in the Notes
+        section below.
     offset : int, optional
         This must be 0 or greater. This maps to the TLMIN value of
         the F_CHAN column (when reading from a FITS file).
@@ -1098,10 +1102,50 @@ class DataRMF(DataOgipResponse):
     the standard, these checks can not cover all cases. If a check fails
     then a warning message is logged.
 
+    The on-disk format for RMF files allows for two-dimensional data
+    to allow for multiple blocks of data (F_CHAN, N_CHAN) for each
+    channel row, accessing into the MATRIX block. The arguments to
+    DataRMF have been simplified so that:
+
+    - any rows with N_GTP=0 have been remove
+    - 2D arrays have been flattened (this is particularly relevant
+      if the data has not been stored as a FITS variable-length array.
+
+    So with the following (where [] is used to indicate a
+    variable-length aray for the column):
+
+      ========  ========  =====  ======  ======  =============
+      energ_lo  energ_hi  n_grp  f_chan  n_chan     matrix
+      ========  ========  =====  ======  ======  =============
+         0.1       0.2      0    []      []      []
+         0.2       0.3      2    [1,4]   [2,1]   [0.1,0.6,0.3]
+         0.3       0.4      1    [4]     [2]     [0.2,0.8]
+      ========  ========  =====  ======  ======  =============
+
+    then the arguments would be::
+
+      detchans=3
+      energ_lo=np.asarray([0.1, 0.2, 0.3])
+      energ_hi=np.asarray([0.2, 0.3, 0.4])
+      n_grp=np.asarray([0, 2, 1])
+      f_chan=np.asarray([1, 4, 4])
+      n_chan=np.asarray([2, 1, 2])
+      matrix=np.asarray([0.1, 0.6, 0.3, 0.2, 0.8])
+
+    The number of elements in f_chan and n_chan must match the NUMGRP
+    value, and the size of matrix must match the NUMELT value (if set
+    in the header).
+
+    Best results - in that the RMF convolution should be fastest - are
+    when n_grp, f_chan, n_chan store numpy.uint64 values and matrix
+    stores numpy.float64 values. The main saving is from getting the
+    size correct (e.g. 64 bit versus 32 bit).
+
     """
+
     _ui_name = "RMF"
-    _fields = ("name", "energ_lo", "energ_hi", "n_grp", "f_chan", "n_chan", "matrix", "e_min",
-               "e_max")
+    _fields = ("name", "energ_lo", "energ_hi", "n_grp", "f_chan",
+               "n_chan", "matrix", "e_min", "e_max")
     _extra_fields = ("detchans", "offset", "ethresh")
 
     def __init__(self,

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -789,7 +789,12 @@ class DataOgipResponse(Data1DInt):
     # The shift to creating a warning message instead of raising an
     # error has made this messier.
     #
-    def _validate_energy_ranges(self, label, elo, ehi, ethresh):
+    def _validate_energy_ranges(self,
+                                label: str,
+                                elo: np.ndarray,
+                                ehi: np.ndarray,
+                                ethresh: float | None
+                                ) -> tuple[np.ndarray, np.ndarray]:
         """Check the lo/hi values are > 0, handling common error case.
 
         Several checks are made, to make sure the parameters follow
@@ -960,8 +965,17 @@ class DataARF(DataOgipResponse):
 
     specresp = property(_get_specresp, _set_specresp)
 
-    def __init__(self, name, energ_lo, energ_hi, specresp, bin_lo=None,
-                 bin_hi=None, exposure=None, header=None, ethresh=None):
+    def __init__(self,
+                 name: str,
+                 energ_lo: np.ndarray,
+                 energ_hi: np.ndarray,
+                 specresp: np.ndarray,
+                 bin_lo=None,
+                 bin_hi=None,
+                 exposure=None,
+                 header=None,
+                 ethresh: float | None = None
+                 ) -> None:
         self.specresp = specresp
         # Keep these fields for now, but they are unused.
         self.bin_lo = None
@@ -1018,10 +1032,14 @@ class DataARF(DataOgipResponse):
             self._lo = self.energ_lo[bin_mask]
             self._hi = self.energ_hi[bin_mask]
 
-    def get_indep(self, filter=False):
+    def get_indep(self,
+                  filter: bool = False
+                  ) -> tuple[np.ndarray, np.ndarray]:
         return (self._lo, self._hi)
 
-    def get_dep(self, filter=False):
+    def get_dep(self,
+                filter: bool = False
+                ) -> np.ndarray:
         return self._rsp
 
     def get_ylabel(self, yfunc=None) -> str:
@@ -1086,9 +1104,21 @@ class DataRMF(DataOgipResponse):
                "e_max")
     _extra_fields = ("detchans", "offset", "ethresh")
 
-    def __init__(self, name, detchans, energ_lo, energ_hi, n_grp, f_chan,
-                 n_chan, matrix, offset=1, e_min=None, e_max=None,
-                 header=None, ethresh=None):
+    def __init__(self,
+                 name: str,
+                 detchans: int,
+                 energ_lo: np.ndarray,
+                 energ_hi: np.ndarray,
+                 n_grp: ArrayType,
+                 f_chan: ArrayType,
+                 n_chan: ArrayType,
+                 matrix: ArrayType,
+                 offset: int = 1,
+                 e_min: ArrayType | None = None,
+                 e_max: ArryaType | None = None,
+                 header=None,
+                 ethresh: float | None = None
+                 ) -> None:
         energ_lo, energ_hi = self._validate(name, energ_lo, energ_hi, ethresh)
 
         # Check it's an integer.
@@ -1221,7 +1251,9 @@ class DataRMF(DataOgipResponse):
         ...
 
     # Note that noticed_chans is not a mask, but the channel values.
-    def notice(self, noticed_chans=None):
+    def notice(self,
+               noticed_chans: np.ndarray | None = None
+               ) -> np.ndarray | None:
         """Filter the response to match the requested channels."""
 
         self._fch = self.f_chan
@@ -1244,10 +1276,14 @@ class DataRMF(DataOgipResponse):
         self._hi = self.energ_hi[bin_mask]
         return bin_mask
 
-    def get_indep(self, filter=False):
+    def get_indep(self,
+                  filter: bool = False
+                  ) -> tuple[np.ndarray, np.ndarray]:
         return (self._lo, self._hi)
 
-    def get_dep(self, filter=False):
+    def get_dep(self,
+                filter: bool = False
+                ) -> np.ndarray:
         return self.apply_rmf(np.ones(self.energ_lo.shape, SherpaFloat))
 
 

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -258,7 +258,13 @@ class RSPModel(CompositeModel, ArithmeticModel):
         self.xlo, self.xhi = self.elo, self.ehi
 
         # Used to rebin against finer or coarser energy grids
-        self.rmfargs = ()
+        #
+        elo, ehi = self.rmf.get_indep()
+        if len(elo) != len(self.elo):
+            self.rmfargs = ((elo, ehi), (self.elo, self.ehi))
+        else:
+            self.rmfargs = ()
+
         self.arfargs = ()
 
     def startup(self, cache: bool = False) -> None:
@@ -481,18 +487,7 @@ class RSPModelPHA(RSPModel):
 
         RSPModel.filter(self)
 
-        # Can this really happen? There is a test of it but it is an
-        # engineered test case rather than "actual" data.
-        #
-        # Should this check be a "or" and not "and", and really it
-        # should check the grid values.
-        #
-        elo, ehi = self.rmf.get_indep()
-        if len(elo) != len(self.elo) and len(ehi) != len(self.ehi):
-            self.rmfargs = ((elo, ehi), (self.elo, self.ehi))
-
-        # Assume energy as default spectral coordinates
-        self.xlo, self.xhi = self.elo, self.ehi
+        # Convert the units if necessary
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
@@ -557,7 +552,7 @@ class RSPModelNoPHA(RSPModel):
              x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x could be channels or x, xhi could be energy|wave
 
-        # Always evaluates source model in keV!
+        # Always evaluates source model in keV as have no PHA.
         src = self.model.calc(p, self.xlo, self.xhi)
         src = self.arf.apply_arf(src, *self.arfargs)
         return self.rmf.apply_rmf(src, *self.rmfargs)

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -35,6 +35,7 @@ Michael F. Corcoran
 from __future__ import annotations
 
 from collections.abc import Sequence
+import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, SupportsFloat
 import os
@@ -356,11 +357,7 @@ class RMFModelPHA(RMFModel):
         rmf = self._rmf  # original
 
         # Create a view of original RMF
-        self.rmf = DataRMF(rmf.name, rmf.detchans, rmf.energ_lo,
-                           rmf.energ_hi, rmf.n_grp, rmf.f_chan,
-                           rmf.n_chan, rmf.matrix, offset=rmf.offset,
-                           e_min=rmf.e_min, e_max=rmf.e_max,
-                           header=rmf.header)
+        self.rmf = copy.copy(rmf)
 
         # Filter the view for current fitting session
         _notice_resp(self.pha.get_noticed_channels(), None, self.rmf)
@@ -429,8 +426,7 @@ class ARFModelPHA(ARFModel):
         pha = self.pha
 
         # Create a view of original ARF
-        self.arf = DataARF(arf.name, arf.energ_lo, arf.energ_hi, arf.specresp,
-                           exposure=arf.exposure, header=arf.header)
+        self.arf = copy.copy(arf)
 
         # Filter the view for current fitting session
         if np.iterable(pha.mask):
@@ -505,15 +501,10 @@ class RSPModelPHA(RSPModel):
         rmf = self._rmf
 
         # Create a view of original RMF
-        self.rmf = DataRMF(rmf.name, rmf.detchans, rmf.energ_lo,
-                           rmf.energ_hi, rmf.n_grp, rmf.f_chan,
-                           rmf.n_chan, rmf.matrix, offset=rmf.offset,
-                           e_min=rmf.e_min, e_max=rmf.e_max,
-                           header=rmf.header)
+        self.rmf = copy.copy(rmf)
 
         # Create a view of original ARF
-        self.arf = DataARF(arf.name, arf.energ_lo, arf.energ_hi, arf.specresp,
-                           exposure=arf.exposure, header=arf.header)
+        self.arf = copy.copy(arf)
 
         # Filter the view for current fitting session
         _notice_resp(self.pha.get_noticed_channels(), self.arf, self.rmf)

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -121,9 +121,19 @@ def apply_areascal(mdl: np.ndarray,
 
 class RMFModel(CompositeModel, ArithmeticModel):
     """Base class for expressing RMF convolution in model expressions.
+
+    .. versionchanged:: 4.18.1
+       This class can now be used, with `RMFModelNoPHA` being
+       identical to it.
+
+    Notes
+    -----
+    Since there is no PHA data set, there is no correction for any
+    AREASCAL setting associated with the data.
+
     """
 
-    def __init__(self, rmf, model) -> None:
+    def __init__(self, rmf: DataRMF, model) -> None:
         self.rmf = rmf
         self.model = model
 
@@ -167,14 +177,26 @@ class RMFModel(CompositeModel, ArithmeticModel):
 
     def calc(self, p: ParamsType,
              x, xhi=None, *args, **kwargs) -> np.ndarray:
-        raise NotImplementedError
+
+        src = self.model.calc(p, self.xlo, self.xhi)
+        return self.rmf.apply_rmf(src, *self.rmfargs)
 
 
 class ARFModel(CompositeModel, ArithmeticModel):
     """Base class for expressing ARF convolution in model expressions.
+
+    .. versionchanged:: 4.18.1
+       This class can now be used, with `ARFModelNoPHA` being
+       identical to it.
+
+    Notes
+    -----
+    Since there is no PHA data set, there is no correction for any
+    AREASCAL setting associated with the data.
+
     """
 
-    def __init__(self, arf, model) -> None:
+    def __init__(self, arf: DataARF, model) -> None:
         self.arf = arf
         self.model = model
 
@@ -217,7 +239,9 @@ class ARFModel(CompositeModel, ArithmeticModel):
 
     def calc(self, p: ParamsType,
              x, xhi=None, *args, **kwargs) -> np.ndarray:
-        raise NotImplementedError
+
+        src = self.model.calc(p, self.xlo, self.xhi)
+        return self.arf.apply_arf(src, *self.arfargs)
 
 
 class RSPModel(CompositeModel, ArithmeticModel):
@@ -309,10 +333,11 @@ class RMFModelPHA(RMFModel):
     -----
     Scaling by the AREASCAL setting (scalar or array) is included in
     this model.
+
     """
 
     def __init__(self,
-                 rmf,
+                 rmf: DataRMF,
                  pha: DataPHA,
                  model
                  ) -> None:
@@ -324,8 +349,6 @@ class RMFModelPHA(RMFModel):
 
         RMFModel.filter(self)
 
-        # Assume energy as default spectral coordinates
-        self.xlo, self.xhi = self.elo, self.ehi
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
@@ -343,12 +366,6 @@ class RMFModelPHA(RMFModel):
         _notice_resp(self.pha.get_noticed_channels(), None, self.rmf)
 
         self.filter()
-
-        # Assume energy as default spectral coordinates
-        self.xlo, self.xhi = self.elo, self.ehi
-        if self.pha.units == 'wavelength':
-            self.xlo, self.xhi = self.lo, self.hi
-
         RMFModel.startup(self, cache)
 
     def teardown(self) -> None:
@@ -359,11 +376,8 @@ class RMFModelPHA(RMFModel):
 
     def calc(self, p: ParamsType,
              x, xhi=None, *args, **kwargs) -> np.ndarray:
-        # x is noticed/full channels here
 
-        src = self.model.calc(p, self.xlo, self.xhi)
-        out = self.rmf.apply_rmf(src, *self.rmfargs)
-
+        out = RMFModel.calc(self, p, x, *args, xhi=xhi, **kwargs)
         return apply_areascal(out, self.pha,
                               f"RMF: {self.rmf.name}")
 
@@ -371,19 +385,15 @@ class RMFModelPHA(RMFModel):
 class RMFModelNoPHA(RMFModel):
     """RMF convolution model without an associated PHA data set.
 
-    Notes
-    -----
-    Since there is no PHA data set, there is no correction for any
-    AREASCAL setting associated with the data.
+    .. versionchanged:: 4.18.1
+       This class is now identical to `RMFModel`.
+
     """
 
-    def calc(self, p: ParamsType,
-             x, xhi=None, *args, **kwargs) -> np.ndarray:
-        # x is noticed/full channels here
-
-        # Always evaluates source model in keV!
-        src = self.model.calc(p, self.xlo, self.xhi)
-        return self.rmf.apply_rmf(src)
+    # Historically RMFModel did not contain the logic to call
+    # calc, but this has changed in Sherpa 4.18.1.
+    #
+    pass
 
 
 class ARFModelPHA(ARFModel):
@@ -399,7 +409,7 @@ class ARFModelPHA(ARFModel):
     """
 
     def __init__(self,
-                 arf,
+                 arf: DataARF,
                  pha: DataPHA,
                  model
                  ) -> None:
@@ -411,8 +421,6 @@ class ARFModelPHA(ARFModel):
 
         ARFModel.filter(self)
 
-        # Assume energy as default spectral coordinates
-        self.xlo, self.xhi = self.elo, self.ehi
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
@@ -431,12 +439,6 @@ class ARFModelPHA(ARFModel):
                 self.arf.notice(mask)
 
         self.filter()
-
-        # Assume energy as default spectral coordinates
-        self.xlo, self.xhi = self.elo, self.ehi
-        if pha.units == 'wavelength':
-            self.xlo, self.xhi = self.lo, self.hi
-
         ARFModel.startup(self, cache)
 
     def teardown(self) -> None:
@@ -447,11 +449,8 @@ class ARFModelPHA(ARFModel):
 
     def calc(self, p: ParamsType,
              x, xhi=None, *args, **kwargs) -> np.ndarray:
-        # x could be channels or x, xhi could be energy|wave
 
-        src = self.model.calc(p, self.xlo, self.xhi)
-        src = self.arf.apply_arf(src, *self.arfargs)
-
+        src = ARFModel.calc(self, p, x, *args, xhi=xhi, **kwargs)
         return apply_areascal(src, self.pha,
                               f"ARF: {self.arf.name}")
 
@@ -459,24 +458,15 @@ class ARFModelPHA(ARFModel):
 class ARFModelNoPHA(ARFModel):
     """ARF convolution model without associated PHA data set.
 
-    Notes
-    -----
-    Since there is no PHA data set, there is no correction for any
-    AREASCAL setting associated with the data.
+    .. versionchanged:: 4.18.1
+       This class is now identical to `ARFModel`.
+
     """
 
-    def calc(self, p: ParamsType,
-             x, xhi=None, *args, **kwargs) -> np.ndarray:
-        # x could be channels or x, xhi could be energy|wave
-
-        # if (xhi is not None and
-        #    x[0] > x[-1] and xhi[0] > xhi[-1]):
-        #    xlo, xhi = self.lo, self.hi
-        # else:
-
-        # Always evaluates source model in keV!
-        src = self.model.calc(p, self.xlo, self.xhi)
-        return self.arf.apply_arf(src)
+    # Historically ARFModel did not contain the logic to call
+    # calc, but this has changed in Sherpa 4.18.1.
+    #
+    pass
 
 
 class RSPModelPHA(RSPModel):
@@ -567,7 +557,7 @@ class RSPModelNoPHA(RSPModel):
 class ARF1D(NoNewAttributesAfterInit):
 
     def __init__(self,
-                 arf,
+                 arf: DataARF,
                  pha: DataPHA | None = None,
                  rmf=None  # TODO: remove this as it is unused?
                  ) -> None:
@@ -637,7 +627,7 @@ class ARF1D(NoNewAttributesAfterInit):
 class RMF1D(NoNewAttributesAfterInit):
 
     def __init__(self,
-                 rmf,
+                 rmf: DataRMF,
                  pha: DataPHA | None = None,
                  arf=None
                  ) -> None:
@@ -1030,7 +1020,7 @@ class MultipleResponse1D(Response1D):
 class PileupRMFModel(CompositeModel, ArithmeticModel):
 
     def __init__(self,
-                 rmf,
+                 rmf: DataRMF,
                  model,
                  pha: DataPHA | None = None
                  ) -> None:

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -790,9 +790,15 @@ class Response1D(NoNewAttributesAfterInit):
 class ResponseNestedModel(Model):
     """Handle a response component for a PHA dataset."""
 
-    def __init__(self, arf=None, rmf=None) -> None:
+    def __init__(self,
+                 arf: DataARF | None = None,
+                 rmf: DataRMF | None = None
+                 ) -> None:
         self.arf = arf
         self.rmf = rmf
+
+        # Is there a need to rebin the model to the RMF grid?
+        self.rmfargs = ()
 
         # TODO: the name is incorrect (it misses out the trailing
         # closing bracket). It is unfortunately not simple to fix.
@@ -800,6 +806,15 @@ class ResponseNestedModel(Model):
         name = ''
         if arf is not None and rmf is not None:
             name = 'apply_rmf(apply_arf('
+
+            # An incomplete check to see whether the data needs
+            # re-gridding.
+            #
+            arf_indep = arf.get_indep()
+            rmf_indep = rmf.get_indep()
+            if len(arf_indep[0]) != len(rmf_indep[0]):
+                self.rmfargs = (rmf_indep, arf_indep)
+
         elif arf is not None:
             name = 'apply_arf('
         elif rmf is not None:
@@ -808,6 +823,13 @@ class ResponseNestedModel(Model):
 
     def calc(self, p: ParamsType,
              *args, **kwargs) -> np.ndarray:
+        """Apply the response to the model.
+
+        Unlike the standard Model class, the first argument contains
+        the model values, and not the grid.
+
+        """
+
         arf = self.arf
         rmf = self.rmf
 
@@ -817,10 +839,10 @@ class ResponseNestedModel(Model):
         if arf is not None:
             src = arf.apply_arf(src)
 
-        if rmf is not None:
-            src = rmf.apply_rmf(src)
+        if rmf is None:
+            return src
 
-        return src
+        return rmf.apply_rmf(src, *self.rmfargs)
 
 
 class MultiResponseSumModel(CompositeModel, ArithmeticModel):
@@ -872,11 +894,14 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         grid = []
         for id in self.pha.response_ids:
             arf, rmf = self.pha.get_response(id)
-            indep = None
             if arf is not None:
                 indep = arf.get_indep()
             elif rmf is not None:
                 indep = rmf.get_indep()
+            else:
+                # This should not be possible (since idval comes from
+                # pha.respose_ids).
+                raise DataErr('norsp', self.pha.name)
             grid.append(indep)
 
         self.elo, self.ehi, self.table = compile_energy_grid(grid)

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -838,25 +838,23 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.table = None
         self.orders = None
 
-        models = []
-        grid = []
+        models: list[ResponseNestedModel] = []
+        grid: list[tuple[np.ndarray, np.ndarray]] = []
 
-        for id in pha.response_ids:
-            arf, rmf = pha.get_response(id)
+        for idval in pha.response_ids:
+            arf, rmf = pha.get_response(idval)
 
-            if arf is None and rmf is None:
-                raise DataErr('norsp', pha.name)
-
-            m = ResponseNestedModel(arf, rmf)
-            indep = None
-
+            # ARF wins out.
             if arf is not None:
                 indep = arf.get_indep()
-
-            if rmf is not None:
+            elif rmf is not None:
                 indep = rmf.get_indep()
+            else:
+                # This should not be possible (since idval comes from
+                # pha.respose_ids).
+                raise DataErr('norsp', pha.name)
 
-            models.append(m)
+            models.append(ResponseNestedModel(arf, rmf))
             grid.append(indep)
 
         # Ensure there is a response.

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -30,6 +30,69 @@ M. George, Keith A. Arnaud, Bill Pence, Laddawan Ruamsuwan and
 Michael F. Corcoran
 <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html>`_.
 
+Handling PHA data
+=================
+
+PHA models are evaluated on an energy grid - e.g. the ENERG_LO and
+ENERG_HI fields of the MATRIX block of a RMF - but then need to "pass
+through" the instrument model (the ARF and RMF) to be converted to the
+channel space (PI or PHA) of the data. The expected use case is that
+the `Response1D` class - which includes `MultipleResponse1D` and
+`PileupResponse1D` - is used to create a convolution-style object
+that, when called with the physical model - creates the model that can
+be used to fit the data.  This is done by returning one of the
+`RSPModel`, `RMFModel`, or `ARFModel` classes. It is these classes
+that take the response date - `DataARF` and `DataRMF` - and convert
+them into model expressions. However, the model expressions can be
+directly created if so required.
+
+In the following, the PHA file "3c273.pi" has automatically-loaded
+ARF and RMF data (so the response_ids array is not empty):
+
+  >>> from sherpa.astro.io import read_pha
+  >>> from sherpa.utils.logging import SherpaVerbosity
+  >>> with SherpaVerbosity("ERROR"):
+  ...    pha = read_pha(data_3c273 + '3c273.pi')
+  >>> pha.response_ids
+  [1]
+
+If we create a model expression - in this case just a power-law,
+but normally it would be something more complex:
+
+  >>> from sherpa.models.basic import PowLaw1D
+  >>> pl = PowLaw1D()
+  >>> pl.gamma = 1.7
+  >>> pl.ampl = 2e-3
+
+then a response can be added by saying:
+
+  >>> resp = Response1D(pha)
+  >>> mdl = resp(pl)
+  >>> print(mdl)
+  apply_rmf(apply_arf(38564.608926889 * powlaw1d))
+     Param        Type          Value          Min          Max      Units
+     -----        ----          -----          ---          ---      -----
+     powlaw1d.gamma thawed          1.7          -10           10
+     powlaw1d.ref frozen            1 -3.40282e+38  3.40282e+38
+     powlaw1d.ampl thawed        0.002            0  3.40282e+38
+
+Notes
+-----
+
+The model evaluation includes the exposure time of the observation (in
+this case taken from the `exposure` field of the `DataPHA` object).
+The behaviour can change depending on exactly which class is used.
+
+The `get_full_response` method of the `DataPHA` class can also be
+used:
+
+  >>> resp = pha.get_full_response()
+
+The `ARF1D` and `RMF1D` classes wrap the `DataARF` and `DataRMF`
+classes, resulting in objects that have the same fields as the
+underlying data object, but that can be called in the same manner that
+`Response1D` is to apply the response to a model.
+
 """
 
 from __future__ import annotations
@@ -246,7 +309,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
 
 
 class RSPModel(CompositeModel, ArithmeticModel):
-    """Base class for expressing RMF + ARF convolution in model expressions
+    """Base class for expressing RMF + ARF convolution in model expressions.
 
     .. versionchanged:: 4.18.1
        This class can now be used, with `RSPModelNoPHA` being
@@ -546,6 +609,7 @@ class RSPModelNoPHA(RSPModel):
 
 
 class ARF1D(NoNewAttributesAfterInit):
+    """Wrap the ARF to allow it to be applied to a model."""
 
     def __init__(self,
                  arf: DataARF,
@@ -616,6 +680,7 @@ class ARF1D(NoNewAttributesAfterInit):
 
 
 class RMF1D(NoNewAttributesAfterInit):
+    """Wrap the RMF to allow it to be applied to a model."""
 
     def __init__(self,
                  rmf: DataRMF,

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -859,6 +859,10 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
             models.append(m)
             grid.append(indep)
 
+        # Ensure there is a response.
+        if len(models) == 0:
+            raise DataErr("norsp", pha.name)
+
         self.models = models
         self.grid = grid
 

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -222,9 +222,23 @@ class ARFModel(CompositeModel, ArithmeticModel):
 
 class RSPModel(CompositeModel, ArithmeticModel):
     """Base class for expressing RMF + ARF convolution in model expressions
+
+    .. versionchanged:: 4.18.1
+       This class can now be used, with `RSPModelNoPHA` being
+       identical to it.
+
+    Notes
+    -----
+    Since there is no PHA data set, there is no correction for any
+    AREASCAL setting associated with the data.
+
     """
 
-    def __init__(self, arf, rmf, model) -> None:
+    def __init__(self,
+                 arf: DataARF,
+                 rmf: DataRMF,
+                 model
+                 ) -> None:
         self.arf = arf
         self.rmf = rmf
         self.model = model
@@ -238,7 +252,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
 
         # Used to rebin against finer or coarser energy grids
         self.rmfargs = ()
-        self.arfargs = ()
+        self.arfargs = ()  # This never gets changed.
 
         # Logic for ArithmeticModel.__init__
         self._pars = ()
@@ -277,7 +291,12 @@ class RSPModel(CompositeModel, ArithmeticModel):
 
     def calc(self, p: ParamsType,
              x, xhi=None, *args, **kwargs) -> np.ndarray:
-        raise NotImplementedError
+        """Evaluate the model and combine with the response."""
+
+        # Evaluate the model on the xlo/xhi grid.
+        src = self.model.calc(p, self.xlo, self.xhi)
+        src = self.arf.apply_arf(src, *self.arfargs)
+        return self.rmf.apply_rmf(src, *self.rmfargs)
 
 
 class RMFModelPHA(RMFModel):
@@ -473,8 +492,8 @@ class RSPModelPHA(RSPModel):
     """
 
     def __init__(self,
-                 arf,
-                 rmf,
+                 arf: DataARF,
+                 rmf: DataRMF,
                  pha: DataPHA,
                  model
                  ) -> None:
@@ -510,12 +529,6 @@ class RSPModelPHA(RSPModel):
         _notice_resp(self.pha.get_noticed_channels(), self.arf, self.rmf)
 
         self.filter()
-
-        # Assume energy as default spectral coordinates
-        self.xlo, self.xhi = self.elo, self.ehi
-        if self.pha.units == 'wavelength':
-            self.xlo, self.xhi = self.lo, self.hi
-
         RSPModel.startup(self, cache)
 
     def teardown(self) -> None:
@@ -527,11 +540,9 @@ class RSPModelPHA(RSPModel):
 
     def calc(self, p: ParamsType,
              x, xhi=None, *args, **kwargs) -> np.ndarray:
-        # x could be channels or x, xhi could be energy|wave
+        """Evaluate the model and combine with the response."""
 
-        src = self.model.calc(p, self.xlo, self.xhi)
-        src = self.arf.apply_arf(src, *self.arfargs)
-        src = self.rmf.apply_rmf(src, *self.rmfargs)
+        src = RSPModel.calc(self, p, x, *args, xhi=xhi, **kwargs)
 
         # Assume any issues with the binning (between AREASCAL
         # and src) is related to the RMF rather than the ARF.
@@ -542,20 +553,15 @@ class RSPModelPHA(RSPModel):
 class RSPModelNoPHA(RSPModel):
     """RMF + ARF convolution model without associated PHA data set.
 
-    Notes
-    -----
-    Since there is no PHA data set, there is no correction for any
-    AREASCAL setting associated with the data.
+    .. versionchanged:: 4.18.1
+       This class is now identical to `RSPModel`.
+
     """
 
-    def calc(self, p: ParamsType,
-             x, xhi=None, *args, **kwargs) -> np.ndarray:
-        # x could be channels or x, xhi could be energy|wave
-
-        # Always evaluates source model in keV as have no PHA.
-        src = self.model.calc(p, self.xlo, self.xhi)
-        src = self.arf.apply_arf(src, *self.arfargs)
-        return self.rmf.apply_rmf(src, *self.rmfargs)
+    # Historically RSPModel did not contain the logic to call
+    # calc, but this has changed in Sherpa 4.18.1.
+    #
+    pass
 
 
 class ARF1D(NoNewAttributesAfterInit):

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2023-2025
+#  Copyright (C) 2010, 2015, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -34,8 +34,9 @@ Michael F. Corcoran
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, SupportsFloat
 import os
 
 import numpy as np
@@ -48,7 +49,8 @@ from sherpa.instrument import PSFModel as _PSFModel
 from sherpa.utils import NoNewAttributesAfterInit
 from sherpa.data import Data1D
 from sherpa.astro import hc
-from sherpa.astro.data import DataARF, DataRMF, _notice_resp, DataIMG
+from sherpa.astro.data import DataARF, DataPHA, DataRMF, DataIMG, \
+    _notice_resp
 from sherpa.astro import io
 from sherpa.utils import sao_fcmp, sum_intervals, sao_arange
 from sherpa.astro.utils import compile_energy_grid
@@ -64,6 +66,9 @@ _tol = np.finfo(np.float32).eps
 
 string_types = (str, )
 
+# An approximation of how the parameters can be supplied.
+ParamsType = Sequence[SupportsFloat]
+
 
 __all__ = ('RMFModel', 'ARFModel', 'RSPModel', 'RMFModelPHA',
            'RMFModelNoPHA', 'ARFModelPHA', 'ARFModelNoPHA',
@@ -74,7 +79,10 @@ __all__ = ('RMFModel', 'ARFModel', 'RSPModel', 'RMFModelPHA',
            'create_non_delta_rmf', 'rmf_to_matrix', 'rmf_to_image' )
 
 
-def apply_areascal(mdl, pha, instlabel):
+def apply_areascal(mdl: np.ndarray,
+                   pha: DataPHA,
+                   instlabel: str
+                   ) -> np.ndarray:
     """Apply the AREASCAL conversion.
 
     This should be done after applying any RMF or ARF.
@@ -115,7 +123,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
     """Base class for expressing RMF convolution in model expressions.
     """
 
-    def __init__(self, rmf, model):
+    def __init__(self, rmf, model) -> None:
         self.rmf = rmf
         self.model = model
 
@@ -136,7 +144,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
         CompositeModel.__init__(self, f'apply_rmf({model.name})', (model,))
         self.filter()
 
-    def filter(self):
+    def filter(self) -> None:
         # Energy grid (keV)
         self.elo, self.ehi = self.rmf.get_indep()
 
@@ -149,15 +157,16 @@ class RMFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.rmfargs = ()
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.model.teardown()
         CompositeModel.teardown(self)
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         raise NotImplementedError
 
 
@@ -165,7 +174,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
     """Base class for expressing ARF convolution in model expressions.
     """
 
-    def __init__(self, arf, model):
+    def __init__(self, arf, model) -> None:
         self.arf = arf
         self.model = model
 
@@ -185,7 +194,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
         CompositeModel.__init__(self, f'apply_arf({model.name})', (model,))
         self.filter()
 
-    def filter(self):
+    def filter(self) -> None:
         # Energy grid (keV)
         self.elo, self.ehi = self.arf.get_indep()
 
@@ -198,15 +207,16 @@ class ARFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.arfargs = ()
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.model.teardown()
         CompositeModel.teardown(self)
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         raise NotImplementedError
 
 
@@ -214,7 +224,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
     """Base class for expressing RMF + ARF convolution in model expressions
     """
 
-    def __init__(self, arf, rmf, model):
+    def __init__(self, arf, rmf, model) -> None:
         self.arf = arf
         self.rmf = rmf
         self.model = model
@@ -237,7 +247,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
                                 (model,))
         self.filter()
 
-    def filter(self):
+    def filter(self) -> None:
         # Energy grid (keV), ARF grid breaks tie
         self.elo, self.ehi = self.arf.get_indep()
 
@@ -251,15 +261,16 @@ class RSPModel(CompositeModel, ArithmeticModel):
         self.rmfargs = ()
         self.arfargs = ()
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.model.teardown()
         CompositeModel.teardown(self)
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         raise NotImplementedError
 
 
@@ -275,12 +286,16 @@ class RMFModelPHA(RMFModel):
     this model.
     """
 
-    def __init__(self, rmf, pha, model):
+    def __init__(self,
+                 rmf,
+                 pha: DataPHA,
+                 model
+                 ) -> None:
         self.pha = pha
         self._rmf = rmf  # store a reference to original
         RMFModel.__init__(self, rmf, model)
 
-    def filter(self):
+    def filter(self) -> None:
 
         RMFModel.filter(self)
 
@@ -289,7 +304,7 @@ class RMFModelPHA(RMFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         rmf = self._rmf  # original
 
         # Create a view of original RMF
@@ -311,13 +326,14 @@ class RMFModelPHA(RMFModel):
 
         RMFModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.rmf = self._rmf
 
         self.filter()
         RMFModel.teardown(self)
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x is noticed/full channels here
 
         src = self.model.calc(p, self.xlo, self.xhi)
@@ -336,10 +352,8 @@ class RMFModelNoPHA(RMFModel):
     AREASCAL setting associated with the data.
     """
 
-    def __init__(self, rmf, model):
-        RMFModel.__init__(self, rmf, model)
-
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x is noticed/full channels here
 
         # Always evaluates source model in keV!
@@ -359,12 +373,16 @@ class ARFModelPHA(ARFModel):
     this model. It is not yet clear if this is handled correctly.
     """
 
-    def __init__(self, arf, pha, model):
+    def __init__(self,
+                 arf,
+                 pha: DataPHA,
+                 model
+                 ) -> None:
         self.pha = pha
         self._arf = arf  # store a reference to original
         ARFModel.__init__(self, arf, model)
 
-    def filter(self):
+    def filter(self) -> None:
 
         ARFModel.filter(self)
 
@@ -373,7 +391,7 @@ class ARFModelPHA(ARFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         arf = self._arf  # original
         pha = self.pha
 
@@ -396,13 +414,14 @@ class ARFModelPHA(ARFModel):
 
         ARFModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.arf = self._arf  # restore original
 
         self.filter()
         ARFModel.teardown(self)
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x could be channels or x, xhi could be energy|wave
 
         src = self.model.calc(p, self.xlo, self.xhi)
@@ -421,10 +440,8 @@ class ARFModelNoPHA(ARFModel):
     AREASCAL setting associated with the data.
     """
 
-    def __init__(self, arf, model):
-        ARFModel.__init__(self, arf, model)
-
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x could be channels or x, xhi could be energy|wave
 
         # if (xhi is not None and
@@ -449,7 +466,12 @@ class RSPModelPHA(RSPModel):
     this model.
     """
 
-    def __init__(self, arf, rmf, pha, model):
+    def __init__(self,
+                 arf,
+                 rmf,
+                 pha: DataPHA,
+                 model
+                 ) -> None:
         self.pha = pha
         self._arf = arf
         self._rmf = rmf
@@ -474,7 +496,7 @@ class RSPModelPHA(RSPModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         arf = self._arf
         rmf = self._rmf
 
@@ -501,14 +523,15 @@ class RSPModelPHA(RSPModel):
 
         RSPModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.arf = self._arf  # restore originals
         self.rmf = self._rmf
 
         self.filter()
         RSPModel.teardown(self)
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x could be channels or x, xhi could be energy|wave
 
         src = self.model.calc(p, self.xlo, self.xhi)
@@ -530,10 +553,8 @@ class RSPModelNoPHA(RSPModel):
     AREASCAL setting associated with the data.
     """
 
-    def __init__(self, arf, rmf, model):
-        RSPModel.__init__(self, arf, rmf, model)
-
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         # x could be channels or x, xhi could be energy|wave
 
         # Always evaluates source model in keV!
@@ -544,12 +565,16 @@ class RSPModelNoPHA(RSPModel):
 
 class ARF1D(NoNewAttributesAfterInit):
 
-    def __init__(self, arf, pha=None, rmf=None):
+    def __init__(self,
+                 arf,
+                 pha: DataPHA | None = None,
+                 rmf=None  # TODO: remove this as it is unused?
+                 ) -> None:
         self._arf = arf
         self._pha = pha
         NoNewAttributesAfterInit.__init__(self)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         arf = None
         try:
             arf = ARF1D.__getattribute__(self, '_arf')
@@ -564,7 +589,7 @@ class ARF1D(NoNewAttributesAfterInit):
 
         return ARF1D.__getattribute__(self, name)
 
-    def __setattr__(self, name, val):
+    def __setattr__(self, name: str, val) -> None:
         arf = None
         try:
             arf = ARF1D.__getattribute__(self, '_arf')
@@ -579,10 +604,10 @@ class ARF1D(NoNewAttributesAfterInit):
     def __dir__(self):
         return dir(self._arf)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._arf)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self._arf)
 
     def __call__(self, model, session=None):
@@ -610,13 +635,17 @@ class ARF1D(NoNewAttributesAfterInit):
 
 class RMF1D(NoNewAttributesAfterInit):
 
-    def __init__(self, rmf, pha=None, arf=None):
+    def __init__(self,
+                 rmf,
+                 pha: DataPHA | None = None,
+                 arf=None
+                 ) -> None:
         self._rmf = rmf
         self._arf = arf
         self._pha = pha
         NoNewAttributesAfterInit.__init__(self)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         rmf = None
         try:
             rmf = RMF1D.__getattribute__(self, '_rmf')
@@ -631,7 +660,7 @@ class RMF1D(NoNewAttributesAfterInit):
 
         return RMF1D.__getattribute__(self, name)
 
-    def __setattr__(self, name, val):
+    def __setattr__(self, name: str, val) -> None:
         rmf = None
         try:
             rmf = RMF1D.__getattribute__(self, '_rmf')
@@ -646,10 +675,10 @@ class RMF1D(NoNewAttributesAfterInit):
     def __dir__(self):
         return dir(self._rmf)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._rmf)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self._rmf)
 
     def __call__(self, model, session=None):
@@ -728,7 +757,7 @@ class Response1D(NoNewAttributesAfterInit):
 
     """
 
-    def __init__(self, pha):
+    def __init__(self, pha: DataPHA) -> None:
         self.pha = pha
         arf, rmf = pha.get_response()
         if arf is None and rmf is None:
@@ -764,12 +793,19 @@ class Response1D(NoNewAttributesAfterInit):
         raise DataErr('norsp', pha.name)
 
 
+# This is very similar to RSPMmodelPHA/NoPHA except that the source
+# model has already been evaluated.
+#
 class ResponseNestedModel(Model):
+    """Handle a response component for a PHA dataset."""
 
-    def __init__(self, arf=None, rmf=None):
+    def __init__(self, arf=None, rmf=None) -> None:
         self.arf = arf
         self.rmf = rmf
 
+        # TODO: the name is incorrect (it misses out the trailing
+        # closing bracket). It is unfortunately not simple to fix.
+        #
         name = ''
         if arf is not None and rmf is not None:
             name = 'apply_rmf(apply_arf('
@@ -779,21 +815,27 @@ class ResponseNestedModel(Model):
             name = 'apply_rmf('
         Model.__init__(self, name)
 
-    def calc(self, p, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             *args, **kwargs) -> np.ndarray:
         arf = self.arf
         rmf = self.rmf
 
-        if arf is not None and rmf is not None:
-            return rmf.apply_rmf(arf.apply_arf(*args, **kwargs))
-        elif self.arf is not None:
-            return arf.apply_arf(*args, **kwargs)
+        # For now we ignore the kwargs
+        assert len(args) == 1, f"internal error, len(args)={len(args)}"
+        src = args[0]
+        if arf is not None:
+            src = arf.apply_arf(src)
 
-        return rmf.apply_rmf(*args, **kwargs)
+        if rmf is not None:
+            src = rmf.apply_rmf(src)
+
+        return src
 
 
 class MultiResponseSumModel(CompositeModel, ArithmeticModel):
+    """Apply the model to multiple responses."""
 
-    def __init__(self, source, pha):
+    def __init__(self, source, pha: DataPHA) -> None:
         self.channel = pha.channel
         self.mask = np.ones(len(pha.channel), dtype=bool)
         self.pha = pha
@@ -833,7 +875,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         name = f'{type(self).__name__}({expr})'
         CompositeModel.__init__(self, name, (source,))
 
-    def _get_noticed_energy_list(self):
+    def _get_noticed_energy_list(self) -> None:
         grid = []
         for id in self.pha.response_ids:
             arf, rmf = self.pha.get_response(id)
@@ -847,7 +889,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.elo, self.ehi, self.table = compile_energy_grid(grid)
         self.lo, self.hi = hc / self.ehi, hc / self.elo
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         pha = self.pha
         if np.iterable(pha.mask):
             pha.notice_response(True)
@@ -856,7 +898,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self._get_noticed_energy_list()
         CompositeModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
         pha = self.pha
         if np.iterable(pha.mask):
             pha.notice_response(False)
@@ -869,11 +911,11 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.hi = None
         CompositeModel.teardown(self)
 
-    def _check_for_user_grid(self, x, xhi=None):
+    def _check_for_user_grid(self, x, xhi=None) -> bool:
         return (len(self.channel) != len(x) or
                 not (sao_fcmp(self.channel, x, _tol) == 0).all())
 
-    def _startup_user_grid(self, x, xhi=None):
+    def _startup_user_grid(self, x, xhi=None) -> None:
         # fit() never comes in here b/c it calls startup()
         pha = self.pha
         self.mask = np.zeros(len(pha.channel), dtype=bool)
@@ -881,7 +923,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         pha.notice_response(True, x)
         self._get_noticed_energy_list()
 
-    def _teardown_user_grid(self):
+    def _teardown_user_grid(self) -> None:
         # fit() never comes in here b/c it calls startup()
         pha = self.pha
         self.mask = np.ones(len(pha.channel), dtype=bool)
@@ -892,7 +934,8 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.lo = None
         self.hi = None
 
-    def calc(self, p, x, xhi=None, *args, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, *args, **kwargs) -> np.ndarray:
         pha = self.pha
 
         # TODO: this should probably include AREASCAL
@@ -985,7 +1028,12 @@ class MultipleResponse1D(Response1D):
 
 class PileupRMFModel(CompositeModel, ArithmeticModel):
 
-    def __init__(self, rmf, model, pha=None):
+    def __init__(self,
+                 rmf,
+                 model,
+                 pha: DataPHA | None = None
+                 ) -> None:
+        # TODO: should this require pha be set?
         self.pha = pha
         self.channel = sao_arange(1, rmf.detchans)  # sao_arange is inclusive
         self.mask = np.ones(rmf.detchans, dtype=bool)
@@ -1001,7 +1049,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
                                 f'apply_rmf({self.model.name})',
                                 (self.model,))
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False) -> None:
         pha = self.pha
         pha.notice_response(False)
         self.channel = pha.get_noticed_channels()
@@ -1009,7 +1057,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
-    def teardown(self):
+    def teardown(self) -> None:
 
         # Note:
         #
@@ -1026,16 +1074,17 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         self.model.teardown()
         CompositeModel.teardown(self)
 
-    def _check_for_user_grid(self, x):
+    def _check_for_user_grid(self, x) -> bool:
         return (len(self.channel) != len(x) or
                 not (sao_fcmp(self.channel, x, _tol) == 0).all())
 
-    def _startup_user_grid(self, x):
+    def _startup_user_grid(self, x) -> None:
         # fit() never comes in here b/c it calls startup()
         self.mask = np.zeros(self.rmf.detchans, dtype=bool)
         self.mask[np.searchsorted(self.pha.channel, x)] = True
 
-    def _calc(self, p, xlo, xhi):
+    def _calc(self, p: ParamsType,
+              xlo, xhi) -> np.ndarray:
         # Evaluate source model on RMF energy/wave grid OR
         # model.calc --> pileup_model
         src = self.model.calc(p, xlo, xhi)
@@ -1043,7 +1092,8 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         # rmf_fold
         return self.rmf.apply_rmf(src)
 
-    def calc(self, p, x, xhi=None, **kwargs):
+    def calc(self, p: ParamsType,
+             x, xhi=None, **kwargs) -> np.ndarray:
         pha = self.pha
         # x is noticed/full channels here
 
@@ -1092,7 +1142,10 @@ class PileupResponse1D(NoNewAttributesAfterInit):
 
     """
 
-    def __init__(self, pha, pileup_model):
+    def __init__(self,
+                 pha: DataPHA,
+                 pileup_model
+                 ) -> None:
         self.pha = pha
         self.pileup_model = pileup_model
         NoNewAttributesAfterInit.__init__(self)
@@ -1136,7 +1189,7 @@ class PileupResponse1D(NoNewAttributesAfterInit):
 
 class PSFModel(_PSFModel):
 
-    def fold(self, data):
+    def fold(self, data) -> None:
         super().fold(data)
 
         # Set WCS coordinates of kernel data set to match source data set.
@@ -1183,8 +1236,14 @@ class PSFModel(_PSFModel):
         raise PSFErr('ndim')
 
 
-def create_arf(elo, ehi, specresp=None, exposure=None, ethresh=None,
-               name='user-arf', header=None):
+def create_arf(elo: np.ndarray,
+               ehi: np.ndarray,
+               specresp: np.ndarray | None = None,
+               exposure: float | None =None,
+               ethresh: float | None = None,
+               name: str = 'user-arf',
+               header=None
+               ) -> DataARF:
     """Create an ARF.
 
     .. versionadded:: 4.10.1
@@ -1225,9 +1284,15 @@ def create_arf(elo, ehi, specresp=None, exposure=None, ethresh=None,
                    exposure=exposure, ethresh=ethresh, header=header)
 
 
-def create_delta_rmf(rmflo, rmfhi, offset=1,
-                     e_min=None, e_max=None, ethresh=None,
-                     name='delta-rmf', header=None):
+def create_delta_rmf(rmflo: np.ndarray,
+                     rmfhi: np.ndarray,
+                     offset: int = 1,
+                     e_min: np.ndarray | None = None,
+                     e_max: np.ndarray | None = None,
+                     ethresh: float | None = None,
+                     name: str = 'delta-rmf',
+                     header=None
+                     ) -> DataRMF:
     """Create an ideal RMF.
 
     The RMF has a unique mapping from channel to energy, in
@@ -1301,9 +1366,16 @@ def create_delta_rmf(rmflo, rmfhi, offset=1,
                    ethresh=ethresh, header=header)
 
 
-def create_non_delta_rmf(rmflo, rmfhi, fname, offset=1,
-                         e_min=None, e_max=None, ethresh=None,
-                         name='delta-rmf', header=None):
+def create_non_delta_rmf(rmflo: np.ndarray,
+                         rmfhi: np.ndarray,
+                         fname: str,
+                         offset: int = 1,
+                         e_min: np.ndarray | None = None,
+                         e_max: np.ndarray | None = None,
+                         ethresh: float | None = None,
+                         name: str = 'delta-rmf',
+                         header=None
+                         ) -> DataRMF:
     """Create a RMF using a matrix from a file.
 
     The RMF matrix (the mapping from channel to energy bin) is

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015 - 2019, 2021 - 2025
+#  Copyright (C) 2007, 2015-2019, 2021-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -697,10 +697,10 @@ def _extract_rmf(matrix: MatrixBlock,
 
     # Since these values are sent to the fold_rmf routine in
     # sherpa.astro.utils._utils, we want the types to match up to
-    # avoid conversion time in that routine. The n_grp, f_chan, and
-    # n_chan arrays should be SherpaUIntArray and the matrix should be
-    # given by sherpa.utils.numeric_types. This conversion should
-    # probably be done by DataRMF itself though.
+    # avoid any need for datatype conversion in that routine. The
+    # n_grp, f_chan, and n_chan arrays should be SherpaUIntArray and
+    # the matrix should be given by sherpa.utils.numeric_types. This
+    # conversion should probably be done by DataRMF itself though.
     #
     f_chan_l = []
     n_chan_l = []

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020 - 2025
+#  Copyright (C) 2020-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,6 +20,7 @@
 
 """Continued testing of sherpa.astro.data."""
 
+import copy
 import logging
 from pathlib import Path
 import pickle
@@ -4626,6 +4627,159 @@ def test_rmf_offset_check_basics(offset):
     # it is internally consistent.
     #
     assert got1 == pytest.approx([0, 0.56, 2.99, 1.85, 0])
+
+
+def test_arf_notice_basic():
+    """Basic checks of ARF notice call."""
+
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4, 0.5])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    specresp = np.asarray([1, 2, 3, 4])
+
+    arf = DataARF("orig", elo, ehi, specresp)
+
+    # It is not entirely clear what argument the DataARF notice
+    # method takes - is it a mask (as suggested from the name)
+    # or a set of channel numbers (as suggested by the fact that
+    # DataPHA get_noticed_channels is used by the DataPHA
+    # notice_response method).
+    #
+    # So, what does sending in channels 2 and 3 return?
+    ochans = np.asarray([2, 3])
+    arf.notice(ochans)
+
+    # There is an argument that this should be "idx = ochans - 1" to
+    # reflect the fact that the default channel numbering starts at 1
+    # rather than 0 - i.e. this should return the middle-two elements
+    # not the last two.
+    #
+    idx = ochans
+    assert arf.specresp == pytest.approx(specresp)
+    assert arf.energ_lo == pytest.approx(elo)
+    assert arf.energ_hi == pytest.approx(ehi)
+
+    assert arf.get_dep() == pytest.approx(specresp[idx])
+
+    x1, x2 = arf.get_indep()
+    assert x1 == pytest.approx(elo[idx])
+    assert x2 == pytest.approx(ehi[idx])
+
+
+def test_arf_notice_copy():
+    """Can we copy an ARF, notice it, and not change the parent?"""
+
+    # This process may be useful in sherpa.astro.instrument so check
+    # that it works as expected (i.e. that after a basic copy of an
+    # ARF we can notice the copy and not change the original).
+    #
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4, 0.5])
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    specresp = np.asarray([1, 2, 3, 4])
+
+    arf1 = DataARF("orig", elo, ehi, specresp)
+    ochans = np.asarray([2, 3])
+    idx1 = ochans
+    arf1.notice(ochans)
+
+    arf2 = copy.copy(arf1)
+
+    assert arf2.get_dep() == pytest.approx(specresp[idx1])
+
+    # Drop the filter from the copy.
+    #
+    arf2.notice()
+    assert arf2.get_dep() == pytest.approx(specresp)
+
+    # Check the original has not changed
+    assert arf1.get_dep() == pytest.approx(specresp[idx1])
+
+
+def test_rmf_notice_basic():
+    """Basic checks of RMF notice call."""
+
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    n_grp = np.asarray([1, 1, 1, 1], dtype=np.int16)
+    f_chan = np.asarray([1, 2, 3, 3], dtype=np.int16)
+    n_chan = np.asarray([1, 2, 2, 2], dtype=np.int16)
+
+    matrix = np.asarray([1.0, 0.2, 0.8, 0.4, 0.6, 0.7, 0.3],
+                        dtype=np.float32)
+
+    rmf = DataRMF("orig", 4, n_grp=n_grp, f_chan=f_chan,
+                  n_chan=n_chan, matrix=matrix, offset=1,
+                  energ_lo=elo, energ_hi=ehi, e_min=elo, e_max=ehi)
+
+    # See discussion of what DataARF.notice takes in
+    # test_arf_notice_basic. However, unlike the ARF, it lools like
+    # the RMF handles the channel numbering (at least for offset=1).
+    #
+    # Treat this as a regression test as it is not quite obvious
+    # to DJB why the results are as they are.
+    #
+    for idx, expected in [(1, [True, False, False, False]),
+                          (2, [True, True, False, False]),
+                          (3, [False, True, True, True]),
+                          (4, [False, True, True, True])]:
+        rmf.notice()
+        assert rmf.notice([idx]) == pytest.approx(expected)
+
+        xlo, xhi = rmf.get_indep()
+        assert xlo == pytest.approx(elo[expected])
+        assert xhi == pytest.approx(ehi[expected])
+
+        # rmf.get_dep() raises an error unless all channels are
+        # noticed, so do not test here.
+
+    # Check apply_rmf works as expected.
+    #
+    assert rmf.notice([1, 2]) == pytest.approx([True, True, False, False])
+
+    # Should this send in a "rmfargs" grid here?
+    #
+    # This applies the matrix from the first two rows to the model.
+    # Is this the expected behaviour?
+    #
+    mdl = np.asarray([10, 20])
+    expected = np.asarray([10 * 1.0, 20 * 0.2, 20 * 0.8, 0])
+    got = rmf.apply_rmf(mdl)
+    assert got == pytest.approx(expected)
+
+
+def test_rmf_notice_copy():
+    """Can we copy an RMF, notice it, and not change the parent?"""
+
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    n_grp = np.asarray([1, 1, 1, 1], dtype=np.int16)
+    f_chan = np.asarray([1, 2, 3, 3], dtype=np.int16)
+    n_chan = np.asarray([1, 2, 2, 2], dtype=np.int16)
+
+    matrix = np.asarray([1.0, 0.2, 0.8, 0.4, 0.6, 0.7, 0.3],
+                        dtype=np.float32)
+
+
+    rmf1 = DataRMF("orig", 4, n_grp=n_grp, f_chan=f_chan,
+                   n_chan=n_chan, matrix=matrix, offset=1,
+                   energ_lo=elo, energ_hi=ehi, e_min=elo, e_max=ehi)
+
+    rmf1.notice([3, 4])
+
+    rmf2 = copy.copy(rmf1)
+    rmf2.notice([1, 2])
+
+    xlo1, _ = rmf1.get_indep()
+    xlo2, _ = rmf2.get_indep()
+
+    # Check the two grids are different
+    assert xlo1 == pytest.approx(elo[1:])
+    assert xlo2 == pytest.approx(elo[:2])
 
 
 @pytest.mark.parametrize("subtract", [True, False])

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1693,15 +1693,10 @@ def test_rspmodelnopha_rmf2_arf_mismatch():
 
     # This does *not* include the exposure time.
     rsp = RSPModelNoPHA(arf=arf, rmf=rmf2, model=src)
+    y = rsp(pha.channel)
 
-    # This is known to fail, so make sure we know how it fails.
-    #
-    with pytest.raises(TypeError,
-                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
-        y = rsp(pha.channel)
-
-    # expected = eval_xrism_like_model_rmf2() / pha.exposure
-    # assert y == pytest.approx(expected)
+    expected = eval_xrism_like_model_rmf2() / pha.exposure
+    assert y == pytest.approx(expected)
 
 
 def test_multi_response_xrism_like():

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -2802,3 +2802,293 @@ def test_rsp_multi_startup(startup):
     # any channel filtering. At least for now.
     #
     # assert y == pytest.approx(expected)
+
+
+def test_rsp_single_setup_wavelength():
+    """RSPModelPHA, wavelength analysis, use of startup.
+
+    This is intended to test the behaviour of setup/filter
+    by evaluating a model.
+
+    This is with a single pair of responses.
+
+    """
+
+    exposure = 200.1
+    rdata = create_non_delta_rmf_local()
+    specresp = create_non_delta_specresp()
+    adata = create_arf(rdata.energ_lo,
+                       rdata.energ_hi,
+                       specresp,
+                       exposure=exposure)
+
+    nchans = rdata.e_min.size
+    channels = np.arange(1, nchans + 1, dtype=np.int16)
+    counts = np.ones(nchans, dtype=np.int16)
+    pha = DataPHA('test-pha', channel=channels, counts=counts,
+                  exposure=exposure)
+
+    pha.set_arf(adata)
+    pha.set_rmf(rdata)
+
+    rsp = Response1D(pha)
+    constant = 2.3
+    slope = -0.25
+    mdl = Polynom1D('mdl')
+    mdl.c0 = constant
+    mdl.c1 = slope
+
+    # Ensure the model is not cached.
+    mdl.cache = 0
+    convolved = rsp(mdl)
+    assert isinstance(convolved, RSPModelPHA)
+
+    # Get the "no startup" values.
+    #
+    pha.set_analysis("energy")
+    orig = convolved(channels)
+
+    # Select channels 3, 4, 5, 6 (of the starting 1-8).
+    #
+    pha.set_analysis("channel")
+    pha.ignore(hi=2)
+    pha.ignore(lo=7)
+
+    # Go through the settings.
+    #
+    out = {}
+    for setting in ["channel", "wavelength", "energy"]:
+        pha.set_analysis(setting)
+        convolved.startup()
+        out[setting] = convolved(channels)
+        convolved.teardown()
+
+    # Channel and energy should be the same.
+    #
+    assert out["energy"] == pytest.approx(out["channel"])
+
+    # Wavelength analysis is different because the model parameters
+    # are now interpreted in Angstroms rather than keV. These
+    # parameters lead to all channels (other than the last) being
+    # negative.
+    #
+    # This is a regression test (with values calculated by a
+    # development branch of 4.18.1) just to know when anything
+    # changes.
+    #
+    expected = np.asarray([-1.21430630e6, -1.41944674e6,
+                           -1.83990472e5, -7.48808180e4,
+                           -2.47166908e4, -2.35095965e4,
+                           -9.35854705e2, 0])
+    assert out["wavelength"] == pytest.approx(expected, rel=1e-4)
+
+    # The channel/energy values should match the original
+    # values for the selected channels.
+    #
+    idx = [2, 3, 4, 5]
+    assert out["energy"][idx] == pytest.approx(orig[idx])
+
+
+def test_rmf_single_setup_wavelength():
+    """RMFModelPHA, wavelength analysis, use of startup.
+
+    This is intended to test the behaviour of setup/filter
+    by evaluating a model.
+
+    This is with a single pair of responses.
+
+    """
+
+    exposure = 200.1
+    rdata = create_non_delta_rmf_local()
+
+    nchans = rdata.e_min.size
+    channels = np.arange(1, nchans + 1, dtype=np.int16)
+    counts = np.ones(nchans, dtype=np.int16)
+    pha = DataPHA('test-pha', channel=channels, counts=counts,
+                  exposure=exposure)
+
+    pha.set_rmf(rdata)
+
+    rsp = Response1D(pha)
+    constant = 2.3
+    slope = -0.25
+    mdl = Polynom1D('mdl')
+    mdl.c0 = constant
+    mdl.c1 = slope
+
+    # Ensure the model is not cached.
+    mdl.cache = 0
+    convolved = rsp(mdl)
+    assert isinstance(convolved, RMFModelPHA)
+
+    # Get the "no startup" values.
+    #
+    pha.set_analysis("energy")
+    orig = convolved(channels)
+
+    # Select channels 3, 4, 5, 6 (of the starting 1-8).
+    #
+    pha.set_analysis("channel")
+    pha.ignore(hi=2)
+    pha.ignore(lo=7)
+
+    # Go through the settings.
+    #
+    out = {}
+    for setting in ["channel", "wavelength", "energy"]:
+        pha.set_analysis(setting)
+        convolved.startup()
+        out[setting] = convolved(channels)
+        convolved.teardown()
+
+    # Channel and energy should be the same.
+    #
+    assert out["energy"] == pytest.approx(out["channel"])
+
+    # Wavelength analysis is different because the model parameters
+    # are now interpreted in Angstroms rather than keV. These
+    # parameters lead to all channels (other than the last) being
+    # negative.
+    #
+    # This is a regression test (with values calculated by a
+    # development branch of 4.18.1) just to know when anything
+    # changes.
+    #
+    expected = np.asarray([-1.50712369e5, -1.60594556e5,
+                           -1.03440118e4, -3.86060019e3,
+                           -1.98967947e3, -1.27644364e3,
+                           -1.47756554e2, 0])
+    assert out["wavelength"] == pytest.approx(expected, rel=1e-4)
+
+    # The channel/energy values should match the original
+    # values for the selected channels.
+    #
+    idx = [2, 3, 4, 5]
+    assert out["energy"][idx] == pytest.approx(orig[idx])
+
+
+def test_arf_single_setup_wavelength():
+    """ARFModelPHA, wavelength analysis, use of startup.
+
+    This is intended to test the behaviour of setup/filter
+    by evaluating a model.
+
+    This is with a single pair of responses.
+
+    """
+
+    exposure = 200.1
+    rdata = create_non_delta_rmf_local()
+    specresp = create_non_delta_specresp()
+    adata = create_arf(rdata.energ_lo,
+                       rdata.energ_hi,
+                       specresp,
+                       exposure=exposure)
+
+    nchans = adata.energ_lo.size
+    channels = np.arange(1, nchans + 1, dtype=np.int16)
+    counts = np.ones(nchans, dtype=np.int16)
+    pha = DataPHA('test-pha', channel=channels, counts=counts,
+                  exposure=exposure)
+
+    pha.set_arf(adata)
+
+    rsp = Response1D(pha)
+    constant = 2.3
+    slope = -0.25
+    mdl = Polynom1D('mdl')
+    mdl.c0 = constant
+    mdl.c1 = slope
+
+    # Ensure the model is not cached.
+    mdl.cache = 0
+    convolved = rsp(mdl)
+    assert isinstance(convolved, ARFModelPHA)
+
+    # Get the "no startup" values.
+    #
+    pha.set_analysis("energy")
+    orig = convolved(channels)
+
+    # Select channels 3, 4, 5, 6 (of the starting 1-20).
+    #
+    pha.set_analysis("channel")
+    pha.ignore(hi=2)
+    pha.ignore(lo=7)
+
+    # Go through the settings.
+    #
+    out = {}
+    for setting in ["channel", "wavelength", "energy"]:
+        pha.set_analysis(setting)
+        convolved.startup()
+        out[setting] = convolved(channels)
+        convolved.teardown()
+
+    # Channel and energy should be the same.
+    #
+    assert out["energy"] == pytest.approx(out["channel"])
+
+    # Unlike RSP/RMFModelPHA, the output here is restricted to the
+    # input size, not the intrinsic range. This may be an issue, but
+    # we do not really have any ARF-only real-life data to check
+    # against.
+    #
+    assert len(out["energy"]) == 4
+
+    # Wavelength analysis is different because the model parameters
+    # are now interpreted in Angstroms rather than keV. These
+    # parameters lead to all channels (other than the last) being
+    # negative.
+    #
+    # This is a regression test (with values calculated by a
+    # development branch of 4.18.1) just to know when anything
+    # changes.
+    #
+    expected = np.asarray([0.0, -288983.46463642, -224901.11145058,
+                           -172341.83467511])
+    assert out["wavelength"] == pytest.approx(expected, rel=1e-4)
+
+    # The channel/energy values should match the original
+    # values for the selected channels.
+    #
+    idx = [2, 3, 4, 5]
+    assert out["energy"] == pytest.approx(orig[idx])
+
+
+def test_rsp_multi_setup_wavelength():
+    """RSPModelPHA, wavelength analysis, use of startup.
+
+    This is intended to test the behaviour of setup/filter
+    by evaluating a model.
+
+    This is with a single pair of responses.
+
+    """
+
+    exposure = 200.1
+    rmf1, rmf2, arf, pha = create_xrism_like_responses()
+
+    src = create_xrism_like_model()
+
+    pha.set_response(arf, rmf1, id=1)
+    pha.set_response(arf, rmf2, id=2)
+
+    rsp = pha.get_full_response()
+    assert isinstance(rsp, MultipleResponse1D)
+
+    # Ensure the model is not cached.
+    src.lhs.cache = 0
+    src.rhs.cache = 0
+    convolved = rsp(src)
+
+    # Get the "no startup" values.
+    #
+    pha.set_analysis("energy")
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match, source: 5 vs effarea: 20$"):
+        orig = convolved(pha.channel)
+
+    # See test_rsp_single_setup_wavelength for tests to run
+    # once the above is fixed.

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -36,7 +36,7 @@ from sherpa.astro import hc, io
 from sherpa.astro.data import DataARF, DataPHA, DataRMF, DataIMG
 from sherpa.astro.instrument import ARF1D, ARFModelNoPHA, ARFModelPHA, \
     Response1D, MultipleResponse1D, RMF1D, RMFModelNoPHA, RMFModelPHA, \
-    RSPModelNoPHA, RSPModelPHA, PSFModel, RMFMatrix, \
+    RSPModelNoPHA, RSPModelPHA, PSFModel, RMFMatrix, MultiResponseSumModel, \
     create_arf, create_delta_rmf, create_non_delta_rmf, \
     rmf_to_matrix, rmf_to_image, has_pha_response
 from sherpa.data import Data1D
@@ -1534,6 +1534,25 @@ def test_rsp_multi_2_filtered(analysis, arfexp, phaexp):
 
     expected2 = expected[[3, 4]]
     assert out == pytest.approx(2 * expected2)
+
+
+def test_rsp_multi_no_response():
+    """Corner chase: check we error out if no response"""
+
+    pha = DataPHA("x", np.asarray([1, 2]), np.asarray([0, 1]))
+    model = Box1D()
+
+    # Note that
+    #    rsp = MultipleResponse1D(pha)
+    #    rsp(model)
+    # could also error out, but MultiResponse1D already checks that
+    # there is at least one response, so there is a need to call
+    # MultiResponseSumModel directly.
+    #
+    with pytest.raises(DataErr,
+                       match="^No instrument response found for "
+                       "dataset x$"):
+        MultiResponseSumModel(model, pha=pha)
 
 
 def create_xrism_like_responses() -> tuple[DataRMF,

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1720,9 +1720,6 @@ def test_rspmodelnopha_rmf2_arf_mismatch():
 
 def test_multi_response_xrism_like():
     """Can we handle XRISM-like responses as separate objects?
-
-    This is currently a regression test, as the answer is no,
-    so we just check we fail as expected.
     """
 
     rmf1, rmf2, arf, pha = create_xrism_like_responses()
@@ -1759,13 +1756,8 @@ def test_multi_response_xrism_like():
     assert y_1 == pytest.approx(expected_1)
     assert y_2 == pytest.approx(expected_2)
 
-    # This is known to fail, so make sure we know how it fails.
-    #
-    with pytest.raises(TypeError,
-                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
-        y_c = model_c(pha.channel)
-
-    # assert y_c == pytest.approx(expected)
+    y_c = model_c(pha.channel)
+    assert y_c == pytest.approx(expected)
 
 
 def test_multi_response_xrism_like_swapped():
@@ -1778,6 +1770,8 @@ def test_multi_response_xrism_like_swapped():
     rmf1, rmf2, arf, pha = create_xrism_like_responses()
     src = create_xrism_like_model()
 
+    # Combine the responses. SWAPPED
+    #
     pha.set_response(arf, rmf2, id=1)
     pha.set_response(arf, rmf1, id=2)
     resp_c = pha.get_full_response()
@@ -1787,13 +1781,8 @@ def test_multi_response_xrism_like_swapped():
     expected_2 = eval_xrism_like_model_rmf2()
     expected = expected_1 + expected_2
 
-    # Combine the responses. SWAPPED
-    #
-    with pytest.raises(TypeError,
-                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
-        y_c = model_c(pha.channel)
-
-    # assert y_c == pytest.approx(expected)
+    y_c = model_c(pha.channel)
+    assert y_c == pytest.approx(expected)
 
 
 class MyPowLaw1D(PowLaw1D):
@@ -2765,7 +2754,6 @@ def test_rsp_multi_startup(startup):
 
     This is with two pairs of responses.
 
-    This is known to fail so we test that it does fail.
     """
 
     exposure = 200.1
@@ -2803,15 +2791,12 @@ def test_rsp_multi_startup(startup):
     if startup:
         convolved.startup()
 
-    emsg = "Mismatched filter between ARF and RMF or PHA and RMF"
-    with pytest.raises(TypeError,
-                       match=f"^{emsg}$"):
-        y = convolved(pha.channel)
+    y = convolved(pha.channel)
 
     # Unlike the single-response case, the result does not reflect
     # any channel filtering. At least for now.
     #
-    # assert y == pytest.approx(expected)
+    assert y == pytest.approx(expected)
 
 
 def test_rsp_single_setup_wavelength():
@@ -3096,9 +3081,47 @@ def test_rsp_multi_setup_wavelength():
     # Get the "no startup" values.
     #
     pha.set_analysis("energy")
-    with pytest.raises(TypeError,
-                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
-        orig = convolved(pha.channel)
+    orig = convolved(pha.channel)
 
-    # See test_rsp_single_setup_wavelength for tests to run
-    # once the above is fixed.
+    # Select channels 3, 4, 5, 6 (of the starting 1-8).
+    # The response is different to test_rsp_single_setup_wavelength
+    # but keep the same channel range.
+    #
+    pha.set_analysis("channel")
+    pha.ignore(hi=2)
+    pha.ignore(lo=7)
+
+    # Go through the settings.
+    #
+    out = {}
+    for setting in ["channel", "wavelength", "energy"]:
+        pha.set_analysis(setting)
+        convolved.startup()
+        out[setting] = convolved(pha.channel)
+        convolved.teardown()
+
+    # Channel and energy should be the same.
+    #
+    assert out["energy"] == pytest.approx(out["channel"])
+
+    # Wavelength analysis is different because the model parameters
+    # are now interpreted in Angstroms rather than keV.
+    #
+    # This is a regression test (with values calculated by a
+    # development branch of 4.18.1) just to know when anything
+    # changes.
+    #
+    expected = np.asarray([32.26217862, 45.16705026, 70.9767945,
+                           96.78653682, 96.78653778, 96.78653682,
+                           96.78653778, 93.56031891, 87.10788381,
+                           80.65544727, 80.65544799, 70.97679354,
+                           43.55394143, 24.19663397, 24.19663397,
+                           24.19663397, 24.19663397, 24.19663397,
+                           24.19663397, 24.19663397])
+    assert out["wavelength"] == pytest.approx(expected, rel=1e-4)
+
+    # The channel/energy values should match the original
+    # values for the selected channels.
+    #
+    idx = [2, 3, 4, 5]
+    assert out["energy"][idx] == pytest.approx(orig[idx])

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1762,7 +1762,7 @@ def test_multi_response_xrism_like():
     # This is known to fail, so make sure we know how it fails.
     #
     with pytest.raises(TypeError,
-                       match="^input array sizes do not match, source: 5 vs effarea: 20$"):
+                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
         y_c = model_c(pha.channel)
 
     # assert y_c == pytest.approx(expected)
@@ -1790,7 +1790,7 @@ def test_multi_response_xrism_like_swapped():
     # Combine the responses. SWAPPED
     #
     with pytest.raises(TypeError,
-                       match="^input array sizes do not match, source: 5 vs effarea: 20$"):
+                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
         y_c = model_c(pha.channel)
 
     # assert y_c == pytest.approx(expected)
@@ -2803,11 +2803,7 @@ def test_rsp_multi_startup(startup):
     if startup:
         convolved.startup()
 
-    if startup:
-        emsg = "Mismatched filter between ARF and RMF or PHA and RMF"
-    else:
-        emsg = "input array sizes do not match, source: 5 vs effarea: 20"
-
+    emsg = "Mismatched filter between ARF and RMF or PHA and RMF"
     with pytest.raises(TypeError,
                        match=f"^{emsg}$"):
         y = convolved(pha.channel)
@@ -3101,7 +3097,7 @@ def test_rsp_multi_setup_wavelength():
     #
     pha.set_analysis("energy")
     with pytest.raises(TypeError,
-                       match="^input array sizes do not match, source: 5 vs effarea: 20$"):
+                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
         orig = convolved(pha.channel)
 
     # See test_rsp_single_setup_wavelength for tests to run

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2020 - 2025
+#  Copyright (C) 2017, 2020-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -33,7 +33,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from sherpa.astro import hc, io
-from sherpa.astro.data import DataPHA, DataRMF, DataIMG
+from sherpa.astro.data import DataARF, DataPHA, DataRMF, DataIMG
 from sherpa.astro.instrument import ARF1D, ARFModelNoPHA, ARFModelPHA, \
     Response1D, MultipleResponse1D, RMF1D, RMFModelNoPHA, RMFModelPHA, \
     RSPModelNoPHA, RSPModelPHA, PSFModel, RMFMatrix, \
@@ -1536,6 +1536,252 @@ def test_rsp_multi_2_filtered(analysis, arfexp, phaexp):
     assert out == pytest.approx(2 * expected2)
 
 
+def create_xrism_like_responses() -> tuple[DataRMF,
+                                           DataRMF,
+                                           DataARF,
+                                           DataPHA]:
+    """Create two RMF and one ARF to emulate XRISM multi-RMF file.
+
+    This is primarily to test whether MultipleResponse1D and
+    MultiResponseSumModel can handle this case. Unlike the
+    multiple-order grating case, the ARF is expected to be the same
+    but the individual RMF grids have different energy scales.
+
+    """
+
+    # First block is "perfect" and the second adds a "blob"
+    # component.
+    #
+    egrid = np.linspace(0.1, 2.1, 21)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    rmf1 = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi,
+                            name="perfect")
+    rmf1.header["TESTBLCK"] = 1
+
+    # reduce the "energy" resolution of the second block.
+    #
+    e4grid = np.linspace(0.1, 2.1, 6)
+    e4lo = e4grid[:-1]
+    e4hi = e4grid[1:]
+    matrix = np.zeros((5, 4), dtype=np.float32)
+    blur = [0.1, 0.3, 0.4, 0.2]
+    for i in range(5):
+        matrix[i] = blur
+
+    rmf2 = DataRMF("blob", detchans=rmf1.detchans,
+                   energ_lo=e4lo, energ_hi=e4hi,
+                   n_grp=np.ones(5, dtype=np.int32),
+                   f_chan=np.asarray([2, 4, 6, 8, 10], dtype=np.int32),
+                   n_chan=4 * np.ones(5, dtype=np.int32),
+                   matrix=matrix.flatten(),
+                   e_min=elo, e_max=ehi,
+                   header={"TESTBLCK": 2})
+
+    specresp = np.full(elo.size, 20.0)
+    specresp[12:] = 15.0
+    arf = DataARF("arfy", energ_lo=elo, energ_hi=ehi,
+                  specresp=specresp)
+
+    chans = np.arange(1, 21, dtype=np.int16)
+    pha = DataPHA("ex", chans, np.zeros(20, dtype=np.int16))
+    pha.exposure = 100.0
+
+    return (rmf1, rmf2, arf, pha)
+
+
+def create_xrism_like_model():
+    """A common model"""
+
+    pl = PowLaw1D()
+    line = Gauss1D()
+    pl.ampl = 2
+    pl.gamma = 2
+    line.fwhm = 0.4
+    line.pos = 0.6
+    line.ampl = 1
+    return pl + line
+
+
+def eval_xrism_like_model_rmf1():
+    """What is the expected value?
+
+    This is multiplied by the PHA exposure time
+    """
+
+    # These values were created by running the code with CIAO 4.18,
+    # rather than calculating them directly from knowledge of the
+    # model and responses.
+    #
+    return np.asarray([20006.50887613, 6691.72203773, 3402.16404438,
+                       2134.98603532, 1522.35747977, 1141.40509882,
+                       849.27174961, 624.3862666, 469.49981551,
+                       370.14523977, 304.23651655, 256.56964413,
+                       164.84642229, 142.857898, 125.00003606,
+                       110.29411887, 98.03921572, 87.71929825,
+                       78.94736842, 71.42857143])
+
+
+def eval_xrism_like_model_rmf2():
+    """What is the expected value?
+
+    This is multiplied by the PHA exposure time
+    """
+
+    # These values were created by running the code with CIAO 4.18,
+    # rather than calculating them directly from knowledge of the
+    # model and responses.
+    #
+    return np.asarray([0., 3223.53814739, 9670.61468234,
+                       13307.8946552, 7688.30252254, 1795.01338626,
+                       1247.61951277, 614.48034306, 442.9897964,
+                       250.81283921, 209.44003681, 134.45378353,
+                       67.22689176, 0., 0., 0, 0, 0, 0, 0])
+
+
+def test_rspmodelpha_rmf1_arf_mismatch():
+    """Can we handle the ARF and RMF grids being different?"""
+
+    rmf1, _, arf, pha = create_xrism_like_responses()
+
+    src = create_xrism_like_model()
+
+    # This does *not* include the exposure time.
+    rsp = RSPModelPHA(arf=arf, rmf=rmf1, pha=pha, model=src)
+    y = rsp(pha.channel)
+
+    expected = eval_xrism_like_model_rmf1() / pha.exposure
+    assert y == pytest.approx(expected)
+
+
+def test_rspmodelpha_rmf2_arf_mismatch():
+    """Can we handle the ARF and RMF grids being different?"""
+
+    _, rmf2, arf, pha = create_xrism_like_responses()
+
+    src = create_xrism_like_model()
+
+    # This does *not* include the exposure time.
+    rsp = RSPModelPHA(arf=arf, rmf=rmf2, pha=pha, model=src)
+    y = rsp(pha.channel)
+
+    expected = eval_xrism_like_model_rmf2() / pha.exposure
+    assert y == pytest.approx(expected)
+
+
+def test_rspmodelnopha_rmf1_arf_mismatch():
+    """Can we handle the ARF and RMF grids being different?"""
+
+    rmf1, _, arf, pha = create_xrism_like_responses()
+
+    src = create_xrism_like_model()
+
+    # This does *not* include the exposure time.
+    rsp = RSPModelNoPHA(arf=arf, rmf=rmf1, model=src)
+    y = rsp(pha.channel)
+
+    expected = eval_xrism_like_model_rmf1() / pha.exposure
+    assert y == pytest.approx(expected)
+
+
+def test_rspmodelnopha_rmf2_arf_mismatch():
+    """Can we handle the ARF and RMF grids being different?"""
+
+    _, rmf2, arf, pha = create_xrism_like_responses()
+
+    src = create_xrism_like_model()
+
+    # This does *not* include the exposure time.
+    rsp = RSPModelNoPHA(arf=arf, rmf=rmf2, model=src)
+
+    # This is known to fail, so make sure we know how it fails.
+    #
+    with pytest.raises(TypeError,
+                       match="^Mismatched filter between ARF and RMF or PHA and RMF$"):
+        y = rsp(pha.channel)
+
+    # expected = eval_xrism_like_model_rmf2() / pha.exposure
+    # assert y == pytest.approx(expected)
+
+
+def test_multi_response_xrism_like():
+    """Can we handle XRISM-like responses as separate objects?
+
+    This is currently a regression test, as the answer is no,
+    so we just check we fail as expected.
+    """
+
+    rmf1, rmf2, arf, pha = create_xrism_like_responses()
+    src = create_xrism_like_model()
+
+    # Evaluate the model with each of the RMFs.
+    #
+    pha.set_response(arf, rmf1, id=1)
+    resp_1 = pha.get_full_response()
+    model_1 = resp_1(src)
+
+    pha.set_response(arf, rmf2, id=1)
+    resp_2 = pha.get_full_response()
+    model_2 = resp_2(src)
+
+    # Combine the responses.
+    #
+    pha.set_response(arf, rmf1, id=1)
+    pha.set_response(arf, rmf2, id=2)
+    resp_c = pha.get_full_response()
+    assert isinstance(resp_c, MultipleResponse1D), type(resp_c)
+    model_c = resp_c(src)
+
+    expected_1 = eval_xrism_like_model_rmf1()
+    expected_2 = eval_xrism_like_model_rmf2()
+    expected = expected_1 + expected_2
+
+    # Check we get the expected values. Note that unlike the
+    # test_rspmodel[no]pha_rmf[12]_arf_mismatch case, the exposure
+    # time is included in this model evaluation.
+    #
+    y_1 = model_1(pha.channel)
+    y_2 = model_2(pha.channel)
+    assert y_1 == pytest.approx(expected_1)
+    assert y_2 == pytest.approx(expected_2)
+
+    # This is known to fail, so make sure we know how it fails.
+    #
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match, source: 5 vs effarea: 20$"):
+        y_c = model_c(pha.channel)
+
+    # assert y_c == pytest.approx(expected)
+
+
+def test_multi_response_xrism_like_swapped():
+    """Can we handle XRISM-like responses as separate objects?
+
+    Change the ordering of the RMFs from
+    test_multi_response_xrism_like.
+    """
+
+    rmf1, rmf2, arf, pha = create_xrism_like_responses()
+    src = create_xrism_like_model()
+
+    pha.set_response(arf, rmf2, id=1)
+    pha.set_response(arf, rmf1, id=2)
+    resp_c = pha.get_full_response()
+    model_c = resp_c(src)
+
+    expected_1 = eval_xrism_like_model_rmf1()
+    expected_2 = eval_xrism_like_model_rmf2()
+    expected = expected_1 + expected_2
+
+    # Combine the responses. SWAPPED
+    #
+    with pytest.raises(TypeError,
+                       match="^input array sizes do not match, source: 5 vs effarea: 20$"):
+        y_c = model_c(pha.channel)
+
+    # assert y_c == pytest.approx(expected)
+
+
 class MyPowLaw1D(PowLaw1D):
     """A model that creates a NaN if the first bin starts <= 0"""
 
@@ -2410,3 +2656,149 @@ def test_has_pha_response():
     # reflexivity check
     assert has_pha_response(rsp(m1) + m2)
     assert has_pha_response(rsp(m1) + rsp(m2))
+
+
+@pytest.mark.parametrize("startup", [False, True])
+def test_rsp_single_startup(startup):
+    """Check we get the same results when startup is called.
+
+    Since startup can lead to different data being used for the
+    responses, and this is used within a fit, check we match the
+    "no-startup" case, which many of the tests use.
+
+    This is with a single pair of responses.
+
+    """
+
+    exposure = 200.1
+    rdata = create_non_delta_rmf_local()
+    specresp = create_non_delta_specresp()
+    adata = create_arf(rdata.energ_lo,
+                       rdata.energ_hi,
+                       specresp,
+                       exposure=exposure)
+
+    nchans = rdata.e_min.size
+    channels = np.arange(1, nchans + 1, dtype=np.int16)
+    counts = np.ones(nchans, dtype=np.int16)
+    pha = DataPHA('test-pha', channel=channels, counts=counts,
+                  exposure=exposure)
+
+    pha.set_arf(adata)
+    pha.set_rmf(rdata)
+    pha.set_analysis("energy")
+
+    rsp = Response1D(pha)
+    constant = 2.3
+    slope = -0.25
+    mdl = Polynom1D('mdl')
+    mdl.c0 = constant
+    mdl.c1 = slope
+
+    # Ensure the model is not cached.
+    mdl.cache = 0
+    convolved = rsp(mdl)
+
+    # Check we are actually filtering things so that startup does
+    # some work.
+    #
+    assert pha.get_indep()[0] == pytest.approx([1, 2, 3, 4, 5, 6, 7, 8])
+    pha.notice(lo=0.4, hi=0.8)
+    assert pha.get_indep()[0] == pytest.approx([3, 4, 5, 6])
+
+    if startup:
+        convolved.startup()
+
+    y = convolved(pha.channel)
+
+    # Calculate the model analytically. Note that the exposure value
+    # is included here.
+    #
+    modvals = exposure * specresp * mdl(rdata.energ_lo, rdata.energ_hi)
+    matrix = get_non_delta_matrix()
+    expected = np.matmul(modvals, matrix)
+
+    # The values are only guaranteed to match for the noticed
+    # channels.  Channels outside this range may get "spill-over" when
+    # startup() has been called, but it is not guaranteed to match the
+    # expected values for the "no filter is applied" case.
+    #
+    idx = [2, 3, 4, 5]
+    assert y[idx] == pytest.approx(expected[idx])
+
+    # Check that the other values agree or do not agree, depending
+    # on the startup flag.
+    #
+    idx = [0, 1, 6, 7]
+    if startup:
+        # The calculated values should be less than the expected ones.
+        # However, there could be cases where some channels agree (as
+        # seen in a CI run, presumably due to numerical issues), so
+        # use <= rather than < here).
+        #
+        assert (y[idx] <= expected[idx]).all()
+    else:
+        assert y[idx] == pytest.approx(expected[idx])
+
+
+@pytest.mark.parametrize("startup", [False, True])
+def test_rsp_multi_startup(startup):
+    """Check we get the same results when startup is called.
+
+    Since startup can lead to different data being used for the
+    responses, and this is used within a fit, check we match the
+    "no-startup" case, which many of the tests use.
+
+    This is with two pairs of responses.
+
+    This is known to fail so we test that it does fail.
+    """
+
+    exposure = 200.1
+
+    rmf1, rmf2, arf, pha = create_xrism_like_responses()
+
+    src = create_xrism_like_model()
+
+    pha.set_response(arf, rmf1, id=1)
+    pha.set_response(arf, rmf2, id=2)
+    pha.set_analysis("energy")
+
+    # Rather than evaluate the model from first principles, use
+    # pre-calculated values.
+    #
+    expected_1 = eval_xrism_like_model_rmf1()
+    expected_2 = eval_xrism_like_model_rmf2()
+    expected = expected_1 + expected_2
+
+    # Ensure the model is not cached. This requires knowledge that src
+    # is cpt1 + cpt2 and cpt1/2 are not composite models.
+    #
+    src.lhs.cache = 0
+    src.rhs.cache = 0
+    rsp = pha.get_full_response()
+    convolved = rsp(src)
+
+    # Check we are actually filtering things so that startup does
+    # some work.
+    #
+    assert pha.get_indep()[0] == pytest.approx(np.arange(1, 21))
+    pha.notice(lo=0.5, hi=1.35)
+    assert pha.get_indep()[0] == pytest.approx(np.arange(5, 14))
+
+    if startup:
+        convolved.startup()
+
+    if startup:
+        emsg = "Mismatched filter between ARF and RMF or PHA and RMF"
+    else:
+        emsg = "input array sizes do not match, source: 5 vs effarea: 20"
+
+    with pytest.raises(TypeError,
+                       match=f"^{emsg}$"):
+        y = convolved(pha.channel)
+
+    # Unlike the single-response case, the result does not reflect
+    # any channel filtering. At least for now.
+    #
+    # assert y == pytest.approx(expected)


### PR DESCRIPTION
# Summary

Support reading in RMF files with multiple matrix blocks from OGIP Calibration Memo CAL/GEN/92-002  https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html. This support should be considered experimental at this time.

# Details

This requires

- #1926 
- ~~#1929~~
- #2017
- #1921
- #2123

Can we handle multi-MATRIX RMF blocks? We have a decision on how to handle this - do we extend `DataRMF` or do we handle this within the multiple-response instrument code? When extending `DataRMF` we have

- [+] it should be seamless to the user (e.g. no difference to using a "normal" RMF)
- [-] this overloads the meaning of the `DataRMF` fields and subverts OO methodology - e.g. https://en.wikipedia.org/wiki/Liskov_substitution_principle
  - I will note we have existing code that does this already, so this is not new 
 
Using the multiple-response code might be nice, but I do not understand that code so I have gone with this version for now. I will note that in issue #1907 I talk about problems we have associating a model with the grid that was used to create it, and I think it's all related.

I have therefore opted to add a `DataMultiRMF` class that extends `DataRMF` since I think the ease-of-use argument is very important. I am slapping on a "this is experimental" notice so we can change it if we find this ends up not working well.

# Issues

One issue is that we only have the spec documentation. There aren't really any files lying around with real data (maybe from XRISM?) which makes testing this out and checking it works properly a bit awkward.

You can not write out a multi-matrix RMF (via `write_rmf`). This should be fixable.

The "representation" of a multi-matrix RMF hides all but the first block - e.g. print(rmf) - which is not ideal. This should be fixable. I think the new `plot_rmf` command should work but I can not be sure.

In part because we have some strange non-OGIP cases (#1871) and in part because of the existing API (#1907) I am not 100% convinced there aren't bugs hiding here.

The new RMF does not do any of the fancy "ignore/notice" handling that `DataRMF` does. I should have this "disabled", but I did mention the issue of hidden bugs, didn't I?

