### PR TITLE
CI: switch to macos-14 for the MacOS build

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -35,9 +35,14 @@ source ${CONDA}/etc/profile.d/conda.sh
 
 # update and add channels
 conda update --yes conda
-conda config --add channels conda-forge
-#Remove defaults to avoid conflicts with conda-forge
-conda config --remove channels defaults
+
+# miniforge has already done this for us, hence the OS restriction.
+#
+if [ "`uname -s`" != "Darwin" ] ; then
+  conda config --add channels conda-forge
+  #Remove defaults to avoid conflicts with conda-forge
+  conda config --remove channels defaults
+fi
 
 # To avoid issues with non-XSPEC builds (e.g.
 # https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -10,6 +10,13 @@ if [ "`uname -s`" == "Darwin" ] ; then
       echo "macOS 10.14 SDK download failed"
     fi
     tar -C ${GITHUB_WORKSPACE}/10.14SDK -xf MacOSX10.14.sdk.tar.xz
+
+    # Install miniforge; see
+    # https://github.com/conda-forge/miniforge?tab=readme-ov-file#downloading-the-installer-as-part-of-a-ci-pipeline
+    CONDA="${HOME}/conda"
+    curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh"
+    bash Miniforge3.sh -b -p $CONDA
+
     #End of Conda compilers section
 else
     compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -49,7 +49,12 @@ fi
 # the XSPEC-related channels are only added if needed
 #
 if [ -n "${XSPECVER}" ]; then
- conda config --add channels ${xspec_channel}
+  if [ "`uname -s`" == "Darwin" ] ; then
+    # we need to use the CXC conda channel to get the ARM XSPEC build for now
+    conda config --add channels https://cxc.harvard.edu/conda/ciao
+  else
+    conda config --add channels ${xspec_channel}
+  fi
 fi
 
 # Figure out requested dependencies

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - name: MacOS Full Build
-            os: macos-latest
+            os: macos-14
             python-version: "3.10"
             install-type: develop
             fits: astropy

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -115,6 +115,9 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         if [ "$RUNNER_OS" != "macOS" ]; then
@@ -127,6 +130,9 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         pip install . --verbose
@@ -136,6 +142,9 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         pip install -e . --verbose
@@ -143,6 +152,9 @@ jobs:
     - name: Install the test data?
       if: matrix.test-data == 'package'
       run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         pip install ./sherpa-test-data
@@ -171,6 +183,9 @@ jobs:
         fi
 
         echo "** smoke test: ${smokevars}"
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         cd /home
@@ -199,6 +214,9 @@ jobs:
           # make sure pytext-xvfb can find Xvfb
           export PATH="${PATH}:/opt/X11/bin"
         fi
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
@@ -207,6 +225,9 @@ jobs:
     - name: sherpa_test Tests
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
       run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          CONDA="${HOME}/conda"
+        fi
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov


### PR DESCRIPTION
Following https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/