### PR TITLE
Better error checks for table loads

### DIFF
--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -2039,6 +2039,22 @@ class TableModel(ArithmeticModel):
             val = numpy.asarray(val)
             if val.ndim != 1:
                 raise ModelErr("Array must be 1D or None")
+
+            # Check we can add 0 to the values. This is to try and
+            # catch cases when a string column is passed to load. It
+            # will not catch all possible problem cases. An
+            # alternative would be to check
+            #    isinstance(val[0], numbers.Number)
+            # but it's not clear which is best.
+            #
+            # We could also check whether values are np.isfinite() but
+            # users may want to read in bad values that we then always
+            # mask out.
+            #
+            try:
+                val + 0
+            except Exception:
+                raise ModelErr(f"Unable to treat array as numeric: {val}") from None
 
             return val
 

--- a/sherpa/models/tests/test_basic.py
+++ b/sherpa/models/tests/test_basic.py
@@ -252,7 +252,6 @@ def test_polynom2d_guess_y0():
         check(par, 0)
 
 
-@pytest.mark.xfail
 def test_tablemodel_invalid_x():
     """We error out if X is invalid."""
 
@@ -262,7 +261,6 @@ def test_tablemodel_invalid_x():
         tbl.load([1, 2, "x"], [3, 4, 5])
 
 
-@pytest.mark.xfail
 def test_tablemodel_invalid_y():
     """We error out if y is invalid."""
 

--- a/sherpa/models/tests/test_basic.py
+++ b/sherpa/models/tests/test_basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2016, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -22,10 +22,11 @@ import numpy as np
 
 import pytest
 
-import sherpa.models.basic as basic
+from sherpa.models import basic
 from sherpa.models.parameter import hugeval
 from sherpa.models.model import ArithmeticModel, RegriddableModel1D, \
     RegriddableModel2D
+from sherpa.utils.err import ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
 
 
@@ -249,3 +250,23 @@ def test_polynom2d_guess_y0():
 
     for par in mdl.pars:
         check(par, 0)
+
+
+@pytest.mark.xfail
+def test_tablemodel_invalid_x():
+    """We error out if X is invalid."""
+
+    tbl = basic.TableModel()
+    with pytest.raises(ModelErr,
+                       match="Unable to treat array as numeric"):
+        tbl.load([1, 2, "x"], [3, 4, 5])
+
+
+@pytest.mark.xfail
+def test_tablemodel_invalid_y():
+    """We error out if y is invalid."""
+
+    tbl = basic.TableModel()
+    with pytest.raises(ModelErr,
+                       match="Unable to treat array as numeric"):
+        tbl.load([3, 4, 5], [1, 2, "x"])


### PR DESCRIPTION
# Summary

Insure that table models are sent numeric columns, to catch cases like #1943.

# Details

This is a minimal check that catches problems like #143 but does not guarantee to catch all cases, because this is Python and it is actually hard to catch all "hey, is this ndarray actually numeric or not" cases. So I just want to catch the obvious cases, which covers the problem seen in #1943.

I explicitly don't check for the values passing the `numpy.isfinite` case since I can imagine use cases where we want to read in an exposure map as a table model and some of it is set to NaN (or Inf) but we then use a spatial filter to ignore these bins. 