### PR TITLE
Tests: better support of optional region/wcs dependencies

### DIFF
--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,7 +25,8 @@ import pytest
 from sherpa.astro.data import DataIMG, Data2D
 from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_region, requires_wcs
 
 
 def backend_is(name):
@@ -147,6 +148,7 @@ def test_image_write_basic(make_data_path, tmp_path):
 
 @requires_fits
 @requires_data
+@requires_wcs  # only needed for physical and world
 @pytest.mark.parametrize("incoord,outcoord,x0,x1",
                          [("logical", None, 1, 1),
                           ("image", "logical", 1, 1),
@@ -189,6 +191,8 @@ def test_can_read_image_as_data2d(make_data_path):
 
 
 @requires_fits
+@requires_region
+@requires_wcs
 def test_axs_ordering(tmp_path):
     """Check out the #1789 #1880 behavior.
 
@@ -222,6 +226,8 @@ def test_axs_ordering(tmp_path):
 
 
 @requires_fits
+@requires_region
+@requires_wcs
 def test_axs_ordering_1880(tmp_path):
     """Check out the #1880 behavior.
 

--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2008, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2008, 2020, 2021, 2024
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,10 +18,24 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import logging
+
 import numpy
 
 from sherpa.utils import NoNewAttributesAfterInit
-from sherpa.astro.utils._wcs import pix2world, world2pix
+
+warning = logging.getLogger(__name__).warning
+
+try:
+    from sherpa.astro.utils._wcs import pix2world, world2pix
+except ImportError:
+    warning('WCS support is not available')
+
+    def pix2world(*args, **kwargs):
+        raise RuntimeError("No WCS support")
+
+    def world2pix(*args, **kwargs):
+        raise RuntimeError("No WCS support")
 
 
 class WCS(NoNewAttributesAfterInit):

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2023
+#  Copyright (C) 2007, 2015 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,11 +25,12 @@ from numpy import sqrt
 from pytest import approx
 import pytest
 
-from sherpa.utils.parallel import ncpus
-from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec, requires_group
 from sherpa.astro import ui
 from sherpa.astro.data import DataPHA
+
+from sherpa.utils.parallel import ncpus
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_xspec, requires_group, requires_region, requires_wcs
 
 try:
     from sherpa.astro import xspec
@@ -225,6 +226,8 @@ def test_sourceandbg(parallel, run_thread, fix_xspec):
 
 @requires_data
 @requires_fits
+@requires_region
+@requires_wcs
 def test_spatial(run_thread, clean_astro_ui):
     tlocals = run_thread('spatial')
     g1 = tlocals['g1']
@@ -287,6 +290,7 @@ def test_radpro_dm(run_thread, clean_astro_ui):
 
 @requires_data
 @requires_fits
+@requires_region
 def test_psf2d(run_thread, clean_astro_ui):
     tlocals = run_thread('psf')
     g1 = tlocals['g1']
@@ -305,6 +309,7 @@ def test_psf2d(run_thread, clean_astro_ui):
 
 @requires_data
 @requires_fits
+@requires_region
 def test_fpsf2d(run_thread, clean_astro_ui):
     tlocals = run_thread('fpsf')
 
@@ -566,6 +571,8 @@ def test_stats_all(run_thread, fix_xspec):
 
 @requires_data
 @requires_fits
+@requires_region
+@requires_wcs
 def test_lev3fft(run_thread, clean_astro_ui):
     tlocals = run_thread('lev3fft', scriptname='bar.py')
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -32,7 +32,8 @@ from sherpa.models.basic import Gauss2D
 from sherpa.utils import parse_expr
 from sherpa.utils.err import ArgumentTypeErr, DataErr
 from sherpa.utils.numeric_types import SherpaFloat
-from sherpa.utils.testing import requires_data, requires_fits, requires_group
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group, requires_region
 
 
 EMPTY_DATA_OBJECTS = [(DataPHA, [None] * 2),
@@ -2704,6 +2705,7 @@ def test_is_mask_reset_pha_channel(caplog):
     assert data.mask == pytest.approx([False, False, True])
 
 
+@requires_region
 @pytest.mark.parametrize("data_args",
                          [IMG_ARGS, IMGINT_ARGS])
 def test_is_mask_reset_img(data_args, caplog):
@@ -3455,6 +3457,7 @@ def get_img_spatial_mask():
                       dtype=bool)
 
 
+@requires_region
 def test_img_spatial_filter():
     """This is really meant to check some of the assumptions of the
     next test: test_img_combine_spatial_filter_and_mask():
@@ -3494,6 +3497,7 @@ def test_img_spatial_filter():
     assert got[mask] == pytest.approx(yimg[mask])
 
 
+@requires_region
 def test_img_combine_spatial_filter_and_mask():
     """What happens when we have both a spatial filter and change the mask attribute?"""
 
@@ -3630,6 +3634,7 @@ def test_image_sparse_get_img(make_image_sparse):
         make_image_sparse.get_img()
 
 
+@requires_region
 def test_image_sparse_region_filter(make_image_sparse):
     """Pick a region that overlaps the missing pixel"""
 
@@ -3648,6 +3653,7 @@ def test_image_sparse_region_filter(make_image_sparse):
     assert out == pytest.approx([6])
 
 
+@requires_region
 def test_image_sparse_region_filter_restore(make_image_sparse):
     """Check we can restore the region"""
 
@@ -3667,6 +3673,7 @@ def test_image_sparse_region_filter_restore(make_image_sparse):
     assert out == pytest.approx([1, 2, 3, 4, 6])
 
 
+@requires_region
 def test_image_sparse_region_filter_out_all(make_image_sparse):
     """Pick a region that removes all points"""
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -33,14 +33,14 @@ from sherpa.astro.data import DataARF, DataIMG, DataIMGInt, DataPHA, DataRMF
 from sherpa.astro.instrument import create_delta_rmf
 from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
-from sherpa.astro.utils._region import Region
 from sherpa.data import Data2D, Data2DInt
 from sherpa.models import Delta2D, Polynom2D
 from sherpa.plot import backend
 from sherpa.stats._statfcts import calc_chi2datavar_errors
 from sherpa.utils import dataspace2d
 from sherpa.utils.err import DataErr
-from sherpa.utils.testing import requires_data, requires_fits, requires_group
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_group, requires_region, requires_wcs
 
 
 def test_can_not_group_ungrouped():
@@ -702,6 +702,7 @@ def test_img_get_img_filter_none1(make_test_image):
     assert ival == pytest.approx(expected)
 
 
+@requires_region
 def test_img_get_img_filter_none2(make_test_image):
     """get_img when all the data has been filtered: mask is array of False"""
 
@@ -718,6 +719,7 @@ def test_img_get_img_filter_none2(make_test_image):
     assert not np.any(np.isfinite(ival))
 
 
+@requires_region
 def test_img_get_img_filter_some(make_test_image):
     """get_img when some of the data has been filtered.
 
@@ -828,6 +830,7 @@ def test_img_get_img_model_filter_none1(make_test_image):
         img.get_img(image_callable)
 
 
+@requires_region
 def test_img_get_img_model_filter_none2(make_test_image):
     """See test_img_get_img_filter_none2. Issue #1447"""
 
@@ -843,6 +846,7 @@ def test_img_get_img_model_filter_none2(make_test_image):
     assert not np.any(np.isfinite(mval))
 
 
+@requires_region
 def test_img_get_img_model_filter_some(make_test_image):
     """get_img with a callable and having a filter"""
 
@@ -876,6 +880,7 @@ def test_img_get_img_model_filter_some(make_test_image):
     assert mval[good] == pytest.approx(expected2[good])
 
 
+@requires_region
 def test_img_get_img_model_filter_some2(make_test_image):
     """test_img_get_img_model_filter_some but with a non-rectangular filter
 
@@ -1012,6 +1017,7 @@ def read_test_image(make_data_path):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord,expected',
                          [('logical', 'logical'),
                           ('image', 'logical'),
@@ -1028,6 +1034,7 @@ def test_img_file_set_coord(coord, expected, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord', ['logical', 'image', 'physical', 'world', 'wcs'])
 def test_img_file_get_logical(coord, read_test_image):
     """get_logical when coord is set"""
@@ -1045,6 +1052,7 @@ def test_img_file_get_logical(coord, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord', ['logical', 'image', 'physical', 'world', 'wcs'])
 def test_img_file_get_physical(coord, read_test_image):
     """get_physical when coord is set"""
@@ -1062,6 +1070,7 @@ def test_img_file_get_physical(coord, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord', ['logical', 'image', 'physical', 'world', 'wcs'])
 def test_img_file_get_world(coord, read_test_image):
     """get_world when coord is set"""
@@ -1116,6 +1125,7 @@ def test_img_file_get_axes_logical(coord, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord', ['physical'])
 def test_img_file_get_axes_physical(coord, read_test_image):
     """get_axes when coord is set: physical"""
@@ -1129,6 +1139,7 @@ def test_img_file_get_axes_physical(coord, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord', ['world', 'wcs'])
 def test_img_file_get_axes_world(coord, read_test_image):
     """get_axes when coord is set: world"""
@@ -1149,6 +1160,7 @@ def test_img_file_get_axes_world(coord, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord,expected',
                          [('logical', 'x0'),
                           ('image', 'x0'),
@@ -1164,6 +1176,7 @@ def test_img_file_get_xlabel(coord, expected, read_test_image):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize('coord,expected',
                          [('logical', 'x1'),
                           ('image', 'x1'),
@@ -1196,6 +1209,7 @@ def test_img_get_bounding_mask_nodata(make_test_image):
     assert ans[1] is None
 
 
+@requires_region
 def test_img_get_bounding_mask_filtered(make_test_image):
     """get_bounding_mask with data partially filtered"""
     d = make_test_image
@@ -1212,6 +1226,7 @@ def test_img_get_bounding_mask_filtered(make_test_image):
     assert ans[1] == (5, 7)
 
 
+@requires_region
 def test_img_get_filter(make_test_image):
     """Simple get_filter check on an image."""
     d = make_test_image
@@ -1222,6 +1237,7 @@ def test_img_get_filter(make_test_image):
     assert d.get_filter() == shape.capitalize()
 
 
+@requires_region
 def test_img_get_filter_exclude(make_test_image):
     """Simple get_filter check on an image."""
     d = make_test_image
@@ -1234,6 +1250,7 @@ def test_img_get_filter_exclude(make_test_image):
     assert d.get_filter() == expected
 
 
+@requires_region
 def test_img_get_filter_none(make_test_image):
     """Simple get_filter check on an image: no data"""
     d = make_test_image
@@ -1246,6 +1263,7 @@ def test_img_get_filter_none(make_test_image):
     assert d.get_filter() == ''
 
 
+@requires_region
 def test_img_get_filter_combined(make_test_image):
     """Simple get_filter check on an image."""
     d = make_test_image
@@ -1262,6 +1280,7 @@ def test_img_get_filter_combined(make_test_image):
     assert d.get_filter() == shape
 
 
+@requires_region
 def test_img_get_filter_excluded(make_test_image):
     """Simple get_filter check on an image."""
     d = make_test_image
@@ -1279,7 +1298,12 @@ def test_img_get_filter_excluded(make_test_image):
 
 
 def check_ignore_ignore(d):
-    """Check removing the shapes works as expected."""
+    """Check removing the shapes works as expected.
+
+    Tests must use requires_region
+    """
+
+    from sherpa.astro.utils._region import Region
 
     shape1 = 'ellipse(4260,3840,3,2,0)'
     d.notice2d(shape1, ignore=True)
@@ -1301,6 +1325,7 @@ def check_ignore_ignore(d):
     assert d.get_filter() == expected
 
 
+@requires_region
 def test_img_get_filter_included_excluded(make_test_image):
     """Simple get_filter check on an image.
 
@@ -1310,6 +1335,7 @@ def test_img_get_filter_included_excluded(make_test_image):
     check_ignore_ignore(d)
 
 
+@requires_region
 def test_img_get_filter_excluded_excluded(make_test_image):
     """Simple get_filter check on an image.
 
@@ -1347,6 +1373,7 @@ def test_img_get_filter_excluded_excluded(make_test_image):
     check_ignore_ignore(d)
 
 
+@requires_region
 def test_img_get_filter_compare_filtering(make_test_image):
     """Check calling notice2d(ignore=True) with 2 shapes is same as once.
 
@@ -2661,6 +2688,7 @@ def test_pickle_image_filter_none(make_test_image):
     assert d2._region is None
 
 
+@requires_region
 @pytest.mark.parametrize("ignore,region,expected",
                          [(False, 'circle(4255, 3840, 20)', 'Circle(4255,3840,20)'),
                           (True, 'circle(4255, 3840, 20)', 'Field()&!Circle(4255,3840,20)'),
@@ -2668,13 +2696,9 @@ def test_pickle_image_filter_none(make_test_image):
                           (True, 'circle(4255, 3840, 20) - field()', 'Field()&!Circle(4255,3840,20)|Field()'),
                           ])
 def test_pickle_image_filter(ignore, region, expected, make_test_image):
-    """Check we can pickle/unpickle with a region filter.
+    """Check we can pickle/unpickle with a region filter."""
 
-    This test assumes we have region support, but we do not
-    currently have any test builds without it so do not
-    bother skipping.
-
-    """
+    from sherpa.astro.utils._region import Region
 
     d = make_test_image
     d.notice2d(region, ignore=ignore)
@@ -2739,6 +2763,7 @@ def test_img_world_show(make_test_image_world):
     assert len(out) == 16
 
 
+@requires_wcs
 def test_img_sky_pickle(make_test_image_sky):
     """Very basic test of pickling"""
     d = make_test_image_sky
@@ -2758,6 +2783,7 @@ def test_img_sky_pickle(make_test_image_sky):
     assert (d2.x1 == d.x1).all()
 
 
+@requires_wcs
 def test_img_world_pickle(make_test_image_world):
     """Very basic test of pickling"""
     d = make_test_image_world
@@ -2777,6 +2803,7 @@ def test_img_world_pickle(make_test_image_world):
     assert (d2.x1 == d.x1).all()
 
 
+@requires_wcs  # not for all, but easiest this way
 @pytest.mark.parametrize("path", [[],
                                   ["logical"],
                                   ["physical", "logical", "physical", "logical", "physical", "logical"]])
@@ -2791,6 +2818,7 @@ def test_img_sky_logical(path, make_test_image_sky):
     assert (d.x1 == x1.flatten()).all()
 
 
+@requires_wcs  # not for all, but easiest this way
 @pytest.mark.parametrize("path", [[],
                                   ["logical"],
                                   ["world", "logical", "world", "logical", "world", "logical"]])
@@ -2805,6 +2833,7 @@ def test_img_world_logical(path, make_test_image_world):
     assert (d.x1 == x1.flatten()).all()
 
 
+@requires_wcs
 @pytest.mark.parametrize("path", [[],
                                   ["physical"],
                                   ["logical", "physical", "logical", "physical", "logical"]])
@@ -2839,6 +2868,7 @@ def test_img_sky_world(make_test_image_sky):
         d.set_coord("world")
 
 
+@requires_wcs
 @pytest.mark.parametrize("path", [[],
                                   ["logical"],
                                   ["world", "logical", "world", "logical", "world", "logical"]])
@@ -2853,6 +2883,7 @@ def test_img_world_world(path, make_test_image_world):
     assert d.x1 == pytest.approx(WORLD_X1)
 
 
+@requires_wcs
 @pytest.mark.parametrize("path", [[],
                                   ["physical"],
                                   ["logical", "physical", "logical", "physical"]])
@@ -2868,6 +2899,7 @@ def test_img_sky_get_logical(path, make_test_image_sky):
     assert (b == x1.flatten()).all()
 
 
+@requires_wcs
 @pytest.mark.parametrize("path", [[],
                                   ["world"],
                                   ["logical", "world", "logical", "world"]])
@@ -2883,6 +2915,7 @@ def test_img_world_get_logical(path, make_test_image_world):
     assert (b == x1.flatten()).all()
 
 
+@requires_wcs
 @pytest.mark.parametrize("path", [[],
                                   ["logical"],
                                   ["physical", "logical", "physical", "logical", "physical", "logical"]])
@@ -2917,6 +2950,7 @@ def test_img_sky_get_world(make_test_image_sky):
         d.get_world()
 
 
+@requires_wcs
 @pytest.mark.parametrize("path", [[],
                                   ["logical"],
                                   ["world", "logical", "world", "logical"]])
@@ -2931,6 +2965,8 @@ def test_img_world_get_world(path, make_test_image_world):
     assert b == pytest.approx(WORLD_X1)
 
 
+@requires_wcs
+@requires_region
 def test_img_sky_can_filter(make_test_image_sky):
     """Check we can filter the image using physical coordinates"""
     data = make_test_image_sky
@@ -2948,6 +2984,8 @@ def test_img_sky_can_filter(make_test_image_sky):
     assert data.get_filter() == "Field()&!Rectangle(2009,-5006,2011,-5000)"
 
 
+@requires_wcs
+@requires_region
 def test_img_sky_can_filter_change_coords(make_test_image_sky, caplog):
     """What happens to a filter after changing coordinates?
 
@@ -3441,6 +3479,7 @@ def test_dataimgint_notice_get_y(make_dataimgint):
     assert (img.get_y(True) == np.asarray([10])).all()
 
 
+@requires_region
 def test_dataimgint_notice2d(make_dataimgint):
     """basic notice2d call.
 
@@ -3453,6 +3492,7 @@ def test_dataimgint_notice2d(make_dataimgint):
     assert (img.mask == np.asarray([True, False])).all()
 
 
+@requires_region
 def test_dataimgint_ignore2d(make_dataimgint):
     """basic ignore2d call.
 
@@ -3464,18 +3504,21 @@ def test_dataimgint_ignore2d(make_dataimgint):
     assert (img.mask == np.asarray([False, True])).all()
 
 
+@requires_region
 def test_dataimgint_notice2d_get_filter(make_dataimgint):
     img = make_dataimgint
     img.notice2d("rect(-100, 10, 100, 11)")
     assert img.get_filter() == 'Rectangle(-100,10,100,11)'
 
 
+@requires_region
 def test_dataimgint_notice2d_get_filter_expr(make_dataimgint):
     img = make_dataimgint
     img.notice2d("rect(-100, 10, 100, 11)")
     assert img.get_filter_expr() == 'Rectangle(-100,10,100,11)'
 
 
+@requires_region
 def test_dataimgint_notice2d_get_x0(make_dataimgint):
     """basic notice2d call + get_x0"""
     img = make_dataimgint
@@ -3484,6 +3527,7 @@ def test_dataimgint_notice2d_get_x0(make_dataimgint):
     assert (img.get_x0(True) == np.asarray([-4.5])).all()
 
 
+@requires_region
 def test_dataimgint_notice2d_get_x1(make_dataimgint):
     """basic notice2d call + get_x1"""
     img = make_dataimgint
@@ -3492,6 +3536,7 @@ def test_dataimgint_notice2d_get_x1(make_dataimgint):
     assert (img.get_x1(True) == np.asarray([10.5])).all()
 
 
+@requires_region
 def test_dataimgint_notice2d_get_y(make_dataimgint):
     """basic notice2d call + get_y"""
     img = make_dataimgint
@@ -3583,6 +3628,7 @@ def test_dataimgint_no_sky(make_dataimgint):
         make_dataimgint.get_physical()
 
 
+@requires_wcs
 def test_dataimgint_sky(make_dataimgint):
     """We can convert coordinates.
 
@@ -3634,6 +3680,7 @@ def test_dataimgint_sky_coords_unchanged(make_dataimgint):
     assert img.get_x1() == pytest.approx(x)
 
 
+@requires_wcs
 def test_dataimgint_set_sky(make_dataimgint):
     """We can change to the SKY coordinate system"""
 
@@ -3648,6 +3695,7 @@ def test_dataimgint_set_sky(make_dataimgint):
     assert img.coord == "physical"
 
 
+@requires_wcs
 def test_dataimgint_set_sky_x0hi(make_dataimgint):
     """x0hi is changed
 
@@ -3666,6 +3714,7 @@ def test_dataimgint_set_sky_x0hi(make_dataimgint):
     assert img.x0hi == pytest.approx(x)
 
 
+@requires_wcs
 def test_dataimgint_set_sky_get_x1(make_dataimgint):
     """get_x1 is changed
 
@@ -3684,6 +3733,7 @@ def test_dataimgint_set_sky_get_x1(make_dataimgint):
     assert img.get_x1() == pytest.approx(x)
 
 
+@requires_wcs
 def test_dataimgint_sky_coords_reset(make_dataimgint):
     """We can get back to the logical units
 
@@ -3791,6 +3841,7 @@ def test_1379_evaluation_model_not_integrated(dclass):
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize("coord", ["logical", "image", "physical", "world", "wcs"])
 def test_1380_data(coord, make_data_path):
     """The contour data should ideally remain the same.
@@ -3829,6 +3880,7 @@ def test_1380_data(coord, make_data_path):
 
 @requires_fits
 @requires_data
+@requires_wcs
 def test_1380_pickle(make_data_path):
     """Can we pickle and restore an image?
 
@@ -4453,6 +4505,8 @@ def test_group_xxx_tabstops_already_grouped():
     assert pha.get_y(filter=True) == pytest.approx([12, 9, 3])
 
 
+@requires_wcs
+@requires_region
 def test_dataimg_axis_ordering():
     """What are the x0/x1 axes meant to be?
 
@@ -4482,6 +4536,8 @@ def test_dataimg_axis_ordering():
     assert a1 == pytest.approx([200, 200, 200, 210, 210, 210])
 
 
+@requires_wcs
+@requires_region
 def test_dataimg_axis_ordering_1880():
     """What are the x0/x1 axes meant to be? See issues #1789 #1880
 

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020, 2021, 2022, 2023
+# Copyright (C) 2020 - 2024
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -31,7 +31,8 @@ import pytest
 from sherpa.astro import data
 from sherpa import plot
 from sherpa.astro.instrument import create_delta_rmf
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_region, requires_wcs
 from sherpa.plot.testing import check_full
 
 
@@ -251,6 +252,7 @@ def test_img(header, old_numpy_printing, all_plot_backends):
 
 @requires_data
 @requires_fits
+@requires_wcs  # only needed for coord=physical
 @pytest.mark.parametrize('coord', ['logical', 'physical'])
 def test_img_real(coord, make_data_path, old_numpy_printing, all_plot_backends):
     """Use an image from a file (easy to set up)"""
@@ -273,9 +275,10 @@ def test_img_real(coord, make_data_path, old_numpy_printing, all_plot_backends):
     assert '<div class="dataval">destreak - CAT3.0.2</div>' in r
 
 
-# does this needs a decorator if region support is not available?
 @requires_data
 @requires_fits
+@requires_region
+@requires_wcs
 @pytest.mark.parametrize("coord,region",
                          [("logical", "circle(90, 190, 20)"),
                           ("physical", "circle(3151.3 , 4524.1, 20 )")

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -48,7 +48,7 @@ from sherpa.models.template import create_template_model
 
 from sherpa.utils.err import ArgumentTypeErr, DataErr, IdentifierErr, ModelErr, PlotErr
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec, requires_pylab
+    requires_xspec, requires_pylab, requires_wcs
 
 import sherpa.ui.utils
 import sherpa.astro.ui.utils
@@ -4405,6 +4405,7 @@ def test_pha_model_plot_filter_range_1024_false(mask, expected, make_data_path,
 
 @requires_fits
 @requires_data
+@requires_wcs
 @pytest.mark.parametrize("coord", ["logical", "image", "physical", "world", "wcs"])
 def test_1380_plot(coord, make_data_path, clean_astro_ui):
     """The contour data should ideally remain the same.

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2017, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -42,7 +42,8 @@ import sherpa.models.basic
 from sherpa.utils import poisson_noise
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, IOErr, ModelErr, StatErr
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_region, requires_wcs
 
 
 def backend_is(name):
@@ -2290,6 +2291,8 @@ def test_pha_what_does_get_dep_return_when_grouped(clean_astro_ui, caplog):
 
 @requires_fits
 @requires_data
+@requires_region
+@requires_wcs
 def test_image_filter_coord_change_same(make_data_path, clean_astro_ui, caplog):
     """What happens to the mask after a coordinate change? NO CHANGE
 
@@ -2335,6 +2338,8 @@ def test_image_filter_coord_change_same(make_data_path, clean_astro_ui, caplog):
 
 @requires_fits
 @requires_data
+@requires_region
+@requires_wcs
 def test_image_filter_coord_change(make_data_path, clean_astro_ui, caplog):
     """What happens to the mask after a coordinate change?
 
@@ -2389,6 +2394,8 @@ def test_image_filter_coord_change(make_data_path, clean_astro_ui, caplog):
 
 @requires_fits
 @requires_data
+@requires_region
+@requires_wcs
 def test_image_filter_coord_change_same_negate(make_data_path, clean_astro_ui, caplog):
     """A ignore2d case of test_image_filter_coord_change_same
 
@@ -2429,6 +2436,8 @@ def test_image_filter_coord_change_same_negate(make_data_path, clean_astro_ui, c
 
 @requires_fits
 @requires_data
+@requires_region
+@requires_wcs
 def test_image_filter_coord_change_negate(make_data_path, clean_astro_ui, caplog):
     """negate the filter used in test_image_filter_coord_change
 
@@ -3166,6 +3175,7 @@ def test_set_bkg_not_a_background(clean_astro_ui):
 
 @requires_fits
 @requires_data
+@requires_wcs  # only needed for physical / world
 @pytest.mark.parametrize("incoord,outcoord,x0,x1",
                          [("logical", None, 1, 1),
                           ("image", "logical", 1, 1),

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2021, 2022
+#  Copyright (C) 2017, 2018, 2021, 2022, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -33,7 +33,8 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.data import Data1DInt, Data2D
 from sherpa.ui.utils import Session
 from sherpa.utils.logging import SherpaVerbosity
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_region
 
 
 def setup_model(make_data_path):
@@ -621,6 +622,7 @@ def test_notice_reporting_data2d(session, caplog):
     assert s.get_filter() == ""
 
 
+@requires_region
 def test_notice2d_reporting(caplog):
     """Check handling of notice2d/ignore2d/... reports"""
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -33,12 +33,15 @@ import pytest
 
 from sherpa.astro.models import JDPileup
 from sherpa.astro import ui
+from sherpa.astro.io.wcs import WCS
+
 from sherpa.models.basic import TableModel
 
 from sherpa.utils.err import ArgumentErr, DataErr, \
     IdentifierErr, IOErr, StatErr
 from sherpa.utils.testing import get_datadir, requires_data, \
-    requires_xspec, has_package_from_list, requires_fits, requires_group
+    requires_xspec, has_package_from_list, requires_fits, \
+    requires_group, requires_region, requires_wcs
 
 
 has_xspec = has_package_from_list("sherpa.astro.xspec")
@@ -2867,6 +2870,7 @@ def test_restore_img_no_filter_no_model(make_data_path):
 
 @requires_data
 @requires_fits
+@requires_region
 def test_restore_img_filter_model(make_data_path):
     """Simple image check"""
 
@@ -3073,6 +3077,7 @@ def test_restore_dataspace1d_int():
     assert ui.get_dep(filter=True) == pytest.approx(expected)
 
 
+@requires_region
 def test_restore_dataspace2d_img():
     """Can we restore a dataspace2d case?"""
 
@@ -3690,6 +3695,7 @@ def test_filter2d_excluded1():
     assert len(ui.get_data().shape) == 2
 
 
+@requires_region
 def test_filter2d_excluded2():
     """Check what happens if all data filtered out.
 
@@ -3710,13 +3716,9 @@ def test_filter2d_excluded2():
         ui.get_dep(filter=True)
 
 
+@requires_wcs
 def test_fake_image_wcs():
     """Can we restore an image with WCS?"""
-
-    try:
-        from sherpa.astro.io.wcs import WCS
-    except ImportError:
-        pytest.skip("sherpa.astro.io.wcs.WCS is not available")
 
     # nx=2, ny=3
     #
@@ -3754,17 +3756,14 @@ def test_fake_image_wcs():
     assert g1 == pytest.approx(x1)
 
 
+@requires_wcs
+@requires_region
 def test_fake_image_wcs_coord():
     """Can we restore an image with WCS when coord has been changed?
 
     We also add a spatial filter to check that we aren't messing
     up x0/y0.
     """
-
-    try:
-        from sherpa.astro.io.wcs import WCS
-    except ImportError:
-        pytest.skip("sherpa.astro.io.wcs.WCS is not available")
 
     # nx=3, ny=2
     #

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021, 2022
+#  Copyright (C) 2017, 2018, 2020, 2021, 2022, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,7 +30,8 @@ from sherpa.astro.utils import do_group, expand_grouped_mask, filter_resp, \
     range_overlap_1dint
 from sherpa.data import Data1D, Data1DInt, Data2D, Data2DInt
 from sherpa.utils.err import DataErr, IOErr
-from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.utils.testing import requires_data, requires_fits, \
+    requires_region
 
 
 # See https://github.com/sherpa/sherpa/issues/405
@@ -569,6 +570,7 @@ def test_calc_data_sum2d_no_range_2d(data_class):
 
 
 # XFAIL: We can not use DataIMGInt here because of issue #1379
+@requires_region
 @pytest.mark.parametrize("data_class", ["img", pytest.param("imgint", marks=pytest.mark.xfail)])
 def test_calc_data_sum2d_filtered_2d(data_class):
     """Call calc_data_sum2d(data, region)"""

--- a/sherpa/astro/utils/tests/test_region_unit.py
+++ b/sherpa/astro/utils/tests/test_region_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2020, 2021
+#  Copyright (C) 2016, 2020, 2021, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -22,7 +22,10 @@ import numpy as np
 
 import pytest
 
-from sherpa.astro.utils._region import Region
+# Allow the tests to be skipped if region support is not present.
+#
+_region = pytest.importorskip("sherpa.astro.utils._region")
+Region = _region.Region
 
 
 # Use a non-rotational shape so we can swap the

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2020, 2021, 2022, 2023
+#  Copyright (C) 2017, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -178,6 +178,14 @@ if HAS_PYTEST:
         """Decorator for test functions requiring stk library"""
         return requires_package("stk library required", 'stk')(test_function)
 
+    def requires_region(test_function):
+        """Decorator for test functions requiring 2D region support"""
+        return requires_package("Region required", 'sherpa.astro.utils._region')(test_function)
+
+    def requires_wcs(test_function):
+        """Decorator for test functions requiring WCS support"""
+        return requires_package("WCS required", 'sherpa.astro.utils._wcs')(test_function)
+
     def requires_ds9(test_function):
         """Decorator for test functions requiring ds9"""
         return requires_package('ds9 required', 'sherpa.image.ds9_backend')(test_function)
@@ -204,6 +212,10 @@ else:
     requires_group = make_fake()
 
     requires_stk = make_fake()
+
+    requires_region = make_fake()
+
+    requires_wcs = make_fake()
 
     requires_ds9 = make_fake()
 


### PR DESCRIPTION
# Summary

Ensure that the tests can pass if the region or WCS code is not available.

# Details

The idea is to allow Sherpa to be built without the region or WCS libraries. These are low-level Astronomy-specific modules so it makes sense to make them optional, but we don't currently make this easy to do so (that is, this commit does not make it easier to avoid building these two extension modules, which should probably be done, but that should only be done once we've decided how to build with Python 3.12 as that is going to be very invasive for the extension building/where this code would live).

This is mainly changes to the tests, to add decorators, but there are code changes

- addition of `requires_region` and `requires_wcs` decorators
- the `sherpa.astro.io.wcs` module has been changed to make the lack of the WCS code an option, rather than being required There are other ways to do this, but for now it's easiest to do it this way, as it depends on the long-term build changes that are planned.

This was work I did to help with converting to Python 3.12 (the `distutils` changes) but it turned out not to be necessary for that.