### PR TITLE
CI: support pytest 8.0.0

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -835,7 +835,7 @@ def test_xspec_convolutionmodel_requires_bin_edges():
     m2 = xs.XScflux()
     mdl = m2(m1)
 
-    # We get warnings from m1 evalated on the grid and then the
+    # We get warnings from m1 evaluated on the grid and then the
     # convolution model m2.
     #
     emsg1 = r'calc\(\) requires pars,rhs,lo,hi arguments, sent 3 arguments'
@@ -858,7 +858,7 @@ def test_xspec_convolutionmodel_requires_bin_edges_low_level():
     m2 = xs.XScflux()
     mdl = m2(m1)
 
-    # We get warnings from m1 evalated on the grid and then the
+    # We get warnings from m1 evaluated on the grid and then the
     # convolution model m2.
     #
     emsg1 = r'calc\(\) requires pars,rhs,lo,hi arguments, sent 3 arguments'

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016-2018, 2019, 2020, 2021, 2023
+#  Copyright (C) 2016 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -835,9 +835,14 @@ def test_xspec_convolutionmodel_requires_bin_edges():
     m2 = xs.XScflux()
     mdl = m2(m1)
 
-    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
-    with pytest.warns(FutureWarning, match=emsg):
-        mdl([0.1, 0.2, 0.3, 0.4])
+    # We get warnings from m1 evalated on the grid and then the
+    # convolution model m2.
+    #
+    emsg1 = r'calc\(\) requires pars,rhs,lo,hi arguments, sent 3 arguments'
+    emsg2 = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg1):
+        with pytest.warns(FutureWarning, match=emsg2):
+            mdl([0.1, 0.2, 0.3, 0.4])
 
 
 @requires_xspec
@@ -853,9 +858,14 @@ def test_xspec_convolutionmodel_requires_bin_edges_low_level():
     m2 = xs.XScflux()
     mdl = m2(m1)
 
-    emsg = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
-    with pytest.warns(FutureWarning, match=emsg):
-        mdl.calc([p.val for p in mdl.pars], [0.1, 0.2, 0.3, 0.4])
+    # We get warnings from m1 evalated on the grid and then the
+    # convolution model m2.
+    #
+    emsg1 = r'calc\(\) requires pars,rhs,lo,hi arguments, sent 3 arguments'
+    emsg2 = r'calc\(\) requires pars,lo,hi arguments, sent 2 arguments'
+    with pytest.warns(FutureWarning, match=emsg1):
+        with pytest.warns(FutureWarning, match=emsg2):
+            mdl.calc([p.val for p in mdl.pars], [0.1, 0.2, 0.3, 0.4])
 
 
 @requires_data


### PR DESCRIPTION
# Summary

Allow the tests to pass when run with pytest 8.0.0.

# Details

Fix #1956

These two tests created two warning messages, first from the additive model (m1) and then the convolution model (m2), but we only checked one as the other one was swallowed by pytest (since, until pytest 8, the other warning was ignored). Well, pytest 8.0.0 changes this behaviour, so fix the test.