### PR TITLE
Ensure tests can be run when the group library does not exist

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2017, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2015, 2017, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1157,7 +1157,7 @@ def test_grouping_filter(analysis, make_data_path):
     pha.group_width(50, tabStops=[0] * 1024)
     dep = np.array([213, 136,  79,  47,  47,  29,  27, 18])
     assert pha.get_dep(filter=True) == pytest.approx(dep)
-    
+
     qual = np.zeros(1024, dtype=int)
     qual[1000:1024] = 2
     assert pha.quality == pytest.approx(qual)
@@ -3770,6 +3770,7 @@ def test_pha_checks_background_size_is_set_bkg():
         pha.set_background(bkg)
 
 
+@requires_group
 def test_pha_group_xxx_with_background(caplog):
     """Do we get any warning from the background?
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1832,6 +1832,7 @@ def test_pha_quality_bad_filter_remove(make_test_pha):
     assert pha.get_filter() == "2:4"
 
 
+@requires_group
 def test_pha_change_quality_values():
     """What happens if we change the quality column?
 
@@ -3999,6 +4000,7 @@ def test_pha_subtract_bkg_filter_cih2datavar():
     assert got == pytest.approx(expected)
 
 
+@requires_group
 @pytest.mark.parametrize("opt,arg",
                          [("bins", 2), ("width", 2),
                           ("counts", 3), ("adapt", 3),
@@ -4397,6 +4399,7 @@ def test_img_checks_coord_no_transform(coord):
                 coord=coord)
 
 
+@requires_group
 @pytest.mark.parametrize("asarray", [True, False])
 def test_group_xxx_tabtops_not_ndarray(asarray):
     """What happens if tabStops is not a ndarray?"""
@@ -4414,6 +4417,7 @@ def test_group_xxx_tabtops_not_ndarray(asarray):
     assert pha.get_mask() is None
 
 
+@requires_group
 @pytest.mark.parametrize("asarray", [True, False])
 @pytest.mark.parametrize("nelem", [4, 6])
 def test_group_xxx_tabtops_wrong_size(asarray, nelem):
@@ -4429,6 +4433,7 @@ def test_group_xxx_tabtops_wrong_size(asarray, nelem):
         pha.group_width(2, tabStops=tabstops)
 
 
+@requires_group
 def test_group_xxx_tabstops_already_grouped():
     """Check what happens if tabStops is sent ~pha.mask when already grouped."""
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -2100,6 +2100,7 @@ def test_fit_bkg_with_bkg_models_missing(clean_astro_ui):
     assert fres.parvals == pytest.approx([15])
 
 
+@requires_group
 @requires_data
 @requires_fits
 def test_get_bkg_stat_info(make_data_path, clean_astro_ui, caplog):

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2021, 2022, 2023
+#  Copyright (C) 2015, 2016, 2018, 2021 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,7 +30,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import ARF1D, RMF1D
 from sherpa.utils.err import ArgumentErr
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec
+    requires_group, requires_xspec
 
 
 FILE_NAME = 'acisf01575_001N001_r0085_pha3.fits'
@@ -136,7 +136,10 @@ def test_hrci_imaging_mode_spectrum(make_data_path, clean_astro_ui):
 
 
 def check_fit_stats():
-    """Do we get the expected results?"""
+    """Do we get the expected results?
+
+    Use of this means @requires_xspec, @requires_group
+    """
 
     ui.set_method("levmar")
     ui.set_stat("chi2xspecvar")
@@ -173,6 +176,7 @@ def check_fit_stats():
 
 
 @requires_xspec
+@requires_group
 @requires_fits
 @requires_data
 def test_pha3_original_check(make_data_path, clean_astro_ui):
@@ -188,6 +192,7 @@ def test_pha3_original_check(make_data_path, clean_astro_ui):
 
 
 @requires_xspec
+@requires_group
 @requires_fits
 @requires_data
 def test_pha3_roundtrip_check(make_data_path, clean_astro_ui, tmp_path):

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2021, 2022, 2023
+#  Copyright (C) 2016, 2018, 2021 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -35,7 +35,7 @@ from sherpa.astro import ui
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec
+    requires_group, requires_xspec
 
 
 # Note that the logic in load_table_model is quite convoluted,
@@ -289,6 +289,7 @@ def test_group_counts_empty_data(arg, clean_astro_ui):
         ui.group_counts(2, tabStops="nofilter")
 
 
+@requires_group
 @pytest.mark.parametrize("tabstops", ["nofilter", [0] * 6])
 def test_group_width_tabstops_nofilter(tabstops, clean_astro_ui):
     """Check tabStops='nofilter'.
@@ -308,6 +309,7 @@ def test_group_width_tabstops_nofilter(tabstops, clean_astro_ui):
     assert d.quality == pytest.approx(np.zeros(6))
 
 
+@requires_group
 def test_group_width_tabstops_notset(clean_astro_ui):
     """Check tabStops 4.16.0 behavior.
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018, 2019, 2020, 2021, 2023
+#  Copyright (C) 2015, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -3114,6 +3114,7 @@ def test_restore_load_arrays_simple():
     assert ui.get_dep("f") == pytest.approx([-2e4, 3e5])
 
 
+@requires_group
 def test_restore_load_arrays_pha():
     """Can we re-create a load_arrays/DataPHA case?"""
 
@@ -3568,6 +3569,7 @@ def test_restore_pha2(make_data_path):
 
 
 @requires_data
+@requires_group
 @requires_fits
 @requires_xspec
 def test_restore_pha_csc(make_data_path):

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018 - 2024
+#  Copyright (C) 2015, 2016, 2018 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #


### PR DESCRIPTION
# Summary

Annotate several tests with the requires_group decorator.

# Details

Update to catch a few tests that need the requires_group decorator. We could add a CI run to catch these but it's not obvious it's worth it (although maybe we should update one of the "basic" pip tests). I wanted to get this done to make it easier to test upgrading to meson or some other build system (although it lools like this won't be needed).

I validated this with the following build change (it also checks we skip those tests that require the stk module, but they are already covered by requires_stk calls, as there's only a few of them):

```
% git diff -u helpers/sherpa_config.py
diff --git a/helpers/sherpa_config.py b/helpers/sherpa_config.py
index f1efbf2b..56856815 100644
--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -76,6 +76,9 @@ class sherpa_config(Command):
         self.stk_location = None
         self.disable_stk = False
 
+        self.disable_group = True
+        self.disable_stk = True
+
     def finalize_options(self):
         incdir = os.path.join(self.install_dir, 'include')
         libdir = os.path.join(self.install_dir, 'lib')
```